### PR TITLE
feat: communicator stats endpoint + audit-logging opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Disable Audit Logging for communicator accounts
+- Communicator (child) accounts now support a `settings["disable_audit_logging"]` flag, matching the existing flag on user accounts. When set, that communicator's word clicks are not recorded as `WordEvent` records. Toggled from the communicator account form.
+- `API::Audits#word_click` and `#public_word_click` now skip `WordEvent.create` when the acting user or the communicator account has audit logging disabled (new `User#audit_logging_disabled?` / `ChildAccount#audit_logging_disabled?` helpers). Previously the user-level flag was honored only by the frontend; it is now enforced server-side as well.
+
+### Added — Range-aware communicator stats endpoint
+- New `GET /api/word_events/stats?account_id=X&days=N` (`API::Audits#communicator_stats`) returns a single bundled, range-filtered stats payload for a communicator account's Stats tab: `range`, `summary` (total events, unique words, active days, most active day, average per active day, top word), `heat_map`, `most_clicked_words`, `part_of_speech_breakdown`, and the word `events` list (capped at 500). `days` accepts 30/60/90/180/365 and falls back to 180 for any other value. Previously the Stats tab pulled an all-time `heat_map` and a fixed 7-day `most_clicked_words` from `child_accounts#show`, so its day-range selector had no effect on the data.
+- `WordEventsHelper#heat_map` now takes an optional range argument; added `WordEventsHelper#word_events_summary(range)` and `#part_of_speech_breakdown(range)`. Existing no-arg `heat_map` callers are unchanged.
+
 ### Added — Communication Prompt Mode for caregivers
 - New `CoachingPromptSet` model + `API::CoachingPrompts` controller (`GET/POST/PATCH/DELETE /api/coaching_prompts`). A caregiver opens a board in Caregiver Mode and the API returns a coaching prompt set with strategies + tappable example phrases. Curated SpeakAnyWay sets ship for Snack Time, Car Ride, Bedtime Story (matched against `Board#tags` / name tokens). For boards without a curated match, `CoachingPromptGenerator` calls OpenAI (`gpt-4o-mini`) once and caches the result on the board's `metadata` jsonb so the second visit costs nothing. Staging skips the paid call and returns the bundled fallback set, mirroring the existing OpenAI image staging stub.
 - Users can create / edit / delete their own custom coaching sets via the same endpoint — owned sets are scoped by `user_id`. Editing SpeakAnyWay-shipped or another user's sets returns 403.

--- a/app/controllers/api/audits_controller.rb
+++ b/app/controllers/api/audits_controller.rb
@@ -1,6 +1,9 @@
 class API::AuditsController < API::ApplicationController
   skip_before_action :authenticate_token!
-  before_action :authenticate_signed_in!, only: [:word_click, :word_events]
+  before_action :authenticate_signed_in!, only: [:word_click, :word_events, :communicator_stats]
+
+  ALLOWED_STATS_DAYS = [30, 60, 90, 180, 365].freeze
+  DEFAULT_STATS_DAYS = 180
 
   def word_click
     user = current_user || current_account.user
@@ -59,7 +62,9 @@ class API::AuditsController < API::ApplicationController
       data: word_event_data,
     }
 
-    WordEvent.create(payload)
+    unless user.audit_logging_disabled? || current_account&.audit_logging_disabled?
+      WordEvent.create(payload)
+    end
     render json: { message: "Word click recorded" }
   end
 
@@ -75,6 +80,34 @@ class API::AuditsController < API::ApplicationController
     end
     render json: @word_events.order(created_at: :desc).map { |event|
       event.api_view(current_user || current_account.user)
+    }
+  end
+
+  def communicator_stats
+    account = ChildAccount.find_by(id: params[:account_id])
+    unless account
+      render json: { error: "Account not found" }, status: :not_found
+      return
+    end
+
+    days = params[:days].to_i
+    days = DEFAULT_STATS_DAYS unless ALLOWED_STATS_DAYS.include?(days)
+    range = days.days.ago.beginning_of_day..Time.current
+
+    events = account.word_events
+                     .includes(:image, :board, :child_account)
+                     .where(timestamp: range)
+                     .order(timestamp: :desc)
+                     .limit(500)
+    viewer = current_user || current_account&.user
+
+    render json: {
+      range: { days: days, start_date: range.begin.iso8601, end_date: range.end.iso8601 },
+      summary: account.word_events_summary(range),
+      heat_map: account.heat_map(range),
+      most_clicked_words: account.most_clicked_words(range),
+      part_of_speech_breakdown: account.part_of_speech_breakdown(range),
+      events: events.map { |event| event.api_view(viewer) },
     }
   end
 
