### PR TITLE
ci: install libvips so image-pipeline specs can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Active Storage variant processing (Doc#tile_url and friends) loads
+      # libvips at runtime via ruby-vips. Without it, any spec that attaches
+      # an image and touches a Doc raises LoadError: cannot open vips.so.42.
+      # Package name differs across Ubuntu versions: 24.04 ships libvips42t64
+      # (time_t transition), 22.04 ships libvips42. Try the newer name first.
+      - name: Install libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvips42t64 || sudo apt-get install -y libvips42
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -272,14 +272,6 @@ RSpec.describe "API::Boards", type: :request do
       Rack::Test::UploadedFile.new(Rails.root.join("public", "logo_bubble.png"), "image/png")
     end
 
-    # Active Storage variant processing depends on libvips, which isn't
-    # installed in CI. We stub Doc#tile_url so the spec exercises controller
-    # logic (current-flipping, ownership gate, board_image.display_image_url
-    # wiring) without needing the image pipeline.
-    before do
-      allow_any_instance_of(Doc).to receive(:tile_url).and_return("https://example.com/tile.png")
-    end
-
     it "creates a new image with the uploaded doc marked current and adds it to the board" do
       expect {
         post "/api/boards/#{board.id}/add_image",


### PR DESCRIPTION
## Summary
- Install `libvips42t64` (Ubuntu 24.04) in the GitHub Actions `rspec` job, with a `libvips42` fallback for 22.04 runners.
- Remove the temporary `Doc#tile_url` stub in `spec/requests/api/boards_spec.rb` that #132 added as a workaround — the real image pipeline can run in CI now.
- Unblocks any future RSpec that attaches an Active Storage file and reaches `Doc#tile_url` / `Image#display_image_url` — without libvips, ruby-vips raises `LoadError: Could not open library 'vips.so.42'`.

## Test plan
- [ ] CI rspec job picks up libvips and the upload spec (`POST /api/boards/:id/add_image (upload)`) passes without the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)