### PR TITLE
Internal API follow-ups: creation_type switch, prompt docs, PDF export, cells, predictive fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,78 @@ curl -X POST https://<host>/api/internal/boards \
 
 Response: `201 Created` with the created board. Generation runs async via Sidekiq.
 
+##### `board_creation_type` reference
+
+`board_creation_type` is a free-form string. The controller switches on it to
+decide which params to forward to `GenerateBoardJob`. The job then switches on
+the same string to decide how to produce a list of words. Both switches must
+agree, so in practice only the values below are usable from the internal API.
+
+After words are produced (by any branch), the job runs the same finishing
+sequence:
+
+1. `Board.find_or_create_images_from_word_list(words)` — for each word, finds an existing image (user-owned, then admin-owned) or creates a new one. If the image has no displayable doc and no admin/user copy, schedules `GenerateImagesJob` (which calls OpenAI image gen in batches of 3).
+2. `Board#reset_layouts` — re-flows the grid for all screen sizes.
+3. `Board#generate_previews` — re-renders the board's preview image.
+4. `board.status` advances `generating_words` → `finding_images` → `processing` → `complete`.
+
+If the branch produces zero words, the job logs a warning and jumps straight to
+`complete` (no images are created).
+
+###### `default` *(default)*
+
+- **Word source:** the `word_list` array you POST. No OpenAI call for words.
+- **Required params:** `word_list` *(array of strings)*. If omitted, **no job is enqueued at all** — the board is created empty.
+- **Other params forwarded to job:** none.
+- **Use when:** you already have the exact words you want.
+
+```json
+{ "board": { "name": "Snacks" }, "word_list": ["apple", "banana", "carrot"] }
+```
+
+###### `scenario`
+
+- **Word source:** OpenAI, via `Board#get_words_for_scenario(topic, age_range, word_count)`.
+- **Prompt sent to OpenAI:**
+  > Generate a list of words for a communication board. The topic or theme of the board is **{topic}**. The name of the board is **{board.name}**. The age range for the person using the board is **{age_range}**. Please provide a list of **{word_count}** words that are appropriate for this age range and context. Exclude words that are too similar to each other or that would not be useful on a communication board. Also exclude words that are already on the board: **{current_words}**.
+- **Required params:** `topic` *(string)*. Falls back to `prompt`, then `board.name`.
+- **Optional params:** `age_range` (or `ageRange`), `word_count` (or `wordCount`, default `12`).
+- **Word count clamping:** the job clamps `word_count` to `1..80`. Out-of-bounds values fall back to `large_screen_columns * 4` (and the model itself defaults to `24` if it sees the same condition).
+- **Use when:** you have a topic/theme but no specific words.
+
+```json
+{
+  "board": { "name": "Coffee Shop" },
+  "board_creation_type": "scenario",
+  "topic": "ordering coffee",
+  "age_range": "10-15",
+  "word_count": 16
+}
+```
+
+###### `predictive`
+
+- **Word source:** OpenAI, via `Board#get_words_for_predictive(starting_phrase_or_word, word_count)` *if* no `word_list` is provided. Otherwise the supplied `word_list` is used directly.
+- **Prompt sent to OpenAI:**
+  > Generate a list of **{word_count}** words that would commonly follow the **{word|phrase}** **'{starting_phrase_or_word}'** in everyday communication. These words will be used on a predictive communication board to help users quickly find and select common phrases. Please provide words that are relevant and commonly used in conjunction with **'{starting_phrase_or_word}'**.
+- **Required job options:** `starting_phrase_or_word` (or `startingPhraseOrWord`) when no `word_list` is given.
+- **⚠️ Internal-API gap:** today the controller forwards only `word_count` for non-`default`/non-`scenario` types, so the job receives no `starting_phrase_or_word` and no `word_list`. The OpenAI call then fails on a `nil.split` and the board is left at status `generating_words`. **Don't use this value via the internal API until the controller is patched to forward `starting_phrase_or_word` and `word_list`.**
+
+###### `menu`
+
+- Recognized by the job, but the branch is a placeholder that returns an empty word list — the board jumps straight to `complete` with zero images. Equivalent to creating a board with no `word_list` under `default`.
+
+###### Anything else
+
+- The job's fallback branch behaves like `default` (uses the supplied `word_list`, no OpenAI). The internal controller's fallback branch only forwards `word_count` and no `word_list`, so this combination produces an empty word list and a no-op completion. Stick to `default` or `scenario` from the internal API.
+
+###### Side effect on `board.board_type`
+
+Regardless of what you pass in `board[board_type]`, the controller overwrites
+`board.board_type` with the `board_creation_type` value *after* `assign_parent`
+runs. That mirrors the public `POST /api/boards` behavior. So a request with
+`board_creation_type: "scenario"` ends with `board.board_type == "scenario"`.
+
 #### `PATCH /api/internal/boards/:id`
 
 Updates board attributes. Accepts an optional `layout` parameter to persist a

