### PR TITLE
fix: AI credits granted+expired same day; free tier 5; non-Stripe refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Pro users showing 0 AI credits ("granted and expired same day")
+- `CreditService.grant_plan!` now clamps `period_end` to a minimum of
+  `Time.current + 1.day` (`CreditService::MIN_GRANT_WINDOW`). A bad
+  upstream value (stale `plan_expires_at`, `trial_end == 0`, etc.) was
+  causing the new `plan_grant` row to land already-expired, and the
+  hourly `ExpirePlanCreditsJob` would sweep it to 0 within the hour.
+  Issue #110 patched the rake task; this patches the service so no
+  caller can reintroduce it. A `Rails.logger.warn` fires on every clamp
+  so we can find any upstream caller still writing bad dates.
+
+### Changed — Free tier is now 5 AI credits/month (was 10)
+- `PLAN_MONTHLY_CREDITS["free"]` lowered from 10 to 5. Applies to
+  signup grants, the daily refresh job, and post-cancellation grants.
+
+### Changed — Canceled/paused subscriptions keep 5 free credits (was 0)
+- `customer.subscription.deleted` and `customer.subscription.paused`
+  webhooks previously called `CreditService.expire_plan_credits!`,
+  leaving the user at 0 until the next daily refresh. Now they call
+  `CreditService.grant_plan!` with the free-tier allowance, so users
+  land on free with 5 credits immediately. The prior balance is still
+  expired (ledger trace preserved); top-ups are still untouched.
+
+### Changed — Monthly credit refresh now covers non-Stripe paying users
+- `RefreshFreeTierCreditsJob` (daily, 3am UTC) used to refresh only
+  `free` and `basic_trial` users. It now also refreshes any user
+  without a `stripe_subscription_id` — App Store / RevenueCat
+  subscribers, admin/demo accounts on paid tiers — granting their
+  actual plan_type's allowance (Pro = 1500, Basic = 400, etc.).
+  Stripe-driven paying users continue to be refreshed by
+  `invoice.payment_succeeded`. Class name unchanged for cron stability.
+
 ### Added — AI word suggestions adapt to the communicator
 - Board generation now accepts an optional communicator profile — `age` / `age_band`,
   `aac_level` (`emerging` / `developing` / `proficient`), and `vocab_type` (`core` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,19 +117,33 @@ Plan-credit lifecycle:
   on Stripe event id.
 - **Stripe trial start:** `customer.subscription.created` with status
   `trialing` grants credits with `period_end = subscription.trial_end`.
-- **Cancel / pause:** plan credits expire via
-  `CreditService.expire_plan_credits!`. Top-up credits are preserved.
+- **Cancel / pause:** `apply_free_plan` flips the user to `free` and
+  calls `CreditService.grant_plan!` with the free-tier allowance, so
+  canceled/paused subscribers land on free with 5 credits (not 0). The
+  prior plan balance is expired in the ledger by `grant_plan!` itself.
+  Top-up credits are preserved.
 - **Soft-trial → free downgrade:** `DowngradeSoftTrialJob` (daily at 2am UTC)
   flips expired `basic_trial` users to `free` and grants the free-tier
   allowance immediately.
-- **Free-tier monthly refresh:** `RefreshFreeTierCreditsJob` (daily at
-  3am UTC) re-grants the tier allowance to non-subscription users
-  (`free`, `basic_trial`) whose `plan_credits_reset_at` has passed.
-  Paid tiers (`myspeak`, `basic`, `pro`, `partner_pro`) refresh through
-  `invoice.payment_succeeded`.
+- **Monthly credit refresh:** `RefreshFreeTierCreditsJob` (daily at
+  3am UTC) re-grants the tier allowance to **any user without a
+  `stripe_subscription_id`** whose `plan_credits_reset_at` has passed —
+  covers free/basic_trial users, App Store/RevenueCat subscribers, and
+  admin/demo accounts on paid tiers (granting their actual plan_type's
+  allowance, e.g. Pro = 1500). Stripe-driven paying users
+  (`myspeak`, `basic`, `pro`, `partner_pro` with an active
+  `stripe_subscription_id`) refresh through `invoice.payment_succeeded`
+  instead. Class name kept for cron stability; scope is broader than
+  the name suggests.
 - **Backstop:** `ExpirePlanCreditsJob` runs hourly and zeroes any plan
   balance whose `plan_credits_reset_at` has passed. Cheap and idempotent —
   safe to invoke any time.
+- **Grant safety:** `CreditService.grant_plan!` clamps any `period_end`
+  earlier than `Time.current + MIN_GRANT_WINDOW` (1 day) forward, and
+  logs a `Rails.logger.warn` when it does. Prevents the
+  "granted and expired same day" failure mode regardless of caller.
+- **Free tier allowance:** 5 credits/month (was 10). Applied on signup,
+  refresh, and post-cancellation.
 
 Tasks:
 

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -424,9 +424,20 @@ class API::WebhooksController < API::ApplicationController
     user.setup_free_limits
     user.stripe_subscription_id = nil
     user.save!
-    # Plan credits expire on cancel/pause. Top-up credits are untouched —
-    # users keep what they paid for ad hoc.
-    CreditService.expire_plan_credits!(user, reason: "subscription_#{status}")
+    # Grant the free tier's allowance immediately so canceled/paused users
+    # land on free with a working balance, not 0. grant_plan! expires any
+    # leftover plan credits internally (writes an `expire` ledger row).
+    # Top-up credits are untouched — users keep what they paid for ad hoc.
+    free_amount = CreditService.monthly_credits_for("free")
+    CreditService.grant_plan!(
+      user,
+      amount: free_amount,
+      period_end: CreditService.initial_period_end_for("free"),
+      metadata: {
+        reason: "subscription_#{status}",
+        previous_plan_type: original_plan_type,
+      },
+    )
   end
 
   def to_int_or_nil(value)

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -33,7 +33,7 @@ class CreditService
 
   # Default monthly grant by plan_type. Stripe Price metadata overrides at grant time.
   PLAN_MONTHLY_CREDITS = {
-    "free" => 10,
+    "free" => 5,
     "basic_trial" => 400, # Soft 14-day Basic trial set by User#set_soft_trial_plan
     "myspeak" => 50,
     "basic" => 400,
@@ -50,6 +50,12 @@ class CreditService
     "basic_trial" => 14, # matches User#TRAIL_PERIOD (sic)
   }.freeze
   DEFAULT_INITIAL_PERIOD_DAYS = 30
+
+  # Floor for `grant_plan!` period_end. Any caller passing a past/today
+  # `period_end` gets clamped forward to this window. Prevents the
+  # "granted and expired same day" bug (issue #110 and follow-ups) where
+  # ExpirePlanCreditsJob would sweep the new grant to 0 within the hour.
+  MIN_GRANT_WINDOW = 1.day
 
   class << self
     def cost_for(feature_key)
@@ -137,6 +143,15 @@ class CreditService
     # so leftover plan credits from the previous period do not roll over.
     def grant_plan!(user, amount:, period_end:, stripe_event_id: nil, stripe_price_id: nil, metadata: {})
       raise ArgumentError, "amount must be positive" if amount <= 0
+
+      min_period_end = Time.current + MIN_GRANT_WINDOW
+      if period_end.blank? || period_end < min_period_end
+        Rails.logger.warn(
+          "[CreditService] grant_plan! period_end #{period_end.inspect} too soon; " \
+          "clamping to #{min_period_end} for user=#{user.id} metadata=#{metadata.inspect}"
+        )
+        period_end = min_period_end
+      end
 
       ActiveRecord::Base.transaction do
         if stripe_event_id.present? && CreditTransaction.exists?(stripe_event_id: stripe_event_id)

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -1,30 +1,45 @@
 # Monthly credit refresh for users who don't have a Stripe subscription
 # driving renewal grants.
 #
-# Stripe-driven users (subscriptions on file) get their monthly plan credits
-# refreshed by the `invoice.payment_succeeded` webhook. Free users — and
-# users whose subscription was canceled but who are still active on the
-# free tier — have no Stripe billing cycle, so this job is their refresh
-# loop. It runs daily; the check is cheap.
+# Stripe-driven paying users get their monthly plan credits refreshed by
+# the `invoice.payment_succeeded` webhook. This job covers everyone else:
+#
+#   - Free-tier users (5 credits/month).
+#   - Soft-trial users (`basic_trial`, 400 credits for 14 days).
+#   - Paying users without a Stripe subscription — App Store / RevenueCat
+#     subscribers, admin/demo accounts on paid tiers, etc. They get their
+#     actual plan_type's allowance.
+#
+# The class name is kept as `RefreshFreeTierCreditsJob` for cron stability
+# (see config/schedule.rb / sidekiq cron entry); scope is broader than the
+# name suggests.
 #
 # Eligibility:
-#   - plan_credits_reset_at IS NULL (never granted) OR plan_credits_reset_at <= now
-#   - stripe_subscription_id IS NULL OR plan_type is one of the non-paid tiers
-#     (covers users who canceled — they still have a stripe_subscription_id
-#     until the webhook clears it)
+#   - plan_type is in REFRESHABLE_PLAN_TYPES
+#   - plan_credits_reset_at IS NULL (never granted) OR has passed
+#   - stripe_subscription_id is blank (no Stripe-driven renewal incoming)
 #   - Skip admins
 #
-# Idempotent on the day's transaction: grant_plan! writes one new row per
-# call and expires leftovers. Running twice in the same day double-resets
-# the user but doesn't accumulate, so we gate on reset_at.
+# Idempotent in practice: grant_plan! expires leftovers and sets
+# plan_credits_reset_at forward, so the same user won't requalify until
+# their next period.
 class RefreshFreeTierCreditsJob
   include Sidekiq::Job
   sidekiq_options queue: :default, retry: 2
 
-  # Tiers without a Stripe subscription driving renewal grants. MySpeak,
-  # Basic, Pro, and Partner Pro are paid Stripe subscriptions and get
-  # refreshed by `invoice.payment_succeeded` instead.
-  NON_PAID_PLAN_TYPES = %w[free basic_trial].freeze
+  # Any plan_type whose allowance we're willing to refresh from this job.
+  # Stripe-driven users are excluded by the `stripe_subscription_id` filter
+  # below regardless of plan_type.
+  REFRESHABLE_PLAN_TYPES = %w[
+    free
+    basic_trial
+    myspeak
+    basic
+    pro
+    partner_pro
+    vendor
+    premium
+  ].freeze
 
   def perform
     refreshed = 0
@@ -40,7 +55,7 @@ class RefreshFreeTierCreditsJob
         user,
         amount: amount,
         period_end: CreditService.initial_period_end_for(plan_type),
-        metadata: { source: "refresh_free_tier_credits_job", plan_type: plan_type },
+        metadata: { source: "refresh_credits_job", plan_type: plan_type },
       )
       refreshed += 1
     rescue => e
