### PR TITLE
Fix mass assignment: remove user_id and status from permit lists

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1078,8 +1078,7 @@ class API::BoardsController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def board_params
-    params.require(:board).permit(:user_id,
-                                  :name,
+    params.require(:board).permit(:name,
                                   :slug,
                                   :text_color,
                                   :bg_color,

--- a/app/controllers/api/scenarios_controller.rb
+++ b/app/controllers/api/scenarios_controller.rb
@@ -187,9 +187,9 @@ class API::ScenariosController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def scenario_params
-    params.require(:scenario).permit(:name, :user_id, :prompt_text, :revised_prompt, :send_now,
+    params.require(:scenario).permit(:name, :prompt_text, :revised_prompt, :send_now,
                                      :deleted_at, :sent_at, :private, :response_type, :age_range, :number_of_images, :token_limit,
-                                     :initial_description, :questions, :answers, :status, :word_list, :finalize)
+                                     :initial_description, :questions, :answers, :word_list, :finalize)
   end
 
   def generate_first_question(scenario)

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -223,6 +223,6 @@ class BoardsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def board_params
-    params.require(:board).permit(:user_id, :name, :parent_id, :parent_type, :description, :number_of_columns, :predefined, :voice)
+    params.require(:board).permit(:name, :parent_id, :parent_type, :description, :number_of_columns, :predefined, :voice)
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -225,6 +225,6 @@ class ImagesController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def image_params
-    params.require(:image).permit(:label, :image_prompt, :private, :user_id, :status, :error, :open_symbol_status, :image_type, :audio_files)
+    params.require(:image).permit(:label, :image_prompt, :private, :error, :open_symbol_status, :image_type, :audio_files)
   end
 end


### PR DESCRIPTION
Closes #27

## Summary

- Remove `:user_id` from `board_params` in both `api/boards_controller.rb` and `boards_controller.rb` — the user is already assigned via `@board.user = current_user` after the `.new` call
- Remove `:user_id` and `:status` from `scenario_params` in `api/scenarios_controller.rb` — the scenario is built via `current_user.scenarios.new(...)` which sets the user correctly
- Remove `:user_id` and `:status` from `image_params` in `images_controller.rb`

Without these changes, any authenticated client could submit `user_id` or `status` in request params and have them persisted, allowing ownership spoofing and status manipulation.

## Test plan

- [ ] Create a board — confirm it is owned by the signed-in user regardless of what `user_id` is submitted in params
- [ ] Create a scenario — confirm `user_id` and `status` in params are silently ignored
- [ ] Update an image — confirm `user_id` and `status` params are ignored
- [ ] Confirm no existing create/update flows are broken (user assignment still works via controller-level assignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)