### PR TITLE
Add internal API under /api/internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - `GOOGLE_CUSTOM_SEARCH_API_KEY` - Google Custom Search API Key
   - `GOOGLE_CUSTOM_SEARCH_CX` - Google Custom Search CX
   - `PREDICTIVE_DEFAULT_ID` - Predictive Default ID (going to be removed)
+  - `INTERNAL_API_KEY` - Shared key used to authenticate the internal API (see "Internal API" section below)
 
 - Database creation:
 
@@ -130,6 +131,182 @@ b. Dynamic Board: A board that _can_ change screens - This is based on the image
 14. Premium Features: Exclusive tools or functionalities available to paying subscribers (e.g., ad-free experience, AI image generation).
 
 15. AI: Artificial Intelligence, used to generate word suggestions, images, and other content on the platform. This feature is powered by OpenAI.
+
+## Internal API
+
+A small, internal-only API mounted under `/api/internal/`. Used for trusted
+server-to-server calls (scripts, internal tools) — not for the React frontend
+and not exposed to end users.
+
+### Authentication
+
+All requests must include a bearer token matching `ENV["INTERNAL_API_KEY"]`:
+
+```
+Authorization: Bearer <INTERNAL_API_KEY>
+```
+
+Missing or incorrect tokens return `401 Unauthorized`. There is no per-user
+auth; every write is performed as the default admin user
+(`User::DEFAULT_ADMIN_ID`).
+
+### Setup
+
+Generate a strong random key and add it to your environment:
+
+```sh
+# Generate
+bin/rails runner 'puts SecureRandom.hex(32)'
+
+# .env (local)
+INTERNAL_API_KEY=<the generated value>
+```
+
+For Hatchbox, set `INTERNAL_API_KEY` in the app's environment variables panel.
+
+### Endpoints
+
+#### `POST /api/internal/boards`
+
+Pure record create. Does **not** enqueue board-generation jobs.
+
+```sh
+curl -X POST https://<host>/api/internal/boards \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "board": {
+      "name": "My Board",
+      "board_type": "static",
+      "voice": "alloy",
+      "language": "en"
+    }
+  }'
+```
+
+Response: `201 Created` with the created board.
+
+#### `PATCH /api/internal/boards/:id`
+
+Updates board attributes. Accepts an optional `layout` parameter to persist a
+grid layout for a screen size; this triggers the same layout-save flow used by
+the public API (board image positions, screen-size column counts, margins,
+per-screen settings, and a preview-image regenerate).
+
+```sh
+curl -X PATCH https://<host>/api/internal/boards/123 \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "board": { "name": "Renamed" },
+    "screen_size": "lg",
+    "layout": [
+      { "i": "<board_image_id>", "x": 0, "y": 0, "w": 1, "h": 1 }
+    ],
+    "small_screen_columns": 3,
+    "medium_screen_columns": 6,
+    "large_screen_columns": 8,
+    "xMargin": 4,
+    "yMargin": 4
+  }'
+```
+
+`layout` may also be passed in object form: `{ "screen_size": "lg", "layout": [...] }`.
+
+Response: `200 OK` with the board's full API view.
+
+#### `POST /api/internal/images`
+
+Creates an image record without generating any AI image. Reuses an existing
+image if one with the same label already exists for the admin user.
+
+```sh
+curl -X POST https://<host>/api/internal/images \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "image": { "label": "apple", "image_prompt": "a red apple" } }'
+```
+
+Response: `201 Created`.
+
+#### `POST /api/internal/images/generate`
+
+Enqueues a `GenerateImageJob` to call OpenAI and attach the resulting image.
+Returns immediately (`202 Accepted`) with the image record in `generating`
+state — see the "Polling for generation status" section below.
+
+```sh
+curl -X POST https://<host>/api/internal/images/generate \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": { "label": "apple", "image_prompt": "a red apple" },
+    "transparent_background": "true"
+  }'
+```
+
+Optional params: `id` (regenerate an existing image), `board_id`,
+`screen_size`, `transparent_background`.
+
+Response: `202 Accepted` with `{ id, label, status: "generating", ... }`.
+
+#### `GET /api/internal/images/:id`
+
+Returns the current state of an image. Used to check whether a previously
+queued generation has finished.
+
+```sh
+curl https://<host>/api/internal/images/456 \
+  -H "Authorization: Bearer $INTERNAL_API_KEY"
+```
+
+Response shape:
+
+```json
+{
+  "id": 456,
+  "label": "apple",
+  "status": "complete",
+  "image_prompt": "a red apple",
+  "src": "https://.../apple.png",
+  "error": null
+}
+```
+
+`status` will be `generating`, `complete`, or `failed`.
+
+### Polling for generation status
+
+OpenAI image calls take several seconds and can occasionally exceed proxy
+timeouts, so generation is intentionally async. After calling
+`POST /api/internal/images/generate`, poll `GET /api/internal/images/:id`
+until `status` is `complete` or `failed`:
+
+```ruby
+require "net/http"
+require "json"
+
+key = ENV.fetch("INTERNAL_API_KEY")
+host = "https://<host>"
+
+resp = Net::HTTP.post(
+  URI("#{host}/api/internal/images/generate"),
+  { image: { label: "apple", image_prompt: "a red apple" } }.to_json,
+  "Authorization" => "Bearer #{key}",
+  "Content-Type" => "application/json",
+)
+image_id = JSON.parse(resp.body).fetch("id")
+
+loop do
+  sleep 2
+  status_resp = Net::HTTP.get_response(
+    URI("#{host}/api/internal/images/#{image_id}"),
+    "Authorization" => "Bearer #{key}",
+  )
+  body = JSON.parse(status_resp.body)
+  break body if %w[complete failed].include?(body["status"])
+end
+```
 
 ## Local Development in Docker
 

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1121,46 +1121,17 @@ class API::BoardsController < API::ApplicationController
       Rails.logger.error "Cannot save layout: Board not found or layout parameter is blank"
       return
     end