@@ -54,7 +69,8 @@ class RefreshFreeTierCreditsJob
 
   def eligible_users
     User
-      .where(plan_type: NON_PAID_PLAN_TYPES)
+      .where(plan_type: REFRESHABLE_PLAN_TYPES)
       .where("plan_credits_reset_at IS NULL OR plan_credits_reset_at <= ?", Time.current)
+      .where(stripe_subscription_id: [nil, ""])
   end
 end

--- a/docs/credits-handoff.md
+++ b/docs/credits-handoff.md
@@ -23,7 +23,7 @@ small ones (a single word suggestion).
 
 | Plan | Monthly credits | Approx. usage |
 |---|---|---|
-| **Free** | 10 | 2 AI images, or 10 word suggestions |
+| **Free** | 5 | 1 AI image, or 5 word suggestions |
 | **Basic Trial** (default for new signups, 14 days) | 400 | Matches Basic so trial users can fully evaluate AI features |
 | **MySpeak** | 50 | 10 AI images, or 50 word suggestions |
 | **Basic** | 400 | 80 AI images, or one full menu + 30 images |
@@ -181,6 +181,7 @@ listed there.
 | **2** ✅ backend | Top-up Checkout endpoint + webhook handler. Frontend "Buy credits" UI still needed. | Yes (additive) once UI lands |
 | **3** ✅ | AI gating switched from Redis counter → credit balance. AI endpoints now return `402 insufficient_credits` when balance is too low. | **Yes — user-visible** the first time a user hits zero credits. Surface the upsell modal! |
 | **4** ✅ | Plan-credit grants on `invoice.payment_succeeded` (renewal) + trial grants on `customer.subscription.created`. Cancellation/pause expires plan credits while preserving top-ups. Hourly backstop job. | No (internal) — renewals now auto-top-up, no more manual rake task. |
