### PR TITLE
fix(mail): authenticate production SMTP instead of relying on IP allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Authenticated SMTP for production mail delivery
+- Production mail now authenticates over SMTP when `SMTP_USERNAME`/`SMTP_PASSWORD` are set, instead of relying solely on `smtp-relay.gmail.com`'s IP-allowlist auth. The `mail:test` diagnostic showed production failing with `OpenSSL::SSL::SSLError: SSL_read: unexpected eof while reading` — the relay dropping unauthenticated connections from a non-allowlisted server IP, so every welcome email and team invite was silently failing.
+- With credentials present, delivery uses authenticated `smtp.gmail.com` (IP-independent). With no credentials present, behavior is unchanged (the IP relay). `SMTP_ADDRESS` overrides the SMTP host — set it to `smtp-relay.gmail.com` to use the relay endpoint *with* authentication.
+
 ### Fixed — Mail delivery diagnostics & production transport config
 - Restored the explicit `config.action_mailer.delivery_method = :smtp` in `config/environments/production.rb` — it was dropped when the SMTP block was swapped to `smtp-relay.gmail.com`, leaving production reliant on the framework default. Documented the relay's IP-allowlist failure mode (delivery fails silently if the EC2/Hatchbox outbound IP is not registered in the Google Workspace SMTP relay console).
 - Added `bin/rails 'mail:test[you@example.com]'`: prints the resolved ActionMailer config and attempts a real delivery, surfacing the actual SMTP error (credential failure, unallowlisted IP, connection refused) instead of letting it be swallowed by the `rescue` blocks in `User#send_welcome_email` and friends.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Background jobs:** Sidekiq (v7) + Redis
 - **Payments:** Stripe and RevenueCat (via webhook)
 - **File storage:** S3 (Active Storage)
-- **Email:** Action Mailer over Gmail SMTP — `smtp-relay.gmail.com` in production (IP-allowlisted, no credentials), `smtp.gmail.com` in development (`SMTP_USERNAME`/`SMTP_PASSWORD` env vars). The `mailgun-ruby` gem is in the Gemfile but is not the active delivery transport. Diagnose delivery with `bin/rails 'mail:test[you@example.com]'`.
+- **Email:** Action Mailer over Gmail SMTP. Both environments authenticate against `smtp.gmail.com` when `SMTP_USERNAME`/`SMTP_PASSWORD` are set (a Google Workspace account + App Password); production falls back to the `smtp-relay.gmail.com` IP-allowlisted relay when no credentials are present. `SMTP_ADDRESS` overrides the SMTP host. The `mailgun-ruby` gem is in the Gemfile but is not the active delivery transport. Diagnose delivery with `bin/rails 'mail:test[you@example.com]'`.
 - **TTS/Audio:** AWS Polly
 - **AI:** OpenAI API (`ruby-openai`) — board generation, scenario builder, image generation
 - **Serializers:** jsonapi-serializer gem

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,18 +127,30 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # Mailer transport. smtp-relay.gmail.com is Google Workspace's SMTP relay; it
-  # authenticates by allowlisted sender IP (authentication: nil), so the
-  # EC2/Hatchbox outbound IP must be registered in the Workspace admin console
-  # (Apps > Google Workspace > Gmail > Routing > SMTP relay service). If the
-  # instance IP changes, delivery fails silently until the new IP is allowlisted.
+  # Mailer transport. Authenticated SMTP submission is preferred: unlike the
+  # IP-allowlisted relay, it does not depend on the server's outbound IP, which
+  # changes when Hatchbox replaces the instance. Set SMTP_USERNAME / SMTP_PASSWORD
+  # on the server (a Google Workspace account plus an App Password).
+  #
+  # - With credentials present: authenticates against smtp.gmail.com.
+  # - Without credentials: falls back to the smtp-relay.gmail.com IP relay,
+  #   which requires the sender IP to be allowlisted in the Workspace admin
+  #   console (Apps > Google Workspace > Gmail > Routing > SMTP relay service).
+  #
+  # SMTP_ADDRESS overrides the host — e.g. set it to smtp-relay.gmail.com to
+  # use the relay endpoint *with* authentication, which permits sending from
+  # any From address in the domain (no per-address "send mail as" alias).
   # Diagnose with: bin/rails 'mail:test[you@example.com]'
   config.action_mailer.delivery_method = :smtp