@@ -160,7 +193,10 @@ class API::AuditsController < API::ApplicationController
       profile_id: profile&.id,
       data: data,
     }
-    word_event = WordEvent.create(payload)
+    word_event = nil
+    unless board&.user&.audit_logging_disabled? || comm_account&.audit_logging_disabled?
+      word_event = WordEvent.create(payload)
+    end
     render json: { message: "Word click recorded", word_event: word_event&.api_view }
   end
 

--- a/app/helpers/word_events_helper.rb
+++ b/app/helpers/word_events_helper.rb
@@ -1,6 +1,11 @@
 module WordEventsHelper
-  def heat_map
-    word_events.group_by_day(:timestamp).count.map do |date, count|
+  def heat_map(range = nil)
+    grouped = if range
+      word_events.group_by_day(:timestamp, range: range)
+    else
+      word_events.group_by_day(:timestamp)
+    end
+    grouped.count.map do |date, count|
       { date: date.strftime("%Y-%m-%d"), count: count }
     end
   end
@@ -34,5 +39,33 @@ module WordEventsHelper
     word_events.group(:word).where(timestamp: range).count.sort_by { |_, v| -v }.first(limit).sort_by { |_, v| -v }.map do |word, count|
       { word: word, count: count }
     end
+  end
+
+  # Aggregate summary metrics for the word events that fall inside `range`.
+  def word_events_summary(range)
+    events = word_events.where(timestamp: range)
+    total = events.count
+    by_day = events.group_by_day(:timestamp).count
+    active_days = by_day.size
+    busiest = by_day.max_by { |_, count| count }
+    top = events.where.not(word: nil).group(:word).count.max_by { |_, count| count }
+    {
+      total_events: total,
+      unique_words: events.where.not(word: nil).distinct.count(:word),
+      active_days: active_days,
+      most_active_day: busiest && { date: busiest.first.strftime("%Y-%m-%d"), count: busiest.last },
+      avg_per_active_day: active_days.zero? ? 0 : (total.to_f / active_days).round(1),
+      top_word: top && { word: top.first, count: top.last },
+    }
+  end
+
+  # Counts word events inside `range` grouped by the linked image's part of speech.
+  def part_of_speech_breakdown(range)
+    word_events.where(timestamp: range)
+               .joins(:image)
+               .group("images.part_of_speech")
+               .count
+               .map { |part_of_speech, count| { label: part_of_speech.presence || "unknown", count: count } }
+               .sort_by { |entry| -entry[:count] }
   end
 end

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -330,6 +330,10 @@ class ChildAccount < ApplicationRecord
     settings["email"]
   end
 
+  def audit_logging_disabled?
+    settings.present? && settings["disable_audit_logging"] == true
+  end
+
   def send_setup_email(sending_user)
     CommunicationAccountMailer.setup_email(self, sending_user).deliver_now
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -480,6 +480,10 @@ class User < ApplicationRecord
     all_required_settings.all? { |setting| settings[setting] }
   end
 
+  def audit_logging_disabled?
+    settings.present? && settings["disable_audit_logging"] == true
+  end
+
   def ensure_settings
     self.settings = {} unless settings
     all_required_settings.each do |setting|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
     resources :board_screenshot_imports
     post "board_screenshot_imports/:id/commit", to: "board_screenshot_imports#commit"
 
+    get "word_events/stats", to: "audits#communicator_stats", as: :word_events_stats
     get "word_events", to: "audits#word_events", as: :word_events
     post "webhooks", to: "webhooks#webhooks"
     resources :subscriptions do

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -40,7 +40,6 @@ namespace :users do
     puts "Communicators: #{user.communicator_accounts.count}"
   end
 