+| **4.1** ✅ | `grant_plan!` safety clamp on `period_end` (`MIN_GRANT_WINDOW = 1.day`) prevents "granted and expired same day" bugs. Cancellation/pause now grants 5 free credits (was 0). Free tier lowered 10 → 5. Monthly refresh job extended to cover any user without a Stripe sub (App Store / RevenueCat / admin / demo on paid tiers). | Yes — canceled subscribers keep a working free balance; free signups now show 5 instead of 10. |
 | **5** | Optional: Stripe metered overage | Decision pending |
 
 ---

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -127,11 +127,11 @@ RSpec.describe User, type: :model do
     # NOTE: User#set_soft_trial_plan (before_save) flips plan_type "free" → "basic_trial"
     # for any user inside their 14-day free trial window. To test the "free" path,
     # explicitly age the user past the trial window before the after_create grant.
-    it "grants the free allowance (10) when the user is post-trial (free)" do
+    it "grants the free allowance (5) when the user is post-trial (free)" do
       user = FactoryBot.build(:user, plan_type: "free", created_at: 30.days.ago)
       user.save!
       expect(user.plan_type).to eq("free")
-      expect(user.plan_credits_balance).to eq(10)
+      expect(user.plan_credits_balance).to eq(5)
     end
 
     it "grants the basic allowance (400) when plan_type is explicitly basic" do

