### PR TITLE
feat(boards): read-only over-limit boards on downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Downgraded users keep their boards (read-only, never deleted)
+- When a paid user (Basic/Pro) cancels and lands back on Free, their existing boards are no longer all fully editable. Boards beyond the Free limit (1) become **read-only**: they still open, cells still tap, audio still plays — so a non-speaking user's communication never breaks — but content-editing (renaming, layout changes, image swaps, audio uploads) is blocked behind an upgrade prompt. Previously, a Pro user with dozens of boards who cancelled kept full edit access to every one of them forever; only *creating* a new board was blocked.
+- Users pick which single board keeps full edit access via `PATCH /api/boards/:id/make_editable`. On downgrade the backend pins a sensible default (favorite or most-recent) so they're never fully locked out before they choose.
+- Locked content-editing endpoints return HTTP 403 with `error: "board_locked"`. Reads, audio playback, and board deletion are never gated.
+
 ### Changed — Menu boards are built from the image with AI vision
 - Creating a "menu" board now sends the uploaded menu photo straight to an AI vision model (`MenuVisionService`, OpenAI Responses API) to extract the food and drink items. Previously the React app ran Tesseract.js OCR in the browser and sent the raw text; OCR on real-world menu photos (glare, angled shots, multi-column layouts) was unreliable, and the backend then stripped digits, punctuation, and line breaks before parsing — erasing the item boundaries the model needed.
 - The menu form no longer runs in-browser OCR; it just uploads the image. The dead OCR text-parsing path (`OpenAiClient#clarify_image_description` / `#describe_menu` / `#strip_image_description`, `ImageHelper#clarify_image_description`, `Menu#describe_menu`) has been removed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,11 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   `users.editable_board_id`. If none is set, `effective_editable_board_id`
   falls back to a favorite or most-recently-updated board so a freshly-
   downgraded user is never fully locked out.
-- On downgrade, `apply_free_plan` pins this fallback into
-  `editable_board_id` so the frontend has a deterministic answer.
+- On downgrade, both paths call `User#pin_default_editable_board!` so the
+  frontend has a deterministic answer: `apply_free_plan` (Stripe
+  cancel/pause) and `DowngradeSoftTrialJob` (soft-trial expiry). Trial users
+  (`basic_trial` and Stripe `trialing`) are treated as paid by
+  `User#paid_plan?` while the trial is active, so the gate doesn't trigger.
 - The gate runs as a `check_board_editable!` `before_action` on the
   content-mutating actions in `API::BoardsController` and the matching set
   in `API::BoardImagesController`. Reads (`show`, `index`, `pdf`, audio

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,16 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   `users.editable_board_id`. If none is set, `effective_editable_board_id`
   falls back to a favorite or most-recently-updated board so a freshly-
   downgraded user is never fully locked out.
+- **Switch cooldown:** `make_editable` enforces a cooldown
+  (`User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS`, default 14, ENV-tunable via
+  `EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS`) between explicit picks. Without it,
+  a free user could rotate the slot to edit every board one at a time and
+  defeat the gate. Admins bypass. The initial auto-pin from
+  `pin_default_editable_board!` does **not** start the clock — the user's
+  first real `make_editable` call does. Returns HTTP 403
+  `editable_board_cooldown` with `available_at` and `cooldown_days` when
+  blocked. A no-op re-pick of the already-designated board doesn't start
+  the clock either.
 - On downgrade, both paths call `User#pin_default_editable_board!` so the
   frontend has a deterministic answer: `apply_free_plan` (Stripe
   cancel/pause) and `DowngradeSoftTrialJob` (soft-trial expiry). Trial users

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,39 @@ backlog size (default 200).
 - Premium features (Menu Board Creator, AI image generation) require active subscription
 - Subscription managed via Stripe/RevenueCat — check status before allowing access to premium endpoints
 
+### Board access on downgrade (read-only rule)
+
+When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
+`free` and `settings["board_limit"]` to 1. Boards beyond that limit become
+**read-only**, never deleted: still openable, tappable, and audio still plays
+(SpeakAnyWay is an AAC app — usage must never break), but
+**content-mutating endpoints return HTTP 403 `board_locked`**.
+
+- Locked state is **computed**, not stored. A board is locked for its owner
+  when the user is not admin, not on a paid plan, is over their board limit,
+  and the board is not their designated editable board. See
+  `User#board_editable?` (`app/models/user.rb`) and `Board#can_edit_for`
+  (`app/models/board.rb`). The board's `api_view` exposes `can_edit`,
+  `locked`, and `lock_reason` for the frontend.
+- The user picks which single board keeps full edit access via
+  `PATCH /api/boards/:id/make_editable`. The selection is persisted on
+  `users.editable_board_id`. If none is set, `effective_editable_board_id`
+  falls back to a favorite or most-recently-updated board so a freshly-
+  downgraded user is never fully locked out.
+- On downgrade, `apply_free_plan` pins this fallback into
+  `editable_board_id` so the frontend has a deterministic answer.
+- The gate runs as a `check_board_editable!` `before_action` on the
+  content-mutating actions in `API::BoardsController` and the matching set
+  in `API::BoardImagesController`. Reads (`show`, `index`, `pdf`, audio
+  playback) and `destroy` (let the user free up the slot) are never gated.
+  `create`/`clone`/`create_from_template` stay on the existing
+  `check_board_create_permissions`.
+- Returns **HTTP 403** with `{ error: "board_locked", message, board_limit,
+  editable_board_id }`. **Not 402** — 402 is reserved for credit exhaustion.
+- **Assumes `FREE_BOARD_LIMIT == 1`.** The single `editable_board_id` only
+  frees one board. If the ENV is ever raised above 1, revisit this to a
+  per-board flag or join table.
+
 ## AI gating: credit ledger (source of truth)
 
 - AI features are gated by **weighted credits** held in two balances on `users`:

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -1,6 +1,7 @@
 class API::BoardImagesController < API::ApplicationController
   respond_to :json
   before_action :set_board_image, only: %i[ show update destroy create_image_variation create_image_edit set_current_audio ]
+  before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation upload_audio reset_audio move destroy ]
 
   # GET /board_images or /board_images.json
   def index
