### PR TITLE
feat: add core_boards:seed task for public "Core + X" boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — `core_boards:seed` rake task for public "Core + X" boards
+- New `bin/rails core_boards:seed` task creates public, predefined boards modeled on the "Core + Lunch" board: an 8-column × 5-row, 40-tile grid with 20 fixed core words on the left half (black-bordered) and 20 topic words on the right half (borderless). Tiles are colored by part of speech via the modified Fitzgerald key.
+- Topic words come from a curated list when the topic is known (`Lunch`, `Playground`, `Swimming`); otherwise they are AI-generated via `Board#get_words_for_scenario`. Controlled by env vars: `TOPICS="Playground,Swimming"`, `COUNT=n`, `AGE_RANGE`, and `DRY_RUN=1`.
+- Reuses existing image artwork only — no image generation is queued, so the task incurs no image API cost. Words without artwork render as placeholders. Idempotent: boards that already have tiles are skipped.
+
 ### Added — Disable Audit Logging for communicator accounts
 - Communicator (child) accounts now support a `settings["disable_audit_logging"]` flag, matching the existing flag on user accounts. When set, that communicator's word clicks are not recorded as `WordEvent` records. Toggled from the communicator account form.
 - `API::Audits#word_click` and `#public_word_click` now skip `WordEvent.create` when the acting user or the communicator account has audit logging disabled (new `User#audit_logging_disabled?` / `ChildAccount#audit_logging_disabled?` helpers). Previously the user-level flag was honored only by the frontend; it is now enforced server-side as well.

