### PR TITLE
Display 404 page instead of throwing RoutingError

### DIFF
--- a/app/controllers/error_controller.rb
+++ b/app/controllers/error_controller.rb
@@ -1,0 +1,9 @@
+class ErrorController < ApplicationController
+  def not_found
+    respond_to do |format|
+      format.html { render :file => "#{Rails.root}/public/404.html", :layout => false, :status => :not_found }
+      format.xml  { head :not_found }
+      format.any  { head :not_found }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,4 +441,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "main#index"
+
+  # Catch-all route for handling 404 errors. This should be the last route in the file to ensure it catches all unmatched routes.
+  match '*path', via: :all, to: 'error#not_found'
 end


### PR DESCRIPTION
Navigating to an unknown path will now display 404 html page, or for json requests, an empty response with a 404 status.

This is to suppress logging errors from bots scanning for vulns, like
```
E, [2025-06-22T17:56:27.352416 #381381] ERROR -- : [8d0b2336-3a53-412c-b63b-35cd0da5aa7e]
[8d0b2336-3a53-412c-b63b-35cd0da5aa7e] ActionController::RoutingError (No route matches [GET] "/vendor/phpunit/src/Util/PHP/eval-stdin.php"):
```