@@ -320,6 +321,32 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   private
+
+  # Block edits to a board image when its board is read-only for this user
+  # (a downgraded user over their board limit). Playing audio and viewing are
+  # never gated — only content mutations. HTTP 403, not 402 (credits).
+  def check_board_image_editable!
+    board = board_for_editable_check
+    return if board.nil?
+    return if current_user&.board_editable?(board)
+
+    render json: {
+      error: "board_locked",
+      message: "This board is read-only on your current plan. Upgrade, or make it your editable board, to make changes.",
+      board_limit: current_user.board_limit,
+      editable_board_id: current_user.effective_editable_board_id,
+    }, status: :forbidden
+  end
+
+  def board_for_editable_check
+    if params[:board_id].present?
+      Board.find_by(id: params[:board_id])
+    elsif @board_image
+      @board_image.board
+    elsif params[:id].present?
+      BoardImage.find_by(id: params[:id])&.board
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_board_image

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -915,7 +915,9 @@ class API::BoardsController < API::ApplicationController
 
   # Designate this board as the user's editable board. On a downgraded (free)
   # plan, all other owned boards become read-only; this lets the user choose
-  # which one keeps full edit access.
+  # which one keeps full edit access. Subject to a cooldown
+  # (User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS) so a user can't rotate the
+  # slot to edit every board one at a time.
   def make_editable
     return if @board.nil?
 
@@ -924,7 +926,29 @@ class API::BoardsController < API::ApplicationController
       return
     end
 
-    current_user.update!(editable_board_id: @board.id)
+    # No-op when the user re-picks the board that's already designated. Skip
+    # the cooldown check so a confirm/double-tap doesn't accidentally start
+    # the clock either.
+    if current_user.editable_board_id == @board.id
+      fresh_user = User.find(current_user.id)
+      render json: { user: fresh_user.api_view, board: @board.api_view(fresh_user) }
+      return
+    end
+
+    if !current_user.admin? && current_user.editable_board_switch_cooldown_active?
+      render json: {
+        error: "editable_board_cooldown",
+        message: "You can switch your editable board again on #{current_user.editable_board_switch_available_at.to_date.iso8601}.",
+        available_at: current_user.editable_board_switch_available_at,
+        cooldown_days: User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS,
+      }, status: :forbidden
+      return
+    end
+
+    current_user.update!(
+      editable_board_id: @board.id,
+      editable_board_id_set_at: Time.current,
+    )
     fresh_user = User.find(current_user.id)
     render json: { user: fresh_user.api_view, board: @board.api_view(fresh_user) }
   end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1,9 +1,10 @@
 class API::BoardsController < API::ApplicationController
   skip_before_action :authenticate_token!, only: %i[ index predictive_image_board show public_boards public_menu_boards common_boards pdf ]
 
-  before_action :set_board, only: %i[ associate_image remove_image destroy associate_images print pdf assign_accounts show ]
+  before_action :set_board, only: %i[ associate_image remove_image destroy associate_images print pdf assign_accounts show make_editable ]
   before_action :check_board_view_edit_permissions, only: %i[update destroy]
   before_action :check_board_create_permissions, only: %i[ create clone ]
+  before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
 
   def index
     limit_param = params[:limit].presence&.to_i
@@ -912,6 +913,22 @@ class API::BoardsController < API::ApplicationController
     render json: { status: "ok", message: "Preview image generation job started" }
   end
 
