### PR TITLE
feat: build menu boards from the image with AI vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Menu boards are built from the image with AI vision
+- Creating a "menu" board now sends the uploaded menu photo straight to an AI vision model (`MenuVisionService`, OpenAI Responses API) to extract the food and drink items. Previously the React app ran Tesseract.js OCR in the browser and sent the raw text; OCR on real-world menu photos (glare, angled shots, multi-column layouts) was unreliable, and the backend then stripped digits, punctuation, and line breaks before parsing — erasing the item boundaries the model needed.
+- The menu form no longer runs in-browser OCR; it just uploads the image. The dead OCR text-parsing path (`OpenAiClient#clarify_image_description` / `#describe_menu` / `#strip_image_description`, `ImageHelper#clarify_image_description`, `Menu#describe_menu`) has been removed.
+- New optional env var `MENU_VISION_MODEL` (default `gpt-4.1-mini`) selects the vision model.
+
 ### Changed — MySpeak is now a free feature, the $3 MySpeak tier is retired
 - The MySpeak ID (a demo communicator with a public profile, QR code, and emergency info) is now included on the **Free** plan. `FREE_DEMO_COMMUNICATOR_LIMIT` default is now `1` (was `0`), so every Free user can create one MySpeak demo communicator. That demo communicator is capped at one board (`ChildAccount::FREE_DEMO_BOARD_LIMIT`); Pro demo accounts keep the 3-board default.
 - The `myspeak` / `myspeak_yearly` plan tier has been removed: dropped from `setup_limits`, Stripe checkout (`PLAN_PRICE_IDS`), `normalize_plan_key`, `BillingController` accepted plans, `CreditService::PLAN_MONTHLY_CREDITS`, `RefreshFreeTierCreditsJob`, and the Mailchimp tagging job. `User#myspeak?` is replaced by `User#has_myspeak_feature?` (true when the user has a demo-communicator slot).

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ b. Dynamic Board: A board that _can_ change screens - This is based on the image
 
 11. Subscription: A paid service that provides access to premium features, such as ad-free experience, AI image generation, and other exclusive tools or functionalities.
 
-12. Menu Board Creator: A premium feature enabling users to generate communication boards from a menu image, using AI to extract text and create a board based on the menu items.
+12. Menu Board Creator: A premium feature enabling users to generate communication boards from a menu image. The uploaded photo is read directly by an AI vision model, which extracts the menu items the board is built from.
 
 13. Scenario: A user-generated description of a situation or context, used to generate a list of words or phrases that may be relevant to that scenario. This feature is powered by AI.
 

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -101,9 +101,7 @@ class API::MenusController < API::ApplicationController
     menu_name = menu_params[:name]
     screen_size = params[:screen_size] || "lg"
     @menu.name = menu_name
-    @menu.description = menu_params[:description]
     @menu.predefined = menu_params[:predefined] || false
-    @menu.raw = menu_params[:description]
     @menu.token_limit = menu_params[:token_limit] || 10
     @menu.user = @current_user
     @menu.menu_image.attach(menu_params[:docs][:image]) if menu_params[:docs] && menu_params[:docs][:image]
@@ -113,8 +111,6 @@ class API::MenusController < API::ApplicationController
     end
     doc = @menu.docs.new(menu_params[:docs])
     doc.user = @current_user
-    # doc.processed = true
-    doc.raw = params[:menu][:description]
     if doc.save
       @board = @menu.boards.new(user: current_user, name: @menu.name, token_limit: @menu.token_limit, predefined: @menu.predefined, display_image_url: doc.tile_url, large_screen_columns: 8, medium_screen_columns: 6, small_screen_columns: 4, board_type: "menu", parent: @menu, voice: "polly:kevin", language: "en")
       @board.generate_unique_slug

--- a/app/models/image_helper.rb
+++ b/app/models/image_helper.rb
@@ -210,38 +210,6 @@ module ImageHelper
     label.parameterize
   end
 
