### PR TITLE
fix: stop enqueuing SaveAudioJob twice per board image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Duplicate `SaveAudioJob` enqueued per board image
+- `Board#add_image` enqueued `SaveAudioJob` twice for every image added to a board: once explicitly, and once via `BoardImage`'s `after_create :create_voice_audio_after_create` callback. Both jobs did the identical Polly audio lookup/creation and board-image update — wasted work and a mild race creating the same audio file concurrently. `add_image` now leaves audio generation entirely to the callback.
+
 ### Changed — MySpeak is now a free feature, the $3 MySpeak tier is retired
 - The MySpeak ID (a demo communicator with a public profile, QR code, and emergency info) is now included on the **Free** plan. `FREE_DEMO_COMMUNICATOR_LIMIT` default is now `1` (was `0`), so every Free user can create one MySpeak demo communicator. That demo communicator is capped at one board (`ChildAccount::FREE_DEMO_BOARD_LIMIT`); Pro demo accounts keep the 3-board default.
 - The `myspeak` / `myspeak_yearly` plan tier has been removed: dropped from `setup_limits`, Stripe checkout (`PLAN_PRICE_IDS`), `normalize_plan_key`, `BillingController` accepted plans, `CreditService::PLAN_MONTHLY_CREDITS`, `RefreshFreeTierCreditsJob`, and the Mailchimp tagging job. `User#myspeak?` is replaced by `User#has_myspeak_feature?` (true when the user has a demo-communicator slot).

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -914,6 +914,7 @@ class Board < ApplicationRecord
 
     language_settings = @image.language_settings || {}
     language_settings[self.language] = { "display_label" => @image.label, "label" => @image.label }
+    self.voice = VoiceService.normalize_voice(self.voice)
     new_board_image = board_images.new(image_id: image_id.to_i, voice: self.voice, position: board_images_count, language: self.language)
     new_board_image.set_labels
     new_board_image.part_of_speech = @image.part_of_speech || "default"
@@ -937,18 +938,10 @@ class Board < ApplicationRecord
       Rails.logger.error "Image not found: #{image_id}"
       return
     end
-    self.voice = VoiceService.normalize_voice(self.voice)
 
-    if @image.existing_voices.include?(self.voice)
-      new_board_image.voice = self.voice
-    else
-      # @image.find_or_create_audio_file_for_voice(self.voice)
-      unless generated?
-        board_image_id = new_board_image.id
-        SaveAudioJob.perform_async([image_id], self.voice, board_image_id)
-      end
-    end
-
+    # Audio generation is enqueued by BoardImage's after_create callback
+    # (create_voice_audio_after_create). Don't enqueue SaveAudioJob a second
+    # time here.
     new_board_image.src = @image.display_image_url(self.user)
 
     unless new_board_image.save

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -257,4 +257,26 @@ RSpec.describe Board, type: :model do
       expect(view[:data]).to eq("current_word_list" => ["apple", "banana"])
     end
   end
+
+  describe "#add_image" do
+    let(:user)  { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user, voice: "polly:kevin") }
+    let(:image) { FactoryBot.create(:image, user: user) }
+
+    # SaveAudioJob used to be enqueued twice per image: once explicitly here
+    # and once by BoardImage's after_create callback. add_image now leaves
+    # audio entirely to the callback.
+    it "enqueues SaveAudioJob exactly once for the new board image" do
+      expect { board.add_image(image.id) }
+        .to change(SaveAudioJob.jobs, :size).by(1)
+    end
+
+    it "enqueues the audio job for the created board image and voice" do
+      board_image = board.add_image(image.id)
+
+      args = SaveAudioJob.jobs.last["args"]
+      expect(args[1]).to eq("polly:kevin")
+      expect(args[2]).to eq(board_image.id)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`SaveAudioJob` was running twice for every image added to a board — visible in Sidekiq as two jobs for the same image/board-image, one with a scalar first arg and one with an array (`259, "polly:kevin", 802` and `[259], "polly:kevin", 802`).

Root cause: `Board#add_image` enqueued `SaveAudioJob` from two places in a single call:

1. **`BoardImage` `after_create` callback** — `add_image` saves the new board image, which fires `after_create :create_voice_audio_after_create`; that method enqueues `SaveAudioJob.perform_async(image_id, voice, id)` (scalar).
2. **An explicit enqueue in `add_image` itself** — `SaveAudioJob.perform_async([image_id], voice, board_image_id)` (array).

Both jobs do the identical work — `find_or_create_audio_file_for_voice` (a Polly call + S3 upload) and updating the board image's `audio_url`. Redundant, and a mild race creating the same audio file concurrently.

This fires once per item during menu/board generation, so a board with N items enqueued 2N audio jobs.

## Fix

`add_image` now leaves audio generation entirely to the `after_create` callback — the centralized path that already fires for every `BoardImage` creation (and was never `generated?`-gated, so generated boards are unaffected). The board voice is normalized *before* the board image is built, so the surviving job carries the same normalized voice the explicit enqueue used.

## Test plan

- [x] `bundle exec rspec` — 561 examples, 0 failures
- [x] New `Board#add_image` specs: `SaveAudioJob` is enqueued exactly once, with the created board image's id and voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)