### PR TITLE
feat: AI credit top-up Checkout (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Phase 2 of usage-based AI pricing
+- `POST /api/stripe/checkout_sessions/topup` — creates a one-time Stripe Checkout Session for a credit pack (`pack_key`: `small` / `medium` / `large`, optional `quantity`).
+- Stripe webhook now branches on `metadata.kind == "topup"` for `checkout.session.completed`. Top-up sessions call `CreditService.grant_topup!`, idempotent on the Stripe event id.
+- Webhook falls back to expanding `line_items.data.price.metadata.credit_amount` when the session metadata is missing — keeps the system working even if the frontend was on an older build that didn't pass `credit_amount` through.
+- New env vars: `STRIPE_PRICE_TOPUP_SMALL`, `STRIPE_PRICE_TOPUP_MEDIUM`, `STRIPE_PRICE_TOPUP_LARGE` (Stripe Price IDs for the three pack sizes).
+
 ### Added — Phase 1 of usage-based AI pricing
 - AI credit ledger (`credit_transactions` table) — immutable record of every grant, spend, expire, and refund of AI credits.
 - `users.plan_credits_balance`, `users.topup_credits_balance`, `users.plan_credits_reset_at` columns — denormalized balances and current-period end.
@@ -17,7 +23,6 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - Shadow-mode telemetry — `check_monthly_limit` in the API base controller now also runs `CreditService.shadow_spend` and logs divergences between the Redis-counter decision and the credit-ledger decision. **No user-visible change yet** — the Redis limiter remains the source of truth in Phase 1.
 
 ### Coming next
-- **Phase 2:** Ad-hoc credit top-up purchases via Stripe Checkout (one-time payment, 100 / 500 / 1500 credit packs).
 - **Phase 3:** Switch AI endpoint enforcement from the Redis monthly counter to credit balance. AI calls that exceed balance will return `402 insufficient_credits` instead of `429 limit_reached`.
 - **Phase 4:** Plan-credit grants driven by `invoice.payment_succeeded` webhook so renewals top up automatically.
 - **Phase 5 (optional):** Stripe Meter-based overage billing.

--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ See `docs/stripe-setup.md` for the full dashboard checklist.
 
 - `GET /api/me/credits` — `{ plan, topup, total, reset_at, plan_type }`
 - `GET /api/me/credit_transactions` — paginated ledger
-- `POST /api/stripe/checkout_sessions/topup` *(coming in Phase 2)* — creates a
-  one-time Checkout Session for a credit pack
+- `POST /api/stripe/checkout_sessions/topup` — creates a one-time Stripe
+  Checkout Session for a credit pack. Body: `{ pack_key: "small"|"medium"|"large", quantity: 1 }`.
+  On payment success, the webhook adds credits to `topup_credits_balance`
+  (idempotent on Stripe event id).
 
 ### Phase 1 status
 

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -15,6 +15,22 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     "partner_pro" => ENV.fetch("STRIPE_PRICE_PARTNER_PRO", nil),
   }.freeze
 
+  # Resolved at request time (not class load) so changes to ENV in deploy
+  # configs or in test setup take effect without a class-cache reset.
+  TOPUP_PRICE_ENV_KEYS = {
+    "small" => "STRIPE_PRICE_TOPUP_SMALL",
+    "medium" => "STRIPE_PRICE_TOPUP_MEDIUM",
+    "large" => "STRIPE_PRICE_TOPUP_LARGE",
+  }.freeze
+
+  # Fallback if a Stripe Price lacks `metadata.credit_amount`. Keep in sync
+  # with docs/credits-handoff.md and docs/stripe-setup.md.
+  TOPUP_CREDIT_AMOUNTS = {
+    "small" => 100,
+    "medium" => 500,
+    "large" => 1500,
+  }.freeze
+
   def create
     plan_key = params[:plan_key].to_s
     price_id = PLAN_PRICE_IDS[plan_key]
@@ -85,6 +101,51 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
   rescue StandardError => e
     Rails.logger.error "Error creating checkout session: #{e.class} - #{e.message}"
     render json: { error: "Failed to create checkout session" }, status: :bad_request
