### PR TITLE
Internal board_images: per-cell style fields + bulk endpoint

### DIFF
--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -2,13 +2,13 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
   def create
     @board = Board.find(params[:board_id])
 
-    image = resolve_image
+    image = resolve_image_from(params)
     return render json: { error: "image_id or label is required" }, status: :unprocessable_entity if image.nil?
 
     board_image = @board.add_image(image.id)
 
     if board_image&.persisted?
-      apply_optional_attributes!(board_image)
+      apply_optional_attributes!(board_image, params)
       render json: board_image.api_view(current_user), status: :created
     else
       errors = board_image&.errors&.full_messages&.join(", ") || "Unable to add image to board"
@@ -16,25 +16,92 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     end
   end
 
+  def bulk
+    @board = Board.find(params[:board_id])
+
+    raw_cells = params[:cells]
+    unless raw_cells.is_a?(Array) && raw_cells.any?
+      return render json: { error: "cells must be a non-empty array" }, status: :unprocessable_entity
+    end
+
+    created = []
+    errors = []
+
+    ActiveRecord::Base.transaction do
+      raw_cells.each_with_index do |cell_params, index|
+        # ActionController::Parameters in nested arrays come through as
+        # ActionController::Parameters instances; coerce to a hash with
+        # indifferent access so resolve_image_from / apply_optional_attributes!
+        # work the same way as in #create.
+        cp = cell_params.respond_to?(:permit!) ? cell_params.permit!.to_h.with_indifferent_access : cell_params.to_h.with_indifferent_access
+
+        image = resolve_image_from(cp)
+        if image.nil?
+          errors << { index: index, error: "image_id or label is required" }
+          next
+        end
+
+        board_image = @board.add_image(image.id)
+        unless board_image&.persisted?
+          msg = board_image&.errors&.full_messages&.join(", ") || "Unable to add image to board"
+          errors << { index: index, error: msg }
+          next
+        end
+
+        unless apply_optional_attributes!(board_image, cp)
+          errors << { index: index, error: board_image.errors.full_messages.join(", ") }
+          next
+        end
+
+        created << board_image
+      end
+
+      raise ActiveRecord::Rollback if errors.any?
+    end
+
+    if errors.any?
+      render json: { errors: errors }, status: :unprocessable_entity
+    else
+      render json: created.map { |bi| bi.api_view(current_user) }, status: :created
+    end
+  end
+
   private
 
-  def resolve_image
-    if params[:image_id].present?
-      Image.find_by(id: params[:image_id])
-    elsif params[:label].present?
-      label = params[:label].to_s.strip
+  def resolve_image_from(p)
+    if p[:image_id].present?
+      Image.find_by(id: p[:image_id])
+    elsif p[:label].present?
+      label = p[:label].to_s.strip
       Image.find_by(label: label, user_id: current_user.id) ||
         Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil]) ||
         Image.create(label: label, user_id: current_user.id)
     end
   end
 
-  def apply_optional_attributes!(board_image)
+  def apply_optional_attributes!(board_image, p)
     updates = {}
-    updates[:position]      = params[:position].to_i if params[:position].present?
-    updates[:voice]         = VoiceService.normalize_voice(params[:voice]) if params[:voice].present?
-    updates[:language]      = params[:language] if params[:language].present?
-    updates[:display_label] = params[:display_label].to_s.strip if params[:display_label].present?
-    board_image.update(updates) if updates.any?
+    updates[:position]      = p[:position].to_i if p[:position].present?
+    updates[:voice]         = VoiceService.normalize_voice(p[:voice]) if p[:voice].present?
+    updates[:language]      = p[:language] if p[:language].present?
+    updates[:display_label] = p[:display_label].to_s.strip if p[:display_label].present?
+
+    updates[:hidden]        = ActiveModel::Type::Boolean.new.cast(p[:hidden]) unless p[:hidden].nil?
+    updates[:font_size]     = p[:font_size].to_i if p[:font_size].present?
+    updates[:border_width]  = p[:border_width].to_i unless p[:border_width].nil?
+    updates[:border_radius] = p[:border_radius].to_i unless p[:border_radius].nil?
+
+    updates[:bg_color]      = ColorHelper.to_hex(p[:bg_color], default: "#FFFFFF") if p[:bg_color].present?
+    updates[:text_color]    = ColorHelper.to_hex(p[:text_color], default: "#000000") if p[:text_color].present?
+    updates[:border_color]  = ColorHelper.to_hex(p[:border_color], default: "#000000") if p[:border_color].present?
+
+    unless p[:hide_label].nil?
+      data = (board_image.data || {}).deep_dup
+      data["hide_label"] = ActiveModel::Type::Boolean.new.cast(p[:hide_label])
+      updates[:data] = data
+    end
+
+    return true if updates.empty?
+    board_image.update(updates)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -339,7 +339,11 @@ Rails.application.routes.draw do
         member do
           get :export, action: :export_pdf, defaults: { format: :pdf }
         end
-        resources :board_images, only: [:create]
+        resources :board_images, only: [:create] do
+          collection do
+            post :bulk
+          end
+        end
       end
       resources :generated_boards, only: [:create]
       resources :images, only: [:create, :show] do

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -73,5 +73,110 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(response).to have_http_status(:created)
       expect(board.board_images.last.display_label).to eq("🙏")
     end
