### PR TITLE
fix: drop payment_method_collection from topup Checkout (invalid for mode=payment)

### DIFF
--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -124,13 +124,17 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
 
     credit_amount = TOPUP_CREDIT_AMOUNTS[pack_key].to_i
 
+    # NOTE: `payment_method_collection` is only valid on subscription-mode
+    # Checkout Sessions. For one-time payment mode (top-up packs), Stripe
+    # rejects the request with "You can only set `payment_method_collection`
+    # if there are recurring prices." Leaving it off; Stripe's default for
+    # mode=payment already collects a payment method.
     session = Stripe::Checkout::Session.create(
       mode: "payment",
       customer: current_user.stripe_customer_id,
       line_items: [{ price: price_id, quantity: quantity }],
       success_url: "#{frontend_base_url}/account/billing/topup/success?session_id={CHECKOUT_SESSION_ID}",
       cancel_url: "#{frontend_base_url}/account/billing",
-      payment_method_collection: "always",
       allow_promotion_codes: true,
       metadata: {
         kind: "topup",

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
     expect(captured[:metadata][:pack_key]).to eq("small")
     expect(captured[:metadata][:credit_amount]).to eq(100)
     expect(captured[:metadata][:user_id]).to eq(user.id)
+    # Regression guard: Stripe rejects `payment_method_collection` on
+    # mode=payment Checkout Sessions with "You can only set
+    # `payment_method_collection` if there are recurring prices."
+    expect(captured).not_to have_key(:payment_method_collection)
   end
 
   it "scales credit_amount by quantity" do


### PR DESCRIPTION
## Summary

Staging hit the actual root cause of the topup 400 — wasn't the env vars (those are now set), it's a Stripe param-validation error:

```
[Topup] Stripe error creating topup session:
  Stripe::InvalidRequestError -
  You can only set \`payment_method_collection\` if there are recurring prices.
```

Stripe accepts `payment_method_collection` only on **subscription-mode** Checkout Sessions. The top-up flow uses `mode: "payment"` (one-time purchase), so the parameter must be omitted. Stripe's default behavior for `mode: "payment"` already collects a payment method, so dropping it is a pure subtraction — no UX change.

## Test plan

- [x] `spec/requests/api/stripe/checkout_sessions_topup_spec.rb` — 7/7 green, including a new regression guard asserting `payment_method_collection` is NOT in the captured Stripe call.
- [ ] After merge + staging deploy: `POST /api/stripe/checkout_sessions/topup { pack_key: "small" }` should return `200 { url: "https://checkout.stripe.com/c/pay/..." }`, not the previous 400.
- [ ] Click "Buy credits → Small" on staging — should land on real Stripe-hosted Checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)