### PR TITLE
feat: auto-grant AI credits on signup + monthly refresh for non-paid tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — AI credits now actually grant on signup and refresh for free users
+- **Signup grant.** New users land in `basic_trial` for 14 days (via `User#set_soft_trial_plan`) but the after-create flow never granted them any credits, so every AI call returned `402 insufficient_credits`. Added `User#grant_initial_plan_credits` (after_create) → `CreditService.ensure_initial_grant!(user)` which writes a `plan_grant` row sized to the tier (`basic_trial` = 400, matching Basic; `free` = 10; etc.) with `expires_at` of 14 days for trial users and 30 days for everyone else.
+- **`basic_trial` plan_type was missing from `CreditService::PLAN_MONTHLY_CREDITS`** — it fell back to free (10 credits) instead of the intended Basic-equivalent (400). Fixed.
+- **Soft-trial downgrade now grants free credits.** `DowngradeSoftTrialJob` (daily at 2am UTC) flips expired trial users to `free`; now also calls `CreditService.grant_plan!` for 10 credits with a 30-day expiry so they don't see balance=0 the moment they're downgraded.
+- **Monthly refresh for non-subscription tiers.** New `RefreshFreeTierCreditsJob` runs daily at 3am UTC and re-grants the tier allowance to users on `free` / `basic_trial` whose `plan_credits_reset_at` has passed. Paid Stripe subscribers (MySpeak, Basic, Pro, Partner Pro) continue to be refreshed by `invoice.payment_succeeded`; the new job is just for users without a Stripe billing cycle.
+
 ### Added — Phase 4 of usage-based AI pricing (renewals + auto-grant)
 - `invoice.payment_succeeded` webhook handler — fires on initial paid period and every renewal. Reads `monthly_credits` and `plan_type` from the subscription line's Price metadata (falls back to `CreditService::PLAN_MONTHLY_CREDITS`), then calls `CreditService.grant_plan!` with `period_end = subscription.current_period_end`. Idempotent on Stripe event id, so retried webhooks never double-credit.
 - `customer.subscription.created` (status `trialing`) now grants trial credits with `period_end = subscription.trial_end`. Paid subscriptions still get their credits via the invoice path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,15 +87,28 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 
 Plan-credit lifecycle:
 
+- **Signup:** `User#after_create` calls `CreditService.ensure_initial_grant!`
+  to grant the tier's monthly allowance immediately. Soft-trial users
+  (`plan_type = "basic_trial"`, set by `User#set_soft_trial_plan`) get the
+  Basic-equivalent allowance with `expires_at = 14.days.from_now`. Other
+  tiers get a 30-day expiry. Idempotent — safe to call again.
 - **First paid period + every renewal:** `invoice.payment_succeeded` webhook
   → `CreditService.grant_plan!` with `period_end = subscription.current_period_end`.
   Reads `monthly_credits` from the subscription line's Stripe Price metadata
   (falls back to `CreditService::PLAN_MONTHLY_CREDITS[plan_type]`). Idempotent
   on Stripe event id.
-- **Trial start:** `customer.subscription.created` with status `trialing`
-  grants credits with `period_end = subscription.trial_end`.
+- **Stripe trial start:** `customer.subscription.created` with status
+  `trialing` grants credits with `period_end = subscription.trial_end`.
 - **Cancel / pause:** plan credits expire via
   `CreditService.expire_plan_credits!`. Top-up credits are preserved.
+- **Soft-trial → free downgrade:** `DowngradeSoftTrialJob` (daily at 2am UTC)
+  flips expired `basic_trial` users to `free` and grants the free-tier
+  allowance immediately.
+- **Free-tier monthly refresh:** `RefreshFreeTierCreditsJob` (daily at
+  3am UTC) re-grants the tier allowance to non-subscription users
+  (`free`, `basic_trial`) whose `plan_credits_reset_at` has passed.
+  Paid tiers (`myspeak`, `basic`, `pro`, `partner_pro`) refresh through
+  `invoice.payment_succeeded`.
 - **Backstop:** `ExpirePlanCreditsJob` runs hourly and zeroes any plan
   balance whose `plan_credits_reset_at` has passed. Cheap and idempotent —
   safe to invoke any time.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,6 +146,15 @@ class User < ApplicationRecord
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
 
