### PR TITLE
Added bin/psql as a convenience to connect to Postgres.

### DIFF
--- a/bin/psql
+++ b/bin/psql
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+PGPASSWORD="${DATABASE_PASSWORD}" psql -h "${DATABASE_HOST:-localhost}" -p "${DATABASE_PORT:-5432}" -U "${DATABASE_USERNAME:-root}" itty_bitty_boards_development


### PR DESCRIPTION
* Added `bin/psql` as a convenience to connect to Postgres. Works well when used within the docker-container since it uses the env vars.