+  end
+
+  # POST /api/stripe/checkout_sessions/topup
+  # Body: { pack_key: "small"|"medium"|"large", quantity: 1 }
+  # Creates a one-time payment Checkout Session for a credit pack.
+  # On payment success the Stripe webhook (checkout.session.completed with
+  # metadata.kind=topup) calls CreditService.grant_topup! — see
+  # API::WebhooksController.
+  def topup
+    pack_key = params[:pack_key].to_s
+    env_key = TOPUP_PRICE_ENV_KEYS[pack_key]
+    price_id = env_key.present? ? ENV[env_key].presence : nil
+    quantity = [params[:quantity].to_i, 1].max
+
+    if price_id.blank?
+      render json: { error: "Unknown or unconfigured pack_key" }, status: :bad_request
+      return
+    end
+
+    ensure_customer!
+
+    credit_amount = TOPUP_CREDIT_AMOUNTS[pack_key].to_i
+
+    session = Stripe::Checkout::Session.create(
+      mode: "payment",
+      customer: current_user.stripe_customer_id,
+      line_items: [{ price: price_id, quantity: quantity }],
+      success_url: "#{frontend_base_url}/account/billing/topup/success?session_id={CHECKOUT_SESSION_ID}",
+      cancel_url: "#{frontend_base_url}/account/billing",
+      payment_method_collection: "always",
+      allow_promotion_codes: true,
+      metadata: {
+        kind: "topup",
+        user_id: current_user.id,
+        pack_key: pack_key,
+        credit_amount: credit_amount * quantity,
+      },
+    )
+    render json: { url: session.url }
+  rescue Stripe::StripeError => e
+    Rails.logger.error "[Topup] Stripe error creating topup session: #{e.class} - #{e.message}"
+    render json: { error: "Failed to create top-up session" }, status: :bad_request
+  rescue StandardError => e
+    Rails.logger.error "[Topup] Unexpected error creating topup session: #{e.class} - #{e.message}"
+    render json: { error: "Failed to create top-up session" }, status: :bad_request
   end
 
   def update_user_from_session

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -28,10 +28,16 @@ class API::WebhooksController < API::ApplicationController
     when "customer.created"
       handle_customer_created(event.data.object)
     when "checkout.session.completed"
-      user = handle_checkout_completed(event.data.object)
-      unless user
-        Rails.logger.error "[StripeWebhook] checkout.session.completed: no user found for session #{event.data.object.id}"
-        result = { error: "no_user_found" }
+      session_obj = event.data.object
+      if (session_obj.metadata || {})["kind"] == "topup"
+        handled = handle_topup_completed(session_obj, event.id)
+        result = { error: "topup_not_credited" } unless handled
+      else
+        user = handle_checkout_completed(session_obj)
+        unless user
+          Rails.logger.error "[StripeWebhook] checkout.session.completed: no user found for session #{session_obj.id}"
+          result = { error: "no_user_found" }
+        end
       end
     when "customer.subscription.created", "customer.subscription.updated"
       handle_subscription_upsert(event.data.object, event.type == "customer.subscription.created")