-  def clarify_image_description(raw, restaurant_name)
-    return if Rails.env.test?
-    response, messages_sent = OpenAiClient.new(open_ai_opts).clarify_image_description(raw, restaurant_name)
-    begin
-      response_text = nil
-      response_hash = nil
-      if response
-        response_text = response[:content].gsub("```json", "").gsub("```", "").strip
-        if valid_json?(response_text)
-          response_text
-        else
-          puts "INVALID JSON: #{response_text}"
-          response_text = transform_into_json(response_text)
-        end
-      else
-        Rails.logger.error "*** ERROR - clarify_image_description *** \nDid not receive valid response. Response: #{response}\n"
-      end
-
-      response_hash = JSON.parse(response_text) if response_text
-
-      if response_hash["menu_items"].blank?
-        puts "NO DESCRIPTION"
-        return nil
-      end
-      puts "response_hash: #{response_hash["menu_items"]} "
-    rescue => e
-      puts "****clarify_image_description--ERROR: #{e.inspect}"
-    end
-
-    [response_hash, messages_sent]
-  end
-
   def get_next_words(label)
     return if Rails.env.test?
     response = OpenAiClient.new(open_ai_opts).get_next_words(label)

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -267,109 +267,55 @@ class Menu < ApplicationRecord
     EnhanceImageDescriptionJob.perform_async(self.id, board_id, screen_size)
   end
 
+  # Primary extraction path for a menu board: send the uploaded menu image
+  # straight to a vision model, persist the structured result, and build the
+  # board from it. Returns the parsed result hash, or nil on failure (the
+  # caller job maps nil to a board "error" status).
   def enhance_image_description(board_id = nil)
-    @board = Board.find_by(id: board_id) if board_id
-    unless @board
+    board = Board.find_by(id: board_id) if board_id
+    unless board
       Rails.logger.error "enhance_image_description> No board found for this menu."
-      puts "No board found for this menu."
       return nil
     end
-    new_doc = self.docs.last
-    raise "NO NEW DOC FOUND" && return unless new_doc
-    # self.update!(description: new_doc.processed)
+
+    image_url = menu_image_for_vision(board)
+    unless image_url
+      Rails.logger.error "enhance_image_description> No menu image attached for Menu #{id} - #{name}"
+      return nil
+    end
+
     begin
-      if new_doc
-
-        # new_processed = describe_menu(@board.display_image_url)
-        # @board.update(status: "error") unless new_processed
-        # @board.update!(description: new_processed) if new_processed
-        restaurant_name = name || "Restaurant"
-        from_text, messages_sent = clarify_image_description(new_doc.raw, restaurant_name)
-        # Rails.logger.debug "clarify_image_description - from_text: #{from_text}, messages_sent: #{messages_sent}"
-        new_processed = from_text || describe_menu(@board.preview_image.url) if @board.preview_image.attached?
-        # new_processed = describe_menu(@board.preview_image.url) if @board.preview_image.attached?
-        unless new_processed
-          Rails.logger.error "Failed to get enhanced image description from OpenAI for Menu #{id} - #{name}"
-          return nil
-        end
-        Rails.logger.debug "describe_menu result: #{new_processed}"
-        # new_processed = describe_menu(@board.display_image_url)
-
-        if from_text && valid_json?(from_text)
-          @board.update!(description: from_text)
-          self.prompt_used = from_text
-          self.save!
-        else
-          new_from_text = transform_into_json(new_processed)
-          self.prompt_used = new_from_text
-          self.save!
-        end
-
-        # new_new_processed = new_processed["menu_items"].to_json
-        new_new_processed = new_processed.to_json
-
-        new_doc.processed = new_new_processed
-        new_doc.current = true
-        new_doc.user_id = self.user_id
-        new_doc.save!
-        self.raw = new_doc.raw
-        self.description = new_new_processed
-        self.prompt_sent = new_processed
-        self.save!
-
-        create_board_from_menu_image(new_doc, board_id)
-      else
-        Rails.logger.error "NO NEW DOC FOUND"
+      result = MenuVisionService.new.extract_menu_items(image_url: image_url)
+      if result.blank? || result["menu_items"].blank?
+        Rails.logger.error "enhance_image_description> No menu items extracted for Menu #{id} - #{name}"
+        return nil
       end
