### PR TITLE
Fix docker dev startup.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,5 +25,8 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3 postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# Redis is run as a separate service in docker-compose.yml. Replace redis-server with a script to avoid Foreman error.
+RUN echo 'echo "sleep infinity" > /usr/bin/redis-server' > /usr/bin/redis-server && chmod +x /usr/bin/redis-server
+
 EXPOSE 4000
 CMD ["sleep", "infinity"]

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 
-  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,6 @@ GEM
       logger
       zeitwerk (~> 2.6)
     erb (5.0.1)
-    error_highlight (0.7.0)
     erubi (1.13.1)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -526,7 +525,6 @@ DEPENDENCIES
   devise-jwt
   devise_invitable (~> 2.0.10)
   down (~> 5.4)
-  error_highlight (>= 0.4.0)
   factory_bot_rails
   faraday
   ffaker

--- a/README.md
+++ b/README.md
@@ -130,3 +130,25 @@ b. Dynamic Board: A board that _can_ change screens - This is based on the image
 14. Premium Features: Exclusive tools or functionalities available to paying subscribers (e.g., ad-free experience, AI image generation).
 
 15. AI: Artificial Intelligence, used to generate word suggestions, images, and other content on the platform. This feature is powered by OpenAI.
+
+## Local Development in Docker
+
+The DB and backend services can be run in Docker using `docker compose`.
+
+To start the services, run the `bin/docker-dev` script.
+This will open the console to a docker container that has Ruby, node, yarn installed.
+From within the container
+```
+bin/dev
+```
+to start the Rails application.
+
+If you notice the service immediately exit with:
+```
+15:03:28 redis.1   | exited with code 0
+15:03:28 system    | sending SIGTERM to all processes
+```
+try running it again.
+
+When finished, run `exit` in the Docker conatiner to close the shell.
+This will then exit the Docker container and stop the Postgres and Redis containers.

--- a/bin/docker-dev
+++ b/bin/docker-dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-docker compose run -it --service-ports --remove-orphans backend "/bin/bash"
+docker compose run -it --build --service-ports --remove-orphans backend "/bin/bash"
 docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,11 @@ services:
     ports:
       - "4000:4000"
     volumes:
+      - bundle_data:/usr/local/bundle
       - .:/app
     environment:
       - BINDING=0.0.0.0
+      - BUNDLE_PATH=/usr/local/bundle
       - DEVISE_JWT_SECRET_KEY=secret
       - REDIS_URL=redis://redis:6379/1
       - REDIS_PROVIDER=REDIS_URL
@@ -42,3 +44,4 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  bundle_data:


### PR DESCRIPTION
Fixed a couple issues with the Docker env starting up.

* Now `bin/docker-dev` will rebuild the `backend` image. Previously, if the `Dockerfile` was edited, the image was not being rebuilt.
* Put a `/usr/bin/redis-server` script into the dev image. Foreman would exit all services if it couldn't run this command when executing `bin/dev`. In the docker environment, Redis is a separate docker image, not run locally inside the same container as the Rails app, so there is no server to start.
* Added a docker volume to retain the `bundle install` results between runs. Previously, you would have to rerun `bundle install` any time you restarted the docker container. Now the installed gems are retained.
* Updated `README.md` to indicate how to use the docker dev env.