### PR TITLE
Add internal API: GET /api/internal/boards/:id

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,20 @@ Regardless of what you pass in `board[board_type]`, the controller overwrites
 runs. That mirrors the public `POST /api/boards` behavior. So a request with
 `board_creation_type: "scenario"` ends with `board.board_type == "scenario"`.
 
+#### `GET /api/internal/boards/:id`
+
+Returns a single board's full API view (same payload shape as `PATCH`'s response).
+Useful for confirming a board exists and inspecting its current images/layout
+before posting cells or layout updates.
+
+```sh
+curl -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  https://<host>/api/internal/boards/123
+```
+
+Response: `200 OK` with the board's full API view, or `404 Not Found` if no
+board has that id.
+
 #### `PATCH /api/internal/boards/:id`
 
 Updates board attributes. Accepts an optional `layout` parameter to persist a

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -35,6 +35,11 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     end
   end
 
+  def show
+    @board = Board.find(params[:id])
+    render json: @board.api_view_with_images(current_user)
+  end
+
   def export_pdf
     @board = Board.find(params[:id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,7 +335,7 @@ Rails.application.routes.draw do
     end
 
     namespace :internal do
-      resources :boards, only: [:create, :update] do
+      resources :boards, only: [:create, :update, :show] do
         member do
           get :export, action: :export_pdf, defaults: { format: :pdf }
         end

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -125,6 +125,33 @@ RSpec.describe "API::Internal::Boards", type: :request do
     end
   end
 
+  describe "GET /api/internal/boards/:id" do
+    let!(:board) { create(:board, name: "Show Me", user: admin_user) }
+
+    context "without a valid bearer token" do
+      it "returns 401" do
+        get "/api/internal/boards/#{board.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "returns the board as JSON" do
+        get "/api/internal/boards/#{board.id}", headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["id"]).to eq(board.id)
+        expect(body["name"]).to eq("Show Me")
+      end
+
+      it "returns 404 when the board does not exist" do
+        get "/api/internal/boards/0", headers: auth_headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe "PATCH /api/internal/boards/:id" do
     let!(:board) { create(:board, name: "Old Name", user: admin_user) }
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/internal/boards/:id` so internal scripts can confirm a board exists and inspect its current state before posting cells or layout updates
- Renders the same full `api_view_with_images` payload that `PATCH` already returns, and `Board.find` lets `ActiveRecord::RecordNotFound` map to a clean 404 via the existing `action_dispatch.show_exceptions = :rescuable` config
- README updated with the new endpoint, slotted between `create` and `update` in the Internal API section

## Test plan
- [x] `bundle exec rspec spec/requests/api/internal/` — 27 examples, 0 failures
- [ ] Manually hit `GET /api/internal/boards/:id` against staging with a real board id and a missing one; confirm 200 + payload and 404 respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)