+
+      json = result.to_json
+      new_doc = docs.last
+      if new_doc
+        new_doc.processed = json
+        new_doc.current = true
+        new_doc.user_id = user_id
+        new_doc.save!
+      end
+
+      update!(description: json, prompt_sent: json, prompt_used: json)
+
+      create_board_from_menu_image(new_doc, board_id)
+      result
     rescue => e
       Rails.logger.error "**** ERROR **** \n#{e.message}\n#{e.backtrace}\n"
-
-      # board = Board.where(id: board_id).first if board_id
-      # board = self.boards.last unless board
-      # board = self.boards.create(user: self.user, name: self.name) unless board
-      # board.update(status: "error") if board
-      # board.update(status: "error - #{e.message}\n#{e.backtrace}\n") if board
       nil
     end
   end
 
-  def describe_menu(url)
-    unless url.present? && url.is_a?(String)
-      Rails.logger.error "Invalid URL: #{url.class} - #{url}"
-      return nil
-    end
-    menu_items = nil
-    begin
-      # image_data = doc.active_storage_to_data_url
-      response = OpenAiClient.new(open_ai_opts).describe_menu(url)
-      menu_items = response[:content] if response
-    rescue => e
-      puts "**** OpenAiClient ERROR **** \n#{e.message}\n"
-      puts e.backtrace
-      Rails.logger.error "**** OpenAiClient ERROR **** \n#{e.message}\n#{e.backtrace}\n"
-    end
-
-    if response
-      begin
-        # Extract the "content" field from the first choice
-        content = response["choices"].first["message"]["content"]
-
-        # Remove Markdown code block formatting (e.g., ```json)
-        json_content = content.gsub(/```json|```/, "").strip
-
-        # Parse the JSON string into a Ruby hash
-        menu_items = JSON.parse(json_content)
-      rescue JSON::ParserError => e
-        puts "Failed to parse JSON: #{e.message}"
-      rescue => e
-        puts "**** ERROR ****"
-        puts e.message
-      end
-    else
-      Rails.logger.error "*** ERROR - get_menu_items *** \nDid not receive valid response. Response: #{response}\n"
-    end
-    Rails.logger.debug "menu_items: #{menu_items}"
-    menu_items
+  # Resolve a publicly reachable URL for the uploaded menu image. The same
+  # file is attached to both menu_image and the board's preview_image; prefer
+  # menu_image_url since it is CDN-aware.
+  def menu_image_for_vision(board)
+    return menu_image_url if menu_image.attached?
+    board.preview_image.url if board&.preview_image&.attached?
   end
 
   def open_ai_opts

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -172,23 +172,6 @@ class OpenAiClient
     end
   end
 
-  def describe_menu(img_url)
-    begin
-      response = openai_client.chat(parameters: {
-                                      model: GPT_VISION_MODEL,
-                                      messages: [{ role: "user",
-                                                  content: [{ type: "text",
-                                                              text: "This is a restaurant menu. Please describe the menu items. Please respond as json in the following format: #{expected_json_schema}" },
-                                                            { type: "image_url", image_url: { url: img_url } }] }],
-                                    })
-      Rails.logger.debug "*** ERROR *** Invaild Menu Description Response: #{response}" unless response
-    rescue => e
-      Rails.logger.debug "**** ERROR **** \n#{e.message}\n#{e.inspect}"
-    end
-    # save_response_locally(response)
-    response
-  end
-
   def create_image_prompt
     new_prompt = specific_image_prompt(@prompt)
     response = openai_client.chat(parameters: { model: GTP_MODEL, messages: [{ role: "user", content: [{ type: "text", text: new_prompt }] }] })
@@ -214,40 +197,6 @@ class OpenAiClient
     response = create_completion
     Rails.logger.debug "*** ERROR *** Invaild Formatted Board Response: #{response}" unless response
     response[:content] if response