-    @layout ||= params[:layout].map(&:to_unsafe_h) # Convert ActionController::Parameters to a Hash
-    sorted_layout = @layout.sort_by { |item| [item["y"].to_i, item["x"].to_i] }
-
-    board_image_ids = []
-    sorted_layout.each_with_index do |item, i|
-      board_image_id = item["i"].to_i
-      board_image = @board&.board_images.find_by(id: board_image_id)
-      if board_image
-        board_image.update!(position: i)
-      else
-        Rails.logger.error "Board image not found for ID: #{board_image_id}"
-      end
-    end
-
-    # Save screen size settings
-    screen_size = params[:screen_size] || "lg"
-    if params[:small_screen_columns].present? || params[:medium_screen_columns].present? || params[:large_screen_columns].present?
-      @board.small_screen_columns = params[:small_screen_columns].to_i if params[:small_screen_columns].present?
-      @board.medium_screen_columns = params[:medium_screen_columns].to_i if params[:medium_screen_columns].present?
-      @board.large_screen_columns = params[:large_screen_columns].to_i if params[:large_screen_columns].present?
-    end
-
-    # Save margin settings
-    margin_x = params[:xMargin].to_i
-    margin_y = params[:yMargin].to_i
-    if margin_x.present? && margin_y.present?
-      @board.margin_settings[screen_size] = { x: margin_x, y: margin_y }
-    end
-
-    # Save additional settings
-    @board.settings[screen_size] = params[:settings] if params[:settings].present?
-    @board.save!
-
-    # Update the grid layout
-    begin
-      @board.update_grid_layout(sorted_layout, screen_size)
-      @board.run_generate_preview_job
-    rescue => e
-      Rails.logger.error "Error updating grid layout: #{e.message}\n#{e.backtrace.join("\n")}"
-    end
-    @board.reload
+    layout_items = (@layout ||= params[:layout].map(&:to_unsafe_h))
+    @board.apply_layout!(
+      layout: layout_items,
+      screen_size: params[:screen_size] || "lg",
+      columns: {
+        small_screen_columns: params[:small_screen_columns],
+        medium_screen_columns: params[:medium_screen_columns],
+        large_screen_columns: params[:large_screen_columns],
+      },
+      margins: { x: params[:xMargin], y: params[:yMargin] },
+      settings: params[:settings],
+    )
   end
 end

