### PR TITLE
fix(sidekiq): skip PreprocessDocTileVariantJob in staging

### DIFF
--- a/app/sidekiq/preprocess_doc_tile_variant_job.rb
+++ b/app/sidekiq/preprocess_doc_tile_variant_job.rb
@@ -3,6 +3,8 @@ class PreprocessDocTileVariantJob
   sidekiq_options queue: :varients, retry: 2
 
   def perform(doc_id)
+    return if AppEnv.staging?
+
     doc = Doc.includes(image_attachment: :blob).find_by(id: doc_id)
     return unless doc&.image&.attached?
     return unless doc.image.variable?

--- a/spec/sidekiq/preprocess_doc_tile_variant_job_spec.rb
+++ b/spec/sidekiq/preprocess_doc_tile_variant_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe PreprocessDocTileVariantJob, type: :sidekiq do
+  describe "#perform" do
+    it "is a no-op in staging so missing-blob errors don't pile up" do
+      allow(AppEnv).to receive(:staging?).and_return(true)
+      expect(Doc).not_to receive(:includes)
+
+      described_class.new.perform(123)
+    end
+
+    it "no-ops when the doc is missing" do
+      allow(AppEnv).to receive(:staging?).and_return(false)
+
+      expect { described_class.new.perform(-1) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Staging's Sidekiq retry queue keeps filling up with `ActiveStorage::FileNotFoundError` from `PreprocessDocTileVariantJob` because staging's S3 doesn't hold the prod-generated blobs that Doc rows reference. Staging also skips paid OpenAI image calls (per CLAUDE.md), so the variant work is meaningless there anyway.

This short-circuits the job on `AppEnv.staging?` so:
- New enqueues no-op immediately.
- Existing queued retries no-op on their next attempt and clear themselves out of the retry set.

Production behavior is unchanged.

## Test plan

- [ ] `bundle exec rspec spec/sidekiq/preprocess_doc_tile_variant_job_spec.rb` (couldn't run locally — Docker/postgres wasn't up in the worktree).
- [ ] After deploy to staging, watch `https://ypk9e.hatchboxapp.com/sidekiq/retries` — the `PreprocessDocTileVariantJob` retries should drain on their next attempt.
- [ ] Confirm production `PreprocessDocTileVariantJob` still runs (no `AppEnv.staging?` in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)