### PR TITLE
Internal API: word_list on boards + new generated_boards endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,30 @@ curl -X PATCH https://<host>/api/internal/boards/123 \
 
 Response: `200 OK` with the board's full API view.
 
+#### `POST /api/internal/generated_boards`
+
+Creates a board and enqueues `GenerateFreeBoardJob` to fill it with AI-generated
+words and images for the given topic. The board is owned by the default admin
+user (`User::DEFAULT_ADMIN_ID`); unlike the public `/api/generated_boards`
+endpoint, no `generated_token` is issued and the board is not claimable.
+
+```sh
+curl -X POST https://<host>/api/internal/generated_boards \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic": "snacks",
+    "age_range": "5-10",
+    "word_count": 12
+  }'
+```
+
+Optional params: `name` (defaults to `"<topic> (Age Range: <age_range>)"`),
+`age_range`, `word_count` (defaults to `12`).
+
+Response: `201 Created` with `{ id, name, status: "generating" }`. Poll the
+board via the existing board endpoints to see when generation finishes.
+
 #### `POST /api/internal/images`
 
 Creates an image record without generating any AI image. Reuses an existing

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -14,6 +14,7 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     @board.slug = @board.generate_unique_slug(board_params[:slug])
 
     if @board.save
+      enqueue_generation_job_if_needed!
       render json: @board, status: :created
     else
       render json: { errors: @board.errors }, status: :unprocessable_entity
@@ -46,6 +47,14 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
   end
 
   private
+
+  def enqueue_generation_job_if_needed!
+    word_list = Array(params[:word_list]).compact.select { |w| w.is_a?(String) && w.present? }
+    return if word_list.blank?
+
+    creation_type = params[:board_creation_type].presence || "default"
+    GenerateBoardJob.perform_async(@board.id, creation_type, { "word_list" => word_list })
+  end
 
   def apply_layout_if_present!
     return if params[:layout].blank?