--- a/lib/tasks/core_boards.rake
+++ b/lib/tasks/core_boards.rake
@@ -1,0 +1,263 @@
+# Creates public "Core + X" boards: a fixed 20-word core vocabulary on the
+# left half of an 8-column grid, paired with 20 topic words on the right.
+# Modeled on the existing "Core + Lunch" board (8 columns x 5 rows, 40 tiles).
+# Core tiles get a black border so they read as the stable vocabulary; topic
+# tiles are borderless.
+module CoreBoardsSeeder
+  # The fixed 20-word core vocabulary. Order is row-major across the 4 core
+  # columns: each line is one grid row. "I" stays capitalized intentionally.
+  CORE_WORDS = %w[
+    I    want help yes
+    you  have give no
+    he   look go   what
+    she  like in   more
+    they it   on   stop
+  ].freeze
+
+  COLUMNS = 8
+  CORE_COLUMNS = 4
+  CORE_VOICE = "polly:kevin".freeze
+  CORE_BORDER_WIDTH = 5
+  CORE_BORDER_COLOR = "#000000".freeze
+
+  # Curated 20-word topic vocabularies (the right half). Any topic not listed
+  # here falls back to AI word generation via Board#get_words_for_scenario.
+  CURATED_TOPICS = {
+    "Lunch" => {
+      tags: ["restaurant", "home", "choice board", "school"],
+      words: ["lunch", "eat", "hot", "cold", "food", "drink", "sauce", "fork",
+              "napkin", "plate", "open", "close", "yummy", "yucky", "pour",
+              "scoop", "poke", "bite", "more please", "all done"],
+    },
+    "Playground" => {
+      tags: ["playground", "outdoors", "recess", "play"],
+      words: ["swing", "slide", "climb", "run", "jump", "ball", "sand", "dig",
+              "push", "catch", "my turn", "your turn", "up", "down", "fast",
+              "friend", "fun", "careful", "fall", "all done"],
+    },
+    "Swimming" => {
+      tags: ["swimming", "water", "pool", "summer"],
+      words: ["swim", "splash", "float", "kick", "jump", "water", "pool",
+              "towel", "goggles", "wet", "cold", "deep", "dive", "hold",
+              "blow bubbles", "my turn", "help", "careful", "fun", "all done"],
+    },
+  }.freeze
+
+  module_function
+
+  # Resolves which topics to build from ENV: an explicit TOPICS list, a COUNT
+  # of curated topics, or all curated topics when neither is given.
+  def resolve_topics
+    if ENV["TOPICS"].present?
+      ENV["TOPICS"].split(",").map { |t| normalize_topic(t) }.reject(&:blank?)
+    elsif ENV["COUNT"].present?
+      count = ENV["COUNT"].to_i.clamp(0, CURATED_TOPICS.size)
+      CURATED_TOPICS.keys.first(count)
+    else
+      CURATED_TOPICS.keys
+    end
+  end
+
+  def normalize_topic(raw)
+    raw.to_s.strip.split(/\s+/).map(&:capitalize).join(" ")
+  end
+
+  # Case-insensitive lookup into CURATED_TOPICS; nil for AI-fallback topics.
+  def curated_topic(topic)
+    _name, data = CURATED_TOPICS.find { |name, _| name.casecmp?(topic) }
+    data
+  end
+
+  def board_tags(topic, curated)
+    base = ["core words", "beginner", "featured"]
+    extra = curated ? curated[:tags] : [topic.downcase]
+    (base + extra).uniq
+  end
+
+  def board_description(topic)
+    "Core vocabulary paired with #{topic.downcase} words — an 8-column starter " \
+      "board with 20 fixed core words on the left and 20 #{topic.downcase} words " \
+      "on the right."
+  end
+
+  # Reuses an existing image with artwork when one exists; otherwise an image
+  # without artwork (the tile renders a placeholder). No image generation is
+  # queued here on purpose.
+  def find_or_build_image(label)
+    matches = Image.public_img.where(label: label).to_a
+    matches.find { |img| img.docs.any? } || matches.first ||
+      Image.public_img.create!(label: label) do |img|
+        img.image_prompt = "Create a simple, clear AAC-style illustration showing " \
+                           "'#{label}' in a literal, easy-to-understand way, with a " \
+                           "transparent background and no stylization. NO TEXT."
+      end
+  end
+
+  # Asks OpenAI for topic words, normalizes them, and drops any that collide
+  # with the core vocabulary.
+  def ai_topic_words(board, topic, age_range)
+    raw = board.get_words_for_scenario(topic, age_range, 24)
+    return [] if raw.blank?
+
+    core_down = CORE_WORDS.map(&:downcase)
+    raw.map { |w| w.to_s.strip.downcase }
+       .reject(&:blank?)
+       .uniq
+       .reject { |w| core_down.include?(w) }
+  end
+
+  def configure_board!(board, admin, topic, curated)
+    board.assign_attributes(
+      description: board_description(topic),
+      predefined: true,
+      published: true,
+      voice: CORE_VOICE,
+      board_type: "default",
+      number_of_columns: COLUMNS,
+      small_screen_columns: COLUMNS,
+      medium_screen_columns: COLUMNS,
+      large_screen_columns: COLUMNS,
+      margin_settings: {
+        "lg" => { "x" => 3, "y" => 3 },
+        "md" => { "x" => 3, "y" => 3 },
+        "sm" => { "x" => 3, "y" => 3 },
+      },
+      tags: board_tags(topic, curated),
+    )
+    board.parent = admin
+    board.layout ||= {}
+    board.generate_unique_slug if board.slug.blank?
+    board.save!
+    board
+  end
+
+  # Adds the 40 tiles in row-major order (4 core, then 4 topic, per row),
+  # recomputes a clean 8-wide grid, and applies the core/topic border style.
+  def add_tiles!(board, topic_words)
+    rows = CORE_WORDS.size / CORE_COLUMNS
+    interleaved = []
+    rows.times do |r|
+      interleaved.concat(CORE_WORDS[r * CORE_COLUMNS, CORE_COLUMNS])
+      interleaved.concat(topic_words[r * CORE_COLUMNS, CORE_COLUMNS])
+    end
+
+    interleaved.each do |word|
+      image = find_or_build_image(word)
+      board.add_image(image.id)
+    end
+
+    board.update_column(:layout, {}) if board.layout.nil?
+    %w[lg md sm].each { |screen| board.calculate_grid_layout_for_screen_size(screen, true) }
+
+    apply_tile_borders!(board)
+
+    board.set_current_word_list
+    board.save!
+  end
+
+  # Core tiles occupy the left CORE_COLUMNS of each row and get a black border;
+  # topic tiles are borderless.
+  def apply_tile_borders!(board)
+    board.board_images.order(:position).each do |bi|
+      if (bi.position % COLUMNS) < CORE_COLUMNS
+        bi.update_columns(border_width: CORE_BORDER_WIDTH, border_color: CORE_BORDER_COLOR)
+      else
+        bi.update_columns(border_width: 0, border_color: nil)
+      end
+    end
+  end
+
+  def attach_coaching_prompt_set!(board)
+    return unless defined?(CoachingPromptSet) && CoachingPromptSet.respond_to?(:match_for)
+
+    cps = CoachingPromptSet.match_for(board)
+    return unless cps
+
+    meta = (board.metadata || {}).merge("coaching_prompt_set_id" => cps.id)
+    board.update_column(:metadata, meta)
+  rescue => e
+    Rails.logger.warn "core_boards: coaching prompt match failed for board #{board.id}: #{e.message}"
+  end
+end
+
+namespace :core_boards do
+  desc "Create public 'Core + X' boards (20 core words + 20 topic words). " \
+       "ENV: TOPICS='Playground,Swimming' | COUNT=3 | AGE_RANGE='5-10' | DRY_RUN=1"
+  task seed: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+    age_range = ENV["AGE_RANGE"].presence || "5-10"
+    dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase)
+    topics = CoreBoardsSeeder.resolve_topics
+
+    puts ""
+    puts "=" * 60
+    puts "Core + X board seeding"
+    puts "=" * 60
+    puts "  Admin user: #{admin.email} (id=#{admin.id})"
+    puts "  Topics (#{topics.size}): #{topics.join(", ")}"
+    puts "  DRY RUN — no database writes, no API calls" if dry_run
+    puts ""
+
+    abort "No topics resolved. Pass TOPICS='A,B' or COUNT=n." if topics.empty?
+
+    created = 0
+    skipped = 0
+    failed = 0
+
+    topics.each do |topic|
+      board_name = "Core + #{topic}"
+      board = Board.find_or_initialize_by(name: board_name, user_id: admin.id, predefined: true)
+
+      if board.persisted? && board.board_images.exists?
+        puts "  skipped: #{board_name} (already has #{board.board_images.count} tiles)"
+        skipped += 1
+        next
+      end
+
+      curated = CoreBoardsSeeder.curated_topic(topic)
+      source = curated ? "curated" : "AI-generated"
+
+      if dry_run
+        puts "  would create: #{board_name} (#{source} topic words)"
+        next
+      end
+
+      CoreBoardsSeeder.configure_board!(board, admin, topic, curated)
+
+      topic_words =
+        if curated
+          curated[:words]
+        else
+          CoreBoardsSeeder.ai_topic_words(board, topic, age_range)
+        end
+
+      need = CoreBoardsSeeder::CORE_WORDS.size
+      if topic_words.blank? || topic_words.size < need
+        got = topic_words&.size.to_i
+        puts "  ERROR: #{board_name} — only #{got} topic word(s) available, need #{need}. " \
+             "Skipped (board left unpublished; pass curated words or re-run)."
+        board.update_columns(published: false)
+        failed += 1
+        next
+      end
+
+      topic_words = topic_words.first(need)
+      CoreBoardsSeeder.add_tiles!(board, topic_words)
+      CoreBoardsSeeder.attach_coaching_prompt_set!(board)
+
+      board.reload
+      puts "  created: #{board_name} (id=#{board.id}, slug=#{board.slug}, " \
+           "#{board.board_images.count} tiles, #{source})"
+      created += 1
+    end
+
+    puts ""
+    unless dry_run
+      puts "Done. created=#{created} skipped=#{skipped} failed=#{failed}"
+      puts "Tiles reuse existing artwork only — no image generation was queued."
+      puts "Words without artwork render as placeholders until artwork is added."
+    end
+    puts ""
+  end
+end

