### PR TITLE
fix(mail): add delivery diagnostics and restore production delivery_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Mail delivery diagnostics & production transport config
+- Restored the explicit `config.action_mailer.delivery_method = :smtp` in `config/environments/production.rb` — it was dropped when the SMTP block was swapped to `smtp-relay.gmail.com`, leaving production reliant on the framework default. Documented the relay's IP-allowlist failure mode (delivery fails silently if the EC2/Hatchbox outbound IP is not registered in the Google Workspace SMTP relay console).
+- Added `bin/rails 'mail:test[you@example.com]'`: prints the resolved ActionMailer config and attempts a real delivery, surfacing the actual SMTP error (credential failure, unallowlisted IP, connection refused) instead of letting it be swallowed by the `rescue` blocks in `User#send_welcome_email` and friends.
+
 ### Fixed — Demo account plan limits & legacy monthly-limit cleanup
 - `MYSPEAK_DEMO_COMMUNICATOR_LIMIT` default changed from 1 to 0 and `PRO_DEMO_COMMUNICATOR_LIMIT` default from 10 to 1, so demo communicator accounts are granted to Pro only (1 account), matching the intended pricing model. `FREE` and `BASIC` were already 0.
 - Removed the dead `API::ApplicationController#check_monthly_limit` helper — a legacy Redis-counter rate limit with no callers. AI features gate on `check_credits!` / `CreditService`. `MonthlyFeatureLimiter` and `User#monthly_limit_for` are intentionally kept: they still back the `can_use_ai?` / `ai_limit_reached?` path, whose cleanup is tracked separately.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Background jobs:** Sidekiq (v7) + Redis
 - **Payments:** Stripe and RevenueCat (via webhook)
 - **File storage:** S3 (Active Storage)
-- **Email:** Mailgun (via Action Mailer)
+- **Email:** Action Mailer over Gmail SMTP — `smtp-relay.gmail.com` in production (IP-allowlisted, no credentials), `smtp.gmail.com` in development (`SMTP_USERNAME`/`SMTP_PASSWORD` env vars). The `mailgun-ruby` gem is in the Gemfile but is not the active delivery transport. Diagnose delivery with `bin/rails 'mail:test[you@example.com]'`.
 - **TTS/Audio:** AWS Polly
 - **AI:** OpenAI API (`ruby-openai`) — board generation, scenario builder, image generation
 - **Serializers:** jsonapi-serializer gem
@@ -59,6 +59,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - `bin/rails db:seed` — seed the database
 - `bundle exec sidekiq` — start Sidekiq worker
 - `bundle exec rspec` — run tests
+- `bin/rails 'mail:test[you@example.com]'` — diagnose mail delivery: prints the resolved ActionMailer config and sends a test email, surfacing the real SMTP error
 
 ## Reading production logs (CLI)
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,30 +127,18 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # SMTP Settings
-  # Username: your e-mail address
-  # Password: the password set in cPanel during the e-mail account set-up
-  # Incoming server type: IMAP or POP3
-  # Incoming server (IMAP): 993 port for SSL, 143 for TLS.
-  # Incoming server (POP3): 995 port for SSL, 110 for TLS.
-  # Outgoing server (SMTP): 465 port for SSL, 25/587 port for TLS.
-
-  #   config.action_mailer.delivery_method = :smtp
-  #   config.action_mailer.smtp_settings = {
-  #     address: "smtp.oxcs.bluehost.com",
-  #     port: 587,
-  #     user_name: ENV["SMTP_USERNAME"],
-  #     password: ENV["SMTP_PASSWORD"],
-  #     authentication: "plain",
-  #   }
-  # end
-
+  # Mailer transport. smtp-relay.gmail.com is Google Workspace's SMTP relay; it
+  # authenticates by allowlisted sender IP (authentication: nil), so the
+  # EC2/Hatchbox outbound IP must be registered in the Workspace admin console
+  # (Apps > Google Workspace > Gmail > Routing > SMTP relay service). If the
+  # instance IP changes, delivery fails silently until the new IP is allowlisted.
+  # Diagnose with: bin/rails 'mail:test[you@example.com]'
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: "smtp-relay.gmail.com",
     port: 587,
     domain: "speakanyway.com",
     enable_starttls_auto: true,
