### PR TITLE
fix(stripe): point top-up success_url at the actual frontend route

### DIFF
--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -147,8 +147,12 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
       mode: "payment",
       customer: current_user.stripe_customer_id,
       line_items: [{ price: price_id, quantity: quantity }],
-      success_url: "#{frontend_base_url}/account/billing/topup/success?session_id={CHECKOUT_SESSION_ID}",
-      cancel_url: "#{frontend_base_url}/account/billing",
+      # Match the frontend's existing /billing/success route, which reads
+      # ?type=topup&credits=N to render the "credits added" screen
+      # (itty-bitty-frontend Welcome.tsx). Stripe interpolates
+      # CHECKOUT_SESSION_ID; the other params are baked in here.
+      success_url: "#{frontend_base_url}/billing/success?session_id={CHECKOUT_SESSION_ID}&type=topup&credits=#{credit_amount * quantity}",
+      cancel_url: "#{frontend_base_url}/billing",
       allow_promotion_codes: true,
       metadata: {
         kind: "topup",

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
            params: { pack_key: "small" },
            headers: auth_headers(user).merge("HTTP_ORIGIN" => netlify_origin)
 
-      expect(captured[:success_url]).to start_with("#{netlify_origin}/account/billing/topup/success")
-      expect(captured[:cancel_url]).to eq("#{netlify_origin}/account/billing")
+      expect(captured[:success_url]).to start_with("#{netlify_origin}/billing/success?session_id={CHECKOUT_SESSION_ID}&type=topup&credits=100")
+      expect(captured[:cancel_url]).to eq("#{netlify_origin}/billing")
     end
 
     it "falls back to FRONT_END_URL when Origin is not on the allowlist" do
@@ -139,8 +139,8 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
            params: { pack_key: "small" },
            headers: auth_headers(user).merge("HTTP_ORIGIN" => "https://evil.example.com")
 
-      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/")
-      expect(captured[:cancel_url]).to eq("https://app.speakanyway.com/account/billing")
+      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/billing/success")
+      expect(captured[:cancel_url]).to eq("https://app.speakanyway.com/billing")
     ensure
       ENV.delete("FRONT_END_URL")
     end
@@ -158,7 +158,7 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
            params: { pack_key: "small" },
            headers: auth_headers(user)
 
-      expect(captured[:success_url]).to start_with("http://localhost:8100/account/billing/topup/success")
+      expect(captured[:success_url]).to start_with("http://localhost:8100/billing/success?session_id={CHECKOUT_SESSION_ID}&type=topup&credits=100")
     end
 
     it "ignores a malformed Origin header" do
@@ -174,9 +174,30 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
            params: { pack_key: "small" },
            headers: auth_headers(user).merge("HTTP_ORIGIN" => "not a url at all")
 
-      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/")
+      expect(captured[:success_url]).to start_with("https://app.speakanyway.com/billing/success")
     ensure
       ENV.delete("FRONT_END_URL")
+    end
+  end
+
+  describe "success_url query string" do
+    before { user.update!(stripe_customer_id: "cus_qs") }
+
+    it "encodes the total credit_amount (pack credits * quantity)" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "medium", quantity: 2 },
+           headers: auth_headers(user)
+
+      # medium pack = 500 credits * 2 = 1000
+      expect(captured[:success_url]).to include("type=topup")
+      expect(captured[:success_url]).to include("credits=1000")
+      expect(captured[:success_url]).to include("session_id={CHECKOUT_SESSION_ID}")
     end
   end
 end


### PR DESCRIPTION
## Summary

Top-up Checkout Sessions were redirecting paying users to `/account/billing/topup/success` — a route that doesn't exist in itty-bitty-frontend. The frontend's actual top-up success handler is `/billing/success` reading `?type=topup&credits=N` from the query string (see [Welcome.tsx:169-183](https://github.com/brittanyjohns/itty-bitty-frontend/blob/main/src/pages/Welcome.tsx#L169)). Users were landing on a blank page after paying, even though the webhook had already granted credits server-side.

- `success_url` now points at `/billing/success?session_id={CHECKOUT_SESSION_ID}&type=topup&credits=<total>` so the frontend can render its "⚡️ N credits added" screen.
- `cancel_url` now points at `/billing` (the existing Upgrade page) instead of the nonexistent `/account/billing`.
- Specs updated; one new spec confirms `credits=` scales with `pack_credits * quantity`.

## Why

Discovered while smoke-testing the fresh Stripe Sandbox setup from #131. The frontend already does the right thing for top-up success — backend just had to send users to the URL the frontend was already listening on.

## Test plan

- [ ] `bundle exec rspec spec/requests/api/stripe/checkout_sessions_topup_spec.rb` — new + updated examples pass.
- [ ] After merge + deploy to staging, run a real top-up on a Netlify preview with test card `4242 4242 4242 4242`. After payment:
  - Browser lands on `<preview-host>/billing/success?...&type=topup&credits=100`.
  - Page shows the "⚡️ 100 credits added" screen.
  - Credit balance in the UI reflects the new total (Welcome.tsx calls `refreshCredits()` on mount).
  - `bin/staging-logs web | grep StripeWebhook` shows the `credited user=...` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)