+  # Grant the user's tier's monthly AI credit allowance on signup so the
+  # very first AI call doesn't 402. Idempotent in CreditService — safe to
+  # call again if a callback runs twice.
+  after_create :grant_initial_plan_credits
+
+  def grant_initial_plan_credits
+    CreditService.ensure_initial_grant!(self)
+  end
+
   def following?(page)
     page_follows.exists?(followed_page_id: page.id)
   end

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -34,6 +34,7 @@ class CreditService
   # Default monthly grant by plan_type. Stripe Price metadata overrides at grant time.
   PLAN_MONTHLY_CREDITS = {
     "free" => 10,
+    "basic_trial" => 400, # Soft 14-day Basic trial set by User#set_soft_trial_plan
     "myspeak" => 50,
     "basic" => 400,
     "pro" => 1500,
@@ -42,6 +43,14 @@ class CreditService
     "vendor" => 1500,
   }.freeze
 
+  # How long an initial grant lasts when the user is NOT on a Stripe-driven
+  # billing cycle (no subscription yet, or canceled). Stripe-driven grants
+  # use `subscription.current_period_end` / `trial_end` instead.
+  INITIAL_PERIOD_DAYS = {
+    "basic_trial" => 14, # matches User#TRAIL_PERIOD (sic)
+  }.freeze
+  DEFAULT_INITIAL_PERIOD_DAYS = 30
+
   class << self
     def cost_for(feature_key)
       FEATURE_COSTS[feature_key.to_s] || 1
@@ -49,6 +58,36 @@ class CreditService
 
     def monthly_credits_for(plan_type)
       PLAN_MONTHLY_CREDITS[plan_type.to_s] || PLAN_MONTHLY_CREDITS["free"]
+    end
+
+    def initial_period_end_for(plan_type, from: Time.current)
+      days = INITIAL_PERIOD_DAYS[plan_type.to_s] || DEFAULT_INITIAL_PERIOD_DAYS
+      from + days.days
+    end
+
+    # Grant the user's tier's monthly allowance — for users who haven't gone
+    # through Stripe yet (free, soft-trial). Idempotent: returns the existing
+    # grant when the user already has any `plan_grant` row, so this is safe
+    # to call from after_create callbacks, sign-in hooks, etc.
+    def ensure_initial_grant!(user)
+      return nil if user.respond_to?(:admin?) && user.admin?
+
+      existing = user.credit_transactions.where(kind: "plan_grant").order(created_at: :asc).first
+      return existing if existing
+
+      plan_type = user.plan_type.presence || "free"
+      amount = monthly_credits_for(plan_type)
+      return nil if amount <= 0
+
+      grant_plan!(
+        user,
+        amount: amount,
+        period_end: initial_period_end_for(plan_type),
+        metadata: { source: "initial_grant", plan_type: plan_type },
+      )
+    rescue => e
+      Rails.logger.error "[CreditService] ensure_initial_grant! failed for user=#{user&.id}: #{e.class} #{e.message}"
+      nil
     end
 
     def balance(user)

--- a/app/sidekiq/downgrade_soft_trial_job.rb
+++ b/app/sidekiq/downgrade_soft_trial_job.rb
@@ -11,6 +11,18 @@ class DowngradeSoftTrialJob
     expired_trial_users.find_each do |user|
       user.setup_free_limits
       user.update!(plan_type: "free")