-    # If you use IP-based authentication only (no username/password):
     authentication: nil,
   }
 end

--- a/lib/tasks/mail.rake
+++ b/lib/tasks/mail.rake
@@ -1,0 +1,53 @@
+namespace :mail do
+  desc "Diagnose mail delivery: print the resolved ActionMailer config and send a test email. " \
+       "Usage: bin/rails 'mail:test[you@example.com]'"
+  task :test, [:to] => :environment do |_task, args|
+    recipient = args[:to].presence || ENV["MAIL_TEST_TO"].presence
+    if recipient.blank?
+      abort "No recipient. Usage: bin/rails 'mail:test[you@example.com]'"
+    end
+
+    am = ActionMailer::Base
+    settings = am.smtp_settings || {}
+
+    puts "=" * 64
+    puts "ActionMailer delivery diagnosis"
+    puts "=" * 64
+    puts "  Rails.env             : #{Rails.env}"
+    puts "  STAGING               : #{ENV['STAGING'].inspect}"
+    puts "  delivery_method       : #{am.delivery_method.inspect}"
+    puts "  perform_deliveries    : #{am.perform_deliveries.inspect}"
+    puts "  raise_delivery_errors : #{am.raise_delivery_errors.inspect}"
+    if am.delivery_method == :smtp
+      puts "  smtp.address          : #{settings[:address].inspect}"
+      puts "  smtp.port             : #{settings[:port].inspect}"
+      puts "  smtp.authentication   : #{settings[:authentication].inspect}"
+      puts "  smtp.user_name        : #{settings[:user_name].present? ? '[set]' : '[blank]'}"
+      puts "  smtp.password         : #{settings[:password].present? ? '[set]' : '[blank]'}"
+    end
+    unless am.perform_deliveries
+      puts "  WARNING: perform_deliveries is false — the app sends no mail in this environment."
+    end
+    puts "-" * 64
+    puts "Sending connectivity test to #{recipient} ..."
+
+    begin
+      message = Mail.new
+      message.from = "SpeakAnyWay <noreply@speakanyway.com>"
+      message.to = recipient
+      message.subject = "SpeakAnyWay mail test (#{Rails.env}) #{Time.current.iso8601}"
+      message.body = "Plain-text connectivity check from #{Rails.env}. " \
+                     "If this arrived, ActionMailer SMTP delivery is working."
+      message.delivery_method(am.delivery_method, settings)
+      message.deliver!
+      puts "OK — handed off to the '#{am.delivery_method}' transport with no error."
+      puts "If the message still doesn't arrive, check the spam folder and the" \
+           " provider's outbound logs/dashboard."
+    rescue => e
+      puts "FAILED — #{e.class}: #{e.message}"
+      puts (e.backtrace || []).first(5).map { |line| "    #{line}" }.join("\n")
+      abort "Mail delivery failed. Fix the error above (commonly SMTP credentials" \
+            " or an unallowlisted sender IP), then re-run."
+    end
+  end
+end