+  # Designate this board as the user's editable board. On a downgraded (free)
+  # plan, all other owned boards become read-only; this lets the user choose
+  # which one keeps full edit access.
+  def make_editable
+    return if @board.nil?
+
+    unless @board.user_id == current_user.id
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    current_user.update!(editable_board_id: @board.id)
+    fresh_user = User.find(current_user.id)
+    render json: { user: fresh_user.api_view, board: @board.api_view(fresh_user) }
+  end
+
   def pdf
     render_data = Boards::RenderAssetData.new(
       board: @board,
@@ -1100,6 +1117,23 @@ class API::BoardsController < API::ApplicationController
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
+  end
+
+  # Boards over a downgraded user's plan limit are read-only: still fully
+  # usable (view/tap/audio) but not editable. Blocks content-mutating actions
+  # on a locked board with HTTP 403 (402 is reserved for credit exhaustion).
+  def check_board_editable!
+    set_board if @board.nil?
+    return if @board.nil? # set_board already rendered 404
+
+    return if current_user&.board_editable?(@board)
+
+    render json: {
+      error: "board_locked",
+      message: "This board is read-only on your current plan. Upgrade, or make it your editable board, to make changes.",
+      board_limit: current_user.board_limit,
+      editable_board_id: current_user.effective_editable_board_id,
+    }, status: :forbidden
   end
 
   def boards_for_user

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -424,6 +424,13 @@ class API::WebhooksController < API::ApplicationController
     user.setup_free_limits
     user.stripe_subscription_id = nil
     user.save!
+    # On downgrade, pin a default editable board so the user keeps one working
+    # edit slot immediately. Their other boards become read-only (still fully
+    # usable) until they upgrade or pick a different one.
+    if user.editable_board_id.blank?
+      default_editable_id = user.effective_editable_board_id
+      user.update_column(:editable_board_id, default_editable_id) if default_editable_id
+    end
     # Grant the free tier's allowance immediately so canceled/paused users
     # land on free with a working balance, not 0. grant_plan! expires any
     # leftover plan credits internally (writes an `expire` ledger row).

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -427,10 +427,7 @@ class API::WebhooksController < API::ApplicationController
     # On downgrade, pin a default editable board so the user keeps one working
     # edit slot immediately. Their other boards become read-only (still fully
     # usable) until they upgrade or pick a different one.
-    if user.editable_board_id.blank?
-      default_editable_id = user.effective_editable_board_id
-      user.update_column(:editable_board_id, default_editable_id) if default_editable_id
-    end
+    user.pin_default_editable_board!
     # Grant the free tier's allowance immediately so canceled/paused users
     # land on free with a working balance, not 0. grant_plan! expires any
     # leftover plan credits internally (writes an `expire` ledger row).

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1720,6 +1720,9 @@ class Board < ApplicationRecord
       #  For future implementation - can add more granular permissions for communicators
       can_edit = current_account.settings["can_edit_boards"] == true
     end
+    # Plan gating: a free user over their board limit can edit only their one
+    # designated board (User#board_editable?). Non-User viewers untouched.
+    can_edit &&= viewing_user.board_editable?(self) if can_edit && viewing_user.is_a?(User)
     {
       id: id,
       board_type: board_type,
@@ -2033,7 +2036,7 @@ class Board < ApplicationRecord
       slug: slug,
       name: name,
       word_list: current_word_list,
-      can_edit: viewing_user && (user_id == viewing_user.id || viewing_user.admin?),
+      can_edit: can_edit_for(viewing_user),
       is_template: is_template,
       display_image_url: display_image_url,
       preview_image_url: preview_image_url,
@@ -2049,8 +2052,21 @@ class Board < ApplicationRecord
     end
   end
 
+  # Whether viewing_user may edit this board's content. Owner/admin gate plus
+  # the plan-based read-only rule (User#board_editable?). Non-User viewers
+  # (e.g. ChildAccount) are not plan-gated here.
+  def can_edit_for(viewing_user)
+    return false unless viewing_user
+    return false unless user_id == viewing_user.id || viewing_user.try(:admin?)
+    return true unless viewing_user.is_a?(User)
+
+    viewing_user.board_editable?(self)
+  end
+
   def api_view(viewing_user = nil)
-    can_edit = viewing_user && (user_id == viewing_user.id || viewing_user.admin?)
+    can_edit = can_edit_for(viewing_user)
+    owned_by_viewer = viewing_user && user_id == viewing_user.id
+    locked = !!(owned_by_viewer && !can_edit && !viewing_user.try(:admin?))
 
     @in_a_public_group = false
     @display_image_url = display_image_url
@@ -2076,6 +2092,8 @@ class Board < ApplicationRecord
       in_use_by: in_use_by,
       communicator_account_data: in_use ? @original_child_boards&.map { |cb| { acct_id: cb.child_account.id, board_id: cb.board_id, original_board_id: cb.original_board_id, acct_name: cb.child_account.name, board_name: cb.board.name, acct_avatar_url: cb.child_account.profile&.avatar_url } } : nil,
       can_edit: can_edit,
+      locked: locked,
+      lock_reason: locked ? "free_plan_board_limit" : nil,
       layout: layout,
       audio_url: audio_url,
       group_layout: group_layout,
@@ -2129,7 +2147,7 @@ class Board < ApplicationRecord
       bg_color: bg_color,
       text_color: text_color,
       # image_count: board_images_count,
-      can_edit: user_id == viewing_user&.id || viewing_user&.admin?,
+      can_edit: can_edit_for(viewing_user),
       display_image_url: display_image_url,
       preview_image_url: preview_image_url,
       word_sample: word_sample,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1226,11 +1226,33 @@ class User < ApplicationRecord
   # is blank, and only if effective_editable_board_id resolves to a board.
   # Called from both downgrade paths: apply_free_plan (Stripe cancel/pause)
   # and DowngradeSoftTrialJob (soft-trial expiry).
+  #
+  # Deliberately does NOT set editable_board_id_set_at — the initial default
+  # is the system's pick, not the user's. The user's first explicit
+  # make_editable call starts the cooldown clock.
   def pin_default_editable_board!
     return unless editable_board_id.blank?
     default_id = effective_editable_board_id
     return if default_id.blank?
     update_column(:editable_board_id, default_id)
+  end
+
+  # How long a user must wait between editable-board switches. Closes the
+  # loophole where a free user could rotate the editable slot to edit every
+  # board one at a time. Configurable for support / experimentation.
+  EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS =
+    ENV.fetch("EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS", 14).to_i
+
+  # When the next make_editable call is permitted. Nil if no prior explicit
+  # pick (so the user can pick immediately) or if the cooldown has passed.
+  def editable_board_switch_available_at
+    return nil if editable_board_id_set_at.blank?
+    available = editable_board_id_set_at + EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS.days
+    available > Time.current ? available : nil
+  end
+
+  def editable_board_switch_cooldown_active?
+    editable_board_switch_available_at.present?
   end
 
   # Whether this user may edit the given board's content. Free users over
@@ -1296,6 +1318,8 @@ class User < ApplicationRecord
       board_limit_reached: board_count >= board_limit,
       can_create_boards: can_create_boards,
       editable_board_id: effective_editable_board_id,
+      editable_board_switch_available_at: editable_board_switch_available_at,
+      editable_board_switch_cooldown_days: EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS,
 
       # AI
       can_use_ai: can_use_ai?,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1221,6 +1221,18 @@ class User < ApplicationRecord
       end
   end
 
+  # Pin a default editable board after a downgrade so the user has a working
+  # edit slot immediately. Idempotent — only writes when editable_board_id
+  # is blank, and only if effective_editable_board_id resolves to a board.
+  # Called from both downgrade paths: apply_free_plan (Stripe cancel/pause)
+  # and DowngradeSoftTrialJob (soft-trial expiry).
+  def pin_default_editable_board!
+    return unless editable_board_id.blank?
+    default_id = effective_editable_board_id
+    return if default_id.blank?
+    update_column(:editable_board_id, default_id)
+  end
+
   # Whether this user may edit the given board's content. Free users over
   # their board limit can edit only their one designated board; everything
   # else they own becomes read-only (still fully usable — view/tap/audio).

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ApplicationRecord
 
   # Associations
   belongs_to :organization, optional: true
+  belongs_to :editable_board, class_name: "Board", optional: true
   has_many :boards, -> { where(is_template: false) }, class_name: "Board", dependent: :destroy
   has_many :template_boards, -> { where(is_template: true) }, class_name: "Board", dependent: :destroy
   has_many :total_boards, class_name: "Board", dependent: :destroy
@@ -1194,6 +1195,44 @@ class User < ApplicationRecord
     board_count < board_limit
   end
 
+  # Count of the user's own (non-predefined) boards. Memoized because board
+  # list serialization calls board_editable? once per board.
+  def owned_board_count
+    @owned_board_count ||= boards.where(predefined: false).count
+  end
+
+  # The single board a limited-plan user keeps full edit access to. Returns
+  # the board they designated; if that's missing, falls back to a favorite or
+  # most-recently-updated owned board so a freshly-downgraded user is never
+  # locked out of everything before they pick one.
+  def effective_editable_board_id
+    return @effective_editable_board_id if defined?(@effective_editable_board_id)
+
+    @effective_editable_board_id =
+      if editable_board_id && boards.exists?(id: editable_board_id)
+        editable_board_id
+      else
+        boards.where(predefined: false)
+              .order(favorite: :desc, updated_at: :desc)
+              .limit(1)
+              .pick(:id)
+      end
+  end
+
+  # Whether this user may edit the given board's content. Free users over
+  # their board limit can edit only their one designated board; everything
+  # else they own becomes read-only (still fully usable — view/tap/audio).
+  # Assumes FREE_BOARD_LIMIT == 1; if that ENV is raised this under-grants
+  # and the single editable_board_id needs to become a per-board flag.
+  def board_editable?(board)
+    return true if admin?
+    return true if board.nil? || board.user_id != id
+    return true if paid_plan?
+    return true if owned_board_count <= board_limit
+
+    board.id == effective_editable_board_id
+  end
+
   def public_page_url
     profile&.public_url
   end
@@ -1242,6 +1281,7 @@ class User < ApplicationRecord
       board_count: board_count,
       board_limit_reached: board_count >= board_limit,
       can_create_boards: can_create_boards,
+      editable_board_id: effective_editable_board_id,
 
       # AI
       can_use_ai: can_use_ai?,

--- a/app/policies/board_policy.rb
+++ b/app/policies/board_policy.rb
@@ -36,8 +36,10 @@ class BoardPolicy < ApplicationPolicy
 
   def update?
     return true if user.admin?
-    return true if record.user == user
-    user.current_team_boards.include?(record)
+    return false unless record.user == user || user.current_team_boards.include?(record)
+    # Free users over their board limit can edit only their one designated
+    # board. Team boards (owned by someone else) are not plan-gated here.
+    user.board_editable?(record)
   end
 
   def current_user_teams

--- a/app/sidekiq/downgrade_soft_trial_job.rb
+++ b/app/sidekiq/downgrade_soft_trial_job.rb
@@ -23,6 +23,10 @@ class DowngradeSoftTrialJob
         metadata: { source: "soft_trial_downgrade" },
       )
 
+      # Pin a default editable board so over-limit boards have a deterministic
+      # editable slot (matches apply_free_plan's behavior for Stripe cancels).
+      user.pin_default_editable_board!
+
       Rails.logger.info "DowngradeSoftTrialJob: downgraded user #{user.id} (#{user.email}) to free"
       count += 1
     rescue => e

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
         put "update_to_default_docs"
         put "set_colors"
         post "regenerate_images"
+        patch "make_editable"
       end
     end
     resources :board_images do

--- a/db/migrate/20260522120000_add_editable_board_id_to_users.rb
+++ b/db/migrate/20260522120000_add_editable_board_id_to_users.rb
@@ -1,0 +1,6 @@
+class AddEditableBoardIdToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :editable_board_id, :bigint
+    add_index :users, :editable_board_id
+  end
+end

--- a/db/migrate/20260522180000_add_editable_board_id_set_at_to_users.rb
+++ b/db/migrate/20260522180000_add_editable_board_id_set_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddEditableBoardIdSetAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :editable_board_id_set_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_16_163820) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -917,12 +917,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_16_163820) do
     t.integer "plan_credits_balance", default: 0, null: false
     t.integer "topup_credits_balance", default: 0, null: false
     t.datetime "plan_credits_reset_at"