+
+      # The user just transitioned from basic_trial (400 credits, expiring
+      # ~now) to free (10 credits/month). grant_plan! expires whatever's
+      # left of the trial allowance and grants a fresh free-tier amount,
+      # so the user doesn't see balance=0 the moment they're downgraded.
+      CreditService.grant_plan!(
+        user,
+        amount: CreditService.monthly_credits_for("free"),
+        period_end: CreditService.initial_period_end_for("free"),
+        metadata: { source: "soft_trial_downgrade" },
+      )
+
       Rails.logger.info "DowngradeSoftTrialJob: downgraded user #{user.id} (#{user.email}) to free"
       count += 1
     rescue => e

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -1,0 +1,60 @@
+# Monthly credit refresh for users who don't have a Stripe subscription
+# driving renewal grants.
+#
+# Stripe-driven users (subscriptions on file) get their monthly plan credits
+# refreshed by the `invoice.payment_succeeded` webhook. Free users — and
+# users whose subscription was canceled but who are still active on the
+# free tier — have no Stripe billing cycle, so this job is their refresh
+# loop. It runs daily; the check is cheap.
+#
+# Eligibility:
+#   - plan_credits_reset_at IS NULL (never granted) OR plan_credits_reset_at <= now
+#   - stripe_subscription_id IS NULL OR plan_type is one of the non-paid tiers
+#     (covers users who canceled — they still have a stripe_subscription_id
+#     until the webhook clears it)
+#   - Skip admins
+#
+# Idempotent on the day's transaction: grant_plan! writes one new row per
+# call and expires leftovers. Running twice in the same day double-resets
+# the user but doesn't accumulate, so we gate on reset_at.
+class RefreshFreeTierCreditsJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 2
+
+  # Tiers without a Stripe subscription driving renewal grants. MySpeak,
+  # Basic, Pro, and Partner Pro are paid Stripe subscriptions and get
+  # refreshed by `invoice.payment_succeeded` instead.
+  NON_PAID_PLAN_TYPES = %w[free basic_trial].freeze
+
+  def perform
+    refreshed = 0
+
+    eligible_users.find_each do |user|
+      next if user.respond_to?(:admin?) && user.admin?
+
+      plan_type = user.plan_type.presence || "free"
+      amount = CreditService.monthly_credits_for(plan_type)
+      next if amount <= 0
+
+      CreditService.grant_plan!(
+        user,
+        amount: amount,
+        period_end: CreditService.initial_period_end_for(plan_type),
+        metadata: { source: "refresh_free_tier_credits_job", plan_type: plan_type },
+      )
+      refreshed += 1
+    rescue => e
+      Rails.logger.error "RefreshFreeTierCreditsJob: failed for user #{user.id} - #{e.class} #{e.message}"
+    end
+
+    Rails.logger.info "RefreshFreeTierCreditsJob: refreshed=#{refreshed}"
+  end
+
+  private
+
+  def eligible_users
+    User
+      .where(plan_type: NON_PAID_PLAN_TYPES)
+      .where("plan_credits_reset_at IS NULL OR plan_credits_reset_at <= ?", Time.current)
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,5 +24,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Zero out plan_credits_balance for users whose plan_credits_reset_at has passed. Backstop for the invoice.payment_succeeded webhook; runs hourly.",
     },
+    "refresh_free_tier_credits" => {
+      "cron" => "0 3 * * *",
+      "class" => "RefreshFreeTierCreditsJob",
+      "queue" => "default",
+      "description" => "Re-grant monthly AI credits to non-subscription users (free, soft trial, MySpeak) whose plan_credits_reset_at has passed. Runs daily at 3am UTC, after DowngradeSoftTrialJob.",
+    },
   })
 end

--- a/docs/credits-handoff.md
+++ b/docs/credits-handoff.md
@@ -24,6 +24,7 @@ small ones (a single word suggestion).
 | Plan | Monthly credits | Approx. usage |
 |---|---|---|
 | **Free** | 10 | 2 AI images, or 10 word suggestions |
+| **Basic Trial** (default for new signups, 14 days) | 400 | Matches Basic so trial users can fully evaluate AI features |
 | **MySpeak** | 50 | 10 AI images, or 50 word suggestions |
 | **Basic** | 400 | 80 AI images, or one full menu + 30 images |
 | **Pro** | 1,500 | 300 AI images, or many full menus |

--- a/spec/models/credit_transaction_spec.rb
+++ b/spec/models/credit_transaction_spec.rb
@@ -3,6 +3,11 @@ require "rails_helper"
 RSpec.describe CreditTransaction, type: :model do
   let(:user) { FactoryBot.create(:user) }
 
+  # Scope tests count rows explicitly created here; clear the after_create
+  # plan_grant that ships with every new user.
+  before { reset_user_credits!(user) }
+
+
   it "validates kind inclusion" do
     t = described_class.new(user: user, amount: 1, kind: "bogus", source: "plan")
     expect(t).not_to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,6 +116,52 @@ RSpec.describe User, type: :model do
     end
   end
 