--- a/spec/lib/tasks/mail_rake_spec.rb
+++ b/spec/lib/tasks/mail_rake_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "mail rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["mail:test"] }
+
+  after { task.reenable }
+
+  describe "mail:test" do
+    it "delivers a connectivity test email to the given recipient" do
+      expect { task.invoke("inbox@example.com") }
+        .to change { Mail::TestMailer.deliveries.size }.by(1)
+
+      expect(Mail::TestMailer.deliveries.last.to).to include("inbox@example.com")
+    end
+
+    it "aborts when no recipient is provided" do
+      expect { task.invoke }.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe BaseMailer, type: :mailer do
+  describe "#team_invitation_email" do
+    let(:inviter) { FactoryBot.create(:user, name: "Alex Reed") }
+    let(:invitee) { FactoryBot.create(:user, name: "Sam Carter") }
+    let(:team) { Team.create!(name: "Speech Crew", created_by: inviter) }
+
+    it "renders the subject, sender, and recipient" do
+      mail = described_class.team_invitation_email(invitee, inviter, team).deliver_now
+
+      expect(mail.subject).to eq("You have been invited to join a team on SpeakAnyWay AAC!")
+      expect(mail.to).to eq([invitee.email])
+      expect(mail.from).to eq(["noreply@speakanyway.com"])
+    end
+
+    it "renders the team name, invitee name, and an invitation link in the body" do
+      mail = described_class.team_invitation_email(invitee, inviter, team).deliver_now
+      body = mail.html_part.body.decoded
+
+      expect(body).to include("Speech Crew")
+      expect(body).to include("Sam Carter")
+      expect(body).to include("/accept-invite/#{team.id}/#{invitee.uuid}")
+    end
+
+    it "stamps invitation_sent_at on the invitee" do
+      expect {
+        described_class.team_invitation_email(invitee, inviter, team).deliver_now
+      }.to change { invitee.reload.invitation_sent_at }.from(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Investigating a report that welcome emails and team invites were not sending. The mailer code, templates, i18n keys, and trigger paths are all correct — and the full RSpec suite passes — so this is a **delivery-transport** issue, not a per-mailer bug.

Two things made it hard to diagnose:

1. **Errors are swallowed.** `User#send_welcome_email`, `#send_partner_welcome_email`, `#send_temp_login_email` etc. `rescue => e` and only log. A misconfigured SMTP transport produces no crash and no API error — the email just never arrives.
2. **Production lost its `delivery_method`.** Git history shows `config.action_mailer.delivery_method = :smtp` was dropped when the SMTP block was swapped to `smtp-relay.gmail.com`, leaving production reliant on the framework default.

## Changes

- **`lib/tasks/mail.rake`** — new `bin/rails 'mail:test[you@example.com]'`. Prints the resolved ActionMailer config (delivery method, SMTP address/port/auth, whether credentials are set, `perform_deliveries`) and attempts a real delivery, surfacing the actual SMTP error (`Net::SMTPAuthenticationError`, relay-denied, timeout, etc.) instead of letting it be swallowed.
- **`config/environments/production.rb`** — restored explicit `delivery_method = :smtp`; documented the `smtp-relay.gmail.com` IP-allowlist failure mode (delivery fails silently if the EC2/Hatchbox outbound IP is not registered in the Google Workspace SMTP relay console). No behavior change — `:smtp` was already the framework default.
- **Tests** — `spec/mailers/base_mailer_spec.rb` covering `team_invitation_email` (previously untested), and `spec/lib/tasks/mail_rake_spec.rb` covering `mail:test`.
- **Docs** — fixed the stale "Email: Mailgun" line in `CLAUDE.md` (actual delivery is Gmail SMTP), documented `bin/rails mail:test`, and added a `CHANGELOG.md` entry.

## Reviewer notes

This PR makes the failure **diagnosable** — it does not change the SMTP credentials or the relay IP allowlist, which are environment config outside the repo. To pin the root cause, run `bin/rails 'mail:test[...]'` in each environment; the error class indicates the fix (missing/stale `SMTP_USERNAME`/`SMTP_PASSWORD` App Password in dev, or an unallowlisted server IP in production).

## Test plan

- [x] `bundle exec rspec` — 537 examples, 0 failures, 17 pending (pre-existing placeholder stubs)
- [x] `mail:test` exercised via spec against the `:test` transport
- [ ] Run `bin/rails 'mail:test[you@example.com]'` in dev and on the prod/staging server to capture the real SMTP error

🤖 Generated with [Claude Code](https://claude.com/claude-code)