### PR TITLE
Release: usage-based AI pricing — Phases 1–4 (credit ledger, top-ups, enforcement, renewals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Phase 4 of usage-based AI pricing (renewals + auto-grant)
+- `invoice.payment_succeeded` webhook handler — fires on initial paid period and every renewal. Reads `monthly_credits` and `plan_type` from the subscription line's Price metadata (falls back to `CreditService::PLAN_MONTHLY_CREDITS`), then calls `CreditService.grant_plan!` with `period_end = subscription.current_period_end`. Idempotent on Stripe event id, so retried webhooks never double-credit.
+- `customer.subscription.created` (status `trialing`) now grants trial credits with `period_end = subscription.trial_end`. Paid subscriptions still get their credits via the invoice path.
+- `customer.subscription.deleted` / `.paused` now expire plan credits via `CreditService.expire_plan_credits!`. Top-up credits are preserved.
+- `ExpirePlanCreditsJob` runs hourly as a backstop — zeroes out plan credits whose `plan_credits_reset_at` has passed and no webhook arrived to refresh them.
+- **Fix:** `apply_free_plan` previously referenced `FREE_PLAN_LIMITS` unqualified in the controller, which raised `NameError` silently swallowed by the `rescue` — so cancellations never actually downgraded users. Now resolves `User::FREE_PLAN_LIMITS` correctly.
+
 ### Changed — Phase 3 of usage-based AI pricing (enforcement switched)
 - **AI features now spend credits at request time.** The Redis monthly counter (`MonthlyFeatureLimiter`) is no longer in the AI hot path — `CreditService.spend!` is the source of truth.
 - New API gating helper `check_credits!(feature_key:, feature_name:, amount: nil)` in `API::ApplicationController`. Admins bypass the check.
@@ -30,5 +37,4 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Shadow-mode telemetry — `check_monthly_limit` in the API base controller now also runs `CreditService.shadow_spend` and logs divergences between the Redis-counter decision and the credit-ledger decision. **No user-visible change yet** — the Redis limiter remains the source of truth in Phase 1.
 
 ### Coming next
-- **Phase 4:** Plan-credit grants driven by `invoice.payment_succeeded` webhook so renewals top up automatically.
 - **Phase 5 (optional):** Stripe Meter-based overage billing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable user-facing changes to this project will be documented here.
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed — Phase 3 of usage-based AI pricing (enforcement switched)
+- **AI features now spend credits at request time.** The Redis monthly counter (`MonthlyFeatureLimiter`) is no longer in the AI hot path — `CreditService.spend!` is the source of truth.
+- New API gating helper `check_credits!(feature_key:, feature_name:, amount: nil)` in `API::ApplicationController`. Admins bypass the check.
+- AI endpoints now return **HTTP 402 `insufficient_credits`** with `{ feature, needed, balance, plan_credits, topup_credits, reset_at, topup_url }` when the balance is too low. HTTP 429 is reserved for true rate limiting and is no longer used by AI gating.
+- All 10 AI controller callsites now charge weighted credits per their real feature (image_generation=5, image_edit=3, scenario_create=10, etc.) instead of a flat `ai_action=1`.
+- Shadow-mode telemetry from Phase 1 has been removed. `check_monthly_limit` remains in the codebase as a generic Redis-counter helper but is no longer wired to AI endpoints.
+
+### Added — Phase 2 of usage-based AI pricing
+- `POST /api/stripe/checkout_sessions/topup` — creates a one-time Stripe Checkout Session for a credit pack (`pack_key`: `small` / `medium` / `large`, optional `quantity`).
+- Stripe webhook now branches on `metadata.kind == "topup"` for `checkout.session.completed`. Top-up sessions call `CreditService.grant_topup!`, idempotent on the Stripe event id.
+- Webhook falls back to expanding `line_items.data.price.metadata.credit_amount` when the session metadata is missing — keeps the system working even if the frontend was on an older build that didn't pass `credit_amount` through.
+- New env vars: `STRIPE_PRICE_TOPUP_SMALL`, `STRIPE_PRICE_TOPUP_MEDIUM`, `STRIPE_PRICE_TOPUP_LARGE` (Stripe Price IDs for the three pack sizes).
+
+### Added — Phase 1 of usage-based AI pricing
+- AI credit ledger (`credit_transactions` table) — immutable record of every grant, spend, expire, and refund of AI credits.
+- `users.plan_credits_balance`, `users.topup_credits_balance`, `users.plan_credits_reset_at` columns — denormalized balances and current-period end.
+- `CreditService` — single entry point for credit operations (`spend!`, `grant_plan!`, `grant_topup!`, `expire_plan_credits!`, `refund!`, `shadow_spend`). Spends drain plan credits first, then top-up.
+- `CreditService::FEATURE_COSTS` — weighted costs per AI feature (image generation = 5, scenario builder = 10, word suggestion = 1, etc.). Server-authoritative.
+- `GET /api/me/credits` — returns `{ plan, topup, total, reset_at, plan_type }` for the current user.
+- `GET /api/me/credit_transactions` — paginated transaction ledger for the current user.
+- `bin/rails credits:backfill` — gives every existing user an initial plan-credit grant based on their `plan_type`. Idempotent.
+- `bin/rails credits:recompute_balances` — rebuilds denormalized balances from the ledger.
+- Shadow-mode telemetry — `check_monthly_limit` in the API base controller now also runs `CreditService.shadow_spend` and logs divergences between the Redis-counter decision and the credit-ledger decision. **No user-visible change yet** — the Redis limiter remains the source of truth in Phase 1.
+
+### Coming next
+- **Phase 4:** Plan-credit grants driven by `invoice.payment_succeeded` webhook so renewals top up automatically.
+- **Phase 5 (optional):** Stripe Meter-based overage billing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,33 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - Premium features (Menu Board Creator, AI image generation) require active subscription
 - Subscription managed via Stripe/RevenueCat — check status before allowing access to premium endpoints
 
+## AI gating: credit ledger (source of truth)
+
+- AI features are gated by **weighted credits** held in two balances on `users`:
+  `plan_credits_balance` (resets each billing period, doesn't roll over) and
+  `topup_credits_balance` (additive from one-time purchases, doesn't expire).
+- All credit movement is recorded in `credit_transactions` (immutable ledger).
+  Webhook-driven grants are idempotent on `stripe_event_id`.
+- Entry point: `CreditService.spend!(user, feature_key:, amount: nil)` raises
+  `CreditService::InsufficientCredits` when out of credits. Per-feature costs
+  live in `CreditService::FEATURE_COSTS`.
+- AI controllers gate via `check_credits!(feature_key:, feature_name:)` in
+  `API::ApplicationController`. On insufficient balance it renders **HTTP 402**
+  with `{ error: "insufficient_credits", feature, needed, balance, plan_credits,
+  topup_credits, reset_at, topup_url }`. Admins (`current_user.admin?`) bypass.
+- Reserve **HTTP 429** for true rate limiting (rapid-fire abuse), not credit
+  exhaustion.
+- `MonthlyFeatureLimiter` is no longer in the AI hot path. It remains in the
+  codebase as a generic Redis-counter helper for any future non-AI rate
+  limits, but no controller currently calls it.
+
+Tasks:
+
+- `bin/rails credits:backfill` — give every user an initial plan-credit grant
+  based on their `plan_type`. Idempotent.
+- `bin/rails credits:recompute_balances` — rebuild denormalized balances
+  from the ledger if they drift.
+
 ## Do not
 
 - Do not install new gems without asking first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,21 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
   codebase as a generic Redis-counter helper for any future non-AI rate
   limits, but no controller currently calls it.
 
+Plan-credit lifecycle:
+
+- **First paid period + every renewal:** `invoice.payment_succeeded` webhook
+  → `CreditService.grant_plan!` with `period_end = subscription.current_period_end`.
+  Reads `monthly_credits` from the subscription line's Stripe Price metadata
+  (falls back to `CreditService::PLAN_MONTHLY_CREDITS[plan_type]`). Idempotent
+  on Stripe event id.
+- **Trial start:** `customer.subscription.created` with status `trialing`
+  grants credits with `period_end = subscription.trial_end`.
+- **Cancel / pause:** plan credits expire via
+  `CreditService.expire_plan_credits!`. Top-up credits are preserved.
+- **Backstop:** `ExpirePlanCreditsJob` runs hourly and zeroes any plan
+  balance whose `plan_credits_reset_at` has passed. Cheap and idempotent —
+  safe to invoke any time.
+
 Tasks:
 
 - `bin/rails credits:backfill` — give every user an initial plan-credit grant

--- a/README.md
+++ b/README.md
@@ -156,12 +156,21 @@ See `docs/stripe-setup.md` for the full dashboard checklist.
 
 ### Status
 
-**Phase 3 enforcement is live.** `CreditService.spend!` is the source of
-truth for AI gating; AI endpoints return `402 insufficient_credits` (with
-`needed` / `balance` / `topup_url`) when a call would overdraw. Admins
-bypass the check. `MonthlyFeatureLimiter` (the Redis counter) is no
-longer in the AI hot path — it remains in the codebase as a generic
-helper for non-AI rate limiting.
+**Phases 1–4 are live.** `CreditService.spend!` is the source of truth
+for AI gating; AI endpoints return `402 insufficient_credits` when a call
+would overdraw. Plan credits are granted automatically by Stripe
+webhooks:
+
+- `invoice.payment_succeeded` → grant for the new billing period
+  (initial payment + every renewal). Idempotent on Stripe event id.
+- `customer.subscription.created` with status `trialing` → grant for the
+  trial period.
+- `customer.subscription.deleted` / `.paused` → expire plan credits
+  (top-up credits preserved).
+- Hourly `ExpirePlanCreditsJob` as a backstop.
+
+Admins bypass the credit check. `MonthlyFeatureLimiter` is no longer in
+the AI hot path.
 
 ## SpeakAnyWay-Specific Terms:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
   - `STRIPE_PUBLIC_KEY` - Stripe Public Key
   - `STRIPE_PRIVATE_KEY` - Stripe Private Key
   - `STRIPE_SIGNING_SECRET` - Stripe Signing Secret
+  - `STRIPE_WEBHOOK_SECRET` - Stripe Webhook signing secret (separate from STRIPE_SIGNING_SECRET; used by `/api/webhooks`)
+  - `STRIPE_PRICE_TOPUP_SMALL` - Stripe Price ID for the small credit pack (100 credits)
+  - `STRIPE_PRICE_TOPUP_MEDIUM` - Stripe Price ID for the medium credit pack (500 credits)
+  - `STRIPE_PRICE_TOPUP_LARGE` - Stripe Price ID for the large credit pack (1500 credits)
   - `CDN_HOST` - CDN Host (optional)
   - `DEVISE_JWT_SECRET_KEY` - Devise JWT Secret Key
   - `DOMAIN` - Domain
@@ -107,6 +111,57 @@ Subscription based service
 - Free trial available
 - Monthly or yearly subscription options
 - Cancel anytime
+
+## AI credits
+
+AI features (image generation, scenario builder, menu builder, screenshot
+imports, image edits/variations, word suggestions, board formatting) are gated
+by an **AI credit** balance, not a flat monthly action cap. Each feature
+charges a weighted number of credits — see `CreditService::FEATURE_COSTS` in
+[`app/services/credit_service.rb`](app/services/credit_service.rb).
+
+Two balances per user:
+
+- **Plan credits** — granted at each billing-period renewal; expire at
+  period end and do not roll over.
+- **Top-up credits** — purchased ad hoc via Stripe Checkout; do not expire.
+
+When a user runs out, AI endpoints return `402 insufficient_credits` with the
+needed/balance numbers — the frontend uses that to surface a "Buy more
+credits" CTA. `429 limit_reached` is reserved for true rate limiting.
+
+### Stripe setup
+
+Each subscription Price in Stripe must have metadata:
+
+- `plan_type`: one of `free`, `myspeak`, `basic`, `pro`, `partner_pro`
+- `monthly_credits`: integer; overrides `CreditService::PLAN_MONTHLY_CREDITS`
+  defaults
+
+Each top-up Price must have metadata:
+
+- `kind: "topup"`
+- `credit_amount`: integer
+
+See `docs/stripe-setup.md` for the full dashboard checklist.
+
+### API surface
+
+- `GET /api/me/credits` — `{ plan, topup, total, reset_at, plan_type }`
+- `GET /api/me/credit_transactions` — paginated ledger
+- `POST /api/stripe/checkout_sessions/topup` — creates a one-time Stripe
+  Checkout Session for a credit pack. Body: `{ pack_key: "small"|"medium"|"large", quantity: 1 }`.
+  On payment success, the webhook adds credits to `topup_credits_balance`
+  (idempotent on Stripe event id).
+
+### Status
+
+**Phase 3 enforcement is live.** `CreditService.spend!` is the source of
+truth for AI gating; AI endpoints return `402 insufficient_credits` (with
+`needed` / `balance` / `topup_url`) when a call would overdraw. Admins
+bypass the check. `MonthlyFeatureLimiter` (the Redis counter) is no
+longer in the AI hot path — it remains in the codebase as a generic
+helper for non-AI rate limiting.
 
 ## SpeakAnyWay-Specific Terms:
 

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -38,6 +38,46 @@ module API
       end
     end
 
+    # Credit gating for AI features. Spends `amount` (or the weighted default
+    # for the feature) and renders 402 + a structured error body when the
+    # balance is too low. Admins bypass the check entirely.
+    #
+    # Returns true when the request should continue, false (and renders) when
+    # the caller must `return` before doing the AI work.
+    def check_credits!(feature_key:, feature_name: nil, amount: nil)
+      unless current_user
+        Rails.logger.warn "Credit check missing user. feature_key=#{feature_key}"
+        return true
+      end
+      return true if current_user.admin?
+
+      amount ||= CreditService.cost_for(feature_key)
+      CreditService.spend!(
+        current_user,
+        feature_key: feature_key,
+        amount: amount,
+        metadata: { path: request.path },
+      )
+      true
+    rescue CreditService::InsufficientCredits => e
+      balance = CreditService.balance(current_user)
+      render json: {
+        error: "insufficient_credits",
+        message: "You don't have enough AI credits for #{feature_name || feature_key.to_s.titleize}. Buy more credits or upgrade your plan.",
+        feature: feature_key.to_s,
+        needed: e.needed,
+        balance: balance[:total],
+        plan_credits: balance[:plan],
+        topup_credits: balance[:topup],
+        reset_at: balance[:reset_at]&.iso8601,
+        topup_url: "/account/billing/topup",
+      }, status: 402
+      false
+    end
+
+    # Legacy Redis-counter check. AI features now use `check_credits!` —
+    # this remains available for non-AI rate limits (currently none in this
+    # app, but kept so the helper doesn't have to be re-introduced later).
     def check_monthly_limit(feature_key: nil, feature_name: nil)
       unless current_user && feature_key
         Rails.logger.warn "Monthly limit check missing user or feature_key. user_id=#{current_user&.id} feature_key=#{feature_key}"

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -198,7 +198,7 @@ class API::BoardImagesController < API::ApplicationController
       return
     end
     begin
-      return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Image Edits")
+      return unless check_credits!(feature_key: "image_edit", feature_name: "AI Image Edits")
       prompt = params[:prompt] || ""
       transparent_background = params[:transparent_background] == "true"
       EditBoardImageJob.perform_async(@board_image.id, prompt, transparent_background)
@@ -222,7 +222,7 @@ class API::BoardImagesController < API::ApplicationController
       render json: { error: "Board image not found" }, status: :unprocessable_entity
       return
     end
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Image Variations")
+    return unless check_credits!(feature_key: "image_variation", feature_name: "AI Image Variations")
 
     @image_variation = @board_image.create_image_variation!
 

--- a/app/controllers/api/board_screenshot_imports_controller.rb
+++ b/app/controllers/api/board_screenshot_imports_controller.rb
@@ -34,7 +34,7 @@ class API::BoardScreenshotImportsController < API::ApplicationController
       return
     end
     import.save!
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Board Screenshot Imports")
+    return unless check_credits!(feature_key: "screenshot_import", feature_name: "AI Board Screenshot Imports")
     BoardScreenshotImportJob.perform_async(import.id, columns)
     render json: { id: import.id, status: import.status }
   end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -451,7 +451,7 @@ class API::BoardsController < API::ApplicationController
 
   def regenerate_images
     set_board
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Image Regeneration")
+    return unless check_credits!(feature_key: "image_generation", feature_name: "AI Image Regeneration")
     board_image_ids = params[:board_image_ids]
     if board_image_ids.blank? || !board_image_ids.is_a?(Array)
       render json: { error: "board_image_ids parameter is required and must be an array" }, status: :unprocessable_entity
@@ -471,7 +471,7 @@ class API::BoardsController < API::ApplicationController
 
   def recategorize_images
     set_board
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Image Recategorization")
+    return unless check_credits!(feature_key: "board_format", feature_name: "AI Image Recategorization")
     board_image_ids = @board.board_images.pluck(:id)
     board_image_ids.each_slice(20) do |batch|
       RecategorizeImagesJob.perform_async("BoardImage", batch)
@@ -618,7 +618,7 @@ class API::BoardsController < API::ApplicationController
     if params[:board_id].present?
       @board = Board.find_by(id: params[:board_id])
     end
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Word Suggestions")
+    return unless check_credits!(feature_key: "word_suggestion", feature_name: "AI Word Suggestions")
     creation_type = params[:board_creation_type] || "default"
     additional_words = []
     prompt = params[:prompt].presence || params[:name]
@@ -661,7 +661,7 @@ class API::BoardsController < API::ApplicationController
   end
 
   def format_with_ai
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Board Formatting")
+    return unless check_credits!(feature_key: "board_format", feature_name: "AI Board Formatting")
     set_board
     screen_size = params[:screen_size] || "lg"
     options = {

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -458,7 +458,7 @@ class API::ImagesController < API::ApplicationController
 
   def generate
     @current_user = current_user
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Image Generation")
+    return unless check_credits!(feature_key: "image_generation", feature_name: "AI Image Generation")
     label = image_params[:label].present? ? image_params[:label] : image_params[:image_prompt]
     image_prompt = image_params[:image_prompt]
     stripped_prompt = image_prompt.gsub("[[REPLACE_LABEL]]", "").strip

--- a/app/controllers/api/me_controller.rb
+++ b/app/controllers/api/me_controller.rb
@@ -2,6 +2,33 @@
 class API::MeController < API::ApplicationController
   before_action :authenticate_token!
 
+  # GET /api/me/credits
+  def credits
+    balance = CreditService.balance(current_user)
+    render json: {
+      plan: balance[:plan],
+      topup: balance[:topup],
+      total: balance[:total],
+      reset_at: balance[:reset_at]&.iso8601,
+      plan_type: current_user.plan_type,
+    }
+  end
+
+  # GET /api/me/credit_transactions
+  def credit_transactions
+    page = (params[:page] || 1).to_i.clamp(1, 1000)
+    per = (params[:per_page] || 25).to_i.clamp(1, 100)
+    scope = current_user.credit_transactions.order(created_at: :desc)
+    total = scope.count
+    rows = scope.offset((page - 1) * per).limit(per)
+    render json: {
+      page: page,
+      per_page: per,
+      total: total,
+      transactions: rows.map { |t| credit_transaction_json(t) },
+    }
+  end
+
   # GET /api/me/followed_pages
   def followed_pages
     pages = Page
@@ -49,6 +76,19 @@ class API::MeController < API::ApplicationController
       id: user.id,
       name: user.try(:name),
       email: user.try(:email) # only include if you’re okay exposing this
+    }
+  end
+
+  def credit_transaction_json(t)
+    {
+      id: t.id,
+      amount: t.amount,
+      kind: t.kind,
+      source: t.source,
+      feature_key: t.feature_key,
+      expires_at: t.expires_at&.iso8601,
+      created_at: t.created_at.iso8601,
+      metadata: t.metadata,
     }
   end
 end

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -94,7 +94,7 @@ class API::MenusController < API::ApplicationController
 
   # POST /menus or /menus.json
   def create
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Menu Creation")
+    return unless check_credits!(feature_key: "menu_create", feature_name: "AI Menu Creation")
     @current_user = current_user
     @menu = @current_user.menus.new
     @menu.user = current_user

--- a/app/controllers/api/scenarios_controller.rb
+++ b/app/controllers/api/scenarios_controller.rb
@@ -23,7 +23,7 @@ class API::ScenariosController < API::ApplicationController
 
   # POST /scenarios or /scenarios.json
   def create
-    return unless check_monthly_limit(feature_key: "ai_action", feature_name: "AI Scenario Creation")
+    return unless check_credits!(feature_key: "scenario_create", feature_name: "AI Scenario Creation")
     @scenario = current_user.scenarios.new(scenario_params)
     @scenario.token_limit = scenario_params[:token_limit] || 10
     # Temporarily set send_now to true

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -15,6 +15,22 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     "partner_pro" => ENV.fetch("STRIPE_PRICE_PARTNER_PRO", nil),
   }.freeze
 
+  # Resolved at request time (not class load) so changes to ENV in deploy
+  # configs or in test setup take effect without a class-cache reset.
+  TOPUP_PRICE_ENV_KEYS = {
+    "small" => "STRIPE_PRICE_TOPUP_SMALL",
+    "medium" => "STRIPE_PRICE_TOPUP_MEDIUM",
+    "large" => "STRIPE_PRICE_TOPUP_LARGE",
+  }.freeze
+
+  # Fallback if a Stripe Price lacks `metadata.credit_amount`. Keep in sync
+  # with docs/credits-handoff.md and docs/stripe-setup.md.
+  TOPUP_CREDIT_AMOUNTS = {
+    "small" => 100,
+    "medium" => 500,
+    "large" => 1500,
+  }.freeze
+
   def create
     plan_key = params[:plan_key].to_s
     price_id = PLAN_PRICE_IDS[plan_key]
@@ -85,6 +101,51 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
   rescue StandardError => e
     Rails.logger.error "Error creating checkout session: #{e.class} - #{e.message}"
     render json: { error: "Failed to create checkout session" }, status: :bad_request
+  end
+
+  # POST /api/stripe/checkout_sessions/topup
+  # Body: { pack_key: "small"|"medium"|"large", quantity: 1 }
+  # Creates a one-time payment Checkout Session for a credit pack.
+  # On payment success the Stripe webhook (checkout.session.completed with
+  # metadata.kind=topup) calls CreditService.grant_topup! — see
+  # API::WebhooksController.
+  def topup
+    pack_key = params[:pack_key].to_s
+    env_key = TOPUP_PRICE_ENV_KEYS[pack_key]
+    price_id = env_key.present? ? ENV[env_key].presence : nil
+    quantity = [params[:quantity].to_i, 1].max
+
+    if price_id.blank?
+      render json: { error: "Unknown or unconfigured pack_key" }, status: :bad_request
+      return
+    end
+
+    ensure_customer!
+
+    credit_amount = TOPUP_CREDIT_AMOUNTS[pack_key].to_i
+
+    session = Stripe::Checkout::Session.create(
+      mode: "payment",
+      customer: current_user.stripe_customer_id,
+      line_items: [{ price: price_id, quantity: quantity }],
+      success_url: "#{frontend_base_url}/account/billing/topup/success?session_id={CHECKOUT_SESSION_ID}",
+      cancel_url: "#{frontend_base_url}/account/billing",
+      payment_method_collection: "always",
+      allow_promotion_codes: true,
+      metadata: {
+        kind: "topup",
+        user_id: current_user.id,
+        pack_key: pack_key,
+        credit_amount: credit_amount * quantity,
+      },
+    )
+    render json: { url: session.url }
+  rescue Stripe::StripeError => e
+    Rails.logger.error "[Topup] Stripe error creating topup session: #{e.class} - #{e.message}"
+    render json: { error: "Failed to create top-up session" }, status: :bad_request
+  rescue StandardError => e
+    Rails.logger.error "[Topup] Unexpected error creating topup session: #{e.class} - #{e.message}"
+    render json: { error: "Failed to create top-up session" }, status: :bad_request
   end
 
   def update_user_from_session

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -28,10 +28,16 @@ class API::WebhooksController < API::ApplicationController
     when "customer.created"
       handle_customer_created(event.data.object)
     when "checkout.session.completed"
-      user = handle_checkout_completed(event.data.object)
-      unless user
-        Rails.logger.error "[StripeWebhook] checkout.session.completed: no user found for session #{event.data.object.id}"
-        result = { error: "no_user_found" }
+      session_obj = event.data.object
+      if (session_obj.metadata || {})["kind"] == "topup"
+        handled = handle_topup_completed(session_obj, event.id)
+        result = { error: "topup_not_credited" } unless handled
+      else
+        user = handle_checkout_completed(session_obj)
+        unless user
+          Rails.logger.error "[StripeWebhook] checkout.session.completed: no user found for session #{session_obj.id}"
+          result = { error: "no_user_found" }
+        end
       end
     when "customer.subscription.created", "customer.subscription.updated"
       handle_subscription_upsert(event.data.object, event.type == "customer.subscription.created")
@@ -71,6 +77,68 @@ class API::WebhooksController < API::ApplicationController
     Rails.logger.info "[StripeWebhook] customer.created: customer #{customer.id} created"
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_customer_created error: #{e.class} - #{e.message}"
+  end
+
+  # checkout.session.completed where metadata.kind == "topup".
+  # Idempotent on the Stripe event id (unique index on credit_transactions).
+  # Returns truthy when credits were granted (or already had been on a retry).
+  def handle_topup_completed(session, event_id)
+    metadata = session.metadata || {}
+
+    user = User.find_by(id: metadata["user_id"]) if metadata["user_id"].present?
+    user ||= User.find_by(stripe_customer_id: session.customer) if session.customer.present?
+    user ||= User.find_by(email: session.customer_details&.email) if session.customer_details&.email.present?
+
+    unless user
+      Rails.logger.error "[StripeWebhook][topup] no user for session #{session.id}"
+      return false
+    end
+
+    credit_amount = metadata["credit_amount"].to_i
+    if credit_amount <= 0
+      credit_amount = derive_credit_amount_from_session(session)
+    end
+
+    if credit_amount <= 0
+      Rails.logger.error "[StripeWebhook][topup] no credit_amount derivable for session #{session.id}"
+      return false
+    end
+
+    price_id = session.try(:line_items)&.data&.first&.price&.id
+
+    CreditService.grant_topup!(
+      user,
+      amount: credit_amount,
+      stripe_event_id: event_id,
+      stripe_price_id: price_id,
+      metadata: {
+        checkout_session_id: session.id,
+        pack_key: metadata["pack_key"],
+        amount_total: session.amount_total,
+        currency: session.currency,
+      },
+    )
+    Rails.logger.info "[StripeWebhook][topup] credited user=#{user.id} amount=#{credit_amount} session=#{session.id}"
+    true
+  rescue => e
+    Rails.logger.error "[StripeWebhook][topup] error: #{e.class} - #{e.message}"
+    false
+  end
+
+  # Last-resort lookup: read the line item Price's metadata.credit_amount.
+  # Stripe's checkout.session.completed event does not include line_items by
+  # default; we retrieve them with an expand.
+  def derive_credit_amount_from_session(session)
+    expanded = Stripe::Checkout::Session.retrieve(id: session.id, expand: ["line_items.data.price"])
+    line_item = expanded.line_items&.data&.first
+    return 0 unless line_item
+
+    per_unit = line_item.price&.metadata&.[]("credit_amount").to_i
+    quantity = line_item.quantity.to_i
+    per_unit * (quantity.positive? ? quantity : 1)
+  rescue => e
+    Rails.logger.error "[StripeWebhook][topup] derive_credit_amount error: #{e.class} - #{e.message}"
+    0
   end
 
   # Expect: you pass metadata[user_id] when creating the Checkout Session.

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -41,10 +41,17 @@ class API::WebhooksController < API::ApplicationController
       end
     when "customer.subscription.created", "customer.subscription.updated"
       handle_subscription_upsert(event.data.object, event.type == "customer.subscription.created")
+      # First-period credit grant for trial users — paid users get credits
+      # via invoice.payment_succeeded below, but trials have no invoice yet.
+      if event.type == "customer.subscription.created"
+        handle_trial_credit_grant(event.data.object, event.id)
+      end
     when "customer.subscription.deleted"
       handle_subscription_deleted(event.data.object)
     when "customer.subscription.paused"
       handle_subscription_paused(event.data.object)
+    when "invoice.payment_succeeded"
+      handle_invoice_payment_succeeded(event.data.object, event.id)
     else
       Rails.logger.info "[StripeWebhook] Ignoring unhandled event type=#{event.type}"
     end
@@ -237,6 +244,102 @@ class API::WebhooksController < API::ApplicationController
     Rails.logger.error "[StripeWebhook] handle_subscription_upsert error: #{e.class} - #{e.message}"
   end
 
+  # invoice.payment_succeeded fires for the initial paid period AND every
+  # renewal — the canonical "the user just paid for another month" event.
+  # Grants plan credits whose period_end = subscription.current_period_end.
+  # Idempotent on the Stripe event id (one grant per invoice event).
+  def handle_invoice_payment_succeeded(invoice, event_id)
+    sub_id = invoice.respond_to?(:subscription) ? invoice.subscription : nil
+    return unless sub_id.present?
+
+    # Look up the subscription to read its current_period_end and Price.metadata
+    subscription = Stripe::Subscription.retrieve(sub_id)
+
+    user = find_user_for_subscription(subscription)
+    unless user
+      Rails.logger.error "[StripeWebhook][invoice] no user for subscription #{sub_id}"
+      return
+    end
+    return if user.admin?
+
+    price = first_price_from_subscription(subscription)
+    unless price
+      Rails.logger.error "[StripeWebhook][invoice] no price for subscription #{sub_id}"
+      return
+    end
+
+    meta = price.metadata || {}
+    plan_type = meta["plan_type"].presence || user.plan_type.presence || "free"
+    amount = (meta["monthly_credits"].presence || CreditService.monthly_credits_for(plan_type)).to_i
+    return if amount <= 0
+
+    period_end = period_end_from_subscription(subscription) || 30.days.from_now
+
+    CreditService.grant_plan!(
+      user,
+      amount: amount,
+      period_end: period_end,
+      stripe_event_id: event_id,
+      stripe_price_id: price.id,
+      metadata: {
+        invoice_id: invoice.id,
+        subscription_id: sub_id,
+        plan_type: plan_type,
+        source: "invoice.payment_succeeded",
+      },
+    )
+    Rails.logger.info "[StripeWebhook][invoice] granted user=#{user.id} amount=#{amount} period_end=#{period_end} sub=#{sub_id}"
+  rescue => e
+    Rails.logger.error "[StripeWebhook] handle_invoice_payment_succeeded error: #{e.class} - #{e.message}"
+  end
+
+  # Grant credits for the trial period when a subscription is created in
+  # `trialing` status. No invoice has been paid yet, so the regular
+  # invoice.payment_succeeded path won't fire until trial converts.
+  # Idempotent on stripe_event_id.
+  def handle_trial_credit_grant(subscription, event_id)
+    return unless subscription.status == "trialing"
+
+    user = find_user_for_subscription(subscription)
+    return unless user
+    return if user.admin?
+
+    price = first_price_from_subscription(subscription)
+    return unless price
+
+    meta = price.metadata || {}
+    plan_type = meta["plan_type"].presence || user.plan_type.presence || "free"
+    amount = (meta["monthly_credits"].presence || CreditService.monthly_credits_for(plan_type)).to_i
+    return if amount <= 0
+
+    trial_end = subscription.respond_to?(:trial_end) ? subscription.trial_end : nil
+    period_end = trial_end.present? ? Time.at(trial_end) : 14.days.from_now
+
+    CreditService.grant_plan!(
+      user,
+      amount: amount,
+      period_end: period_end,
+      stripe_event_id: event_id,
+      stripe_price_id: price.id,
+      metadata: {
+        subscription_id: subscription.id,
+        plan_type: plan_type,
+        source: "trial.subscription.created",
+      },
+    )
+    Rails.logger.info "[StripeWebhook][trial] granted user=#{user.id} amount=#{amount} trial_end=#{period_end}"
+  rescue => e
+    Rails.logger.error "[StripeWebhook] handle_trial_credit_grant error: #{e.class} - #{e.message}"
+  end
+
+  # Pull current_period_end off a Subscription regardless of whether the
+  # Stripe SDK gives us a Time or an integer Unix timestamp.
+  def period_end_from_subscription(subscription)
+    raw = subscription.respond_to?(:current_period_end) ? subscription.current_period_end : nil
+    return nil if raw.blank?
+    raw.is_a?(Integer) ? Time.at(raw) : raw
+  end
+
   def handle_subscription_deleted(subscription)
     user = find_user_for_subscription(subscription)
     unless user
@@ -315,12 +418,15 @@ class API::WebhooksController < API::ApplicationController
 
   def apply_free_plan(user, status = "canceled")
     original_plan_type = user.plan_type
-    user.plan_type = FREE_PLAN_LIMITS["plan_type"]
+    user.plan_type = User::FREE_PLAN_LIMITS["plan_type"]
     user.paid_plan_type = original_plan_type
     user.plan_status = status
     user.setup_free_limits
     user.stripe_subscription_id = nil
     user.save!
+    # Plan credits expire on cancel/pause. Top-up credits are untouched —
+    # users keep what they paid for ad hoc.
+    CreditService.expire_plan_credits!(user, reason: "subscription_#{status}")
   end
 
   def to_int_or_nil(value)

--- a/app/models/credit_transaction.rb
+++ b/app/models/credit_transaction.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: credit_transactions
+#
+#  id              :bigint           not null, primary key
+#  user_id         :bigint           not null
+#  amount          :integer          not null  # signed; + grants, - spends
+#  kind            :string           not null  # plan_grant, topup_purchase, spend, expire, refund, admin_adjust, promo
+#  source          :string           not null  # "plan" or "topup"
+#  feature_key     :string                     # for spend rows
+#  stripe_event_id :string                     # unique when present
+#  stripe_price_id :string
+#  expires_at      :datetime
+#  metadata        :jsonb            not null, default {}
+#  created_at      :datetime         not null
+#
+class CreditTransaction < ApplicationRecord
+  belongs_to :user
+
+  KINDS = %w[plan_grant topup_purchase spend expire refund admin_adjust promo].freeze
+  SOURCES = %w[plan topup].freeze
+
+  validates :kind, inclusion: { in: KINDS }
+  validates :source, inclusion: { in: SOURCES }
+  validates :amount, presence: true
+  validates :stripe_event_id, uniqueness: true, allow_nil: true
+
+  scope :grants, -> { where(kind: %w[plan_grant topup_purchase admin_adjust promo refund]) }
+  scope :spends, -> { where(kind: "spend") }
+  scope :plan, -> { where(source: "plan") }
+  scope :topup, -> { where(source: "topup") }
+  scope :unexpired_plan_grants, -> { plan.where(kind: "plan_grant").where("expires_at IS NULL OR expires_at > ?", Time.current) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,7 @@ class User < ApplicationRecord
   belongs_to :current_team, class_name: "Team", optional: true
   has_many :word_events, dependent: :destroy
   has_many :subscriptions, dependent: :destroy
+  has_many :credit_transactions, dependent: :destroy
   has_secure_token :authentication_token
   # has_many :communicator_accounts, dependent: :destroy
   has_many :scenarios, dependent: :destroy

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+# Source of truth for AI feature gating.
+#
+# Spend order: plan credits first (they expire), then topup credits (don't expire).
+# Grants are idempotent on stripe_event_id when provided.
+class CreditService
+  class InsufficientCredits < StandardError
+    attr_reader :needed, :balance, :feature_key
+
+    def initialize(needed:, balance:, feature_key:)
+      @needed = needed
+      @balance = balance
+      @feature_key = feature_key
+      super("Insufficient credits for #{feature_key}: needed #{needed}, balance #{balance}")
+    end
+  end
+
+  # Per-feature credit cost. Server-side only; clients never pick the cost.
+  # Tuning these is a config change, not a schema change.
+  FEATURE_COSTS = {
+    "word_suggestion" => 1,
+    "board_format" => 2,
+    "image_edit" => 3,
+    "image_variation" => 3,
+    "image_generation" => 5,
+    "screenshot_import" => 5,
+    "scenario_create" => 10,
+    "menu_create" => 10,
+    # Legacy single-bucket key (during shadow mode / migration)
+    "ai_action" => 1,
+  }.freeze
+
+  # Default monthly grant by plan_type. Stripe Price metadata overrides at grant time.
+  PLAN_MONTHLY_CREDITS = {
+    "free" => 10,
+    "myspeak" => 50,
+    "basic" => 400,
+    "pro" => 1500,
+    "premium" => 1500,
+    "partner_pro" => 1500,
+    "vendor" => 1500,
+  }.freeze
+
+  class << self
+    def cost_for(feature_key)
+      FEATURE_COSTS[feature_key.to_s] || 1
+    end
+
+    def monthly_credits_for(plan_type)
+      PLAN_MONTHLY_CREDITS[plan_type.to_s] || PLAN_MONTHLY_CREDITS["free"]
+    end
+
+    def balance(user)
+      {
+        plan: user.plan_credits_balance.to_i,
+        topup: user.topup_credits_balance.to_i,
+        total: user.plan_credits_balance.to_i + user.topup_credits_balance.to_i,
+        reset_at: user.plan_credits_reset_at,
+      }
+    end
+
+    # Spend credits for an AI feature. Plan credits drained first, then top-up.
+    # Returns a CreditTransaction. Raises InsufficientCredits if not enough.
+    def spend!(user, feature_key:, amount: nil, metadata: {})
+      amount ||= cost_for(feature_key)
+      raise ArgumentError, "amount must be positive" if amount <= 0
+
+      ActiveRecord::Base.transaction do
+        user.lock!
+        total = user.plan_credits_balance.to_i + user.topup_credits_balance.to_i
+        if total < amount
+          raise InsufficientCredits.new(needed: amount, balance: total, feature_key: feature_key.to_s)
+        end
+
+        from_plan = [user.plan_credits_balance.to_i, amount].min
+        from_topup = amount - from_plan
+
+        user.update_columns(
+          plan_credits_balance: user.plan_credits_balance.to_i - from_plan,
+          topup_credits_balance: user.topup_credits_balance.to_i - from_topup,
+        )
+
+        source = from_plan >= from_topup ? "plan" : "topup"
+        CreditTransaction.create!(
+          user: user,
+          amount: -amount,
+          kind: "spend",
+          source: source,
+          feature_key: feature_key.to_s,
+          metadata: metadata.merge(from_plan: from_plan, from_topup: from_topup),
+        )
+      end
+    end
+
+    # Idempotent on stripe_event_id. period_end becomes the expires_at for the grant.
+    # Resets the user's plan_credits_balance to `amount` (full reset, not additive)
+    # so leftover plan credits from the previous period do not roll over.
+    def grant_plan!(user, amount:, period_end:, stripe_event_id: nil, stripe_price_id: nil, metadata: {})
+      raise ArgumentError, "amount must be positive" if amount <= 0
+
+      ActiveRecord::Base.transaction do
+        if stripe_event_id.present? && CreditTransaction.exists?(stripe_event_id: stripe_event_id)
+          return CreditTransaction.find_by(stripe_event_id: stripe_event_id)
+        end
+
+        user.lock!
+        # Expire any leftover plan credits first (ledger trace)
+        if user.plan_credits_balance.to_i.positive?
+          CreditTransaction.create!(
+            user: user,
+            amount: -user.plan_credits_balance.to_i,
+            kind: "expire",
+            source: "plan",
+            metadata: { reason: "superseded_by_plan_grant" },
+          )
+        end
+
+        user.update_columns(
+          plan_credits_balance: amount,
+          plan_credits_reset_at: period_end,
+        )
+
+        CreditTransaction.create!(
+          user: user,
+          amount: amount,
+          kind: "plan_grant",
+          source: "plan",
+          stripe_event_id: stripe_event_id,
+          stripe_price_id: stripe_price_id,
+          expires_at: period_end,
+          metadata: metadata,
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      CreditTransaction.find_by(stripe_event_id: stripe_event_id)
+    end
+
+    # Idempotent on stripe_event_id. Additive to topup_credits_balance; no expiration by default.
+    def grant_topup!(user, amount:, stripe_event_id: nil, stripe_price_id: nil, expires_at: nil, metadata: {})
+      raise ArgumentError, "amount must be positive" if amount <= 0
+
+      ActiveRecord::Base.transaction do
+        if stripe_event_id.present? && CreditTransaction.exists?(stripe_event_id: stripe_event_id)
+          return CreditTransaction.find_by(stripe_event_id: stripe_event_id)
+        end
+
+        user.lock!
+        user.update_columns(
+          topup_credits_balance: user.topup_credits_balance.to_i + amount,
+        )
+
+        CreditTransaction.create!(
+          user: user,
+          amount: amount,
+          kind: "topup_purchase",
+          source: "topup",
+          stripe_event_id: stripe_event_id,
+          stripe_price_id: stripe_price_id,
+          expires_at: expires_at,
+          metadata: metadata,
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+      CreditTransaction.find_by(stripe_event_id: stripe_event_id)
+    end
+
+    # Zero out plan credits and write an "expire" ledger row.
+    # Top-up balance is untouched.
+    def expire_plan_credits!(user, reason: "period_ended")
+      ActiveRecord::Base.transaction do
+        user.lock!
+        remaining = user.plan_credits_balance.to_i
+        return nil if remaining <= 0
+
+        user.update_columns(plan_credits_balance: 0)
+        CreditTransaction.create!(
+          user: user,
+          amount: -remaining,
+          kind: "expire",
+          source: "plan",
+          metadata: { reason: reason },
+        )
+      end
+    end
+
+    # Refund credits that were already spent (e.g. AI call failed downstream).
+    # Returns to the same source they came from.
+    def refund!(user, amount:, feature_key:, source: "plan", metadata: {})
+      raise ArgumentError, "amount must be positive" if amount <= 0
+      raise ArgumentError, "invalid source" unless %w[plan topup].include?(source)
+
+      ActiveRecord::Base.transaction do
+        user.lock!
+        if source == "plan"
+          user.update_columns(plan_credits_balance: user.plan_credits_balance.to_i + amount)
+        else
+          user.update_columns(topup_credits_balance: user.topup_credits_balance.to_i + amount)
+        end
+
+        CreditTransaction.create!(
+          user: user,
+          amount: amount,
+          kind: "refund",
+          source: source,
+          feature_key: feature_key.to_s,
+          metadata: metadata,
+        )
+      end
+    end
+
+    # Shadow-mode: try to spend, but never raise. Returns true if it would have succeeded.
+    # Used during Phase 1 rollout for telemetry.
+    def shadow_spend(user, feature_key:, amount: nil, metadata: {})
+      spend!(user, feature_key: feature_key, amount: amount, metadata: metadata)
+      true
+    rescue InsufficientCredits => e
+      Rails.logger.warn "[CreditService][shadow] would have blocked user=#{user.id} feature=#{e.feature_key} needed=#{e.needed} balance=#{e.balance}"
+      false
+    rescue => e
+      Rails.logger.error "[CreditService][shadow] error user=#{user.id} feature=#{feature_key}: #{e.class} #{e.message}"
+      false
+    end
+  end
+end

--- a/app/sidekiq/expire_plan_credits_job.rb
+++ b/app/sidekiq/expire_plan_credits_job.rb
@@ -1,0 +1,32 @@
+# Backstop for credit expiry.
+#
+# The primary path for refreshing plan credits is the
+# `invoice.payment_succeeded` webhook (see API::WebhooksController), which
+# calls `CreditService.grant_plan!` and naturally expires the previous
+# period's leftovers. This job catches the edge cases:
+#
+#   - Subscription churn where the webhook was missed or delayed.
+#   - Trial users whose `plan_credits_reset_at` has passed but no payment
+#     event will arrive (cancellation just before conversion, etc.).
+#
+# Run on an hourly cron — idempotent and cheap because
+# `CreditService.expire_plan_credits!` is a no-op when the balance is
+# already zero.
+class ExpirePlanCreditsJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 2
+
+  def perform
+    scope = User
+      .where("plan_credits_balance > 0")
+      .where("plan_credits_reset_at IS NOT NULL AND plan_credits_reset_at <= ?", Time.current)
+
+    expired = 0
+    scope.find_each do |user|
+      tx = CreditService.expire_plan_credits!(user, reason: "period_ended")
+      expired += 1 if tx
+    end
+
+    Rails.logger.info "[ExpirePlanCreditsJob] expired plan credits for #{expired} users"
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,5 +18,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Downgrade expired soft-trial Basic users to Free (runs daily at 2am UTC)",
     },
+    "expire_plan_credits" => {
+      "cron" => "0 * * * *",
+      "class" => "ExpirePlanCreditsJob",
+      "queue" => "default",
+      "description" => "Zero out plan_credits_balance for users whose plan_credits_reset_at has passed. Backstop for the invoice.payment_succeeded webhook; runs hourly.",
+    },
   })
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,11 @@ Rails.application.routes.draw do
   #  API routes
   namespace :api, defaults: { format: :json } do
     namespace :stripe do
-      resources :checkout_sessions, only: :create
+      resources :checkout_sessions, only: :create do
+        collection do
+          post "topup"
+        end
+      end
       post "update_user_from_session", to: "checkout_sessions#update_user_from_session"
     end
     namespace :profiles do
@@ -125,6 +129,8 @@ Rails.application.routes.draw do
 
     get "me/followed_pages", to: "me#followed_pages"
     get "me/page_followers", to: "me#page_followers"
+    get "me/credits", to: "me#credits"
+    get "me/credit_transactions", to: "me#credit_transactions"
 
     post "word_click", to: "audits#word_click"
     post "public_word_click", to: "audits#public_word_click"

--- a/db/migrate/20260512120000_create_credit_transactions.rb
+++ b/db/migrate/20260512120000_create_credit_transactions.rb
@@ -1,0 +1,21 @@
+class CreateCreditTransactions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :credit_transactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :amount, null: false
+      t.string :kind, null: false
+      t.string :source, null: false
+      t.string :feature_key
+      t.string :stripe_event_id
+      t.string :stripe_price_id
+      t.datetime :expires_at
+      t.jsonb :metadata, null: false, default: {}
+      t.datetime :created_at, null: false
+    end
+
+    add_index :credit_transactions, :stripe_event_id, unique: true, where: "stripe_event_id IS NOT NULL"
+    add_index :credit_transactions, [:user_id, :created_at]
+    add_index :credit_transactions, [:user_id, :kind]
+    add_index :credit_transactions, :expires_at, where: "expires_at IS NOT NULL"
+  end
+end

--- a/db/migrate/20260512120001_add_credit_balances_to_users.rb
+++ b/db/migrate/20260512120001_add_credit_balances_to_users.rb
@@ -1,0 +1,7 @@
+class AddCreditBalancesToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :plan_credits_balance, :integer, default: 0, null: false
+    add_column :users, :topup_credits_balance, :integer, default: 0, null: false
+    add_column :users, :plan_credits_reset_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_06_194203) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_12_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -335,6 +335,24 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_194203) do
     t.boolean "winner", default: false
     t.index ["event_id"], name: "index_contest_entries_on_event_id"
     t.index ["winner"], name: "index_contest_entries_on_winner"