+  context "initial plan-credit grant on signup" do
+    it "grants the basic_trial allowance (400) by default since new users land in basic_trial" do
+      user = FactoryBot.create(:user)
+      expect(user.plan_type).to eq("basic_trial")
+      expect(user.plan_credits_balance).to eq(400)
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+    end
+
+    # NOTE: User#set_soft_trial_plan (before_save) flips plan_type "free" → "basic_trial"
+    # for any user inside their 14-day free trial window. To test the "free" path,
+    # explicitly age the user past the trial window before the after_create grant.
+    it "grants the free allowance (10) when the user is post-trial (free)" do
+      user = FactoryBot.build(:user, plan_type: "free", created_at: 30.days.ago)
+      user.save!
+      expect(user.plan_type).to eq("free")
+      expect(user.plan_credits_balance).to eq(10)
+    end
+
+    it "grants the basic allowance (400) when plan_type is explicitly basic" do
+      user = FactoryBot.create(:user, plan_type: "basic")
+      expect(user.plan_credits_balance).to eq(400)
+    end
+
+    it "grants the pro allowance (1500) when plan_type is explicitly pro" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      expect(user.plan_credits_balance).to eq(1500)
+    end
+
+    it "sets plan_credits_reset_at = 14 days from now for basic_trial users" do
+      user = FactoryBot.create(:user)
+      expect(user.plan_credits_reset_at).to be_within(5.seconds).of(14.days.from_now)
+    end
+
+    it "sets plan_credits_reset_at = 30 days from now for post-trial free users" do
+      user = FactoryBot.build(:user, plan_type: "free", created_at: 30.days.ago)
+      user.save!
+      expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
+    end
+
+    it "does not grant credits to admins" do
+      admin = FactoryBot.create(:admin_user)
+      expect(admin.plan_credits_balance).to eq(0)
+      expect(admin.credit_transactions.where(kind: "plan_grant")).to be_empty
+    end
+  end
+
   context "monthly_limit_for" do
     it "returns a high limit for admin users" do
       admin = FactoryBot.create(:user)

--- a/spec/requests/api/board_images_rate_limit_spec.rb
+++ b/spec/requests/api/board_images_rate_limit_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe "BoardImages AI gating (credits)", type: :request do
       .to receive(:authenticate_token!).and_return(true)
     allow_any_instance_of(API::ApplicationController)
       .to receive(:current_user).and_return(user)
+    # These tests need an explicit balance; wipe the after_create plan_grant.
+    reset_user_credits!(user)
   end
 
   let!(:user)        { create(:user) }

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -6,6 +6,11 @@ require "rails_helper"
 RSpec.describe "Credit enforcement on AI endpoints", type: :request do
   let(:user) { FactoryBot.create(:user) }
 
+  # Most tests below dictate exact balances; clear the after_create grant
+  # so we're not fighting it. The grant_plan! calls in inner `before`
+  # blocks then set up the specific scenario each test needs.
+  before { reset_user_credits!(user) }
+
   def auth
     auth_headers(user)
   end

--- a/spec/requests/api/webhooks_plan_credits_spec.rb
+++ b/spec/requests/api/webhooks_plan_credits_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "POST /api/webhooks (plan credits)", type: :request do
 
   let!(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_plan_user") }
 
-  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+  before do
+    ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy"
+    # New users get an after_create plan_grant; clear it so these webhook
+    # specs can assert exact "from 0 to N" changes.
+    reset_user_credits!(user)
+  end
 
   def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
     event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe CreditService, type: :service do
   let(:user) { FactoryBot.create(:user) }
 
+  # New users land in `basic_trial` and get an after_create plan_grant (400).
+  # These specs test CreditService in isolation, so wipe the auto-grant first.
+  before { reset_user_credits!(user) }
+
   describe ".cost_for" do
     it "returns the configured weight for a known feature" do
       expect(described_class.cost_for("image_generation")).to eq(5)
@@ -19,11 +23,57 @@ RSpec.describe CreditService, type: :service do
     it "returns the configured allowance per plan" do
       expect(described_class.monthly_credits_for("free")).to eq(10)
       expect(described_class.monthly_credits_for("basic")).to eq(400)
+      expect(described_class.monthly_credits_for("basic_trial")).to eq(400)
       expect(described_class.monthly_credits_for("pro")).to eq(1500)
     end
 
     it "falls back to free for unknown plan" do
       expect(described_class.monthly_credits_for("nope")).to eq(described_class::PLAN_MONTHLY_CREDITS["free"])
+    end
+  end
+
+  describe ".initial_period_end_for" do
+    it "is 14 days for basic_trial (matches the soft-trial window)" do
+      from = Time.utc(2026, 5, 1)
+      expect(described_class.initial_period_end_for("basic_trial", from: from)).to eq(from + 14.days)
+    end
+
+    it "is 30 days by default for other plans" do
+      from = Time.utc(2026, 5, 1)
+      expect(described_class.initial_period_end_for("free", from: from)).to eq(from + 30.days)
+      expect(described_class.initial_period_end_for("basic", from: from)).to eq(from + 30.days)
+    end
+  end
+
+  describe ".ensure_initial_grant!" do
+    it "grants the tier's monthly allowance with the right expiry on first call" do
+      user.update_column(:plan_type, "basic_trial")
+      # Clear any after_create grant so we can test the method in isolation
+      user.credit_transactions.destroy_all
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: nil)
+
+      tx = described_class.ensure_initial_grant!(user)
+      expect(tx).to be_present
+      expect(tx.kind).to eq("plan_grant")
+      expect(tx.amount).to eq(400)
+      expect(tx.expires_at).to be_within(2.seconds).of(14.days.from_now)
+      expect(user.reload.plan_credits_balance).to eq(400)
+    end
+
+    it "is idempotent: a second call returns the existing grant without adding credits" do
+      user.update_column(:plan_type, "free")
+      first = described_class.ensure_initial_grant!(user)
+      expect {
+        second = described_class.ensure_initial_grant!(user)
+        expect(second.id).to eq(first.id)
+      }.not_to change { user.reload.credit_transactions.where(kind: "plan_grant").count }
+    end
+
+    it "is a no-op for admins" do
+      admin = FactoryBot.create(:admin_user)
+      admin.credit_transactions.destroy_all
+      expect(described_class.ensure_initial_grant!(admin)).to be_nil
+      expect(admin.reload.credit_transactions.where(kind: "plan_grant")).to be_empty
     end
   end
 

