### PR TITLE
fix: keep QR code visible in board PDF header

### DIFF
--- a/app/services/boards/asset_rendering.rb
+++ b/app/services/boards/asset_rendering.rb
@@ -28,8 +28,9 @@ module Boards
       Base64.strict_encode64(File.binread(path))
     end
 
-    def board_title_for(board)
-      board.try(:name).presence || "Communication Board"
+    def board_title_for(board, max_length: 50)
+      raw = board.try(:name).presence || "Communication Board"
+      raw.truncate(max_length, omission: "…")
     end
   end
 end

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -40,7 +40,8 @@
       }
 
       .header-inner {
-        display: flex;
+        display: grid;
+        grid-template-columns: 14mm minmax(0, 1fr) auto;
         align-items: center;
         gap: 8mm;
         width: 100%;
@@ -48,7 +49,6 @@
 
       .logo {
         width: 14mm;
-        flex: 0 0 auto;
         margin-left: 4mm;
       }
 
@@ -64,8 +64,8 @@
         flex-direction: column;
         align-items: flex-start;
         justify-content: center;
-        flex: 1 1 auto;
         min-width: 0;
+        overflow: hidden;
       }
 
       .board-title {
@@ -92,15 +92,14 @@
         color: #666;
         padding: 1mm 0;
         min-width: 0;
+        overflow: hidden;
       }
 
       .board-link a {
         color: #666;
         font-weight: bold;
-      }
-
-      .qr-small {
-        flex: 0 0 auto;
+        word-break: break-all;
+        overflow-wrap: anywhere;
       }
 
       .qr-small img {

--- a/spec/services/boards/asset_rendering_spec.rb
+++ b/spec/services/boards/asset_rendering_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Boards::AssetRendering, type: :service do
+  describe ".board_title_for" do
+    it "returns the board name when present and short" do
+      board = double("Board", name: "My Board")
+      expect(described_class.board_title_for(board)).to eq("My Board")
+    end
+
+    it "falls back to a default when the name is blank" do
+      board = double("Board", name: "")
+      expect(described_class.board_title_for(board)).to eq("Communication Board")
+    end
+
+    it "falls back to a default when the name is nil" do
+      board = double("Board", name: nil)
+      expect(described_class.board_title_for(board)).to eq("Communication Board")
+    end
+
+    it "truncates names longer than 50 characters with an ellipsis" do
+      long_name = "A" * 60
+      board = double("Board", name: long_name)
+      title = described_class.board_title_for(board)
+
+      expect(title.length).to eq(50)
+      expect(title).to end_with("…")
+    end
+
+    it "respects a custom max_length" do
+      board = double("Board", name: "abcdefghij")
+      expect(described_class.board_title_for(board, max_length: 5)).to eq("abcd…")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Long board names were pushing the QR code off the right edge of the generated PDF header — sometimes the QR was clipped entirely.
- Truncate the board title server-side at 50 chars (with `…`) so the title can't dominate the header.
- Switch `.header-inner` from flexbox to a CSS grid (`14mm minmax(0, 1fr) auto`) so the QR column is always reserved regardless of what the middle column tries to do.
- Wrap long URLs in the "Scan the code or visit ..." link with `word-break: break-all; overflow-wrap: anywhere;` so a long URL can't blow out the layout.

## Files

- `app/services/boards/asset_rendering.rb` — `board_title_for` now accepts `max_length:` (default 50) and truncates with `…`.
- `app/views/layouts/pdf.html.erb` — header CSS hardened: grid layout, `overflow: hidden` on `.header-copy` / `.board-link`, wrappable anchors.
- `spec/services/boards/asset_rendering_spec.rb` — new spec covers short/blank/nil/long names + custom `max_length`.

## Test plan

- [x] `bundle exec rspec spec/services/boards/asset_rendering_spec.rb` — 5 examples, 0 failures.
- [x] Full RSpec suite run locally. 6 unrelated pre-existing failures on `main` filed separately: #69 (board_images rate-limit specs) and #70 (User plan_type default / DowngradeSoftTrialJob). Verified by re-running those specs against a clean stash on the base commit — same failures.
- [ ] Manual PDF check: open `/api/boards/:id/pdf?preview=1` for a board with a >50-char name. Confirm title shows `…`, QR is fully visible in both portrait and landscape, and the displayed URL wraps instead of pushing the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)