@@ -71,6 +77,68 @@ class API::WebhooksController < API::ApplicationController
     Rails.logger.info "[StripeWebhook] customer.created: customer #{customer.id} created"
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_customer_created error: #{e.class} - #{e.message}"
+  end
+
+  # checkout.session.completed where metadata.kind == "topup".
+  # Idempotent on the Stripe event id (unique index on credit_transactions).
+  # Returns truthy when credits were granted (or already had been on a retry).
+  def handle_topup_completed(session, event_id)
+    metadata = session.metadata || {}
+
+    user = User.find_by(id: metadata["user_id"]) if metadata["user_id"].present?
+    user ||= User.find_by(stripe_customer_id: session.customer) if session.customer.present?
+    user ||= User.find_by(email: session.customer_details&.email) if session.customer_details&.email.present?
+
+    unless user
+      Rails.logger.error "[StripeWebhook][topup] no user for session #{session.id}"
+      return false
+    end
+
+    credit_amount = metadata["credit_amount"].to_i
+    if credit_amount <= 0
+      credit_amount = derive_credit_amount_from_session(session)
+    end
+
+    if credit_amount <= 0
+      Rails.logger.error "[StripeWebhook][topup] no credit_amount derivable for session #{session.id}"
+      return false
+    end
+
+    price_id = session.try(:line_items)&.data&.first&.price&.id
+
+    CreditService.grant_topup!(
+      user,
+      amount: credit_amount,
+      stripe_event_id: event_id,
+      stripe_price_id: price_id,
+      metadata: {
+        checkout_session_id: session.id,
+        pack_key: metadata["pack_key"],
+        amount_total: session.amount_total,
+        currency: session.currency,
+      },
+    )
+    Rails.logger.info "[StripeWebhook][topup] credited user=#{user.id} amount=#{credit_amount} session=#{session.id}"
+    true
+  rescue => e
+    Rails.logger.error "[StripeWebhook][topup] error: #{e.class} - #{e.message}"
+    false
+  end
+
+  # Last-resort lookup: read the line item Price's metadata.credit_amount.
+  # Stripe's checkout.session.completed event does not include line_items by
+  # default; we retrieve them with an expand.
+  def derive_credit_amount_from_session(session)
+    expanded = Stripe::Checkout::Session.retrieve(id: session.id, expand: ["line_items.data.price"])
+    line_item = expanded.line_items&.data&.first
+    return 0 unless line_item
+
+    per_unit = line_item.price&.metadata&.[]("credit_amount").to_i
+    quantity = line_item.quantity.to_i
+    per_unit * (quantity.positive? ? quantity : 1)
+  rescue => e
+    Rails.logger.error "[StripeWebhook][topup] derive_credit_amount error: #{e.class} - #{e.message}"
+    0
   end
 
   # Expect: you pass metadata[user_id] when creating the Checkout Session.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,11 @@ Rails.application.routes.draw do
   #  API routes
   namespace :api, defaults: { format: :json } do
     namespace :stripe do
-      resources :checkout_sessions, only: :create
+      resources :checkout_sessions, only: :create do
+        collection do
+          post "topup"
+        end
+      end
       post "update_user_from_session", to: "checkout_sessions#update_user_from_session"
     end
     namespace :profiles do

--- a/docs/credits-handoff.md
+++ b/docs/credits-handoff.md
@@ -177,7 +177,7 @@ listed there.
 | Phase | What ships | User-visible? |
 |---|---|---|
 | **1** ✅ | Backend ledger, service, shadow mode telemetry | No |
-| **2** | Top-up Checkout flow + `/api/me/credits` UI | Yes (additive) |
+| **2** ✅ backend | Top-up Checkout endpoint + webhook handler. Frontend "Buy credits" UI still needed. | Yes (additive) once UI lands |
 | **3** | Switch AI gating from Redis counter → credits. `402` responses. | Yes — change of behavior |
 | **4** | Plan grants on invoice renewal webhook | No (internal) |
 | **5** | Optional: Stripe metered overage | Decision pending |

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    ENV["STRIPE_PRICE_TOPUP_SMALL"] = "price_topup_small"
+    ENV["STRIPE_PRICE_TOPUP_MEDIUM"] = "price_topup_medium"
+    ENV["STRIPE_PRICE_TOPUP_LARGE"] = "price_topup_large"
+  end
+
+  it "creates a one-time Checkout Session with topup metadata and returns its url" do
+    user.update!(stripe_customer_id: "cus_existing")
+
+    captured = nil
+    expect(Stripe::Checkout::Session).to receive(:create) do |params|
+      captured = params
+      OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_test_topup_small")
+    end
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["url"]).to match(%r{checkout\.stripe\.com})
+
+    expect(captured[:mode]).to eq("payment")
+    expect(captured[:customer]).to eq("cus_existing")
+    expect(captured[:line_items]).to eq([{ price: "price_topup_small", quantity: 1 }])
+    expect(captured[:metadata][:kind]).to eq("topup")
+    expect(captured[:metadata][:pack_key]).to eq("small")
+    expect(captured[:metadata][:credit_amount]).to eq(100)
+    expect(captured[:metadata][:user_id]).to eq(user.id)
+  end
+
+  it "scales credit_amount by quantity" do
+    user.update!(stripe_customer_id: "cus_q")
+
+    captured = nil
+    allow(Stripe::Checkout::Session).to receive(:create) do |params|
+      captured = params
+      OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_test_q")
+    end
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "medium", quantity: 3 },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(captured[:line_items].first[:quantity]).to eq(3)
+    expect(captured[:metadata][:credit_amount]).to eq(1500) # 500 * 3
+  end
+
+  it "creates a stripe customer if the user does not have one yet" do
+    expect(user.stripe_customer_id).to be_blank
+    expect(Stripe::Customer).to receive(:create).with(email: user.email).and_return(OpenStruct.new(id: "cus_new"))
+    expect(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://example/cs"))
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "large" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.stripe_customer_id).to eq("cus_new")
+  end
+
+  it "rejects an unknown pack_key" do
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "ginormous" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(JSON.parse(response.body)["error"]).to match(/Unknown/i)
+  end
+
+  it "rejects when the configured Price ID is blank" do
+    ENV["STRIPE_PRICE_TOPUP_SMALL"] = ""
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+  end
+
+  it "returns 401 when unauthenticated" do
+    post "/api/stripe/checkout_sessions/topup", params: { pack_key: "small" }
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns 400 when Stripe raises" do
+    user.update!(stripe_customer_id: "cus_existing")
+    allow(Stripe::Checkout::Session).to receive(:create).and_raise(Stripe::APIError.new("boom"))
+
+    post "/api/stripe/checkout_sessions/topup",
+         params: { pack_key: "small" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:bad_request)
+    expect(JSON.parse(response.body)["error"]).to match(/Failed/i)
+  end
+end

