### PR TITLE
fix(ai-formatter): deterministic packing so AI board layouts save correctly

### DIFF
--- a/app/models/ai_board_formatter.rb
+++ b/app/models/ai_board_formatter.rb
@@ -1,14 +1,14 @@
-# app/services/ai_board_formatter.rb
+# app/models/ai_board_formatter.rb
 # frozen_string_literal: true
 
 class AiBoardFormatter
   def self.call(...) = new(...).call
 
   # name: Board name (for context only)
-  # columns: max grid columns (Integer)
-  # rows: max grid rows (Integer)
+  # columns: max grid columns for the largest screen (Integer, informational)
+  # rows: hint only (Integer, informational)
   # existing: [{ word:, size: [w,h], board_type: <optional> }, ...]
-  # maintain_existing: true/false
+  # maintain_existing: true/false (informational; placement is now deterministic)
   def initialize(name:, columns:, rows:, existing:, maintain_existing:)
     @name = name.to_s
     @columns = columns.to_i
@@ -19,8 +19,8 @@ class AiBoardFormatter
 
   # Returns a parsed Hash like:
   # {
-  #   "grid" => [
-  #     {"word"=>"I","position"=>[0,0],"part_of_speech"=>"pronoun","frequency"=>"high","size"=>[1,1]},
+  #   "ordered_words" => [
+  #     { "word"=>"I", "size"=>[1,1], "frequency"=>"high", "part_of_speech"=>"pronoun" },
   #     ...
   #   ],
   #   "personable_explanation"  => "...",
@@ -31,7 +31,8 @@ class AiBoardFormatter
   def call
     text = prompt
     raw = request_openai(text)
-    parse_jsonish(raw)
+    payload = parse_jsonish(raw)
+    normalize(payload)
   rescue => e
     Rails.logger.error("[AiBoardFormatter] #{e.class}: #{e.message}")
     nil
@@ -43,84 +44,63 @@ class AiBoardFormatter
     words = @existing.map { |w| w[:word].to_s }.reject(&:blank?)
 
     <<~PROMPT
-      You are formatting an AAC communication board layout.
+      You are organizing words for an AAC communication board.
 
-      Return ONLY valid JSON. Do not include markdown, comments, or extra text.
+      Return ONLY a single valid JSON object. No prose, no markdown, no comments.
 
-      Goal:
-      Create a clean, predictable AAC board using evidence-informed AAC layout practices:
-      - Put high-frequency core words first.
-      - Keep layout simple, consistent, and easy to scan.
-      - Avoid random placement, gaps, and excessive rows.
-      - Use stable left-to-right, top-to-bottom placement (motor planning consistency).
-      - Prioritize communication usefulness over visual complexity.
+      Your job is to ORDER the supplied words and assign each one a tile size.
+      You do NOT assign x/y positions — placement is computed downstream.
 
-      Grid constraints:
-      - Max columns: #{@columns}
-      - Max rows: #{@rows}
-      - Coordinates are [x, y], where x starts at 0 from the left and y starts at 0 from the top.
-      - Stay completely inside the grid.
-      - Do not overlap cells.
-      - Do not create more rows than needed.
-      - Fill rows left-to-right before moving down.
-      - Use a strict row-major layout (like reading text).
+      AAC ordering rules (apply in this priority):
+      1. Communication starters and high-frequency core words first
+         (e.g. "I", "you", "want", "more", "stop", "help", "yes", "no", "go").
+      2. Common action words next (verbs like "eat", "play", "look").
+      3. Descriptive words next (adjectives, feelings, colors).
+      4. Specific or lower-frequency words last (nouns, named items).
 
       Tile sizing rules:
