### PR TITLE
ci: make staging-deploy manual-only

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,24 +1,20 @@
-name: Sync main → staging & deploy
+name: Deploy staging (manual)
 
-# Fast-forwards the `staging` branch to match `main` on every push to main,
-# then triggers a Hatchbox deploy of ypk9e.hatchboxapp.com so staging always
-# mirrors the latest merged code.
+# Manual resync of the `staging` branch to any ref (defaults to `main`) + a
+# Hatchbox deploy of ypk9e.hatchboxapp.com. Run this when you want staging
+# to match prod again — e.g. after iterating on experimental commits directly
+# on `staging` and wanting a clean slate.
 #
-# Triggers:
-#   - Push to `main`
-#   - Manual workflow_dispatch with an optional ref (defaults to main)
-#
-# Concurrency cancels in-flight runs so back-to-back merges only deploy once
-# (the latest, which already contains the earlier commits).
+# Trigger: workflow_dispatch only. This used to auto-fire on push to `main`,
+# which conflicted with using `staging` as a long-lived experimental branch
+# (every merge would clobber in-flight staging work). If you want every main
+# merge to redeploy staging, re-add a `push: branches: [main]` trigger.
 #
 # Don't put branch protection on `staging` - the workflow needs to push it.
-# If `staging` ever diverges from `main` (commits exist on staging that aren't
-# on main), the non-force push fails and the workflow auto-opens an issue
-# with the recovery command.
+# If `staging` has commits not present on the chosen ref, the non-force push
+# fails and the workflow auto-opens an issue with the recovery command.
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
@@ -42,7 +38,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref || 'main' }}
 
-      - name: Fast-forward staging to main
+      - name: Fast-forward staging to chosen ref
         id: ff
         run: git push origin HEAD:refs/heads/staging
 
@@ -52,23 +48,24 @@ jobs:
         with:
           script: |
             const sha = context.sha.slice(0, 7);
+            const ref = context.payload.inputs?.ref || 'main';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `staging diverged from main (${sha}) — manual reset needed`,
+              title: `staging diverged from ${ref} (${sha}) — manual reset needed`,
               labels: ['staging', 'ci'],
               body: [
-                "The `Sync main → staging` workflow failed because",
-                "`staging` has commits not present on `main`.",
+                "The `Deploy staging (manual)` workflow failed because",
+                "`staging` has commits not present on the chosen ref.",
                 "",
                 "**Fix:** locally run",
                 "",
                 "```sh",
                 "git fetch origin",
-                "git push origin origin/main:staging --force-with-lease",
+                `git push origin origin/${ref}:staging --force-with-lease`,
                 "```",
                 "",
-                "Then re-run the workflow or push to main again.",
+                "Then re-run the workflow.",
                 "",
                 `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               ].join('\n'),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Serializers:** jsonapi-serializer gem
 - **Hosting:** Hatchbox / EC2
   - Production: `main` branch → `speakanyway.com` (Hatchbox app `670kd.hatchboxapp.com`)
-  - Staging: `staging` branch → `https://ypk9e.hatchboxapp.com`. Automatically mirrors `main` — every push to `main` fast-forwards `staging` and triggers a Hatchbox staging deploy (see `.github/workflows/staging-deploy.yml`). To redeploy a specific SHA, run the workflow via `workflow_dispatch`. Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`.
+  - Staging: `staging` branch → `https://ypk9e.hatchboxapp.com`. Long-lived branch — push experimental commits directly to it (deploys are handled by Hatchbox's own push hook on the `staging` branch). To resync `staging` to match `main` (or any ref) and trigger a deploy, run the `Deploy staging (manual)` workflow via `workflow_dispatch` (see `.github/workflows/staging-deploy.yml`). Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`.
 
 ## Frontend
 


### PR DESCRIPTION
## Summary

- Drop the `push: branches: [main]` trigger from `.github/workflows/staging-deploy.yml`; keep `workflow_dispatch`.
- Rename workflow to `Deploy staging (manual)`; update header comment and the divergence-issue body to reference the chosen ref rather than hard-coded `main`.
- Update `CLAUDE.md` to describe `staging` as a long-lived branch you push to directly, with manual resync available via the workflow.

## Why

The auto-mirror assumed `staging` should always equal `main`. In practice, Brittany uses `staging` as a long-lived experimental branch, so every merge to `main` was:

1. clobbering in-flight staging work,
2. firing an unwanted Hatchbox deploy, and
3. opening a `staging` / `ci` divergence issue whenever staging had commits not on `main`.

Making the workflow manual-only fixes all three while preserving the one-button "resync staging from any ref + deploy" capability for when it's actually wanted.

## Reviewer notes

- The Hatchbox app `ypk9e.hatchboxapp.com` must be configured to auto-deploy on push to the `staging` branch for the new flow ("push to staging → it deploys") to work. If that's not on, either enable it in Hatchbox or follow up with a small `push: branches: [staging]` workflow that calls `script/hatchbox/trigger_deploy.rb`.
- No code paths changed; no tests added (workflow YAML + docs only).

## Test plan

- [ ] After merge, push a no-op commit to `main` and confirm no staging deploy is triggered.
- [ ] Manually run `Deploy staging (manual)` via `workflow_dispatch` (with default `ref: main`) and confirm `staging` advances and Hatchbox deploys.
- [ ] Push a test commit directly to `staging` and confirm Hatchbox auto-deploys (or, if that's not configured, follow up per reviewer note).
- [ ] Close any open `staging` / `ci` divergence issues from prior failed runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)