### PR TITLE
refactor(ai-prompts): centralize JSON parsing and tighten scenario prompts

### DIFF
--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -205,17 +205,6 @@ class OpenAiClient
     image_prompt_content
   end
 
-  def generate_formatted_board(name, num_of_columns, words = [], max_num_of_rows = 4, maintain_existing = false)
-    @model = GTP_MODEL
-    Rails.logger.debug "generate_formatted_board - model: #{@model} -- name: #{name} -- num_of_columns: #{num_of_columns} -- words: #{words.count} -- max_num_of_rows: #{max_num_of_rows}"
-    @messages = [{ role: "user",
-                  content: [{ type: "text",
-                              text: format_board_prompt(name, num_of_columns, words, max_num_of_rows, maintain_existing) }] }]
-    response = create_completion
-    Rails.logger.debug "*** ERROR *** Invaild Formatted Board Response: #{response}" unless response
-    response[:content] if response
-  end
-
   def clarify_image_description(image_description, restaurant_name)
     Rails.logger.debug "Missing image description.\n" && return unless image_description
     @model = GTP_5_MODEL
@@ -327,52 +316,6 @@ class OpenAiClient
     Make your best attempt to provide a list of 24 words or short phrases (2 words max) that are foundational for basic communication in an AAC device. Respond with 'NO NEXT WORDS' if there are no common follow-up words for '#{label}' that would be used in conversation & an AAC device. Use json format. Respond with a JSON object in the following format: {\"next_words\": [\"word1\", \"word2\", \"word3\", ...]}"
   end
 
-  def maintain_existing_instructions(existing_grid)
-    "The existing grid layout is as follows: #{existing_grid}. Please maintain the existing size of each word, changing only the position of the words as needed.
-    Give priority to the words with the 'board_type' of 'category' when placing them on the grid. If the word is a 'category' word, it should be placed in the top or around top side of the grid."
-  end
-
-  def format_board_prompt(name, num_of_columns, existing_grid = [], max_num_of_rows = 4, maintain_existing = false)
-    words = existing_grid.map { |word_obj| word_obj[:word] }
-
-    Rails.logger.debug "\nName: #{name} -- Num of Columns: #{num_of_columns} -- Max Num of Rows: #{max_num_of_rows} -- Existing Grid: #{existing_grid.count} -- Maintain Existing: #{maintain_existing}"
-    word_str = words.join(", ") unless words.blank?
-    word_count = words.size
-    text = <<-PROMPT
-      Create an AAC communication board formatted as a grid layout.
-
-      Organize the words based on these guidelines:
-      1. Core words should be placed first and grouped together, prioritizing high-frequency words - Stating with the coordinate [0,0].
-      2. Group words by parts of speech (e.g., pronouns, verbs, adjectives).
-      3. Consider how speech-language pathologists arrange words for ease of use in communication, ensuring frequently used words are near the top left.
-      4. Use a grid layout with a MAXIMUM of #{num_of_columns} columns and MAX rows: #{max_num_of_rows}.
-      5. Each entry should include the word, its grid position as [x, y], its part of speech, its size, and its frequency of use.
-      6. The size of each word should be based on its frequency of use, with high-frequency words being larger. Size is represented as number of grid spaces the word occupies. [1,1] is a single grid space. [2,2] is a 2x2 grid space. & so on.
-      7. Do not overlap words or exceed the grid size.
-      #{maintain_existing_instructions(existing_grid) if maintain_existing}
-
-      Please create a grid layout that include the words: '#{words}', grouped and positioned based on their typical use in AAC communication.
-      It is VERY important that the Y-COOORDINATE should not exceed #{max_num_of_rows} and the X-COORDINATE should not exceed #{num_of_columns}.
-             Please respond as a valid JSON object with the following structure:
-
-      {
-        "grid": [
-          {"word": "I", "position": [0,0], "part_of_speech": "pronoun", "frequency": "medium", "size": [1,1]},
-          {"word": "banana", "position": [0,1], "part_of_speech": "noun", "frequency": "low", "size": [1,1]},
-          {"word": "more", "position": [2,4], "part_of_speech": "adverb", "frequency": "high", "size": [1,1]},
-          ...
-          {"word": "elevator", "position": [5,10], "part_of_speech": "noun", "frequency": "low", "size": [1,1]}
-        ],
-              }
-    PROMPT
-  end
-
-  def explanation_prompt
-    'Please also provide a professional explanation (for a speech-language pathologist) and a personable explanation (for a caregiver or user - but still professional) of the layout.
-    {"professional_explanation": "This layout is designed to help users quickly find and use the most common words in AAC communication. The words are grouped by parts of speech and arranged in a grid to make it easy to locate and select the right word.
-    "personable_explanation": "This board is set up to help you find the words you need to communicate quickly and easily. The words are grouped by type and placed in a grid so you can find them easily.}'
-  end
-
   def get_next_words(label)
     @model = GTP_MODEL
     @messages = [{ role: "user",
@@ -404,22 +347,45 @@ class OpenAiClient
                           'th': "Thai" }.freeze
 
   def get_words_for_scenario(scenario_description, number_of_words = 24, language = "en", profile: nil)
-    prompt = <<~PROMPT
-      I have a scenario description: "#{scenario_description}".
+    user_prompt = <<~PROMPT
+      Scenario: "#{scenario_description}"
 
-      Please provide #{number_of_words} words that are foundational for basic communication in an AAC device.
-      These words should relate to the context of the scenario and be broadly applicable, supporting users in expressing a variety of intents, needs, and responses across different situations.
-      Do not repeat any words that are already on the board & only provide #{number_of_words} words.
-      Respond with a JSON object in the following format: {\"words\": [\"word1\", \"word2\", \"word3\", ...]}
+      Generate EXACTLY #{number_of_words} unique words or short (max 2 words) phrases that someone communicating
+      via an AAC device would most likely need to say or hear during this scenario.
+
+      Rules:
+      - Prefer single words. Use a 2-word phrase only when it is a common AAC phrase (e.g. "all done", "thank you").
+      - No duplicates, no near-duplicates (e.g. "happy" and "happiness" — pick one).
+      - Lowercase only, except proper nouns.
+      - No punctuation, no quotes, no leading/trailing whitespace.
+      - Mix of word types: include core communication words (I, want, more, stop, help, yes, no),
+        scenario-specific nouns/verbs, and a few descriptors (feelings, qualities).
+      - Skip any word already on the board (none supplied yet means include everything).
+
+      Output: exactly #{number_of_words} entries.
     PROMPT
-    prompt = append_profile_guidance(prompt, profile)
+    user_prompt = append_profile_guidance(user_prompt, profile)
+
+    if language.present? && language != "en"
+      long = LONG_LANGUAGE_NAMES[language.to_sym]
+      user_prompt += "\nRespond in #{long}." if long
+    end
 
     @model = GTP_MODEL
-    @messages = [{ role: "user",
-                   content: [{ type: "text", text: prompt }] }]
+    @messages = [
+      {
+        role: "system",
+        content: <<~SYSTEM.strip,
+          You generate vocabulary for AAC (Augmentative and Alternative Communication) boards.
+          You always return a single valid JSON object with a top-level "words" array.
+          No prose, no markdown fences, no commentary.
+        SYSTEM
+      },
+      { role: "user", content: user_prompt },
+    ]
+
     response = create_chat
-    Rails.logger.debug "*** ERROR *** Invaild Words for Scenario Response: #{response}" unless response
-    Rails.logger.debug "Words for Scenario Response: #{response.inspect}"
+    Rails.logger.debug "*** ERROR *** Invalid Words for Scenario Response: #{response}" unless response
     response
   end
 

--- a/app/models/openai_prompt.rb
+++ b/app/models/openai_prompt.rb
@@ -26,14 +26,9 @@ class OpenaiPrompt < ApplicationRecord
   include UtilHelper
 
   def send_prompt_to_openai
-    return if Rails.env.test?
     opts = open_ai_opts.merge({ messages: messages })
-    puts "\nsend_prompt_to_openai\n\nopts: #{opts}\n\n"
     response = OpenAiClient.new(opts).create_chat
-    puts "response: #{response}"
-    if response
-      update!(sent_at: Time.now)
-    end
+    update!(sent_at: Time.now) if response
     response
   end
 
@@ -51,15 +46,25 @@ class OpenaiPrompt < ApplicationRecord
   end
 
   def example_scenario_description_response
-    # {
-    #   "scenario": "First day of school",
-    #   "description": "arrival at the preschool, meeting the teacher and other kids, participating in introductory activities, understanding simple instructions, asking for help, expressing basic needs like hunger, thirst or need for restroom and expressing emotions like happiness, sadness, fear or excitement"
-    # }
-    "{\"scenario\": \"First day of school\", \"description\": \"arrival at the preschool, meeting the teacher and other kids, participating in introductory activities, understanding simple instructions, asking for help, expressing basic needs like hunger, thirst or need for restroom and expressing emotions like happiness, sadness, fear or excitement\"}"
+    {
+      "scenario" => "First day of school",
+      "description" => "arrival at the preschool, meeting the teacher and other kids, participating in introductory activities, understanding simple instructions, asking for help, expressing basic needs like hunger, thirst or need for restroom and expressing emotions like happiness, sadness, fear or excitement",
+    }.to_json
   end
 
   def describe_scenario_prompt
-    "Please describe the scenario of #{prompt_text} for a person at the age of #{age_range}. Please keep it simple but also very detailed. This will be used to create AAC material for people with speech difficulties. Please respond in JSON with the keys 'scenario' and 'description'.\n\nExample: #{example_scenario_description_response}"
+    age_clause = age_range.present? ? " for a person aged #{age_range}" : ""
+    <<~PROMPT.strip
+      Describe the scenario "#{prompt_text}"#{age_clause} as it would be experienced
+      by an AAC user — the people and things they encounter, the actions involved,
+      and the feelings or needs they might want to express. Keep it concrete and
+      grounded; this will be used to generate vocabulary for an AAC board.
+
+      Respond as a JSON object with exactly two string keys: "scenario" and "description".
+
+      Example:
+      #{example_scenario_description_response}
+    PROMPT
   end
 
   def resource_type
@@ -67,28 +72,23 @@ class OpenaiPrompt < ApplicationRecord
   end
 
   def set_scenario_description
-    return if Rails.env.test?
     response = OpenAiClient.new({ messages: [
       { role: "system", content: speech_expert },
       { role: "user", content: describe_scenario_prompt },
     ] }).create_chat
 
-    response_text = nil
-    if response
-      response_text = response[:content].gsub("```json", "").gsub("```", "").strip
-      if valid_json?(response_text)
-        response_text
-      else
-        puts "INVALID JSON: #{response_text}"
-        response_text = transform_into_json(response_text)
-      end
-    else
-      Rails.logger.error "*** ERROR - set_scenario_description *** \nDid not receive valid response. Response: #{response}\n"
+    content = response&.dig(:content)
+    if content.blank?
+      Rails.logger.error "*** ERROR - set_scenario_description *** empty response: #{response.inspect}"
+      return self
     end
-    puts "set_scenario_description - response_text: #{response_text}"
-    description = JSON.parse(response_text)["description"]
-    # description = JSON.parse(parsed_response)["description"]
-    puts "description: #{description}"
+
+    description = AiResponseParser.fetch(content, key: "description")
+    if description.blank?
+      Rails.logger.error "*** ERROR - set_scenario_description *** missing 'description' key in: #{content.inspect}"
+      return self
+    end
+
     self.description = description
     self
   end
@@ -107,32 +107,43 @@ class OpenaiPrompt < ApplicationRecord
 
   def word_list_prompt
     prompt_template = PromptTemplate.find_by(method_name: "word_list_prompt")
-    unless prompt_template
-      puts "PromptTemplate not found for 'word_list_prompt'"
-      return "Please generate a list of exactly #{number_of_images} unique words or short phrases (2 words max - prefer SINGLE WORDS) that are relevant to the scenario #{name}. Ensure that the list includes a mix of nouns, verbs, adjectives, and adverbs relevant to the activities and items involved in #{name} using the following description for additional context. Please make the words appropriate for a person at the age given. You can use common/core words if not able to meet number requirement of #{number_of_images} words/phrases. Please respond in JSON with the array key 'words_phrases'."
-    end
-
     text = prompt_template&.prompt_text
 
-    unless text
-      puts "PromptTemplate 'word_list_prompt' does not have prompt_text"
-      return "Please generate a list of exactly #{number_of_images} unique words or short phrases (2 words max - prefer SINGLE WORDS) that are relevant to the scenario #{name}. Ensure that the list includes a mix of nouns, verbs, adjectives, and adverbs relevant to the activities and items involved in #{name} using the following description for additional context. Please make the words appropriate for a person at the age given. You can use common/core words if not able to meet number requirement of #{number_of_images} words/phrases. Please respond in JSON with the array key 'words_phrases'."
+    if text.blank?
+      Rails.logger.warn "PromptTemplate 'word_list_prompt' missing or empty; using fallback"
+      return default_word_list_prompt
     end
 
-    num_of_imgs = number_of_images
-    puts "text: #{text}"
-    name_to_send = name || "the scenario"
-    prompt_text = text.gsub!("{QUANTITY}", num_of_imgs.to_s)
-    prompt_text.gsub!("{SCENARIO}", scenario)
-    prompt_text.gsub!("{AGE_RANGE}", age_range)
-    prompt_text.gsub!("{NAME}", name_to_send)
+    name_to_send = name.presence || "the scenario"
+    rendered = text
+      .gsub("{QUANTITY}", number_of_images.to_s)
+      .gsub("{SCENARIO}", scenario.to_s)
+      .gsub("{AGE_RANGE}", age_range.to_s)
+      .gsub("{NAME}", name_to_send)
+
     self.prompt_template_id = prompt_template.id
     save!
 
-    puts "****prompt_text: #{prompt_text}"
-    # "You will be given a scenario description and age range of the USER. Please provide EXACTLY #{num_of_imgs} words or short phrases (2 words max - prefer SINGLE WORDS) that are most likely to be communicated by the USER in the following scenario. These will be used to create AAC material for people with speech difficulties. Please make the words appropriate for a person at the age give. Please respond in JSON with the array key 'words_phrases'."
-    # "Please generate a list of exactly #{num_of_imgs} unique words or short phrases (2 words max - prefer SINGLE WORDS) that are relevant to the scenario #{name}. Ensure that the list includes a mix of nouns, verbs, adjectives, and adverbs relevant to the activities and items involved in #{name} using the following description for additional context. Please make the words appropriate for a person at the age given. You can use common/core words if not able to meet number requirement of #{num_of_imgs} words/phrases. Please respond in JSON with the array key 'words_phrases'."
-    prompt_text
+    rendered
+  end
+
+  def default_word_list_prompt
+    name_to_send = name.presence || "the scenario"
+    age_clause = age_range.present? ? " appropriate for a person aged #{age_range}" : ""
+    <<~PROMPT.strip
+      Generate EXACTLY #{number_of_images} unique words or short (max 2 words) phrases
+      that someone using an AAC device would most likely need during "#{name_to_send}".
+
+      Rules:
+      - Prefer single words. Use a 2-word phrase only when it is the natural AAC form.
+      - Include a mix of nouns, verbs, adjectives, and adverbs related to the scenario.
+      - Include core communication words (I, want, more, stop, help) when relevant.
+      - Lowercase only, except proper nouns. No punctuation.
+      - No duplicates or near-duplicates.
+      - Keep the words#{age_clause}.
+
+      Respond as a JSON object with a single array key "words_phrases".
+    PROMPT
   end
 
   def messages

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -142,37 +142,22 @@ class Scenario < ApplicationRecord
 
   def get_words_for_scenario(description, number_of_words)
     if description.blank? || number_of_words.blank?
-      Rails.logger.error "*** ERROR - get_words_for_scenario *** \nDescription or number_of_words is blank. Description: #{description}, Number of words: #{number_of_words}\n"
+      Rails.logger.error "*** ERROR - get_words_for_scenario *** description or number_of_words blank (desc=#{description.inspect}, n=#{number_of_words.inspect})"
       return
     end
+
     response = OpenAiClient.new({}).get_words_for_scenario(description, number_of_words)
-    begin
-      if response
-        if response[:content].blank?
-          Rails.logger.error "*** ERROR - get_words_for_scenario *** \nDid not receive valid response. Response: #{response}\n"
-          return
-        end
-        words = response[:content].gsub("```json", "").gsub("```", "").strip
-        if words.blank? || words.include?("NO ADDITIONAL WORDS")
-          return
-        end
-        if valid_json?(words)
-          words = JSON.parse(words)
-        else
-          start_index = words.index("{")
-          end_index = words.rindex("}")
-          words = words[start_index..end_index]
-          words = transform_into_json(words)
-        end
-      else
-        Rails.logger.error "*** ERROR - get_words_for_scenario *** \nDid not receive valid response. Response: #{response}\n"
-      end
-      words_to_include = words["words"] || []
-      words_to_include = words_to_include.map { |w| w.downcase }
-      words_to_include = words_to_include.uniq
-      words_to_include
-    rescue => e
-      Rails.logger.error "Error getting words for scenario: #{e}"
+    content = response&.dig(:content)
+    if content.blank?
+      Rails.logger.error "*** ERROR - get_words_for_scenario *** empty response: #{response.inspect}"
+      return
     end
+    return if content.include?("NO ADDITIONAL WORDS")
+
+    words = AiResponseParser.fetch_array(content, key: "words")
+    words.map { |w| w.to_s.downcase.strip }.reject(&:blank?).uniq
+  rescue => e
+    Rails.logger.error "Error getting words for scenario: #{e.class}: #{e.message}"
+    nil
   end
 end

--- a/app/services/ai_response_parser.rb
+++ b/app/services/ai_response_parser.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Centralized parser for OpenAI chat responses that are expected to be JSON.
+#
+# Even with `response_format: { type: "json_object" }`, callers in this app
+# historically got back content wrapped in ``` fences, with trailing commas,
+# or with leading/trailing prose. Each AI-touching model used to copy-paste
+# the same `gsub("```json", "").gsub("```", "").strip; valid_json?;
+# transform_into_json` block. This class centralizes that.
+#
+# Usage:
+#   parsed = AiResponseParser.parse(response[:content])
+#   words  = AiResponseParser.fetch_array(response[:content], key: "words")
+#
+# Returns nil (never raises) on unparseable input.
+class AiResponseParser
+  class << self
+    # Returns a Hash on success, nil on failure.
+    def parse(raw)
+      return nil if raw.blank?
+      return raw if raw.is_a?(Hash)
+
+      str = strip_fences(raw.to_s)
+      return nil if str.blank?
+
+      try_parse(str) ||
+        try_parse(str.gsub(/,(\s*[}\]])/, '\1')) ||
+        try_parse(extract_first_object(str))
+    end
+
+    # Returns the value at `key` from a parsed payload, or nil.
+    # If the value is itself a JSON-encoded string, parses it.
+    def fetch(raw, key:)
+      payload = parse(raw)
+      return nil unless payload.is_a?(Hash)
+
+      value = payload[key.to_s] || payload[key.to_sym]
+      return nil if value.nil?
+
+      if value.is_a?(String) && looks_like_json?(value)
+        parse(value) || value
+      else
+        value
+      end
+    end
+
+    # Returns an Array at `key`. Coerces single values to a one-element array.
+    # Returns [] if the key is missing or the value can't be coerced.
+    def fetch_array(raw, key:)
+      value = fetch(raw, key: key)
+      case value
+      when Array then value
+      when nil then []
+      else [value]
+      end
+    end
+
+    private
+
+    def strip_fences(str)
+      s = str.dup
+      s.sub!(/\A\s*```json\s*/i, "")
+      s.sub!(/\A\s*```\s*/i, "")
+      s.sub!(/```\s*\z/i, "")
+      s.strip
+    end
+
+    def try_parse(str)
+      return nil if str.blank?
+      JSON.parse(str)
+    rescue JSON::ParserError
+      nil
+    end
+
+    # Finds the first {...} block in the string (best-effort) so we can
+    # recover when the LLM prepends prose. Returns "" on no match.
+    def extract_first_object(str)
+      start = str.index("{")
+      stop = str.rindex("}")
+      return "" if start.nil? || stop.nil? || stop <= start
+      str[start..stop]
+    end
+
+    def looks_like_json?(str)
+      stripped = str.strip
+      stripped.start_with?("{", "[")
+    end
+  end
+end

--- a/spec/models/openai_prompt_spec.rb
+++ b/spec/models/openai_prompt_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe OpenaiPrompt, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:prompt) do
+    OpenaiPrompt.create!(
+      user: user,
+      prompt_text: "First day of school",
+      age_range: "4-6",
+      number_of_images: 6,
+    )
+  end
+
+  def stub_create_chat(content)
+    fake_client = instance_double(OpenAiClient)
+    allow(OpenAiClient).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:create_chat).and_return({ role: "assistant", content: content })
+    fake_client
+  end
+
+  describe "#describe_scenario_prompt" do
+    it "mentions the prompt_text and age_range" do
+      text = prompt.describe_scenario_prompt
+      expect(text).to include("First day of school")
+      expect(text).to include("aged 4-6")
+    end
+
+    it "omits the age clause when age_range is blank" do
+      prompt.update!(age_range: nil)
+      text = prompt.describe_scenario_prompt
+      expect(text).to include("First day of school")
+      expect(text).not_to include("aged")
+    end
+
+    it "names the required JSON keys" do
+      text = prompt.describe_scenario_prompt
+      expect(text).to include("\"scenario\"")
+      expect(text).to include("\"description\"")
+    end
+  end
+
+  describe "#set_scenario_description" do
+    it "writes description from a valid JSON response" do
+      stub_create_chat('{"scenario":"First day of school","description":"meeting the teacher, finding the bathroom, sharing toys"}')
+
+      prompt.set_scenario_description
+
+      expect(prompt.description).to eq("meeting the teacher, finding the bathroom, sharing toys")
+    end
+
+    it "tolerates fenced JSON" do
+      stub_create_chat("```json\n{\"description\":\"clean text\"}\n```")
+
+      prompt.set_scenario_description
+
+      expect(prompt.description).to eq("clean text")
+    end
+
+    it "does not crash on blank response" do
+      stub_create_chat(nil)
+
+      expect { prompt.set_scenario_description }.not_to raise_error
+      expect(prompt.description).to be_nil
+    end
+
+    it "does not crash when 'description' key is missing" do
+      stub_create_chat('{"scenario":"X"}')
+
+      expect { prompt.set_scenario_description }.not_to raise_error
+      expect(prompt.description).to be_nil
+    end
+  end
+
+  describe "#send_prompt_to_openai" do
+    it "calls OpenAiClient.create_chat with the built messages and stamps sent_at" do
+      fake_client = instance_double(OpenAiClient)
+      expect(OpenAiClient).to receive(:new) do |opts|
+        expect(opts[:messages]).to be_an(Array)
+        expect(opts[:messages].length).to eq(2)
+        fake_client
+      end
+      expect(fake_client).to receive(:create_chat).and_return({ role: "assistant", content: '{"words_phrases":["a","b"]}' })
+
+      expect { prompt.send_prompt_to_openai }.to change { prompt.reload.sent_at }
+    end
+
+    it "does not stamp sent_at when the client returns nil" do
+      fake_client = instance_double(OpenAiClient, create_chat: nil)
+      allow(OpenAiClient).to receive(:new).and_return(fake_client)
+
+      expect { prompt.send_prompt_to_openai }.not_to(change { prompt.reload.sent_at })
+    end
+  end
+
+  describe "#word_list_prompt fallback" do
+    it "returns the default prompt when no PromptTemplate exists" do
+      allow(PromptTemplate).to receive(:find_by).with(method_name: "word_list_prompt").and_return(nil)
+
+      text = prompt.word_list_prompt
+
+      expect(text).to include("EXACTLY 6")
+      expect(text).to include("First day of school")
+      expect(text).to include("\"words_phrases\"")
+    end
+
+    it "renders the template's placeholders when a PromptTemplate exists" do
+      template = PromptTemplate.create!(
+        method_name: "word_list_prompt",
+        prompt_text: "Give {QUANTITY} words for {NAME} ({AGE_RANGE}) — scenario: {SCENARIO}",
+        prompt_type: "word_list",
+        response_type: "json",
+      )
+
+      text = prompt.word_list_prompt
+
+      expect(text).to eq("Give 6 words for First day of school (4-6) — scenario: First day of school")
+      expect(prompt.reload.prompt_template_id).to eq(template.id)
+    end
+  end
+end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -19,8 +19,62 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Scenario, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { FactoryBot.create(:user) }
+  let(:scenario) { FactoryBot.create(:scenario, user: user, name: "First day of school") }
+
+  def stub_openai_words(content)
+    fake_client = instance_double(OpenAiClient)
+    allow(OpenAiClient).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:get_words_for_scenario).and_return({ role: "assistant", content: content })
+    fake_client
+  end
+
+  describe "#get_words_for_scenario" do
+    it "returns a deduped, lowercased word list from a valid response" do
+      stub_openai_words('{"words":["Apple","banana","APPLE","Cherry"]}')
+
+      result = scenario.get_words_for_scenario("a scenario", 4)
+
+      expect(result).to eq(%w[apple banana cherry])
+    end
+
+    it "tolerates fenced JSON output" do
+      stub_openai_words("```json\n{\"words\":[\"a\",\"b\"]}\n```")
+
+      expect(scenario.get_words_for_scenario("x", 2)).to eq(%w[a b])
+    end
+
+    it "returns nil when description is blank" do
+      expect(OpenAiClient).not_to receive(:new)
+      expect(scenario.get_words_for_scenario("", 5)).to be_nil
+    end
+
+    it "returns nil when number_of_words is blank" do
+      expect(OpenAiClient).not_to receive(:new)
+      expect(scenario.get_words_for_scenario("x", nil)).to be_nil
+    end
+
+    it "returns nil when the AI returns blank content" do
+      stub_openai_words(nil)
+
+      expect(scenario.get_words_for_scenario("x", 5)).to be_nil
+    end
+
+    it "returns nil when the AI returns the NO ADDITIONAL WORDS sentinel" do
+      stub_openai_words('NO ADDITIONAL WORDS — {"words":["a"]}')
+
+      expect(scenario.get_words_for_scenario("x", 5)).to be_nil
+    end
+
+    it "passes description and number_of_words to OpenAiClient" do
+      fake_client = instance_double(OpenAiClient)
+      allow(OpenAiClient).to receive(:new).and_return(fake_client)
+      expect(fake_client).to receive(:get_words_for_scenario).with("road trip", 12).and_return({ content: '{"words":[]}' })
+
+      scenario.get_words_for_scenario("road trip", 12)
+    end
+  end
 end

--- a/spec/services/ai_response_parser_spec.rb
+++ b/spec/services/ai_response_parser_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe AiResponseParser do
+  describe ".parse" do
+    it "parses a clean JSON object" do
+      expect(described_class.parse('{"a":1}')).to eq({ "a" => 1 })
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.parse(nil)).to be_nil
+      expect(described_class.parse("")).to be_nil
+      expect(described_class.parse("   ")).to be_nil
+    end
+
+    it "returns a Hash passed through unchanged" do
+      h = { "a" => 1 }
+      expect(described_class.parse(h)).to equal(h)
+    end
+
+    it "strips ```json fences" do
+      raw = <<~JSON
+        ```json
+        {"words": ["a", "b"]}
+        ```
+      JSON
+      expect(described_class.parse(raw)).to eq({ "words" => %w[a b] })
+    end
+
+    it "strips bare ``` fences" do
+      raw = "```\n{\"x\":1}\n```"
+      expect(described_class.parse(raw)).to eq({ "x" => 1 })
+    end
+
+    it "tolerates trailing commas in objects and arrays" do
+      raw = '{"words": ["a", "b",],}'
+      expect(described_class.parse(raw)).to eq({ "words" => %w[a b] })
+    end
+
+    it "extracts the first JSON object when prose surrounds it" do
+      raw = 'Here is your data: {"x": 1, "y": 2} hope this helps!'
+      expect(described_class.parse(raw)).to eq({ "x" => 1, "y" => 2 })
+    end
+
+    it "returns nil for truly unparseable input" do
+      expect(described_class.parse("not json at all { ] }")).to be_nil
+    end
+  end
+
+  describe ".fetch" do
+    it "returns the value at the key" do
+      expect(described_class.fetch('{"name":"Alice"}', key: "name")).to eq("Alice")
+    end
+
+    it "accepts symbol keys" do
+      expect(described_class.fetch('{"name":"Alice"}', key: :name)).to eq("Alice")
+    end
+
+    it "returns nil when key is missing" do
+      expect(described_class.fetch('{"x":1}', key: "y")).to be_nil
+    end
+
+    it "returns nil for unparseable input" do
+      expect(described_class.fetch("garbage", key: "x")).to be_nil
+    end
+
+    it "parses a JSON-encoded string value" do
+      raw = '{"payload": "{\"a\":1}"}'
+      expect(described_class.fetch(raw, key: "payload")).to eq({ "a" => 1 })
+    end
+  end
+
+  describe ".fetch_array" do
+    it "returns the array at the key" do
+      raw = '{"words": ["a", "b", "c"]}'
+      expect(described_class.fetch_array(raw, key: "words")).to eq(%w[a b c])
+    end
+
+    it "returns [] when the key is missing" do
+      expect(described_class.fetch_array('{"x":1}', key: "words")).to eq([])
+    end
+
+    it "returns [] for blank or unparseable input" do
+      expect(described_class.fetch_array(nil, key: "words")).to eq([])
+      expect(described_class.fetch_array("not json", key: "words")).to eq([])
+    end
+
+    it "wraps a single non-array value into a one-element array" do
+      raw = '{"words": "lonely"}'
+      expect(described_class.fetch_array(raw, key: "words")).to eq(["lonely"])
+    end
+
+    it "handles fenced + trailing-comma JSON" do
+      raw = "```json\n{\"words\": [\"a\", \"b\",],}\n```"
+      expect(described_class.fetch_array(raw, key: "words")).to eq(%w[a b])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Independent of [#127](https://github.com/brittanyjohns/itty_bitty_boards/pull/127). Starts an OpenAI-prompt cleanup sweep with the **scenario-type flow** and a shared parsing helper.

- **New `AiResponseParser`** centralizes the *"strip ```json fences → tolerate trailing commas → recover from prose"* dance that was copy-pasted in Scenario / Board / OpenaiPrompt / Menu / ImageHelper. This PR routes Scenario and OpenaiPrompt through it; the other callers will be migrated in follow-up PRs.
- **`OpenAiClient#get_words_for_scenario`** gets a real system prompt, dedup / single-word-preference / lowercase / language gating, and keeps the existing communicator-profile guidance.
- **`OpenaiPrompt` is now testable.** Dropped the `return if Rails.env.test?` short-circuits in `send_prompt_to_openai` and `set_scenario_description` so they can be exercised with stubbed `OpenAiClient`. Tightened `describe_scenario_prompt` and added a `default_word_list_prompt` fallback for when the `PromptTemplate` record is missing.
- **Dead-code removal** from `OpenAiClient`: `generate_formatted_board`, `format_board_prompt`, `maintain_existing_instructions`, `explanation_prompt`. All unused since `AiBoardFormatter` replaced them.

## What changed

- `app/services/ai_response_parser.rb` (new) — `parse / fetch / fetch_array`, returns nil/`[]` instead of raising.
- `app/models/open_ai_client.rb` — better scenario prompt; dead methods removed.
- `app/models/scenario.rb` — `#get_words_for_scenario` collapsed from ~35 lines of bespoke parsing to ~10 using the new helper.
- `app/models/openai_prompt.rb` — testable + tighter prompts + cleaner placeholder rendering; removed `puts` debug noise and large commented-out earlier prompt versions.
- `spec/services/ai_response_parser_spec.rb` (new) — 18 examples.
- `spec/models/scenario_spec.rb` — 7 examples for `#get_words_for_scenario`.
- `spec/models/openai_prompt_spec.rb` (new) — 11 examples covering `describe_scenario_prompt`, `set_scenario_description`, `send_prompt_to_openai`, and `word_list_prompt` (template + fallback paths).

## Behavior

Per design, **prompt outputs may improve but should not get worse**: I added structure, dedup hints, and a system role, but kept the same model defaults (`gpt-4.1-mini`), the same JSON shape (`{"words": [...]}`, `{"words_phrases": [...]}`), and the same calling conventions. Existing callers see identical API.

## Test plan

- [x] `bundle exec rspec spec/services/ai_response_parser_spec.rb spec/models/scenario_spec.rb spec/models/openai_prompt_spec.rb` — 36 examples, 0 failures
- [x] Full suite: `bundle exec rspec` — **525 examples, 0 failures, 16 pending**
- [ ] Manual: trigger a scenario in dev and confirm word_list still populates (no behavior regression)

## Out of scope (follow-ups)

- Migrating Board's 4 other AI methods (`get_words`, `get_word_suggestions`, `get_social_story_word_suggestions`, `get_word_suggestions_from_prompt`) through `AiResponseParser` — same pattern, separate PR.
- Migrating ImageHelper / Menu callers.
- Improving non-scenario prompts (additional_words branches, social-story, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)