-      - Default size is [1,1].
-      - Use [1,1] for almost all words.
-      - Only use [2,1] for extremely important words like "I want", "help", or "stop" if space allows.
-      - Do NOT use [2,2].
-      - Do NOT randomly vary sizes.
-      - Keep sizing consistent and predictable.
+      - Default size is [1, 1].
+      - You may use [2, 1] for up to 2 of the most important phrase-style
+        tiles (e.g. "I want", "help"). Only when it clearly helps motor
+        planning.
+      - Never use [2, 2] or any size larger than [2, 1].
+      - Keep sizing consistent and predictable — most tiles should be [1, 1].
 
-      Word ordering rules:
-      1. First rows: high-frequency core words (communication starters)
-      2. Next rows: common action words
-      3. Next rows: descriptive words
-      4. Last rows: specific or lower-frequency words
+      Word inclusion rules:
+      - Use every supplied word exactly once.
+      - Do not invent, drop, duplicate, or rename words.
+      - Preserve the original spelling and casing of each word.
 
-      Frequency values:
-      - high
-      - medium
-      - low
+      Frequency values must be one of: "high", "medium", "low".
+      Part of speech should be one of: "pronoun", "noun", "verb",
+      "adjective", "adverb", "preposition", "conjunction", "interjection",
+      "determiner", "phrase", "other".
 
-      Important:
-      - Use every provided word exactly once.
-      - Do not add new words.
-      - Do not remove words.
-      - Do not duplicate words.
-      - If there are too many words to fit, include only what fits and mention overflow in explanations.
-      - Do not leave empty gaps between tiles.
-      - Keep the layout compact and structured.
+      Grid hint (informational only — placement is computed downstream):
+      - Target columns: #{@columns}
+      - Approximate rows: #{@rows}
 
-      Existing words:
+      Words to order:
       #{words.join(", ")}
 
-      Expected JSON format:
+      Required JSON shape:
       {
-        "grid": [
-          {
-            "word": "I",
-            "position": [0, 0],
-            "frequency": "high",
-            "size": [1, 1]
-          },
-          {
-            "word": "banana",
-            "position": [1, 0],
-            "frequency": "low",
-            "size": [1, 1]
-          }
+        "ordered_words": [
+          { "word": "I",    "size": [1,1], "frequency": "high",   "part_of_speech": "pronoun" },
+          { "word": "want", "size": [1,1], "frequency": "high",   "part_of_speech": "verb" }
         ],
-        "personable_explanation": "Simple one-liner explaining the layout.",
-        "professional_explanation": "Simple one-liner explaining the AAC reasoning."
+        "personable_explanation":  "One short sentence the caregiver will read.",
+        "professional_explanation": "One short sentence explaining the AAC reasoning."
       }
     PROMPT
   end
 
   def request_openai(text)
     messages = [{ role: "user", content: [{ type: "text", text: text }] }]
-    OpenAiClient.new({ messages: messages }).create_completion&.dig(:content)
+    OpenAiClient.new({
+      messages: messages,
+      response_format: { type: "json_object" },
+    }).create_completion&.dig(:content)
   end
 
   # 1) strips ``` and ```json fences
@@ -136,11 +116,54 @@ class AiBoardFormatter
     str.strip!
 
     begin
-      return JSON.parse(str)
+      JSON.parse(str)
     rescue JSON::ParserError
-      # remove trailing commas: {"a":1,} or [1,2,]
       cleaned = str.gsub(/,(\s*[}\]])/, '\1')
-      return JSON.parse(cleaned)
+      JSON.parse(cleaned)
     end