--- a/spec/requests/api/webhooks_plan_credits_spec.rb
+++ b/spec/requests/api/webhooks_plan_credits_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "POST /api/webhooks (plan credits)", type: :request do
   end
 
   describe "customer.subscription.deleted" do
-    it "expires plan credits and keeps top-up credits" do
+    it "expires the paid plan credits and grants the free-tier allowance, keeping top-ups" do
       CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
       CreditService.grant_topup!(user, amount: 50, stripe_event_id: "evt_topup_seed")
 
@@ -141,25 +141,30 @@ RSpec.describe "POST /api/webhooks (plan credits)", type: :request do
 
       post_webhook("{}", header_with_signature)
       user.reload
-      expect(user.plan_credits_balance).to eq(0)
+      # Canceled users land on free with 5 credits, not 0 — so they aren't
+      # stranded until the next daily refresh job.
+      expect(user.plan_credits_balance).to eq(CreditService.monthly_credits_for("free"))
       expect(user.topup_credits_balance).to eq(50)
+      # Ledger has an `expire` row for the old balance and a new `plan_grant`
+      # row for the free allowance.
       expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to be >= 1
-      # Note: plan_type may stay on "basic_trial" if the user is still in the
-      # 14-day soft trial window (see User#set_soft_trial_plan). The Phase 4
-      # contract is about credits, not plan_type — DowngradeSoftTrialJob
-      # owns that downgrade.
+      expect(user.credit_transactions.where(kind: "plan_grant").last.amount)
+        .to eq(CreditService.monthly_credits_for("free"))
+      # plan_credits_reset_at pushed out so ExpirePlanCreditsJob won't sweep
+      # immediately.
+      expect(user.plan_credits_reset_at).to be > Time.current + CreditService::MIN_GRANT_WINDOW
     end
   end
 
   describe "customer.subscription.paused" do
-    it "expires plan credits and marks status=paused" do
+    it "grants the free-tier allowance and marks status=paused" do
       CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
       subscription = build_subscription(status: "paused")
       stub_event(subscription, type: "customer.subscription.paused")
 
       post_webhook("{}", header_with_signature)
       user.reload
-      expect(user.plan_credits_balance).to eq(0)
+      expect(user.plan_credits_balance).to eq(CreditService.monthly_credits_for("free"))
       expect(user.plan_status).to eq("paused")
     end
   end

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CreditService, type: :service do
 
   describe ".monthly_credits_for" do
     it "returns the configured allowance per plan" do
