### PR TITLE
feat: rake task to seed teacher boards into the School board group

### DIFF
--- a/docs/free-printable-aac-boards-build-plan.md
+++ b/docs/free-printable-aac-boards-build-plan.md
@@ -1,0 +1,258 @@
+# Build Plan — `/free-printable-aac-boards` (revised)
+
+*Revised after deep-diving the existing frontend + backend. The original
+plan assumed we were building from scratch; we're not — most of the
+infrastructure already exists.*
+
+---
+
+## What I found that changes the plan
+
+### 1. The PDF endpoint is already public ✅
+`API::BoardsController` explicitly skips auth for the `pdf` action:
+
+```ruby
+skip_before_action :authenticate_token!, only: %i[ index predictive_image_board show public_boards public_menu_boards common_boards pdf ]
+```
+
+→ **"Logged-out PDF download" is not an open question. It works today.**
+
+The frontend `downloadBoardPdf` ([src/data/boards.ts:317](itty-bitty-frontend/src/data/boards.ts:317)) does send auth headers, but the backend ignores missing tokens for `pdf`. So in practice it already works for anonymous users — just a tiny code smell to clean up.
+
+### 2. "Public boards" is a real, working system ✅
+`Board.public_boards` scope = `admin-owned + predefined + published`. There's already an existing pool of admin-curated, publicly-viewable, downloadable boards. The questions is **how many are teacher-relevant**, not whether the system exists.
+
+### 3. A taxonomy of teacher-relevant tags already exists ✅
+[src/data/constants.ts](itty-bitty-frontend/src/data/constants.ts) defines `SUGGESTED_BOARD_TAGS` — these are already teacher-relevant:
+- `school`, `home`, `visual schedule`, `daily routine`
+- `choice board`, `first-then`, `feelings`, `safety`
+- `social story`, `beginner`, `core words`
+
+→ **No new taxonomy needed.** Curate existing tags onto existing boards.
+
+### 4. The grid + filter UI exists ✅
+- [BoardsScreen.tsx](itty-bitty-frontend/src/pages/boards/BoardsScreen.tsx) supports `gridType="public"` — that's what `/public-boards` already uses
+- [PresetBoardGroupsScreen.tsx](itty-bitty-frontend/src/pages/board_groups/PresetBoardGroupsScreen.tsx) powers `/board-categories`, `/board-sets`, `/categories` with featured/all/user segments + search
+- [BoardTagFilterBar](itty-bitty-frontend/src/components/boards/) — tag filter UI
+- [BoardGroupGrid](itty-bitty-frontend/src/components/board_groups/), `PresetBoardGrid`, `BoardGrid` — three grid components, ready to reuse
+
+→ **No new grid components needed.** Either embed one, or route to one.
+
+### 5. "Featured board groups" is a curation primitive ✅
+[src/data/board_groups.ts:22](itty-bitty-frontend/src/data/board_groups.ts:22) — every `BoardGroup` has a `featured` boolean. `getPresetBoardGroups()` returns `featured_board_groups` as a separate bucket. Brittany (or any admin) can flip one switch to make a group front-page-featured.
+
+→ **Curation tool already in place.** Create one group called "Classroom Essentials" with `featured: true`, drop existing boards into it.
+
+### 6. The Free Generator hero pattern is reusable ✅
+[FreeAACBoardGeneratorPage.tsx](itty-bitty-frontend/src/pages/public/FreeAACBoardGeneratorPage.tsx) already has the exact marketing-page chrome we need: TopNav, hero, CTA buttons, PostHog wiring (`free board generated`, `topic-selection-clicked`, etc.), back-to-home button, mobile-responsive layout, brand-consistent visual style.
+
+→ **Copy the pattern, change the copy.** No new design system work.
+
+### 7. What's actually missing
+- **`hide_colors` and `qr_code` URL params** on `downloadPdf()` — backend supports them ([backend README §`GET /api/internal/boards/:id/export.pdf`](itty_bitty_boards/README.md)), frontend doesn't pass them. ~20 lines of code.
+- **A "Classroom Essentials" featured board group** doesn't exist yet.
+- **A teacher-themed landing page** doesn't exist yet.
+- **`?source=teachers` attribution tagging** doesn't exist.
+
+---
+
+## Revised chunks (in priority order)
+
+### Chunk A — Content audit + curation *(Brittany, 30–60 min)*
+Run in `bin/console`:
+
+```ruby
+# What admin-owned public boards already exist that match teacher tags?
+Board.public_boards.where("tags && ARRAY[?]::varchar[]",
+  %w[school "visual schedule" "daily routine" "choice board" "first-then" feelings safety])
+  .pluck(:name, :slug, :tags)
+```
+
+Pick the best ~8–12. Identify which (if any) of the six target categories aren't covered:
+- Morning Routine
+- Visual Schedule
+- Emotions
+- Center Choices / Activity Choice
+- Lunch & Snack
+- Transitions
+
+For any genuinely missing category, seed via the existing admin UI (`/admin/predefined-boards`) — no DB migration, no seed file edit.
+
+Then in the admin UI:
+1. Create a Board Group named **"Classroom Essentials"**
+2. Add the curated boards
+3. Set `featured: true`
+
+That's it. The existing `PresetBoardGroupsScreen` now displays it in the "Featured" tab of `/board-categories`.
+
+### Chunk B — PDF options in the frontend *(30 min)*
+[src/data/boards.ts:317](itty-bitty-frontend/src/data/boards.ts:317) — extend `downloadBoardPdf` to accept `hideColors` and `qrCode` params, append them to the query string. The backend already handles them.
+
+```typescript
+export const downloadBoardPdf = async (
+  id: string,
+  screenSize: string,
+  opts?: { hideHeader?: boolean; hideColors?: boolean; qrCode?: boolean },
+) => { /* ... */ }
+```
+
+Then update the existing PDF-download UI on board view pages to expose "Black & White" and "Include QR code" toggles. Optional polish — not blocking for the landing page.
+
+### Chunk C — The landing page itself *(2–3 hours)*
+New: `src/pages/public/FreePrintableAACBoardsPage.tsx`.
+
+Structure:
+1. **Hero** — copy the chrome from `FreeAACBoardGeneratorPage` (TopNav, kinda-light-overlay background, IonPage shell). Swap in the teacher copy from [free-printable-aac-boards.md](free-printable-aac-boards.md).
+2. **CTAs** point to:
+   - Primary: `/board-categories?source=teachers` (lands on Classroom Essentials featured group)
+   - Secondary: `/free-aac-board-generator?source=teachers` (custom board generator with attribution)
+3. **Six-card example grid** — pull the Classroom Essentials board group via existing `getBoardGroup()` or `getPresetBoardGroups()`. Each card links to `/boards/:slug` for view, with a small "Download PDF" link that calls `downloadPdf()` with the QR + B&W options exposed.
+4. **Final CTA** + footer.
+
+No new components. Reuse `TopNav`, `MarketingHeader`, `MarketingSideMenu`, `BoardGrid` (or a cut-down variant).
+
+### Chunk D — Route + redirect + analytics *(30 min)*
+- Add `/free-printable-aac-boards` to `App.tsx`
+- `netlify.toml` redirect `/for-teachers` → `/free-printable-aac-boards`
+- PostHog event `teachers_landing_cta_clicked` — mirror the pattern from `FreeAACBoardGeneratorPage.tsx:46–48`
+- Use `posthog.capture()` with `target_path` + `label` properties
+- Pick up `?source=teachers` query param wherever signup-attribution lives (it already does for the generator)
+
+### Chunk E — OG image + SEO *(1–2 hours, can punt to design)*
+- 1200×630 standard OG
+- 1000×1500 Pinterest variant
+- Title + meta description (drafted)
+- Add to `sitemap.xml`
+- Internal links from `/`, `/features`
+
+### Chunk F — Verification + PR *(1 hour)*
+- `npm run dev`, click every CTA
+- Logged-out → click a Classroom Essentials board → download PDF → scan QR → verify it opens the public board view
+- Mobile spot-checks (iPad, iPhone, Android)
+- CHANGELOG entry
+- PR open with screenshots + test plan
+
+---
+
+## Revised time estimate
+
+| Chunk | Original | Revised |
+|---|---|---|
+| Content (seeding) | 2–4 hrs | 30–60 min *(audit + curate, not build)* |
+| Landing page | 2–3 hrs | 2–3 hrs *(same, but heavy reuse)* |
+| PDF B&W / QR options | — | 30 min *(was implicit, now explicit)* |
+| Routes + redirects + analytics | 30 min | 30 min |
+| OG images + SEO | 1–2 hrs | 1–2 hrs |
+| Verification + PR | 1 hr | 1 hr |
+| **Total** | **1.5–2 days** | **~½ day to 1 day** |
+
+**~60% reduction**, driven entirely by the realization that the public-boards/featured-groups/PDF-export infrastructure already works.
+
+---
+
+## Open questions remaining
+
+These are smaller now:
+
+1. **Does Free plan have a separate PDF download cap?** Was a big risk before; now I'd bet it's ungated (the `pdf` action is unauthenticated, so there's no per-user counter wired to it). Worth a 5-min grep of `subscription.rb` and `application_controller.rb` to confirm.
+2. **What's actually in `Board.public_boards` today?** Chunk A answers this in 5 minutes via Rails console. The whole plan flexes based on the answer — if there are already 30+ relevant boards, this is mostly a curation + landing-page exercise. If there are only 5 and most are demo-quality, we need to seed more before launching.
+3. **Should "Classroom Essentials" be a Board Group (a curated set of boards) or just a tag-based filter view?** Board Group gives a nicer landing experience (featured, ordered, on its own page). Tag filter is more flexible. Recommendation: Board Group, since the featured-groups UX already exists and is more visually polished.
+
+---
+
+## Recommended next move
+
+**Do Chunk A first, alone, before any code.** 30 minutes in Rails console + admin UI tells us whether we're building a thin landing page on top of strong existing content (likely) or whether we need a substantial seeding pass (possible). The answer dictates whether this is a half-day project or a multi-day one.
+
+If Chunk A reveals strong content → ship Chunks B–F as a single PR over a focused day.
+
+If Chunk A reveals weak content → pause, decide whether to invest in seeding (Brittany's time) or punt the landing page until the public-boards library is fuller.
+
+---
+
+## Addendum — seed-state audit from outside the database
+
+*Added after a deeper read of `db/seeds.rb`, `db/seed_data/`, `app/models/seed_helper.rb`, and `lib/tasks/words.rake`. The production database state can't be known from outside, but the seed files and rake tasks tell us what content the codebase ships with.*
+
+### What the seed files contain
+
+| File | Topics defined | Teacher-relevant? |
+|---|---|---|
+| `seed_data/default/default1.json` | Basic Needs, Social Interaction, Feelings/Emotions, Questions, Common Verbs, Descriptive Words | ⭐ Feelings/Emotions, Social Interaction, Questions, Common Verbs — all core classroom vocabulary |
+| `seed_data/default/default2.json`, `default3.json` | *(not inspected — likely more vocabulary buckets)* | Probably more of the same |
+| `seed_data/routines/routines1.json` | Getting Ready for Bed, **Morning Routine**, **Mealtime**, + more | ⭐ Morning Routine and Mealtime map directly to our targets |
+| `seed_data/scenarios/scenarios1.json` | At the Bank, Grocery Store, Restaurant, Post Office, **Doctor's Office** | Mostly community settings; Doctor's Office is teacher-adjacent |
+| `seed_data/words/core.rb` | Core words | Universal |
+
+### Coverage map to the six target landing categories
+
+| Landing card | Covered in seed? | How |
+|---|---|---|
+| Morning Routine | ✅ Yes | `routines1.json` → "Morning Routine" |
+| Visual Schedule | ❌ No | Would need new seed (can derive from routine data) |
+| Emotions | ✅ Yes | `default1.json` → "Feelings/Emotions" |
+| Center Choices | ❌ No | Would need new seed |
+| Lunch & Snack | ⚠️ Close | `routines1.json` → "Mealtime" (rename or split) |
+| Transitions | ❌ No | Would need new seed |
+
+→ **3 of 6 cards have existing seed content. 3 need to be created.**
+
+### The two flag-setting traps
+
+Big finding: **none of the existing seed paths produce boards that show up in `Board.public_boards`.**
+
+`Board.public_boards` requires `predefined: true` AND `published: true`. But:
+
+- **`SeedHelper.seed_boards_from_file`** (the only active seeder in `seeds.rb`) sets neither flag. Boards created via `SeedHelper.run_all` are admin-owned but not predefined and not published. They won't appear publicly.
+- **`lib/tasks/words.rake`** sets `predefined: true` but **not** `published: true`. Boards from that task are also invisible to `public_boards`.
+
+This means **whatever public boards exist today were almost certainly created/published manually via the admin UI** (`/admin/predefined-boards` and similar). The seed scripts on their own don't produce public-visible content.
+
+### What this tells us about the production DB
+
+I can't see live state, but I can infer:
+
+- If Brittany has been actively curating in `/admin/predefined-boards`, there are probably *some* public boards — quality and topic coverage unknown.
+- If she hasn't, `Board.public_boards.count` is likely small or zero, and `/public-boards` is mostly empty.
+- The "Classroom Essentials" Board Group definitely doesn't exist yet — there's no code path that creates it.
+
+### Recommendation: a one-line read-only audit
+
+Brittany can run this in her terminal (not Rails console — just `bin/rails runner`):
+
+```bash
+bin/rails runner '
+  puts "Total public boards: #{Board.public_boards.count}"
+  puts "Public boards with school/visual/routine/choice tags:"
+  Board.public_boards.where("tags && ARRAY[?]::varchar[]",
+    %w[school home "visual schedule" "daily routine" "choice board" "first-then" feelings safety])
+    .pluck(:name, :tags).each { |n, t| puts "  - #{n} #{t.inspect}" }
+  puts ""
+  puts "Featured board groups: #{BoardGroup.featured.pluck(:name).inspect}"
+  puts "Classroom group exists: #{BoardGroup.exists?(name: "Classroom Essentials")}"
+'
+```
+
+Output tells us in 30 seconds whether to:
+- **Build immediately** (strong existing content, no seeding needed)
+- **Seed first** (need to create 3–6 missing boards + the Classroom Essentials group)
+- **Punt** (public board library is too thin to support a teacher campaign right now)
+
+### If we need to seed
+
+I can write `lib/tasks/classroom_boards.rake` that creates the missing 3 boards (Visual Schedule, Center Choices, Transitions) and a "Classroom Essentials" featured Board Group, following the `words.rake` pattern but *also* setting `published: true` and tags. This is the lowest-risk path because:
+
+- It's a one-shot rake task, not a destructive migration
+- It uses `find_or_create_by!` so re-runs are safe
+- It mirrors a pattern that already exists in the codebase
+- It can be reviewed before running
+
+### Updated time estimate after this audit
+
+| Scenario | Engineering time |
+|---|---|
+| Strong existing public boards (≥8 teacher-relevant, already published) | ~½ day |
+| Partial coverage (3–6 boards exist, need to seed 3–6 more + create Classroom group) | ~1 day (½ day for seeding + ½ day for landing page) |
+| Weak coverage (need to seed 6+ boards from scratch with AI images) | 2 days |
+
+The bash one-liner above tells us which row we're in.

--- a/lib/tasks/classroom_boards.rake
+++ b/lib/tasks/classroom_boards.rake
@@ -1,0 +1,196 @@
+namespace :classroom_boards do
+  TARGET_GROUP_NAME = "School".freeze
+
+  CLASSROOM_BOARDS = [
+    {
+      name: "Morning Routine",
+      description: "Get the school day started — wake-up through walking into class.",
+      tags: %w[school daily-routine visual-schedule beginner],
+      labels: [
+        "wake up", "stretch", "brush teeth", "wash face", "get dressed",
+        "eat breakfast", "pack bag", "put on shoes", "leave house",
+        "ride bus", "walk to school", "good morning",
+      ],
+    },
+    {
+      name: "Visual Schedule",
+      description: "First / then / next — sequencing the school day for students who do better with a clear order.",
+      tags: %w[school visual-schedule first-then daily-routine],
+      labels: [
+        "first", "then", "next", "last",
+        "morning meeting", "work time", "snack", "recess",
+        "lunch", "specials", "reading", "math",
+        "centers", "clean up", "dismissal", "go home",
+      ],
+    },
+    {
+      name: "Emotions",
+      description: "Name what you feel — a starter emotions board for the classroom.",
+      tags: %w[school feelings beginner core-words],
+      labels: [
+        "happy", "sad", "mad", "tired", "frustrated", "proud",
+        "calm", "excited", "scared", "surprised", "okay", "not okay",
+      ],
+    },
+    {
+      name: "Center Choices",
+      description: "Pick a center — for choice time, center rotations, and free play.",
+      tags: %w[school choice-board play],
+      labels: [
+        "reading corner", "art", "blocks", "sensory bin",
+        "writing", "computer", "puzzles", "dramatic play",
+        "math games", "library", "music", "outside",
+      ],
+    },
+    {
+      name: "Lunch and Snack",
+      description: "Lunchroom and snack-time vocabulary — for cafeteria, classroom snack, and home lunches.",
+      tags: %w[school choice-board home],
+      labels: [
+        "milk", "water", "juice", "sandwich",
+        "fruit", "crackers", "apple", "banana",
+        "yogurt", "more please", "all done", "help",
+      ],
+    },
+    {
+      name: "Transitions",
+      description: "Move between activities — the in-between moments that are often the hardest part of the day.",
+      tags: %w[school daily-routine visual-schedule],
+      labels: [
+        "line up", "hallway", "quiet voice", "walking feet",
+        "restroom", "water fountain", "back to seat", "clean up",
+        "calm down", "deep breath", "wait", "ready",
+      ],
+    },
+  ].freeze
+
+  desc "Audit teacher-relevant public boards (read-only)"
+  task audit: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN
+    admin_id = User::DEFAULT_ADMIN_ID
+    teacher_tags = %w[school home visual-schedule visual\ schedule daily-routine daily\ routine choice-board choice\ board first-then feelings safety]
+
+    puts ""
+    puts "=" * 60
+    puts "Classroom Boards Audit"
+    puts "=" * 60
+    puts "Admin user id: #{admin_id}"
+    puts "Total public boards: #{Board.public_boards.count}"
+
+    puts ""
+    puts "Public boards with teacher-relevant tags:"
+    matches = Board.public_boards.where("tags && ARRAY[?]::varchar[]", teacher_tags)
+    if matches.empty?
+      puts "  (none)"
+    else
+      matches.pluck(:name, :tags).each { |name, tags| puts "  - #{name.inspect} #{tags.inspect}" }
+    end
+
+    puts ""
+    puts "Target board name → status:"
+    CLASSROOM_BOARDS.each do |b|
+      existing = Board.where(name: b[:name], user_id: admin_id)
+      if existing.exists?
+        flags = existing.pluck(:predefined, :published).map { |p, pub| "predefined=#{p} published=#{pub}" }.join(", ")
+        puts "  ✓ #{b[:name]} exists (#{flags})"
+      else
+        puts "  ✗ #{b[:name]} missing"
+      end
+    end
+
+    puts ""
+    puts "Featured board groups: #{BoardGroup.featured.pluck(:name).inspect}"
+    target_group = BoardGroup.find_by(name: TARGET_GROUP_NAME)
+    if target_group
+      puts "Target group #{TARGET_GROUP_NAME.inspect}: id=#{target_group.id} predefined=#{target_group.predefined} featured=#{target_group.featured} boards=#{target_group.boards.count}"
+      puts "Existing boards in #{TARGET_GROUP_NAME.inspect}:"
+      target_group.boards.each do |b|
+        puts "  - #{b.name} (id=#{b.id}, published=#{b.published}, predefined=#{b.predefined}, tags=#{b.tags.inspect}, images=#{b.images.count})"
+      end
+    else
+      puts "Target group #{TARGET_GROUP_NAME.inspect}: does not exist (seed will create it)"
+    end
+    puts ""
+  end
+
+  desc "Seed 6 teacher boards into the target Board Group (idempotent, no AI calls)"
+  task seed: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+    parent_resource = PredefinedResource.find_or_create_by!(name: "Default", resource_type: "Board")
+
+    puts ""
+    puts "Seeding teacher boards into #{TARGET_GROUP_NAME.inspect}..."
+    puts "  Admin user: #{admin.email} (id=#{admin.id})"
+
+    seeded_boards = CLASSROOM_BOARDS.map do |spec|
+      board = Board.find_or_initialize_by(name: spec[:name], user_id: admin.id, predefined: true)
+      is_new = board.new_record?
+
+      board.assign_attributes(
+        description: spec[:description],
+        parent: parent_resource,
+        predefined: true,
+        published: true,
+        tags: spec[:tags],
+      )
+      board.generate_unique_slug if board.slug.blank?
+      board.save!
+
+      spec[:labels].each do |label|
+        next if board.images.where("LOWER(images.label) = ?", label.downcase).exists?
+        image = Image.public_img.find_or_create_by!(label: label.downcase) do |img|
+          img.image_prompt = "Create a clean, simple image representing '#{label}'."
+        end
+        board.add_image(image.id)
+      end
+
+      action = is_new ? "created" : "updated"
+      puts "  #{action.rjust(7)}: #{spec[:name]} (id=#{board.id}, #{spec[:labels].size} cells, tags=#{spec[:tags].inspect})"
+      board
+    end
+
+    group = BoardGroup.find_or_initialize_by(name: TARGET_GROUP_NAME)
+    group_is_new = group.new_record?
+    if group_is_new
+      group.assign_attributes(user_id: admin.id, predefined: true, featured: true)
+      group.save!
+    end
+
+    seeded_boards.each do |board|
+      group.board_group_boards.find_or_create_by!(board: board)
+    end
+
+    action = group_is_new ? "created" : "found existing"
+    puts ""
+    puts "  Target group: #{action} #{TARGET_GROUP_NAME.inspect} (id=#{group.id}, predefined=#{group.predefined}, featured=#{group.featured}, total boards now=#{group.boards.count})"
+    puts ""
+    puts "Done. Run 'bin/rails classroom_boards:audit' to verify."
+    puts "Next: 'bin/rails classroom_boards:generate_images' to queue symbol/image generation."
+    puts ""
+  end
+
+  desc "Queue symbol/AI image generation for any Classroom Essentials cells missing artwork"
+  task generate_images: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN
+    group = BoardGroup.find_by(name: TARGET_GROUP_NAME)
+    unless group
+      abort "#{TARGET_GROUP_NAME.inspect} group not found. Run 'bin/rails classroom_boards:seed' first."
+    end
+
+    seeded_names = CLASSROOM_BOARDS.map { |b| b[:name] }
+    new_boards = group.boards.where(name: seeded_names)
+
+    image_ids = new_boards.flat_map do |board|
+      board.images.reject { |img| img.docs.any? || img.image_prompt.blank? }.map(&:id)
+    end.uniq
+
+    if image_ids.empty?
+      puts "All teacher-board images already have artwork. Nothing to queue."
+    else
+      puts "Queuing GetSymbolsJob for #{image_ids.size} image(s) across #{new_boards.count} board(s)..."
+      GetSymbolsJob.perform_async(image_ids, 10)
+      puts "Queued. Check Sidekiq for progress."
+    end
+  end
+end

--- a/lib/tasks/classroom_boards.rake
+++ b/lib/tasks/classroom_boards.rake
@@ -170,9 +170,11 @@ namespace :classroom_boards do
     puts ""
   end
 
-  desc "Queue OpenAI image generation for any teacher-board cells missing artwork (incurs API cost)"
+  desc "Queue OpenAI image generation for missing teacher-board artwork. DRY_RUN=1 to preview without queuing."
   task generate_images: :environment do
     ActiveRecord::Base.logger.level = Logger::WARN
+    dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase)
+
     group = BoardGroup.find_by(name: TARGET_GROUP_NAME)
     unless group
       abort "#{TARGET_GROUP_NAME.inspect} group not found. Run 'bin/rails classroom_boards:seed' first."
@@ -182,8 +184,7 @@ namespace :classroom_boards do
     new_boards = group.boards.where(name: seeded_names).includes(:images)
 
     # One job per (image, board) so each BoardImage status is tracked correctly.
-    # GenerateImageJob is idempotent on existing docs but skip anything that
-    # already has artwork to avoid burning credits.
+    # Skip anything that already has artwork to avoid burning credits.
     pending = []
     new_boards.each do |board|
       board.images.each do |image|
@@ -199,8 +200,34 @@ namespace :classroom_boards do
     end
 
     admin_id = User::DEFAULT_ADMIN_ID
+    estimated_low = pending.size * 0.04
+    estimated_high = pending.size * 0.08
+
+    if dry_run
+      puts ""
+      puts "DRY RUN — no jobs queued, no API calls, no $$ spent."
+      puts "=" * 60
+      puts "Would queue GenerateImageJob for #{pending.size} (image, board) pair(s):"
+      puts ""
+      pending.group_by { |_, board| board.name }.each do |board_name, pairs|
+        puts "  #{board_name} (#{pairs.size} image(s)):"
+        pairs.each do |image, _|
+          prompt = image.image_prompt.to_s
+          prompt_preview = prompt.length > 60 ? "#{prompt[0, 60]}..." : prompt
+          puts "    - id=#{image.id} label=#{image.label.inspect} prompt=#{prompt_preview.inspect}"
+        end
+      end
+      puts ""
+      puts "Estimated OpenAI cost: $#{format("%.2f", estimated_low)} – $#{format("%.2f", estimated_high)} (varies by model/size)"
+      puts ""
+      puts "Run without DRY_RUN to queue for real:"
+      puts "  bin/rails classroom_boards:generate_images"
+      next
+    end
+
     puts "Queuing GenerateImageJob for #{pending.size} (image, board) pair(s) across #{new_boards.count} board(s)..."
     puts "  NOTE: GenerateImageJob calls OpenAI image generation — this incurs real API costs."
+    puts "  Estimated cost: $#{format("%.2f", estimated_low)} – $#{format("%.2f", estimated_high)}"
 
     pending.each do |image, board|
       options = {

--- a/lib/tasks/classroom_boards.rake
+++ b/lib/tasks/classroom_boards.rake
@@ -170,7 +170,7 @@ namespace :classroom_boards do
     puts ""
   end
 
-  desc "Queue symbol/AI image generation for any Classroom Essentials cells missing artwork"
+  desc "Queue OpenAI image generation for any teacher-board cells missing artwork (incurs API cost)"
   task generate_images: :environment do
     ActiveRecord::Base.logger.level = Logger::WARN
     group = BoardGroup.find_by(name: TARGET_GROUP_NAME)
@@ -179,18 +179,40 @@ namespace :classroom_boards do
     end
 
     seeded_names = CLASSROOM_BOARDS.map { |b| b[:name] }
-    new_boards = group.boards.where(name: seeded_names)
+    new_boards = group.boards.where(name: seeded_names).includes(:images)
 
-    image_ids = new_boards.flat_map do |board|
-      board.images.reject { |img| img.docs.any? || img.image_prompt.blank? }.map(&:id)
-    end.uniq
-
-    if image_ids.empty?
-      puts "All teacher-board images already have artwork. Nothing to queue."
-    else
-      puts "Queuing GetSymbolsJob for #{image_ids.size} image(s) across #{new_boards.count} board(s)..."
-      GetSymbolsJob.perform_async(image_ids, 10)
-      puts "Queued. Check Sidekiq for progress."
+    # One job per (image, board) so each BoardImage status is tracked correctly.
+    # GenerateImageJob is idempotent on existing docs but skip anything that
+    # already has artwork to avoid burning credits.
+    pending = []
+    new_boards.each do |board|
+      board.images.each do |image|
+        next if image.docs.any?
+        next if image.image_prompt.blank?
+        pending << [image, board]
+      end
     end
+
+    if pending.empty?
+      puts "All teacher-board images already have artwork. Nothing to queue."
+      next
+    end
+
+    admin_id = User::DEFAULT_ADMIN_ID
+    puts "Queuing GenerateImageJob for #{pending.size} (image, board) pair(s) across #{new_boards.count} board(s)..."
+    puts "  NOTE: GenerateImageJob calls OpenAI image generation — this incurs real API costs."
+
+    pending.each do |image, board|
+      options = {
+        "image_prompt" => image.image_prompt,
+        "board_id" => board.id,
+        "screen_size" => "lg",
+        "transparent_bg" => true,
+      }
+      image.update_column(:status, "generating") if image.has_attribute?(:status)
+      GenerateImageJob.perform_async(image.id, admin_id, options)
+    end
+
+    puts "Queued. Check Sidekiq for progress."
   end
 end


### PR DESCRIPTION
## Summary
Adds `lib/tasks/classroom_boards.rake` — three rake tasks for curating teacher-relevant boards into the existing **"School"** featured Board Group:

```
bin/rails classroom_boards:audit                          # read-only inventory
bin/rails classroom_boards:seed                           # idempotent, no API cost
DRY_RUN=1 bin/rails classroom_boards:generate_images      # preview what would be queued
bin/rails classroom_boards:generate_images                # queues GenerateImageJob (OpenAI — costs $)
```

Also includes `docs/free-printable-aac-boards-build-plan.md` — engineering build plan moved here from the marketing repo.

## What `:seed` does
Creates 6 admin-owned boards (Morning Routine, Visual Schedule, Emotions, Center Choices, Lunch and Snack, Transitions) with appropriate teacher tags, sets `predefined+published=true`, and joins them to the existing **"School"** Board Group. Idempotent — re-runs don't duplicate. Does not touch the 7 boards already in the School group.

## Two latent issues fixed along the way
Both surfaced while running `:seed` against dev:
1. `Board#generate_unique_slug` exists but isn't on any callback — new boards default to `slug=""` and collide on save. Task calls it explicitly.
2. `board.images.where("LOWER(label) = ?", ...)` was ambiguous — both `images` and `board_images` have a `label` column. Qualified as `images.label`.

If these affect other seed paths (`words.rake`, `SeedHelper`), worth a separate cleanup PR.

## Image generation: GenerateImageJob, not GetSymbolsJob
`:generate_images` uses `GenerateImageJob` (OpenAI), matching the pattern in `API::ImagesController`. The standard options hash is passed: `image_prompt`, `board_id`, `screen_size`, `transparent_bg: true` (per the AAC transparent-PNG rule).

**⚠️ Cost note:** `GenerateImageJob` calls OpenAI image generation. Verified via dry-run in dev: 19 pending (image, board) pairs, estimated \$0.76–\$1.52 for the full set (~\$0.04–\$0.08 per image, varies by model/size).

## DRY_RUN preview
`DRY_RUN=1 bin/rails classroom_boards:generate_images` prints exactly which (image, board) pairs would be queued, grouped by board with label + prompt preview + estimated cost range. No jobs queued, no API calls, no $$ spent. Use this before running for real, especially in production.

Example output (dev):
```
DRY RUN — no jobs queued, no API calls, no $$ spent.
========================================================
Would queue GenerateImageJob for 19 (image, board) pair(s):

  Morning Routine (4 image(s)):
    - id=11438 label="pack bag" prompt="Create a clean, simple image..."
    ...
  Transitions (7 image(s)):
    - id=11456 label="deep breath" prompt="Create a clean, simple image..."

Estimated OpenAI cost: $0.76 – $1.52 (varies by model/size)
```

## Effect on running app
**None.** This PR only adds files — no controllers, models, routes, callbacks, jobs, migrations, or configs are modified. The rake task runs only when explicitly invoked. Merging this PR is safe; OpenAI cost only kicks in when someone runs `:generate_images` without `DRY_RUN=1`.

## Test plan
- [x] `bin/rails classroom_boards:audit` — read-only, ran cleanly
- [x] `bin/rails classroom_boards:seed` — created 6 boards, added to School group, no API calls, idempotent on re-run
- [x] `DRY_RUN=1 bin/rails classroom_boards:generate_images` — verified output, 19 pending pairs, est. \$0.76–\$1.52
- [ ] Verify live `GenerateImageJob` path against dev (would re-queue paid OpenAI calls — pending decision)
- [ ] Production audit before pointing paid traffic at this content

🤖 Generated with [Claude Code](https://claude.com/claude-code)