+  rescue JSON::ParserError => e
+    Rails.logger.error("[AiBoardFormatter] parse failed: #{e.message}")
+    nil
+  end
+
+  # Accepts either the new "ordered_words" shape or the legacy "grid" shape
+  # (back-compat with prompts/responses that still include "position").
+  # Always returns a hash with "ordered_words" populated.
+  def normalize(payload)
+    return nil if payload.blank?
+
+    items =
+      if payload["ordered_words"].is_a?(Array)
+        payload["ordered_words"]
+      elsif payload["grid"].is_a?(Array)
+        payload["grid"]
+      else
+        []
+      end
+
+    ordered = items.filter_map do |item|
+      next unless item.is_a?(Hash)
+      word = item["word"].to_s.strip
+      next if word.blank?
+
+      size = Array(item["size"])
+      w = size[0].to_i
+      h = size[1].to_i
+      w = 1 if w < 1
+      h = 1 if h < 1
+
+      {
+        "word" => word,
+        "size" => [w, h],
+        "frequency" => item["frequency"].presence,
+        "part_of_speech" => item["part_of_speech"].presence,
+      }
+    end
+
+    {
+      "ordered_words" => ordered,
+      "personable_explanation" => payload["personable_explanation"].presence,
+      "professional_explanation" => payload["professional_explanation"].presence,
+    }
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1303,13 +1303,24 @@ class Board < ApplicationRecord
     (screen_dimension / num_of_columns).to_i
   end
 
+  # Format the board's layout using AI for word ordering + tile sizing, then
+  # deterministically pack tiles in Ruby so we never persist overlapping or
+  # gap-ridden layouts. Writes per-board_image layouts (primary source of
+  # truth for ViewBoard / EditBoardScreen via DraggableGrid) AND the board's
+  # aggregate layout (source of truth for BoardNativeGridPage) for all three
+  # screen sizes in one pass.
+  #
+  # screen_size is accepted for back-compat with callers but no longer affects
+  # behavior — all three screens are always written.
   def format_board_with_ai(screen_size: "lg", maintain_existing_layout: false)
-    columns = get_number_of_columns(screen_size)
     images = board_images.includes(:image).to_a
-    rows = (images.size / columns.to_f).ceil
+    return self if images.empty?
+
+    lg_columns = get_number_of_columns("lg")
+    rows_hint = (images.size / lg_columns.to_f).ceil
 
     existing = images.map do |bi|
