### PR TITLE
Internal API: edit Profile w/ Safety ID + Device Tag regen

### DIFF
--- a/app/controllers/api/internal/profiles_controller.rb
+++ b/app/controllers/api/internal/profiles_controller.rb
@@ -1,0 +1,70 @@
+class API::Internal::ProfilesController < API::Internal::ApplicationController
+  before_action :find_profile!
+
+  def show
+    render json: response_payload
+  end
+
+  def update
+    apply_rich_text_fields
+
+    if @profile.update(profile_params)
+      @profile.enqueue_audio_job_if_needed
+      @profile.generate_attachments! if @profile.safety?
+      render json: response_payload
+    else
+      Rails.logger.debug("[Internal::Profiles#update] errors=#{@profile.errors.full_messages}")
+      render json: {
+        error: "Profile update failed",
+        details: @profile.errors.full_messages,
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def find_profile!
+    @profile = Profile.find_by(id: params[:id]) if params[:id].to_s.match?(/\A\d+\z/)
+    @profile ||= Profile.find_by(slug: params[:id])
+
+    render json: { error: "Profile not found" }, status: :not_found unless @profile
+  end
+
+  def apply_rich_text_fields
+    {
+      public_about: params.dig(:profile, :public_about_html),
+      public_intro: params.dig(:profile, :public_intro_html),
+      public_bio: params.dig(:profile, :public_bio_html),
+    }.each do |attr, html|
+      @profile.public_send("#{attr}=", html) if html.present?
+    end
+  end
+
+  def profile_params
+    params.require(:profile).permit(
+      :username, :bio, :intro, :avatar, :allow_discovery,
+      settings: {},
+    )
+  end
+
+  def response_payload
+    {
+      profile: @profile.api_view(current_user),
+      assets: attachment_urls,
+    }
+  end
+
+  def attachment_urls
+    {
+      safety_id_png_url: url_for_attached(@profile.safety_id_png),
+      safety_id_pdf_url: url_for_attached(@profile.safety_id_pdf),
+      device_tag_png_url: url_for_attached(@profile.device_tag_png),
+      device_tag_pdf_url: url_for_attached(@profile.device_tag_pdf),
+    }.compact
+  end
+
+  def url_for_attached(attachment)
+    return nil unless attachment.attached?
+    @profile.url_for_attachment(attachment)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -351,6 +351,7 @@ Rails.application.routes.draw do
           post :generate
         end
       end
+      resources :profiles, only: [:show, :update]
     end
 
     namespace :v1 do

--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::Profiles", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let(:json_headers) { auth_headers.merge("Content-Type" => "application/json") }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let(:profile_owner) { create(:child_account) }
+  let!(:profile) do
+    create(:profile,
+           profileable: profile_owner,
+           profile_kind: "safety",
+           slug: "ada-lovelace",
+           settings: { "allergies" => "none" })
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+    allow(Communicators::GenerateSafetyIdCard).to receive(:call)
+    allow(Communicators::GenerateDeviceTag).to receive(:call)
+  end
+
+  describe "GET /api/internal/profiles/:id" do
+    context "without a valid bearer token" do
+      it "returns 401" do
+        get "/api/internal/profiles/#{profile.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    it "returns the profile when found by id" do
+      get "/api/internal/profiles/#{profile.id}", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.dig("profile", "id")).to eq(profile.id)
+      expect(body).to have_key("assets")
+    end
+
+    it "returns the profile when found by slug" do
+      get "/api/internal/profiles/#{profile.slug}", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).dig("profile", "id")).to eq(profile.id)
+    end
+
+    it "returns 404 when neither id nor slug matches" do
+      get "/api/internal/profiles/does-not-exist", headers: auth_headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /api/internal/profiles/:id" do
+    it "returns 401 without the bearer token" do
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: { bio: "x" } }.to_json,
+            headers: { "Content-Type" => "application/json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "updates settings and persists them" do
+      new_settings = {
+        "allergies" => "peanuts",
+        "ice_contact_1" => { "name" => "Mom", "phone" => "555", "relationship" => "parent" },
+      }
+
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: { settings: new_settings } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(profile.reload.settings).to include(new_settings)
+    end
+
+    it "regenerates safety_id and device_tag attachments for safety profiles" do
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: { bio: "Updated bio" } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Communicators::GenerateSafetyIdCard).to have_received(:call).with(profile)
+      expect(Communicators::GenerateDeviceTag).to have_received(:call).with(profile)
+    end
+
+    it "does not regenerate attachments for non-safety profiles" do
+      profile.update!(profile_kind: "public_page")
+
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: { bio: "Updated" } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Communicators::GenerateSafetyIdCard).not_to have_received(:call)
+      expect(Communicators::GenerateDeviceTag).not_to have_received(:call)
+    end
+
+    it "supports lookup by slug" do
+      patch "/api/internal/profiles/#{profile.slug}",
+            params: { profile: { bio: "From slug" } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(profile.reload.bio).to eq("From slug")
+    end
+
+    it "returns 404 when the profile cannot be found" do
+      patch "/api/internal/profiles/nope-nope",
+            params: { profile: { bio: "x" } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 422 when validation fails" do
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: { username: "" } }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Profile update failed")
+      expect(body["details"]).to be_an(Array)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `GET` and `PATCH /api/internal/profiles/:id` (in the `INTERNAL_API_KEY`-auth'd internal namespace) so internal services can read and edit a Profile.
- Lookup accepts the numeric id **or** the slug on the same route, so callers that only have the public slug (e.g. from a printed QR) can use it directly.
- On safety profiles the update triggers `Communicators::GenerateSafetyIdCard` and `GenerateDeviceTag` via the existing `Profile#generate_attachments!`, and returns the fresh `safety_id_png/pdf` + `device_tag_png/pdf` URLs alongside the `api_view`. For non-safety profiles the update still succeeds and the `assets` block is just empty.
- Permitted params mirror the public `PATCH /api/profiles/:id`: `username`, `bio`, `intro`, `avatar`, `allow_discovery`, and the `settings` hash (allergies, ICE contacts, medical info, etc.). Rich-text fields (`public_about_html`, `public_intro_html`, `public_bio_html`) supported, matching the public controller.

## Test plan
- [x] `bundle exec rspec spec/requests/api/internal/` — 48 examples, 0 failures (11 new for profiles).
- [x] `bin/rails routes | grep internal/profiles` shows `GET`/`PATCH`/`PUT /api/internal/profiles/:id`.
- [ ] Manual smoke after merge: `curl -X PATCH -H "Authorization: Bearer \$INTERNAL_API_KEY" -d '{"profile":{"settings":{"allergies":"peanuts"}}}' /api/internal/profiles/<id-or-slug>` returns 200, settings persist, and the response `assets` URLs point to freshly re-rendered Safety ID + Device Tag files.
- [ ] `curl` without the bearer header returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)