### PR TITLE
Internal boards#create: don't coerce missing column params to 0

### DIFF
--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -15,9 +15,14 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     @board.board_type = creation_type
 
     @board.predefined = false
-    @board.small_screen_columns  = board_params["small_screen_columns"].to_i
-    @board.medium_screen_columns = board_params["medium_screen_columns"].to_i
-    @board.large_screen_columns  = board_params["large_screen_columns"].to_i
+    # Only assign columns when the param is actually present. Blind .to_i
+    # turns a missing param into 0, which suppresses Board#set_screen_sizes
+    # defaults (which only fill in nil) and breaks downstream callers like
+    # GenerateBoardJob's `large_screen_columns || 6` (0 is truthy in Ruby).
+    @board.small_screen_columns  = board_params["small_screen_columns"].to_i  if board_params["small_screen_columns"].present?
+    @board.medium_screen_columns = board_params["medium_screen_columns"].to_i if board_params["medium_screen_columns"].present?
+    @board.large_screen_columns  = board_params["large_screen_columns"].to_i  if board_params["large_screen_columns"].present?
+    Rails.logger.info "Normalized voice for board creation: #{board_params["voice"]}, #{params[:voice]}, #{params[:voice_label]} -> #{VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])}"
 
     voice = VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])
     @board.voice = voice
@@ -43,8 +48,9 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
   def export_pdf
     @board = Board.find(params[:id])
 
-    qr_requested  = ActiveModel::Type::Boolean.new.cast(params[:qr_code])
+    qr_requested = ActiveModel::Type::Boolean.new.cast(params[:qr_code])
     qr_target_url = qr_requested ? params[:qr_target_url].presence : nil
+    Rails.logger.info "Parameters for PDF export: #{params.to_unsafe_h.except(:board_id, :controller, :action).inspect}, QR requested: #{qr_requested}, QR target URL: #{qr_target_url}"
 
     render_data = Boards::RenderAssetData.new(
       board: @board,
@@ -93,7 +99,7 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     end
 
     @board.parent_type = "User"
-    @board.parent_id   = @board.user_id || User::DEFAULT_ADMIN_ID
+    @board.parent_id = @board.user_id || User::DEFAULT_ADMIN_ID
 
     if board_params[:slug].present? && board_params[:slug] != @board.slug
       @board.slug = @board.generate_unique_slug(board_params[:slug])
@@ -145,12 +151,12 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     return if params[:layout].blank?
 
     if params[:layout].is_a?(Array)
-      layout      = params[:layout].map(&:to_unsafe_h)
+      layout = params[:layout].map(&:to_unsafe_h)
       screen_size = params[:screen_size] || "lg"
     else
       layout_param = params[:layout]
-      screen_size  = layout_param[:screen_size] || layout_param["screen_size"] || "lg"
-      layout       = (layout_param[:layout] || layout_param["layout"] || []).map(&:to_unsafe_h)
+      screen_size = layout_param[:screen_size] || layout_param["screen_size"] || "lg"
+      layout = (layout_param[:layout] || layout_param["layout"] || []).map(&:to_unsafe_h)
     end
 
     return if @board.layout[screen_size] == layout
@@ -159,9 +165,9 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       layout: layout,
       screen_size: screen_size,
       columns: {
-        small_screen_columns:  params[:small_screen_columns],
+        small_screen_columns: params[:small_screen_columns],
         medium_screen_columns: params[:medium_screen_columns],
-        large_screen_columns:  params[:large_screen_columns],
+        large_screen_columns: params[:large_screen_columns],
       },
       margins: { x: params[:xMargin], y: params[:yMargin] },
       settings: params[:settings],

--- a/app/sidekiq/generate_board_job.rb
+++ b/app/sidekiq/generate_board_job.rb
@@ -18,7 +18,10 @@ class GenerateBoardJob
           age_range = options["age_range"].presence || options["ageRange"].presence
           if word_count <= 0 || word_count > 80
             Rails.logger.warn "Word count of #{word_count} is out of bounds for Board ID #{board.id}."
-            lrg_cols = board.large_screen_columns || 6
+            # `|| 6` doesn't fire on 0 (truthy in Ruby), which mattered when
+            # api/internal/boards#create coerced missing columns to 0. Guard
+            # against any caller that still produces a zero column count.
+            lrg_cols = board.large_screen_columns.to_i.positive? ? board.large_screen_columns : 6
             word_count = lrg_cols * 4
           end
           words = board.get_words_for_scenario(topic, age_range, word_count)

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -105,6 +105,50 @@ RSpec.describe "API::Internal::Boards", type: :request do
         })
       end
 