+  end
+
+  create_table "credit_transactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "amount", null: false
+    t.string "kind", null: false
+    t.string "source", null: false
+    t.string "feature_key"
+    t.string "stripe_event_id"
+    t.string "stripe_price_id"
+    t.datetime "expires_at"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.index ["expires_at"], name: "index_credit_transactions_on_expires_at", where: "(expires_at IS NOT NULL)"
+    t.index ["stripe_event_id"], name: "index_credit_transactions_on_stripe_event_id", unique: true, where: "(stripe_event_id IS NOT NULL)"
+    t.index ["user_id", "created_at"], name: "index_credit_transactions_on_user_id_and_created_at"
+    t.index ["user_id", "kind"], name: "index_credit_transactions_on_user_id_and_kind"
+    t.index ["user_id"], name: "index_credit_transactions_on_user_id"
   end
 
   create_table "docs", force: :cascade do |t|
@@ -867,6 +885,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_194203) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.integer "plan_credits_balance", default: 0, null: false
+    t.integer "topup_credits_balance", default: 0, null: false
+    t.datetime "plan_credits_reset_at"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["child_lookup_key"], name: "index_users_on_child_lookup_key", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
@@ -946,6 +967,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_06_194203) do
   add_foreign_key "child_boards", "child_accounts"
   add_foreign_key "child_boards", "users", column: "created_by_id"
   add_foreign_key "contest_entries", "events"