-      layout = (bi.layout || {}).dig(screen_size) || {}
+      layout = (bi.layout || {}).dig("lg") || {}
       {
         word: bi.label,
         size: [layout["w"], layout["h"]].compact.presence || [1, 1],
@@ -1319,60 +1330,148 @@ class Board < ApplicationRecord
 
     payload = AiBoardFormatter.call(
       name: name,
-      columns: columns,
-      rows: rows,
+      columns: lg_columns,
+      rows: rows_hint,
       existing: existing,
       maintain_existing: maintain_existing_layout,
     )
 
     return self if payload.blank?
 
-    grid = payload["grid"].to_a
+    ordered = Array(payload["ordered_words"])
     by_label = images.index_by { |bi| bi.label.to_s.downcase }
 
+    # Build ordered (board_image, w, h, meta) tuples from the AI output.
+    ordered_items = []
+    seen_ids = Set.new
+    ordered.each do |item|
+      label = item["word"].to_s
+      bi = by_label[label.downcase]
+      next if bi.nil? || seen_ids.include?(bi.id)
+      seen_ids << bi.id
+
+      size = Array(item["size"])
+      w = size[0].to_i
+      h = size[1].to_i
+      w = 1 if w < 1
+      h = 1 if h < 1
+
+      ordered_items << {
+        board_image: bi,
+        w: w,
+        h: h,
+        frequency: item["frequency"],
+        part_of_speech: item["part_of_speech"],
+      }
+    end
+
+    # Append any board_images the AI dropped so we never lose tiles.
+    images.each do |bi|
+      next if seen_ids.include?(bi.id)
+      ordered_items << { board_image: bi, w: 1, h: 1, frequency: nil, part_of_speech: nil }
+    end
+
+    # Pack a layout per screen size using the same ordering.
+    packed_by_screen = {}
+    SCREEN_SIZES_FOR_AI_LAYOUT.each do |screen|
+      columns = get_number_of_columns(screen)
+      packed_by_screen[screen] = pack_layout_row_major(ordered_items, columns: columns)
+    end
+
     ActiveRecord::Base.transaction do
-      grid.each_with_index do |item, idx|
-        label = item["word"].to_s
-        bi = by_label[label.downcase]
-        next unless bi
+      ordered_items.each_with_index do |item, idx|
+        bi = item[:board_image]
 
-        pos = Array(item["position"] || [0, 0])
-        size = Array(item["size"] || [1, 1])
-        x = pos[0].to_i.clamp(0, columns - 1)
-        y = pos[1].to_i.clamp(0, [rows - 1, 0].max)
+        bi.data ||= {}
+        bi.data["label"] = bi.label.to_s
+        bi.data["part_of_speech"] = item[:part_of_speech] if item[:part_of_speech].present?
+        bi.data["bg_color"] = bi.background_color_for(item[:part_of_speech]) if item[:part_of_speech].present?
 
-        bi.data["label"] = label
-        bi.data[screen_size] ||= {}
-        bi.data[screen_size]["frequency"] = item["frequency"]
-        bi.data[screen_size]["size"] = size
-        bi.data["part_of_speech"] = item["part_of_speech"]
-        bi.data["bg_color"] = bi.background_color_for(item["part_of_speech"])
+        bi.layout ||= {}
+        SCREEN_SIZES_FOR_AI_LAYOUT.each do |screen|
+          cell = packed_by_screen[screen][idx]
+          bi.data[screen] ||= {}
+          bi.data[screen]["frequency"] = item[:frequency] if item[:frequency].present?
+          bi.data[screen]["size"] = [cell["w"], cell["h"]]
+          bi.layout[screen] = cell
+        end
 
         bi.position = idx
-        bi.layout ||= {}
-        bi.layout[screen_size] = { "x" => x, "y" => y, "w" => size[0], "h" => size[1], "i" => bi.id.to_s }
+        bi.skip_create_voice_audio = true if bi.respond_to?(:skip_create_voice_audio=)
         bi.save!
+        bi.clean_up_layout
 
-        if item["part_of_speech"].present? && bi.image.part_of_speech.blank?
-          bi.image.update!(part_of_speech: item["part_of_speech"])
+        if item[:part_of_speech].present? && bi.image && bi.image.part_of_speech.blank?
+          bi.image.update!(part_of_speech: item[:part_of_speech])
         end
       end
 
-      # optional explanations
+      # Mirror per-image layout up to board.layout for each screen so
+      # BoardNativeGridPage (which reads board.layout) stays in lockstep.
+      self.layout ||= {}
+      SCREEN_SIZES_FOR_AI_LAYOUT.each do |screen|
+        self.layout[screen] = packed_by_screen[screen]
+      end
+
       personable = payload["personable_explanation"].presence
       professional = payload["professional_explanation"].presence
 
-      if personable || professional
-        self.data["personable_explanation"] = "#{personable}" if personable
-        self.data["professional_explanation"] = "#{professional}" if professional
-        self.description = [self.data["personable_explanation"], self.data["professional_explanation"]].compact.join("\n") if description.blank?
-        save!
+      self.data ||= {}
+      self.data["personable_explanation"] = personable if personable
+      self.data["professional_explanation"] = professional if professional
+      if (personable || professional) && description.blank?
+        self.description = [self.data["personable_explanation"], self.data["professional_explanation"]].compact.join("\n")
       end
-      reset_layouts if maintain_existing_layout == false
+
+      save!
+      board_images.reset
     end
 
     self
   end
+
+  SCREEN_SIZES_FOR_AI_LAYOUT = %w[sm md lg].freeze
+  private_constant :SCREEN_SIZES_FOR_AI_LAYOUT
+
+  # Row-major packer with occupancy tracking. Walks ordered items, places
+  # each tile at the first free top-left cell that fits its w×h footprint
+  # without overlap. Clamps w to the column count and h to 2 (frontend assumes
+  # short tiles).
+  #
+  # ordered_items: array of { board_image:, w:, h:, ... }
+  # returns: array of { "i", "x", "y", "w", "h" } in the same order as input.
+  def pack_layout_row_major(ordered_items, columns:)
+    columns = columns.to_i
+    columns = 1 if columns < 1
+    occupied = Set.new
+    out = []
+
+    ordered_items.each do |item|
+      w = item[:w].to_i.clamp(1, columns)
+      h = item[:h].to_i.clamp(1, 2)
+
+      placed = false
+      y = 0
+      until placed
+        (0..(columns - w)).each do |x|
+          cells = []
+          w.times do |dx|
+            h.times { |dy| cells << [x + dx, y + dy] }
+          end
+          if cells.none? { |c| occupied.include?(c) }
+            cells.each { |c| occupied << c }
+            out << { "i" => item[:board_image].id.to_s, "x" => x, "y" => y, "w" => w, "h" => h }
+            placed = true
+            break
+          end
+        end
+        y += 1 unless placed
+      end
+    end
+
+    out
+  end
+  private :pack_layout_row_major
 
   def tmp_board_type
     case resource_type

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -715,9 +715,9 @@ class OpenAiClient
     opts = {
       model: @model, # Required.
       messages: @messages, # Required.
-    # temperature: 0.7,
-    # response_format: { type: "json_object" },
     }
+    opts[:response_format] = @opts[:response_format] if @opts[:response_format].present?
+    opts[:temperature] = @opts[:temperature] if @opts[:temperature].present?
     begin
       response = openai_client.chat(
         parameters: opts,

--- a/spec/models/ai_board_formatter_spec.rb
+++ b/spec/models/ai_board_formatter_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe AiBoardFormatter do
+  let(:args) do
+    {
+      name: "Test Board",
+      columns: 8,
+      rows: 2,
+      existing: [
+        { word: "I",    size: [1, 1] },
+        { word: "want", size: [1, 1] },
+        { word: "more", size: [1, 1] },
+      ],
+      maintain_existing: false,
+    }
+  end
+
+  def stub_openai_response(content)
+    fake_client = instance_double(OpenAiClient)
+    allow(OpenAiClient).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:create_completion).and_return({ role: "assistant", content: content })
+  end
+
+  describe ".call" do
+    it "returns a normalized hash for valid ordered_words JSON" do
+      stub_openai_response(<<~JSON)
+        {
+          "ordered_words": [
+            { "word": "I", "size": [1,1], "frequency": "high", "part_of_speech": "pronoun" },
+            { "word": "want", "size": [1,1], "frequency": "high", "part_of_speech": "verb" },
+            { "word": "more", "size": [1,1], "frequency": "high", "part_of_speech": "adjective" }
+          ],
+          "personable_explanation": "Easy to use.",
+          "professional_explanation": "Core words first."
+        }
+      JSON
+
+      result = described_class.call(**args)
+
+      expect(result).to be_a(Hash)
+      expect(result["ordered_words"].map { |w| w["word"] }).to eq(%w[I want more])
+      expect(result["ordered_words"].first["size"]).to eq([1, 1])
+      expect(result["personable_explanation"]).to eq("Easy to use.")
+      expect(result["professional_explanation"]).to eq("Core words first.")
+    end
+
+    it "strips ```json code fences" do
+      stub_openai_response(<<~JSON)
+        ```json
+        {
+          "ordered_words": [
+            { "word": "I", "size": [1,1] }
+          ]
+        }
+        ```
+      JSON
+
+      result = described_class.call(**args)
+      expect(result["ordered_words"].length).to eq(1)
+      expect(result["ordered_words"].first["word"]).to eq("I")
+    end
+
+    it "tolerates trailing commas" do
+      stub_openai_response(<<~JSON)
+        {
+          "ordered_words": [
+            { "word": "I", "size": [1,1], },
+          ],
+        }
+      JSON
+
+      result = described_class.call(**args)
+      expect(result["ordered_words"].length).to eq(1)
+    end
+
+    it "falls back to legacy 'grid' key when ordered_words is missing" do
+      stub_openai_response(<<~JSON)
+        {
+          "grid": [
+            { "word": "I",    "position": [0,0], "size": [1,1], "frequency": "high" },
+            { "word": "want", "position": [1,0], "size": [1,1], "frequency": "high" }
+          ]
+        }
+      JSON
+
+      result = described_class.call(**args)
+      expect(result["ordered_words"].map { |w| w["word"] }).to eq(%w[I want])
+    end
+
+    it "drops items with blank words and clamps sizes below 1" do
+      stub_openai_response(<<~JSON)
+        {
+          "ordered_words": [
+            { "word": "",    "size": [1,1] },
+            { "word": "I",   "size": [0,0] },
+            { "word": "more","size": [2,1] }
+          ]
+        }
+      JSON
+
+      result = described_class.call(**args)
+      expect(result["ordered_words"].length).to eq(2)
+      expect(result["ordered_words"][0]).to include("word" => "I", "size" => [1, 1])
+      expect(result["ordered_words"][1]).to include("word" => "more", "size" => [2, 1])
+    end
+
+    it "returns nil on unparseable output" do
+      stub_openai_response("not json at all { ] }")
+      expect(described_class.call(**args)).to be_nil
+    end
+
+    it "returns nil when the client returns blank content" do
+      stub_openai_response(nil)
+      expect(described_class.call(**args)).to be_nil
+    end
+
+    it "passes response_format: json_object to OpenAiClient" do
+      fake_client = instance_double(OpenAiClient)
+      allow(fake_client).to receive(:create_completion).and_return({ content: '{"ordered_words": []}' })
+      expect(OpenAiClient).to receive(:new).with(hash_including(response_format: { type: "json_object" })).and_return(fake_client)
+
+      described_class.call(**args)
+    end
+  end
+end

--- a/spec/models/board_format_with_ai_spec.rb
+++ b/spec/models/board_format_with_ai_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe Board, "#format_board_with_ai", type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:board) do
+    FactoryBot.create(
+      :board,
+      user: user,
+      small_screen_columns: 3,
+      medium_screen_columns: 4,
+      large_screen_columns: 6,
+    )
+  end
+
+  # Words chosen so we can predict the AAC ordering used by the stub.
+  let(:words) { %w[I want help more stop go yes no] }
+
+  let!(:board_images) do
+    words.map do |word|
+      image = FactoryBot.create(:image, user: user, label: word)
+      bi = FactoryBot.build(:board_image, board: board, image: image)
+      bi.skip_create_voice_audio = true
+      bi.save!
+      bi
+    end
+  end
+
+  let(:ai_payload) do
+    {
+      "ordered_words" => [
+        { "word" => "I",     "size" => [1, 1], "frequency" => "high", "part_of_speech" => "pronoun" },
+        { "word" => "want",  "size" => [2, 1], "frequency" => "high", "part_of_speech" => "verb" },
+        { "word" => "help",  "size" => [2, 1], "frequency" => "high", "part_of_speech" => "verb" },
+        { "word" => "more",  "size" => [1, 1], "frequency" => "high", "part_of_speech" => "determiner" },
+        { "word" => "stop",  "size" => [1, 1], "frequency" => "high", "part_of_speech" => "verb" },
+        { "word" => "go",    "size" => [1, 1], "frequency" => "high", "part_of_speech" => "verb" },
+        { "word" => "yes",   "size" => [1, 1], "frequency" => "high", "part_of_speech" => "interjection" },
+        { "word" => "no",    "size" => [1, 1], "frequency" => "high", "part_of_speech" => "interjection" },
+      ],
+      "personable_explanation" => "Friendly summary.",
+      "professional_explanation" => "AAC reasoning.",
+    }
+  end
+
+  before do
+    allow(AiBoardFormatter).to receive(:call).and_return(ai_payload)
+    allow(SaveAudioJob).to receive(:perform_async)
+  end
+
+  def cells_for(layout_array)
+    layout_array.flat_map do |item|
+      w = item["w"].to_i
+      h = item["h"].to_i
+      (0...w).flat_map { |dx| (0...h).map { |dy| [item["x"].to_i + dx, item["y"].to_i + dy] } }
+    end
+  end
+
+  it "places every board_image exactly once on every screen with no overlapping cells" do
+    board.format_board_with_ai
+    board.reload
+
+    %w[sm md lg].each do |screen|
+      layout = board.layout[screen]
+      expect(layout).to be_an(Array), "expected board.layout[#{screen.inspect}] to be an Array"
+      expect(layout.length).to eq(words.length), "wrong tile count for #{screen}"
+
+      cells = cells_for(layout)
+      expect(cells.length).to eq(cells.uniq.length), "overlapping cells in #{screen}: #{cells.tally.select { |_, n| n > 1 }}"
+    end
+  end
+
+  it "keeps board_image.layout in lockstep with board.layout for every screen" do
+    board.format_board_with_ai
+    board.reload
+
+    %w[sm md lg].each do |screen|
+      indexed = board.layout[screen].index_by { |cell| cell["i"] }
+      board.board_images.each do |bi|
+        per_image = bi.layout[screen]
+        expect(per_image).to be_present, "#{bi.label} missing layout for #{screen}"
+        expect(per_image.slice("x", "y", "w", "h", "i")).to eq(indexed[bi.id.to_s])
+      end
+    end
+  end
+
+  it "sets board_image#position to match the AI ordering" do
+    board.format_board_with_ai
+    board.reload
+
+    expect(board.board_images.order(:position).pluck(:label)).to eq(words)
+  end
+
+  it "does not place a w=2 tile so it overlaps the previous tile (regression)" do
+    board.format_board_with_ai
+    board.reload
+
+    # On lg (6 cols): I(1) at (0,0), want(2) at (1,0), help(2) at (3,0),
+    # more(1) at (5,0), stop(1) wraps to (0,1), etc. No overlap.
+    lg = board.layout["lg"]
+    want = lg.find { |c| c["i"] == board.board_images.find_by(label: "want").id.to_s }
+    help = lg.find { |c| c["i"] == board.board_images.find_by(label: "help").id.to_s }
+
+    expect(want["w"]).to eq(2)
+    expect(help["w"]).to eq(2)
+    expect(want["x"] + want["w"]).to be <= help["x"]
+  end
+
+  it "wraps a w=2 tile to the next row when it would not fit on the current row" do
+    # Force small column count so wrapping is deterministic.
+    board.update!(large_screen_columns: 3)
+
+    board.format_board_with_ai
+    board.reload
+
+    lg = board.layout["lg"]
+    # 3 columns: I(1) at (0,0), want(2) at (1,0). help(2) can't fit at (?,0) — wraps to (0,1).
+    help = lg.find { |c| c["i"] == board.board_images.find_by(label: "help").id.to_s }
+    expect(help["y"]).to be >= 1
+    expect(help["x"]).to eq(0)
+  end
+
+  it "writes the explanation fields and seeds description when blank" do
+    board.update!(description: nil)
+    board.format_board_with_ai
+    board.reload
+
+    expect(board.data["personable_explanation"]).to eq("Friendly summary.")
+    expect(board.data["professional_explanation"]).to eq("AAC reasoning.")
+    expect(board.description).to include("Friendly summary.").and include("AAC reasoning.")
+  end
+
+  it "preserves existing description if already set" do
+    board.update!(description: "Keep me.")
+    board.format_board_with_ai
+    board.reload
+
+    expect(board.description).to eq("Keep me.")
+  end
+
+  it "appends any board_image dropped by the AI so no tile is lost" do
+    short_payload = ai_payload.deep_dup
+    short_payload["ordered_words"] = short_payload["ordered_words"].first(5)
+    allow(AiBoardFormatter).to receive(:call).and_return(short_payload)
+
+    board.format_board_with_ai
+    board.reload
+
+    expect(board.board_images.count).to eq(words.length)
+    %w[sm md lg].each do |screen|
+      expect(board.layout[screen].length).to eq(words.length)
+    end
+  end
+
+  it "returns self without raising when AI payload is blank" do
+    allow(AiBoardFormatter).to receive(:call).and_return(nil)
+
+    expect { board.format_board_with_ai }.not_to raise_error
+  end
+
+  it "is a no-op when the board has no images" do
+    empty_board = FactoryBot.create(:board, user: user)
+    expect { empty_board.format_board_with_ai }.not_to raise_error
+    expect(empty_board.layout || {}).to satisfy { |h| h["lg"].blank? }
+  end
+end


