### PR TITLE
Allow ActiveStorage to be selected using ACTIVE_STORAGE_SERVICE env var.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   config.action_controller.default_url_options = { host: "http://localhost:4000" }
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV["ACTIVE_STORAGE_SERVICE"] || :amazon
   config.active_storage.content_types_to_serve_as_binary -= ["image/svg+xml", "image/svg"]
   config.active_storage.content_types_allowed_inline += ["image/svg+xml", "image/svg"]
   # Don't care if the mailer can't send.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,9 +8,9 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY_ID") %>
-  secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY") %>
-  region: us-east-1
+  access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY_ID", "") %>
+  secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY", "") %>
+  region: <%= ENV.fetch("AWS_REGION", "us-east-1") %>
   bucket: itty-bitty-boards-<%= ENV.fetch("RAILS_ENV", "development") %>
   public: true
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - DATABASE_PASSWORD=itty_bitty_password
       - DATABASE_HOST=postgres
       - DATABASE_PORT=5432
+      - ACTIVE_STORAGE_SERVICE=local
     depends_on:
       - redis
       - postgres


### PR DESCRIPTION
* `ACTIVE_STORAGE_SERVICE` env var can be used to select ActiveStorage location. Defaults to `amazon` if not set.
* The default for `bin/docker-dev` is set to `local`.
* Allow AWS region to be set with `AWS_REGION` env var. Defaults to `us-east-1` if not set.