### PR TITLE
Added bin/docker-dev to run docker-composed dev environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=3.1.1
+ARG RUBY_VERSION=3.3.0
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 
 # Rails app lives here

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,29 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=3.3.0
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-bookworm AS base
+
+# Rails app lives here
+WORKDIR /app
+
+# Set environment
+ENV RAILS_ENV="development" \
+    BUNDLE_PATH="/usr/local/bundle"
+
+# Install JavaScript dependencies
+ARG NODE_VERSION=21.5.0
+ARG YARN_VERSION=1.22.21
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+
+# Install packages
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3 postgresql-client && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+EXPOSE 4000
+CMD ["sleep", "infinity"]

--- a/bin/docker-dev
+++ b/bin/docker-dev
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+docker compose run -it --service-ports --remove-orphans backend "/bin/bash"
+docker compose down

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,19 +27,19 @@ development:
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: itty_bitty_boards
+  username: <%= ENV["DATABASE_USERNAME"] || nil %>
 
   # The password associated with the PostgreSQL role (username).
-  #password:
+  password: <%= ENV["DATABASE_PASSWORD"] || nil %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: <%= ENV["DATABASE_HOST"] || "localhost" %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  port: <%= ENV["DATABASE_PORT"] || 5432 %>
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: itty_bitty_boards
+      POSTGRES_PASSWORD: itty_bitty_password
+      POSTGRES_DB: itty_bitty_boards_development
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/app
+    environment:
+      - BINDING=0.0.0.0
+      - DEVISE_JWT_SECRET_KEY=secret
+      - REDIS_URL=redis://redis:6379/1
+      - REDIS_PROVIDER=REDIS_URL
+      - DATABASE_USERNAME=itty_bitty_boards
+      - DATABASE_PASSWORD=itty_bitty_password
+      - DATABASE_HOST=postgres
+      - DATABASE_PORT=5432
+    depends_on:
+      - redis
+      - postgres
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
Set up a dev env that can be run in `docker compose`.

Added a `bin/docker-dev` script to run `docker compose` which brings up 3 containers:
* postgres - stores data in a docker volume
* redis - stores data in a docker volume
* ruby / debian - maps the project directory to `/app` in container so an IDE or other commands can be run outside the container.

and leaves the user in a `bash` shell on the ruby container where they can perform dev work.

## To Use:

* Install docker on your host machine
* `/bin/docker-dev`
* from within the container:
  * `bundle install`
  * `bin/dev`
  * `exit` when finished
* when the shell exits, `docker compose down` will be run automatically to stop the other containers.