### PR TITLE
fix: allow Netlify deploy previews through CORS and Action Cable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,8 +68,7 @@ Rails.application.configure do
     "https://ypk9e.hatchboxapp.com", # staging
     /https:\/\/.*\.speakanyway\.com/,
     "capacitor://localhost",         # Capacitor iOS/Android WebView
-    "https://realtime-boards--speakanyway.netlify.app",
-    "https://deploy-preview-54--speakanyway.netlify.app",
+    %r{\Ahttps://([a-z0-9-]+--)?speakanyway\.netlify\.app\z}, # Netlify previews + branch deploys
   ]
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -17,7 +17,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
             "https://localhost",
             "http://localhost",
             "ionic://localhost",
-            "http://192.168.11.65:8100")
+            "http://192.168.11.65:8100",
+            %r{\Ahttps://([a-z0-9-]+--)?speakanyway\.netlify\.app\z})
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
## Summary

Companion to [itty-bitty-frontend#85](https://github.com/brittanyjohns/itty-bitty-frontend/pull/85), which points Netlify deploy previews at the staging backend. Without this, the previews get CORS-blocked the moment they try to call the API.

- `config/initializers/cors.rb`: add a regex origin matching `https://speakanyway.netlify.app`, `https://deploy-preview-N--speakanyway.netlify.app`, and `https://<branch>--speakanyway.netlify.app`.
- `config/environments/production.rb`: same regex replaces two hardcoded preview URLs in `action_cable.allowed_request_origins` so WebSocket connections work too.

Regex is anchored on both ends so `https://evil.netlify.app` and `https://speakanyway.netlify.app.evil.com` remain blocked.

Test the regex locally:
```
ruby -e 'r = %r{\Ahttps://([a-z0-9-]+--)?speakanyway\.netlify\.app\z}; ["https://deploy-preview-85--speakanyway.netlify.app", "https://evil.netlify.app"].each { |u| puts "#{r.match?(u)} #{u}" }'
```
→ allows the first, blocks the second.

## Test plan

- [x] `ruby -c` clean on both files
- [x] Manual regex tests pass (allows 3 legit shapes, blocks 3 attacker shapes)
- [ ] Once merged, label this PR `deploy-to-staging` so staging picks up the CORS change
- [ ] After Netlify preview from frontend#85 redeploys, DevTools → Network shows API calls succeeding
- [ ] ActionCable WebSocket from the preview connects to `wss://ypk9e.hatchboxapp.com/cable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)