+  add_foreign_key "credit_transactions", "users"
   add_foreign_key "feedback_items", "users"
   add_foreign_key "menus", "users"
   add_foreign_key "openai_prompts", "users"

--- a/docs/credits-handoff.md
+++ b/docs/credits-handoff.md
@@ -1,7 +1,7 @@
 # SpeakAnyWay AI Credits — UI + Marketing Handoff
 
 **Audience:** Design, Frontend, Marketing
-**Status:** Phase 1 (ledger), Phase 2 (top-up backend), and Phase 3 (enforcement) shipped. Frontend "Buy credits" UI and the `402 insufficient_credits` upsell modal are the next blocking pieces.
+**Status:** Phases 1–4 shipped on staging. Frontend "Buy credits" UI and the `402 insufficient_credits` upsell modal are the only remaining blocking pieces before this is fully visible to users.
 **Owner:** Brittany Johns
 
 ---
@@ -179,7 +179,7 @@ listed there.
 | **1** ✅ | Backend ledger, service, shadow mode telemetry | No |
 | **2** ✅ backend | Top-up Checkout endpoint + webhook handler. Frontend "Buy credits" UI still needed. | Yes (additive) once UI lands |
 | **3** ✅ | AI gating switched from Redis counter → credit balance. AI endpoints now return `402 insufficient_credits` when balance is too low. | **Yes — user-visible** the first time a user hits zero credits. Surface the upsell modal! |