--- a/spec/sidekiq/downgrade_soft_trial_job_spec.rb
+++ b/spec/sidekiq/downgrade_soft_trial_job_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
         user = create_soft_trial_user
         expect { job.perform }.to change { user.reload.plan_type }.from("basic_trial").to("free")
       end
+
+      it "grants the free-tier credit allowance after downgrade" do
+        user = create_soft_trial_user
+        # Pretend they spent most of their basic_trial allowance.
+        user.update_columns(plan_credits_balance: 12, plan_credits_reset_at: 1.day.ago)
+
+        expect { job.perform }.to change { user.reload.plan_credits_balance }.to(10)
+        expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
+        tx = user.credit_transactions.where(kind: "plan_grant").order(created_at: :desc).first
+        expect(tx.metadata["source"]).to eq("soft_trial_downgrade")
+      end
     end
 
     context "when a user has no stripe_customer_id (Apple/RevenueCat)" do

--- a/spec/sidekiq/expire_plan_credits_job_spec.rb
+++ b/spec/sidekiq/expire_plan_credits_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ExpirePlanCreditsJob, type: :sidekiq do
   describe "#perform" do
     it "zeros plan credits whose reset_at has passed" do
-      user = FactoryBot.create(:user)
+      user = reset_user_credits!(FactoryBot.create(:user))
       CreditService.grant_plan!(user, amount: 100, period_end: 1.day.ago)
       expect(user.reload.plan_credits_balance).to eq(100)
 

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
+  describe "#perform" do
+    it "refreshes a free user whose plan_credits_reset_at has passed" do
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      # Backdate reset_at so the user is eligible
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+
+      expect {
+        described_class.new.perform
+      }.to change { user.reload.plan_credits_balance }.from(0).to(10)
+      expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
+    end
+
+    it "refreshes a basic_trial user whose reset_at has passed" do
+      user = FactoryBot.create(:user) # defaults to basic_trial
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago)
+
+      described_class.new.perform
+      expect(user.reload.plan_credits_balance).to eq(400)
+    end
+
+    it "leaves users whose reset_at is in the future alone" do
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user.update_columns(plan_credits_balance: 5, plan_credits_reset_at: 5.days.from_now)
+
+      expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
+    end
+
+    it "leaves paid users alone (their refresh comes from invoice.payment_succeeded)" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+
+      expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
+    end
+
+    it "leaves myspeak users alone (paid Stripe subscription)" do
+      user = FactoryBot.create(:user, plan_type: "myspeak")
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+
+      expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
+    end
+
+    it "skips admins" do
+      admin = FactoryBot.create(:admin_user)
+      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+
+      expect { described_class.new.perform }.not_to change { admin.reload.plan_credits_balance }
+    end
+
+    it "expires leftover credits before granting (no rollover for plan credits)" do
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user.update_columns(plan_credits_balance: 7, plan_credits_reset_at: 2.days.ago)
+
+      described_class.new.perform
+      user.reload
+      expect(user.plan_credits_balance).to eq(10)
+      expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to be >= 1
+    end
+
+    it "leaves top-up credits untouched" do
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50)
+
+      described_class.new.perform
+      expect(user.reload.topup_credits_balance).to eq(50)
+    end
+  end
+end