--- a/spec/requests/api/webhooks_topup_spec.rb
+++ b/spec/requests/api/webhooks_topup_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/webhooks (top-up)", type: :request do
+  include StripeHelpers
+
+  let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_topup_user") }
+
+  # The webhook handler does `ENV.fetch("STRIPE_WEBHOOK_SECRET")`; we stub
+  # Stripe::Webhook.construct_event below so the actual secret doesn't matter,
+  # but ENV.fetch still needs a non-nil value to avoid raising before the stub.
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def build_topup_session(overrides = {})
+    OpenStruct.new(
+      {
+        id: "cs_test_topup_#{SecureRandom.hex(4)}",
+        customer: "cus_topup_user",
+        customer_details: OpenStruct.new(email: user.email),
+        amount_total: 499,
+        currency: "usd",
+        metadata: {
+          "kind" => "topup",
+          "user_id" => user.id.to_s,
+          "pack_key" => "small",
+          "credit_amount" => "100",
+        },
+      }.merge(overrides),
+    )
+  end
+
+  def stub_event(session_object, type: "checkout.session.completed", event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(
+      id: event_id,
+      type: type,
+      data: OpenStruct.new(object: session_object),
+    )
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  it "grants top-up credits and is idempotent on the Stripe event id" do
+    session = build_topup_session
+    event = stub_event(session)
+
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.to change { user.reload.topup_credits_balance }.from(0).to(100)
+    expect(response).to have_http_status(:ok)
+    expect(CreditTransaction.where(stripe_event_id: event.id).count).to eq(1)
+
+    # Replay the same event
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.not_to change { user.reload.topup_credits_balance }
+    expect(CreditTransaction.where(stripe_event_id: event.id).count).to eq(1)
+  end
+
+  it "uses metadata.credit_amount even when the price metadata is absent" do
+    session = build_topup_session(metadata: {
+      "kind" => "topup",
+      "user_id" => user.id.to_s,
+      "credit_amount" => "750",
+    })
+    stub_event(session)
+
+    expect(Stripe::Checkout::Session).not_to receive(:retrieve)
+
+    post_webhook("{}", header_with_signature)
+    expect(user.reload.topup_credits_balance).to eq(750)
+  end
+
+  it "falls back to retrieving line_items when credit_amount is missing from metadata" do
+    session = build_topup_session(metadata: { "kind" => "topup", "user_id" => user.id.to_s })
+    stub_event(session)
+
+    fake_price_metadata = Class.new do
+      def [](k) = { "credit_amount" => "500" }[k]
+    end.new
+    expanded = OpenStruct.new(
+      line_items: OpenStruct.new(
+        data: [
+          OpenStruct.new(
+            quantity: 2,
+            price: OpenStruct.new(metadata: fake_price_metadata, id: "price_topup_medium"),
+          ),
+        ],
+      ),
+    )
+    expect(Stripe::Checkout::Session).to receive(:retrieve).and_return(expanded)
+
+    post_webhook("{}", header_with_signature)
+    expect(user.reload.topup_credits_balance).to eq(1000) # 500 * 2
+  end
+
+  it "logs an error and reports topup_not_credited when no user can be found" do
+    session = OpenStruct.new(
+      id: "cs_topup_nouser",
+      customer: "cus_unknown",
+      customer_details: OpenStruct.new(email: "nobody@example.com"),
+      metadata: { "kind" => "topup", "credit_amount" => "100" },
+    )
+    stub_event(session)
+
+    post_webhook("{}", header_with_signature)
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["error"]).to eq("topup_not_credited")
+  end
+
+  it "does not affect the existing subscription checkout flow" do
+    session = OpenStruct.new(
+      id: "cs_sub_normal",
+      customer: "cus_topup_user",
+      subscription: "sub_abc",
+      customer_details: OpenStruct.new(email: user.email),
+      metadata: { "user_id" => user.id.to_s }, # no `kind` key
+    )
+    stub_event(session)
+
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.not_to change { user.reload.topup_credits_balance }
+    expect(user.reload.stripe_subscription_id).to eq("sub_abc")
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 of the usage-based AI pricing plan. Builds on Phase 1's credit ledger ([#76](https://github.com/brittanyjohns/itty_bitty_boards/pull/76), already merged) to let users buy ad-hoc credit packs through Stripe Checkout. Purely additive — no behavior change for users who don't purchase a pack.

