### PR TITLE
fix: save menu board display image at full size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Menu board display image saved at full size
+- A menu board's `display_image_url` was set to the 288×288 tile variant (`Doc#tile_url`) of the uploaded menu photo, so the menu looked blurry whenever it was shown at any meaningful size. It now stores the full-resolution image (`Doc#display_url`) — a menu has fine print and must stay legible on a full screen. Applies to both menu board creation and re-run.
+
 ### Added — `ai_credits` in admin user views
 - `User#admin_api_view` and `User#admin_index_view` now include an `ai_credits` object (`CreditService.balance`: `plan`, `topup`, `total`, `reset_at`), so the admin user pages can display each user's AI credit balance.
 

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -56,7 +56,7 @@ class API::MenusController < API::ApplicationController
     @menu = Menu.find(params[:id])
     screen_size = params[:screen_size] || "lg"
     @board = @menu.boards.last
-    @board = @menu.boards.new(user: current_user, name: @menu.name, token_limit: @menu.token_limit, predefined: false, display_image_url: @menu.docs.last.tile_url, large_screen_columns: 8, medium_screen_columns: 6, small_screen_columns: 4, board_type: "menu", parent: @menu) if @board.nil?
+    @board = @menu.boards.new(user: current_user, name: @menu.name, token_limit: @menu.token_limit, predefined: false, display_image_url: @menu.docs.last.display_url, large_screen_columns: 8, medium_screen_columns: 6, small_screen_columns: 4, board_type: "menu", parent: @menu) if @board.nil?
     @board.generate_unique_slug
     @board.status = "pending"
     unless @board.save
@@ -112,7 +112,7 @@ class API::MenusController < API::ApplicationController
     doc = @menu.docs.new(menu_params[:docs])
     doc.user = @current_user
     if doc.save
-      @board = @menu.boards.new(user: current_user, name: @menu.name, token_limit: @menu.token_limit, predefined: @menu.predefined, display_image_url: doc.tile_url, large_screen_columns: 8, medium_screen_columns: 6, small_screen_columns: 4, board_type: "menu", parent: @menu, voice: "polly:kevin", language: "en")
+      @board = @menu.boards.new(user: current_user, name: @menu.name, token_limit: @menu.token_limit, predefined: @menu.predefined, display_image_url: doc.display_url, large_screen_columns: 8, medium_screen_columns: 6, small_screen_columns: 4, board_type: "menu", parent: @menu, voice: "polly:kevin", language: "en")
       @board.generate_unique_slug
       @board.status = "pending"
       @board.preview_image.attach(menu_params[:docs][:image]) if menu_params[:docs] && menu_params[:docs][:image]

--- a/spec/requests/api/menus_spec.rb
+++ b/spec/requests/api/menus_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe "API::Menus", type: :request do
       expect(body["boardId"]).to be_present
     end
 
+    it "saves the menu board's display image full size, not the small tile variant" do
+      post "/api/menus",
+           params: { menu: { name: "Joe's Diner", docs: { image: image } } },
+           headers: auth_headers(user)
+
+      board = Menu.last.boards.last
+      doc = Menu.last.docs.last
+      expect(board.display_image_url).to be_present
+      expect(board.display_image_url).not_to eq(doc.tile_url)
+    end
+
     it "enqueues the vision extraction job" do
       expect {
         post "/api/menus",


### PR DESCRIPTION
## Summary

A menu-type board's `display_image_url` was being saved as `Doc#tile_url` — the **288×288** tile variant (`ApplicationRecord::TILE_VARIANT_TRANSFORMATIONS`) of the uploaded menu photo. That variant is sized for small board-image tiles, not for showing a whole menu. A menu has fine print, so it rendered blurry/unreadable whenever the board's display image was shown at any meaningful size.

`API::MenusController` now stores `Doc#display_url` — the full-resolution uploaded image — for the menu board's `display_image_url`, in both the `create` and `rerun` paths. The full image is already in Active Storage; only which URL gets saved on the board changes.

The 288px tile variant is unchanged and still used for board-image tiles elsewhere — this only affects the menu board's own display image.

## Notes

- `Board#api_view` already exposes `display_image_url` and `preview_image_url`; no API-shape change.
- `generate_preview` does not overwrite a menu board's `display_image_url` (its overwrite condition only fires when the value is blank or equals the pre-generation preview URL), so the full-size menu photo persists after generation.

## Test plan

- [x] `bundle exec rspec` — 579 examples, 0 failures
- [x] New request spec: a created menu board's `display_image_url` is present and is not the tile-variant URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)