--- a/README.md
+++ b/README.md
@@ -168,7 +168,20 @@ For Hatchbox, set `INTERNAL_API_KEY` in the app's environment variables panel.
 
 #### `POST /api/internal/boards`
 
-Pure record create. Does **not** enqueue board-generation jobs.
+Creates a board, then optionally enqueues `GenerateBoardJob` based on
+`board_creation_type` — same dispatch as the public `POST /api/boards`.
+
+The board is owned by the default admin (`User::DEFAULT_ADMIN_ID`).
+
+**Top-level params**
+
+- `board_creation_type` *(optional, default `"default"`)* — one of `"default"`, `"scenario"`, or any other string. Determines what (if anything) is enqueued; also overwrites `board.board_type` after `assign_parent`.
+- `word_list` *(default branch only)* — array of strings. If present, enqueues `GenerateBoardJob` with the list. If omitted, no job is enqueued.
+- `topic`, `age_range` (or `ageRange`), `word_count` (or `wordCount`) *(scenario branch)* — passed straight to the job.
+- `word_count` *(other branches)* — defaults to 12.
+- `voice` / `voice_label` — fallback if `board[voice]` isn't set.
+
+**Default — pure record create (no job enqueued):**
 
 ```sh
 curl -X POST https://<host>/api/internal/boards \
@@ -184,7 +197,34 @@ curl -X POST https://<host>/api/internal/boards \
   }'
 ```
 
-Response: `201 Created` with the created board.
+**Default — with a `word_list` (enqueues `GenerateBoardJob` to find/create images for each word):**
+
+```sh
+curl -X POST https://<host>/api/internal/boards \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "board": { "name": "Snacks" },
+    "word_list": ["apple", "banana", "carrot"]
+  }'
+```
+
+**Scenario — generate words from a topic:**
+
+```sh
+curl -X POST https://<host>/api/internal/boards \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "board": { "name": "Coffee Shop" },
+    "board_creation_type": "scenario",
+    "topic": "ordering coffee",
+    "age_range": "10-15",
+    "word_count": 16
+  }'
+```
+
+Response: `201 Created` with the created board. Generation runs async via Sidekiq.
 
 #### `PATCH /api/internal/boards/:id`
 

--- a/README.md
+++ b/README.md
@@ -280,8 +280,17 @@ If the branch produces zero words, the job logs a warning and jumps straight to
 - **Word source:** OpenAI, via `Board#get_words_for_predictive(starting_phrase_or_word, word_count)` *if* no `word_list` is provided. Otherwise the supplied `word_list` is used directly.
 - **Prompt sent to OpenAI:**
   > Generate a list of **{word_count}** words that would commonly follow the **{word|phrase}** **'{starting_phrase_or_word}'** in everyday communication. These words will be used on a predictive communication board to help users quickly find and select common phrases. Please provide words that are relevant and commonly used in conjunction with **'{starting_phrase_or_word}'**.
-- **Required job options:** `starting_phrase_or_word` (or `startingPhraseOrWord`) when no `word_list` is given.
-- **⚠️ Internal-API gap:** today the controller forwards only `word_count` for non-`default`/non-`scenario` types, so the job receives no `starting_phrase_or_word` and no `word_list`. The OpenAI call then fails on a `nil.split` and the board is left at status `generating_words`. **Don't use this value via the internal API until the controller is patched to forward `starting_phrase_or_word` and `word_list`.**
+- **Required params:** `starting_phrase_or_word` (or `startingPhraseOrWord`) when no `word_list` is given.
+- **Optional params:** `word_list` (skip the OpenAI call), `word_count` (default `12`).
+
+```json
+{
+  "board": { "name": "After 'I want'" },
+  "board_creation_type": "predictive",
+  "starting_phrase_or_word": "I want",
+  "word_count": 12
+}
+```
 
 ###### `menu`
 