+    t.bigint "editable_board_id"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["child_lookup_key"], name: "index_users_on_child_lookup_key", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["current_team_id"], name: "index_users_on_current_team_id"
     t.index ["delete_account_token"], name: "index_users_on_delete_account_token", unique: true
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
+    t.index ["editable_board_id"], name: "index_users_on_editable_board_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["jti"], name: "index_users_on_jti", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_22_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_22_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -918,6 +918,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_22_120000) do
     t.integer "topup_credits_balance", default: 0, null: false
     t.datetime "plan_credits_reset_at"
     t.bigint "editable_board_id"
+    t.datetime "editable_board_id_set_at"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["child_lookup_key"], name: "index_users_on_child_lookup_key", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -90,6 +90,17 @@ FactoryBot.define do
     role { "admin" }
   end
 
+  # A real Free user (no longer in the soft-trial window). User#set_soft_trial_plan
+  # flips plan_type="free" to "basic_trial" when created_at is within the
+  # 14-day trial period, so we backdate created_at to stay genuinely free.
+  factory(:free_user, class: "User") do
+    sequence(:email) { |n| "free#{n}@example.com" }
+    password { "password123" }
+    role { "user" }
+    plan_type { "free" }
+    created_at { 1.year.ago }
+  end
+
   factory(:board) do
     sequence(:name) { |n| "Board #{n}" }
     sequence(:slug) { |n| "board-#{n}" }

