### PR TITLE
feat(monitoring): hourly disk-space alert job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ Env overrides: `PROD_HOST`, `PROD_WEB_UNIT`, `PROD_WORKER_UNIT`,
 `PROD_ALL_UNIT` (and `STAGING_*` equivalents). `LINES=N` controls the
 backlog size (default 200).
 
+## Monitoring / alerting
+
+- `DiskSpaceAlertJob` (`app/sidekiq/`) runs hourly via sidekiq-cron and
+  emails an admin (`ADMIN_EMAIL`) when the root disk crosses 80% (warn) or
+  90% (critical). Alerts are debounced in Redis to once per severity per 6h.
+  Skipped on staging, since staging shares the production EC2 box. Added
+  after a disk-full outage wedged the box during a deploy.
+
 ## Subscription model
 
 - Most features are free

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -24,4 +24,15 @@ class AdminMailer < BaseMailer
     @admin = User.find_by(id: User::DEFAULT_ADMIN_ID)
     mail(to: to_email, subject: subject, from: "noreply@speakanyway.com")
   end
+
+  # Server disk-space alert, sent by DiskSpaceAlertJob.
+  def disk_space_alert(usage:, severity:)
+    to_email = ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"
+    @usage = usage
+    @severity = severity
+    @host = Socket.gethostname
+    prefix = severity == :critical ? "CRITICAL" : "WARNING"
+    subject = "[#{prefix}] SpeakAnyWay server disk at #{usage}%"
+    mail(to: to_email, subject: subject, from: "noreply@speakanyway.com")
+  end
 end

--- a/app/sidekiq/disk_space_alert_job.rb
+++ b/app/sidekiq/disk_space_alert_job.rb
@@ -1,0 +1,60 @@
+# Hourly root-disk watchdog.
+#
+# Reads the root filesystem's usage with `df` and emails an admin alert when it
+# crosses a warning or critical threshold. Added after a 2026-05-22 incident
+# where the production disk filled silently and wedged the box during a deploy.
+#
+# Alerts are debounced through Redis so a sustained high-disk condition emails
+# at most once per severity per DEBOUNCE_WINDOW. Staging is skipped — it shares
+# the same EC2 box as production and would otherwise duplicate every alert.
+class DiskSpaceAlertJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 2
+
+  WARN_THRESHOLD = 80
+  CRITICAL_THRESHOLD = 90
+  DEBOUNCE_WINDOW = 6.hours.to_i
+
+  def perform
+    return if AppEnv.staging?
+
+    usage = root_disk_usage_percent
+    return if usage.nil?
+
+    severity = severity_for(usage)
+    return unless severity
+    return unless claim_alert_slot(severity)
+
+    AdminMailer.disk_space_alert(usage: usage, severity: severity).deliver_now
+    Rails.logger.warn("[DiskSpaceAlertJob] root disk at #{usage}% — #{severity} alert emailed")
+  end
+
+  # Integer use-percent of the root filesystem, or nil if `df` can't be read.
+  # `-P` forces POSIX single-line output so field 5 is always the capacity.
+  def root_disk_usage_percent
+    fields = `df -P -k /`.lines.last&.split
+    fields&.fetch(4, nil)&.delete("%")&.to_i
+  rescue StandardError => e
+    Rails.logger.error("[DiskSpaceAlertJob] could not read disk usage: #{e.message}")
+    nil
+  end
+
+  private
+
+  def severity_for(usage)
+    return :critical if usage >= CRITICAL_THRESHOLD
+    return :warn if usage >= WARN_THRESHOLD
+
+    nil
+  end
+
+  # Reserves the right to send one alert for `severity`. Returns false when an
+  # alert for that severity was already sent within DEBOUNCE_WINDOW. Separate
+  # keys per severity so a warn -> critical escalation still alerts immediately.
+  def claim_alert_slot(severity)
+    result = Sidekiq.redis do |conn|
+      conn.call("SET", "disk_space_alert:#{severity}", Time.current.to_i, "NX", "EX", DEBOUNCE_WINDOW)
+    end
+    result == "OK"
+  end
+end

--- a/app/views/admin_mailer/disk_space_alert.html.erb
+++ b/app/views/admin_mailer/disk_space_alert.html.erb
@@ -1,0 +1,18 @@
+<div class="container">
+    <div class="header">
+        <p>Server disk space <%= @severity == :critical ? "CRITICAL" : "warning" %></p>
+    </div>
+    <div class="content">
+        <p>The SpeakAnyWay production server's root disk is at <strong><%= @usage %>%</strong>.</p>
+        <p>Host: <%= @host %></p>
+        <p>Severity: <%= @severity.to_s.upcase %></p>
+        <hr>
+        <p>
+          Free disk space before the next deploy. If the disk fills completely the
+          box can wedge; recovery is to grow the EBS volume and reboot the instance
+          (cloud-init auto-extends the filesystem on boot).
+        </p>
+        <hr>
+        <p>This is an automated alert from DiskSpaceAlertJob.</p>
+    </div>
+</div>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -30,5 +30,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Re-grant monthly AI credits to non-subscription users (free, basic_trial) whose plan_credits_reset_at has passed. Paid Stripe subscribers (MySpeak, Basic, Pro, Partner Pro) refresh via invoice.payment_succeeded and are skipped. Runs daily at 3am UTC, after DowngradeSoftTrialJob.",
     },
+    "disk_space_alert" => {
+      "cron" => "0 * * * *",
+      "class" => "DiskSpaceAlertJob",
+      "queue" => "default",
+      "description" => "Hourly root-disk check; emails an admin at 80% (warn) / 90% (critical). Skipped on staging.",
+    },
   })
 end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe AdminMailer, type: :mailer do