+  smtp_username = ENV["SMTP_USERNAME"].presence
+  smtp_password = ENV["SMTP_PASSWORD"].presence
   config.action_mailer.smtp_settings = {
-    address: "smtp-relay.gmail.com",
+    address: ENV["SMTP_ADDRESS"].presence || (smtp_username ? "smtp.gmail.com" : "smtp-relay.gmail.com"),
     port: 587,
     domain: "speakanyway.com",
     enable_starttls_auto: true,
-    authentication: nil,
+    user_name: smtp_username,
+    password: smtp_password,
+    authentication: smtp_username ? :plain : nil,
   }
 end


### PR DESCRIPTION
## Summary

Follow-up to #145. The `bin/rails mail:test` diagnostic, run on the production server, returned the root cause:

```
delivery_method       : :smtp
smtp.address          : "smtp-relay.gmail.com"
smtp.authentication   : nil
smtp.user_name        : [blank]
smtp.password         : [blank]
FAILED — OpenSSL::SSL::SSLError: SSL_read: unexpected eof while reading
```

Production connects to `smtp-relay.gmail.com:587` with `authentication: nil` and **no credentials**. The `SSL_read: unexpected eof` is Google's relay accepting the TLS connection and then dropping the socket — how `smtp-relay.gmail.com` rejects an unauthenticated connection from a server IP that isn't allowlisted in the Workspace SMTP relay console. Result: every welcome email and team invite silently failed.

## What changed

`config/environments/production.rb` now builds `smtp_settings` from `SMTP_USERNAME` / `SMTP_PASSWORD`:

- **Credentials present** → authenticates against `smtp.gmail.com`. Authenticated submission does **not** depend on the server's outbound IP, so it survives Hatchbox instance/IP changes.
- **No credentials** → unchanged: falls back to the `smtp-relay.gmail.com` IP relay. No regression for the current deploy.
- `SMTP_ADDRESS` overrides the host — set it to `smtp-relay.gmail.com` to use the relay endpoint *with* authentication (permits any in-domain `From` without a per-address send-as alias).

## ⚠️ Required to actually fix production

This PR makes production *able* to authenticate; it does not ship credentials. After merge + deploy, set on the production server (Hatchbox env):

- `SMTP_USERNAME` — a Google Workspace account (ideally `noreply@speakanyway.com` so it matches the `From` header)
- `SMTP_PASSWORD` — a Gmail **App Password** for that account (requires 2-Step Verification enabled)

`From` note: the app sends as `noreply@speakanyway.com`. With `smtp.gmail.com`, Gmail aligns the sender to the authenticated account — so either authenticate as `noreply@speakanyway.com`, add it as a verified "Send mail as" alias, or set `SMTP_ADDRESS=smtp-relay.gmail.com` (authenticated relay allows any in-domain `From`).

Verify after deploy: `bin/rails 'mail:test[you@example.com]'` on the server should report `OK`.

## Test plan

- [x] `bundle exec rspec` — 537 examples, 0 failures, 17 pending (pre-existing placeholder stubs)
- [x] `ruby -c config/environments/production.rb` — syntax OK
- [x] Config-only change; `production.rb` is not loaded in the test environment. Behavior verified by the `mail:test` diagnostic, which reports the resolved auth/credentials.
- [ ] Post-deploy: set `SMTP_USERNAME`/`SMTP_PASSWORD`, then confirm `mail:test` reports `OK` on the production server

🤖 Generated with [Claude Code](https://claude.com/claude-code)