### PR TITLE
fix: repair 9 failing RSpec specs + protect paid users from soft-trial downgrade

### DIFF
--- a/app/sidekiq/downgrade_soft_trial_job.rb
+++ b/app/sidekiq/downgrade_soft_trial_job.rb
@@ -26,7 +26,11 @@ class DowngradeSoftTrialJob
     # Target users who:
     #   - are still on the soft-trial Basic Trial plan (never upgraded or explicitly chose free)
     #   - signed up more than SOFT_TRIAL_DAYS ago
+    #   - have a stripe_customer_id (skip Apple/RevenueCat-managed users)
+    #   - have no paid_plan_type (skip users who've actually paid for a plan)
     User.where(plan_type: "basic_trial")
         .where("created_at <= ?", SOFT_TRIAL_DAYS.days.ago)
+        .where.not(stripe_customer_id: [nil, ""])
+        .where(paid_plan_type: [nil, ""])
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe User, type: :model do
     end
   end
   context "plan_type checks" do
-    it "defaults to basic plan (soft trial) on signup" do
+    it "defaults to basic_trial plan (soft trial) on signup" do
       user = FactoryBot.create(:user)
-      expect(user.plan_type).to eq("basic")
+      expect(user.plan_type).to eq("basic_trial")
     end
 
     it "does not override an explicitly set plan_type on create" do
@@ -91,7 +91,7 @@ RSpec.describe User, type: :model do
     it "does not change plan_type on subsequent saves" do
       user = FactoryBot.create(:user)
       user.update!(name: "Updated")
-      expect(user.plan_type).to eq("basic")
+      expect(user.plan_type).to eq("basic_trial")
     end
 
     it "recognizes pro plan" do
@@ -154,6 +154,7 @@ RSpec.describe User, type: :model do
     before do
       # Create a team and add the current user to it
       team.add_member!(current_user, "admin")
+      allow(User).to receive(:create_stripe_customer).and_return("cus_test_#{SecureRandom.hex(4)}")
     end
     it "adds the invited user to the team" do
       subject

--- a/spec/requests/api/board_images_rate_limit_spec.rb
+++ b/spec/requests/api/board_images_rate_limit_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "BoardImages rate limiting", type: :request do
 
   after { travel_back }
 
-  let!(:user)        { create(:user) }
+  let!(:user)        { create(:user).tap { |u| u.update_column(:plan_type, "free") } }
   let!(:board)       { create(:board, user: user) }
   let!(:image)       { create(:image, user: user) }
   let!(:board_image) { create(:board_image, board: board, image: image) }

--- a/spec/sidekiq/downgrade_soft_trial_job_spec.rb
+++ b/spec/sidekiq/downgrade_soft_trial_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
   subject(:job) { described_class.new }
 
   def create_soft_trial_user(overrides = {})
-    attrs = { plan_type: "basic", stripe_customer_id: "cus_test123", paid_plan_type: nil }.merge(overrides)
+    attrs = { plan_type: "basic_trial", stripe_customer_id: "cus_test123", paid_plan_type: nil }.merge(overrides)
     user = FactoryBot.create(:user, **attrs)
     user.update_column(:created_at, 15.days.ago) unless overrides.key?(:created_at)
     user
@@ -14,7 +14,7 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
     context "when a user is an expired soft-trial Basic user" do
       it "downgrades plan_type to free" do
         user = create_soft_trial_user
-        expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+        expect { job.perform }.to change { user.reload.plan_type }.from("basic_trial").to("free")
       end
     end
 


### PR DESCRIPTION
## Summary

`bundle exec rspec` was reporting 9 failing examples (out of 252). All 9 were real regressions in **the specs**, not in production code — except for two specs that exposed a real bug in `DowngradeSoftTrialJob`.

Root causes:
- The soft-trial change in #59 made `\"basic_trial\"` the new default plan on signup, but several specs still assumed the pre-#59 defaults of `\"free\"` / `\"basic\"`.
- Two `DowngradeSoftTrialJob` specs document that Apple/RevenueCat users (no `stripe_customer_id`) and users with a `paid_plan_type` are protected from downgrade — but the job didn't actually filter either group, so paying users would have been silently downgraded to free.

## Changes

**Spec fixes (stale after #59):**
- `spec/models/user_spec.rb` — expect `\"basic_trial\"` as default plan on signup; stub `User.create_stripe_customer` in the invite-team context (was hitting the real Stripe API).
- `spec/sidekiq/downgrade_soft_trial_job_spec.rb` — factory starts users on `\"basic_trial\"` (matching what the job targets).
- `spec/requests/api/board_images_rate_limit_spec.rb` — pin user to `\"free\"` plan via `update_column` so AI limit is 5 (basic_trial gives 100, so 6 calls never hit 429).

**Production fix:**
- `app/sidekiq/downgrade_soft_trial_job.rb` — `expired_trial_users` now excludes users with no `stripe_customer_id` (Apple/RevenueCat) and users with a `paid_plan_type` set.

## Test plan
- [x] `bundle exec rspec` → 252 examples, 0 failures, 18 pending (down from 9 failures)
- [x] `bundle exec rspec spec/models/user_spec.rb` passes
- [x] `bundle exec rspec spec/sidekiq/downgrade_soft_trial_job_spec.rb` passes
- [x] `bundle exec rspec spec/requests/api/board_images_rate_limit_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)