### PR TITLE
chore(bin): add wt-clean script for git worktree cleanup

### DIFF
--- a/bin/wt-clean
+++ b/bin/wt-clean
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Audit and clean up stale git worktrees under .claude/worktrees/.
+#
+# Why: spawned Claude agents create worktrees that don't always self-clean.
+# Stale clean worktrees pile up, and any one parked on `main` will block
+# future `main`-based worktrees with:
+#   fatal: 'main' is already used by worktree at ...
+#
+# Usage:
+#   bin/wt-clean           # audit only (default; never removes anything)
+#   bin/wt-clean --prune   # remove clean worktrees; preserve dirty/unpushed
+#   bin/wt-clean --force   # implies --prune, also rm orphan dirs
+#                          # (on disk under .claude/worktrees/ but not
+#                          # registered with git)
+#
+# Always preserves:
+#   - the primary repo
+#   - the worktree you're currently inside
+#   - any worktree with uncommitted changes or unpushed commits
+set -euo pipefail
+
+MODE="audit"
+case "${1:-}" in
+  ""|--audit) MODE="audit" ;;
+  --prune)    MODE="prune" ;;
+  --force)    MODE="force" ;;
+  -h|--help)  sed -n '2,20p' "$0"; exit 0 ;;
+  *) echo "Unknown flag: $1 (try --help)" >&2; exit 2 ;;
+esac
+
+CURRENT_ROOT="$(git rev-parse --show-toplevel)"
+
+PRIMARY_ROOT=""
+REGISTERED=()
+while IFS= read -r line; do
+  if [[ "$line" == worktree\ * ]]; then
+    p="${line#worktree }"
+    [[ -z "$PRIMARY_ROOT" ]] && PRIMARY_ROOT="$p"
+    REGISTERED+=("$p")
+  fi
+done < <(git worktree list --porcelain)
+
+WT_DIR="$PRIMARY_ROOT/.claude/worktrees"
+
+echo "Primary repo : $PRIMARY_ROOT"
+echo "Current      : $CURRENT_ROOT"
+echo "Worktree dir : $WT_DIR"
+echo "Mode         : $MODE"
+echo
+
+PROTECTED=()
+REMOVABLE=()
+
+for wt in "${REGISTERED[@]}"; do
+  [[ "$wt" == "$PRIMARY_ROOT" ]] && continue
+  if [[ "$wt" == "$CURRENT_ROOT" ]]; then
+    PROTECTED+=("$wt  (current worktree)")
+    continue
+  fi
+  if [[ ! -d "$wt" ]]; then
+    REMOVABLE+=("$wt|missing-on-disk")
+    continue
+  fi
+  dirty=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  unpushed=$(git -C "$wt" log '@{u}..' --oneline 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "$dirty" != "0" || "$unpushed" != "0" ]]; then
+    PROTECTED+=("$wt  (dirty=$dirty, unpushed=$unpushed)")
+  else
+    REMOVABLE+=("$wt|clean")
+  fi
+done
+
+ORPHANS=()
+if [[ -d "$WT_DIR" ]]; then
+  for d in "$WT_DIR"/*/; do
+    [[ -d "$d" ]] || continue
+    d="${d%/}"
+    found=0
+    for wt in "${REGISTERED[@]}"; do
+      [[ "$wt" == "$d" ]] && found=1 && break
+    done
+    [[ "$found" == 0 ]] && ORPHANS+=("$d")
+  done
+fi
+
+print_list() {
+  local label="$1"; shift
+  echo "=== $label ==="
+  if (( $# == 0 )); then
+    echo "  (none)"
+  else
+    for x in "$@"; do echo "  $x"; done
+  fi
+  echo
+}
+
+print_list "Protected (will NOT be touched)" ${PROTECTED[@]+"${PROTECTED[@]}"}
+print_list "Removable worktrees"             ${REMOVABLE[@]+"${REMOVABLE[@]}"}
+print_list "Orphan directories (on disk, not registered)" ${ORPHANS[@]+"${ORPHANS[@]}"}
+
+if [[ "$MODE" == "audit" ]]; then
+  echo "Audit only. Pass --prune to remove worktrees, --force to also rm orphan dirs."
+  exit 0
+fi
+
+if (( ${#REMOVABLE[@]} > 0 )); then
+  echo "--- removing worktrees ---"
+  for entry in "${REMOVABLE[@]}"; do
+    path="${entry%|*}"
+    echo "git worktree remove $path"
+    git worktree remove "$path" 2>&1 \
+      || git worktree remove --force "$path" 2>&1 \
+      || echo "  (failed; skipping)"
+  done
+  echo
+fi
+
+echo "--- git worktree prune ---"
+git worktree prune -v
+echo
+
+if [[ "$MODE" == "force" && ${#ORPHANS[@]} -gt 0 ]]; then
+  echo "--- removing orphan dirs ---"
+  for d in "${ORPHANS[@]}"; do
+    echo "rm -rf $d"
+    rm -rf "$d"
+  done
+  echo
+fi
+
+echo "Done. Remaining worktrees:"
+git worktree list


### PR DESCRIPTION
## Summary

Adds `bin/wt-clean`, a small bash script that audits and (optionally) prunes the git worktrees that pile up under `.claude/worktrees/` from spawned Claude agents.

**Why:** stale agent worktrees accumulate, and any one parked on `main` blocks future `main`-based worktrees with:

```
fatal: 'main' is already used by worktree at ...
```

This script makes the cleanup a one-liner instead of a hand-audit.

## Usage

```
bin/wt-clean           # audit only (default — never removes anything)
bin/wt-clean --prune   # remove clean worktrees, preserve dirty/unpushed
bin/wt-clean --force   # also rm orphan dirs (on disk but not registered with git)
```

## Safeguards

Always preserves:
- the primary repo
- the worktree you're currently inside
- any worktree with uncommitted changes or unpushed commits

Orphan directories (on disk under `.claude/worktrees/` but not registered with git) are only removed under `--force`.

## Test plan

- [x] Ran `bin/wt-clean` from inside this worktree — correctly identified protected/removable/orphan entries without modifying anything
- [x] Audited output matches `git worktree list` + manual `git status` checks per worktree
- [x] Confirmed it preserves the current worktree (this one) and a dirty sibling (`friendly-easley-42fc0e`)
- [ ] Optional follow-up: try `--prune` on a fresh batch of agent worktrees in a future session

## Notes for reviewer

- No tests added — this is a tooling script, not application code. The script is read-only by default; only `--prune`/`--force` mutate, and both are gated by the safeguards above.
- No docs updated. If we want it documented, [CLAUDE.md](CLAUDE.md) under "Common commands" would be the spot — happy to do in a follow-up if you want it called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)