+
+    it "persists per-cell style overrides (hidden/font/border/colors)" do
+      image = create(:image, label: "kiwi-style", user_id: admin_user.id)
+
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: {
+             image_id: image.id,
+             hidden: true,
+             font_size: 28,
+             border_width: 4,
+             border_radius: 12,
+             bg_color: "yellow",
+             text_color: "#000000",
+             border_color: "rgb(255, 0, 0)",
+           }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      bi = board.board_images.last
+      expect(bi.hidden).to eq(true)
+      expect(bi.font_size).to eq(28)
+      expect(bi.border_width).to eq(4)
+      expect(bi.border_radius).to eq(12)
+      expect(bi.bg_color).to eq("#FFEA75")           # word -> hex via ColorHelper
+      expect(bi.text_color).to eq("#000000")
+      expect(bi.border_color).to eq("#FF0000")       # rgb() -> hex via ColorHelper
+    end
+
+    it "merges hide_label into the data jsonb without clobbering existing keys" do
+      image = create(:image, label: "kiwi-data", user_id: admin_user.id)
+
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: { image_id: image.id, hide_label: true }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      bi = board.board_images.last
+      expect(bi.data).to include("hide_label" => true)
+    end
+  end
+
+  describe "POST /api/internal/boards/:board_id/board_images/bulk" do
+    it "returns 401 without a valid bearer token" do
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: [{ label: "apple" }] }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 422 when cells is missing or empty" do
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: [] }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/cells must be a non-empty array/)
+    end
+
+    it "creates N cells in one request and returns them in input order" do
+      img_a = create(:image, label: "apple-bulk", user_id: admin_user.id)
+      img_b = create(:image, label: "banana-bulk", user_id: admin_user.id)
+      img_c = create(:image, label: "cherry-bulk", user_id: admin_user.id)
+
+      expect {
+        post "/api/internal/boards/#{board.id}/board_images/bulk",
+             params: {
+               cells: [
+                 { image_id: img_a.id, position: 0, bg_color: "yellow", hide_label: true },
+                 { image_id: img_b.id, position: 1, border_width: 6 },
+                 { image_id: img_c.id, position: 2 },
+               ],
+             }.to_json,
+             headers: auth_headers
+      }.to change { board.reload.board_images.count }.by(3)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body.size).to eq(3)
+      expect(body.map { |c| c["image_id"] }).to eq([img_a.id, img_b.id, img_c.id])
+
+      created = board.board_images.order(:position).to_a
+      expect(created[0].bg_color).to eq("#FFEA75")
+      expect(created[0].data).to include("hide_label" => true)
+      expect(created[1].border_width).to eq(6)
+    end
+
+    it "rolls back atomically when any entry is invalid" do
+      img_a = create(:image, label: "apple-rb", user_id: admin_user.id)
+
+      expect {
+        post "/api/internal/boards/#{board.id}/board_images/bulk",
+             params: {
+               cells: [
+                 { image_id: img_a.id, position: 0 },
+                 { position: 1 }, # missing image_id and label — should fail
+               ],
+             }.to_json,
+             headers: auth_headers
+      }.not_to change { board.reload.board_images.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      errors = JSON.parse(response.body)["errors"]
+      expect(errors).to be_an(Array)
+      expect(errors.first["index"]).to eq(1)
+      expect(errors.first["error"]).to match(/image_id or label is required/)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Permit per-cell style/display columns on `POST /api/internal/boards/:board_id/board_images`: `hidden`, `font_size`, `border_width`, `border_radius`, `bg_color`, `text_color`, `border_color`, plus a `hide_label` flag merged into the existing `data` jsonb. Colors normalized via `ColorHelper.to_hex` so word/rgb inputs work too. Same shape as the `display_label` add in #66.
- Add `POST /api/internal/boards/:board_id/board_images/bulk` — atomic bulk-create. Body is `{ cells: [...] }` where each entry accepts the same fields as single-create. Wrapped in a transaction; any invalid entry returns `422 { errors: [{ index, error }] }` and rolls back the whole batch. Reuses `resolve_image_from` / `apply_optional_attributes!` so the two paths stay in lockstep.

The existing single-create endpoint is unchanged — pick whichever matches your batch size.

## Why

The printables generator wants per-cell visual treatment (heavier border on a "matching game" answer cell, hidden labels on emoji-only cells, color-coding by part of speech, etc.). And it currently makes N HTTP round-trips to add N cells to a board, which doesn't scale past the 16-cell scenario boards.

Companion change on the printables side switches the cell-add loop to a single bulk call.

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/board_images_spec.rb` — 12 examples, 0 failures
  - existing single-create specs unchanged
  - new specs cover style-field round-trip, color-word normalization (`"yellow"` → `#FFEA75`, `"rgb(255,0,0)"` → `#FF0000`), `hide_label` merge into `data`
  - bulk specs cover auth, empty/missing `cells`, ordered success response, atomic rollback
- [ ] After merge: deploy to prod SAW before merging the printables companion (otherwise printables 404s on `/bulk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)