--- a/spec/models/board_read_only_spec.rb
+++ b/spec/models/board_read_only_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+# Read-only boards for downgraded users: a free user over their board limit
+# keeps full edit access to one designated board; the rest become read-only
+# (still fully usable — view/tap/audio).
+RSpec.describe "Board read-only on downgrade", type: :model do
+  describe "User#board_editable?" do
+    let(:user) { create(:free_user) } # board_limit 1, past trial window
+
+    it "is true for every board when the user is under their board limit" do
+      board = create(:board, user: user)
+      expect(user.board_editable?(board)).to be true
+    end
+
+    context "when a free user is over their board limit" do
+      let!(:board_a) { create(:board, user: user) }
+      let!(:board_b) { create(:board, user: user) }
+
+      it "allows only the designated editable board" do
+        user.update!(editable_board_id: board_a.id)
+        fresh = User.find(user.id)
+        expect(fresh.board_editable?(board_a)).to be true
+        expect(fresh.board_editable?(board_b)).to be false
+      end
+
+      it "falls back to a favorite board when none is designated" do
+        board_b.update!(favorite: true)
+        fresh = User.find(user.id)
+        expect(fresh.board_editable?(board_b)).to be true
+        expect(fresh.board_editable?(board_a)).to be false
+      end
+    end
+
+    it "never locks boards for a paid user" do
+      paid = create(:user, plan_type: "pro")
+      expect(paid.board_editable?(create(:board, user: paid))).to be true
+      expect(paid.board_editable?(create(:board, user: paid))).to be true
+    end
+
+    it "never locks boards for an admin" do
+      admin = create(:admin_user)
+      create(:board, user: admin)
+      expect(admin.board_editable?(create(:board, user: admin))).to be true
+    end
+
+    it "does not gate boards the user does not own" do
+      others_board = create(:board, user: create(:user))
+      create(:board, user: user)
+      create(:board, user: user)
+      expect(user.board_editable?(others_board)).to be true
+    end
+  end
+
+  describe "User#effective_editable_board_id" do
+    let(:user) { create(:free_user) }
+
+    it "returns the designated board when it still belongs to the user" do
+      board = create(:board, user: user)
+      user.update!(editable_board_id: board.id)
+      expect(User.find(user.id).effective_editable_board_id).to eq(board.id)
+    end
+
+    it "falls back to the most-recently-updated board when none is designated" do
+      old = create(:board, user: user)
+      recent = create(:board, user: user)
+      old.update_column(:updated_at, 2.days.ago)
+      recent.update_column(:updated_at, 1.hour.ago)
+      expect(user.effective_editable_board_id).to eq(recent.id)
+    end
+
+    it "prefers a favorite board over a more recent non-favorite" do
+      fav = create(:board, user: user, favorite: true)
+      recent = create(:board, user: user)
+      fav.update_column(:updated_at, 2.days.ago)
+      recent.update_column(:updated_at, 1.hour.ago)
+      expect(user.effective_editable_board_id).to eq(fav.id)
+    end
+  end
+
+  describe "Board#can_edit_for" do
+    it "is false on a locked board and true on the designated board" do
+      user = create(:free_user)
+      designated = create(:board, user: user)
+      locked = create(:board, user: user)
+      user.update!(editable_board_id: designated.id)
+      fresh = User.find(user.id)
+      expect(designated.can_edit_for(fresh)).to be true
+      expect(locked.can_edit_for(fresh)).to be false
+    end
+  end
+
+  describe "Board#api_view locked fields" do
+    it "marks an over-limit non-designated board as locked" do
+      user = create(:free_user)
+      designated = create(:board, user: user)
+      locked = create(:board, user: user)
+      user.update!(editable_board_id: designated.id)
+      fresh = User.find(user.id)
+
+      expect(locked.api_view(fresh)[:locked]).to be true
+      expect(locked.api_view(fresh)[:lock_reason]).to eq("free_plan_board_limit")
+      expect(designated.api_view(fresh)[:locked]).to be false
+      expect(designated.api_view(fresh)[:lock_reason]).to be_nil
+    end
+  end
+end

