### PR TITLE
feat(admin): expose ai_credits in admin user views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — `ai_credits` in admin user views
+- `User#admin_api_view` and `User#admin_index_view` now include an `ai_credits` object (`CreditService.balance`: `plan`, `topup`, `total`, `reset_at`), so the admin user pages can display each user's AI credit balance.
+
 ### Changed — Menu boards are built from the image with AI vision
 - Creating a "menu" board now sends the uploaded menu photo straight to an AI vision model (`MenuVisionService`, OpenAI Responses API) to extract the food and drink items. Previously the React app ran Tesseract.js OCR in the browser and sent the raw text; OCR on real-world menu photos (glare, angled shots, multi-column layouts) was unreliable, and the backend then stripped digits, punctuation, and line breaks before parsing — erasing the item boundaries the model needed.
 - The menu form no longer runs in-browser OCR; it just uploads the image. The dead OCR text-parsing path (`OpenAiClient#clarify_image_description` / `#describe_menu` / `#strip_image_description`, `ImageHelper#clarify_image_description`, `Menu#describe_menu`) has been removed.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1039,6 +1039,7 @@ class User < ApplicationRecord
   def admin_index_view
     view = as_json
     view["board_count"] = boards.count
+    view["ai_credits"] = CreditService.balance(self)
     view["stripe_customer_id"] = stripe_customer_id
     view["trial_days_left"] = trial_days_left
     view["last_sign_in_at"] = time_ago_in_words(last_sign_in_at) if last_sign_in_at
@@ -1082,6 +1083,7 @@ class User < ApplicationRecord
     view["current_sign_in_ip"] = current_sign_in_ip
     view["sign_in_count"] = sign_in_count
     view["tokens"] = tokens
+    view["ai_credits"] = CreditService.balance(self)
     view["phrase_board_id"] = settings["phrase_board_id"]
     view["opening_board_id"] = settings["opening_board_id"]
     view["has_dynamic_default"] = opening_board.present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -272,4 +272,27 @@ RSpec.describe User, type: :model do
       expect(user.i18n_locale).to eq(:en)
     end
   end
+
+  context "admin views expose ai_credits" do
+    it "includes the credit balance in admin_api_view" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      credits = user.admin_api_view["ai_credits"]
+      expect(credits[:total]).to eq(1500)
+      expect(credits[:plan]).to eq(1500)
+      expect(credits[:topup]).to eq(0)
+    end
+
+    it "includes the credit balance in admin_index_view" do
+      user = FactoryBot.create(:user, plan_type: "pro")
+      expect(user.admin_index_view["ai_credits"][:total]).to eq(1500)
+    end
+
+    it "reflects topup credits in the total" do
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      CreditService.grant_topup!(user, amount: 25)
+      credits = user.reload.admin_api_view["ai_credits"]
+      expect(credits[:topup]).to eq(25)
+      expect(credits[:total]).to eq(credits[:plan] + 25)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds an `ai_credits` object to `User#admin_api_view` and `User#admin_index_view` — `{ plan, topup, total, reset_at }` from `CreditService.balance`.
- Lets the admin user pages display each user's AI credit balance. No schema change — the balance columns already exist on `users`.

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb` — 3 new specs for `ai_credits` in both admin views (incl. top-up balance) pass; full file green.

## Companion PR
- Frontend consumer: brittanyjohns/itty-bitty-frontend#150

🤖 Generated with [Claude Code](https://claude.com/claude-code)