@@ -326,6 +335,60 @@ curl -X PATCH https://<host>/api/internal/boards/123 \
 `layout` may also be passed in object form: `{ "screen_size": "lg", "layout": [...] }`.
 
 Response: `200 OK` with the board's full API view.
+
+#### `GET /api/internal/boards/:id/export.pdf`
+
+Renders the board as a PDF (Letter, Grover/Chromium under the hood) and returns
+it as an attachment download. The same template the public `/api/boards/:id/pdf`
+endpoint uses, with the QR code optional and overrideable.
+
+**Query params**
+
+- `qr_code` *(default `false`)* — boolean. Set to `true` to include a QR code in the header.
+- `qr_target_url` *(optional)* — when `qr_code=true`, the URL the QR code should encode. If omitted, falls back to the board's own public URL (the same default the public PDF endpoint uses).
+- `screen_size` *(default `"lg"`)* — which screen-size layout to render.
+- `hide_colors` *(default `"0"`)* — `"1"` to render the grid in black and white.
+- `hide_header` *(default `"0"`)* — `"1"` to hide the entire header row (logo, title, QR section).
+
+```sh
+curl -L -o board-123.pdf \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  "https://<host>/api/internal/boards/123/export.pdf?qr_code=true&qr_target_url=https%3A%2F%2Fexample.com%2Fclaim%2Fabc"
+```
+
+Response: `200 OK` with `Content-Type: application/pdf` and
+`Content-Disposition: attachment; filename="<board-slug>-board.pdf"`.
+
+#### `POST /api/internal/boards/:id/board_images`
+
+Adds a single cell (a `BoardImage`) to a board. Equivalent to one iteration of
+`Board#find_or_create_images_from_word_list`, but exposed as a discrete call so
+internal scripts can build a board cell-by-cell.
+
+**Body params**
+
+- `image_id` *(preferred)* — id of an existing `Image`. Used directly.
+- `label` *(fallback)* — used only if `image_id` is omitted. Looks up an admin/user-owned `Image` by label, then a public image, then creates a new admin-owned image with that label.
+- `position` *(optional)* — integer used to set `BoardImage#position` after creation. If omitted, the cell is appended at `board_images_count` (its existing default).
+- `voice` *(optional)* — overrides the cell's voice. Normalized via `VoiceService`.
+- `language` *(optional)* — overrides the cell's language code.
+
+If neither `image_id` nor `label` is given, the request returns `422`.
+Duplicate cells (same image already on the board) are allowed — the model
+permits multiple `BoardImage` rows per `(board_id, image_id)` pair.
+
+The cell's grid placement is auto-assigned by `BoardImage#set_initial_layout!`
+across all screen sizes; use `PATCH /api/internal/boards/:id` with a `layout`
+to move cells into specific positions afterward.
+
+```sh
+curl -X POST https://<host>/api/internal/boards/123/board_images \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "label": "apple", "position": 0 }'
+```
+
+Response: `201 Created` with the new `BoardImage`'s `api_view`.
 
 #### `POST /api/internal/generated_boards`
 

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -1,0 +1,39 @@
+class API::Internal::BoardImagesController < API::Internal::ApplicationController
+  def create
+    @board = Board.find(params[:board_id])
+
+    image = resolve_image
+    return render json: { error: "image_id or label is required" }, status: :unprocessable_entity if image.nil?
+
+    board_image = @board.add_image(image.id)
+
+    if board_image&.persisted?
+      apply_optional_attributes!(board_image)
+      render json: board_image.api_view(current_user), status: :created
+    else
+      errors = board_image&.errors&.full_messages&.join(", ") || "Unable to add image to board"
+      render json: { error: errors }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def resolve_image
+    if params[:image_id].present?
+      Image.find_by(id: params[:image_id])
+    elsif params[:label].present?
+      label = params[:label].to_s.strip
+      Image.find_by(label: label, user_id: current_user.id) ||
+        Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil]) ||
+        Image.create(label: label, user_id: current_user.id)
+    end
+  end
+
+  def apply_optional_attributes!(board_image)
+    updates = {}
+    updates[:position] = params[:position].to_i if params[:position].present?
+    updates[:voice]    = VoiceService.normalize_voice(params[:voice]) if params[:voice].present?
+    updates[:language] = params[:language] if params[:language].present?
+    board_image.update(updates) if updates.any?
+  end
+end

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -35,6 +35,48 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     end
   end
 