-      expect(described_class.monthly_credits_for("free")).to eq(10)
+      expect(described_class.monthly_credits_for("free")).to eq(5)
       expect(described_class.monthly_credits_for("basic")).to eq(400)
       expect(described_class.monthly_credits_for("basic_trial")).to eq(400)
       expect(described_class.monthly_credits_for("pro")).to eq(1500)
@@ -105,6 +105,46 @@ RSpec.describe CreditService, type: :service do
       user.reload
       expect(user.plan_credits_balance).to eq(200)
       expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to eq(1)
+    end
+
+    context "period_end clamp (prevents same-day-expire bug, issue #110)" do
+      it "clamps a past period_end forward to MIN_GRANT_WINDOW" do
+        allow(Rails.logger).to receive(:warn)
+        described_class.grant_plan!(user, amount: 100, period_end: 1.day.ago)
+        user.reload
+        expect(user.plan_credits_reset_at).to be_within(5.seconds)
+          .of(Time.current + described_class::MIN_GRANT_WINDOW)
+        expect(user.credit_transactions.where(kind: "plan_grant").last.expires_at)
+          .to be_within(5.seconds).of(Time.current + described_class::MIN_GRANT_WINDOW)
+      end
+
+      it "clamps a Time.current period_end forward" do
+        allow(Rails.logger).to receive(:warn)
+        described_class.grant_plan!(user, amount: 100, period_end: Time.current)
+        user.reload
+        expect(user.plan_credits_reset_at).to be_within(5.seconds)
+          .of(Time.current + described_class::MIN_GRANT_WINDOW)
+      end
+
+      it "clamps a nil period_end forward" do
+        allow(Rails.logger).to receive(:warn)
+        described_class.grant_plan!(user, amount: 100, period_end: nil)
+        user.reload
+        expect(user.plan_credits_reset_at).to be_within(5.seconds)
+          .of(Time.current + described_class::MIN_GRANT_WINDOW)
+      end
+
+      it "leaves a future period_end untouched" do
+        future = 45.days.from_now
+        described_class.grant_plan!(user, amount: 100, period_end: future)
+        user.reload
+        expect(user.plan_credits_reset_at).to be_within(2.seconds).of(future)
+      end
+
+      it "logs a warning when clamping" do
+        expect(Rails.logger).to receive(:warn).with(/too soon; clamping/)
+        described_class.grant_plan!(user, amount: 100, period_end: 1.hour.ago)
+      end
     end
   end
 

--- a/spec/sidekiq/downgrade_soft_trial_job_spec.rb
+++ b/spec/sidekiq/downgrade_soft_trial_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
         # Pretend they spent most of their basic_trial allowance.
         user.update_columns(plan_credits_balance: 12, plan_credits_reset_at: 1.day.ago)
 
-        expect { job.perform }.to change { user.reload.plan_credits_balance }.to(10)
+        expect { job.perform }.to change { user.reload.plan_credits_balance }.to(5)
         expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
         tx = user.credit_transactions.where(kind: "plan_grant").order(created_at: :desc).first
         expect(tx.metadata["source"]).to eq("soft_trial_downgrade")

--- a/spec/sidekiq/expire_plan_credits_job_spec.rb
+++ b/spec/sidekiq/expire_plan_credits_job_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe ExpirePlanCreditsJob, type: :sidekiq do
   describe "#perform" do
     it "zeros plan credits whose reset_at has passed" do
       user = reset_user_credits!(FactoryBot.create(:user))
-      CreditService.grant_plan!(user, amount: 100, period_end: 1.day.ago)
-      expect(user.reload.plan_credits_balance).to eq(100)
+      # Simulate an expired grant directly — grant_plan! clamps past period_ends
+      # forward, so we can't use it to seed an already-expired state.
+      user.update_columns(plan_credits_balance: 100, plan_credits_reset_at: 1.day.ago)
 
       described_class.new.perform
 