--- a/spec/models/board_read_only_spec.rb
+++ b/spec/models/board_read_only_spec.rb
@@ -77,6 +77,46 @@ RSpec.describe "Board read-only on downgrade", type: :model do
     end
   end
 
+  describe "editable-board switch cooldown" do
+    let(:user) { create(:free_user) }
+    let!(:board_a) { create(:board, user: user) }
+    let!(:board_b) { create(:board, user: user) }
+
+    it "is inactive while editable_board_id_set_at is nil" do
+      expect(user.editable_board_switch_available_at).to be_nil
+      expect(user.editable_board_switch_cooldown_active?).to be false
+    end
+
+    it "is active during the cooldown window after an explicit pick" do
+      user.update!(
+        editable_board_id: board_a.id,
+        editable_board_id_set_at: 3.days.ago,
+      )
+      fresh = User.find(user.id)
+      expect(fresh.editable_board_switch_cooldown_active?).to be true
+      expect(fresh.editable_board_switch_available_at).to be_within(5.seconds).of(
+        3.days.ago + User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS.days,
+      )
+    end
+
+    it "is inactive once the cooldown has elapsed" do
+      user.update!(
+        editable_board_id: board_a.id,
+        editable_board_id_set_at: (User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS + 1).days.ago,
+      )
+      fresh = User.find(user.id)
+      expect(fresh.editable_board_switch_cooldown_active?).to be false
+    end
+
+    it "pin_default_editable_board! does NOT start the cooldown clock" do
+      user.pin_default_editable_board!
+      fresh = User.find(user.id)
+      expect(fresh.editable_board_id).not_to be_nil
+      expect(fresh.editable_board_id_set_at).to be_nil
+      expect(fresh.editable_board_switch_cooldown_active?).to be false
+    end
+  end
+
   describe "Board#can_edit_for" do
     it "is false on a locked board and true on the designated board" do
       user = create(:free_user)