+  def export_pdf
+    @board = Board.find(params[:id])
+
+    qr_requested  = ActiveModel::Type::Boolean.new.cast(params[:qr_code])
+    qr_target_url = qr_requested ? params[:qr_target_url].presence : nil
+
+    render_data = Boards::RenderAssetData.new(
+      board: @board,
+      screen_size: params[:screen_size] || "lg",
+      hide_colors: params[:hide_colors] == "1",
+      hide_header: params[:hide_header] == "1",
+      routes: Rails.application.routes.url_helpers,
+      include_qr: qr_requested,
+      qr_target_url: qr_target_url || :default,
+    ).call
+
+    render_data.each { |k, v| instance_variable_set("@#{k}", v) }
+
+    html = render_to_string(
+      template: "api/boards/print",
+      layout: "pdf",
+      formats: [:html],
+    )
+
+    grover_options = {
+      format: "Letter",
+      landscape: @landscape,
+      viewport: { width: @landscape ? 792 : 612, height: @landscape ? 612 : 792 },
+      full_page: false,
+      prefer_css_page_size: true,
+      print_background: true,
+    }
+
+    file_data = Grover.new(html, **grover_options).to_pdf
+
+    response.headers["Cache-Control"] = "no-store"
+    send_data file_data,
+      filename: "#{@board.slug}-board.pdf",
+      type: "application/pdf",
+      disposition: "attachment"
+  end
+
   def update
     @board = Board.find(params[:id])
     @board.assign_attributes(board_params.except(:settings, :voice))
@@ -67,16 +109,31 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
 
     case creation_type
     when "default"
-      word_list = Array(params[:word_list]).compact.select { |w| w.is_a?(String) && w.present? }
+      word_list = sanitized_word_list
       return if word_list.blank?
       GenerateBoardJob.perform_async(@board.id, creation_type, { "word_list" => word_list })
     when "scenario"
       topic = params[:topic] || params[:prompt] || @board.name
       age_range = params[:ageRange].presence || params[:age_range].presence
       GenerateBoardJob.perform_async(@board.id, creation_type, { "topic" => topic, "age_range" => age_range, "word_count" => word_count })
+    when "predictive"
+      starting = params[:starting_phrase_or_word].presence || params[:startingPhraseOrWord].presence
+      GenerateBoardJob.perform_async(
+        @board.id,
+        creation_type,
+        {
+          "word_list" => sanitized_word_list,
+          "starting_phrase_or_word" => starting,
+          "word_count" => word_count,
+        },
+      )
     else
       GenerateBoardJob.perform_async(@board.id, creation_type, { "word_count" => word_count })
     end
+  end
+
+  def sanitized_word_list
+    Array(params[:word_list]).compact.select { |w| w.is_a?(String) && w.present? }
   end
 
   def apply_layout_if_present!

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -2,19 +2,33 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
   def create
     @board = Board.new(board_params)
     @board.user = current_user
-    @board.predefined = false
-    @board.board_type = params[:board_type] || board_params[:board_type] || "static"
-    @board.voice = VoiceService.normalize_voice(board_params[:voice]) if board_params[:voice].present?
+
+    initial_board_type = params[:board_type] || board_params[:board_type]
+    settings = board_params[:settings].presence || params[:settings] || {}
+    settings["board_type"] = initial_board_type
+    @board.board_type = initial_board_type || "static"
     @board.assign_parent
 
-    settings = board_params[:settings].presence || params[:settings] || {}
-    settings["board_type"] = @board.board_type
+    creation_type = params[:board_creation_type].presence || "default"
+    # Public boards#create overwrites board_type with creation_type after
+    # assign_parent (which would otherwise force "static" for User-owned boards).
+    @board.board_type = creation_type
+
+    @board.predefined = false
+    @board.small_screen_columns  = board_params["small_screen_columns"].to_i
+    @board.medium_screen_columns = board_params["medium_screen_columns"].to_i
+    @board.large_screen_columns  = board_params["large_screen_columns"].to_i
+
+    voice = VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])
+    @board.voice = voice
+    @board.language = board_params["language"] if board_params["language"].present?
+    @board.tags = board_params["tags"] if board_params["tags"].present?
     @board.settings = settings
 
     @board.slug = @board.generate_unique_slug(board_params[:slug])
 
     if @board.save
