### PR TITLE
feat: switch staging to local disk storage

### DIFF
--- a/.github/workflows/staging-sync-env.yml
+++ b/.github/workflows/staging-sync-env.yml
@@ -30,9 +30,14 @@ jobs:
           FRONT_END_URL: https://ypk9e.hatchboxapp.com
           WEBHOOK_URL: https://ypk9e.hatchboxapp.com/api/webhooks
           PAY_WEBHOOK_URL: https://ypk9e.hatchboxapp.com/pay/webhooks/stripe
+          # Local disk storage on staging — keeps the env simple and avoids
+          # S3/CDN bucket-policy juggling. Files live under the release's
+          # storage/ dir; ephemeral across deploys, which is fine for staging.
+          ACTIVE_STORAGE_SERVICE: local
+          # CDN_HOST intentionally unset. Removed from manifest so the sync
+          # script no longer pushes it, but you must also delete it once from
+          # the Hatchbox env panel (the sync script doesn't remove keys).
           AWS_BUCKET: itty-bitty-boards-staging
-          ACTIVE_STORAGE_SERVICE: amazon
-          CDN_HOST: https://itty-bitty-boards-staging.s3.amazonaws.com
 
           # ---- Core Rails ----
           RAILS_MASTER_KEY:                 ${{ secrets.STAGING_RAILS_MASTER_KEY }}

--- a/script/hatchbox/staging_env_vars.yml
+++ b/script/hatchbox/staging_env_vars.yml
@@ -31,12 +31,16 @@ vars:
   - PAY_WEBHOOK_URL            # https://ypk9e.hatchboxapp.com/pay/webhooks/stripe
 
   # ---- AWS / Active Storage ----
+  # Staging uses local disk storage (ACTIVE_STORAGE_SERVICE=local). The AWS
+  # creds remain set for sidekiq/polly/etc., and AWS_BUCKET is preserved in
+  # case we switch back to S3. CDN_HOST is intentionally absent — was removed
+  # from this manifest so the sync no longer pushes it. Delete it manually
+  # from Hatchbox if it's still there.
   - AWS_ACCESS_KEY_ID
   - AWS_SECRET_ACCESS_KEY
-  - CDN_HOST                   # https://itty-bitty-boards-staging.s3.amazonaws.com
   - AWS_REGION
-  - AWS_BUCKET                 # itty-bitty-boards-staging
-  - ACTIVE_STORAGE_SERVICE     # amazon
+  - AWS_BUCKET                 # itty-bitty-boards-staging (unused with local svc)
+  - ACTIVE_STORAGE_SERVICE     # local
 
   # ---- Stripe (test mode) ----
   - STRIPE_PRIVATE_KEY


### PR DESCRIPTION
## Summary

Staging was mirroring prod's S3 + CloudFront stack, which kept dragging in unrelated friction (bucket policies, ACLs, CORS, direct-upload signing) every time we tried to get a feature working. Replaces that with `ACTIVE_STORAGE_SERVICE=local` on staging — files live on the Hatchbox EC2 box.

- Cuts `CDN_HOST` from the sync manifest so the workflow stops setting it.
- Switches `ACTIVE_STORAGE_SERVICE` literal in the sync workflow from `amazon` → `local`.
- Prod is untouched (the sync workflow only writes to the staging Hatchbox app).

## Trade-offs

- Files don't survive a Hatchbox deploy (each release dir is fresh). Acceptable for a throwaway staging env. If we want persistence later, point `storage/` at `shared/storage` via a deploy hook.
- The staging S3 bucket (`itty-bitty-boards-staging`) is now dormant. Can stay around for cheap or be deleted later.

## After merge

1. Re-run **Sync staging env vars to Hatchbox** workflow → pushes `ACTIVE_STORAGE_SERVICE=local`.
2. **Manually delete `CDN_HOST`** from the staging app's Environment panel on Hatchbox. The sync script only adds/updates; it can't remove keys, and `CDN_HOST` still being present would override the new behavior.
3. Hatchbox redeploys staging automatically when `staging` branch updates (it should already have the new code via the auto-mirror workflow).
4. Wipe any leftover blob rows on staging (the previous attempts left orphan AS records):
   ```
   ssh deploy@<staging-ip>
   cd ~/staging-speakanyway/current
   RAILS_ENV=production bundle exec rails runner '
     ActiveStorage::Attachment.delete_all
     ActiveStorage::VariantRecord.delete_all
     ActiveStorage::Blob.delete_all
   '
   ```
5. Upload a test image through the staging UI. The URL should now be `https://ypk9e.hatchboxapp.com/rails/active_storage/...` and the image should render directly from disk.

## Test plan

- [x] Manifest + workflow YAML aligned, both 67 vars
- [x] CDN_HOST removed from both
- [ ] After merge: env var sync workflow runs green
- [ ] After deletion of CDN_HOST in Hatchbox UI: app boots, image upload via UI works and renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)