### PR TITLE
feat: language-aware backend content (i18n Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Multilingual backend content (i18n Phase 1)
+- **AI generation now respects the user's language.** Word suggestions, board
+  generation, and scenario word lists previously always came back in English.
+  The AI word-suggestion paths (`GET /api/boards/words`,
+  `POST /api/boards/:id/additional_words`, `GET /api/scenarios/get_words`, and
+  the async board/scenario generators) now thread the requesting user's
+  language through to OpenAI, which is instructed to "Respond in <language>".
+  English users see byte-identical output.
+- **New boards default to the creator's language.** `POST /api/boards` now sets
+  `board.language` from the creator's language setting when no explicit
+  `language` param is sent (an explicit param still wins).
+- **Per-language TTS audio.** The audio pipeline previously wrote
+  `_<lang>`-suffixed files but synthesized the *English* label with
+  *English-only* Polly voices. It now synthesizes the translated label and
+  picks language-appropriate voices (`VoiceService.voices_for_language`).
+  `TranslateImageJob` chains a `CreateAllAudioJob` so localized audio is
+  generated once a translation lands.
+
+### Fixed — Translated tile labels were silently ignored
+- `BoardImage#set_labels` looked up the `language_settings` jsonb with symbol
+  keys, but the column stores string keys — so translated labels were never
+  read and tiles always fell back to English. Now uses string keys.
+
 ### Added — AI word suggestions adapt to the communicator
 - Board generation now accepts an optional communicator profile — `age` / `age_band`,
   `aac_level` (`emerging` / `developing` / `proficient`), and `vocab_type` (`core` /

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -325,7 +325,7 @@ class API::BoardsController < API::ApplicationController
     @board.large_screen_columns  = board_params["large_screen_columns"].to_i  if board_params["large_screen_columns"].present?
     voice = VoiceService.normalize_voice(board_params["voice"] || params[:voice] || params[:voice_label])
     @board.voice = voice
-    @board.language = board_params["language"] if board_params["language"].present?
+    @board.language = board_params["language"].presence || current_user.i18n_locale.to_s
     @board.tags = board_params["tags"] if board_params["tags"].present?
     @board.settings = settings
 
@@ -634,23 +634,26 @@ class API::BoardsController < API::ApplicationController
     num_of_words = params[:num_of_words].to_i || 24
     words_to_exclude = params[:words_to_exclude].is_a?(Array) ? params[:words_to_exclude] : @board&.current_word_list || []
     profile = CommunicatorProfile.from_params(params)
+    # The board may be a transient, unsaved object (no board_id), so the
+    # requesting user's language is the source of truth for AI output here.
+    user_language = current_user.i18n_locale.to_s
     @board ||= Board.new(name: prompt) # create a temporary board object to use the word suggestion methods if no board_id is provided
     if creation_type == "social_story"
       number_of_steps = params[:number_of_steps].to_i
       additional_words = @board.get_social_story_word_suggestions(prompt, number_of_steps, num_of_words, words_to_exclude)
     elsif creation_type == "predictive"
-      additional_words = @board.get_words_for_predictive(prompt, num_of_words, profile: profile)
+      additional_words = @board.get_words_for_predictive(prompt, num_of_words, language: user_language, profile: profile)
     elsif creation_type == "custom"
       text = "Please give a list of #{num_of_words} words/phrases based on the following prompt: #{prompt} \n Theses will be used to create an AAC board so keep that in mind. Use lower case unless it's a proper noun and avoid special characters. Do not include any words on the board already: #{words_to_exclude.join(", ")}."
-      additional_words = @board.get_word_suggestions_from_prompt(text, profile: profile)
+      additional_words = @board.get_word_suggestions_from_prompt(text, language: user_language, profile: profile)
     elsif @board&.board_type == "menu"
-      additional_words = @board.get_word_suggestions_from_default_prompt(prompt, num_of_words, profile: profile)
+      additional_words = @board.get_word_suggestions_from_default_prompt(prompt, num_of_words, language: user_language, profile: profile)
     else
       board_name = @board&.name || prompt
       if prompt == board_name
-        additional_words = @board.get_word_suggestions(prompt, num_of_words, words_to_exclude, profile: profile)
+        additional_words = @board.get_word_suggestions(prompt, num_of_words, words_to_exclude, language: user_language, profile: profile)
       else
-        additional_words = @board.get_word_suggestions_from_default_prompt(prompt, num_of_words, profile: profile)
+        additional_words = @board.get_word_suggestions_from_default_prompt(prompt, num_of_words, language: user_language, profile: profile)
       end
     end
     if additional_words.blank?

--- a/app/controllers/api/scenarios_controller.rb
+++ b/app/controllers/api/scenarios_controller.rb
@@ -120,7 +120,7 @@ class API::ScenariosController < API::ApplicationController
     @scenario = Scenario.new(name: @name, age_range: @age_range, initial_description: @description, user: current_user)
     Rails.logger.debug "Generating words for scenario with name: #{@name}, age_range: #{@age_range}, description: #{@description}"
 
-    additional_words = @scenario.get_words_for_scenario(@description, @num_of_images)
+    additional_words = @scenario.get_words_for_scenario(@description, @num_of_images, current_user.i18n_locale.to_s)
     Rails.logger.debug "Additional words: #{additional_words.inspect}"
 
     render json: { words: additional_words }

--- a/app/models/audio_helper.rb
+++ b/app/models/audio_helper.rb
@@ -1,4 +1,13 @@
 module AudioHelper
+  # Text to synthesize for a given language: the translated label when
+  # available, falling back to the English `label`. `localized_label` lazily
+  # enqueues a TranslateImageJob when a supported translation is missing.
+  def text_for_audio(language)
+    lang = language.to_s
+    return label if lang.blank? || lang == "en"
+    localized_label(lang).presence || label
+  end
+
   # Always return [provider, raw_voice]
   def split_voice(voice_value)
     v = voice_value.to_s.strip
@@ -147,7 +156,7 @@ module AudioHelper
     existing = candidates.lazy.map { |fn| find_audio_by_filename(fn) }.find(&:present?)
     return existing if existing.present?
 
-    create_audio_from_text(label, voice_value, lang)
+    create_audio_from_text(text_for_audio(lang), voice_value, lang)
   end
 
   def default_audio_files

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2150,14 +2150,14 @@ class Board < ApplicationRecord
     end
   end
 
-  def get_words_for_predictive(starting_phrase_or_word, word_count, profile: nil)
+  def get_words_for_predictive(starting_phrase_or_word, word_count, language: nil, profile: nil)
     word_or_phrase = starting_phrase_or_word.split(" ").size > 1 ? "phrase" : "word"
     text = "Generate a list of #{word_count} words that would commonly follow the #{word_or_phrase} '#{starting_phrase_or_word}' in everyday communication. These words will be used on a predictive communication board to help users quickly find and select common phrases. Please provide words that are relevant and commonly used in conjunction with '#{starting_phrase_or_word}'."
-    words = get_word_suggestions_from_prompt(text, profile: profile)
+    words = get_word_suggestions_from_prompt(text, language: language, profile: profile)
     words
   end
 
-  def get_words_for_scenario(topic, age_range, word_count, profile: nil)
+  def get_words_for_scenario(topic, age_range, word_count, language: nil, profile: nil)
     words_to_exclude = data["current_word_list"] || []
     # ensure word count is reasonable to avoid excessively long prompts & not 0
     if word_count <= 0 || word_count > 80
@@ -2170,12 +2170,13 @@ class Board < ApplicationRecord
     text += "The age range for the person using the board is #{age_range}. Please provide a list of #{word_count} words that are appropriate for this age range and context. " if age_range.present?
     text += "Please provide a list of #{word_count} words that are appropriate for this context. " if age_range.blank?
     text += "Exclude words that are too similar to each other or that would not be useful on a communication board. Also exclude words that are already on the board: #{words_to_exclude.join(", ")}." if words_to_exclude.any?
-    words = get_word_suggestions_from_prompt(text, profile: profile)
+    words = get_word_suggestions_from_prompt(text, language: language, profile: profile)
     words
   end
 
-  def get_word_suggestions(name_to_use, number_of_words, words_to_exclude = [], profile: nil)
-    response = OpenAiClient.new({}).get_word_suggestions(name_to_use, number_of_words, words_to_exclude, board_type, profile: profile)
+  def get_word_suggestions(name_to_use, number_of_words, words_to_exclude = [], language: nil, profile: nil)
+    lang = language.presence || self.language.presence || "en"
+    response = OpenAiClient.new({}).get_word_suggestions(name_to_use, number_of_words, words_to_exclude, board_type, language: lang, profile: profile)
     begin
       if response && response[:content].present?
         word_suggestions = response[:content].gsub("```json", "").gsub("```", "").strip
@@ -2224,7 +2225,7 @@ class Board < ApplicationRecord
     end
   end
 
-  def get_word_suggestions_from_default_prompt(prompt, number_of_words, profile: nil)
+  def get_word_suggestions_from_default_prompt(prompt, number_of_words, language: nil, profile: nil)
     words_to_exclude = current_word_list || []
     text = "Generate a list of EXACTLY #{number_of_words} words or short phrases based on the following prompt: #{prompt}. "
     unless words_to_exclude.blank?
@@ -2236,11 +2237,12 @@ class Board < ApplicationRecord
       text += "The words/phrases will be used on an AAC board, so please prioritize common, relevant, and useful words/phrases that would help someone communicate effectively. "
     end
     text += "Please make them lowercase with the exception of proper nouns, senetences, etc. that should be capitalized. "
-    get_word_suggestions_from_prompt(text, profile: profile)
+    get_word_suggestions_from_prompt(text, language: language, profile: profile)
   end
 
-  def get_word_suggestions_from_prompt(prompt, profile: nil)
-    response = OpenAiClient.new({}).get_word_suggestions_from_prompt(prompt, profile: profile)
+  def get_word_suggestions_from_prompt(prompt, language: nil, profile: nil)
+    lang = language.presence || self.language.presence || "en"
+    response = OpenAiClient.new({}).get_word_suggestions_from_prompt(prompt, language: lang, profile: profile)
     begin
       if response && response[:content].present?
         word_suggestions = response[:content].gsub("```json", "").gsub("```", "").strip

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -104,11 +104,12 @@ class BoardImage < ApplicationRecord
   end
 
   def set_labels
-    lang = language || board.language || "en"
-    image_language_settings = image.language_settings[lang.to_sym] || {}
+    lang = (language || board&.language || "en").to_s
+    # language_settings is a jsonb column with string keys (see Image#translate_to)
+    image_language_settings = (image.language_settings || {})[lang] || {}
     self.language = lang
-    self.label = image_language_settings[:label] || image.label
-    self.display_label = image_language_settings[:display_label] || label
+    self.label = image_language_settings["label"] || image.label
+    self.display_label = image_language_settings["display_label"] || label
   end
 
   # Delegates to the underlying Image's language_settings. Stored `label` /

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -360,10 +360,11 @@ class Image < ApplicationRecord
   end
 
   def create_voice_audio_files(language_to_use = "en")
-    Image.voices.each do |voice|
+    text = text_for_audio(language_to_use)
+    VoiceService.voices_for_language(language_to_use).each do |voice|
       voice_file = find_audio_for_voice(voice, language_to_use)
       if !voice_file
-        result = create_audio_from_text(label, voice, language_to_use)
+        result = create_audio_from_text(text, voice, language_to_use)
         if !result
           Rails.logger.error "Failed to create audio file for #{label} - #{voice} - #{language_to_use}"
         end
@@ -594,8 +595,15 @@ class Image < ApplicationRecord
   end
 
   def create_audio_for_select_voices(language = "en")
-    # select_voices = ["polly:kevin", "polly:salli", "polly:ivy", "polly:joanna", "openai:marin", "openai:cedar"]
-    select_voices = ["polly:kevin", "polly:ivy", "polly:joanna"]
+    if language.to_s == "en"
+      select_voices = ["polly:kevin", "polly:ivy", "polly:joanna"]
+    else
+      # Prefer the language's Polly voices; fall back to OpenAI voices (which
+      # follow the input text) when Polly has no voice for that language.
+      lang_voices = VoiceService.voices_for_language(language)
+      polly_voices = lang_voices.select { |v| v.to_s.start_with?("polly:") }
+      select_voices = polly_voices.presence || lang_voices.first(2)
+    end
     select_voices.each do |voice|
       unless audio_file_exists_for?(voice)
         result = find_or_create_audio_file_for_voice(voice, language)

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -403,6 +403,19 @@ class OpenAiClient
                           'pl': "Polish",
                           'th': "Thai" }.freeze
 
+  # Appends a "Respond in <language>" instruction when `language` is a supported
+  # non-English code. No-op for `en`, blank, or unknown codes, so English
+  # callers produce exactly the same prompt as before.
+  def append_language_instruction(text, language)
+    lang = language.to_s.strip.downcase
+    return text if lang.blank? || lang == "en"
+
+    formatted_language = LONG_LANGUAGE_NAMES[lang.to_sym]
+    return text if formatted_language.blank?
+
+    "#{text} Respond in #{formatted_language}."
+  end
+
   def get_words_for_scenario(scenario_description, number_of_words = 24, language = "en", profile: nil)
     prompt = <<~PROMPT
       I have a scenario description: "#{scenario_description}".
@@ -412,6 +425,7 @@ class OpenAiClient
       Do not repeat any words that are already on the board & only provide #{number_of_words} words.
       Respond with a JSON object in the following format: {\"words\": [\"word1\", \"word2\", \"word3\", ...]}
     PROMPT
+    prompt = append_language_instruction(prompt, language)
     prompt = append_profile_guidance(prompt, profile)
 
     @model = GTP_MODEL
@@ -459,11 +473,7 @@ class OpenAiClient
         If the board is 'food', words like 'apple', 'banana', 'cookie', etc. would be appropriate."
     end
     format_instructions = "Do not repeat any words that are already on the board & only provide #{number_of_words} words. DO NOT INCLUDE [#{exclude_words_prompt}]. Respond with a JSON object in the following format: {\"additional_words\": [\"word1\", \"word2\", \"word3\", ...]}"
-    language = language || "en"
-    if language != "en"
-      formatted_language = LONG_LANGUAGE_NAMES[language.to_sym]
-      format_instructions += " Respond in #{formatted_language}." if formatted_language
-    end
+    format_instructions = append_language_instruction(format_instructions, language)
     text = "#{text} #{format_instructions} #{ending}"
     text = append_profile_guidance(text, profile)
     @messages = [{ role: "user",
@@ -478,7 +488,7 @@ class OpenAiClient
     response
   end
 
-  def get_word_suggestions(name, number_of_words = 24, words_to_exclude = [], board_type = "default", profile: nil)
+  def get_word_suggestions(name, number_of_words = 24, words_to_exclude = [], board_type = "default", language: "en", profile: nil)
     if words_to_exclude.is_a?(String)
       words_to_exclude = words_to_exclude.split(",").map(&:strip)
     end
@@ -493,6 +503,7 @@ class OpenAiClient
     end
     format_instructions = "Respond with a JSON object in the following format: {\"words\": [\"word1\", \"word2\", \"word3\", ...]}"
     text += format_instructions
+    text = append_language_instruction(text, language)
     text = append_profile_guidance(text, profile)
     @messages = [{ role: "user",
                   content: [{ type: "text",
@@ -554,11 +565,12 @@ class OpenAiClient
     create_chat
   end
 
-  def get_word_suggestions_from_prompt(prompt, profile: nil)
+  def get_word_suggestions_from_prompt(prompt, language: "en", profile: nil)
     @model = GTP_MODEL
     text = prompt
     format_instructions = "Respond with a JSON object in the following format: {\"words\": [\"word_or_phrase_1\", \"word_or_phrase_2\", \"word_or_phrase_3\", ...]}"
     text += format_instructions
+    text = append_language_instruction(text, language)
     text = append_profile_guidance(text, profile)
     @messages = [{ role: "user",
                   content: [{ type: "text",

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -140,12 +140,12 @@ class Scenario < ApplicationRecord
     item_name
   end
 
-  def get_words_for_scenario(description, number_of_words)
+  def get_words_for_scenario(description, number_of_words, language = "en")
     if description.blank? || number_of_words.blank?
       Rails.logger.error "*** ERROR - get_words_for_scenario *** \nDescription or number_of_words is blank. Description: #{description}, Number of words: #{number_of_words}\n"
       return
     end
-    response = OpenAiClient.new({}).get_words_for_scenario(description, number_of_words)
+    response = OpenAiClient.new({}).get_words_for_scenario(description, number_of_words, language.presence || "en")
     begin
       if response
         if response[:content].blank?

--- a/app/services/voice_service.rb
+++ b/app/services/voice_service.rb
@@ -126,6 +126,19 @@ class VoiceService
     VOICES.map { |v| v[:value] }
   end
 
+  # Voice `value`s appropriate for synthesizing text in the given language.
+  # Polly voices carry an ISO-region `language` tag (e.g. "es-US"); we match on
+  # the ISO 639-1 prefix. OpenAI voices have no language tag — the model follows
+  # the input text — so they're always included.
+  def self.voices_for_language(iso)
+    iso = iso.to_s.strip.downcase.split(/[-_]/).first
+    iso = "en" if iso.blank?
+
+    VOICES.select do |v|
+      v[:language].blank? || v[:language].to_s.downcase.split(/[-_]/).first == iso
+    end.map { |v| v[:value] }
+  end
+
   # Support looking up by label OR by value
   def self.get_voice(value_or_label)
     v = VOICES.find { |opt| opt[:value].casecmp(value_or_label.to_s) == 0 }

--- a/app/sidekiq/translate_image_job.rb
+++ b/app/sidekiq/translate_image_job.rb
@@ -18,5 +18,9 @@ class TranslateImageJob
 
     image.translate_to(language)
     image.save!
+
+    # Generate localized audio now that the translated label exists, so
+    # text_for_audio resolves the translation instead of falling back to English.
+    CreateAllAudioJob.perform_async(image.id, language, "select")
   end
 end

--- a/docs/i18n-handoff.md
+++ b/docs/i18n-handoff.md
@@ -16,8 +16,8 @@ non-English language gets:
 
 1. **UI chrome** (buttons, headings, menus, forms, errors) in their language — *partially done* (Settings page only).
 2. **Board content** — image/tile labels in their language — *backend done, flows automatically*.
-3. **Audio** — TTS playback in their language — *partially done, needs verification*.
-4. **AI-generated content** — word suggestions, board/scenario generation in their language — *NOT done*.
+3. **Audio** — TTS playback in their language — *backend done* (Phase 1; per-language voices + translated text).
+4. **AI-generated content** — word suggestions, board/scenario generation in their language — *backend done* (Phase 1).
 5. **Emails** — transactional emails in their language — *infra done, 1 of ~20 templates migrated*.
 
 The 12 supported languages (canonical list = `Image.languages`):
@@ -80,54 +80,59 @@ The 12 supported languages (canonical list = `Image.languages`):
 
 ### Phase 1 — Backend content completeness (highest leverage)
 
-The backend is the source of truth for everything except UI chrome. Finish it
-first so the frontend has localized data to render.
+**Status: DONE except 1.4 (the prod backfill run).** Shipped: `language` is
+threaded through every AI word/board/scenario path, new boards default to the
+creator's language, the `set_labels` key bug is fixed, and the TTS pipeline now
+synthesizes translated text with language-appropriate voices.
 
-**1.1 — AI generation must respect language** *(the known gap; no issue yet — file one)*
-- `OpenAiClient#get_word_suggestions(name, count, exclude, board_type)`
-  (`app/models/open_ai_client.rb:477`) takes **no language param** — always
-  English. Add a `language` param and append `"Respond in #{LONG_LANGUAGE_NAMES[lang]}."`
-  to the prompt, mirroring `get_additional_words` (`open_ai_client.rb:459-462`).
-- `Board#get_word_suggestions` (`app/models/board.rb:2161`) must pass a
-  language through. **Decide the source of truth**: `board.language` or the
-  requesting `current_user.i18n_locale`. Recommendation: pass
-  `current_user.i18n_locale` from the controller, fall back to
-  `board.language`, fall back to `"en"`.
-- Same treatment for the scenario builder path (`Board#get_words_for_scenario`,
-  `app/models/board.rb:2147`) and `get_words` /`get_additional_words` — confirm
-  they receive the *user's* language, not just `board.language`.
-- Controllers to thread language through: `app/controllers/api/boards_controller.rb`
-  (word suggestion / generation actions), `app/controllers/api/scenarios_controller.rb`.
-- Tests: each `OpenAiClient` method with a non-`en` language asserts the
-  prompt contains the "Respond in <language>" instruction.
+**1.1 — AI generation respects language — DONE**
+- `OpenAiClient#append_language_instruction(text, language)` — shared helper
+  that appends `"Respond in <language>."` for supported non-`en` codes.
+  Applied in `get_word_suggestions`, `get_word_suggestions_from_prompt`,
+  `get_words_for_scenario`, and `get_additional_words`.
+- `Board`'s AI methods (`get_word_suggestions`,
+  `get_word_suggestions_from_prompt`, `get_word_suggestions_from_default_prompt`,
+  `get_words_for_predictive`, `get_words_for_scenario`) take an optional
+  `language:` kwarg, defaulting to `self.language`, falling back to `"en"`.
+- `Scenario#get_words_for_scenario` takes a `language` arg.
+- **Precedence:** synchronous controller endpoints
+  (`api/boards_controller#words`, `api/scenarios_controller#get_words`) pass
+  `current_user.i18n_locale.to_s` explicitly (the board may be a transient
+  unsaved object). The async `GenerateBoardJob` relies on `board.language`
+  (now defaulted by 1.2).
 
-**1.2 — New boards/images should default to the creator's language**
-- `app/controllers/api/boards_controller.rb:320,384` only set
-  `@board.language` when the param is present. On create, default it to
-  `current_user.i18n_locale.to_s` when the param is blank.
-- Verify `BoardImage` / `Image` `language` columns inherit sensibly (see
-  `BoardImage#set_labels`).
+**1.2 — New boards default to the creator's language — DONE**
+- `api/boards_controller#create` sets
+  `@board.language = board_params["language"].presence || current_user.i18n_locale.to_s`.
+  `#update` is unchanged (don't silently rewrite an existing board's language).
 
-**1.3 — Fix the `BoardImage#set_labels` symbol/string bug**
-- `app/models/board_image.rb:106-112`: `image.language_settings[lang.to_sym]`
-  — but `language_settings` is a jsonb column with **string** keys (see how
-  `Image#translate_to` writes them). This lookup silently returns `{}`.
-  Change to `lang.to_s`. Add a regression test.
+**1.3 — `BoardImage#set_labels` symbol/string bug — DONE**
+- `app/models/board_image.rb` now looks up `language_settings` with string
+  keys (`lang.to_s`, `["label"]`, `["display_label"]`), matching how
+  `Image#translate_to` writes them.
 
-**1.4 — Backfill translations for the public image library**
-- Existing admin/public images have empty `language_settings`. The
-  `translate:public_images LANG=<iso>` rake task exists but has not been run.
-- Run it per target language **after** Phase 4's language decision, or at
-  least for `es` now. Watch OpenAI cost — it's one API call per untranslated
-  image.
+**1.4 — Backfill translations for the public image library — PENDING (ops run)**
+- The `translate:public_images LANG=<iso>` rake task enqueues a
+  `TranslateImageJob` per untranslated public image (idempotent). Each job
+  makes one OpenAI translation call **and** — with the Phase 1.5 chaining —
+  one `CreateAllAudioJob`.
+- **Not yet run.** Needs to run against **production** (`RAILS_ENV=production`)
+  to translate the real library; running locally only touches the dev DB.
+  Watch the OpenAI bill and the Sidekiq `default`/`audio` queue depth.
 
-**1.5 — Verify per-language TTS audio generation**
-- Audio files are stored with a `_<lang>` filename suffix
-  (`app/models/audio_helper.rb`). Confirm that when a board/image has a
-  non-`en` language, `CreateAllAudioJob` / `VoiceService.synthesize_speech`
-  actually generates and resolves the language-specific audio, and that
-  `default_audio_url` picks the right file for the viewer's language.
-- Manual test: a Spanish board image → tap → hear Spanish audio.
+**1.5 — Per-language TTS audio generation — DONE**
+- `VoiceService.voices_for_language(iso)` — returns voices whose Polly
+  `language` tag matches the ISO prefix, plus all (language-agnostic) OpenAI
+  voices.
+- `AudioHelper#text_for_audio(language)` — resolves the translated label
+  (falling back to English `label`) as the text to synthesize.
+- `Image#create_voice_audio_files` / `#create_audio_for_select_voices` iterate
+  language-appropriate voices and synthesize translated text;
+  `AudioHelper#find_or_create_audio_file_for_voice` uses translated text too.
+- `TranslateImageJob` enqueues `CreateAllAudioJob(image_id, language, "select")`
+  after translating, so localized audio follows the translation.
+- Manual test still recommended (see Phase 5): a Spanish board image → tap →
+  hear Spanish audio.
 
 ### Phase 2 — Frontend UI chrome migration (the bulk of the work)
 
@@ -226,8 +231,8 @@ depth on the first few non-English signups.
 - itty_bitty_boards#102 — remaining mailer templates (Phase 3)
 - itty-bitty-frontend#95–#99 — per-area UI migration (Phase 2)
 - itty-bitty-frontend#100 — locale bundles for the other 10 languages (Phase 4)
-- **Not yet filed**: "AI word suggestions + board/scenario generation respect
-  language" (Phase 1.1) — file under the `multilingual support` label.
+- **Phase 1.4 (ops)**: run `RAILS_ENV=production bin/rails translate:public_images LANG=es`
+  to backfill the public image library — not yet done.
 
 ## Reference — the proven patterns
 

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -45,6 +45,32 @@ RSpec.describe BoardImage, type: :model do
     end
   end
 
+  describe "#set_labels" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:image) do
+      FactoryBot.create(:image,
+        label: "hello",
+        language_settings: { "es" => { "label" => "hola", "display_label" => "Hola" } })
+    end
+    let(:board) { FactoryBot.create(:board, user: user, language: "es") }
+
+    it "reads the translated label from the string-keyed language_settings jsonb" do
+      board_image = FactoryBot.create(:board_image, board: board, image: image, language: "es")
+      board_image.set_labels
+      expect(board_image.language).to eq("es")
+      expect(board_image.label).to eq("hola")
+      expect(board_image.display_label).to eq("Hola")
+    end
+
+    it "falls back to the English image label when no translation exists" do
+      image.update!(language_settings: {})
+      board_image = FactoryBot.create(:board_image, board: board, image: image, language: "es")
+      board_image.set_labels
+      expect(board_image.label).to eq("hello")
+      expect(board_image.display_label).to eq("hello")
+    end
+  end
+
   describe "#api_view" do
     let(:user) { FactoryBot.create(:user) }
     let(:image) do

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -242,4 +242,46 @@ RSpec.describe Board, type: :model do
       end
     end
   end
+
+  describe "AI word-generation language threading" do
+    let(:openai) { instance_double(OpenAiClient) }
+
+    before { allow(OpenAiClient).to receive(:new).and_return(openai) }
+
+    describe "#get_word_suggestions" do
+      let(:board) { FactoryBot.create(:board, language: "es", board_type: "static") }
+
+      it "defaults the language to the board's own language" do
+        expect(openai).to receive(:get_word_suggestions)
+          .with("drink", 5, [], anything, hash_including(language: "es"))
+          .and_return({ content: '{"words":[]}' })
+        board.get_word_suggestions("drink", 5, [])
+      end
+
+      it "lets an explicit language override the board's language" do
+        expect(openai).to receive(:get_word_suggestions)
+          .with("drink", 5, [], anything, hash_including(language: "fr"))
+          .and_return({ content: '{"words":[]}' })
+        board.get_word_suggestions("drink", 5, [], language: "fr")
+      end
+    end
+
+    describe "#get_word_suggestions_from_prompt" do
+      let(:board) { FactoryBot.create(:board, language: "de", board_type: "static") }
+
+      it "defaults the language to the board's own language" do
+        expect(openai).to receive(:get_word_suggestions_from_prompt)
+          .with("a prompt", hash_including(language: "de"))
+          .and_return({ content: '{"words":[]}' })
+        board.get_word_suggestions_from_prompt("a prompt")
+      end
+
+      it "lets an explicit language override the board's language" do
+        expect(openai).to receive(:get_word_suggestions_from_prompt)
+          .with("a prompt", hash_including(language: "it"))
+          .and_return({ content: '{"words":[]}' })
+        board.get_word_suggestions_from_prompt("a prompt", language: "it")
+      end
+    end
+  end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -149,4 +149,29 @@ RSpec.describe Image, type: :model do
       expect(image.localized_display_label("es")).to eq("Hola")
     end
   end
+
+  describe "#text_for_audio" do
+    let(:image) do
+      FactoryBot.create(:image,
+        label: "hello",
+        language_settings: { "es" => { "label" => "hola", "display_label" => "Hola" } })
+    end
+
+    it "returns the English label for 'en'" do
+      expect(image.text_for_audio("en")).to eq("hello")
+    end
+
+    it "returns the English label when language is blank" do
+      expect(image.text_for_audio("")).to eq("hello")
+    end
+
+    it "returns the translated label when a translation exists" do
+      expect(image.text_for_audio("es")).to eq("hola")
+    end
+
+    it "falls back to the English label when no translation exists" do
+      allow(TranslateImageJob).to receive(:perform_async)
+      expect(image.text_for_audio("fr")).to eq("hello")
+    end
+  end
 end

--- a/spec/models/open_ai_client_spec.rb
+++ b/spec/models/open_ai_client_spec.rb
@@ -69,4 +69,79 @@ RSpec.describe OpenAiClient do
       end
     end
   end
+
+  describe "language-aware prompts" do
+    subject(:client) { described_class.new({}) }
+
+    before { allow(client).to receive(:create_chat).and_return({ content: "{}" }) }
+
+    def last_prompt
+      client.instance_variable_get(:@messages).to_s
+    end
+
+    describe "#append_language_instruction" do
+      it "appends the instruction for a supported non-English code" do
+        expect(client.append_language_instruction("base", "es")).to eq("base Respond in Spanish.")
+      end
+
+      it "is a no-op for English" do
+        expect(client.append_language_instruction("base", "en")).to eq("base")
+      end
+
+      it "is a no-op for blank or unknown codes" do
+        expect(client.append_language_instruction("base", "")).to eq("base")
+        expect(client.append_language_instruction("base", "xx")).to eq("base")
+      end
+    end
+
+    describe "#get_word_suggestions" do
+      it "instructs OpenAI to respond in the language for non-English" do
+        client.get_word_suggestions("drink", 5, [], "default", language: "es")
+        expect(last_prompt).to include("Respond in Spanish.")
+      end
+
+      it "does not add a language instruction for English" do
+        client.get_word_suggestions("drink", 5, [], "default", language: "en")
+        expect(last_prompt).not_to include("Respond in")
+      end
+    end
+
+    describe "#get_word_suggestions_from_prompt" do
+      it "instructs OpenAI to respond in the language for non-English" do
+        client.get_word_suggestions_from_prompt("a prompt", language: "fr")
+        expect(last_prompt).to include("Respond in French.")
+      end
+
+      it "does not add a language instruction for English" do
+        client.get_word_suggestions_from_prompt("a prompt", language: "en")
+        expect(last_prompt).not_to include("Respond in")
+      end
+    end
+
+    describe "#get_words_for_scenario" do
+      it "instructs OpenAI to respond in the language for non-English" do
+        client.get_words_for_scenario("a scenario", 5, "de")
+        expect(last_prompt).to include("Respond in German.")
+      end
+
+      it "does not add a language instruction for English" do
+        client.get_words_for_scenario("a scenario", 5, "en")
+        expect(last_prompt).not_to include("Respond in")
+      end
+    end
+
+    describe "#get_additional_words" do
+      let(:board) { FactoryBot.build(:board, board_type: "static") }
+
+      it "instructs OpenAI to respond in the language for non-English" do
+        client.get_additional_words(board, "feelings", 5, [], false, "it")
+        expect(last_prompt).to include("Respond in Italian.")
+      end
+
+      it "does not add a language instruction for English" do
+        client.get_additional_words(board, "feelings", 5, [], false, "en")
+        expect(last_prompt).not_to include("Respond in")
+      end
+    end
+  end
 end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -22,5 +22,29 @@
 require 'rails_helper'
 
 RSpec.describe Scenario, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#get_words_for_scenario" do
+    let(:scenario) { FactoryBot.build(:scenario) }
+    let(:openai) { instance_double(OpenAiClient) }
+
+    before { allow(OpenAiClient).to receive(:new).and_return(openai) }
+
+    it "passes the language through to OpenAiClient" do
+      expect(openai).to receive(:get_words_for_scenario)
+        .with("a description", 12, "es")
+        .and_return({ content: '{"words":[]}' })
+      scenario.get_words_for_scenario("a description", 12, "es")
+    end
+
+    it "defaults to English when no language is given" do
+      expect(openai).to receive(:get_words_for_scenario)
+        .with("a description", 12, "en")
+        .and_return({ content: '{"words":[]}' })
+      scenario.get_words_for_scenario("a description", 12)
+    end
+
+    it "returns early without calling OpenAI when the description is blank" do
+      expect(OpenAiClient).not_to receive(:new)
+      expect(scenario.get_words_for_scenario("", 12, "es")).to be_nil
+    end
+  end
 end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -83,6 +83,37 @@ RSpec.describe "API::Boards", type: :request do
           expect(Board.order(:created_at).last.large_screen_columns).to eq(6)
         end
       end
+
+      describe "language defaulting on create" do
+        it "defaults the board language to the creator's language when no param is sent" do
+          creator.update!(settings: { "voice" => { "language" => "es-US" } })
+          post "/api/boards",
+               params: { board: { name: "Spanish Board" } },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(Board.order(:created_at).last.language).to eq("es")
+        end
+
+        it "uses an explicit language param over the creator's language" do
+          creator.update!(settings: { "voice" => { "language" => "es-US" } })
+          post "/api/boards",
+               params: { board: { name: "French Board", language: "fr" } },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(Board.order(:created_at).last.language).to eq("fr")
+        end
+
+        it "defaults to English for a creator with no language setting" do
+          post "/api/boards",
+               params: { board: { name: "Default Board" } },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(Board.order(:created_at).last.language).to eq("en")
+        end
+      end
     end
   end
 

--- a/spec/services/voice_service_spec.rb
+++ b/spec/services/voice_service_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe VoiceService, type: :service do
     end
   end
 
+  describe ".voices_for_language" do
+    it "returns English Polly voices plus OpenAI voices for 'en'" do
+      values = described_class.voices_for_language("en")
+      expect(values).to include("polly:kevin", "polly:amy", "openai:alloy")
+      expect(values).not_to include("polly:lupe")
+    end
+
+    it "returns Spanish Polly voices plus OpenAI voices for 'es'" do
+      values = described_class.voices_for_language("es")
+      expect(values).to include("polly:lupe", "polly:lucia", "openai:alloy")
+      expect(values).not_to include("polly:kevin")
+    end
+
+    it "matches on the ISO prefix of a BCP-47 code" do
+      expect(described_class.voices_for_language("es-US")).to include("polly:lupe")
+    end
+
+    it "returns OpenAI voices for a language with no Polly voice" do
+      values = described_class.voices_for_language("ja")
+      expect(values).to include("openai:alloy")
+      expect(values).not_to include("polly:kevin", "polly:lupe")
+    end
+
+    it "defaults to English when the code is blank" do
+      expect(described_class.voices_for_language("")).to include("polly:kevin")
+    end
+  end
+
   describe ".synthesize_speech" do
     it "raises ArgumentError for an unrecognised voice" do
       expect {

--- a/spec/sidekiq/translate_image_job_spec.rb
+++ b/spec/sidekiq/translate_image_job_spec.rb
@@ -33,6 +33,21 @@ RSpec.describe TranslateImageJob, type: :job do
     allow(Image).to receive(:find_by).with(id: image.id).and_return(image)
     expect(image).to receive(:translate_to).with("es").and_return("hola")
     expect(image).to receive(:save!)
+    allow(CreateAllAudioJob).to receive(:perform_async)
+    described_class.new.perform(image.id, "es")
+  end
+
+  it "enqueues localized audio generation after translating" do
+    allow(Image).to receive(:find_by).with(id: image.id).and_return(image)
+    allow(image).to receive(:translate_to).and_return("hola")
+    allow(image).to receive(:save!)
+    expect(CreateAllAudioJob).to receive(:perform_async).with(image.id, "es", "select")
+    described_class.new.perform(image.id, "es")
+  end
+
+  it "does not enqueue audio when translation is skipped" do
+    image.update!(language_settings: { "es" => { "label" => "hola" } })
+    expect(CreateAllAudioJob).not_to receive(:perform_async)
     described_class.new.perform(image.id, "es")
   end
 end


### PR DESCRIPTION
## Summary

Phase 1 of the i18n handoff (`docs/i18n-handoff.md`) — makes the backend content layer fully language-aware so non-English users get localized AI output, audio, and tile labels.

- **1.1 — AI generation respects language.** New `OpenAiClient#append_language_instruction` helper appends "Respond in <language>" for supported non-`en` codes; applied across `get_word_suggestions`, `get_word_suggestions_from_prompt`, `get_words_for_scenario`, `get_additional_words`. `Board` AI methods take an optional `language:` kwarg (defaults to `board.language`); `Scenario#get_words_for_scenario` takes a `language` arg. Controllers (`boards#words`, `scenarios#get_words`) pass `current_user.i18n_locale` explicitly since the board may be a transient unsaved object.
- **1.2 — New boards default to the creator's language.** `POST /api/boards` sets `board.language` from the creator's setting when no explicit param is sent.
- **1.3 — Fixed `BoardImage#set_labels`.** It read the `language_settings` jsonb with symbol keys, but the column stores string keys — translated tile labels were silently ignored. Now uses string keys.
- **1.5 — Per-language TTS audio.** The pipeline previously wrote `_<lang>`-suffixed files but synthesized the *English* label with *English-only* Polly voices. Added `VoiceService.voices_for_language` + `AudioHelper#text_for_audio`; `create_voice_audio_files` / `create_audio_for_select_voices` now iterate language-appropriate voices and synthesize translated text. `TranslateImageJob` chains a `CreateAllAudioJob` so localized audio follows each translation.

**Not in this PR — Phase 1.4 (ops):** backfilling the public image library requires running `RAILS_ENV=production bin/rails translate:public_images LANG=es` on prod. Documented as a pending step in the handoff doc. Brittany will run it post-merge; watch the OpenAI bill and the Sidekiq `default`/`audio` queue depth.

## Test plan

- [x] `bundle exec rspec` — full suite, **454 examples, 0 failures, 16 pending** (pre-existing placeholders)
- [x] New/updated specs: `open_ai_client_spec` (language instruction in prompts), `board_spec` (language threading + override), `scenario_spec` (language passthrough), `board_image_spec` (`set_labels` regression), `image_spec` (`text_for_audio`), `voice_service_spec` (`voices_for_language`), `translate_image_job_spec` (chained audio job), `requests/api/boards_spec` (create language default)
- [ ] Manual: Spanish board → tile labels Spanish, tap a tile → Spanish audio (after Phase 1.4 backfill + jobs drain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)