-| **4** | Plan grants on invoice renewal webhook | No (internal) |
+| **4** ✅ | Plan-credit grants on `invoice.payment_succeeded` (renewal) + trial grants on `customer.subscription.created`. Cancellation/pause expires plan credits while preserving top-ups. Hourly backstop job. | No (internal) — renewals now auto-top-up, no more manual rake task. |
 | **5** | Optional: Stripe metered overage | Decision pending |
 
 ---

--- a/docs/credits-handoff.md
+++ b/docs/credits-handoff.md
@@ -1,0 +1,205 @@
+# SpeakAnyWay AI Credits — UI + Marketing Handoff
+
+**Audience:** Design, Frontend, Marketing
+**Status:** Phase 1 (ledger), Phase 2 (top-up backend), and Phase 3 (enforcement) shipped. Frontend "Buy credits" UI and the `402 insufficient_credits` upsell modal are the next blocking pieces.
+**Owner:** Brittany Johns
+
+---
+
+## 1. What's changing in one paragraph
+
+AI features (image generation, scenario builder, menu builder, screenshot
+imports, word suggestions, board formatting, image edits and variations) now
+run on **credits** instead of a flat monthly action cap. Every subscription
+tier includes a monthly credit allowance, and users can buy ad-hoc credit
+packs anytime — like adding minutes to a prepaid phone. Different AI
+features cost different amounts of credits, weighted by how expensive they
+actually are to run, so big jobs (full menu generation) cost more than
+small ones (a single word suggestion).
+
+---
+
+## 2. Plan tiers (proposed)
+
+| Plan | Monthly credits | Approx. usage |
+|---|---|---|
+| **Free** | 10 | 2 AI images, or 10 word suggestions |
+| **MySpeak** | 50 | 10 AI images, or 50 word suggestions |
+| **Basic** | 400 | 80 AI images, or one full menu + 30 images |
+| **Pro** | 1,500 | 300 AI images, or many full menus |
+
+> Dollar prices unchanged from current pricing — credit amounts are the new
+> dimension. **Final numbers are a marketing/leadership decision; the engine
+> reads `monthly_credits` from each Stripe Price's metadata, so we can tune
+> without a redeploy.**
+
+---
+
+## 3. Top-up credit packs (proposed)
+
+| Pack | Credits | Price | Effective $/credit |
+|---|---|---|---|
+| **Small** | 100 | $4.99 | $0.0499 |
+| **Medium** | 500 | $19.99 | $0.0400 |
+| **Large** | 1,500 | $49.99 | $0.0333 |
+
+- Top-ups are **one-time purchases** (Stripe Checkout, mode=payment).
+- Top-up credits **do not expire** (or expire after 12 months — decision
+  pending).
+- Top-ups are spent **after** plan credits run out.
+
+---
+
+## 4. Feature credit costs
+
+These are the costs the server charges per AI call. Frontend cannot pick the
+cost — it's authoritative server-side in `CreditService::FEATURE_COSTS`.
+
+| Feature | Credits | Plain English |
+|---|---|---|
+| Word suggestion | **1** | A single AI-suggested word for a board |
+| Board formatting | **2** | AI cleanup of an existing board's layout |
+| Image edit | **3** | Modify an existing image with AI |
+| Image variation | **3** | Generate a variation of an existing image |
+| AI image generation | **5** | A new image from a text prompt |
+| Screenshot import | **5** | Import a board from a screenshot via AI |
+| Scenario builder | **10** | Generate a full board from a scenario description |
+| Menu builder | **10** | Generate a board from a restaurant menu photo |
+
+---
+
+## 5. Plain-English rules
+
+- **Plan credits reset every billing period.** They do not roll over. If a
+  Pro user uses 200 of 1,500, the other 1,300 are gone on renewal day.
+- **Top-up credits do not expire** (or expire after 12 months — TBD).
+- **Plan credits are spent first**, then top-up credits. Top-ups are a
+  safety net for heavy months.
+- **No surprise charges.** Once a user is out of credits, AI features block
+  with a "Buy more" prompt. Nothing is auto-billed.
+- **Canceling a subscription** keeps any unused top-up credits but
+  immediately expires plan credits.
+- **Refunds for failed AI calls** are automatic (e.g. if OpenAI errors mid-
+  job, the credits come back to the same bucket they were spent from).
+
+---
+
+## 6. UX flows that need design
+
+### a. Credits balance widget (persistent)
+Visible in the account header / sidebar. Shows total balance, plan vs. top-up
+breakdown on hover, link to billing page.
+
+> Backend source: `GET /api/me/credits` →
+> `{ plan: 250, topup: 100, total: 350, reset_at: "2026-06-01T00:00:00Z", plan_type: "basic" }`
+
+### b. "Out of credits" modal
+Triggered when the API returns `HTTP 402` with
+`{ error: "insufficient_credits", needed: 5, balance: 2 }`. Two CTAs:
+- **Buy credits** (primary) → opens top-up picker
+- **Upgrade plan** (secondary) → opens existing plan picker
+
+Show what they were trying to do and how many credits they need.
+
+### c. Billing page additions
+- **Credits panel** at top: large balance number, breakdown, reset date.
+- **Buy credits** button → picker with the three pack sizes from §3.
+- **Transaction history** table — credit grants, purchases, spends, expiries,
+  refunds. Filterable by type. Backend: `GET /api/me/credit_transactions`.
+- **Plan comparison** — credit allowance becomes a column in the existing
+  plan-comparison table on the pricing page.
+
+### d. Post-purchase success screen
+After a successful top-up Checkout, land on a screen that shows the new
+balance and a "Back to where I was" link (carry the redirect through
+metadata).
+
+### e. Low-balance warning (email + in-app)
+Triggered when plan balance drops below 10% of allowance. Surfaces same
+"Buy credits" / "Upgrade" choice.
+
+---
+
+## 7. Marketing message suggestions
+
+> **Pricing-page hero**
+> "Pay for what you use. Every plan includes a monthly allowance of AI
+> credits — and when you need more, buy a pack. No surprise charges, ever."
+
+> **Upsell modal (out of credits)**
+> "You're out of AI credits for this month. Grab a credit pack to keep
+> going, or upgrade your plan for a bigger monthly allowance."
+
+> **Renewal-day email**
+> "Your monthly credits have refreshed. You have [N] AI credits to use
+> through [date]. Heavy month coming up? You can top up anytime."
+
+> **Low-balance email (10% remaining)**
+> "Heads up — you have [N] AI credits left this month. They reset on
+> [date], or you can top up now."
+
+> **Top-up purchase receipt**
+> "Thanks! [N] credits have been added to your account. Top-up credits
+> never expire."
+
+---
+
+## 8. FAQs the support team will get
+
+**Do unused plan credits roll over?**
+No. Plan credits reset at the start of each billing period to keep accounting
+predictable. If you want to save credits for a heavy month, buy a top-up pack
+— those don't expire.
+
+**What happens to my top-up credits if I cancel my subscription?**
+You keep them. They don't expire when your subscription ends.
+
+**Can I get a refund on a credit pack?**
+Within 14 days of purchase, yes, if the credits are unused. After that,
+case-by-case via support.
+
+**Why did that AI image cost 5 credits and a word suggestion only 1?**
+Different features cost different amounts of compute and OpenAI tokens
+behind the scenes. Generating a full image is more expensive than suggesting
+a single word, so we pass that through.
+
+**If an AI image fails to generate, do I lose the credits?**
+No — the system automatically refunds credits for any failed AI call.
+
+**How do I see where my credits are going?**
+Account → Billing → Transaction History. Every grant, spend, and refund is
+listed there.
+
+---
+
+## 9. Rollout timeline (phased)
+
+| Phase | What ships | User-visible? |
+|---|---|---|
+| **1** ✅ | Backend ledger, service, shadow mode telemetry | No |
+| **2** ✅ backend | Top-up Checkout endpoint + webhook handler. Frontend "Buy credits" UI still needed. | Yes (additive) once UI lands |
+| **3** ✅ | AI gating switched from Redis counter → credit balance. AI endpoints now return `402 insufficient_credits` when balance is too low. | **Yes — user-visible** the first time a user hits zero credits. Surface the upsell modal! |
+| **4** | Plan grants on invoice renewal webhook | No (internal) |
+| **5** | Optional: Stripe metered overage | Decision pending |
+
+---
+
+## 10. Open decisions for marketing / leadership
+
+- [ ] Final dollar prices for the three top-up packs
+- [ ] Final per-tier monthly credit amounts (the §2 table above is a draft)
+- [ ] Do top-up credits expire after 12 months, or never?
+- [ ] Launch promo? (e.g. "First top-up: double credits")
+- [ ] Should Pro users get a "soft overage" (auto-bill) instead of a hard
+  block, or is the same buy-a-pack flow fine?
+- [ ] Mobile (RevenueCat) top-up SKUs — Apple/Google's IAP cuts will affect
+  these prices. Out of scope for v1.
+- [ ] In-app messaging when a heavy power user hits zero mid-session — copy
+  + frequency cap.
+
+---
+
+**Engineering contact:** see `app/services/credit_service.rb` for the
+authoritative cost table and `README.md` → "AI credits" for the technical
+overview. The credit ledger is `credit_transactions`; balances are denormalized
+onto `users` for fast reads.

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -51,7 +51,7 @@ There's already a Stripe webhook configured at `/api/webhooks` that uses
 - `customer.subscription.deleted`
 - `customer.subscription.paused`
 - `customer.created`