+      describe "screen-column handling on create" do
+        it "applies model defaults when no column params are sent" do
+          post "/api/internal/boards",
+               params: { board: { name: "Defaults" } }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          board = Board.last
+          # Board#set_screen_sizes only fills nil; verifying defaults landed
+          # confirms the controller no longer coerces missing params to 0.
+          expect(board.small_screen_columns).to be > 0
+          expect(board.medium_screen_columns).to be > 0
+          expect(board.large_screen_columns).to be > 0
+        end
+
+        it "honors large_screen_columns when provided" do
+          post "/api/internal/boards",
+               params: { board: { name: "Six Wide", large_screen_columns: 6 } }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          expect(Board.last.large_screen_columns).to eq(6)
+        end
+
+        it "honors all three column params when provided" do
+          post "/api/internal/boards",
+               params: {
+                 board: {
+                   name: "All Columns",
+                   small_screen_columns: 2,
+                   medium_screen_columns: 4,
+                   large_screen_columns: 6,
+                 },
+               }.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          board = Board.last
+          expect(board.small_screen_columns).to eq(2)
+          expect(board.medium_screen_columns).to eq(4)
+          expect(board.large_screen_columns).to eq(6)
+        end
+      end
+
       it "enqueues GenerateBoardJob with word_count for other creation_types" do
         expect {
           post "/api/internal/boards",

--- a/spec/sidekiq/generate_board_job_spec.rb
+++ b/spec/sidekiq/generate_board_job_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe GenerateBoardJob, type: :job do
+  let(:user) { create(:user) }
+
+  describe "scenario word_count fallback when large_screen_columns is 0" do
+    # Boards created via api/internal/boards#create historically coerced
+    # missing column params to 0. The job's `|| 6` fallback didn't fire on
+    # 0 (truthy in Ruby), so word_count became 0 and no words were generated.
+    # The fix uses `.to_i.positive?`. Lock that in.
+    let(:board) do
+      create(
+        :board,
+        user: user,
+        name: "Zero-cols Scenario",
+        board_type: "scenario",
+        large_screen_columns: 0,
+        medium_screen_columns: 0,
+        small_screen_columns: 0,
+      )
+    end
+
+    before do
+      allow_any_instance_of(Board).to receive(:find_or_create_images_from_word_list)
+      allow_any_instance_of(Board).to receive(:reset_layouts)
+      allow_any_instance_of(Board).to receive(:generate_previews)
+      # Avoid the literal 2-second sleep in the job for fast tests.
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
+
+    it "uses 6 as the column fallback (-> 24 words) when word_count is out of bounds" do
+      expect(board).to receive(:get_words_for_scenario)
+        .with("ordering coffee", "10-15", 24)
+        .and_return(["hi"])
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+
+      described_class.new.perform(
+        board.id,
+        "scenario",
+        { "topic" => "ordering coffee", "age_range" => "10-15", "word_count" => 0 },
+      )
+    end
+  end
+
+  describe "scenario word_count fallback uses positive large_screen_columns" do
+    let(:board) do
+      create(
+        :board,
+        user: user,
+        name: "Five-cols Scenario",
+        board_type: "scenario",
+        large_screen_columns: 5,
+      )
+    end
+
+    before do
+      allow_any_instance_of(Board).to receive(:find_or_create_images_from_word_list)
+      allow_any_instance_of(Board).to receive(:reset_layouts)
+      allow_any_instance_of(Board).to receive(:generate_previews)
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
+
+    it "uses the board's large_screen_columns (-> 20 words)" do
+      expect(board).to receive(:get_words_for_scenario)
+        .with("ordering coffee", "10-15", 20)
+        .and_return(["hi"])
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+
+      described_class.new.perform(
+        board.id,
+        "scenario",
+        { "topic" => "ordering coffee", "age_range" => "10-15", "word_count" => 0 },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Internal `boards#create` was assigning `small/medium/large_screen_columns` via blind `.to_i` of params, turning a missing param into `0`. That defeated `Board#set_screen_sizes` (which only fills `nil`) and bit `GenerateBoardJob`, where `board.large_screen_columns || 6` doesn't fall back on `0` (truthy in Ruby).
- Only assign columns when the param is actually present, letting the model defaults run on omission.
- Replace the `|| 6` fallback in `GenerateBoardJob` with a positive-value check to defend against any zero-column board still in the wild.
- New / extended specs cover the create-time column behavior and the job's word-count derivation under both zero and positive column values.

## Why this matters

The printable service (and any other internal-API caller that doesn't send columns) was creating boards at 0/0/0. For scenario boards specifically, `GenerateBoardJob` would derive `word_count = 0 * 4 = 0` whenever the requested word count fell out of bounds, producing empty boards.

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/boards_spec.rb spec/sidekiq/generate_board_job_spec.rb`
- [ ] Manual sanity: hit `POST /api/internal/boards` with no column params → board comes back with model defaults; with `large_screen_columns: 6` → board persists `6`.

## Note

`app/controllers/api/boards_controller.rb` (the public API) has the same `.to_i` pattern at lines 311-313 and 364-365. Out of scope for this PR — flagging for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)