### PR TITLE
fix(credits): clamp credits:backfill period_end to future + add recovery task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,11 @@ Tasks:
   based on their `plan_type`. Idempotent.
 - `bin/rails credits:recompute_balances` — rebuild denormalized balances
   from the ledger if they drift.
+- `bin/rails credits:regrant_stale_backfill` — one-off recovery for users
+  zeroed out by the original `credits:backfill` bug (issue #110): finds
+  users with a `plan_grant` row, a matching `period_ended` `expire` row,
+  and `plan_credits_balance = 0`, then re-grants their tier allowance with
+  `period_end = 30.days.from_now`.
 
 ## Do not
 

--- a/lib/tasks/credits.rake
+++ b/lib/tasks/credits.rake
@@ -8,7 +8,8 @@ namespace :credits do
 
       plan_type = user.plan_type.presence || "free"
       amount = CreditService.monthly_credits_for(plan_type)
-      period_end = user.plan_expires_at.presence || 30.days.from_now
+      candidate = user.plan_expires_at
+      period_end = (candidate.present? && candidate > Time.current) ? candidate : 30.days.from_now
 
       CreditService.grant_plan!(
         user,
@@ -20,6 +21,36 @@ namespace :credits do
       print "." if granted % 100 == 0
     end
     puts "\nBackfill complete. granted=#{granted} skipped=#{skipped}"
+  end
+
+  desc "Re-grant plan credits to users zeroed out by the stale-plan_expires_at backfill bug (issue #110)"
+  task regrant_stale_backfill: :environment do
+    regranted = 0
+    skipped = 0
+
+    affected_user_ids = CreditTransaction
+      .where(kind: "expire", source: "plan")
+      .where("metadata->>'reason' = ?", "period_ended")
+      .distinct.pluck(:user_id)
+
+    User.where(id: affected_user_ids, plan_credits_balance: 0).find_each do |user|
+      unless CreditTransaction.exists?(user_id: user.id, kind: "plan_grant")
+        skipped += 1
+        next
+      end
+
+      plan_type = user.plan_type.presence || "free"
+      amount = CreditService.monthly_credits_for(plan_type)
+      CreditService.grant_plan!(
+        user,
+        amount: amount,
+        period_end: 30.days.from_now,
+        metadata: { reason: "manual_regrant_stale_plan_expires_at", plan_type: plan_type },
+      )
+      regranted += 1
+    end
+
+    puts "Re-grant complete. regranted=#{regranted} skipped=#{skipped}"
   end
 
   desc "Recompute denormalized balances from the credit_transactions ledger"

--- a/spec/lib/tasks/credits_rake_spec.rb
+++ b/spec/lib/tasks/credits_rake_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "credits rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task[task_name] }
+
+  after { task.reenable }
+
+  describe "credits:backfill" do
+    let(:task_name) { "credits:backfill" }
+
+    it "uses 30.days.from_now when plan_expires_at is stale" do
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "pro"))
+      user.update_columns(plan_expires_at: 2.months.ago)
+
+      task.invoke
+
+      grant = user.credit_transactions.find_by(kind: "plan_grant")
+      expect(grant).to be_present
+      expect(grant.expires_at).to be > Time.current
+      expect(grant.expires_at).to be_within(1.minute).of(30.days.from_now)
+    end
+
+    it "uses plan_expires_at when it is in the future" do
+      future = 45.days.from_now
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "pro"))
+      user.update_columns(plan_expires_at: future)
+
+      task.invoke
+
+      grant = user.credit_transactions.find_by(kind: "plan_grant")
+      expect(grant.expires_at).to be_within(1.second).of(future)
+    end
+
+    it "uses 30.days.from_now when plan_expires_at is nil" do
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "pro"))
+      user.update_columns(plan_expires_at: nil)
+
+      task.invoke
+
+      grant = user.credit_transactions.find_by(kind: "plan_grant")
+      expect(grant.expires_at).to be_within(1.minute).of(30.days.from_now)
+    end
+
+    it "skips users who already have a plan_grant row" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      # ensure_initial_grant! already created a plan_grant on after_create
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+      grant_before = user.credit_transactions.find_by(kind: "plan_grant")
+
+      task.invoke
+
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+      expect(user.credit_transactions.find_by(kind: "plan_grant").id).to eq(grant_before.id)
+    end
+  end
+
+  describe "credits:regrant_stale_backfill" do
+    let(:task_name) { "credits:regrant_stale_backfill" }
+
+    def seed_stale_backfill_victim!(plan_type: "pro")
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: plan_type))
+      CreditTransaction.create!(
+        user: user,
+        amount: 1500,
+        kind: "plan_grant",
+        source: "plan",
+        expires_at: 2.months.ago,
+        metadata: { reason: "phase1_backfill", plan_type: plan_type },
+      )
+      CreditTransaction.create!(
+        user: user,
+        amount: -1500,
+        kind: "expire",
+        source: "plan",
+        metadata: { reason: "period_ended" },
+      )
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.months.ago)
+      user
+    end
+
+    it "re-grants users zeroed out by the stale-backfill bug" do
+      user = seed_stale_backfill_victim!(plan_type: "pro")
+
+      task.invoke
+
+      user.reload
+      expect(user.plan_credits_balance).to eq(CreditService.monthly_credits_for("pro"))
+      latest_grant = user.credit_transactions.where(kind: "plan_grant").order(:created_at).last
+      expect(latest_grant.expires_at).to be > Time.current
+      expect(latest_grant.metadata["reason"]).to eq("manual_regrant_stale_plan_expires_at")
+    end
+
+    it "does not re-grant users with a healthy non-zero plan balance" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      # User has a fresh plan_grant from after_create and a positive balance — skip them.
+      grants_before = user.credit_transactions.where(kind: "plan_grant").count
+
+      task.invoke
+
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(grants_before)
+    end
+
+    it "does not re-grant users zeroed out for unrelated reasons (no period_ended expire row)" do
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "free"))
+      CreditTransaction.create!(
+        user: user,
+        amount: 25,
+        kind: "plan_grant",
+        source: "plan",
+        expires_at: 30.days.from_now,
+        metadata: { reason: "phase1_backfill", plan_type: "free" },
+      )
+      CreditTransaction.create!(
+        user: user,
+        amount: -25,
+        kind: "spend",
+        source: "plan",
+        metadata: { reason: "ai_feature_x" },
+      )
+      user.update_columns(plan_credits_balance: 0)
+
+      task.invoke
+
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `credits:backfill` used `user.plan_expires_at.presence || 30.days.from_now`, which only filters `nil` / `""` — past timestamps slip through and the grant's `expires_at` is created already-expired. The hourly `ExpirePlanCreditsJob` sweep then zeroes the balance, and because the task is idempotent on the presence of any `plan_grant` row, re-running it is a no-op for affected users.
- Clamp the value: keep `plan_expires_at` only when it's in the future; otherwise fall back to `30.days.from_now`. Safe — the next `invoice.payment_succeeded` webhook overwrites `period_end` with the real Stripe subscription period.
- Add `credits:regrant_stale_backfill` recovery task for users already zeroed by the bug. Filters on `plan_credits_balance = 0` **and** the smoking-gun `expire(period_ended)` ledger row, so legitimately-spent-down balances are left alone.

Closes #110

## Test plan

- [x] `bundle exec rspec spec/lib/tasks/credits_rake_spec.rb` — 7 examples, 0 failures
  - `credits:backfill` with stale / future / nil `plan_expires_at`
  - `credits:backfill` skips users already holding a `plan_grant` row
  - `credits:regrant_stale_backfill` re-grants stale-backfill victims
  - `credits:regrant_stale_backfill` skips users with healthy balances
  - `credits:regrant_stale_backfill` skips users zeroed for other reasons (no `period_ended` row)
- [ ] Reviewer-side: run on staging against user id=86 (`bhannajohns+trial@gmail.com`) to confirm a fresh `plan_grant` is created with `expires_at` ~30 days out.

## Files

- [lib/tasks/credits.rake](lib/tasks/credits.rake) — clamp fix + new recovery task
- [spec/lib/tasks/credits_rake_spec.rb](spec/lib/tasks/credits_rake_spec.rb) — new
- [CLAUDE.md](CLAUDE.md) — document the new task

🤖 Generated with [Claude Code](https://claude.com/claude-code)