--- a/app/controllers/api/internal/generated_boards_controller.rb
+++ b/app/controllers/api/internal/generated_boards_controller.rb
@@ -1,0 +1,65 @@
+class API::Internal::GeneratedBoardsController < API::Internal::ApplicationController
+  WORD_COUNT_OPTIONS = [9, 12, 16, 20, 24, 30, 36, 42, 48, 54, 60].freeze
+
+  def create
+    topic     = params[:topic].to_s.strip
+    age_range = params[:ageRange].presence || params[:age_range].presence
+    word_count = (params[:wordCount].presence || params[:word_count].presence || 12).to_i
+    board_name = params[:name].presence || generated_board_name(topic, age_range)
+
+    if topic.blank?
+      render json: { error: "Topic is required" }, status: :unprocessable_entity
+      return
+    end
+
+    board = nil
+    begin
+      board = Board.new(user: current_user, name: board_name)
+      columns = ideal_columns_for(word_count)
+      board.large_screen_columns  = columns
+      board.medium_screen_columns = columns
+      board.small_screen_columns  = columns / 2
+      board.settings = { disable_scroll: true }
+      board.assign_parent
+      # assign_parent overwrites board_type to "static" for User-owned boards;
+      # set it back so this board is identifiable as AI-generated.
+      board.board_type = "generated"
+      board.slug = board.generate_unique_slug
+      board.voice  = "polly:kevin"
+      board.status = "generating"
+
+      if board.save
+        GenerateFreeBoardJob.perform_async(board.id, topic, age_range, word_count)
+        render json: { id: board.id, name: board.name, status: board.status }, status: :created
+      else
+        Rails.logger.error("API::Internal::GeneratedBoardsController#create save failed: #{board.errors.full_messages.join(", ")}")
+        render json: { error: board.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      end
+    rescue => e
+      Rails.logger.error("API::Internal::GeneratedBoardsController#create raised: #{e.class} - #{e.message}")
+      board.destroy if board&.persisted?
+      render json: { error: "Unable to generate board" }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def generated_board_name(topic, age_range)
+    base = topic.presence || "Generated Board"
+    age_range.present? ? "#{base} (Age Range: #{age_range})" : base
+  end
+
+  def ideal_columns_for(word_count)
+    case word_count
+    when 0..9   then 3
+    when 10..16 then 4
+    when 17..20 then 5
+    when 21..36 then 6
+    when 37..42 then 7
+    when 43..48 then 8
+    when 49..54 then 9
+    when 55..60 then 10
+    else [12, (word_count / 8.0).ceil].min
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -336,6 +336,7 @@ Rails.application.routes.draw do
 
     namespace :internal do
       resources :boards, only: [:create, :update]
+      resources :generated_boards, only: [:create]
       resources :images, only: [:create, :show] do
         collection do
           post :generate

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::Boards", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/boards" do
+    context "without a valid bearer token" do
+      it "returns 401" do
+        post "/api/internal/boards", params: { board: { name: "Nope" } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "creates a board and returns 201" do
+        expect {
+          post "/api/internal/boards",
+               params: { board: { name: "Internal Board" } }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(Board, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(Board.last.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      end
+
+      it "does not enqueue GenerateBoardJob when no word_list is given" do
+        expect {
+          post "/api/internal/boards",
+               params: { board: { name: "Quiet Board" } }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.not_to change(GenerateBoardJob.jobs, :size)
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it "enqueues GenerateBoardJob with the word_list when one is given" do
+        word_list = ["apple", "banana"]
+
+        expect {
+          post "/api/internal/boards",
+               params: { board: { name: "Word List Board" }, word_list: word_list }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(GenerateBoardJob.jobs, :size).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        job = GenerateBoardJob.jobs.last
+        expect(job["args"][0]).to eq(Board.last.id)
+        expect(job["args"][1]).to eq("default")
+        expect(job["args"][2]).to eq({ "word_list" => word_list })
+      end
+    end
+  end
+
+  describe "PATCH /api/internal/boards/:id" do
+    let!(:board) { create(:board, name: "Old Name", user: admin_user) }
+
+    context "without a valid bearer token" do
+      it "returns 401" do
+        patch "/api/internal/boards/#{board.id}", params: { board: { name: "New" } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "renames the board and returns 200" do
+        patch "/api/internal/boards/#{board.id}",
+              params: { board: { name: "New Name" } }.to_json,
+              headers: auth_headers.merge("Content-Type" => "application/json")
+
+        expect(response).to have_http_status(:ok)
+        expect(board.reload.name).to eq("New Name")
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/generated_boards_spec.rb
+++ b/spec/requests/api/internal/generated_boards_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::GeneratedBoards", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}", "Content-Type" => "application/json" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/generated_boards" do
+    context "without a valid bearer token" do
+      it "returns 401" do
+        post "/api/internal/generated_boards", params: { topic: "snacks" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "returns 422 when topic is missing" do
+        post "/api/internal/generated_boards",
+             params: {}.to_json,
+             headers: auth_headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to eq("Topic is required")
+      end
+
+      it "creates a generated board owned by the default admin and enqueues GenerateFreeBoardJob" do
+        expect {
+          post "/api/internal/generated_boards",
+               params: { topic: "snacks", age_range: "5-10", word_count: 9 }.to_json,
+               headers: auth_headers
+        }.to change(Board, :count).by(1)
+         .and change(GenerateFreeBoardJob.jobs, :size).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        body = JSON.parse(response.body)
+        expect(body).to include("id", "name", "status")
+        expect(body["status"]).to eq("generating")
+
+        board = Board.find(body["id"])
+        expect(board.user_id).to eq(User::DEFAULT_ADMIN_ID)
+        expect(board.board_type).to eq("generated")
+        expect(board.generated_token).to be_nil
+
+        job = GenerateFreeBoardJob.jobs.last
+        expect(job["args"]).to eq([board.id, "snacks", "5-10", 9])
+      end
+    end
+  end
+end

--- a/spec/requests/api/internal/images_spec.rb
+++ b/spec/requests/api/internal/images_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::Images", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/images" do
+    context "without a valid bearer token" do
+      it "returns 401" do
+        post "/api/internal/images", params: { image: { label: "apple" } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "creates an image and returns 201" do
+        expect {
+          post "/api/internal/images",
+               params: { image: { label: "apple", image_prompt: "a red apple" } }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(Image, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(Image.last.label).to eq("apple")
+        expect(Image.last.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      end
+    end
+  end
+
+  describe "POST /api/internal/images/generate" do
+    it "enqueues GenerateImageJob and returns 202" do
+      expect {
+        post "/api/internal/images/generate",
+             params: { image: { label: "banana", image_prompt: "a yellow banana" } }.to_json,
+             headers: auth_headers.merge("Content-Type" => "application/json")
+      }.to change(GenerateImageJob.jobs, :size).by(1)
+
+      expect(response).to have_http_status(:accepted)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("generating")
+      expect(body["label"]).to eq("banana")
+
+      job = GenerateImageJob.jobs.last
+      expect(job["args"][0]).to eq(body["id"])
+      expect(job["args"][1]).to eq(User::DEFAULT_ADMIN_ID)
+    end
+  end
+
+  describe "GET /api/internal/images/:id" do
+    let!(:image) { create(:image, label: "carrot", user_id: admin_user.id) }
+
+    it "returns the image status payload" do
+      get "/api/internal/images/#{image.id}", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["id"]).to eq(image.id)
+      expect(body["label"]).to eq("carrot")
+      expect(body).to have_key("status")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `POST /api/internal/boards` now accepts a `word_list` param and enqueues `GenerateBoardJob` when present, mirroring the public `api/boards_controller.rb` flow (no behavior change when `word_list` is absent).
- New endpoint `POST /api/internal/generated_boards` creates an AI-generated board owned by the default admin and enqueues `GenerateFreeBoardJob`. Unlike the public `/api/generated_boards`, no `generated_token` is issued — these boards are not part of the claim flow.
- Added request specs for all five pre-existing internal endpoints plus the new one. `bundle exec rspec spec/requests/api/internal/` → 13 examples, 0 failures.
- README updated with the new endpoint.

One implementation note worth flagging: in `generated_boards_controller.rb`, `board_type = "generated"` is set **after** `board.assign_parent` because the `else` branch of `assign_parent` overwrites `board_type` to `"static"` for any User-owned board (the public controller dodges this by passing `user: nil`).

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/` — 13 / 13 passing
- [ ] Live curl `POST /api/internal/boards` with and without `word_list` (deferred — running server is on a different branch)
- [ ] Live curl `POST /api/internal/generated_boards` with a tiny topic — verify board is created, owned by `User::DEFAULT_ADMIN_ID`, and Sidekiq runs `GenerateFreeBoardJob` to completion (deferred for the same reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)