--- a/app/controllers/api/internal/application_controller.rb
+++ b/app/controllers/api/internal/application_controller.rb
@@ -1,0 +1,24 @@
+module API
+  module Internal
+    class ApplicationController < ::ApplicationController
+      skip_before_action :verify_authenticity_token, raise: false
+      before_action :authenticate_internal_api_key!
+
+      private
+
+      def authenticate_internal_api_key!
+        expected = ENV["INTERNAL_API_KEY"].to_s
+        provided = request.headers["Authorization"].to_s.split(" ", 2).last.to_s
+
+        if expected.blank? || provided.blank? ||
+           !ActiveSupport::SecurityUtils.secure_compare(expected, provided)
+          render json: { error: "Unauthorized" }, status: :unauthorized
+        end
+      end
+
+      def current_user
+        @current_user ||= User.find(User::DEFAULT_ADMIN_ID)
+      end
+    end
+  end
+end

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -1,0 +1,99 @@
+class API::Internal::BoardsController < API::Internal::ApplicationController
+  def create
+    @board = Board.new(board_params)
+    @board.user = current_user
+    @board.predefined = false
+    @board.board_type = params[:board_type] || board_params[:board_type] || "static"
+    @board.voice = VoiceService.normalize_voice(board_params[:voice]) if board_params[:voice].present?
+    @board.assign_parent
+
+    settings = board_params[:settings].presence || params[:settings] || {}
+    settings["board_type"] = @board.board_type
+    @board.settings = settings
+
+    @board.slug = @board.generate_unique_slug(board_params[:slug])
+
+    if @board.save
+      render json: @board, status: :created
+    else
+      render json: { errors: @board.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    @board = Board.find(params[:id])
+    @board.assign_attributes(board_params.except(:settings, :voice))
+    @board.voice = VoiceService.normalize_voice(board_params[:voice]) if board_params[:voice].present?
+
+    if board_params[:settings].present? || params[:settings].present?
+      incoming_settings = board_params[:settings].presence || params[:settings] || {}
+      @board.settings = @board.settings.merge(incoming_settings)
+    end
+
+    @board.parent_type = "User"
+    @board.parent_id   = @board.user_id || User::DEFAULT_ADMIN_ID
+
+    if board_params[:slug].present? && board_params[:slug] != @board.slug
+      @board.slug = @board.generate_unique_slug(board_params[:slug])
+    end
+
+    if @board.save
+      apply_layout_if_present!
+      render json: @board.api_view_with_images(current_user)
+    else
+      render json: { errors: @board.errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def apply_layout_if_present!
+    return if params[:layout].blank?
+
+    if params[:layout].is_a?(Array)
+      layout      = params[:layout].map(&:to_unsafe_h)
+      screen_size = params[:screen_size] || "lg"
+    else
+      layout_param = params[:layout]
+      screen_size  = layout_param[:screen_size] || layout_param["screen_size"] || "lg"
+      layout       = (layout_param[:layout] || layout_param["layout"] || []).map(&:to_unsafe_h)
+    end
+
+    return if @board.layout[screen_size] == layout
+
+    @board.apply_layout!(
+      layout: layout,
+      screen_size: screen_size,
+      columns: {
+        small_screen_columns:  params[:small_screen_columns],
+        medium_screen_columns: params[:medium_screen_columns],
+        large_screen_columns:  params[:large_screen_columns],
+      },
+      margins: { x: params[:xMargin], y: params[:yMargin] },
+      settings: params[:settings],
+    )
+  end
+
+  def board_params
+    params.require(:board).permit(
+      :name,
+      :slug,
+      :description,
+      :board_type,
+      :voice,
+      :language,
+      :small_screen_columns,
+      :medium_screen_columns,
+      :large_screen_columns,
+      :number_of_columns,
+      :predefined,
+      :published,
+      :favorite,
+      :category,
+      :display_image_url,
+      :bg_color,
+      settings: {},
+      tags: [],
+    )
+  end
+end

--- a/app/controllers/api/internal/images_controller.rb
+++ b/app/controllers/api/internal/images_controller.rb
@@ -1,0 +1,86 @@
+class API::Internal::ImagesController < API::Internal::ApplicationController
+  def create
+    label = image_params[:label]
+
+    if label.blank?
+      render json: { error: "label is required" }, status: :unprocessable_entity
+      return
+    end
+
+    @image = Image.find_or_create_by(label: label, user_id: current_user.id) do |img|
+      img.image_prompt = image_params[:image_prompt]
+      img.image_type   = image_params[:image_type] || "User"
+      img.private      = image_params[:private] || false
+    end
+
+    if @image.persisted?
+      render json: @image.with_display_doc(current_user), status: :created
+    else
+      render json: { errors: @image.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def generate
+    label  = image_params[:label].presence || image_params[:image_prompt]
+    prompt = image_params[:image_prompt].to_s.gsub("[[REPLACE_LABEL]]", "").strip
+
+    if label.blank?
+      render json: { error: "label or image_prompt is required" }, status: :unprocessable_entity
+      return
+    end
+
+    @image = if params[:id].present?
+        Image.find(params[:id])
+      else
+        Image.find_or_create_by(
+          label: label,
+          user_id: current_user.id,
+          private: false,
+          image_prompt: prompt,
+          image_type: "Generated",
+        )
+      end
+
+    @image.image_prompt = prompt if prompt.present?
+    @image.status = "generating"
+    @image.save!
+
+    options = {
+      "image_prompt"   => @image.image_prompt,
+      "board_id"       => params[:board_id],
+      "screen_size"    => params[:screen_size] || "lg",
+      "transparent_bg" => params[:transparent_background] == "true" || params[:transparent_background] == true,
+    }
+    GenerateImageJob.perform_async(@image.id, current_user.id, options)
+
+    render json: image_status_payload(@image), status: :accepted
+  end
+
+  def show
+    @image = Image.find(params[:id])
+    render json: image_status_payload(@image)
+  end
+
+  private
+
+  def image_status_payload(image)
+    {
+      id: image.id,
+      label: image.label,
+      status: image.status,
+      image_prompt: image.image_prompt,
+      src: image.display_image_url(current_user),
+      error: image.error,
+    }
+  end
+
+  def image_params
+    params.require(:image).permit(
+      :label,
+      :image_prompt,
+      :image_type,
+      :private,
+      :board_id,
+    )
+  end
+end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1231,6 +1231,45 @@ class Board < ApplicationRecord
     self.save!
   end
 
+  # Persist a layout change for a given screen size. Sorts the items, updates
+  # each board_image's position, optionally writes screen-size column counts,
+  # margin settings, and per-screen settings, then delegates to
+  # update_grid_layout and queues a preview regenerate.
+  def apply_layout!(layout:, screen_size: "lg", columns: {}, margins: {}, settings: nil)
+    return if layout.blank?
+
+    sorted_layout = layout.sort_by { |item| [item["y"].to_i, item["x"].to_i] }
+
+    sorted_layout.each_with_index do |item, i|
+      board_image_id = item["i"].to_i
+      board_image = board_images.find_by(id: board_image_id)
+      if board_image
+        board_image.update!(position: i)
+      else
+        Rails.logger.error "Board image not found for ID: #{board_image_id}"
+      end
+    end
+
+    self.small_screen_columns  = columns[:small_screen_columns].to_i  if columns[:small_screen_columns].present?
+    self.medium_screen_columns = columns[:medium_screen_columns].to_i if columns[:medium_screen_columns].present?
+    self.large_screen_columns  = columns[:large_screen_columns].to_i  if columns[:large_screen_columns].present?
+
+    if margins[:x].present? && margins[:y].present?
+      self.margin_settings[screen_size] = { x: margins[:x].to_i, y: margins[:y].to_i }
+    end
+
+    self.settings[screen_size] = settings if settings.present?
+    save!
+
+    begin
+      update_grid_layout(sorted_layout, screen_size)
+      run_generate_preview_job
+    rescue => e
+      Rails.logger.error "Error updating grid layout: #{e.message}\n#{e.backtrace.join("\n")}"
+    end
+    reload
+  end
+
   def grid_layout(screen_size = "lg")
     layout_to_set = []
     board_images.order(:position).map do |bi|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,15 @@ Rails.application.routes.draw do
       end
     end
 
+    namespace :internal do
+      resources :boards, only: [:create, :update]
+      resources :images, only: [:create, :show] do
+        collection do
+          post :generate
+        end
+      end
+    end
+
     namespace :v1 do
       resource :auth, only: [:create, :destroy]
       delete "/child_accounts/logout", to: "child_auths#destroy"


### PR DESCRIPTION
## Summary
- New `/api/internal/` namespace authenticated by a single shared `INTERNAL_API_KEY` via `Authorization: Bearer <key>`. All writes act as the default admin user (`User::DEFAULT_ADMIN_ID`). Intended for trusted server-to-server calls only — not the React frontend.
- Endpoints: `POST /boards` (pure record create, no AI job), `PATCH /boards/:id` (with full layout support — both array and `{screen_size, layout}` shapes), `POST /images` (pure create), `POST /images/generate` (enqueues `GenerateImageJob`, returns 202), `GET /images/:id` (status polling).
- Extracted the layout-save logic from `API::BoardsController#save_layout!` into `Board#apply_layout!` so both the existing public controller and the new internal controller use the same code path. Public-controller behavior preserved.

## Why async for image generation
OpenAI image calls can run 5–30 seconds and occasionally exceed proxy timeouts. The internal API reuses the existing `GenerateImageJob` pipeline and exposes a `GET /api/internal/images/:id` status endpoint for polling — keeping Puma workers free and inheriting the job's existing retry behavior.

## Test plan
- [ ] Set `INTERNAL_API_KEY` locally; confirm requests without/with wrong bearer return 401.
- [ ] `POST /api/internal/boards` creates a board owned by the default admin and does NOT enqueue `GenerateBoardJob`.
- [ ] `PATCH /api/internal/boards/:id` with a `layout` array updates board_image positions, screen-size columns, margins, and queues a preview regenerate (verify against the existing public flow's behavior).
- [ ] `PATCH /api/internal/boards/:id` with `layout` in object form (`{screen_size, layout}`) behaves identically.
- [ ] `POST /api/internal/images` returns the existing image when one with the same label exists for the admin user; otherwise creates a fresh record.
- [ ] `POST /api/internal/images/generate` returns 202 with `status: "generating"` and enqueues `GenerateImageJob` on the `ai_images` queue.
- [ ] `GET /api/internal/images/:id` reflects `complete` / `failed` once the job finishes.
- [ ] Existing public `PATCH /api/boards/:id` with a layout still works end-to-end (regression — `save_layout!` now delegates to `Board#apply_layout!`).
- [ ] `bundle exec rspec` passes.

## Follow-ups
- No request specs added for the new internal namespace (pending owner direction).
- Webhook callback variant for image generation intentionally deferred — easy to add later as a non-breaking option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)