Supersedes [#77](https://github.com/brittanyjohns/itty_bitty_boards/pull/77), which was auto-closed when GitHub deleted Phase 1's base branch on merge.

## What's new

- **`POST /api/stripe/checkout_sessions/topup`** — creates a `mode=payment` Stripe Checkout Session. Body: `{ pack_key: "small"|"medium"|"large", quantity?: 1 }`. The pack → credit_amount mapping is server-side; clients cannot pick the credit count.
- **Webhook handler** for `checkout.session.completed` with `metadata.kind == "topup"`. Calls `CreditService.grant_topup!`, idempotent on the Stripe event id (replays don't double-credit).
- **`line_items` fallback** — if the session metadata is missing `credit_amount`, the webhook retrieves the session with `expand: ["line_items.data.price"]` and reads it from the Price metadata configured in the Stripe dashboard. Degrades gracefully if a frontend build forgets to pass it through.
- **New env vars**: `STRIPE_PRICE_TOPUP_SMALL`, `STRIPE_PRICE_TOPUP_MEDIUM`, `STRIPE_PRICE_TOPUP_LARGE`. Dashboard checklist already in `docs/stripe-setup.md` from #76.
- **Price IDs resolved at request time** (not class-load) so deploy-config and test-stub changes both take effect without a class-cache reset. Avoids an eager-load vs. lazy-load divergence between CI and local that bit the original #77.

## Test plan

- [x] 12 new specs across the topup endpoint and webhook handler — all green
- [x] Full local suite: `293 examples, 0 failures, 18 pending`
- [ ] Reviewer: in staging, set the three top-up Price IDs in env and configure each Stripe Price with `metadata: { kind: "topup", credit_amount: <int> }` (per `docs/stripe-setup.md`). Then `stripe trigger checkout.session.completed --add metadata.kind=topup` and verify a `credit_transactions` row + `users.topup_credits_balance` increase
- [ ] Reviewer: verify replaying the same event doesn't double-credit (`stripe events resend <evt_id>`)

## Not in this PR

- Frontend "Buy credits" picker — separate `itty-bitty-frontend` repo
- Phase 3: switch AI gating from Redis counter → credits + `402 insufficient_credits`
- Phase 4: plan-credit renewal grants via `invoice.payment_succeeded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)