-      enqueue_generation_job_if_needed!
+      enqueue_generation_job!(creation_type)
       render json: @board, status: :created
     else
       render json: { errors: @board.errors }, status: :unprocessable_entity
@@ -48,12 +62,21 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
 
   private
 
-  def enqueue_generation_job_if_needed!
-    word_list = Array(params[:word_list]).compact.select { |w| w.is_a?(String) && w.present? }
-    return if word_list.blank?
+  def enqueue_generation_job!(creation_type)
+    word_count = (params[:wordCount].presence || params[:word_count].presence || 12).to_i
 
-    creation_type = params[:board_creation_type].presence || "default"
-    GenerateBoardJob.perform_async(@board.id, creation_type, { "word_list" => word_list })
+    case creation_type
+    when "default"
+      word_list = Array(params[:word_list]).compact.select { |w| w.is_a?(String) && w.present? }
+      return if word_list.blank?
+      GenerateBoardJob.perform_async(@board.id, creation_type, { "word_list" => word_list })
+    when "scenario"
+      topic = params[:topic] || params[:prompt] || @board.name
+      age_range = params[:ageRange].presence || params[:age_range].presence
+      GenerateBoardJob.perform_async(@board.id, creation_type, { "topic" => topic, "age_range" => age_range, "word_count" => word_count })
+    else
+      GenerateBoardJob.perform_async(@board.id, creation_type, { "word_count" => word_count })
+    end
   end
 
   def apply_layout_if_present!

--- a/app/services/boards/render_asset_data.rb
+++ b/app/services/boards/render_asset_data.rb
@@ -1,16 +1,19 @@
 # app/services/boards/render_asset_data.rb
 module Boards
   class RenderAssetData
-    def initialize(board:, screen_size: "lg", hide_colors: false, hide_header: false, routes:)
+    def initialize(board:, screen_size: "lg", hide_colors: false, hide_header: false, routes:, qr_target_url: :default, include_qr: true)
       @board = board
       @screen_size = screen_size
       @hide_colors = hide_colors
       @hide_header = hide_header
       @routes = routes
+      @qr_target_url_override = qr_target_url
+      @include_qr = include_qr
     end
 
     def call
-      qr_target_url = AssetRendering.qr_target_url_for(board, routes: routes)
+      qr_target_url = resolved_qr_target_url
+      qr_data_url   = qr_target_url.present? ? AssetRendering.qr_data_url_for(qr_target_url, size: 480) : nil
       tiles = normalized_tiles
       columns = resolved_columns
       rows = resolved_rows(tiles)
