### PR TITLE
fix(internal-api): accept empty profile patch so regenerate-only PATCH works

### DIFF
--- a/app/controllers/api/internal/profiles_controller.rb
+++ b/app/controllers/api/internal/profiles_controller.rb
@@ -41,7 +41,7 @@ class API::Internal::ProfilesController < API::Internal::ApplicationController
   end
 
   def profile_params
-    params.require(:profile).permit(
+    params.fetch(:profile, {}).permit(
       :username, :bio, :intro, :avatar, :allow_discovery,
       settings: {},
     )

--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -83,6 +83,16 @@ RSpec.describe "API::Internal::Profiles", type: :request do
       expect(Communicators::GenerateDeviceTag).to have_received(:call).with(profile)
     end
 
+    it "accepts an empty profile patch and regenerates safety attachments" do
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { profile: {} }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Communicators::GenerateSafetyIdCard).to have_received(:call).with(profile)
+      expect(Communicators::GenerateDeviceTag).to have_received(:call).with(profile)
+    end
+
     it "does not regenerate attachments for non-safety profiles" do
       profile.update!(profile_kind: "public_page")
 


### PR DESCRIPTION
## Summary

- Internal `PATCH /api/internal/profiles/:id` returned **400 Bad Request** when the printables generator hit it with `{ profile: {} }` — the documented "regenerate Safety ID + Device Tag without changing fields" sentinel. Cause: `params.require(:profile)` treats an empty hash as blank and raises `ParameterMissing`.
- Switched to `params.fetch(:profile, {}).permit(...)`. The permit safelist still guards which attributes can change; an empty payload just yields a no-op `update({})` followed by the existing `generate_attachments!` call for `profile_kind == "safety"` profiles.
- Added a request spec for the empty-body case so the contract the printables client (and `.claude-notes/saw-internal-api.md` in `speakanyway-printables`) already advertises is now enforced.

This unblocks the printables `device_tag` and `safety_id` product types — both go through the same `fetchProfile(ctx, cfg)` helper that sends the empty patch when `regenerate: true` (the default).

Repro: `device_tag` generator run for Notion entry `35f866f3-0727-8105-943f-da1ac5e1b156` crashed at step 5 with `PATCH /api/internal/profiles/test → 400: {"status":400,"error":"Bad Request"}`.

## Test plan

- [x] `bundle exec rspec spec/requests/api/internal/profiles_spec.rb -e "PATCH"` — all 8 PATCH examples pass (7 existing + the new empty-body case).
- [ ] After deploy: re-run the failed printables generator (`workflow_dispatch` on `generate-printable.yml`, page id `35f866f3-0727-8105-943f-da1ac5e1b156`, product type `device_tag`) and confirm step 5 completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)