### PR TITLE
ci: auto-mirror staging to main on every push

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,49 +1,78 @@
-name: Deploy to staging
+name: Sync main → staging & deploy
 
-# Force-pushes a PR's HEAD to the `staging` branch and triggers a Hatchbox
-# deploy of ypk9e.hatchboxapp.com.
+# Fast-forwards the `staging` branch to match `main` on every push to main,
+# then triggers a Hatchbox deploy of ypk9e.hatchboxapp.com so staging always
+# mirrors the latest merged code.
 #
 # Triggers:
-#   - PR labeled `deploy-to-staging`
-#   - Subsequent pushes to a PR that already has that label
-#   - Manual workflow_dispatch with a ref (branch or SHA)
+#   - Push to `main`
+#   - Manual workflow_dispatch with an optional ref (defaults to main)
 #
-# Single shared staging: concurrency cancels in-flight deploys so the latest
-# wins. Don't put branch protection on `staging` - the workflow needs to
-# force-push it.
+# Concurrency cancels in-flight runs so back-to-back merges only deploy once
+# (the latest, which already contains the earlier commits).
+#
+# Don't put branch protection on `staging` - the workflow needs to push it.
+# If `staging` ever diverges from `main` (commits exist on staging that aren't
+# on main), the non-force push fails and the workflow auto-opens an issue
+# with the recovery command.
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
-        description: "Branch or SHA to deploy to staging"
-        required: true
+        description: "Branch or SHA to mirror to staging (defaults to main)"
+        required: false
+        default: main
 
 concurrency:
   group: staging-deploy
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'deploy-to-staging') ||
-      (github.event.action == 'synchronize' &&
-       contains(github.event.pull_request.labels.*.name, 'deploy-to-staging'))
+  sync_and_deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.ref }}
+          ref: ${{ github.event.inputs.ref || 'main' }}
 
-      - name: Force-push to staging branch
-        run: git push --force origin HEAD:refs/heads/staging
+      - name: Fast-forward staging to main
+        id: ff
+        run: git push origin HEAD:refs/heads/staging
+
+      - name: Open issue on divergence
+        if: failure() && steps.ff.conclusion == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha.slice(0, 7);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `staging diverged from main (${sha}) — manual reset needed`,
+              labels: ['staging', 'ci'],
+              body: [
+                "The `Sync main → staging` workflow failed because",
+                "`staging` has commits not present on `main`.",
+                "",
+                "**Fix:** locally run",
+                "",
+                "```sh",
+                "git fetch origin",
+                "git push origin origin/main:staging --force-with-lease",
+                "```",
+                "",
+                "Then re-run the workflow or push to main again.",
+                "",
+                `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ].join('\n'),
+            });
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -56,16 +85,3 @@ jobs:
           HATCHBOX_STAGING_APP_ID:      ${{ secrets.HATCHBOX_STAGING_APP_ID }}
           HATCHBOX_STAGING_DEPLOY_HOOK: ${{ secrets.HATCHBOX_STAGING_DEPLOY_HOOK }}
         run: ruby script/hatchbox/trigger_deploy.rb
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = context.payload.pull_request.head.sha.slice(0, 7);
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Staging deploy started for \`${sha}\`.\nLive at https://ypk9e.hatchboxapp.com in ~2-3 min.`
-            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Serializers:** jsonapi-serializer gem
 - **Hosting:** Hatchbox / EC2
   - Production: `main` branch → `speakanyway.com` (Hatchbox app `670kd.hatchboxapp.com`)
-  - Staging: `staging` branch → `https://ypk9e.hatchboxapp.com`. Deployed by labeling a PR `deploy-to-staging` (see `.github/workflows/staging-deploy.yml`). Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`.
+  - Staging: `staging` branch → `https://ypk9e.hatchboxapp.com`. Automatically mirrors `main` — every push to `main` fast-forwards `staging` and triggers a Hatchbox staging deploy (see `.github/workflows/staging-deploy.yml`). To redeploy a specific SHA, run the workflow via `workflow_dispatch`. Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary

- Rewrites `.github/workflows/staging-deploy.yml` to trigger on `push: main` instead of the `deploy-to-staging` label, so `staging` is always a 1:1 mirror of `main`.
- Non-force push (fast-forward only). If `staging` ever diverges from `main`, the workflow fails and auto-opens an issue with the exact `--force-with-lease` recovery command.
- Retains `workflow_dispatch` with a `ref` input for manual redeploys of a specific SHA.
- Concurrency group `staging-deploy` with `cancel-in-progress` so back-to-back merges only deploy the latest commit.
- Updates `CLAUDE.md` Hosting bullet to describe the new auto-mirror flow.

## Why

The old flow made `staging` represent a single PR candidate (whatever was last labeled). The new flow makes `staging` a true "prod clone" — every merged commit on `main` smoke-tests on staging within ~30s of merge.

## Pre-flight

Verified `origin/staging` is currently an ancestor of `origin/main`, so the first run after merge will fast-forward cleanly without manual reset.

## Follow-up after merge

- Delete the `deploy-to-staging` label from the repo (it's a no-op now).
- The first `push: main` (this PR's merge) will be the first real exercise of the workflow.

## Test plan

- [ ] Merge this PR; confirm the workflow auto-fires and `staging` ref on GitHub matches `main`.
- [ ] Confirm Hatchbox staging deploy starts and `https://ypk9e.hatchboxapp.com` comes up on the new SHA.
- [ ] (Optional) Push an empty commit directly to `staging` and then to `main` to exercise the divergence path; confirm the workflow fails and opens an issue.
- [ ] (Optional) Merge two trivial PRs back-to-back; confirm only one Hatchbox deploy completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)