### PR TITLE
fix: return plain Hash from communicator_profile_params for Sidekiq

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1095,9 +1095,11 @@ class API::BoardsController < API::ApplicationController
 
   # Optional communicator-profile fields passed by the frontend's
   # "Who is this board for?" picker. Returns a plain hash so it stays
-  # JSON-serializable for Sidekiq job args. All fields are optional.
+  # JSON-serializable for Sidekiq job args (strict_args rejects
+  # HashWithIndifferentAccess, which is what `to_h` alone returns).
+  # All fields are optional.
   def communicator_profile_params
-    params.permit(:age, :age_band, :aac_level, :vocab_type).to_h
+    params.permit(:age, :age_band, :aac_level, :vocab_type).to_h.to_hash
   end
 
   # Only allow a list of trusted parameters through.

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -83,6 +83,53 @@ RSpec.describe "API::Boards", type: :request do
           expect(Board.order(:created_at).last.large_screen_columns).to eq(6)
         end
       end
+
+      describe "GenerateBoardJob enqueue args" do
+        # Sidekiq strict_args rejects HashWithIndifferentAccess. The job's
+        # `profile` arg used to be `params.permit(...).to_h`, which is a
+        # HWIA — so any scenario-creation POST raised ArgumentError at
+        # enqueue time. Lock the args to plain Hash/JSON-native types.
+        before { allow(GenerateBoardJob).to receive(:perform_async) }
+
+        it "enqueues with a plain Hash options arg (no HashWithIndifferentAccess) for scenario creation" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Scenario Board" },
+                 board_creation_type: "scenario",
+                 topic: "ordering coffee",
+                 ageRange: "10-15",
+                 wordCount: 12,
+                 age: 4,
+                 aac_level: "emerging",
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts.class).to eq(Hash)
+            expect(opts["profile"].class).to eq(Hash)
+          end
+        end
+
+        it "enqueues with a plain Hash options arg even when no profile params are sent" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Scenario No Profile" },
+                 board_creation_type: "scenario",
+                 topic: "ordering coffee",
+                 ageRange: "10-15",
+                 wordCount: 12,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts.class).to eq(Hash)
+            expect(opts["profile"].class).to eq(Hash)
+            expect(opts["profile"]).to be_empty
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Sidekiq `strict_args!` was rejecting every scenario-board POST with:
  > ArgumentError: Job arguments to GenerateBoardJob must be native JSON types, but {} is a ActiveSupport::HashWithIndifferentAccess
- Root cause: `Api::BoardsController#communicator_profile_params` returned `params.permit(...).to_h`, which on `ActionController::Parameters` is a `HashWithIndifferentAccess` — not a plain `Hash`. Adding `.to_hash` flattens it to a plain `Hash` with string keys, which is what `GenerateBoardJob` already reads (`options["profile"]`, etc.).
- Added two regression request specs that POST a scenario board (with and without profile params) and assert the enqueued options arg is `Hash` exactly, with `opts["profile"]` also a plain `Hash`. Both would have caught the original bug.
- No call-site edits needed — fixing at the source covers both enqueue points ([boards_controller.rb:347, :349](app/controllers/api/boards_controller.rb:347)).

## Test plan

- [x] `bundle exec rspec spec/requests/api/boards_spec.rb` — 17 examples, 0 failures (includes 2 new regression specs)
- [x] `bundle exec rspec spec/sidekiq/generate_board_job_spec.rb` — 2 examples, 0 failures
- [x] `bundle exec rspec` (full suite) — 391 examples, 0 failures, 17 pending
- [ ] Manual smoke: create a scenario board from the frontend and confirm no `ArgumentError` in Sidekiq logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)