@@ -16,14 +17,14 @@ RSpec.describe ExpirePlanCreditsJob, type: :sidekiq do
 
     it "leaves users whose reset_at is in the future alone" do
       user = FactoryBot.create(:user)
-      CreditService.grant_plan!(user, amount: 100, period_end: 1.day.from_now)
+      CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
     end
 
     it "leaves top-up credits untouched" do
-      user = FactoryBot.create(:user)
-      CreditService.grant_plan!(user, amount: 50, period_end: 1.day.ago)
+      user = reset_user_credits!(FactoryBot.create(:user))
+      user.update_columns(plan_credits_balance: 50, plan_credits_reset_at: 1.day.ago)
       CreditService.grant_topup!(user, amount: 100, stripe_event_id: "evt_topup_keep")
 
       described_class.new.perform

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -4,18 +4,17 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
   describe "#perform" do
     it "refreshes a free user whose plan_credits_reset_at has passed" do
       user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
-      # Backdate reset_at so the user is eligible
-      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       expect {
         described_class.new.perform
-      }.to change { user.reload.plan_credits_balance }.from(0).to(10)
+      }.to change { user.reload.plan_credits_balance }.from(0).to(5)
       expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
     end
 
     it "refreshes a basic_trial user whose reset_at has passed" do
       user = FactoryBot.create(:user) # defaults to basic_trial
-      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago)
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
       expect(user.reload.plan_credits_balance).to eq(400)
@@ -23,45 +22,74 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
     it "leaves users whose reset_at is in the future alone" do
       user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
-      user.update_columns(plan_credits_balance: 5, plan_credits_reset_at: 5.days.from_now)
+      user.update_columns(plan_credits_balance: 5, plan_credits_reset_at: 5.days.from_now, stripe_subscription_id: nil)
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
     end
 
-    it "leaves paid users alone (their refresh comes from invoice.payment_succeeded)" do
+    it "refreshes a non-Stripe Pro user (App Store / RevenueCat / admin-set) with the Pro allowance" do
       user = FactoryBot.create(:user, plan_type: "pro")
-      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+      user.update_columns(
+        plan_credits_balance: 0,
+        plan_credits_reset_at: 2.days.ago,
+        stripe_subscription_id: nil,
+      )
+
+      expect {
+        described_class.new.perform
+      }.to change { user.reload.plan_credits_balance }.from(0).to(1500)
+    end
+
+    it "refreshes a non-Stripe Basic user with the Basic allowance" do
+      user = FactoryBot.create(:user, plan_type: "basic")
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
+
+      described_class.new.perform
+      expect(user.reload.plan_credits_balance).to eq(400)
+    end
+
+    it "leaves Stripe-driven paid users alone (refresh comes from invoice.payment_succeeded)" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      user.update_columns(
+        plan_credits_balance: 0,
+        plan_credits_reset_at: 2.days.ago,
+        stripe_subscription_id: "sub_stripe_123",
+      )
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
     end
 
-    it "leaves myspeak users alone (paid Stripe subscription)" do
+    it "leaves Stripe-driven myspeak users alone" do
       user = FactoryBot.create(:user, plan_type: "myspeak")
-      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+      user.update_columns(
+        plan_credits_balance: 0,
+        plan_credits_reset_at: 2.days.ago,
+        stripe_subscription_id: "sub_stripe_456",
+      )
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
     end
 
     it "skips admins" do
       admin = FactoryBot.create(:admin_user)
-      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago)
+      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       expect { described_class.new.perform }.not_to change { admin.reload.plan_credits_balance }
     end
 
     it "expires leftover credits before granting (no rollover for plan credits)" do
       user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
-      user.update_columns(plan_credits_balance: 7, plan_credits_reset_at: 2.days.ago)
+      user.update_columns(plan_credits_balance: 7, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
       user.reload
-      expect(user.plan_credits_balance).to eq(10)
+      expect(user.plan_credits_balance).to eq(5)
       expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to be >= 1
     end
 
     it "leaves top-up credits untouched" do
       user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
-      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50)
+      user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50, stripe_subscription_id: nil)
 
       described_class.new.perform
       expect(user.reload.topup_credits_balance).to eq(50)


### PR DESCRIPTION
## Summary