--- a/spec/lib/tasks/core_boards_rake_spec.rb
+++ b/spec/lib/tasks/core_boards_rake_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "core_boards rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["core_boards:seed"] }
+
+  # Run the task, resetting the rake invocation guard so it can be called again.
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  before do
+    # Public/predefined boards are owned by the admin user the task looks up.
+    FactoryBot.create(:user, id: User::DEFAULT_ADMIN_ID)
+    # part-of-speech classification calls OpenAI on Image creation — stub it.
+    allow(AacWordCategorizer).to receive(:categorize).and_return("noun")
+    # Tile creation enqueues TTS audio jobs; keep the queue out of the test.
+    allow(SaveAudioJob).to receive(:perform_async)
+  end
+
+  after do
+    %w[TOPICS COUNT AGE_RANGE DRY_RUN].each { |k| ENV.delete(k) }
+    task.reenable
+  end
+
+  describe "curated topic (Core + Lunch)" do
+    before do
+      ENV["TOPICS"] = "Lunch"
+      run_task
+    end
+
+    let(:board) { Board.find_by(name: "Core + Lunch") }
+
+    it "creates a published, predefined public board owned by the admin" do
+      expect(board).to be_present
+      expect(board.predefined).to be(true)
+      expect(board.published).to be(true)
+      expect(board.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      expect(board.parent).to eq(User.find(User::DEFAULT_ADMIN_ID))
+      expect(board.slug).to eq("core-lunch")
+      expect(board.voice).to eq("polly:kevin")
+      expect(board.tags).to include("core words", "featured")
+    end
+
+    it "builds an 8-wide grid with 40 tiles" do
+      expect(board.number_of_columns).to eq(8)
+      expect(board.large_screen_columns).to eq(8)
+      expect(board.board_images.count).to eq(40)
+    end
+
+    it "places core words on the left half and topic words on the right half" do
+      labels = board.board_images.order(:position).pluck(:label)
+      expect(labels[0, 4]).to eq(%w[I want help yes])
+      expect(labels[4, 4]).to eq(%w[lunch eat hot cold])
+      expect(labels[8]).to eq("you") # next core row starts again at column 0
+    end
+
+    it "gives core tiles a black border and leaves topic tiles borderless" do
+      core_tile = board.board_images.find_by(position: 0)
+      topic_tile = board.board_images.find_by(position: 4)
+
+      expect(core_tile.border_width).to eq(5)
+      expect(core_tile.border_color).to eq("#000000")
+      expect(topic_tile.border_width).to eq(0)
+      expect(topic_tile.border_color).to be_nil
+    end
+
+    it "lays tiles out row-major across 8 columns" do
+      expect(board.board_images.find_by(position: 0).layout["lg"]).to include("x" => 0, "y" => 0)
+      expect(board.board_images.find_by(position: 4).layout["lg"]).to include("x" => 4, "y" => 0)
+      expect(board.board_images.find_by(position: 8).layout["lg"]).to include("x" => 0, "y" => 1)
+      expect(board.board_images.find_by(position: 39).layout["lg"]).to include("x" => 7, "y" => 4)
+    end
+
+    it "records the full word list on the board data" do
+      expect(board.data["current_word_list"]).to include("I", "want", "lunch", "all done")
+    end
+  end
+
+  describe "idempotency" do
+    it "does not duplicate a board or its tiles on a second run" do
+      ENV["TOPICS"] = "Lunch"
+      run_task
+      run_task
+
+      boards = Board.where(name: "Core + Lunch")
+      expect(boards.count).to eq(1)
+      expect(boards.first.board_images.count).to eq(40)
+    end
+  end
+
+  describe "AI fallback for uncurated topics" do
+    let(:ai_words) do
+      %w[bed pajamas brush\ teeth book story lamp pillow blanket sleep dream
+         night quiet hug kiss tired yawn dark cozy snore rest]
+    end
+
+    before do
+      allow_any_instance_of(Board).to receive(:get_words_for_scenario).and_return(ai_words)
+      ENV["TOPICS"] = "Bedtime"
+      run_task
+    end
+
+    it "builds a full board from AI-generated topic words" do
+      board = Board.find_by(name: "Core + Bedtime")
+      expect(board).to be_present
+      expect(board.board_images.count).to eq(40)
+      expect(board.tags).to include("bedtime")
+      expect(board.board_images.order(:position).pluck(:label)[4]).to eq("bed")
+    end
+  end
+
+  describe "insufficient topic words" do
+    before do
+      allow_any_instance_of(Board).to receive(:get_words_for_scenario).and_return(%w[bed book lamp])
+      ENV["TOPICS"] = "Bedtime"
+      run_task
+    end
+
+    it "leaves the board unpublished with no tiles rather than a broken grid" do
+      board = Board.find_by(name: "Core + Bedtime")
+      expect(board).to be_present
+      expect(board.published).to be(false)
+      expect(board.board_images.count).to eq(0)
+    end
+  end
+
+  describe "DRY_RUN" do
+    it "writes nothing to the database" do
+      ENV["TOPICS"] = "Lunch"
+      ENV["DRY_RUN"] = "1"
+      run_task
+
+      expect(Board.where(name: "Core + Lunch")).to be_empty
+    end
+  end
+
+  describe "COUNT" do
+    it "creates the first N curated topic boards" do
+      ENV["COUNT"] = "2"
+      run_task
+
+      expect(Board.where(name: ["Core + Lunch", "Core + Playground"]).count).to eq(2)
+      expect(Board.find_by(name: "Core + Swimming")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `lib/tasks/core_boards.rake` (`core_boards:seed`) — creates public, predefined "Core + X" boards modeled on the existing Core + Lunch board (id 4440): an 8-column × 5-row, 40-tile grid pairing **20 fixed core words** on the left half (black-bordered) with **20 topic words** on the right half (borderless). Tiles are colored by part of speech via the modified Fitzgerald key.
- Topic words are **curated** when the topic is known (`Lunch`, `Playground`, `Swimming`) and **AI-generated** via `Board#get_words_for_scenario` otherwise. Controlled by env vars: `TOPICS="Playground,Swimming"`, `COUNT=n`, `AGE_RANGE`, `DRY_RUN=1`.
- **Reuses existing image artwork only** — no image generation is queued, so the task incurs no image API cost. Words without artwork render as placeholders. `next_words` is left empty. Idempotent: boards that already have tiles are skipped.
- Each board is owned by the admin user (`User::DEFAULT_ADMIN_ID`), `predefined: true`, `published: true`, voice `polly:kevin`, auto-slugged, tagged, and matched to a `CoachingPromptSet` in `metadata`.

## Usage
```
bin/rails core_boards:seed                              # all curated topics
bin/rails core_boards:seed TOPICS="Playground,Swimming" # specific topics
bin/rails core_boards:seed COUNT=2                      # first N curated topics
bin/rails core_boards:seed TOPICS="Bedtime"             # uncurated -> AI-generated topic words
bin/rails core_boards:seed TOPICS="Lunch" DRY_RUN=1     # preview, no writes
```
Add more curated topics by editing the `CURATED_TOPICS` hash at the top of the rake file.

## Note
Each board's `parent` is set to the admin **User** (matching the liked board 4440), whereas `classroom_boards.rake` uses a `PredefinedResource` parent. Both function as public boards.

## Test plan
- [x] `spec/lib/tasks/core_boards_rake_spec.rb` — 11 examples, 0 failures (curated happy path, board attributes, 40 tiles, core/topic border distinction, row-major layout, idempotency, AI fallback, insufficient-words guard, DRY_RUN, COUNT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)