-  end
-
-  def clarify_image_description(image_description, restaurant_name)
-    Rails.logger.debug "Missing image description.\n" && return unless image_description
-    @model = GTP_5_MODEL
-    @messages = [{ role: "user", content: [{ type: "text",
-                                           text: "Please parse the following text from a restaurant menu from the
-                                                restaurant '#{restaurant_name}' to
-                                                form a clear list of the food and beverage options ONLY.
-                                                Create a short image description for each item based on the name and description.
-                                                The NAME of the food or beverage is the most important part. Ensure that the name is accurate.
-                                                The description is optional. If no description is provided, then try to create a description based on the name.
-                                                Respond as json. 
-                                                Here is an EXAMPLE RESPONSE: #{expected_json_schema}\n
-                                                This is the text to parse: #{strip_image_description(image_description)}\n\n" }] }]
-    response = create_chat
-    Rails.logger.debug "*** ERROR *** Invaild Image Description Response: #{response}" unless response
-    [response, @messages[0][:content][0][:text]]
-  end
-
-  def format_menu_description(menu_description)
-    @model = GTP_MODEL
-    @messages = [{ role: "user", content: [{ type: "text",
-                                           text: "Please parse the following description from a restaurant menu to
-                                                form a clear list of the food and beverage options ONLY.
-                                                Create a short image description for each item based on the name and description.
-                                                The NAME of the food or beverage is the most important part. Ensure that the name is accurate.
-                                                The description is optional. If no description is provided, then try to create a description based on the name.
-                                                Respond as json.
-                                                Here is an EXAMPLE RESPONSE: #{expected_json_schema}\n
-                                                This is the text to parse: #{strip_image_description(menu_description)}\n" }] }]
-    response = create_chat
-    Rails.logger.debug "*** ERROR *** Invaild Menu Description Response: #{response}" unless response
-    response
   end
 
   # def categorize_word(word)
@@ -631,40 +580,6 @@ class OpenAiClient
     response = create_chat(false)
     Rails.logger.debug "*** ERROR *** Invalid board description Response: #{response}" unless response
     response
-  end
-
-  def strip_image_description(image_description)
-    Rails.logger.debug "Missing image description.\n" && return unless image_description
-    stripped_description = image_description.gsub(/[^a-z ]/i, "")
-    stripped_description
-  end
-
-  def expected_json_schema
-    {
-      "menu_items": [
-        {
-          "name": "Chicken Tenders",
-          "description": "Served with french fries and honey mustard sauce.",
-          "image_description": "Chicken tenders with french fries and honey mustard sauce.",
-        },
-        {
-          "name": "Cheeseburger",
-          "description": "Served with french fries.",
-          "image_description": "Cheeseburger with french fries.",
-        },
-        {
-          "name": "Milk",
-        },
-        {
-          "name": "Apple Juice",
-          "image_description": "Apple juice in a cup.",
-        },
-        {
-          "name": "Ice Cream",
-          "description": "Vanilla ice cream with chocolate sauce.",
-        },
-      ],
-    }
   end
 
   def save_response_locally(response)

--- a/app/services/menu_vision_service.rb
+++ b/app/services/menu_vision_service.rb
@@ -1,0 +1,131 @@
+# app/services/menu_vision_service.rb
+require "openai"
+require "json"
+
+# Extracts structured menu items directly from a photo of a restaurant menu
+# using a vision model via the OpenAI Responses API.
+#
+# This is the primary extraction path for "menu" boards — the image is sent
+# straight to the model, so accuracy no longer depends on in-browser OCR.
+class MenuVisionService
+  MODEL = ENV.fetch("MENU_VISION_MODEL", "gpt-4.1-mini").freeze
+
+  SYSTEM_PROMPT = <<~PROMPT.freeze
+    You are an expert at reading photos of restaurant, cafeteria, and cafe menus.
+    Your job is to transcribe every food and beverage item shown in the image.
+  PROMPT
+
+  USER_PROMPT = <<~PROMPT.freeze
+    This image is a restaurant menu.
+
+    Extract EVERY distinct food and beverage item on the menu.
+
+    For each item:
+    - name: the exact item name as printed. This is the most important field —
+      get it accurate. Use lowercase except for proper nouns.
+    - description: the menu's description of the item, if one is printed.
+      Omit this field if the menu shows no description.
+    - image_description: a short, concrete description of what the dish looks
+      like, suitable for generating a picture. Base it on the name and
+      description.
+
+    Rules:
+    - Only include food and drink items. Ignore prices, headings, section
+      titles, addresses, hours, and other non-item text.
+    - Do not invent items that are not on the menu.
+    - If the image is not a menu or no items are readable, return an empty list.
+
+    Return ONLY JSON with this exact shape:
+
+    {
+      "menu_items": [
+        {
+          "name": "cheeseburger",
+          "description": "Served with french fries.",
+          "image_description": "A cheeseburger with french fries."
+        }
+      ]
+    }
+  PROMPT
+
+  def initialize(openai_client: default_openai_client, logger: default_logger)
+    @client = openai_client
+    @logger = logger
+  end
+
+  # image_url: a publicly reachable https URL (Active Storage / CDN URL).
+  #
+  # Returns a Hash: { "menu_items" => [ { "name", "description", "image_description" } ] }
+  def extract_menu_items(image_url:)
+    raise ArgumentError, "image_url required" if image_url.blank?
+
+    @logger.debug "[MenuVisionService] Parsing menu from #{image_url}"
+
+    response = @client.responses.create(
+      parameters: {
+        model: MODEL,
+        input: [
+          {
+            role: "system",
+            content: [
+              { type: "input_text", text: SYSTEM_PROMPT },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: USER_PROMPT },
+              { type: "input_image", image_url: image_url },
+            ],
+          },
+        ],
+        text: {
+          format: { type: "json_object" },
+        },
+      },
+    )
+
+    raw_json = extract_output_text(response)
+    raise "No output_text from Responses API" if raw_json.blank?
+
+    normalize(JSON.parse(raw_json))
+  rescue => e
+    @logger.error "[MenuVisionService] Error: #{e.class}: #{e.message}"
+    raise
+  end
+
+  private
+
+  # Handle the Responses API payload shape safely.
+  def extract_output_text(response)
+    return response["output_text"] if response["output_text"].present?
+
+    content = response.dig("output", 0, "content") || []
+    text_chunk = content.find { |c| c["type"] == "output_text" } || content.first
+    text_chunk && text_chunk["text"]
+  end
+
+  # Keep only well-formed items and the fields the board pipeline consumes.
+  def normalize(obj)
+    items = Array(obj["menu_items"]).filter_map do |item|
+      next unless item.is_a?(Hash)
+      name = item["name"].to_s.strip
+      next if name.blank?
+
+      result = { "name" => name }
+      result["description"] = item["description"].to_s.strip if item["description"].present?
+      result["image_description"] = item["image_description"].to_s.strip if item["image_description"].present?
+      result
+    end
+
+    { "menu_items" => items }
+  end
+
+  def default_openai_client
+    OpenAI::Client.new(access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"))
+  end
+
+  def default_logger
+    defined?(Rails) ? Rails.logger : Logger.new($stdout)
+  end
+end

--- a/app/services/menu_vision_service.rb
+++ b/app/services/menu_vision_service.rb
@@ -122,7 +122,7 @@ class MenuVisionService
   end
 
   def default_openai_client
-    OpenAI::Client.new(access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"))
+    OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
   end
 
   def default_logger

--- a/spec/controllers/api/menus_controller_spec.rb
+++ b/spec/controllers/api/menus_controller_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe API::MenusController, type: :controller do
     before { CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now) }
 
     it "creates a new menu" do
-      post :create, params: { menu: { name: "New Menu", description: "Test Description" } }, as: :json
+      post :create, params: { menu: { name: "New Menu" } }, as: :json
       expect(response).to have_http_status(:created)
       json_response = JSON.parse(response.body)
       expect(json_response["name"]).to eq("New Menu")
-      expect(json_response["description"]).to eq("Test Description")
+      expect(json_response["boardId"]).to be_present
       expect(json_response["user_id"]).to eq(user.id)
     end
   end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Menu, type: :model do
+  describe "#enhance_image_description" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:menu) { FactoryBot.create(:menu, user: user, name: "Joe's Diner") }
+    let(:board) do
+      FactoryBot.create(:board, user: user, board_type: "menu",
+                                parent_type: "Menu", parent_id: menu.id)
+    end
+    let(:vision_result) do
+      { "menu_items" => [{ "name" => "cheeseburger",
+                           "image_description" => "A cheeseburger." }] }
+    end
+
+    before do
+      menu.docs.create!(user: user)
+      allow_any_instance_of(MenuVisionService)
+        .to receive(:extract_menu_items).and_return(vision_result)
+      allow(menu).to receive(:menu_image_for_vision)
+        .and_return("https://example.com/menu.jpg")
+    end
+
+    it "persists the vision result to the menu and its doc" do
+      allow(menu).to receive(:create_board_from_menu_image)
+
+      menu.enhance_image_description(board.id)
+
+      expect(menu.reload.description).to eq(vision_result.to_json)
+      expect(menu.docs.reload.last.processed).to eq(vision_result.to_json)
+    end
+
+    it "builds the board from the extracted menu items" do
+      expect(menu).to receive(:create_board_from_menu_image)
+        .with(an_instance_of(Doc), board.id)
+
+      menu.enhance_image_description(board.id)
+    end
+
+    it "returns nil and skips board build when no menu image is available" do
+      allow(menu).to receive(:menu_image_for_vision).and_return(nil)
+      expect(menu).not_to receive(:create_board_from_menu_image)
+
+      expect(menu.enhance_image_description(board.id)).to be_nil
+    end
+
+    it "returns nil when no board is found" do
+      expect(menu.enhance_image_description(nil)).to be_nil
+    end
+
+    it "returns nil when the vision service extracts no items" do
+      allow_any_instance_of(MenuVisionService)
+        .to receive(:extract_menu_items).and_return({ "menu_items" => [] })
+      expect(menu).not_to receive(:create_board_from_menu_image)
+
+      expect(menu.enhance_image_description(board.id)).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/menus_spec.rb
+++ b/spec/requests/api/menus_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "API::Menus", type: :request do
+  let(:user) { create(:user) }
+
+  describe "POST /api/menus" do
+    let(:image) do
+      Rack::Test::UploadedFile.new(
+        Rails.root.join("spec/data/path_images/images/happy.png"), "image/png"
+      )
+    end
+
+    it "requires authentication" do
+      post "/api/menus", params: { menu: { name: "Lunch" } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "creates a menu board from a name and image with no extracted text" do
+      expect {
+        post "/api/menus",
+             params: { menu: { name: "Joe's Diner", docs: { image: image } } },
+             headers: auth_headers(user)
+      }.to change(Menu, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body["name"]).to eq("Joe's Diner")
+      expect(body["boardId"]).to be_present
+    end
+
+    it "enqueues the vision extraction job" do
+      expect {
+        post "/api/menus",
+             params: { menu: { name: "Joe's Diner", docs: { image: image } } },
+             headers: auth_headers(user)
+      }.to change(EnhanceImageDescriptionJob.jobs, :size).by(1)
+    end
+  end
+end

--- a/spec/services/menu_vision_service_spec.rb
+++ b/spec/services/menu_vision_service_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe MenuVisionService, type: :service do
+  let(:responses) { double("responses") }
+  let(:client) { double("openai_client", responses: responses) }
+  subject(:service) { described_class.new(openai_client: client) }
+
+  describe "#extract_menu_items" do
+    it "raises ArgumentError when image_url is blank" do
+      expect { service.extract_menu_items(image_url: "") }
+        .to raise_error(ArgumentError)
+    end
+
+    it "parses menu items from the vision response" do
+      json = {
+        menu_items: [
+          { name: "cheeseburger", description: "With fries.",
+            image_description: "A cheeseburger with fries." },
+          { name: "milk" },
+        ],
+      }.to_json
+      allow(responses).to receive(:create).and_return({ "output_text" => json })
+
+      result = service.extract_menu_items(image_url: "https://example.com/menu.jpg")
+
+      expect(result["menu_items"].size).to eq(2)
+      expect(result["menu_items"].first).to eq(
+        "name" => "cheeseburger",
+        "description" => "With fries.",
+        "image_description" => "A cheeseburger with fries.",
+      )
+      expect(result["menu_items"].last).to eq("name" => "milk")
+    end
+
+    it "reads the Responses API output-array payload shape" do
+      json = { menu_items: [{ name: "soup" }] }.to_json
+      payload = {
+        "output" => [
+          { "content" => [{ "type" => "output_text", "text" => json }] },
+        ],
+      }
+      allow(responses).to receive(:create).and_return(payload)
+
+      result = service.extract_menu_items(image_url: "https://example.com/menu.jpg")
+
+      expect(result["menu_items"]).to eq([{ "name" => "soup" }])
+    end
+
+    it "drops items with a blank name" do
+      json = { menu_items: [{ name: "" }, { name: "  " }, { name: "fries" }] }.to_json
+      allow(responses).to receive(:create).and_return({ "output_text" => json })
+
+      result = service.extract_menu_items(image_url: "https://example.com/menu.jpg")
+
+      expect(result["menu_items"]).to eq([{ "name" => "fries" }])
+    end
+
+    it "returns an empty list when the menu has no items" do
+      allow(responses).to receive(:create)
+        .and_return({ "output_text" => { menu_items: [] }.to_json })
+
+      result = service.extract_menu_items(image_url: "https://example.com/menu.jpg")
+
+      expect(result).to eq("menu_items" => [])
+    end
+
+    it "raises when the response has no output text" do
+      allow(responses).to receive(:create).and_return({})
+
+      expect { service.extract_menu_items(image_url: "https://example.com/menu.jpg") }
+        .to raise_error(/No output_text/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Menu boards (`board_type: "menu"`) previously relied on **in-browser Tesseract.js OCR**: the React app extracted text from the uploaded menu photo and sent that text for the backend to parse. OCR on real-world menu photos — glare, angled shots, multi-column layouts, decorative fonts — was unreliable, and `OpenAiClient#strip_image_description` then stripped every digit, punctuation mark, and line break before parsing, collapsing the menu into one blob and erasing the item boundaries the model needed.

This switches menu extraction to **vision-first**:

- New `MenuVisionService` (`app/services/menu_vision_service.rb`) sends the uploaded menu image straight to a vision model via the OpenAI Responses API (JSON mode), mirroring the existing `BoardScreenshotVisionService` pattern. Model is overridable via the optional `MENU_VISION_MODEL` env var (default `gpt-4.1-mini`).
- `Menu#enhance_image_description` rewritten to use it as the single extraction path; adds a `menu_image_for_vision` helper.
- Deletes the now-dead OCR text-parsing chain: `OpenAiClient#clarify_image_description` / `#describe_menu` / `#format_menu_description` / `#strip_image_description` / `#expected_json_schema`, `ImageHelper#clarify_image_description`, `Menu#describe_menu`.
- `menus_controller#create` no longer reads the unused `description` param.

The companion frontend change (drop in-browser OCR from the menu form) is a separate PR in `itty-bitty-frontend`.

## Test plan

- [x] `bundle exec rspec` — 564 examples, 0 failures (17 pre-existing pending placeholders)
- [x] New specs: `menu_vision_service_spec`, `menu_spec` (`#enhance_image_description`), `requests/api/menus_spec`
- [x] Updated `menus_controller_spec` (it asserted the old `description` echo)
- [ ] Manual: upload a clear menu photo and a harder angled/glare one, confirm generated board items match — best done on staging, which runs the vision call for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)