### PR TITLE
chore(logs): silence 404 scanner spam in lograge

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,3 +1,10 @@
 Rails.application.configure do
   config.lograge.enabled = true
+
+  # Drop the catch-all 404 controller from request logs. Vulnerability
+  # scanners probe for /.env, /phpinfo.php, /.git/config, /wp-admin/…
+  # constantly and there's no signal in those lines. ErrorController is
+  # the sink for the `match "*path"` catch-all in config/routes.rb, so
+  # this also hides 404s from real users mistyping URLs — acceptable.
+  config.lograge.ignore_actions = ["ErrorController#not_found"]
 end


### PR DESCRIPTION
## Summary

- Production logs are being drowned by botnets probing for `/.env*`, `/phpinfo.php`, `/.git/config`, `/wp-admin/*`, etc. Every hit falls through the `match \"*path\"` catch-all in `config/routes.rb` into `ErrorController#not_found` and prints a lograge line.
- Add `config.lograge.ignore_actions = [\"ErrorController#not_found\"]` so those requests still return a proper 404 but are no longer logged.
- Trade-off (chosen explicitly): real users mistyping a URL also stop logging. That signal is rarely actionable; readability wins.

## Why this approach

- nginx/Hatchbox config is off-limits per backend `CLAUDE.md`.
- `rack-attack` isn't installed and would be overkill — scanners aren't a DoS, just noisy.
- `lograge` is already a dependency; this is one line of its documented API (`ignore_actions`, verified in lograge 0.14.0 source at `lib/lograge.rb:71` / `setup.rb:145`).

## Test plan

- [x] `ruby -c config/initializers/lograge.rb` — syntax OK
- [x] Confirmed `Lograge.ignore_actions` API exists in installed gem (0.14.0)
- [ ] After deploy: `bin/prod-logs` for ~30s, `grep \"ErrorController action=not_found\"` → expect zero matches; real `controller=API::*` lines keep flowing
- [ ] Local sanity (requires `.env`): `curl -i http://localhost:4000/.env.prod` → 404 with no matching lograge line; `curl http://localhost:4000/` → still logs normally

No automated tests — logging-only config change, no response-side behavior delta (per the global \"log-only is test-irrelevant, say so in the PR\" carveout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)