-
   desc "Seed word events for a single existing communicator account. Example: rake users:seed_word_events_for_communicator[99,60]"
   task :seed_word_events_for_communicator, [:account_id, :days_ago] => :environment do |t, args|
     communicator_account = ChildAccount.includes(:user, child_boards: :board).find(args[:account_id])
@@ -64,8 +63,8 @@ namespace :users do
 
       adj_days = rand(adj_min..adj_max)
       timestamp = Time.current - adj_days.days + idx.seconds
-      create_word_events(words, user, board, communicator_account, timestamp: timestamp)
-      puts "  Created #{words.size * 2} events for '#{board.name}' (~#{adj_days} days ago)"
+      count = create_word_events(words, user, board, communicator_account, timestamp: timestamp)
+      puts "  Created #{count} events for '#{board.name}' (~#{adj_days} days ago)"
     end
 
     puts "\n=== Done! ==="
@@ -280,6 +279,17 @@ def create_word_events(words, user, board, communicator_account, timestamp:, ses
   base_day = timestamp.beginning_of_day
   total = 0
 
+  # Map each word to its board tile so seeded events can carry the same rich
+  # data a real click records: the image (which provides part of speech) and
+  # the tile's grid coordinates.
+  screen_size = "lg"
+  tiles_by_label = board.board_images.includes(:image).order(:position).index_by(&:label)
+  columns = board.columns_for_screen_size(screen_size).to_i
+  columns = 6 if columns < 1
+  rows = board.rows_for_screen_size(screen_size).to_i
+  rows = (tiles_by_label.size / columns.to_f).ceil if rows < 1
+  rows = 1 if rows < 1
+
   sessions.times do |s|
     # Each session is on a different day offset from the base timestamp
     day_offset = s * (30 / sessions.to_f).floor
@@ -294,6 +304,7 @@ def create_word_events(words, user, board, communicator_account, timestamp:, ses
     session_words.each_with_index do |word, i|
       # Clicks are a few seconds apart, like a real board session
       click_time = session_start + (i * rand(3..10)).seconds
+      tile = tiles_by_label[word]
       WordEvent.create(
         word: word,
         previous_word: prev_word,
@@ -301,6 +312,9 @@ def create_word_events(words, user, board, communicator_account, timestamp:, ses
         user_id: user.id,
         board_id: board.id,
         child_account_id: communicator_account&.id,
+        image_id: tile&.image_id,
+        board_image_id: tile&.id,
+        data: word_event_seed_data(tile, screen_size, columns, rows),
       )
       prev_word = word
       total += 1
@@ -308,4 +322,31 @@ def create_word_events(words, user, board, communicator_account, timestamp:, ses
   end
 
   total
+end
+
+# Mirrors the `data` jsonb that API::AuditsController#word_click records for a
+# real click, so seeded events render correctly on the Stats tab Board Click
+# Map. Falls back to a position-derived grid cell when a tile has no layout.
+def word_event_seed_data(board_image, screen_size, columns, rows)
+  return nil unless board_image
+
+  layout = board_image.layout.is_a?(Hash) ? board_image.layout[screen_size] : nil
+  cell =
+    if layout.is_a?(Hash) && layout["x"] && layout["y"]
+      { "x" => layout["x"], "y" => layout["y"], "w" => layout["w"] || 1, "h" => layout["h"] || 1 }
+    else
+      index = board_image.position.to_i
+      { "x" => index % columns, "y" => index / columns, "w" => 1, "h" => 1 }
+    end
+
+  {
+    screen_size: screen_size,
+    layout: cell,
+    x_position: cell["x"],
+    y_position: cell["y"],
+    width: cell["w"],
+    height: cell["h"],
+    number_of_columns: columns,
+    number_of_rows: rows,
+  }
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -131,6 +131,12 @@ FactoryBot.define do
     user
   end
 
+  factory(:word_event) do
+    association :user
+    sequence(:word) { |n| "word#{n}" }
+    timestamp { Time.current }
+  end
+
   factory(:coaching_prompt_set) do
     sequence(:name) { |n| "Coaching Set #{n}" }
     sequence(:slug) { |n| "coaching-set-#{n}" }

--- a/spec/models/word_events_helper_spec.rb
+++ b/spec/models/word_events_helper_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+# WordEventsHelper is a model concern mixed into ChildAccount; exercised here
+# through a ChildAccount and its word_events association.
+RSpec.describe WordEventsHelper, type: :model do
+  let(:user) { create(:user) }
+  let(:account) { create(:child_account, user: user) }
+  let(:range) { 90.days.ago.beginning_of_day..Time.current }
+
+  def add_event(attrs = {})
+    create(:word_event, { user: user, child_account: account }.merge(attrs))
+  end
+
+  describe "#heat_map" do
+    it "with no range groups every word event by day" do
+      add_event(timestamp: 1.day.ago)
+      add_event(timestamp: 1.day.ago)
+      add_event(timestamp: 300.days.ago)
+
+      expect(account.heat_map.sum { |entry| entry[:count] }).to eq(3)
+    end
+
+    it "with a range only counts events inside it" do
+      add_event(timestamp: 1.day.ago)
+      add_event(timestamp: 1.day.ago)
+      add_event(timestamp: 300.days.ago)
+
+      expect(account.heat_map(range).sum { |entry| entry[:count] }).to eq(2)
+    end
+  end
+
+  describe "#word_events_summary" do
+    it "computes totals over the range" do
+      add_event(word: "hello", timestamp: 1.day.ago)
+      add_event(word: "hello", timestamp: 1.day.ago)
+      add_event(word: "bye", timestamp: 2.days.ago)
+      add_event(word: "stale", timestamp: 300.days.ago)
+
+      summary = account.word_events_summary(range)
+
+      expect(summary[:total_events]).to eq(3)
+      expect(summary[:unique_words]).to eq(2)
+      expect(summary[:active_days]).to eq(2)
+      expect(summary[:most_active_day][:count]).to eq(2)
+      expect(summary[:avg_per_active_day]).to eq(1.5)
+      expect(summary[:top_word]).to eq(word: "hello", count: 2)
+    end
+
+    it "returns zeroed metrics when there are no events in range" do
+      summary = account.word_events_summary(range)
+
+      expect(summary[:total_events]).to eq(0)
+      expect(summary[:active_days]).to eq(0)
+      expect(summary[:avg_per_active_day]).to eq(0)
+      expect(summary[:most_active_day]).to be_nil
+      expect(summary[:top_word]).to be_nil
+    end
+  end
+
+  describe "#part_of_speech_breakdown" do
+    it "counts events grouped by the linked image's part of speech" do
+      noun = create(:image).tap { |i| i.update_columns(part_of_speech: "noun") }
+      verb = create(:image).tap { |i| i.update_columns(part_of_speech: "verb") }
+      add_event(image: noun, timestamp: 1.day.ago)
+      add_event(image: noun, timestamp: 1.day.ago)
+      add_event(image: verb, timestamp: 1.day.ago)
+      add_event(image: nil, timestamp: 1.day.ago)
+
+      expect(account.part_of_speech_breakdown(range)).to eq([
+        { label: "noun", count: 2 },
+        { label: "verb", count: 1 },
+      ])
+    end
+  end
+end

--- a/spec/requests/api/audits_public_word_click_spec.rb
+++ b/spec/requests/api/audits_public_word_click_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "API::Audits public word click", type: :request do
+  let!(:user) { create(:user) }
+  let!(:account) { create(:child_account, user: user) }
+  let!(:profile) { create(:profile, profileable: account) }
+  let!(:board) { create(:board, user: user) }
+
+  before do
+    allow_any_instance_of(API::AuditsController)
+      .to receive(:get_ip_location).and_return({})
+  end
+
+  def public_params(overrides = {})
+    { word: "hello", profileId: profile.id, boardId: board.id }.merge(overrides)
+  end
+
+  describe "POST /api/public_word_click" do
+    it "creates a WordEvent" do
+      expect {
+        post "/api/public_word_click", params: public_params, as: :json
+      }.to change(WordEvent, :count).by(1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not create a WordEvent when the communicator account has audit logging disabled" do
+      account.update!(settings: { "disable_audit_logging" => true })
+
+      expect {
+        post "/api/public_word_click", params: public_params, as: :json
+      }.not_to change(WordEvent, :count)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not create a WordEvent when the board owner has audit logging disabled" do
+      user.update!(settings: (user.settings || {}).merge("disable_audit_logging" => true))
+
+      expect {
+        post "/api/public_word_click", params: public_params, as: :json
+      }.not_to change(WordEvent, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/audits_word_click_spec.rb
+++ b/spec/requests/api/audits_word_click_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "API::Audits word click", type: :request do
+  let!(:user) { create(:user) }
+  let!(:account) { create(:child_account, user: user) }
+
+  def word_click_params(overrides = {})
+    { word: "hello", layout: {}, screenSize: "lg" }.merge(overrides)
+  end
+
+  describe "POST /api/word_click" do
+    it "requires authentication" do
+      post "/api/word_click", params: word_click_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "creates a WordEvent for an authenticated user" do
+      expect {
+        post "/api/word_click", params: word_click_params, headers: auth_headers(user), as: :json
+      }.to change(WordEvent, :count).by(1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "creates a WordEvent for a communicator account" do
+      expect {
+        post "/api/word_click", params: word_click_params, headers: auth_headers(account), as: :json
+      }.to change(WordEvent, :count).by(1)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not create a WordEvent when the user has audit logging disabled" do
+      user.update!(settings: (user.settings || {}).merge("disable_audit_logging" => true))
+
+      expect {
+        post "/api/word_click", params: word_click_params, headers: auth_headers(user), as: :json
+      }.not_to change(WordEvent, :count)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not create a WordEvent when the communicator account has audit logging disabled" do
+      account.update!(settings: (account.settings || {}).merge("disable_audit_logging" => true))
+
+      expect {
+        post "/api/word_click", params: word_click_params, headers: auth_headers(account), as: :json
+      }.not_to change(WordEvent, :count)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/word_events_stats_spec.rb
+++ b/spec/requests/api/word_events_stats_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "API::Audits communicator_stats", type: :request do
+  let!(:user) { create(:user) }
+  let!(:account) { create(:child_account, user: user) }
+
+  def create_event(attrs = {})
+    create(:word_event, { user: user, child_account: account }.merge(attrs))
+  end
+
+  describe "GET /api/word_events/stats" do
+    it "requires authentication" do
+      get "/api/word_events/stats", params: { account_id: account.id }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 404 when the account does not exist" do
+      get "/api/word_events/stats", params: { account_id: 999_999_999 }, headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns the bundled stats payload for the account" do
+      create_event(word: "hello", timestamp: 1.day.ago)
+      create_event(word: "hello", timestamp: 1.day.ago)
+      create_event(word: "hello", timestamp: 1.day.ago)
+      create_event(word: "bye", timestamp: 1.day.ago)
+
+      get "/api/word_events/stats", params: { account_id: account.id, days: 90 }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body["range"]["days"]).to eq(90)
+      expect(body["summary"]["total_events"]).to eq(4)
+      expect(body["summary"]["unique_words"]).to eq(2)
+      expect(body["summary"]["active_days"]).to eq(1)
+      expect(body["summary"]["most_active_day"]["count"]).to eq(4)
+      expect(body["summary"]["top_word"]).to eq("word" => "hello", "count" => 3)
+      expect(body["events"].size).to eq(4)
+      expect(body["heat_map"]).to be_an(Array)
+      expect(body["most_clicked_words"].first).to eq("word" => "hello", "count" => 3)
+    end
+
+    it "only counts word events belonging to the requested account" do
+      other_account = create(:child_account, user: user)
+      create_event(word: "mine", timestamp: 1.day.ago)
+      create(:word_event, user: user, child_account: other_account, word: "theirs", timestamp: 1.day.ago)
+
+      get "/api/word_events/stats", params: { account_id: account.id, days: 90 }, headers: auth_headers(user)
+
+      body = JSON.parse(response.body)
+      expect(body["summary"]["total_events"]).to eq(1)
+      expect(body["events"].map { |e| e["word"] }).to eq(["mine"])
+    end
+
+    it "excludes events outside the selected day range" do
+      create_event(word: "recent", timestamp: 10.days.ago)
+      create_event(word: "stale", timestamp: 200.days.ago)
+
+      get "/api/word_events/stats", params: { account_id: account.id, days: 90 }, headers: auth_headers(user)
+      body = JSON.parse(response.body)
+      expect(body["summary"]["total_events"]).to eq(1)
+
+      get "/api/word_events/stats", params: { account_id: account.id, days: 365 }, headers: auth_headers(user)
+      body = JSON.parse(response.body)
+      expect(body["summary"]["total_events"]).to eq(2)
+    end
+
+    it "falls back to the default range for an invalid days value" do
+      get "/api/word_events/stats", params: { account_id: account.id, days: 9999 }, headers: auth_headers(user)
+      expect(JSON.parse(response.body)["range"]["days"]).to eq(180)
+    end
+
+    it "breaks down events by the linked image's part of speech" do
+      noun = create(:image).tap { |i| i.update_columns(part_of_speech: "noun") }
+      verb = create(:image).tap { |i| i.update_columns(part_of_speech: "verb") }
+      create_event(word: "dog", image: noun, timestamp: 1.day.ago)
+      create_event(word: "cat", image: noun, timestamp: 1.day.ago)
+      create_event(word: "run", image: verb, timestamp: 1.day.ago)
+
+      get "/api/word_events/stats", params: { account_id: account.id, days: 90 }, headers: auth_headers(user)
+      breakdown = JSON.parse(response.body)["part_of_speech_breakdown"]
+      expect(breakdown).to contain_exactly(
+        { "label" => "noun", "count" => 2 },
+        { "label" => "verb", "count" => 1 },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two changes, bundled because they both modify `app/controllers/api/audits_controller.rb`.

### Communicator stats (Stats tab backend)
- New `GET /api/word_events/stats?account_id=X&days=N` (`API::Audits#communicator_stats`) returns one range-filtered bundle for the View Communicator Account → Stats tab: `range`, `summary` (total events, unique words, active days, most active day, avg per active day, top word), `heat_map`, `most_clicked_words`, `part_of_speech_breakdown`, and the `events` list (capped at 500). `days` accepts 30/60/90/180/365 and falls back to 180.
- `WordEventsHelper#heat_map` now takes an optional range; adds `word_events_summary` and `part_of_speech_breakdown`. Existing no-arg callers unchanged.
- `users.rake` seed tasks (`seed_word_events_for_communicator`, `seed_word_events_for_user`, `create_demo`) now record `image_id`, `board_image_id`, and the `data` jsonb (grid coordinates), so seeded events carry part of speech and tap positions like real clicks.

**Why:** the Stats tab's day-range selector previously had no effect — `heat_map` was all-time and `most_clicked_words` was a fixed 7-day window from `child_accounts#show`. The new endpoint makes the selector actually drive every section.

### Audit-logging opt-out
- `User#audit_logging_disabled?` / `ChildAccount#audit_logging_disabled?` read `settings["disable_audit_logging"]`.
- `word_click` / `public_word_click` skip `WordEvent.create` when the acting user or communicator account has audit logging disabled — enforcing the setting server-side (previously honored only by the frontend).

## Test plan
- [x] `bundle exec rspec` — 520 examples, 0 failures, 17 pending
- [x] New specs: `word_events_stats_spec`, `word_events_helper_spec`, `audits_word_click_spec`, `audits_public_word_click_spec`
- [x] `GET /api/word_events/stats` smoke-tested against a local server (401 unauthenticated; 200 with auth)

## Notes
- Frontend counterpart (Stats tab UI + audit-logging toggle) is in a paired PR on `brittanyjohns/itty-bitty-frontend`; that UI consumes the new endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)