### PR TITLE
fix(billing): demo accounts Pro-only + drop dead check_monthly_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Demo account plan limits & legacy monthly-limit cleanup
+- `MYSPEAK_DEMO_COMMUNICATOR_LIMIT` default changed from 1 to 0 and `PRO_DEMO_COMMUNICATOR_LIMIT` default from 10 to 1, so demo communicator accounts are granted to Pro only (1 account), matching the intended pricing model. `FREE` and `BASIC` were already 0.
+- Removed the dead `API::ApplicationController#check_monthly_limit` helper — a legacy Redis-counter rate limit with no callers. AI features gate on `check_credits!` / `CreditService`. `MonthlyFeatureLimiter` and `User#monthly_limit_for` are intentionally kept: they still back the `can_use_ai?` / `ai_limit_reached?` path, whose cleanup is tracked separately.
+
 ### Added — `core_boards:seed` rake task for public "Core + X" boards
 - New `bin/rails core_boards:seed` task creates public, predefined boards modeled on the "Core + Lunch" board: an 8-column × 5-row, 40-tile grid with 20 fixed core words on the left half (black-bordered) and 20 topic words on the right half (borderless). Tiles are colored by part of speech via the modified Fitzgerald key.
 - Topic words come from a curated list when the topic is known (`Lunch`, `Playground`, `Swimming`); otherwise they are AI-generated via `Board#get_words_for_scenario`. Controlled by env vars: `TOPICS="Playground,Swimming"`, `COUNT=n`, `AGE_RANGE`, and `DRY_RUN=1`.

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -75,29 +75,6 @@ module API
       false
     end
 
-    # Legacy Redis-counter check. AI features now use `check_credits!` —
-    # this remains available for non-AI rate limits (currently none in this
-    # app, but kept so the helper doesn't have to be re-introduced later).
-    def check_monthly_limit(feature_key: nil, feature_name: nil)
-      unless current_user && feature_key
-        Rails.logger.warn "Monthly limit check missing user or feature_key. user_id=#{current_user&.id} feature_key=#{feature_key}"
-        return true
-      end
-      limiter = MonthlyFeatureLimiter.new(
-        user_id: current_user.id,
-        feature_key: feature_key,
-        limit: current_user.monthly_limit_for(feature_key),
-        tz: current_user.timezone || "America/New_York",
-      )
-      allowed, meta = limiter.increment_and_check!
-      error_message = "Monthly limit reached for #{feature_name || feature_key.titleize}. Please upgrade your plan or wait until next month."
-      unless allowed
-        render json: { error: "limit_reached", message: error_message, **meta }, status: 429
-        return false
-      end
-      true
-    end
-
     def preset_colors
       @colors = ColorHelper::PRESET_DATA
       render json: { preset_colors: @colors }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,7 +223,7 @@ class User < ApplicationRecord
     "plan_type" => "myspeak",
     "board_limit" => ENV.fetch("MYSPEAK_BOARD_LIMIT", 3).to_i,
     "paid_communicator_limit" => ENV.fetch("MYSPEAK_PAID_COMMUNICATOR_LIMIT", 0).to_i,
-    "demo_communicator_limit" => ENV.fetch("MYSPEAK_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
+    "demo_communicator_limit" => ENV.fetch("MYSPEAK_DEMO_COMMUNICATOR_LIMIT", 0).to_i,
     "ai_monthly_limit" => ENV.fetch("MYSPEAK_AI_MONTHLY_LIMIT", 20).to_i,
   }.freeze
   BASIC_PLAN_LIMITS = {
@@ -237,7 +237,7 @@ class User < ApplicationRecord
     "plan_type" => "pro",
     "board_limit" => ENV.fetch("PRO_BOARD_LIMIT", 300).to_i,
     "paid_communicator_limit" => ENV.fetch("PRO_PAID_COMMUNICATOR_LIMIT", 3).to_i,
-    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 10).to_i,
+    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
     "ai_monthly_limit" => ENV.fetch("PRO_AI_MONTHLY_LIMIT", 300).to_i,
   }.freeze
 

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User, "plan limit constants", type: :model do
+  describe "demo communicator limits" do
+    # Demo communicator accounts are intended for Pro only (1 account).
+    # Defaults are read from ENV at class load; with the ENV vars unset
+    # (the test environment) these reflect the in-code defaults.
+    it "grants demo communicator accounts to Pro only" do
+      expect(User::FREE_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
+      expect(User::MYSPEAK_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
+      expect(User::BASIC_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
+      expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Demo communicator accounts were granted to the wrong tiers (MySpeak 1, Pro 10). Changed the ENV defaults in the `user.rb` plan-limit constants: `MYSPEAK_DEMO_COMMUNICATOR_LIMIT` 1→0 and `PRO_DEMO_COMMUNICATOR_LIMIT` 10→1 (Free/Basic were already 0). Net model: demo accounts are **Pro-only, 1**.
- Removed the dead `API::ApplicationController#check_monthly_limit` helper — a legacy Redis-counter rate limit with zero callers. AI features gate on `check_credits!` / `CreditService`.

## ⚠️ Config follow-up required
The `user.rb` constants are only **ENV fallbacks**. Effective values come from `config/application.yml` (Figaro, **gitignored**) and host config vars:
- I updated `config/application.yml` locally (`MYSPEAK_DEMO_COMMUNICATOR_LIMIT: "0"`, `PRO_DEMO_COMMUNICATOR_LIMIT: "1"`) — not in this PR, since the file is gitignored.
- **Staging/production config vars must be updated** to the same values, or the demo-limit change will not take effect in those environments.

## Scope note
`MonthlyFeatureLimiter` and `User#monthly_limit_for` were **not** removed: despite the audit note, `monthly_limit_for` still has live callers (`ai_limit_reached?`, `reset_ai_limits!`) that feed `can_use_ai?` / `api_view`. Fully retiring that path is the separate `can_use_ai` cleanup. Only `check_monthly_limit` is genuinely dead.

## Companion PR
Frontend pricing-page changes live in `itty-bitty-frontend` on the same branch name.

## Test plan
- [x] `bundle exec rspec spec/models/user_plan_limits_spec.rb spec/services/monthly_feature_limiter_spec.rb` — 23 examples, 0 failures (incl. new `user_plan_limits_spec.rb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)