### PR DESCRIPTION
## Summary

- **Root cause:** `Board#format_board_with_ai` asked the LLM to assign `x/y` and then called `reset_layouts`, which re-packed by enumerate-index with no occupancy tracking — so any `w=2` tile collided with the next tile. It also only wrote `lg`; `sm`/`md` were derived blindly by the auto-packer. Both `board_image.layout` (read by `DraggableGrid` in ViewBoard/EditBoardScreen) and `board.layout` (read by BoardNativeGridPage) ended up overlapping. Users had to nudge a tile in the UI to trigger `apply_layout!` and persist a correct layout.
- **Fix:** Treat LLM output as **ordering + suggested sizes only**. Pack the grid deterministically in Ruby (row-major, occupancy-aware, handles `w>1`). Write per-image layouts AND `board.layout` for `sm`/`md`/`lg` in one transaction. Bypass `reset_layouts` on the AI path.
- **Prompt cleanup:** Drop the `position` field from the AI contract. Force OpenAI JSON mode (`response_format: { type: "json_object" }`). Keep a legacy `grid` shape fallback during rollout.

## What changed

- `app/models/ai_board_formatter.rb` — returns `ordered_words` (no x/y), JSON mode, normalizer + legacy `grid` fallback.
- `app/models/board.rb` — rewrites `format_board_with_ai`; adds private `pack_layout_row_major`; mirrors `bi.layout` ↔ `board.layout` across all three screens; appends AI-dropped tiles so nothing is lost.
- `app/models/open_ai_client.rb` — `create_completion` now honors `response_format` and `temperature` opts.
- `spec/models/ai_board_formatter_spec.rb` (new) — 8 examples.
- `spec/models/board_format_with_ai_spec.rb` (new) — 10 examples covering no-overlap, lockstep, w=2 packing, wrap-on-row-end, missing-tile recovery, no-op safety.

## Test plan

- [x] `bundle exec rspec spec/models/ai_board_formatter_spec.rb spec/models/board_format_with_ai_spec.rb` — 18 examples, 0 failures.
- [x] Related: `bundle exec rspec spec/models/board_spec.rb spec/models/board_image_spec.rb spec/models/open_ai_client_spec.rb` — 31 examples, 0 failures.
- [x] Full suite: `bundle exec rspec` — **490 examples, 0 failures, 17 pending**.
- [ ] Manual: enqueue `FormatBoardWithAiJob` on a dev board with mixed-size tiles, refresh ViewBoard/EditBoardScreen and the native predictive grid — all three views should match without a manual nudge.

## Out of scope

- No switch to Anthropic / Claude SDK (per offline decision).
- `reset_layouts` and `calculate_grid_layout_for_screen_size` left untouched — they have other callers.
- No frontend changes; no backfill of previously-formatted boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)