-- `invoice.payment_succeeded` *(Phase 4 — for plan-credit renewal grants)*
+- `invoice.payment_succeeded` *(triggers plan-credit grants on first paid period and every renewal — Phase 4)*
 
 ## 4. Verifying
 

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -1,0 +1,64 @@
+# Stripe setup — AI credits
+
+Every environment (test, live) needs these Stripe objects configured the
+same way. The webhook and `CreditService` read metadata from Stripe — there
+are no hard-coded plan or pack values in the app.
+
+## 1. Subscription Prices (existing tiers)
+
+For each tier — Free, MySpeak, Basic, Pro, Partner Pro — open the Price in
+the Stripe Dashboard and set its **metadata**:
+
+| Key | Value | Notes |
+|---|---|---|
+| `plan_type` | `free` / `myspeak` / `basic` / `pro` / `partner_pro` | Webhook reads this to set `users.plan_type` |
+| `monthly_credits` | integer | Number of AI credits granted each billing period; overrides `CreditService::PLAN_MONTHLY_CREDITS` |
+
+Existing env vars stay as they are (`STRIPE_PRICE_MYSPEAK`,
+`STRIPE_PRICE_BASIC`, `STRIPE_PRICE_PRO`, yearly variants, partner pro).
+
+## 2. Top-up credit pack Products (new)
+
+Create three **one-time** Products in Stripe:
+
+| Product name | Price | Price metadata |
+|---|---|---|
+| Credit Pack — Small | $4.99 USD | `kind: topup`, `credit_amount: 100` |
+| Credit Pack — Medium | $19.99 USD | `kind: topup`, `credit_amount: 500` |
+| Credit Pack — Large | $49.99 USD | `kind: topup`, `credit_amount: 1500` |
+
+Each Price must be `type: one_time` (not recurring).
+
+Then set env vars to the resulting Price IDs:
+
+```
+STRIPE_PRICE_TOPUP_SMALL=price_...
+STRIPE_PRICE_TOPUP_MEDIUM=price_...
+STRIPE_PRICE_TOPUP_LARGE=price_...
+```
+
+> Final dollar prices and credit amounts are a marketing call —
+> see `docs/credits-handoff.md` §3. The table above is the working proposal.
+
+## 3. Webhook endpoint
+
+There's already a Stripe webhook configured at `/api/webhooks` that uses
+`STRIPE_WEBHOOK_SECRET`. The following events must be enabled:
+
+- `checkout.session.completed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `customer.subscription.paused`
+- `customer.created`
+- `invoice.payment_succeeded` *(Phase 4 — for plan-credit renewal grants)*
+
+## 4. Verifying
+
+```bash
+stripe listen --forward-to localhost:4000/api/webhooks
+stripe trigger checkout.session.completed --add checkout_session:metadata.kind=topup
+```
+
+Then check that a `credit_transactions` row was written with the matching
+`stripe_event_id` and that `users.topup_credits_balance` increased.

--- a/lib/tasks/credits.rake
+++ b/lib/tasks/credits.rake
@@ -1,0 +1,41 @@
+namespace :credits do
+  desc "Backfill an initial plan credit grant for every user based on their plan_type"
+  task backfill: :environment do
+    granted = 0
+    skipped = 0
+    User.find_each do |user|
+      next skipped += 1 if CreditTransaction.where(user_id: user.id, kind: "plan_grant").exists?
+
+      plan_type = user.plan_type.presence || "free"
+      amount = CreditService.monthly_credits_for(plan_type)
+      period_end = user.plan_expires_at.presence || 30.days.from_now
+
+      CreditService.grant_plan!(
+        user,
+        amount: amount,
+        period_end: period_end,
+        metadata: { reason: "phase1_backfill", plan_type: plan_type },
+      )
+      granted += 1
+      print "." if granted % 100 == 0
+    end
+    puts "\nBackfill complete. granted=#{granted} skipped=#{skipped}"
+  end
+
+  desc "Recompute denormalized balances from the credit_transactions ledger"
+  task recompute_balances: :environment do
+    fixed = 0
+    User.find_each do |user|
+      plan = user.credit_transactions.where(source: "plan").sum(:amount)
+      topup = user.credit_transactions.where(source: "topup").sum(:amount)
+      if user.plan_credits_balance != plan || user.topup_credits_balance != topup
+        user.update_columns(
+          plan_credits_balance: [plan, 0].max,
+          topup_credits_balance: [topup, 0].max,
+        )
+        fixed += 1
+      end
+    end
+    puts "Balances recomputed. fixed=#{fixed}"
+  end
+end

--- a/spec/controllers/api/menus_controller_spec.rb
+++ b/spec/controllers/api/menus_controller_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe API::MenusController, type: :controller do
     # end
   end
   describe "POST #create" do
+    before { CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now) }
+
     it "creates a new menu" do
       post :create, params: { menu: { name: "New Menu", description: "Test Description" } }, as: :json
       expect(response).to have_http_status(:created)

--- a/spec/models/credit_transaction_spec.rb
+++ b/spec/models/credit_transaction_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe CreditTransaction, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
+  it "validates kind inclusion" do
+    t = described_class.new(user: user, amount: 1, kind: "bogus", source: "plan")
+    expect(t).not_to be_valid
+    expect(t.errors[:kind]).to be_present
+  end
+
+  it "validates source inclusion" do
+    t = described_class.new(user: user, amount: 1, kind: "plan_grant", source: "wallet")
+    expect(t).not_to be_valid
+    expect(t.errors[:source]).to be_present
+  end
+
+  it "enforces unique stripe_event_id when present" do
+    described_class.create!(user: user, amount: 5, kind: "topup_purchase", source: "topup", stripe_event_id: "evt_unique")
+    dup = described_class.new(user: user, amount: 5, kind: "topup_purchase", source: "topup", stripe_event_id: "evt_unique")
+    expect(dup).not_to be_valid
+  end
+
+  it "allows multiple rows with no stripe_event_id" do
+    described_class.create!(user: user, amount: -1, kind: "spend", source: "plan", feature_key: "word_suggestion")
+    second = described_class.new(user: user, amount: -1, kind: "spend", source: "plan", feature_key: "word_suggestion")
+    expect(second).to be_valid
+  end
+
+  describe "scopes" do
+    before do
+      described_class.create!(user: user, amount: 100, kind: "plan_grant", source: "plan", expires_at: 30.days.from_now)
+      described_class.create!(user: user, amount: 50, kind: "topup_purchase", source: "topup")
+      described_class.create!(user: user, amount: -3, kind: "spend", source: "plan", feature_key: "image_edit")
+    end
+
+    it "spends returns only spend rows" do
+      expect(described_class.spends.count).to eq(1)
+    end
+
+    it "grants returns positive non-spend rows" do
+      expect(described_class.grants.count).to eq(2)
+    end
+
+    it "plan/topup scope by source" do
+      expect(described_class.plan.count).to eq(2)
+      expect(described_class.topup.count).to eq(1)
+    end
+  end
+end

--- a/spec/requests/api/board_images_rate_limit_spec.rb
+++ b/spec/requests/api/board_images_rate_limit_spec.rb
@@ -1,111 +1,69 @@
 # spec/requests/api/board_images_rate_limit_spec.rb
+#
+# Phase 3 of usage-based pricing replaced the Redis monthly counter with the
+# credit ledger for AI gating, so these endpoints no longer return 429 when
+# limited — they return 402 insufficient_credits. The spec used to assert
+# 429 on the 6th call; it now asserts 402 the moment the credit balance
+# drops below the per-call cost.
+#
+# The broader 402 + spend-weight behavior across all AI endpoints lives in
+# spec/requests/api/credit_enforcement_spec.rb. This file is kept for the
+# board-image-specific edit/variation endpoints + missing-image edge case.
+
 require "rails_helper"
 
-RSpec.describe "BoardImages rate limiting", type: :request do
-  include ActiveSupport::Testing::TimeHelpers
-
-  
-
-  # Minimal JSON helper
+RSpec.describe "BoardImages AI gating (credits)", type: :request do
   def j
     JSON.parse(response.body) rescue {}
   end
 
-  before(:all) do
-    # Ensure Redis.current exists and points to a test DB
-    unless Redis.respond_to?(:current)
-      class << Redis; attr_accessor :current; end
-    end
-    Redis.current ||= Redis.new(
-      url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") # use a test DB
-    )
-  end
-
   before do
-    # clean slate rate-limit keys for the test DB
-    Redis.current.flushdb
-
     allow_any_instance_of(API::ApplicationController)
       .to receive(:authenticate_token!).and_return(true)
     allow_any_instance_of(API::ApplicationController)
       .to receive(:current_user).and_return(user)
   end
 
-  after { travel_back }
-
-  let!(:user)        { create(:user).tap { |u| u.update_column(:plan_type, "free") } }
+  let!(:user)        { create(:user) }
   let!(:board)       { create(:board, user: user) }
   let!(:image)       { create(:image, user: user) }
   let!(:board_image) { create(:board_image, board: board, image: image) }
 
-  describe "POST /api/board_images/:id/create_image_edit" do
-    it "returns 429 on the 6th call (limit 5/day), without any stubs" do
-      # we don't assert specific success payloads for the first 5 calls;
-      # we only require that the limiter does NOT return 429 before the 6th.
-      statuses = []
+  describe "POST /api/board_images/:id/create_edit" do
+    it "returns 402 insufficient_credits when balance is below image_edit cost (3)" do
+      post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
+      expect(response.status).to eq(402)
+      expect(j["error"]).to eq("insufficient_credits")
+      expect(j["feature"]).to eq("image_edit")
+      expect(j["needed"]).to eq(3)
+    end
 
-      puts "Starting test: making 6 requests to create_image_edit: BoardImage ID #{board_image.id}, User ID #{user.id}"
+    it "succeeds while credits are available, then blocks once exhausted" do
+      CreditService.grant_plan!(user, amount: 9, period_end: 30.days.from_now)
 
-      5.times do
-        post "/api/board_images/#{board_image.id}/create_edit",
-             params: { prompt: "any" }
-        statuses << response.status
-        puts "Request #{statuses.size}: response status #{response.status}"
-        expect(response.status).not_to eq(429), "unexpected 429 before limit"
+      3.times do
+        post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
+        expect(response.status).not_to eq(402)
       end
 
-      # 6th should be blocked by the limiter
-      post "/api/board_images/#{board_image.id}/create_edit",
-           params: { prompt: "any" }
-      expect(response.status).to eq(429)
-      expect(j["error"]).to eq("limit_reached")
-      expect(j["limit"]).to eq(5)
-      expect(j["used"]).to be >= 6
+      post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
+      expect(response.status).to eq(402)
+      expect(j["error"]).to eq("insufficient_credits")
     end
   end
 
-  describe "POST /api/board_images/:id/create_image_variation" do
-    it "tracks a separate counter and hits 429 after 5 calls to variations" do
-      5.times do
-        post "/api/board_images/#{board_image.id}/create_variation"
-        expect(response.status).not_to eq(429)
-      end
-
+  describe "POST /api/board_images/:id/create_variation" do
+    it "returns 402 with feature=image_variation" do
       post "/api/board_images/#{board_image.id}/create_variation"
-      expect(response.status).to eq(429)
-      expect(j["error"]).to eq("limit_reached")
-    end
-  end
-
-  describe "monthly reset behavior" do
-    it "resets at the start of a new month (integration-level check)" do
-      # Use future dates so Redis expireat timestamps stay ahead of wall-clock time.
-      # Traveling to the past causes expireat to receive a past timestamp, which
-      # Redis treats as immediate expiry — making every increment reset to 1.
-      travel_to Time.utc(2027, 6, 30, 20, 0, 0) do
-        5.times do
-          post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
-          expect(response.status).not_to eq(429)
-        end
-        post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
-        expect(response.status).to eq(429)
-      end
-
-      # Move into a new month — the limiter generates a new Redis key, so counter resets
-      travel_to Time.utc(2027, 7, 1, 8, 0, 0) do
-        post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
-        expect(response.status).not_to eq(429)
-      end
+      expect(response.status).to eq(402)
+      expect(j["feature"]).to eq("image_variation")
+      expect(j["needed"]).to eq(3)
     end
   end
 
   context "when the board image is missing" do
-    it "returns 422 and not 429 (ensuring the limiter runs first)" do
-      5.times do
-        post "/api/board_images/999999/create_image_edit", params: { prompt: "x" }
-        # Either 422 (not found) or 404 depending on your find logic; importantly, not 429
-        expect([422, 404]).to include(response.status)
-      end
+    it "returns 404/422 (not 402) — auth/find layer runs before credit gating" do
+      CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
       post "/api/board_images/999999/create_image_edit", params: { prompt: "x" }
       expect([422, 404]).to include(response.status)
     end

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# Verifies Phase 3 enforcement: AI endpoints spend credits via CreditService
+# and return 402 insufficient_credits when the balance is too low. Each AI
+# endpoint is covered, plus the shape of the 402 body and admin bypass.
+RSpec.describe "Credit enforcement on AI endpoints", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  def auth
+    auth_headers(user)
+  end
+
+  describe "402 body shape" do
+    it "includes feature, needed, balance, plan_credits, topup_credits, topup_url" do
+      post "/api/scenarios", params: { scenario: { name: "x" } }, headers: auth
+      expect(response).to have_http_status(402)
+      body = JSON.parse(response.body)
+      expect(body).to include(
+        "error" => "insufficient_credits",
+        "feature" => "scenario_create",
+        "needed" => 10,
+        "balance" => 0,
+        "plan_credits" => 0,
+        "topup_credits" => 0,
+        "topup_url" => "/account/billing/topup",
+      )
+      expect(body["message"]).to match(/scenario/i)
+    end
+  end
+
+  describe "spending the configured weight per feature" do
+    before { CreditService.grant_plan!(user, amount: 1000, period_end: 30.days.from_now) }
+
+    it "image_generation costs 5" do
+      expect {
+        post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
+      }.to change { user.reload.plan_credits_balance }.by(-5)
+    end
+
+    it "word_suggestion costs 1" do
+      # Stub the OpenAI call so the action doesn't actually hit the network
+      allow_any_instance_of(Board).to receive(:get_word_suggestions).and_return(["red", "blue"])
+      expect {
+        get "/api/boards/words", params: { name: "school", num_of_words: 10 }, headers: auth
+      }.to change { user.reload.plan_credits_balance }.by(-1)
+    end
+
+    it "scenario_create costs 10" do
+      expect {
+        post "/api/scenarios", params: { scenario: { name: "morning routine" } }, headers: auth
+      }.to change { user.reload.plan_credits_balance }.by(-10)
+    end
+  end
+
+  describe "admin bypass" do
+    let(:admin) { FactoryBot.create(:admin_user) }
+
+    it "lets admins call AI endpoints with zero credits" do
+      expect(admin.plan_credits_balance).to eq(0)
+      post "/api/scenarios",
+           params: { scenario: { name: "morning routine" } },
+           headers: auth_headers(admin)
+      expect(response).not_to have_http_status(402)
+      expect(admin.reload.plan_credits_balance).to eq(0) # not charged
+    end
+  end
+
+  describe "drains plan credits before top-up" do
+    before do
+      CreditService.grant_plan!(user, amount: 3, period_end: 30.days.from_now)
+      CreditService.grant_topup!(user, amount: 100, stripe_event_id: "evt_seed")
+    end
+
+    it "uses plan balance first for an image_generation call" do
+      post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
+      user.reload
+      # cost 5 — plan had 3, topup absorbs 2
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.topup_credits_balance).to eq(98)
+    end
+  end
+end

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    ENV["STRIPE_PRICE_TOPUP_SMALL"] = "price_topup_small"
+    ENV["STRIPE_PRICE_TOPUP_MEDIUM"] = "price_topup_medium"
+    ENV["STRIPE_PRICE_TOPUP_LARGE"] = "price_topup_large"
+  end
+
+  it "creates a one-time Checkout Session with topup metadata and returns its url" do
+    user.update!(stripe_customer_id: "cus_existing")
+
+    captured = nil
+    expect(Stripe::Checkout::Session).to receive(:create) do |params|
+      captured = params
+      OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_test_topup_small")
+    end
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["url"]).to match(%r{checkout\.stripe\.com})
+
+    expect(captured[:mode]).to eq("payment")
+    expect(captured[:customer]).to eq("cus_existing")
+    expect(captured[:line_items]).to eq([{ price: "price_topup_small", quantity: 1 }])
+    expect(captured[:metadata][:kind]).to eq("topup")
+    expect(captured[:metadata][:pack_key]).to eq("small")
+    expect(captured[:metadata][:credit_amount]).to eq(100)
+    expect(captured[:metadata][:user_id]).to eq(user.id)
+  end
+
+  it "scales credit_amount by quantity" do
+    user.update!(stripe_customer_id: "cus_q")
+
+    captured = nil
+    allow(Stripe::Checkout::Session).to receive(:create) do |params|
+      captured = params
+      OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_test_q")
+    end
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "medium", quantity: 3 },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(captured[:line_items].first[:quantity]).to eq(3)
+    expect(captured[:metadata][:credit_amount]).to eq(1500) # 500 * 3
+  end
+
+  it "creates a stripe customer if the user does not have one yet" do
+    expect(user.stripe_customer_id).to be_blank
+    expect(Stripe::Customer).to receive(:create).with(email: user.email).and_return(OpenStruct.new(id: "cus_new"))
+    expect(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://example/cs"))
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "large" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.stripe_customer_id).to eq("cus_new")
+  end
+
+  it "rejects an unknown pack_key" do
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "ginormous" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(JSON.parse(response.body)["error"]).to match(/Unknown/i)
+  end
+
+  it "rejects when the configured Price ID is blank" do
+    ENV["STRIPE_PRICE_TOPUP_SMALL"] = ""
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "returns 401 when unauthenticated" do
+    post "/api/stripe/checkout_sessions/topup", params: { pack_key: "small" }
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns 400 when Stripe raises" do
+    user.update!(stripe_customer_id: "cus_existing")
+    allow(Stripe::Checkout::Session).to receive(:create).and_raise(Stripe::APIError.new("boom"))
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(JSON.parse(response.body)["error"]).to match(/Failed/i)
+  end
+end

--- a/spec/requests/api/webhooks_plan_credits_spec.rb
+++ b/spec/requests/api/webhooks_plan_credits_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+# Phase 4: plan-credit grants flow from Stripe webhooks.
+# - invoice.payment_succeeded => grant plan credits for the new billing period
+# - customer.subscription.created (status=trialing) => grant trial credits
+# - customer.subscription.deleted / .paused => expire plan credits
+RSpec.describe "POST /api/webhooks (plan credits)", type: :request do
+  include StripeHelpers
+
+  let!(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_plan_user") }
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic")
+    fake_metadata = Class.new do
+      def initialize(h) @h = h.transform_keys(&:to_s) end
+      def [](k) = @h[k.to_s]
+      def presence; @h.presence; end
+    end.new("plan_type" => plan_type, "monthly_credits" => monthly_credits.to_s)
+    OpenStruct.new(id: id, metadata: fake_metadata)
+  end
+
+  def build_subscription(status: "active", price: build_price, current_period_end: 30.days.from_now, trial_end: nil)
+    OpenStruct.new(
+      id: "sub_test_#{SecureRandom.hex(3)}",
+      customer: user.stripe_customer_id,
+      status: status,
+      current_period_end: current_period_end.to_i,
+      trial_end: trial_end&.to_i,
+      items: OpenStruct.new(data: [OpenStruct.new(price: price, quantity: 1)]),
+    )
+  end
+
+  describe "invoice.payment_succeeded" do
+    let(:subscription) { build_subscription }
+    let(:invoice) { OpenStruct.new(id: "in_test_1", subscription: subscription.id) }
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with(subscription.id).and_return(subscription)
+    end
+
+    it "grants the monthly_credits from Price metadata, idempotent on event id" do
+      event = stub_event(invoice, type: "invoice.payment_succeeded")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { user.reload.plan_credits_balance }.from(0).to(400)
+      expect(response).to have_http_status(:ok)
+
+      tx = user.credit_transactions.where(stripe_event_id: event.id).first
+      expect(tx).to be_present
+      expect(tx.kind).to eq("plan_grant")
+      expect(tx.amount).to eq(400)
+      expect(tx.expires_at).to be_within(60.seconds).of(Time.at(subscription.current_period_end))
+
+      # Replay same event — no double-credit
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change { user.reload.plan_credits_balance }
+    end
+
+    it "renewal: a fresh invoice replaces leftover plan credits from the previous period" do
+      # Existing balance from a prior period
+      CreditService.grant_plan!(user, amount: 50, period_end: 1.day.ago)
+      stub_event(invoice, type: "invoice.payment_succeeded", event_id: "evt_renewal")
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { user.reload.plan_credits_balance }.to(400)
+      # Leftover got expired and re-granted, not stacked
+      expect(user.credit_transactions.where(kind: "expire").count).to eq(1)
+    end
+
+    it "falls back to CreditService.monthly_credits_for(plan_type) when metadata is absent" do
+      price_without_credits = OpenStruct.new(id: "price_x", metadata: OpenStruct.new("[]" => ->(_) { nil }))
+      # Use a real hash-like metadata that returns nil for both keys
+      empty_meta = Class.new { def [](_) = nil }.new
+      price = OpenStruct.new(id: "price_x", metadata: empty_meta)
+      sub_no_meta = build_subscription(price: price)
+      sub_no_meta.define_singleton_method(:id) { "sub_no_meta" }
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_no_meta").and_return(sub_no_meta)
+
+      user.update!(plan_type: "pro")
+      stub_event(OpenStruct.new(id: "in_2", subscription: "sub_no_meta"), type: "invoice.payment_succeeded")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { user.reload.plan_credits_balance }.to(CreditService.monthly_credits_for("pro"))
+    end
+
+    it "skips admins" do
+      user.update!(role: "admin")
+      stub_event(invoice, type: "invoice.payment_succeeded", event_id: "evt_admin")
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change { user.reload.plan_credits_balance }
+    end
+  end
+
+  describe "customer.subscription.created (trialing)" do
+    it "grants credits with expiry = trial_end" do
+      trial_end = 14.days.from_now
+      subscription = build_subscription(status: "trialing", trial_end: trial_end)
+      stub_event(subscription, type: "customer.subscription.created", event_id: "evt_trial_1")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { user.reload.plan_credits_balance }.from(0).to(400)
+
+      tx = user.credit_transactions.where(stripe_event_id: "evt_trial_1").first
+      expect(tx.expires_at).to be_within(60.seconds).of(trial_end)
+    end
+
+    it "does NOT grant when status is active (invoice.payment_succeeded covers paid subs)" do
+      subscription = build_subscription(status: "active")
+      stub_event(subscription, type: "customer.subscription.created")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change { user.reload.plan_credits_balance }
+    end
+  end
+
+  describe "customer.subscription.deleted" do
+    it "expires plan credits and keeps top-up credits" do
+      CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      CreditService.grant_topup!(user, amount: 50, stripe_event_id: "evt_topup_seed")
+
+      subscription = build_subscription
+      stub_event(subscription, type: "customer.subscription.deleted")
+
+      post_webhook("{}", header_with_signature)
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.topup_credits_balance).to eq(50)
+      expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to be >= 1
+      # Note: plan_type may stay on "basic_trial" if the user is still in the
+      # 14-day soft trial window (see User#set_soft_trial_plan). The Phase 4
+      # contract is about credits, not plan_type — DowngradeSoftTrialJob
+      # owns that downgrade.
+    end
+  end
+
+  describe "customer.subscription.paused" do
+    it "expires plan credits and marks status=paused" do
+      CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      subscription = build_subscription(status: "paused")
+      stub_event(subscription, type: "customer.subscription.paused")
+
+      post_webhook("{}", header_with_signature)
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.plan_status).to eq("paused")
+    end
+  end
+end

--- a/spec/requests/api/webhooks_topup_spec.rb
+++ b/spec/requests/api/webhooks_topup_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/webhooks (top-up)", type: :request do
+  include StripeHelpers
+
+  let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_topup_user") }
+
+  # The webhook handler does `ENV.fetch("STRIPE_WEBHOOK_SECRET")`; we stub
+  # Stripe::Webhook.construct_event below so the actual secret doesn't matter,
+  # but ENV.fetch still needs a non-nil value to avoid raising before the stub.
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def build_topup_session(overrides = {})
+    OpenStruct.new(
+      {
+        id: "cs_test_topup_#{SecureRandom.hex(4)}",
+        customer: "cus_topup_user",
+        customer_details: OpenStruct.new(email: user.email),
+        amount_total: 499,
+        currency: "usd",
+        metadata: {
+          "kind" => "topup",
+          "user_id" => user.id.to_s,
+          "pack_key" => "small",
+          "credit_amount" => "100",
+        },
+      }.merge(overrides),
+    )
+  end
+
+  def stub_event(session_object, type: "checkout.session.completed", event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(
+      id: event_id,
+      type: type,
+      data: OpenStruct.new(object: session_object),
+    )
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  it "grants top-up credits and is idempotent on the Stripe event id" do
+    session = build_topup_session
+    event = stub_event(session)
+
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.to change { user.reload.topup_credits_balance }.from(0).to(100)
+    expect(response).to have_http_status(:ok)
+    expect(CreditTransaction.where(stripe_event_id: event.id).count).to eq(1)
+
+    # Replay the same event
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.not_to change { user.reload.topup_credits_balance }
+    expect(CreditTransaction.where(stripe_event_id: event.id).count).to eq(1)
+  end
+
+  it "uses metadata.credit_amount even when the price metadata is absent" do
+    session = build_topup_session(metadata: {
+      "kind" => "topup",
+      "user_id" => user.id.to_s,
+      "credit_amount" => "750",
+    })
+    stub_event(session)
+
+    expect(Stripe::Checkout::Session).not_to receive(:retrieve)
+
+    post_webhook("{}", header_with_signature)
+    expect(user.reload.topup_credits_balance).to eq(750)
+  end
+
+  it "falls back to retrieving line_items when credit_amount is missing from metadata" do
+    session = build_topup_session(metadata: { "kind" => "topup", "user_id" => user.id.to_s })
+    stub_event(session)
+
+    fake_price_metadata = Class.new do
+      def [](k) = { "credit_amount" => "500" }[k]
+    end.new
+    expanded = OpenStruct.new(
+      line_items: OpenStruct.new(
+        data: [
+          OpenStruct.new(
+            quantity: 2,
+            price: OpenStruct.new(metadata: fake_price_metadata, id: "price_topup_medium"),
+          ),
+        ],
+      ),
+    )
+    expect(Stripe::Checkout::Session).to receive(:retrieve).and_return(expanded)
+
+    post_webhook("{}", header_with_signature)
+    expect(user.reload.topup_credits_balance).to eq(1000) # 500 * 2
+  end
+
+  it "logs an error and reports topup_not_credited when no user can be found" do
+    session = OpenStruct.new(
+      id: "cs_topup_nouser",
+      customer: "cus_unknown",
+      customer_details: OpenStruct.new(email: "nobody@example.com"),
+      metadata: { "kind" => "topup", "credit_amount" => "100" },
+    )
+    stub_event(session)
+
+    post_webhook("{}", header_with_signature)
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["error"]).to eq("topup_not_credited")
+  end
+
+  it "does not affect the existing subscription checkout flow" do
+    session = OpenStruct.new(
+      id: "cs_sub_normal",
+      customer: "cus_topup_user",
+      subscription: "sub_abc",
+      customer_details: OpenStruct.new(email: user.email),
+      metadata: { "user_id" => user.id.to_s }, # no `kind` key
+    )
+    stub_event(session)
+
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.not_to change { user.reload.topup_credits_balance }
+    expect(user.reload.stripe_subscription_id).to eq("sub_abc")
+  end
+end

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -1,0 +1,197 @@
+require "rails_helper"
+
+RSpec.describe CreditService, type: :service do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe ".cost_for" do
+    it "returns the configured weight for a known feature" do
+      expect(described_class.cost_for("image_generation")).to eq(5)
+      expect(described_class.cost_for(:word_suggestion)).to eq(1)
+      expect(described_class.cost_for("menu_create")).to eq(10)
+    end
+
+    it "defaults to 1 for unknown features" do
+      expect(described_class.cost_for("not_a_feature")).to eq(1)
+    end
+  end
+
+  describe ".monthly_credits_for" do
+    it "returns the configured allowance per plan" do
+      expect(described_class.monthly_credits_for("free")).to eq(10)
+      expect(described_class.monthly_credits_for("basic")).to eq(400)
+      expect(described_class.monthly_credits_for("pro")).to eq(1500)
+    end
+
+    it "falls back to free for unknown plan" do
+      expect(described_class.monthly_credits_for("nope")).to eq(described_class::PLAN_MONTHLY_CREDITS["free"])
+    end
+  end
+
+  describe ".grant_plan!" do
+    it "sets plan_credits_balance and writes a plan_grant row" do
+      period_end = 30.days.from_now
+      described_class.grant_plan!(user, amount: 100, period_end: period_end)
+      user.reload
+      expect(user.plan_credits_balance).to eq(100)
+      expect(user.plan_credits_reset_at).to be_within(2.seconds).of(period_end)
+      tx = user.credit_transactions.last
+      expect(tx.kind).to eq("plan_grant")
+      expect(tx.amount).to eq(100)
+      expect(tx.source).to eq("plan")
+      expect(tx.expires_at).to be_within(2.seconds).of(period_end)
+    end
+
+    it "is idempotent on stripe_event_id" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now, stripe_event_id: "evt_1")
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now, stripe_event_id: "evt_1")
+      user.reload
+      expect(user.plan_credits_balance).to eq(100)
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+    end
+
+    it "expires leftover plan credits before granting" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      described_class.grant_plan!(user, amount: 200, period_end: 30.days.from_now)
+      user.reload
+      expect(user.plan_credits_balance).to eq(200)
+      expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to eq(1)
+    end
+  end
+
+  describe ".grant_topup!" do
+    it "adds to topup balance and writes a topup_purchase row" do
+      described_class.grant_topup!(user, amount: 500, stripe_event_id: "evt_topup_1")
+      user.reload
+      expect(user.topup_credits_balance).to eq(500)
+      tx = user.credit_transactions.last
+      expect(tx.kind).to eq("topup_purchase")
+      expect(tx.source).to eq("topup")
+      expect(tx.amount).to eq(500)
+    end
+
+    it "stacks additive purchases" do
+      described_class.grant_topup!(user, amount: 100, stripe_event_id: "evt_a")
+      described_class.grant_topup!(user, amount: 250, stripe_event_id: "evt_b")
+      user.reload
+      expect(user.topup_credits_balance).to eq(350)
+    end
+
+    it "is idempotent on stripe_event_id" do
+      described_class.grant_topup!(user, amount: 100, stripe_event_id: "evt_dup")
+      described_class.grant_topup!(user, amount: 100, stripe_event_id: "evt_dup")
+      user.reload
+      expect(user.topup_credits_balance).to eq(100)
+    end
+  end
+
+  describe ".spend!" do
+    before do
+      described_class.grant_plan!(user, amount: 10, period_end: 30.days.from_now)
+    end
+
+    it "drains plan credits first" do
+      described_class.grant_topup!(user, amount: 50, stripe_event_id: "t1")
+      described_class.spend!(user, feature_key: "image_generation") # cost 5
+      user.reload
+      expect(user.plan_credits_balance).to eq(5)
+      expect(user.topup_credits_balance).to eq(50)
+      tx = user.credit_transactions.spends.last
+      expect(tx.feature_key).to eq("image_generation")
+      expect(tx.amount).to eq(-5)
+    end
+
+    it "spills into topup when plan is insufficient" do
+      described_class.grant_topup!(user, amount: 50, stripe_event_id: "t2")
+      described_class.spend!(user, feature_key: "menu_create") # cost 10, plan has 10
+      described_class.spend!(user, feature_key: "menu_create") # cost 10, must come from topup
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.topup_credits_balance).to eq(40)
+    end
+
+    it "raises InsufficientCredits when total balance < cost" do
+      # plan=10, topup=0, try to spend 11
+      expect {
+        described_class.spend!(user, feature_key: "image_generation", amount: 11)
+      }.to raise_error(CreditService::InsufficientCredits) do |e|
+        expect(e.needed).to eq(11)
+        expect(e.balance).to eq(10)
+        expect(e.feature_key).to eq("image_generation")
+      end
+      user.reload
+      expect(user.plan_credits_balance).to eq(10) # untouched
+    end
+
+    it "accepts explicit amount override" do
+      described_class.spend!(user, feature_key: "image_generation", amount: 3)
+      user.reload
+      expect(user.plan_credits_balance).to eq(7)
+    end
+
+    it "rejects non-positive amounts" do
+      expect {
+        described_class.spend!(user, feature_key: "image_generation", amount: 0)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe ".expire_plan_credits!" do
+    it "zeros the plan balance and writes an expire row" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      described_class.expire_plan_credits!(user)
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.credit_transactions.where(kind: "expire").count).to eq(1)
+    end
+
+    it "is a no-op when balance is already zero" do
+      result = described_class.expire_plan_credits!(user)
+      expect(result).to be_nil
+      expect(user.credit_transactions.where(kind: "expire").count).to eq(0)
+    end
+
+    it "does not touch topup balance" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      described_class.grant_topup!(user, amount: 50, stripe_event_id: "t3")
+      described_class.expire_plan_credits!(user)
+      user.reload
+      expect(user.topup_credits_balance).to eq(50)
+    end
+  end
+
+  describe ".refund!" do
+    it "returns credits to the named source" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+      described_class.spend!(user, feature_key: "image_generation", amount: 5)
+      described_class.refund!(user, amount: 5, feature_key: "image_generation", source: "plan")
+      user.reload
+      expect(user.plan_credits_balance).to eq(100)
+    end
+  end
+
+  describe ".balance" do
+    it "returns plan, topup, total, reset_at" do
+      described_class.grant_plan!(user, amount: 10, period_end: 30.days.from_now)
+      described_class.grant_topup!(user, amount: 5, stripe_event_id: "evt_b")
+      user.reload
+      b = described_class.balance(user)
+      expect(b[:plan]).to eq(10)
+      expect(b[:topup]).to eq(5)
+      expect(b[:total]).to eq(15)
+      expect(b[:reset_at]).to be_present
+    end
+  end
+
+  describe ".shadow_spend" do
+    it "returns true and decrements when there are enough credits" do
+      described_class.grant_plan!(user, amount: 10, period_end: 30.days.from_now)
+      expect(described_class.shadow_spend(user, feature_key: "word_suggestion")).to be true
+      user.reload
+      expect(user.plan_credits_balance).to eq(9)
+    end
+
+    it "returns false but does not raise when balance is insufficient" do
+      expect(described_class.shadow_spend(user, feature_key: "image_generation")).to be false
+    end
+  end
+end

--- a/spec/sidekiq/expire_plan_credits_job_spec.rb
+++ b/spec/sidekiq/expire_plan_credits_job_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe ExpirePlanCreditsJob, type: :sidekiq do
+  describe "#perform" do
+    it "zeros plan credits whose reset_at has passed" do
+      user = FactoryBot.create(:user)
+      CreditService.grant_plan!(user, amount: 100, period_end: 1.day.ago)
+      expect(user.reload.plan_credits_balance).to eq(100)
+
+      described_class.new.perform
+
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.credit_transactions.where(kind: "expire").count).to eq(1)
+    end
+
+    it "leaves users whose reset_at is in the future alone" do
+      user = FactoryBot.create(:user)
+      CreditService.grant_plan!(user, amount: 100, period_end: 1.day.from_now)
+
+      expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
+    end
+
+    it "leaves top-up credits untouched" do
+      user = FactoryBot.create(:user)
+      CreditService.grant_plan!(user, amount: 50, period_end: 1.day.ago)
+      CreditService.grant_topup!(user, amount: 100, stripe_event_id: "evt_topup_keep")
+
+      described_class.new.perform
+      user.reload
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.topup_credits_balance).to eq(100)
+    end
+
+    it "is a no-op for users with zero plan balance even if reset_at has passed" do
+      user = FactoryBot.create(:user)
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.day.ago)
+
+      expect { described_class.new.perform }.not_to change { CreditTransaction.count }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Replaces the flat "5/100/300 AI actions per month" cap with a **weighted credit system** for AI features. Each AI feature charges credits proportional to its real cost (image gen = 5, scenario = 10, word suggestion = 1, …). Users get a monthly credit allowance from their subscription, and can buy ad-hoc credit packs at any time. Bundles four staging PRs into one main release:

- [#76](https://github.com/brittanyjohns/itty_bitty_boards/pull/76) Phase 1 — credit ledger + `CreditService`
- [#85](https://github.com/brittanyjohns/itty_bitty_boards/pull/85) Phase 2 — top-up Checkout endpoint + webhook
- [#89](https://github.com/brittanyjohns/itty_bitty_boards/pull/89) Phase 3 — switch AI gating to credits (`402`)
- [#90](https://github.com/brittanyjohns/itty_bitty_boards/pull/90) Phase 4 — renewal grants via webhooks + auto-expire

## What users see

- AI endpoints that previously returned **`429 limit_reached`** when over their monthly cap now return **`402 insufficient_credits`** with a structured body (`feature`, `needed`, `balance`, `plan_credits`, `topup_credits`, `reset_at`, `topup_url`). The frontend can drive a "Buy credits / Upgrade" modal from those fields.
- A new **Buy Credits** flow is available at `POST /api/stripe/checkout_sessions/topup` (one-time payment Checkout). UI hookup is still TODO in the frontend repo.
- Admins always bypass credit gating.

## Schema changes

New migrations:

- `db/migrate/20260512120000_create_credit_transactions.rb` — immutable ledger table with unique index on `stripe_event_id` for webhook idempotency.
- `db/migrate/20260512120001_add_credit_balances_to_users.rb` — adds `plan_credits_balance`, `topup_credits_balance`, `plan_credits_reset_at` to `users`.

Run `bin/rails db:migrate` after deploy.

## New API surface

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/me/credits` | `{ plan, topup, total, reset_at, plan_type }` |
| `GET` | `/api/me/credit_transactions` | Paginated ledger |
| `POST` | `/api/stripe/checkout_sessions/topup` | One-time credit-pack Checkout. Body: `{ pack_key: "small"|"medium"|"large", quantity?: 1 }` |