+  describe "#disk_space_alert" do
+    it "addresses the admin and renders a WARNING subject and body" do
+      mail = described_class.disk_space_alert(usage: 85, severity: :warn).deliver_now
+
+      expect(mail.to).to eq([ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"])
+      expect(mail.subject).to eq("[WARNING] SpeakAnyWay server disk at 85%")
+      expect(mail.html_part.body.decoded).to include("85%")
+      expect(mail.html_part.body.decoded).to include("WARN")
+    end
+
+    it "uses a CRITICAL subject for critical severity" do
+      mail = described_class.disk_space_alert(usage: 93, severity: :critical).deliver_now
+
+      expect(mail.subject).to eq("[CRITICAL] SpeakAnyWay server disk at 93%")
+      expect(mail.html_part.body.decoded).to include("CRITICAL")
+    end
+  end
+end

--- a/spec/sidekiq/disk_space_alert_job_spec.rb
+++ b/spec/sidekiq/disk_space_alert_job_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe DiskSpaceAlertJob, type: :sidekiq do
+  let(:job) { described_class.new }
+
+  def perform_with_usage(pct)
+    allow(job).to receive(:root_disk_usage_percent).and_return(pct)
+    job.perform
+  end
+
+  describe "#perform" do
+    context "below the warn threshold" do
+      it "sends no email" do
+        allow(job).to receive(:claim_alert_slot).and_return(true)
+        expect { perform_with_usage(75) }.not_to change { ActionMailer::Base.deliveries.size }
+      end
+    end
+
+    context "at or above the warn threshold" do
+      it "emails a WARNING alert" do
+        allow(job).to receive(:claim_alert_slot).and_return(true)
+        expect { perform_with_usage(85) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        expect(ActionMailer::Base.deliveries.last.subject).to include("WARNING").and(include("85%"))
+      end
+    end
+
+    context "at or above the critical threshold" do
+      it "emails a CRITICAL alert" do
+        allow(job).to receive(:claim_alert_slot).and_return(true)
+        expect { perform_with_usage(95) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        expect(ActionMailer::Base.deliveries.last.subject).to include("CRITICAL")
+      end
+    end
+
+    context "when df cannot be read" do
+      it "no-ops without raising" do
+        allow(job).to receive(:root_disk_usage_percent).and_return(nil)
+        expect { job.perform }.not_to change { ActionMailer::Base.deliveries.size }
+      end
+    end
+
+    context "on staging" do
+      it "sends no email even when the disk is critical" do
+        allow(AppEnv).to receive(:staging?).and_return(true)
+        expect { perform_with_usage(95) }.not_to change { ActionMailer::Base.deliveries.size }
+      end
+    end
+
+    context "when an alert for the severity was already sent" do
+      it "does not send a second email until the debounce window passes" do
+        allow(job).to receive(:root_disk_usage_percent).and_return(85)
+        # claim_alert_slot reserves a Redis slot: true the first time, false
+        # while the debounce window is still open.
+        allow(job).to receive(:claim_alert_slot).and_return(true, false)
+
+        expect { job.perform }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        expect { job.perform }.not_to change { ActionMailer::Base.deliveries.size }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds **`DiskSpaceAlertJob`** — an hourly `sidekiq-cron` job that watches the production server's root disk and emails an admin before it fills up.

**Why:** On 2026-05-22 a Hatchbox deploy filled the EC2 box's 30 GB root disk, wedging the host (SSH dead at banner exchange, the deploy failed, the app degraded to 20s+ responses). Recovery required growing the EBS volume and rebooting. The disk crept up silently — there was **no warning**. This adds that early warning.

## What changed

- **`app/sidekiq/disk_space_alert_job.rb`** — hourly job: reads root-disk usage via `df -P -k /`, alerts at **80% (warn)** / **90% (critical)** (thresholds are named constants). Debounced through Redis to at most once per severity per 6h, with separate keys per severity so a warn → critical escalation still alerts immediately. A `df` read failure logs and no-ops rather than crashing.
- **`AdminMailer#disk_space_alert`** + `app/views/admin_mailer/disk_space_alert.html.erb` — reuses the existing admin mailer and `ENV["ADMIN_EMAIL"]`. Subject e.g. `[CRITICAL] SpeakAnyWay server disk at 92%`.
- **`config/initializers/sidekiq.rb`** — one new entry in the existing `Sidekiq::Cron::Job.load_from_hash` block (`0 * * * *`).
- **`CLAUDE.md`** — new Monitoring/alerting section documenting the job.

## Reviewer notes

- **Staging is skipped** (`AppEnv.staging?`) — staging shares the same EC2 box as production and would otherwise duplicate every alert.
- The debounce spec stubs `claim_alert_slot` for determinism; asserting real Redis state across calls was flaky in the full suite (the Redis-in-test fragility called out in `CLAUDE.md`).
- **Known gap (out of scope):** the job can't fire if the box is already fully wedged. A follow-up option is a free external dead-man's-switch (e.g. Healthchecks.io) — left out here because it needs an external account.

## Test plan

- [x] New specs: `spec/sidekiq/disk_space_alert_job_spec.rb` (thresholds, debounce, staging skip, df-failure) + `spec/mailers/admin_mailer_spec.rb` — 8 examples, all passing
- [x] Full suite: `bundle exec rspec` → **545 examples, 0 failures** (17 pre-existing pending placeholders)
- [ ] After deploy: confirm `disk_space_alert` appears in `Sidekiq::Cron::Job.all` / the Sidekiq-Cron web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)