Pro users (including the account owner) reported AI credits being granted and then expiring the **same day**, leaving balance at 0. Root cause: the ledger's hourly `ExpirePlanCreditsJob` sweeps any grant whose `plan_credits_reset_at <= Time.current` — same shape as #110, but `CreditService.grant_plan!` had no internal guard against past `period_end` values, so any caller (Stripe SDK quirk, rake task, console, etc.) could silently corrupt the ledger.

This PR fixes the immediate bug, hardens the service so it can't be reintroduced, and lands two product changes Brittany flagged while we were in there.

## Changes

- **`CreditService.grant_plan!` clamps `period_end`** forward to a minimum of `Time.current + MIN_GRANT_WINDOW` (1 day) and `Rails.logger.warn`s when it does. Defensive at the right layer — no caller can write a same-day-expiring grant regardless of where the stale date comes from.
- **Free tier lowered from 10 → 5 credits/month.** Applies to signup grants, the daily refresh, and post-cancellation.
- **`apply_free_plan` (cancel/pause webhooks)** now grants the free-tier allowance via `grant_plan!` instead of `expire_plan_credits!`. Canceled/paused subscribers land on free with 5 working credits, not stranded at 0 until the next daily refresh job. Prior balance is still expired in the ledger (audit trail preserved).
- **`RefreshFreeTierCreditsJob`** now refreshes any user without a `stripe_subscription_id` using their actual plan_type's allowance — covers App Store / RevenueCat subscribers and admin/demo accounts on paid tiers that were previously orphaned. Stripe-driven paid users continue to renew via `invoice.payment_succeeded`. Class name kept for cron stability; scope is broader than the name suggests.
- Docs: `CLAUDE.md` (credit lifecycle section), `docs/credits-handoff.md` (free tier row + new Phase 4.1 line), `CHANGELOG.md` (Unreleased entries).

## Recovery for affected users

Phase 1 of the plan is console-only. For the user that filed this:

\`\`\`ruby
user = User.find_by(email: \"<their email>\")
user.credit_transactions.order(created_at: :desc).limit(20).pluck(:created_at, :kind, :amount, :expires_at, :metadata)

sub = Stripe::Subscription.retrieve(user.stripe_subscription_id) if user.stripe_subscription_id.present?
period_end = (sub && Time.at(sub.current_period_end) > Time.current) ? Time.at(sub.current_period_end) : 30.days.from_now

CreditService.grant_plan!(user, amount: CreditService.monthly_credits_for(user.plan_type),
  period_end: period_end,
  metadata: { reason: \"manual_regrant_same_day_expire\", plan_type: user.plan_type })
\`\`\`

## Test plan

- [x] `bundle exec rspec` — **430 examples, 0 failures**, 17 pending (pre-existing).
- [x] Added/extended specs:
  - [spec/services/credit_service_spec.rb](spec/services/credit_service_spec.rb) — clamp behavior (past, now, nil, future, log assertion); `monthly_credits_for(\"free\") == 5`.
  - [spec/sidekiq/refresh_free_tier_credits_job_spec.rb](spec/sidekiq/refresh_free_tier_credits_job_spec.rb) — refreshes non-Stripe Pro/Basic users, skips Stripe-driven paying users.
  - [spec/requests/api/webhooks_plan_credits_spec.rb](spec/requests/api/webhooks_plan_credits_spec.rb) — cancel/pause now grants 5 free credits (was 0).
  - Updated existing specs that asserted old behavior (free=10, expire-to-0, etc.).
- [ ] Post-deploy: tail `bin/prod-logs worker` for any `grant_plan! period_end .* too soon; clamping` warnings — surfaces upstream callers still writing bad dates.
- [ ] Post-deploy: re-grant affected user(s) on console (see snippet above); confirm they can use AI features.

## Notes / out of scope

- The grant clamp masks (but doesn't fix) `handle_trial_credit_grant` accepting `trial_end == 0` as a valid value (`0.present?` is true). Worth a follow-up issue.
- The Stripe SDK on `~> 12.0` still exposes `current_period_end` on the top-level Subscription. Newer Stripe API versions move it to subscription items — file a follow-up if/when we upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)