--- a/spec/policies/board_policy_spec.rb
+++ b/spec/policies/board_policy_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe BoardPolicy do
+  describe "#update?" do
+    context "a free user over their board limit" do
+      let(:user) { create(:free_user) }
+      let!(:designated) { create(:board, user: user) }
+      let!(:other_board) { create(:board, user: user) }
+
+      it "denies editing a non-designated owned board" do
+        user.update!(editable_board_id: designated.id)
+        policy = described_class.new(User.find(user.id), other_board)
+        expect(policy.update?).to be false
+      end
+
+      it "permits editing the designated board" do
+        user.update!(editable_board_id: other_board.id)
+        policy = described_class.new(User.find(user.id), other_board)
+        expect(policy.update?).to be true
+      end
+    end
+
+    it "permits an admin to edit any board" do
+      admin = create(:admin_user)
+      board = create(:board, user: create(:user))
+      expect(described_class.new(admin, board).update?).to be true
+    end
+
+    it "permits a paid user to edit all of their boards" do
+      paid = create(:user, plan_type: "pro")
+      create(:board, user: paid)
+      board = create(:board, user: paid)
+      expect(described_class.new(paid, board).update?).to be true
+    end
+  end
+end

--- a/spec/requests/api/board_read_only_spec.rb
+++ b/spec/requests/api/board_read_only_spec.rb
@@ -56,4 +56,65 @@ RSpec.describe "API board read-only gating", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  # The cooldown closes the loophole where a free user could rotate the
+  # editable slot to edit every board one at a time.
+  describe "make_editable cooldown" do
+    it "starts the cooldown clock on the first explicit pick (not on the auto-pin)" do
+      # User starts with editable_board_id set by the let-block (auto-pin in
+      # the test setup, mimicking apply_free_plan). That's not a real pick —
+      # the timestamp should still be nil.
+      expect(user.reload.editable_board_id_set_at).to be_nil
+
+      patch "/api/boards/#{locked_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.editable_board_id_set_at).not_to be_nil
+    end
+
+    it "blocks a second switch within the cooldown window" do
+      user.update!(
+        editable_board_id: editable_board.id,
+        editable_board_id_set_at: 1.day.ago,
+      )
+
+      patch "/api/boards/#{locked_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:forbidden)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("editable_board_cooldown")
+      expect(body["cooldown_days"]).to eq(User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS)
+      # The editable board did not change.
+      expect(user.reload.editable_board_id).to eq(editable_board.id)
+    end
+
+    it "allows a switch once the cooldown has elapsed" do
+      user.update!(
+        editable_board_id: editable_board.id,
+        editable_board_id_set_at: (User::EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS + 1).days.ago,
+      )
+
+      patch "/api/boards/#{locked_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.editable_board_id).to eq(locked_board.id)
+    end
+
+    it "is a no-op (doesn't start the clock) when re-picking the same board" do
+      patch "/api/boards/#{editable_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.editable_board_id_set_at).to be_nil
+    end
+
+    it "lets admins bypass the cooldown" do
+      admin = create(:admin_user)
+      board_x = create(:board, user: admin)
+      board_y = create(:board, user: admin)
+      admin.update!(
+        editable_board_id: board_x.id,
+        editable_board_id_set_at: 1.day.ago,
+      )
+
+      patch "/api/boards/#{board_y.id}/make_editable", headers: auth_headers(admin)
+      expect(response).to have_http_status(:ok)
+      expect(admin.reload.editable_board_id).to eq(board_y.id)
+    end
+  end
 end

--- a/spec/requests/api/board_read_only_spec.rb
+++ b/spec/requests/api/board_read_only_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+# A downgraded (free) user over their board limit: the boards beyond their
+# limit are read-only. They can still be viewed (usage never breaks), but
+# content-mutating endpoints return HTTP 403 board_locked.
+RSpec.describe "API board read-only gating", type: :request do
+  let(:user) { create(:free_user) } # board_limit 1, past trial window
+  let!(:editable_board) { create(:board, user: user, name: "Editable") }
+  let!(:locked_board)   { create(:board, user: user, name: "Locked") }
+
+  before { user.update!(editable_board_id: editable_board.id) }
+
+  describe "PATCH /api/boards/:id" do
+    it "returns 403 board_locked when editing a locked board" do
+      patch "/api/boards/#{locked_board.id}",
+            params: { board: { name: "Nope" } },
+            headers: auth_headers(user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("board_locked")
+    end
+
+    it "allows editing the designated board" do
+      patch "/api/boards/#{editable_board.id}",
+            params: { board: { name: "Renamed" } },
+            headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /api/boards/:id on a locked board" do
+    it "still serves the board so it stays usable" do
+      get "/api/boards/#{locked_board.id}", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["can_edit"]).to be false
+    end
+  end
+
+  describe "PATCH /api/boards/:id/make_editable" do
+    it "moves the editable slot, locking the previous board" do
+      patch "/api/boards/#{locked_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.editable_board_id).to eq(locked_board.id)
+
+      patch "/api/boards/#{editable_board.id}",
+            params: { board: { name: "Now locked" } },
+            headers: auth_headers(user)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "rejects designating a board the user does not own" do
+      others_board = create(:board, user: create(:user))
+      patch "/api/boards/#{others_board.id}/make_editable", headers: auth_headers(user)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/api/webhooks_plan_credits_spec.rb
+++ b/spec/requests/api/webhooks_plan_credits_spec.rb
@@ -154,6 +154,18 @@ RSpec.describe "POST /api/webhooks (plan credits)", type: :request do
       # immediately.
       expect(user.plan_credits_reset_at).to be > Time.current + CreditService::MIN_GRANT_WINDOW
     end