## Stripe webhook events newly handled

Make sure these are enabled on the production webhook endpoint (`/api/webhooks`) before merging:

- `checkout.session.completed` — already handled; now also branches on `metadata.kind == "topup"` to grant top-up credits
- `invoice.payment_succeeded` — **new**; grants plan credits on first paid period and every renewal
- `customer.subscription.created` (status `trialing`) — **new behavior**; grants trial credits with `expires_at = trial_end`
- `customer.subscription.deleted` / `.paused` — now also expires plan credits (top-ups preserved)

Stripe Price metadata required (per `docs/stripe-setup.md`):

- Subscription Prices: `plan_type` + `monthly_credits`
- Top-up Prices: `kind: "topup"` + `credit_amount`

## New env vars (production)

```
STRIPE_PRICE_TOPUP_SMALL=price_...
STRIPE_PRICE_TOPUP_MEDIUM=price_...
STRIPE_PRICE_TOPUP_LARGE=price_...
```

## New Sidekiq cron

`ExpirePlanCreditsJob` runs hourly as a backstop — zeroes plan credits whose `plan_credits_reset_at` has passed when a webhook was missed. Registered in `config/initializers/sidekiq.rb`.

## Rake tasks for migration

- `bin/rails credits:backfill` — gives every existing user an initial plan-credit grant based on their `plan_type`. Idempotent (skips users that already have a `plan_grant` row).
- `bin/rails credits:recompute_balances` — rebuilds `plan_credits_balance` / `topup_credits_balance` from the `credit_transactions` ledger. Safe to run any time if balances drift.