@@ -22,7 +25,7 @@ module Boards
       {
         board: board,
         qr_target_url: qr_target_url,
-        qr_data_url: AssetRendering.qr_data_url_for(qr_target_url, size: 480),
+        qr_data_url: qr_data_url,
         screen_size: screen_size,
         hide_colors: hide_colors,
         hide_header: hide_header,
@@ -42,6 +45,16 @@ module Boards
     private
 
     attr_reader :board, :screen_size, :hide_colors, :hide_header, :routes
+
+    def resolved_qr_target_url
+      return nil unless @include_qr
+
+      if @qr_target_url_override == :default
+        AssetRendering.qr_target_url_for(board, routes: routes)
+      else
+        @qr_target_url_override.presence
+      end
+    end
 
     def normalized_tiles
       # Replace this with your real logic if normalize_tiles lives elsewhere

--- a/app/views/api/boards/print.html.erb
+++ b/app/views/api/boards/print.html.erb
@@ -23,18 +23,22 @@
           </div>
         <% end %>
 
-        <div class="board-link">
-          Scan the code or visit
-          <a href="<%= @qr_target_url %>" target="_blank" rel="noopener noreferrer">
-            <%= @qr_target_url %>
-          </a>
-          for the full interactive version of this board. 
-        </div>
+        <% if @qr_data_url.present? %>
+          <div class="board-link">
+            Scan the code or visit
+            <a href="<%= @qr_target_url %>" target="_blank" rel="noopener noreferrer">
+              <%= @qr_target_url %>
+            </a>
+            for the full interactive version of this board.
+          </div>
+        <% end %>
       </div>
 
-      <div class="qr-small">
-        <img src="<%= @qr_data_url %>" alt="QR code">
-      </div>
+      <% if @qr_data_url.present? %>
+        <div class="qr-small">
+          <img src="<%= @qr_data_url %>" alt="QR code">
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,7 +335,12 @@ Rails.application.routes.draw do
     end
 
     namespace :internal do
-      resources :boards, only: [:create, :update]
+      resources :boards, only: [:create, :update] do
+        member do
+          get :export, action: :export_pdf, defaults: { format: :pdf }
+        end
+        resources :board_images, only: [:create]
+      end
       resources :generated_boards, only: [:create]
       resources :images, only: [:create, :show] do
         collection do

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::BoardImages", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}", "Content-Type" => "application/json" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let!(:board) { create(:board, user: admin_user) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/boards/:board_id/board_images" do
+    it "returns 401 without a valid bearer token" do
+      post "/api/internal/boards/#{board.id}/board_images", params: { label: "apple" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 422 when neither image_id nor label is given" do
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: {}.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/image_id or label is required/)
+    end
+
+    it "adds a cell using an existing image_id and returns 201" do
+      image = create(:image, label: "kiwi", user_id: admin_user.id)
+
+      expect {
+        post "/api/internal/boards/#{board.id}/board_images",
+             params: { image_id: image.id }.to_json,
+             headers: auth_headers
+      }.to change { board.reload.board_images.count }.by(1)
+
+      expect(response).to have_http_status(:created)
+      bi = board.board_images.last
+      expect(bi.image_id).to eq(image.id)
+    end
+
+    it "creates an Image when only label is given and adds the cell" do
+      expect {
+        post "/api/internal/boards/#{board.id}/board_images",
+             params: { label: "mango" }.to_json,
+             headers: auth_headers
+      }.to change(Image, :count).by(1)
+       .and change { board.reload.board_images.count }.by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(Image.last.label).to eq("mango")
+    end
+
+    it "honors an explicit position" do
+      image = create(:image, label: "pear", user_id: admin_user.id)
+
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: { image_id: image.id, position: 7 }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      expect(board.board_images.last.position).to eq(7)
+    end
+  end
+end

--- a/spec/requests/api/internal/board_pdf_export_spec.rb
+++ b/spec/requests/api/internal/board_pdf_export_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::Boards#export_pdf", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let!(:board) { create(:board, name: "PDF Board", user: admin_user) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+
+    # Bypass actual Chromium / Grover rendering
+    fake_grover = instance_double(Grover, to_pdf: "%PDF-fake")
+    allow(Grover).to receive(:new).and_return(fake_grover)
+
+    # Bypass the heavy template render — the action's only template-related
+    # responsibility is to feed render_data into render_to_string.
+    allow_any_instance_of(API::Internal::BoardsController)
+      .to receive(:render_to_string).and_return("<html></html>")
+  end
+
+  describe "GET /api/internal/boards/:id/export.pdf" do
+    it "returns 401 without a valid bearer token" do
+      get "/api/internal/boards/#{board.id}/export.pdf"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns a PDF with the QR code when qr_code=true and a qr_target_url is provided" do
+      expect(Boards::RenderAssetData).to receive(:new).with(
+        hash_including(
+          board: board,
+          include_qr: true,
+          qr_target_url: "https://example.com/claim/abc",
+        ),
+      ).and_call_original
+
+      get "/api/internal/boards/#{board.id}/export.pdf",
+          params: { qr_code: "true", qr_target_url: "https://example.com/claim/abc" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+      expect(response.headers["Content-Disposition"]).to include("attachment")
+      expect(response.body).to start_with("%PDF")
+    end
+
+    it "omits the QR code when qr_code is not true" do
+      expect(Boards::RenderAssetData).to receive(:new).with(
+        hash_including(include_qr: false),
+      ).and_call_original
+
+      get "/api/internal/boards/#{board.id}/export.pdf",
+          params: { qr_code: "false" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+    end
+  end
+end

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -56,6 +56,49 @@ RSpec.describe "API::Internal::Boards", type: :request do
         expect(job["args"][1]).to eq("default")
         expect(job["args"][2]).to eq({ "word_list" => word_list })
       end
+
+      it "enqueues GenerateBoardJob with topic/age_range/word_count for scenario creation_type" do
+        expect {
+          post "/api/internal/boards",
+               params: {
+                 board: { name: "Scenario Board" },
+                 board_creation_type: "scenario",
+                 topic: "ordering coffee",
+                 age_range: "10-15",
+                 word_count: 16,
+               }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(GenerateBoardJob.jobs, :size).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(Board.last.board_type).to eq("scenario")
+
+        job = GenerateBoardJob.jobs.last
+        expect(job["args"][1]).to eq("scenario")
+        expect(job["args"][2]).to eq({
+          "topic" => "ordering coffee",
+          "age_range" => "10-15",
+          "word_count" => 16,
+        })
+      end
+
+      it "enqueues GenerateBoardJob with word_count for other creation_types" do
+        expect {
+          post "/api/internal/boards",
+               params: {
+                 board: { name: "Other Board" },
+                 board_creation_type: "ai_generated",
+                 word_count: 24,
+               }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(GenerateBoardJob.jobs, :size).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        job = GenerateBoardJob.jobs.last
+        expect(job["args"][1]).to eq("ai_generated")
+        expect(job["args"][2]).to eq({ "word_count" => 24 })
+      end
     end
   end
 

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -82,6 +82,29 @@ RSpec.describe "API::Internal::Boards", type: :request do
         })
       end
 
+      it "forwards starting_phrase_or_word and word_list for predictive creation_type" do
+        expect {
+          post "/api/internal/boards",
+               params: {
+                 board: { name: "After 'I want'" },
+                 board_creation_type: "predictive",
+                 starting_phrase_or_word: "I want",
+                 word_count: 9,
+               }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+        }.to change(GenerateBoardJob.jobs, :size).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        job = GenerateBoardJob.jobs.last
+        expect(job["args"][1]).to eq("predictive")
+        expect(job["args"][2]).to eq({
+          "word_list" => [],
+          "starting_phrase_or_word" => "I want",
+          "word_count" => 9,
+        })
+      end
+
       it "enqueues GenerateBoardJob with word_count for other creation_types" do
         expect {
           post "/api/internal/boards",


### PR DESCRIPTION
## Context

These three commits were pushed to PR #61 after the squash merge had already
captured the first commit, so they didn't make it into main. Re-opening as a
fresh PR off the latest main.

## Summary

- **`POST /api/internal/boards`** — switch on `board_creation_type` to mirror the public `boards#create` flow. `default` (word_list), `scenario` (topic + age_range + word_count), `predictive` (starting_phrase_or_word + word_list + word_count), and a fallback that forwards `word_count`.
- **`POST /api/internal/boards`** — fixes the predictive gap: the controller now forwards `starting_phrase_or_word` and `word_list` so the job's `get_words_for_predictive` doesn't crash on `nil.split`.
- **`GET /api/internal/boards/:id/export.pdf`** — new endpoint, same Grover-based render the public PDF uses, with optional `qr_code=true&qr_target_url=<url>`. `Boards::RenderAssetData` gained `include_qr` / `qr_target_url` kwargs (defaults preserve existing behavior); `app/views/api/boards/print.html.erb` wraps the QR blocks in `if @qr_data_url.present?`.
- **`POST /api/internal/boards/:id/board_images`** — new endpoint to add a single cell to a board. Accepts `image_id` (preferred) or `label`, with optional `position`, `voice`, `language`. Auto-layout via `BoardImage#set_initial_layout!`.
- **README** — documents the `board_creation_type` parameter (each value, prompt, params, status progression) and the two new endpoints.
- **RSpec** — 24 examples, 0 failures across `spec/requests/api/internal/`.

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/` → 24/24
- [ ] Live curl `GET /api/internal/boards/:id/export.pdf?qr_code=true&qr_target_url=<url>` against a server running this branch — verify the PDF downloads and the QR code appears.
- [ ] Live curl `POST /api/internal/boards/:id/board_images` with `{ "label": "apple" }` — verify the cell appears on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)