+
+    it "pins a default editable board so the downgraded user keeps one edit slot" do
+      create(:board, user: user)
+      newest = create(:board, user: user)
+
+      subscription = build_subscription
+      stub_event(subscription, type: "customer.subscription.deleted")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.editable_board_id).to eq(newest.id)
+    end
   end
 
   describe "customer.subscription.paused" do

--- a/spec/sidekiq/downgrade_soft_trial_job_spec.rb
+++ b/spec/sidekiq/downgrade_soft_trial_job_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
         tx = user.credit_transactions.where(kind: "plan_grant").order(created_at: :desc).first
         expect(tx.metadata["source"]).to eq("soft_trial_downgrade")
       end
+
+      it "pins a default editable board so over-limit boards have an edit slot" do
+        user = create_soft_trial_user
+        create(:board, user: user)
+        newest = create(:board, user: user)
+
+        expect { job.perform }.to change { user.reload.editable_board_id }.from(nil).to(newest.id)
+      end
     end
 
     context "when a user has no stripe_customer_id (Apple/RevenueCat)" do


### PR DESCRIPTION
## Summary

- When a paid user (Basic/Pro) downgrades to Free, boards beyond the Free limit (1) become **read-only**: still openable, tappable, and audio still plays (SpeakAnyWay is an AAC app — usage must never break), but content-editing endpoints return **HTTP 403 `board_locked`**.
- Users pick which single board keeps full edit access via `PATCH /api/boards/:id/make_editable`; `apply_free_plan` pins a favorite/most-recent fallback so a freshly-downgraded user is never fully locked out before they choose.
- Locked state is **computed**, not stored (`User#board_editable?`, `Board#can_edit_for`). Only persisted addition is `users.editable_board_id`. No `read_only` column on boards.
- Assumes `FREE_BOARD_LIMIT == 1`; if that ENV is ever raised, revisit to a per-board flag or join table (documented in `CLAUDE.md`).

## What's gated vs not

- **Gated (HTTP 403 `board_locked`):** content-mutating endpoints in `API::BoardsController` (`update`, `save_layout`, `rearrange_images`, `add_image`, `associate_image[s]`, `remove_image`, `regenerate_images`, `recategorize_images`, `update_to_default_docs`, `set_colors`, `update_preset_display_image`, `format_with_ai`, `generate_preview_image`) and the matching set in `API::BoardImagesController` (`update`, `update_multiple`, `remove_multiple`, `save_layout`, `set_current_audio`, `upload_audio`, `reset_audio`, `create_image_edit`, `create_image_variation`, `move`, `destroy`).
- **Not gated:** all reads (`show`, `index`, `pdf`, audio playback), `destroy` on a board (let the user free up the slot — the system never deletes), and `create`/`clone`/`create_from_template` (already covered by the existing `check_board_create_permissions`).
- `assign_accounts` / `add_to_team` / `add_to_groups` were left ungated — they share/organize, they don't mutate content. Happy to gate them if reviewers disagree.
- Uses **403**, not 402 — 402 is reserved for credit exhaustion per `CLAUDE.md`.

## Frontend follow-up (separate PR, `../itty-bitty-frontend`)

Not in this PR; required for users to actually see the feature. Reads `can_edit`/`locked`/`lock_reason` on boards, disables edit UI + shows a lock badge on locked boards, adds a "Make this my editable board" action calling `PATCH /api/boards/:id/make_editable`, and surfaces an upgrade prompt.

## Test plan

- [x] `bundle exec rspec` — 21 new specs (models/board_read_only_spec.rb, policies/board_policy_spec.rb, requests/api/board_read_only_spec.rb, +1 in webhooks_plan_credits_spec.rb), all green.
- [x] Full suite: 594 examples, 0 new regressions. (5 pre-existing local-env failures from `FREE_DEMO_COMMUNICATOR_LIMIT="0"` in the maintainer's `config/application.yml` — unrelated, will pass on CI.)
- [x] Migration `20260522120000_add_editable_board_id_to_users.rb` applied locally; `db/schema.rb` updated.
- [ ] Manual: as a downgraded user with 2+ boards — `GET` on a locked board still serves audio_url; `PATCH` content edit → 403 `board_locked`; `PATCH /api/boards/:id/make_editable` flips which one is editable.
- [ ] Manual: paid user + admin see no `locked` boards (api_view `locked: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)