### PR TITLE
Internal board_images display_label + public boards columns fix

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -308,9 +308,13 @@ class API::BoardsController < API::ApplicationController
     @board.board_type = creation_type
 
     @board.predefined = false
-    @board.small_screen_columns = board_params["small_screen_columns"].to_i
-    @board.medium_screen_columns = board_params["medium_screen_columns"].to_i
-    @board.large_screen_columns = board_params["large_screen_columns"].to_i
+    # Only assign columns when the param is actually present. Blind .to_i
+    # turns a missing param into 0, which suppresses Board#set_screen_sizes
+    # defaults (which only fill in nil) and breaks downstream callers like
+    # GenerateBoardJob's `large_screen_columns || 6` (0 is truthy in Ruby).
+    @board.small_screen_columns  = board_params["small_screen_columns"].to_i  if board_params["small_screen_columns"].present?
+    @board.medium_screen_columns = board_params["medium_screen_columns"].to_i if board_params["medium_screen_columns"].present?
+    @board.large_screen_columns  = board_params["large_screen_columns"].to_i  if board_params["large_screen_columns"].present?
     voice = VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])
     @board.voice = voice
     @board.language = board_params["language"] if board_params["language"].present?
@@ -361,9 +365,12 @@ class API::BoardsController < API::ApplicationController
       return
     else
       @board.number_of_columns = board_params["number_of_columns"].to_i
-      @board.small_screen_columns = board_params["small_screen_columns"].to_i
-      @board.medium_screen_columns = board_params["medium_screen_columns"].to_i
-      @board.large_screen_columns = board_params["large_screen_columns"].to_i
+      # Same guard as create: only assign columns when the param is actually
+      # present so an omitted value doesn't silently overwrite saved columns
+      # with 0.
+      @board.small_screen_columns  = board_params["small_screen_columns"].to_i  if board_params["small_screen_columns"].present?
+      @board.medium_screen_columns = board_params["medium_screen_columns"].to_i if board_params["medium_screen_columns"].present?
+      @board.large_screen_columns  = board_params["large_screen_columns"].to_i  if board_params["large_screen_columns"].present?
       voice = VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])
       @board.voice = voice
       @board.name = board_params["name"] unless board_params["name"].blank?

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -31,9 +31,10 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
 
   def apply_optional_attributes!(board_image)
     updates = {}
-    updates[:position] = params[:position].to_i if params[:position].present?
-    updates[:voice]    = VoiceService.normalize_voice(params[:voice]) if params[:voice].present?
-    updates[:language] = params[:language] if params[:language].present?
+    updates[:position]      = params[:position].to_i if params[:position].present?
+    updates[:voice]         = VoiceService.normalize_voice(params[:voice]) if params[:voice].present?
+    updates[:language]      = params[:language] if params[:language].present?
+    updates[:display_label] = params[:display_label].to_s.strip if params[:display_label].present?
     board_image.update(updates) if updates.any?
   end
 end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe "API::Boards", type: :request do
         created_board = Board.order(:created_at).last
         expect(created_board.user_id).to eq(creator.id)
       end
+
+      describe "screen-column handling on create" do
+        it "applies model defaults when no column params are sent" do
+          post "/api/boards",
+               params: { board: { name: "Defaults" } },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          created_board = Board.order(:created_at).last
+          # Board#set_screen_sizes only fills nil; verifying defaults landed
+          # confirms the controller no longer coerces missing params to 0.
+          expect(created_board.small_screen_columns).to be > 0
+          expect(created_board.medium_screen_columns).to be > 0
+          expect(created_board.large_screen_columns).to be > 0
+        end
+
+        it "honors large_screen_columns when provided" do
+          post "/api/boards",
+               params: { board: { name: "Six Wide", large_screen_columns: 6 } },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(Board.order(:created_at).last.large_screen_columns).to eq(6)
+        end
+      end
     end
   end
 
@@ -75,6 +100,29 @@ RSpec.describe "API::Boards", type: :request do
               params: { board: { name: "Updated Name" } },
               headers: auth_headers(user)
         expect(response).to have_http_status(:ok)
+      end
+
+      it "doesn't zero out screen-column values when the name is the only field changed" do
+        board.update!(small_screen_columns: 3, medium_screen_columns: 4, large_screen_columns: 6)
+
+        patch "/api/boards/#{board.id}",
+              params: { board: { name: "Renamed only" } },
+              headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        board.reload
+        expect(board.small_screen_columns).to eq(3)
+        expect(board.medium_screen_columns).to eq(4)
+        expect(board.large_screen_columns).to eq(6)
+      end
+
+      it "honors large_screen_columns when explicitly provided" do
+        patch "/api/boards/#{board.id}",
+              params: { board: { large_screen_columns: 8 } },
+              headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(board.reload.large_screen_columns).to eq(8)
       end
     end
 

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -62,5 +62,16 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(response).to have_http_status(:created)
       expect(board.board_images.last.position).to eq(7)
     end
+
+    it "honors an explicit display_label" do
+      image = create(:image, label: "thank you", user_id: admin_user.id)
+
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: { image_id: image.id, display_label: "🙏" }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      expect(board.board_images.last.display_label).to eq("🙏")
+    end
   end
 end


### PR DESCRIPTION
Two related backlog items from [speakanyway-printables/.claude-notes/backlog.md](https://github.com/brittanyjohns/speakanyway-printables/blob/main/.claude-notes/backlog.md).

## 1. Internal `board_images#create`: permit `display_label` override

`board_images.display_label` is a real column and is auto-filled in `BoardImage#set_labels` from the image's `language_settings` (falling back to `label`), but the internal `BoardImagesController#apply_optional_attributes!` never permitted callers to override it.

Without the override there's no way to ship a printable where the visible cell text differs from the spoken TTS — e.g. a single-emoji caption with a multi-word audio label, or a translated caption with an English TTS.

Permits `display_label` alongside `position` / `voice` / `language`, with `.to_s.strip` for whitespace normalization. Default auto-fill behavior is unchanged when the param is omitted.

## 2. Public `boards#create` / `boards#update`: don't coerce missing column params to 0

Mirror of #65 on the public, user-facing boards controller. Both `create` and `update` were assigning the three `*_screen_columns` attributes via blind `.to_i`, turning a missing param into 0. On create that suppresses `Board#set_screen_sizes` (which only fills nil); on update it silently overwrites saved column values with 0 any time the client PATCHes another field without echoing the columns back.

Guards all three column assignments with `.present?` on both actions.

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/board_images_spec.rb spec/requests/api/boards_spec.rb` — 23 examples, 0 failures.
- [ ] Manual: `POST /api/internal/boards/:board_id/board_images` with `display_label: "🙏"` returns a cell whose `display_label` is `"🙏"` while `label` still holds the underlying word.
- [ ] Manual: `PATCH /api/boards/:id` with only `{ name: "x" }` leaves existing screen-column values intact instead of zeroing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)