**Recommended deploy order:**
1. Merge this PR (deploys via Hatchbox).
2. Run `bin/rails credits:backfill` once on production to grant existing users their initial allowance.
3. Configure the Stripe Prices + webhook events listed above.
4. Watch logs for `[StripeWebhook][topup]`, `[StripeWebhook][invoice]`, `[ExpirePlanCreditsJob]` entries to confirm the pipeline.

## Notable bonus fix

`apply_free_plan` in the webhook controller referenced `FREE_PLAN_LIMITS` unqualified — it raised `NameError` silently swallowed by the surrounding `rescue`, so **subscription cancellations have been a no-op in production for some time**. Phase 4 (#90) fixed this; now correctly resolves `User::FREE_PLAN_LIMITS` and downgrades work.

## Per-feature credit costs

Server-authoritative in `CreditService::FEATURE_COSTS`:

| feature_key | cost |
|---|---|
| `word_suggestion` | 1 |
| `board_format` | 2 |
| `image_edit` | 3 |
| `image_variation` | 3 |
| `image_generation` | 5 |
| `screenshot_import` | 5 |
| `scenario_create` | 10 |
| `menu_create` | 10 |

## Plan credit allowances (defaults)

Defined in `CreditService::PLAN_MONTHLY_CREDITS`; overridden per-environment by `monthly_credits` Stripe Price metadata:

| Plan | Monthly credits |
|---|---|
| Free | 10 |
| MySpeak | 50 |
| Basic | 400 |
| Pro / Premium / Partner Pro / Vendor | 1,500 |

## Test plan

- [x] **Full suite green:** `311 examples, 0 failures, 18 pending` — see CI checks above (rspec + Brakeman + Bundler audit all SUCCESS).
- [x] New specs cover: ledger model, `CreditService` (spend order, idempotency, refund, expiry), top-up Checkout endpoint, webhook idempotency, invoice grant, trial grant, cancellation/pause expiry, hourly `ExpirePlanCreditsJob`, 402 body shape across all 10 AI endpoints, admin bypass.
- [ ] After merge: run `bin/rails credits:backfill` on production.
- [ ] After merge: verify Stripe Prices have the required metadata (subscriptions: `monthly_credits`, `plan_type`; top-ups: `kind`, `credit_amount`).
- [ ] After merge: enable `invoice.payment_succeeded` on the production webhook endpoint.
- [ ] After merge: in Stripe CLI, `stripe trigger invoice.payment_succeeded` against staging and confirm a `credit_transactions` row + `plan_credits_balance` increase.

## What's NOT in this PR

- **Frontend changes** — the "Buy credits" picker, the `402 insufficient_credits` upsell modal, and the credits widget for the account header all live in `itty-bitty-frontend` and are TODO. Backend is ready for them via the API endpoints + response shapes listed above. See `docs/credits-handoff.md` for the full design + marketing handoff.
- **Phase 5** (optional Stripe metered overage) — depends on real-traffic telemetry from this release.
- **RevenueCat (mobile IAP) parity** — top-ups via mobile are out of scope for v1.

## Docs updated

- `README.md` — env vars, API surface, status
- `CLAUDE.md` — credit ledger as source of truth, plan-credit lifecycle
- `CHANGELOG.md` — Phases 1–4 entries
- `docs/credits-handoff.md` — UI + marketing handoff (tiers, pack pricing, feature costs, UX flows, copy, FAQs, open decisions)
- `docs/stripe-setup.md` — Stripe dashboard checklist