--- a/spec/support/credits_helper.rb
+++ b/spec/support/credits_helper.rb
@@ -1,0 +1,21 @@
+# Test helper for the AI credit ledger.
+#
+# New users land in `basic_trial` and get an automatic plan-credit grant
+# from User#after_create. Specs that test credit-related behavior in
+# isolation usually want to start from a clean ledger, so they can set
+# up the exact balance they want to exercise. This helper does that.
+module CreditsTestHelper
+  def reset_user_credits!(user)
+    user.credit_transactions.destroy_all
+    user.update_columns(
+      plan_credits_balance: 0,
+      topup_credits_balance: 0,
+      plan_credits_reset_at: nil,
+    )
+    user
+  end
+end
+
+RSpec.configure do |config|
+  config.include CreditsTestHelper
+end


### PR DESCRIPTION
## Summary

The credits system shipped in #84 only granted plan credits through Stripe webhooks — `invoice.payment_succeeded` for paid renewals, `customer.subscription.created` for Stripe trials. **New signups land in the soft `basic_trial` plan via `User#set_soft_trial_plan`, which never goes through Stripe** — so they had zero credits and every AI call returned `402 insufficient_credits`. Free users on a non-Stripe billing cycle were stuck once their (also-never-granted) allowance ran out.

This wires the missing paths.

## What's new

| Layer | Change |
|---|---|
| `CreditService::PLAN_MONTHLY_CREDITS` | Add `"basic_trial" => 400` (previously fell back to `"free"` → 10) |
| `CreditService.ensure_initial_grant!(user)` | Idempotent helper — grants the user's tier's allowance with 14d expiry for `basic_trial`, 30d for everyone else. No-op for admins or users who already have a `plan_grant` |
| `CreditService.initial_period_end_for(plan_type)` | Picks the right expiry based on plan |
| `User#after_create :grant_initial_plan_credits` | Every new signup now gets credits before they hit their first AI feature |
| `DowngradeSoftTrialJob` (daily at 2am UTC) | After flipping `basic_trial` → `free`, now also `CreditService.grant_plan!`s 10 credits with 30d expiry |
| **New** `RefreshFreeTierCreditsJob` (daily at 3am UTC) | Re-grants the tier allowance to users on `free` / `basic_trial` whose `plan_credits_reset_at` has passed. Skips `myspeak` / `basic` / `pro` / `partner_pro` — those refresh via `invoice.payment_succeeded` |

## Notes on tier boundaries

- `myspeak` is a paid Stripe-subscription tier (has `STRIPE_PRICE_MYSPEAK`), so it's *excluded* from `RefreshFreeTierCreditsJob` — its refresh path is `invoice.payment_succeeded`, same as Basic and Pro. The new job covers only `free` and `basic_trial`. There's an explicit regression-guard spec asserting this.
- Soft trial vs. Stripe trial: `basic_trial` is the User-callback soft trial (no Stripe yet). `customer.subscription.created` with `status: trialing` is a Stripe trial — handled separately in `API::WebhooksController` (unchanged).

## Test plan

- [x] **Full suite: 332 examples, 0 failures, 18 pending.**
- [x] New specs cover: signup grant per plan_type, idempotency, admin bypass, soft-trial downgrade grant, monthly refresh eligibility (incl. paid-tier exclusion), top-up preservation through refresh.
- [x] Existing specs that assumed new users have zero credits now use a new `reset_user_credits!(user)` helper (`spec/support/credits_helper.rb`).
- [ ] **Reviewer:** sign up a fresh test user in staging → `GET /api/me/credits` should show `plan: 400, plan_type: "basic_trial", reset_at: <14 days out>`.
- [ ] Reviewer: hit any AI endpoint on that fresh user — should succeed (no more 402 on first call).

## What's NOT in this PR

- Frontend changes — the existing `CreditsContext.refresh` already polls `/api/me/credits`, so the new balance will surface automatically on next refresh. No UI changes needed.
- README pricing table updates — that's [#105](https://github.com/brittanyjohns/itty_bitty_boards/pull/105), still open. Once both merge I'll add the `basic_trial` row to the README table too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)