### PR TITLE
feat: CLI scripts for tailing prod/staging logs over SSH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,23 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - `bundle exec sidekiq` — start Sidekiq worker
 - `bundle exec rspec` — run tests
 
+## Reading production logs (CLI)
+
+Hatchbox runs Puma + Sidekiq as **user** systemd services on the deploy
+user, so logs are in the user journal (no sudo needed).
+
+- `bin/prod-logs` — tail production Puma (`itty-bitty-boards-server.service`) over SSH
+- `bin/prod-logs worker` — tail production Sidekiq (`itty-bitty-boards-sidekiq.service`)
+- `bin/prod-logs all` — tail every `itty-bitty-boards-*.service` unit
+- `bin/prod-logs <unit-name>` — tail a specific unit (pass-through)
+- `bin/staging-logs [web|worker|all]` — same shape for staging
+- `bin/prod-disk-audit` — read-only snapshot of disk + journald + nginx
+  + app `log/` and `tmp/` sizes. Run any time you suspect disk pressure.
+
+Env overrides: `PROD_HOST`, `PROD_WEB_UNIT`, `PROD_WORKER_UNIT`,
+`PROD_ALL_UNIT` (and `STAGING_*` equivalents). `LINES=N` controls the
+backlog size (default 200).
+
 ## Subscription model
 
 - Most features are free

--- a/bin/prod-disk-audit
+++ b/bin/prod-disk-audit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Read-only disk + log-size snapshot of the production EC2 box.
+# Run any time you're worried about disk pressure on the Hatchbox host.
+#
+# Usage:
+#   bin/prod-disk-audit              # audit production
+#   PROD_HOST=... bin/prod-disk-audit
+set -euo pipefail
+
+HOST="${PROD_HOST:-deploy@670kd.hatchboxapp.com}"
+
+ssh "$HOST" 'bash -s' <<'REMOTE'
+echo "=== disk usage ==="
+df -h /
+
+echo; echo "=== top 15 dirs under / ==="
+sudo du -h -d 2 -x / 2>/dev/null | sort -h | tail -15
+
+echo; echo "=== system journald ==="
+sudo journalctl --disk-usage
+echo "--- journald.conf caps ---"
+sudo grep -E '^[^#]*(SystemMaxUse|MaxRetentionSec)' /etc/systemd/journald.conf \
+  || echo "(no caps set — journald will use up to 10% of disk)"
+
+echo; echo "=== user journald (deploy user — where puma/sidekiq logs live) ==="
+journalctl --user --disk-usage 2>/dev/null || echo "(no user journal yet)"
+
+echo; echo "=== nginx logs ==="
+sudo ls -lh /var/log/nginx/ 2>/dev/null || echo "(no /var/log/nginx)"
+echo "--- logrotate config ---"
+sudo cat /etc/logrotate.d/nginx 2>/dev/null || echo "(no /etc/logrotate.d/nginx)"
+
+echo; echo "=== rails app log + tmp ==="
+du -sh /home/deploy/*/current/log /home/deploy/*/current/tmp /home/deploy/*/shared/log 2>/dev/null
+REMOTE

--- a/bin/prod-logs
+++ b/bin/prod-logs
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tail production logs over SSH via systemd-journal.
+#
+# Usage:
+#   bin/prod-logs                       # tail web (puma)
+#   bin/prod-logs worker                # tail sidekiq
+#   bin/prod-logs all                   # tail every app unit
+#   bin/prod-logs <unit-name>           # tail a specific unit
+#   LINES=1000 bin/prod-logs web        # bigger backlog
+#
+# Override defaults with env vars: PROD_HOST, PROD_WEB_UNIT,
+# PROD_WORKER_UNIT, PROD_ALL_UNIT.
+#
+# Hatchbox runs Puma + Sidekiq as **user** systemd services under the
+# deploy user, so we use `journalctl --user-unit` (no sudo). To find
+# the real unit names if these defaults drift, SSH in and run:
+#   systemctl --user list-units --type=service | grep itty
+set -euo pipefail
+
+HOST="${PROD_HOST:-deploy@670kd.hatchboxapp.com}"
+TARGET="${1:-web}"
+LINES="${LINES:-200}"
+
+case "$TARGET" in
+  web)    UNIT="${PROD_WEB_UNIT:-itty-bitty-boards-server.service}" ;;
+  worker) UNIT="${PROD_WORKER_UNIT:-itty-bitty-boards-sidekiq.service}" ;;
+  all)    UNIT="${PROD_ALL_UNIT:-itty-bitty-boards-*.service}" ;;
+  *)      UNIT="$TARGET" ;;
+esac
+
+exec ssh -t "$HOST" "journalctl --user-unit '$UNIT' -f -n $LINES --output=cat"

--- a/bin/staging-logs
+++ b/bin/staging-logs
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Tail staging logs over SSH via systemd-journal.
+# See bin/prod-logs for full docs.
+set -euo pipefail
+
+HOST="${STAGING_HOST:-deploy@ypk9e.hatchboxapp.com}"
+TARGET="${1:-web}"
+LINES="${LINES:-200}"
+
+case "$TARGET" in
+  web)    UNIT="${STAGING_WEB_UNIT:-itty-bitty-boards-server.service}" ;;
+  worker) UNIT="${STAGING_WORKER_UNIT:-itty-bitty-boards-sidekiq.service}" ;;
+  all)    UNIT="${STAGING_ALL_UNIT:-itty-bitty-boards-*.service}" ;;
+  *)      UNIT="$TARGET" ;;
+esac
+
+exec ssh -t "$HOST" "journalctl --user-unit '$UNIT' -f -n $LINES --output=cat"


### PR DESCRIPTION
## Summary

- Add `bin/prod-logs` and `bin/staging-logs` — wrappers around `journalctl --user-unit` over SSH so we can tail Hatchbox-managed Puma + Sidekiq from a terminal instead of clicking through the Hatchbox UI.
- Add `bin/prod-disk-audit` — read-only snapshot of disk + journald + nginx + app log/tmp sizes, for spot-checking that the EC2 box isn't filling up.
- Document all three under a new "Reading production logs (CLI)" section in `CLAUDE.md`.

## Why

Reading prod logs required logging into the Hatchbox UI — slow, no `tail -f`, no grep. Brittany also wanted reassurance the EC2 box wasn't quietly filling up with log files.

Verified in the repo: Rails (`config/environments/production.rb`) and Sidekiq (`config/initializers/sidekiq.rb`) both log to STDOUT in production, so Rails itself writes zero log files. Disk pressure can only come from journald, nginx, or app `tmp/`. The audit script targets exactly those three.

Hatchbox runs the app as **user** systemd services on the deploy user (unit `itty-bitty-boards-server.service` for web, presumed `itty-bitty-boards-sidekiq.service` for worker — pass-through for any unit name is supported via `bin/prod-logs <unit-name>` if the worker name differs).

## Out of scope (deferred)

If terminal tailing isn't enough longer-term, follow-up: ship journald → Better Stack / Logtail via Vector. Free tier covers our volume; ~$25/mo for 30-day retention. Don't pay for it pre-emptively.

## Test plan

- [ ] `bin/prod-logs` streams live web logs from `itty-bitty-boards-server.service`.
- [ ] `bin/prod-logs worker` streams Sidekiq logs (correct unit name TBD on first run; pass-through covers it either way).
- [ ] `bin/prod-logs all | grep '"status":5'` surfaces 5xx.
- [ ] `bin/prod-disk-audit` prints disk usage, journald cap, nginx log sizes, and app log/tmp sizes without errors.
- [ ] No production code or config changed; no new gems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)