### PR TITLE
fix(boards): expose locked field on the show endpoint

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1752,6 +1752,8 @@ class Board < ApplicationRecord
       description: description,
       featured: featured,
       can_edit: can_edit,
+      locked: locked_for?(viewing_user),
+      lock_reason: locked_for?(viewing_user) ? "free_plan_board_limit" : nil,
       category: category,
       parent_type: parent_type,
       parent_id: parent_id,
@@ -2030,6 +2032,8 @@ class Board < ApplicationRecord
       name: name,
       word_list: current_word_list,
       can_edit: can_edit_for(viewing_user),
+      locked: locked_for?(viewing_user),
+      lock_reason: locked_for?(viewing_user) ? "free_plan_board_limit" : nil,
       is_template: is_template,
       display_image_url: display_image_url,
       preview_image_url: preview_image_url,
@@ -2056,10 +2060,23 @@ class Board < ApplicationRecord
     viewing_user.board_editable?(self)
   end
 
+  # True ONLY when this board is read-only for viewing_user because of the
+  # plan-based gate (User#board_editable?). False for non-owners, admins,
+  # paid users, ChildAccount viewers (their can_edit comes from a different
+  # permission, not a lock), and any case where the user could edit.
+  # This is what the frontend uses to show the "Read-only — make this my
+  # editable board" banner.
+  def locked_for?(viewing_user)
+    return false unless viewing_user.is_a?(User)
+    return false unless user_id == viewing_user.id
+    return false if viewing_user.admin?
+
+    !viewing_user.board_editable?(self)
+  end
+
   def api_view(viewing_user = nil)
     can_edit = can_edit_for(viewing_user)
-    owned_by_viewer = viewing_user && user_id == viewing_user.id
-    locked = !!(owned_by_viewer && !can_edit && !viewing_user.try(:admin?))
+    locked = locked_for?(viewing_user)
 
     @in_a_public_group = false
     @display_image_url = display_image_url
@@ -2141,6 +2158,8 @@ class Board < ApplicationRecord
       text_color: text_color,
       # image_count: board_images_count,
       can_edit: can_edit_for(viewing_user),
+      locked: locked_for?(viewing_user),
+      lock_reason: locked_for?(viewing_user) ? "free_plan_board_limit" : nil,
       display_image_url: display_image_url,
       preview_image_url: preview_image_url,
       word_sample: word_sample,

--- a/spec/requests/api/board_read_only_spec.rb
+++ b/spec/requests/api/board_read_only_spec.rb
@@ -34,7 +34,23 @@ RSpec.describe "API board read-only gating", type: :request do
       get "/api/boards/#{locked_board.id}", headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)["can_edit"]).to be false
+      body = JSON.parse(response.body)
+      expect(body["can_edit"]).to be false
+      # The frontend keys its read-only banner off these fields, so the
+      # show response (api_view_with_predictive_images) must include them
+      # alongside can_edit. Regression guard for issue #155.
+      expect(body["locked"]).to be true
+      expect(body["lock_reason"]).to eq("free_plan_board_limit")
+    end
+
+    it "does not mark the designated editable board as locked" do
+      get "/api/boards/#{editable_board.id}", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["can_edit"]).to be true
+      expect(body["locked"]).to be false
+      expect(body["lock_reason"]).to be_nil
     end
   end
 


### PR DESCRIPTION
## Summary

Hotfix for the read-only feature that just landed (#154). The frontend's read-only banner keys off `Board.locked`, but I only added `locked` / `lock_reason` to `Board#api_view`. The boards `show` controller renders `api_view_with_predictive_images` — so `locked` was undefined in the show response and the banner never showed up for free users on a locked board.

`can_edit` was correctly `false`, so the edit buttons (Edit, Add Image, AI Help, Assign) hid as intended — just no banner explaining why.

## Changes

- New `Board#locked_for?(viewing_user)` helper — returns true ONLY for the plan-gating case (false for non-owners, admins, paid users, and `ChildAccount` viewers whose `can_edit` comes from a different permission like `settings["can_edit_boards"]`).
- Populate `locked` + `lock_reason` in **all four** view methods: `api_view_with_predictive_images`, `api_view_with_images`, `api_view`, `user_api_view`. So whichever serializer is in play, the frontend gets the same answer.
- Regression spec on `GET /api/boards/:id` (the show endpoint) asserting `locked: true` / `lock_reason: "free_plan_board_limit"` for a locked board, and `locked: false` for the designated editable board.

## Test plan

- [x] `bundle exec rspec spec/models/board_read_only_spec.rb spec/requests/api/board_read_only_spec.rb spec/policies/board_policy_spec.rb` — 30/30 green.
- [x] Full suite: 612 examples, 0 new regressions (same 5 pre-existing local-env failures).
- [ ] Manual on staging once merged: as a free user with 2+ boards, open a locked board → banner appears with "Make this my editable board" + Upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)