### PR TITLE
fix: correct RefreshFreeTierCreditsJob cron description re MySpeak

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -28,7 +28,7 @@ Sidekiq.configure_server do |config|
       "cron" => "0 3 * * *",
       "class" => "RefreshFreeTierCreditsJob",
       "queue" => "default",
-      "description" => "Re-grant monthly AI credits to non-subscription users (free, soft trial, MySpeak) whose plan_credits_reset_at has passed. Runs daily at 3am UTC, after DowngradeSoftTrialJob.",
+      "description" => "Re-grant monthly AI credits to non-subscription users (free, basic_trial) whose plan_credits_reset_at has passed. Paid Stripe subscribers (MySpeak, Basic, Pro, Partner Pro) refresh via invoice.payment_succeeded and are skipped. Runs daily at 3am UTC, after DowngradeSoftTrialJob.",
     },
   })
 end


### PR DESCRIPTION
## Summary

Addresses [Brittany's review comment on #106](https://github.com/brittanyjohns/itty_bitty_boards/pull/106#discussion_r3235973343): *\"Myspeak is a subscription plan.\"*

The job code already excludes MySpeak (`NON_PAID_PLAN_TYPES = %w[free basic_trial]`, and there's a regression-guard spec asserting MySpeak users aren't touched), but the cron registry description string still listed MySpeak as a non-subscription tier — stale from an earlier iteration of the PR. Updated to:

> Re-grant monthly AI credits to non-subscription users (free, basic_trial) whose plan_credits_reset_at has passed. Paid Stripe subscribers (MySpeak, Basic, Pro, Partner Pro) refresh via invoice.payment_succeeded and are skipped. Runs daily at 3am UTC, after DowngradeSoftTrialJob.

No code or behavior change.

## Test plan

- [x] Description-only edit, no test impact.
- [x] Doc/code already reflects the correct boundary (`spec/sidekiq/refresh_free_tier_credits_job_spec.rb` has an explicit "leaves myspeak users alone" example).