### PR TITLE
feat(stripe): seed sandboxes and unblock staging top-ups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -4,6 +4,20 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
 
   NO_CC_KEY = "NOCC".freeze
 
+  # Hosts we trust as Stripe Checkout `success_url` / `cancel_url` targets.
+  # We derive the redirect host from the incoming request's Origin/Referer
+  # so Netlify preview deploys "just work" without per-deploy env vars, but
+  # we don't want to be an open redirect — Stripe will happily send users
+  # to whatever success_url we hand it. Anything not on this list falls
+  # back to ENV["FRONT_END_URL"].
+  ALLOWED_FRONTEND_HOSTS = [
+    /\Alocalhost\z/,
+    /\A127\.0\.0\.1\z/,
+    /\A(.+\.)?speakanyway\.com\z/,
+    /\A(.+\.)?netlify\.app\z/,
+    /\A(.+\.)?hatchboxapp\.com\z/,
+  ].freeze
+
   PLAN_PRICE_IDS = {
     "free" => nil,
     "myspeak" => ENV.fetch("STRIPE_PRICE_MYSPEAK", nil),
@@ -183,7 +197,30 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     current_user.update!(stripe_customer_id: customer.id)
   end
 
+  # Prefer the request's Origin (then Referer) when it points at a trusted
+  # host. This lets Netlify preview deploys, the production app, and local
+  # dev all redirect back to themselves after Stripe Checkout without
+  # needing the deploy URL baked into a server-side env var.
+  #
+  # Falls back to ENV["FRONT_END_URL"] when the request didn't supply a
+  # recognized origin (e.g. server-to-server calls in tests, mis-set CORS).
   def frontend_base_url
-    ENV["FRONT_END_URL"] || "http://localhost:8100"
+    candidate = request.headers["Origin"].presence || request.headers["Referer"].presence
+
+    if candidate.present?
+      begin
+        uri = URI.parse(candidate)
+        host = uri.host.to_s.downcase
+        if uri.scheme.in?(%w[http https]) && ALLOWED_FRONTEND_HOSTS.any? { |re| host.match?(re) }
+          base = +"#{uri.scheme}://#{uri.host}"
+          base << ":#{uri.port}" if uri.port && ![80, 443].include?(uri.port)
+          return base
+        end
+      rescue URI::InvalidURIError
+        # fall through to env fallback
+      end
+    end
+
+    ENV["FRONT_END_URL"].presence || "http://localhost:8100"
   end
 end

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -4,6 +4,25 @@ Every environment (test, live) needs these Stripe objects configured the
 same way. The webhook and `CreditService` read metadata from Stripe — there
 are no hard-coded plan or pack values in the app.
 
+## Quickstart: seeding a fresh Stripe Sandbox
+
+When you spin up a new Stripe Sandbox workspace, you don't need to click
+through the dashboard. Run the seed rake task — it's idempotent and
+creates every Product, Price, and the `PARTNERPILOT26` promotion code:
+
+```bash
+export STRIPE_API_KEY=sk_test_...   # SECRET key from the new sandbox
+bundle exec rake stripe:seed_sandbox
+```
+
+The task refuses to run against a live-mode key (`sk_live_...`) unless you
+also set `ALLOW_LIVE=true`. At the end it prints an env-var block to paste
+into Hatchbox (or your local `.env`). Rerunning prints `[skip]` lines for
+existing objects — safe to repeat.
+
+The sections below explain what those objects are and how the app reads
+them, in case you need to set anything up by hand.
+
 ## 1. Subscription Prices (existing tiers)
 
 For each tier — Free, MySpeak, Basic, Pro, Partner Pro — open the Price in
@@ -53,7 +72,49 @@ There's already a Stripe webhook configured at `/api/webhooks` that uses
 - `customer.created`
 - `invoice.payment_succeeded` *(triggers plan-credit grants on first paid period and every renewal — Phase 4)*
 
-## 4. Verifying
+## 4. Redirect URLs (success_url / cancel_url)
+
+`API::Stripe::CheckoutSessionsController#frontend_base_url` derives the
+host for Stripe Checkout's `success_url` / `cancel_url` from the incoming
+request's `Origin` (or `Referer`) header, _when that header points at a
+trusted host_. The trust allowlist lives in `ALLOWED_FRONTEND_HOSTS` on
+the controller and currently covers:
+
+- `localhost` / `127.0.0.1`
+- `*.speakanyway.com`
+- `*.netlify.app` (so any Netlify preview deploy works automatically)
+- `*.hatchboxapp.com`
+
+When the request doesn't carry a recognized origin, the controller falls
+back to `ENV["FRONT_END_URL"]`, then to `http://localhost:8100`. This is
+why staging doesn't need a per-preview env var — the redirect follows the
+browser, not the server config. Keep `FRONT_END_URL` set as a sensible
+fallback anyway (production points at the live frontend; staging can
+point at the staging marketing site).
+
+If you add a new trusted frontend host, update both the allowlist and
+this section.
+
+## 5. Staging-specific setup (Stripe Sandbox)
+
+Staging has its own webhook endpoint pointing at the staging app. To set
+it up from scratch in a Sandbox workspace:
+
+1. Stripe Sandbox dashboard → Developers → Webhooks → Add endpoint.
+2. **URL:** `https://ypk9e.hatchboxapp.com/api/webhooks`
+3. **Events to send** — at minimum the events listed in §3 above.
+4. Save, then reveal and copy the endpoint's signing secret.
+5. In Hatchbox staging env vars, set:
+   - `STRIPE_API_KEY` = the sandbox `sk_test_...` secret key
+   - `STRIPE_WEBHOOK_SECRET` = the signing secret from step 4 (NOT the
+     production endpoint's signing secret — they're different)
+   - `STRIPE_PRICE_*` env vars from `rake stripe:seed_sandbox` output
+6. Send a test event from the endpoint page (`checkout.session.completed`).
+   `bin/staging-logs web | grep StripeWebhook` should show
+   `Received event evt_...`. If you see `Signature error` instead, the
+   signing secret doesn't match.
+
+## 6. Verifying
 
 ```bash
 stripe listen --forward-to localhost:4000/api/webhooks

--- a/lib/tasks/stripe_sandbox.rake
+++ b/lib/tasks/stripe_sandbox.rake
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+# Seed a fresh Stripe Sandbox (or any test-mode Stripe account) with every
+# Product, Price, and Promotion Code the app expects. Idempotent — safe to
+# rerun; existing objects are skipped.
+#
+# Usage:
+#   export STRIPE_API_KEY=sk_test_...   # from the target sandbox
+#   bundle exec rake stripe:seed_sandbox
+#
+# Refuses to run against live-mode keys unless ALLOW_LIVE=true is set. The
+# script never persists the key anywhere; it only reads it from ENV at
+# request time (the `stripe` gem picks it up automatically).
+namespace :stripe do
+  desc "Create all Products, Prices, and the partner promo code in the current Stripe (test) account. Idempotent."
+  task seed_sandbox: :environment do
+    require "stripe"
+
+    api_key = ENV["STRIPE_API_KEY"].to_s
+    if api_key.empty?
+      abort "[stripe:seed_sandbox] STRIPE_API_KEY is not set. Export the SANDBOX secret key (sk_test_...) and rerun."
+    end
+
+    unless api_key.start_with?("sk_test_") || ENV["ALLOW_LIVE"] == "true"
+      abort "[stripe:seed_sandbox] STRIPE_API_KEY does not look like a test key (sk_test_...). Refusing to run. " \
+            "Set ALLOW_LIVE=true to override (you almost certainly do not want to)."
+    end
+
+    Stripe.api_key = api_key
+
+    # ---- Spec ---------------------------------------------------------------
+    # currency is USD throughout. Prices are in cents.
+    plans = [
+      { product_name: "SpeakAnyWay MySpeak", env_var: "STRIPE_PRICE_MYSPEAK",
+        unit_amount: 300, interval: "month",
+        metadata: { plan_type: "myspeak", monthly_credits: "50" } },
+      { product_name: "SpeakAnyWay MySpeak", env_var: "STRIPE_PRICE_MYSPEAK_YEAR",
+        unit_amount: 3000, interval: "year",
+        metadata: { plan_type: "myspeak", monthly_credits: "600" } },
+      { product_name: "SpeakAnyWay Basic", env_var: "STRIPE_PRICE_BASIC",
+        unit_amount: 800, interval: "month",
+        metadata: { plan_type: "basic", monthly_credits: "400" } },
+      { product_name: "SpeakAnyWay Basic", env_var: "STRIPE_PRICE_BASIC_YEAR",
+        unit_amount: 8000, interval: "year",
+        metadata: { plan_type: "basic", monthly_credits: "4800" } },
+      { product_name: "SpeakAnyWay Pro", env_var: "STRIPE_PRICE_PRO",
+        unit_amount: 2000, interval: "month",
+        metadata: { plan_type: "pro", monthly_credits: "1500" } },
+      { product_name: "SpeakAnyWay Pro", env_var: "STRIPE_PRICE_PRO_YEAR",
+        unit_amount: 20000, interval: "year",
+        metadata: { plan_type: "pro", monthly_credits: "18000" } },
+      { product_name: "SpeakAnyWay Partner Pro", env_var: "STRIPE_PRICE_PARTNER_PRO",
+        unit_amount: 2000, interval: "month",
+        metadata: { plan_type: "partner_pro", monthly_credits: "1500" } },
+    ]
+
+    topups = [
+      { product_name: "Credit Pack — Small", env_var: "STRIPE_PRICE_TOPUP_SMALL",
+        unit_amount: 499,
+        metadata: { kind: "topup", credit_amount: "100" } },
+      { product_name: "Credit Pack — Medium", env_var: "STRIPE_PRICE_TOPUP_MEDIUM",
+        unit_amount: 1999,
+        metadata: { kind: "topup", credit_amount: "500" } },
+      { product_name: "Credit Pack — Large", env_var: "STRIPE_PRICE_TOPUP_LARGE",
+        unit_amount: 4999,
+        metadata: { kind: "topup", credit_amount: "1500" } },
+    ]
+
+    promo_code = "PARTNERPILOT26"
+
+    # ---- Helpers ------------------------------------------------------------
+    products_by_name = {}
+
+    find_or_create_product = lambda do |name|
+      cached = products_by_name[name]
+      return cached if cached
+
+      existing = Stripe::Product.search(query: %(name:"#{name}" AND active:"true")).data.first
+      product = existing || Stripe::Product.create(name: name)
+      puts "#{existing ? '[skip]' : '[create]'} Product #{product.id} — #{name}"
+      products_by_name[name] = product
+      product
+    rescue Stripe::StripeError => e
+      warn "[error] Product '#{name}': #{e.class} — #{e.message}"
+      nil
+    end
+
+    # Looks for an existing Price on a Product that matches all required
+    # metadata keys AND the same recurrence shape. Recurrence comparison is
+    # done in Ruby because Stripe's Price.search doesn't filter on
+    # `recurring.interval` directly.
+    find_matching_price = lambda do |product_id:, metadata:, interval: nil|
+      meta_clauses = metadata.map { |k, v| %(metadata["#{k}"]:"#{v}") }
+      query = ([%(product:"#{product_id}"), %(active:"true")] + meta_clauses).join(" AND ")
+      Stripe::Price.search(query: query, limit: 10).data.find do |price|
+        if interval
+          price.recurring && price.recurring.interval == interval
+        else
+          price.type == "one_time"
+        end
+      end
+    end
+
+    results = {} # env_var => price_id
+
+    seed_price = lambda do |entry, interval: nil|
+      product = find_or_create_product.call(entry[:product_name])
+      next unless product
+
+      existing = find_matching_price.call(
+        product_id: product.id,
+        metadata: entry[:metadata],
+        interval: interval,
+      )
+
+      price =
+        if existing
+          puts "[skip]   Price   #{existing.id} — #{entry[:env_var]} (#{entry[:product_name]} #{interval || 'one_time'})"
+          existing
+        else
+          params = {
+            product: product.id,
+            currency: "usd",
+            unit_amount: entry[:unit_amount],
+            metadata: entry[:metadata],
+          }
+          params[:recurring] = { interval: interval } if interval
+          created = Stripe::Price.create(params)
+          puts "[create] Price   #{created.id} — #{entry[:env_var]} (#{entry[:product_name]} #{interval || 'one_time'})"
+          created
+        end
+
+      results[entry[:env_var]] = price.id
+    rescue Stripe::StripeError => e
+      warn "[error] Price for #{entry[:env_var]}: #{e.class} — #{e.message}"
+    end
+
+    # ---- Run ---------------------------------------------------------------
+    puts "Seeding Stripe (mode=#{api_key.start_with?('sk_test_') ? 'test' : 'LIVE'})..."
+
+    plans.each   { |p| seed_price.call(p, interval: p[:interval]) }
+    topups.each  { |t| seed_price.call(t) }
+
+    # Partner pilot promo: 100% off, first 3 months. Create the underlying
+    # Coupon first, then a Promotion Code pointing at it.
+    begin
+      existing_promo = Stripe::PromotionCode.list(code: promo_code, limit: 1).data.first
+      if existing_promo
+        puts "[skip]   Promo   #{existing_promo.id} — #{promo_code}"
+      else
+        coupon = Stripe::Coupon.create(
+          name: "Partner Pilot — 3 months free",
+          percent_off: 100,
+          duration: "repeating",
+          duration_in_months: 3,
+          metadata: { purpose: "partner_pro_pilot_2026" },
+        )
+        created_promo = Stripe::PromotionCode.create(
+          coupon: coupon.id,
+          code: promo_code,
+          active: true,
+        )
+        puts "[create] Promo   #{created_promo.id} — #{promo_code} (coupon=#{coupon.id})"
+      end
+    rescue Stripe::StripeError => e
+      warn "[error] Promotion code #{promo_code}: #{e.class} — #{e.message}"
+    end
+
+    # ---- Output ------------------------------------------------------------
+    puts
+    puts "=== Paste into Hatchbox staging (Environment Variables) ==="
+    %w[
+      STRIPE_PRICE_MYSPEAK
+      STRIPE_PRICE_MYSPEAK_YEAR
+      STRIPE_PRICE_BASIC
+      STRIPE_PRICE_BASIC_YEAR
+      STRIPE_PRICE_PRO
+      STRIPE_PRICE_PRO_YEAR
+      STRIPE_PRICE_PARTNER_PRO
+      STRIPE_PRICE_TOPUP_SMALL
+      STRIPE_PRICE_TOPUP_MEDIUM
+      STRIPE_PRICE_TOPUP_LARGE
+    ].each do |key|
+      val = results[key] || "<MISSING — see [error] above>"
+      puts "#{key}=#{val}"
+    end
+    puts
+    puts "Don't forget to also set on Hatchbox staging:"
+    puts "  STRIPE_API_KEY=<this same sk_test_... key>"
+    puts "  STRIPE_WEBHOOK_SECRET=<signing secret for the sandbox endpoint pointing at /api/webhooks>"
+    puts
+    puts "Done."
+  end
+end

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -105,4 +105,78 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
     expect(response).to have_http_status(:bad_request)
     expect(JSON.parse(response.body)["error"]).to match(/Failed/i)
   end
+
+  describe "success_url / cancel_url derivation" do
+    let(:netlify_origin) { "https://deploy-preview-42--speakanyway-app.netlify.app" }
+
+    before { user.update!(stripe_customer_id: "cus_origin") }
+
+    it "uses an allowed Netlify preview Origin for success_url" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small" },
+           headers: auth_headers(user).merge("HTTP_ORIGIN" => netlify_origin)
+
+      expect(captured[:success_url]).to start_with("#{netlify_origin}/account/billing/topup/success")
+      expect(captured[:cancel_url]).to eq("#{netlify_origin}/account/billing")
+    end
+
+    it "falls back to FRONT_END_URL when Origin is not on the allowlist" do
+      ENV["FRONT_END_URL"] = "https://app.speakanyway.com"
+
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small" },
+           headers: auth_headers(user).merge("HTTP_ORIGIN" => "https://evil.example.com")
+
+      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/")
+      expect(captured[:cancel_url]).to eq("https://app.speakanyway.com/account/billing")
+    ensure
+      ENV.delete("FRONT_END_URL")
+    end
+
+    it "falls back to localhost when no Origin and no FRONT_END_URL" do
+      ENV.delete("FRONT_END_URL")
+
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small" },
+           headers: auth_headers(user)
+
+      expect(captured[:success_url]).to start_with("http://localhost:8100/account/billing/topup/success")
+    end
+
+    it "ignores a malformed Origin header" do
+      ENV["FRONT_END_URL"] = "https://app.speakanyway.com"
+
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small" },
+           headers: auth_headers(user).merge("HTTP_ORIGIN" => "not a url at all")
+
+      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/")
+    ensure
+      ENV.delete("FRONT_END_URL")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **`rake stripe:seed_sandbox`** — idempotent seeder for every Product, Price, and the `PARTNERPILOT26` promo code. Refuses live-mode keys without `ALLOW_LIVE=true`. Prints a paste-ready env-var block at the end so populating Hatchbox is copy/paste, not click-around.
- **Request-origin-aware `success_url` / `cancel_url`** in `API::Stripe::CheckoutSessionsController` — uses the incoming request's `Origin`/`Referer` when it points at a trusted host (`*.speakanyway.com`, `*.netlify.app`, `*.hatchboxapp.com`, `localhost`), with `ENV["FRONT_END_URL"]` as a fallback. Netlify preview deploys now work without per-deploy env vars; an allowlist prevents open-redirect abuse.
- **Docs:** `docs/stripe-setup.md` gets a quickstart for the seeder, the allowlist behavior, and a staging Sandbox webhook setup checklist.

## Why

Two pain points hit at once:

1. Brittany had to recreate a Stripe Sandbox workspace from scratch. Manually clicking through 7 plan prices, 3 top-up prices, and a promo code is tedious and error-prone.
2. Top-ups in staging didn't credit users. Payment went through, but the success URL was `http://localhost:8100/...` (because `FRONT_END_URL` is set to localhost for Netlify preview compatibility) and we never confirmed the webhook side because the failure looked like a redirect bug.

Decoupling the redirect URL from a single env var removes the staging vs. production friction permanently.

## Test plan

- [ ] **Local tests not run** — Postgres wasn't running locally during dev and the harness blocked starting it. Need: `brew services start postgresql@16 && bundle exec rspec`. New specs are in `spec/requests/api/stripe/checkout_sessions_topup_spec.rb` (4 new examples under `describe "success_url / cancel_url derivation"`).
- [ ] Run the seeder against the new Sandbox: `STRIPE_API_KEY=sk_test_... bundle exec rake stripe:seed_sandbox`. Confirm `[create]` lines on first run, `[skip]` lines on second run.
- [ ] Paste the printed env-var block into Hatchbox staging. Set `STRIPE_API_KEY` (sandbox key) and `STRIPE_WEBHOOK_SECRET` (sandbox endpoint signing secret).
- [ ] Configure the Stripe Sandbox webhook endpoint per `docs/stripe-setup.md` §5.
- [ ] End-to-end on a Netlify preview deploy: top up with test card `4242 4242 4242 4242`. Verify:
  - Browser lands on the **Netlify preview** `/account/billing/topup/success`, not localhost.
  - `bin/staging-logs web | grep StripeWebhook` shows `credited user=<id> amount=<n>`.
  - `User.find(<id>).topup_credits_balance` reflects the purchase in staging Rails console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)