### PR TITLE
fix(ci): pin ActiveJob to :test so attach() doesn't hang rspec

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,14 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Queue ActiveJob jobs but don't execute them. The default `:async` adapter
+  # runs jobs on a thread pool, which means ActiveStorage::AnalyzeJob fires
+  # after `attach` and shells out to `ffprobe` / `mediainfo` — fine locally
+  # where those binaries exist, but hangs on CI runners that don't have
+  # them. The test process then can't exit because the async pool waits on
+  # the stuck thread. `:test` adapter queues without executing.
+  config.active_job.queue_adapter = :test
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
## Summary

After [#124](https://github.com/brittanyjohns/itty_bitty_boards/pull/124) landed, rspec on GitHub Actions started hanging indefinitely (one run sat at \"in_progress\" for 35+ minutes before I cancelled it; local runs the full suite in 1:35).

**Root cause:** the new `CoachingPhraseAudio` spec is the first in the test suite to actually call `audio.attach(...)`. Existing `Image` specs use `has_many_attached :audio_files` but never exercise `attach` in tests. Rails' default ActiveJob adapter in test env is `:async`, so each `attach` enqueues an `ActiveStorage::AnalyzeJob` that shells out to `ffprobe` / `mediainfo` on a background thread. Those binaries don't exist on the CI runner — the thread blocks. When rspec finishes its examples and exits, the async `ThreadPoolExecutor` waits for the stuck thread, and the whole process hangs until the runner timeout.

**Fix:** pin ActiveJob to the `:test` adapter in `config/environments/test.rb`. That queues jobs without executing them. Nothing else in the suite depends on jobs running automatically — specs that exercise jobs use `Sidekiq::Testing` directly, which is unaffected.

## Test plan

- [x] Local: `bundle exec rspec` — 472 examples, 0 failures, 1m35s (matches pre-fix timing — no behavior change).
- [x] Local: `CI=1 RAILS_ENV=test bundle exec rspec` (mirrors CI's `eager_load = true`) — same result.

## Risk

Very low. Existing specs already either (a) never enqueue jobs, or (b) drive `Sidekiq::Testing.fake!` (which still works). The new adapter only affects jobs routed through ActiveJob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)