### PR TITLE
docs: add AI credit pricing tables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,47 @@ When a user runs out, AI endpoints return `402 insufficient_credits` with the
 needed/balance numbers — the frontend uses that to surface a "Buy more
 credits" CTA. `429 limit_reached` is reserved for true rate limiting.
 
+### Pricing
+
+> Numbers below are the defaults baked into `CreditService` and the staging
+> Stripe Prices. Production tier prices and final allowances are a
+> marketing/leadership decision — values are overridable per environment
+> via Stripe Price metadata (`monthly_credits` on subscription Prices,
+> `credit_amount` on top-up Prices) without a redeploy.
+> See `docs/credits-handoff.md` for the working pricing proposal and the
+> rationale behind these numbers.
+
+**Plan tier allowances** (`CreditService::PLAN_MONTHLY_CREDITS`):
+
+| Plan         | Monthly credits |
+| ------------ | --------------- |
+| Free         | 10              |
+| MySpeak      | 50              |
+| Basic        | 400             |
+| Pro          | 1,500           |
+| Partner Pro  | 1,500           |
+
+**Top-up packs** (one-time Stripe Checkout, do not expire):
+
+| Pack    | Credits | Price (USD) | `pack_key` |
+| ------- | ------- | ----------- | ---------- |
+| Small   | 100     | $4.99       | `small`    |
+| Medium  | 500     | $19.99      | `medium`   |
+| Large   | 1,500   | $49.99      | `large`    |
+
+**Per-feature credit cost** (`CreditService::FEATURE_COSTS`, server-authoritative):
+
+| Feature                    | `feature_key`        | Credits |
+| -------------------------- | -------------------- | ------- |
+| AI word suggestions        | `word_suggestion`    | 1       |
+| AI board formatting        | `board_format`       | 2       |
+| AI image edit              | `image_edit`         | 3       |
+| AI image variation         | `image_variation`    | 3       |
+| AI image generation        | `image_generation`   | 5       |
+| AI screenshot import       | `screenshot_import`  | 5       |
+| AI scenario builder        | `scenario_create`    | 10      |
+| AI menu builder            | `menu_create`        | 10      |
+
 ### Stripe setup
 
 Each subscription Price in Stripe must have metadata:


### PR DESCRIPTION
## Summary

The README's **AI credits** section described the model but never listed actual numbers. Adds three tables inline:

1. **Plan tier monthly allowances** — Free 10, MySpeak 50, Basic 400, Pro/Partner Pro 1,500.
2. **Top-up pack pricing** — Small 100/$4.99, Medium 500/$19.99, Large 1,500/$49.99 (matches the test-mode Prices already configured on staging via PR #97).
3. **Per-feature credit cost** — `word_suggestion`=1, `board_format`=2, `image_edit`/`image_variation`=3, `image_generation`/`screenshot_import`=5, `scenario_create`/`menu_create`=10.

Notes upfront that these are defaults from `CreditService` and that Stripe Price metadata overrides per environment without a redeploy. Links to `docs/credits-handoff.md` for the working pricing proposal + rationale.

## Test plan

- [x] No code change — README only.
- [x] Numbers verified against `app/services/credit_service.rb` (`FEATURE_COSTS` + `PLAN_MONTHLY_CREDITS`) and the test-mode Stripe Prices created in PR #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)