### PR TITLE
feat: loaner lifecycle — retire is_demo, ship SLP→parent hand-off

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -833,7 +833,7 @@ class API::BoardsController < API::ApplicationController
       end
       communicator_account_ids.each do |communicator_account_id|
         communicator_account = ChildAccount.find(communicator_account_id)
-        if communicator_account.is_demo?
+        if communicator_account.sandbox?
           board_count = communicator_account.child_boards.all.count
           demo_limit = (communicator_account.settings["demo_board_limit"] || ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT).to_i
           if board_count >= demo_limit

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -268,17 +268,14 @@ class API::ChildAccountsController < API::ApplicationController
     @child_account.owner = current_user
     @child_account.user = current_user if @child_account.respond_to?(:user=) # legacy (optional)
 
-    # Validate basic fields first
-    unless @child_account.valid?
-      render json: { errors: @child_account.errors.full_messages.join(", ") }, status: :unprocessable_entity
-      return
-    end
-
-    # Passcode is required for loaner/active; sandbox accounts have no login.
+    # Passcode is required for loaner/active; sandbox accounts have no
+    # login. Assign before validation runs — the B3
+    # `loaner_or_active_must_have_login` validation will otherwise trip
+    # on every non-sandbox create.
     password = params[:password]
     password_confirmation = params[:password_confirmation]
 
-    if password != password_confirmation
+    if password.present? && password_confirmation.present? && password != password_confirmation
       render json: { error: "Passwords do not match" }, status: :unprocessable_entity
       return
     end

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -27,24 +27,25 @@ class API::ChildAccountsController < API::ApplicationController
   # POST /child_accounts
   def create
     is_demo = params[:is_demo] ? ActiveModel::Type::Boolean.new.cast(params[:is_demo]) : false
+    # Prefer the explicit lifecycle status param; fall back to legacy is_demo.
+    requested_status = params[:status].presence || (is_demo ? ChildAccount::SANDBOX : ChildAccount::ACTIVE)
 
-    allowed, status, error = Permissions::CommunicatorLimits.can_create?(
+    allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
       user: current_user,
-      is_demo: is_demo,
+      status: requested_status,
     )
 
     unless allowed
-      render json: { error: error }, status: status
+      render json: { error: error }, status: http_status
       return
     end
     username = params[:username]
     name = params[:name]
     nickname = params[:nickname]
 
-    @child_account = ChildAccount.new(username: username, name: name)
+    @child_account = ChildAccount.new(username: username, name: name, status: requested_status)
 
-    # Type + ownership
-    @child_account.is_demo = is_demo
+    # Ownership
     @child_account.owner = current_user
     @child_account.user = current_user if @child_account.respond_to?(:user=) # legacy (optional)
 
@@ -69,9 +70,9 @@ class API::ChildAccountsController < API::ApplicationController
     @child_account.settings = params[:settings] if params[:settings].present?
     @child_account.details = params[:details] if params[:details].present?
 
-    # A Free user's MySpeak demo communicator is capped at one board; Pro demo
+    # A Free user's sandbox communicator is capped at one board; Pro sandbox
     # accounts fall through to ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT.
-    if is_demo && current_user.free?
+    if requested_status == ChildAccount::SANDBOX && current_user.free?
       @child_account.settings ||= {}
       @child_account.settings["demo_board_limit"] = ChildAccount::FREE_DEMO_BOARD_LIMIT
     end
@@ -129,18 +130,19 @@ class API::ChildAccountsController < API::ApplicationController
     username = params[:username]
     @child_account.username = username unless username.blank?
     @child_account.name = name unless name.blank?
-    was_a_demo = @child_account.sandbox?
+    was_sandbox = @child_account.sandbox?
     is_demo = params[:is_demo] ? ActiveModel::Type::Boolean.new.cast(params[:is_demo]) : false
-    @child_account.is_demo = is_demo
-    if was_a_demo && !is_demo
-      # Changing from demo to paid - check limits
-      allowed, status, error = Permissions::CommunicatorLimits.can_create?(
+    requested_status = params[:status].presence || (is_demo ? ChildAccount::SANDBOX : ChildAccount::ACTIVE)
+    @child_account.status = requested_status
+    if was_sandbox && requested_status != ChildAccount::SANDBOX
+      # Promoting sandbox → loaner/active — re-check slot limits.
+      allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
         user: current_user,
-        is_demo: is_demo,
+        status: requested_status,
       )
 
       unless allowed
-        render json: { error: error }, status: status
+        render json: { error: error }, status: http_status
         return
       end
     end
@@ -187,7 +189,7 @@ class API::ChildAccountsController < API::ApplicationController
     @child_account = ChildAccount.find(params[:id])
     board_ids = params[:board_ids]
     total_boards = @child_account.child_boards.count + board_ids.size
-    if @child_account.is_demo?
+    if @child_account.sandbox?
       demo_limit = (@child_account.settings["demo_board_limit"] || ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT).to_i
       if total_boards > demo_limit
         render json: { error: "Demo board limit exceeded. You can have up to #{demo_limit} boards." }, status: :unprocessable_entity

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,5 +1,8 @@
 class API::ChildAccountsController < API::ApplicationController
-  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner ]
+  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner claim_link end_loan ]
+  # Claim preview is the parent's "this is what you're about to claim"
+  # page — they may not be signed in yet, so it runs token-only.
+  skip_before_action :authenticate_token!, only: %i[ claim_preview ]
 
   # GET /child_accounts
   # GET /child_accounts.json
@@ -56,6 +59,87 @@ class API::ChildAccountsController < API::ApplicationController
     rescue ActiveRecord::RecordInvalid => e
       render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
     end
+  end
+
+  # POST /api/child_accounts/:id/claim_link
+  # SLP-only. Generates (or rotates) the claim token a parent uses to
+  # take ownership of this loaner. Returns the URL the SLP shares.
+  def claim_link
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    unless @child_account.loaner?
+      render json: { error: "Only loaners can issue a claim link" }, status: :unprocessable_entity
+      return
+    end
+
+    @child_account.generate_claim_token!
+    render json: {
+      claim_token: @child_account.claim_token,
+      claim_url: @child_account.claim_link_url,
+      claim_token_sent_at: @child_account.claim_token_sent_at,
+    }, status: :ok
+  end
+
+  # GET /api/child_accounts/claim/:token
+  # Public preview shown on the parent's claim page before they sign in.
+  def claim_preview
+    account = ChildAccount.find_by(claim_token: params[:token])
+    unless account&.loaner?
+      render json: { error: "Invalid or expired claim link" }, status: :not_found
+      return
+    end
+
+    render json: {
+      id: account.id,
+      name: account.display_name,
+      owner_name: account.owner&.display_name,
+      created_at: account.created_at,
+    }, status: :ok
+  end
+
+  # POST /api/child_accounts/claim/:token
+  # Parent (signed in) claims the loaner. Transfers ownership, swaps
+  # onto the parent's plan, frees the SLP's slot, keeps the SLP on the
+  # child's team as a supervisor.
+  def claim
+    account = ChildAccount.find_by(claim_token: params[:token])
+    unless account&.loaner?
+      render json: { error: "Invalid or expired claim link" }, status: :not_found
+      return
+    end
+
+    begin
+      account.claim_by!(user: current_user)
+      render json: account.api_view(current_user), status: :ok
+    rescue ChildAccount::SlotFull => e
+      render json: {
+        error: "slot_full",
+        message: e.message,
+        upgrade_url: "/account/billing/upgrade",
+      }, status: :unprocessable_entity
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
+  # POST /api/child_accounts/:id/end_loan
+  # SLP ends the loan immediately (B5). Returns the slot.
+  def end_loan
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    unless @child_account.loaner?
+      render json: { error: "Only loaners can be reclaimed" }, status: :unprocessable_entity
+      return
+    end
+
+    @child_account.reclaim!(reason: "manual")
+    render json: @child_account.api_view(current_user), status: :ok
   end
 
   # POST /child_accounts

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -129,7 +129,7 @@ class API::ChildAccountsController < API::ApplicationController
     username = params[:username]
     @child_account.username = username unless username.blank?
     @child_account.name = name unless name.blank?
-    was_a_demo = @child_account.is_demo
+    was_a_demo = @child_account.sandbox?
     is_demo = params[:is_demo] ? ActiveModel::Type::Boolean.new.cast(params[:is_demo]) : false
     @child_account.is_demo = is_demo
     if was_a_demo && !is_demo

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,5 +1,5 @@
 class API::ChildAccountsController < API::ApplicationController
-  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner claim_link end_loan ]
+  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan ]
   # Claim preview is the parent's "this is what you're about to claim"
   # page — they may not be signed in yet, so it runs token-only.
   skip_before_action :authenticate_token!, only: %i[ claim_preview ]
@@ -61,6 +61,42 @@ class API::ChildAccountsController < API::ApplicationController
     end
   end
 
+  # POST /api/child_accounts/:id/lend
+  # SLP-facing "Lend to a family" action. Promotes the sandbox to loaner
+  # (provisioning a passcode) and issues the claim token in one round
+  # trip so the frontend immediately sees `claim_url` on the returned
+  # account. Idempotent on a loaner — just rotates the claim token.
+  def lend
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    if @child_account.active?
+      render json: { error: "This communicator has already been claimed" }, status: :unprocessable_entity
+      return
+    end
+
+    if @child_account.sandbox?
+      allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
+        user: @child_account.owner,
+        status: ChildAccount::LOANER,
+      )
+      unless allowed
+        render json: { error: error }, status: http_status
+        return
+      end
+    end
+
+    begin
+      @child_account.promote_to_loaner!(passcode: params[:passcode]) if @child_account.sandbox?
+      @child_account.generate_claim_token!
+      render json: @child_account.api_view(current_user), status: :ok
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
+  end
+
   # POST /api/child_accounts/:id/claim_link
   # SLP-only. Generates (or rotates) the claim token a parent uses to
   # take ownership of this loaner. Returns the URL the SLP shares.
@@ -83,27 +119,80 @@ class API::ChildAccountsController < API::ApplicationController
     }, status: :ok
   end
 
-  # GET /api/child_accounts/claim/:token
-  # Public preview shown on the parent's claim page before they sign in.
-  def claim_preview
-    account = ChildAccount.find_by(claim_token: params[:token])
-    unless account&.loaner?
-      render json: { error: "Invalid or expired claim link" }, status: :not_found
+  # POST /api/child_accounts/:id/send_claim_link
+  # Generates (or rotates) the claim token and emails it to the parent.
+  # Owner-only. Body: { email: "parent@example.com" }.
+  def send_claim_link
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
 
+    unless @child_account.loaner?
+      render json: { error: "Only loaners can issue a claim link" }, status: :unprocessable_entity
+      return
+    end
+
+    email = params[:email].to_s.strip
+    if email.blank? || !email.include?("@")
+      render json: { error: "A valid email is required" }, status: :unprocessable_entity
+      return
+    end
+
+    @child_account.generate_claim_token! if @child_account.claim_token.blank?
+
+    begin
+      CommunicationAccountMailer.claim_link_email(@child_account, email, current_user).deliver_later
+    rescue => e
+      Rails.logger.error "[send_claim_link] mailer failed for child_account=#{@child_account.id}: #{e.message}"
+      render json: { error: "Couldn't send the email. Please try again." }, status: :service_unavailable
+      return
+    end
+
+    render json: { ok: true, claim_url: @child_account.claim_link_url, sent_to: email }, status: :ok
+  end
+
+  # GET /api/communicator_claims/:token
+  # Public preview shown on the parent's claim page before they sign in.
+  # Returns a stable shape so the frontend can render expired/claimed
+  # states without a separate request.
+  def claim_preview
+    account = ChildAccount.find_by(claim_token: params[:token])
+    if account.nil?
+      render json: { error: "Invalid or expired claim link", expired: true }, status: :not_found
+      return
+    end
+
+    if account.active?
+      render json: {
+        status: "claimed",
+        already_claimed: true,
+        owner_name: account.owner&.display_name,
+      }, status: :ok
+      return
+    end
+
+    expired = account.claim_token_sent_at.present? &&
+              account.claim_token_sent_at < LoanerReclaimJob::RECLAIM_AFTER.ago
+
     render json: {
-      id: account.id,
-      name: account.display_name,
+      status: expired ? "expired" : account.status,
+      expired: expired,
+      already_claimed: false,
+      child_name: account.display_name,
+      communicator_name: account.display_name,
       owner_name: account.owner&.display_name,
-      created_at: account.created_at,
+      owner_email: account.owner&.email,
     }, status: :ok
   end
 
-  # POST /api/child_accounts/claim/:token
+  # POST /api/communicator_claims/:token/claim
   # Parent (signed in) claims the loaner. Transfers ownership, swaps
   # onto the parent's plan, frees the SLP's slot, keeps the SLP on the
   # child's team as a supervisor.
+  #
+  # Response is wrapped as `{ account: ..., error: ... }` so the
+  # frontend can branch on `result.error` regardless of HTTP status.
   def claim
     account = ChildAccount.find_by(claim_token: params[:token])
     unless account&.loaner?
@@ -113,7 +202,7 @@ class API::ChildAccountsController < API::ApplicationController
 
     begin
       account.claim_by!(user: current_user)
-      render json: account.api_view(current_user), status: :ok
+      render json: { account: account.api_view(current_user) }, status: :ok
     rescue ChildAccount::SlotFull => e
       render json: {
         error: "slot_full",
@@ -121,7 +210,7 @@ class API::ChildAccountsController < API::ApplicationController
         upgrade_url: "/account/billing/upgrade",
       }, status: :unprocessable_entity
     rescue ActiveRecord::RecordInvalid => e
-      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,5 +1,5 @@
 class API::ChildAccountsController < API::ApplicationController
-  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan ]
+  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan archive unarchive ]
   # Claim preview is the parent's "this is what you're about to claim"
   # page — they may not be signed in yet, so it runs token-only.
   skip_before_action :authenticate_token!, only: %i[ claim_preview ]
@@ -71,16 +71,23 @@ class API::ChildAccountsController < API::ApplicationController
   # frontend's "replace state with response" pattern doesn't blow away
   # the status field and flip the UI into a misleading state.
   def lend
+    # Ownership guard. By the time we pass this, the caller IS the
+    # current owner — which means a `status: active` here is a
+    # self-created active (not a family-claimed one). #164 lets the
+    # SLP lend it out (passcode gets rotated in promote_to_loaner!).
     unless @child_account.owner_id == current_user.id || current_user.admin?
-      render json: account_error_payload("Unauthorized"), status: :unauthorized
+      if @child_account.active?
+        render json: account_error_payload("This communicator is owned by someone else and can't be lent."),
+               status: :unprocessable_entity
+      else
+        render json: account_error_payload("Unauthorized"), status: :unauthorized
+      end
       return
     end
 
-    if @child_account.active?
-      render json: account_error_payload("This communicator has already been claimed"), status: :unprocessable_entity
-      return
-    end
-
+    # Slot check — only meaningful when the account isn't already in
+    # the slot pool (sandbox). Loaners already count; active → loaner
+    # is a net-zero change to the slot count.
     if @child_account.sandbox?
       allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
         user: @child_account.owner,
@@ -100,7 +107,7 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     begin
-      @child_account.promote_to_loaner!(passcode: params[:passcode]) if @child_account.sandbox?
+      @child_account.promote_to_loaner!(passcode: params[:passcode]) unless @child_account.loaner?
       @child_account.generate_claim_token!
       render json: @child_account.api_view(current_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
@@ -240,6 +247,45 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     @child_account.reclaim!(reason: "manual")
+    render json: @child_account.api_view(current_user), status: :ok
+  end
+
+  # POST /api/child_accounts/:id/archive
+  # Soft-archive a sandbox communicator (issue #165). The record stays
+  # in the database with all its boards/settings/history — it just
+  # drops out of the default-scoped lists and stops counting against
+  # the sandbox limit. Sandbox-only; loaner/active have downstream
+  # effects (slot accounting, claim tokens) that need their own paths.
+  def archive
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
+      return
+    end
+
+    unless @child_account.sandbox?
+      render json: account_error_payload("Only sandbox communicators can be archived"), status: :unprocessable_entity
+      return
+    end
+
+    @child_account.archive!
+    render json: @child_account.api_view(current_user), status: :ok
+  end
+
+  # POST /api/child_accounts/:id/unarchive
+  # Restore a previously-archived sandbox. Sandbox-only (loaner/active
+  # can't get into the archived state in the first place).
+  def unarchive
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
+      return
+    end
+
+    unless @child_account.sandbox?
+      render json: account_error_payload("Only sandbox communicators can be unarchived"), status: :unprocessable_entity
+      return
+    end
+
+    @child_account.unarchive!
     render json: @child_account.api_view(current_user), status: :ok
   end
 
@@ -442,9 +488,11 @@ class API::ChildAccountsController < API::ApplicationController
   private
 
   # Use callbacks to share common setup or constraints between actions.
+  # `with_archived` so unarchive (and admin maintenance) can target a
+  # soft-archived record — the default scope hides them otherwise.
   def set_child_account
     @parent_account = current_user
-    @child_account = ChildAccount.find(params[:id])
+    @child_account = ChildAccount.with_archived.find(params[:id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,5 +1,5 @@
 class API::ChildAccountsController < API::ApplicationController
-  before_action :set_child_account, only: %i[ show update destroy ]
+  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner ]
 
   # GET /child_accounts
   # GET /child_accounts.json
@@ -22,6 +22,40 @@ class API::ChildAccountsController < API::ApplicationController
     @child_account = ChildAccount.find(params[:id])
     @child_account.send_setup_email(current_user)
     render json: { success: true }
+  end
+
+  # POST /api/child_accounts/:id/promote_to_loaner
+  # Promotes a sandbox communicator to a loaner: provisions a passcode
+  # (caller may supply one), lifts the sandbox board cap, and starts
+  # counting against the owner's slot. The owner must be authorized to
+  # add a loaner slot (B2 limits).
+  def promote_to_loaner
+    unless @child_account.owner_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    unless @child_account.sandbox?
+      render json: { error: "Only sandbox communicators can be promoted to loaner" }, status: :unprocessable_entity
+      return
+    end
+
+    allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
+      user: @child_account.owner,
+      status: ChildAccount::LOANER,
+    )
+
+    unless allowed
+      render json: { error: error }, status: http_status
+      return
+    end
+
+    begin
+      @child_account.promote_to_loaner!(passcode: params[:passcode])
+      render json: @child_account.api_view(current_user), status: :ok
+    rescue ActiveRecord::RecordInvalid => e
+      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
   end
 
   # POST /child_accounts
@@ -55,7 +89,7 @@ class API::ChildAccountsController < API::ApplicationController
       return
     end
 
-    # Passcode (required)
+    # Passcode is required for loaner/active; sandbox accounts have no login.
     password = params[:password]
     password_confirmation = params[:password_confirmation]
 
@@ -64,7 +98,7 @@ class API::ChildAccountsController < API::ApplicationController
       return
     end
 
-    @child_account.passcode = password
+    @child_account.passcode = password if password.present? && requested_status != ChildAccount::SANDBOX
 
     # Optional attrs
     @child_account.settings = params[:settings] if params[:settings].present?

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -335,7 +335,8 @@ class API::ChildAccountsController < API::ApplicationController
       render json: @child_account.api_view(current_user), status: :created
     else
       Rails.logger.info "Invalid Child Account: errors: #{@child_account.errors.inspect}"
-      render json: { errors: @child_account.errors }, status: :unprocessable_entity
+      message = @child_account.errors.full_messages.join(", ")
+      render json: { error: message, errors: message }, status: :unprocessable_entity
     end
   end
 
@@ -397,7 +398,8 @@ class API::ChildAccountsController < API::ApplicationController
     if @child_account.save
       render json: @child_account.api_view(current_user), status: :ok
     else
-      render json: @child_account.errors, status: :unprocessable_entity
+      message = @child_account.errors.full_messages.join(", ")
+      render json: account_error_payload(message), status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -34,12 +34,12 @@ class API::ChildAccountsController < API::ApplicationController
   # add a loaner slot (B2 limits).
   def promote_to_loaner
     unless @child_account.owner_id == current_user.id || current_user.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
     unless @child_account.sandbox?
-      render json: { error: "Only sandbox communicators can be promoted to loaner" }, status: :unprocessable_entity
+      render json: account_error_payload("Only sandbox communicators can be promoted to loaner"), status: :unprocessable_entity
       return
     end
 
@@ -49,7 +49,7 @@ class API::ChildAccountsController < API::ApplicationController
     )
 
     unless allowed
-      render json: { error: error }, status: http_status
+      render json: account_error_payload(error), status: http_status
       return
     end
 
@@ -57,7 +57,7 @@ class API::ChildAccountsController < API::ApplicationController
       @child_account.promote_to_loaner!(passcode: params[:passcode])
       render json: @child_account.api_view(current_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
-      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_entity
     end
   end
 
@@ -66,14 +66,18 @@ class API::ChildAccountsController < API::ApplicationController
   # (provisioning a passcode) and issues the claim token in one round
   # trip so the frontend immediately sees `claim_url` on the returned
   # account. Idempotent on a loaner — just rotates the claim token.
+  #
+  # Error responses always include the current account view so the
+  # frontend's "replace state with response" pattern doesn't blow away
+  # the status field and flip the UI into a misleading state.
   def lend
     unless @child_account.owner_id == current_user.id || current_user.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
     if @child_account.active?
-      render json: { error: "This communicator has already been claimed" }, status: :unprocessable_entity
+      render json: account_error_payload("This communicator has already been claimed"), status: :unprocessable_entity
       return
     end
 
@@ -83,7 +87,14 @@ class API::ChildAccountsController < API::ApplicationController
         status: ChildAccount::LOANER,
       )
       unless allowed
-        render json: { error: error }, status: http_status
+        Rails.logger.warn(
+          "[lend] denied for user=#{@child_account.owner_id} child_account=#{@child_account.id} " \
+          "plan_type=#{@child_account.owner&.plan_type.inspect} " \
+          "paid_limit=#{@child_account.owner&.settings&.dig("paid_communicator_limit").inspect} " \
+          "owned_slots=#{@child_account.owner ? Permissions::CommunicatorLimits.owned_slot_count(@child_account.owner) : "?"} " \
+          "reason=#{error}"
+        )
+        render json: account_error_payload(error), status: http_status
         return
       end
     end
@@ -93,7 +104,8 @@ class API::ChildAccountsController < API::ApplicationController
       @child_account.generate_claim_token!
       render json: @child_account.api_view(current_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
-      render json: { errors: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      Rails.logger.warn "[lend] validation failed for child_account=#{@child_account.id}: #{e.record.errors.full_messages.join(", ")}"
+      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_entity
     end
   end
 
@@ -124,18 +136,18 @@ class API::ChildAccountsController < API::ApplicationController
   # Owner-only. Body: { email: "parent@example.com" }.
   def send_claim_link
     unless @child_account.owner_id == current_user.id || current_user.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
     unless @child_account.loaner?
-      render json: { error: "Only loaners can issue a claim link" }, status: :unprocessable_entity
+      render json: account_error_payload("Only loaners can issue a claim link"), status: :unprocessable_entity
       return
     end
 
     email = params[:email].to_s.strip
     if email.blank? || !email.include?("@")
-      render json: { error: "A valid email is required" }, status: :unprocessable_entity
+      render json: account_error_payload("A valid email is required"), status: :unprocessable_entity
       return
     end
 
@@ -145,7 +157,7 @@ class API::ChildAccountsController < API::ApplicationController
       CommunicationAccountMailer.claim_link_email(@child_account, email, current_user).deliver_later
     rescue => e
       Rails.logger.error "[send_claim_link] mailer failed for child_account=#{@child_account.id}: #{e.message}"
-      render json: { error: "Couldn't send the email. Please try again." }, status: :service_unavailable
+      render json: account_error_payload("Couldn't send the email. Please try again."), status: :service_unavailable
       return
     end
 
@@ -218,12 +230,12 @@ class API::ChildAccountsController < API::ApplicationController
   # SLP ends the loan immediately (B5). Returns the slot.
   def end_loan
     unless @child_account.owner_id == current_user.id || current_user.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
+      render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
     unless @child_account.loaner?
-      render json: { error: "Only loaners can be reclaimed" }, status: :unprocessable_entity
+      render json: account_error_payload("Only loaners can be reclaimed"), status: :unprocessable_entity
       return
     end
 
@@ -439,5 +451,15 @@ class API::ChildAccountsController < API::ApplicationController
   # Only allow a list of trusted parameters through.
   def child_account_params
     params.require(:child_account).permit(:user_id, :username, :name)
+  end
+
+  # Mutation endpoints (lend, end_loan, etc.) return the current account
+  # view in error responses so a frontend that does
+  # `setState(response)` doesn't lose the status / is_demo fields and
+  # flip into the wrong UI state. The error message is included as a
+  # sibling field so callers that DO check can still surface it.
+  def account_error_payload(error)
+    view = @child_account ? @child_account.reload.api_view(current_user) : {}
+    view.merge(error: error.to_s, errors: error.to_s)
   end
 end

--- a/app/helpers/permissions/communicator_limits.rb
+++ b/app/helpers/permissions/communicator_limits.rb
@@ -1,28 +1,91 @@
 module Permissions
   module CommunicatorLimits
-    module_function
+    extend self
 
-    # Returns: [allowed(Boolean), status(Symbol), error_message(String|nil)]
-    def can_create?(user:, is_demo:)
+    # Slot math (per the loaner-lifecycle spec — issue #158):
+    #
+    #   Free  — 0 self-created (loaner/active). May host 1 *claimed* (a loaner
+    #           handed off SLP → parent). Plus the no-login sandbox.
+    #   Basic — 2 communicators (loaner + active total).
+    #   Pro   — 3 communicators, loaner-capable, recycling.
+    #
+    # A `loaner` counts against the owner's (SLP's) slot. On claim the
+    # ownership transfers and the slot frees on the SLP's side (see B4).
+    #
+    # Returns: [allowed(Boolean), http_status(Symbol), error_message(String|nil)]
+    def can_create?(user:, is_demo: nil, status: nil)
+      return [false, :unauthorized, "Unauthorized"] unless user
+
+      status ||= is_demo ? ChildAccount::SANDBOX : ChildAccount::ACTIVE
+      settings = user.settings || {}
+
+      case status
+      when ChildAccount::SANDBOX
+        check_sandbox_quota(user, settings)
+      when ChildAccount::LOANER, ChildAccount::ACTIVE
+        check_slot_self_create(user, settings)
+      else
+        [false, :unprocessable_entity, "Unknown communicator status: #{status}"]
+      end
+    end
+
+    # Slot check for receiving a *claimed* communicator (B4). Unlike
+    # self-create, Free users may host 1 claimed slot — that's the whole
+    # point of the hand-off — so this skips the self-create paywall.
+    def can_claim?(user:)
       return [false, :unauthorized, "Unauthorized"] unless user
 
       settings = user.settings || {}
+      slot_limit = slot_limit_for(settings)
+      owned_count = owned_slot_count(user)
 
-      if is_demo
-        demo_limit = (settings["demo_communicator_limit"] || 1).to_i
-        demo_count = user.demo_communicator_accounts.count
+      return [false, :forbidden, "Your plan does not include communicator accounts."] if slot_limit <= 0
+      return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if owned_count >= slot_limit
 
-        return [false, :forbidden, "Your plan does not include demo communicators."] if demo_limit <= 0
-        return [false, :unprocessable_entity, "Demo communicator limit reached."] if demo_count >= demo_limit
+      [true, :ok, nil]
+    end
 
-        return [true, :ok, nil]
+    # The total non-sandbox slots a user occupies right now. Used by the
+    # claim flow and by frontends rendering "X of Y communicators."
+    def owned_slot_count(user)
+      user.communicator_accounts.where(status: [ChildAccount::LOANER, ChildAccount::ACTIVE]).count
+    end
+
+    def slot_limit_for(settings)
+      (settings["communicator_slot_limit"] || settings["paid_communicator_limit"] || 0).to_i
+    end
+
+    def sandbox_limit_for(settings)
+      (settings["sandbox_communicator_limit"] || settings["demo_communicator_limit"] || 0).to_i
+    end
+
+    def self_create_allowed?(user)
+      return true if user.admin?
+      user.paid_plan?
+    end
+
+    private
+
+    def check_sandbox_quota(user, settings)
+      limit = sandbox_limit_for(settings)
+      count = user.communicator_accounts.where(status: ChildAccount::SANDBOX).count
+
+      return [false, :forbidden, "Your plan does not include sandbox communicators."] if limit <= 0
+      return [false, :unprocessable_entity, "Sandbox communicator limit reached."] if count >= limit
+
+      [true, :ok, nil]
+    end
+
+    def check_slot_self_create(user, settings)
+      unless self_create_allowed?(user)
+        return [false, :forbidden, "Your plan does not allow creating communicator accounts. Upgrade to Basic or Pro, or have one handed to you."]
       end
 
-      comm_limit = (settings["paid_communicator_limit"] || 0).to_i
-      real_count = user.paid_communicator_accounts.count
+      limit = slot_limit_for(settings)
+      count = owned_slot_count(user)
 
-      return [false, :forbidden, "Your plan does not include communicator accounts."] if comm_limit <= 0
-      return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if real_count >= comm_limit
+      return [false, :forbidden, "Your plan does not include communicator accounts."] if limit <= 0
+      return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if count >= limit
 
       [true, :ok, nil]
     end

--- a/app/mailers/communication_account_mailer.rb
+++ b/app/mailers/communication_account_mailer.rb
@@ -8,4 +8,15 @@ class CommunicationAccountMailer < ApplicationMailer
     title = "Welcome to SpeakAnyWay AAC!"
     mail(to: @email, subject: title)
   end
+
+  # B4: SLP → family hand-off invite. Sends the parent the claim URL.
+  def claim_link_email(account, recipient_email, sending_user = nil)
+    @account = account
+    @sending_user = sending_user
+    @claim_url = account.claim_link_url
+    @owner_name = sending_user&.display_name || account.owner&.display_name
+    @child_name = account.display_name
+    subject = "#{@owner_name || "Your therapist"} sent you a SpeakAnyWay communicator"
+    mail(to: recipient_email, subject: subject)
+  end
 end

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -263,6 +263,15 @@ class ChildAccount < ApplicationRecord
 
   class SlotFull < StandardError; end
 
+  # Surfaced on api_view so the frontend can render a countdown / "link
+  # expires" copy without needing to know the reclaim job's cutoff.
+  def loan_expires_at
+    return nil unless loaner?
+    anchor = claim_token_sent_at || loaner_started_at
+    return nil if anchor.blank?
+    anchor + LoanerReclaimJob::RECLAIM_AFTER
+  end
+
   # Sandbox communicators are no-login scratch spaces. Guarded by
   # new_record?/passcode_changed? so we don't break legacy sandbox rows
   # that already carry a passcode from the pre-lifecycle era.
@@ -393,6 +402,11 @@ class ChildAccount < ApplicationRecord
       layout: layout,
       status: status,
       is_demo: is_demo?,
+      claim_token: claim_token,
+      claim_url: claim_link_url,
+      loaned_at: loaner_started_at,
+      claimed_at: claimed_at,
+      loan_expires_at: loan_expires_at,
       voice: voice,
       vendor: is_vendor ? cached_user.vendor.api_view(viewing_user) : nil,
       vendor_profile: is_vendor ? cached_profile.api_view(viewing_user) : nil,
@@ -713,6 +727,11 @@ class ChildAccount < ApplicationRecord
       layout: layout,
       status: status,
       is_demo: is_demo?,
+      claim_token: claim_token,
+      claim_url: claim_link_url,
+      loaned_at: loaner_started_at,
+      claimed_at: claimed_at,
+      loan_expires_at: loan_expires_at,
       device_tag_url: device_tag_url,
       safety_id_url: safety_id_url,
       voice: voice,

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -71,8 +71,10 @@ class ChildAccount < ApplicationRecord
 
   validates :username, presence: true, uniqueness: true
   validates :status, inclusion: { in: STATUSES }
-  validate :sandbox_cannot_have_login
-  validate :loaner_or_active_must_have_login
+  # Passcodes are optional regardless of status. `promote_to_loaner!`
+  # still mints one when none was supplied, so the "promote" path
+  # produces a working sign-in by default — but no rule blocks a
+  # loaner/active without a passcode or a sandbox with one.
 
   delegate :display_docs_for_image, to: :user
 
@@ -270,29 +272,6 @@ class ChildAccount < ApplicationRecord
     anchor = claim_token_sent_at || loaner_started_at
     return nil if anchor.blank?
     anchor + LoanerReclaimJob::RECLAIM_AFTER
-  end
-
-  # Sandbox communicators are no-login scratch spaces. Guarded by
-  # new_record?/passcode_changed? so we don't break legacy sandbox rows
-  # that already carry a passcode from the pre-lifecycle era.
-  def sandbox_cannot_have_login
-    return unless sandbox?
-    return unless new_record? || passcode_changed?
-    if passcode.present?
-      errors.add(:passcode, "must be blank for sandbox communicators")
-    end
-  end
-
-  # Loaner and active communicators are real accounts a child uses, so
-  # they must have a passcode. Only enforced for new records or when the
-  # status just changed (e.g. sandbox → loaner promotion) so legacy
-  # records that never had a passcode aren't retroactively invalidated.
-  def loaner_or_active_must_have_login
-    return if sandbox?
-    return unless new_record? || status_changed?
-    if passcode.blank?
-      errors.add(:passcode, "is required for loaner and active communicators")
-    end
   end
 
   def primary_team

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -71,9 +71,8 @@ class ChildAccount < ApplicationRecord
 
   validates :username, presence: true, uniqueness: true
   validates :status, inclusion: { in: STATUSES }
-  # Repaired in B3 (#159):
-  # validate :sandbox_cannot_have_login
-  # validate :loaner_or_active_must_have_login
+  validate :sandbox_cannot_have_login
+  validate :loaner_or_active_must_have_login
 
   delegate :display_docs_for_image, to: :user
 
@@ -169,17 +168,48 @@ class ChildAccount < ApplicationRecord
     account
   end
 
-  def demo_accounts_cannot_have_login
-    return unless is_demo?
-    if username.present? || passcode.present?
-      errors.add(:base, "Demo communicators cannot have a username or passcode.")
+  # Promote a sandbox communicator to a loaner: provision a passcode if
+  # one wasn't supplied and lift the sandbox board cap so the full plan
+  # limit applies. Idempotent on a loaner; raises on active.
+  def promote_to_loaner!(passcode: nil)
+    case status
+    when LOANER
+      return self
+    when ACTIVE
+      raise ArgumentError, "Cannot promote an active communicator back to loaner"
+    end
+
+    self.status = LOANER
+    self.passcode = passcode if passcode.present?
+    self.passcode = SecureRandom.alphanumeric(8) if self.passcode.blank?
+    # Sandbox board cap was per-account in settings["demo_board_limit"];
+    # remove it so the owner's plan board limit applies.
+    self.settings ||= {}
+    self.settings.delete("demo_board_limit")
+    save!
+    self
+  end
+
+  # Sandbox communicators are no-login scratch spaces. Guarded by
+  # new_record?/passcode_changed? so we don't break legacy sandbox rows
+  # that already carry a passcode from the pre-lifecycle era.
+  def sandbox_cannot_have_login
+    return unless sandbox?
+    return unless new_record? || passcode_changed?
+    if passcode.present?
+      errors.add(:passcode, "must be blank for sandbox communicators")
     end
   end
 
-  def paid_accounts_must_have_login
-    return if is_demo?
-    if username.blank? || passcode.blank?
-      errors.add(:base, "Paid communicators must have a username and passcode.")
+  # Loaner and active communicators are real accounts a child uses, so
+  # they must have a passcode. Only enforced for new records or when the
+  # status just changed (e.g. sandbox → loaner promotion) so legacy
+  # records that never had a passcode aren't retroactively invalidated.
+  def loaner_or_active_must_have_login
+    return if sandbox?
+    return unless new_record? || status_changed?
+    if passcode.blank?
+      errors.add(:passcode, "is required for loaner and active communicators")
     end
   end
 

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -180,6 +180,7 @@ class ChildAccount < ApplicationRecord
     end
 
     self.status = LOANER
+    self.loaner_started_at ||= Time.current
     self.passcode = passcode if passcode.present?
     self.passcode = SecureRandom.alphanumeric(8) if self.passcode.blank?
     # Sandbox board cap was per-account in settings["demo_board_limit"];
@@ -189,6 +190,78 @@ class ChildAccount < ApplicationRecord
     save!
     self
   end
+
+  # Generate (or rotate) the claim token the parent uses to take over
+  # this loaner. Loaner-only. The claim URL is built by the controller.
+  def generate_claim_token!
+    raise ArgumentError, "Only loaners can issue a claim token" unless loaner?
+    self.claim_token = SecureRandom.urlsafe_base64(24)
+    self.claim_token_sent_at = Time.current
+    save!
+    claim_token
+  end
+
+  def claim_link_url
+    return nil if claim_token.blank?
+    base = ENV["FRONT_END_URL"] || "http://localhost:8100"
+    "#{base}/claim/#{claim_token}"
+  end
+
+  # Execute the SLP→parent hand-off (B4). Transfers ownership, swaps the
+  # account onto the parent's plan, keeps the SLP on the team as a
+  # supervisor by default, and marks the account active.
+  #
+  # Returns self. Raises ArgumentError on misuse and
+  # Permissions::CommunicatorLimits::SlotFull when the parent has no
+  # room (caller should rescue and surface an upgrade prompt).
+  def claim_by!(user:)
+    raise ArgumentError, "user is required" unless user
+    raise ArgumentError, "Only loaners can be claimed" unless loaner?
+
+    allowed, _http_status, error = Permissions::CommunicatorLimits.can_claim?(user: user)
+    raise SlotFull, (error || "No claim slot available") unless allowed
+
+    previous_owner = owner
+
+    transaction do
+      self.owner = user
+      # `user` is the legacy parent field; the rest of the app uses it
+      # for things like display_name and admin checks. Mirror owner so
+      # account.parent_name reflects the new owner.
+      self.user = user if has_attribute?(:user_id)
+      self.status = ACTIVE
+      self.claimed_at = Time.current
+      self.claim_token = nil
+      self.claim_token_sent_at = nil
+      save!
+
+      if previous_owner && previous_owner != user
+        team = primary_team || ensure_team!(creator: user)
+        team.add_member!(previous_owner, "supervisor")
+        team.add_member!(user, "admin")
+      end
+    end
+
+    self
+  end
+
+  # Manual reclaim / end-loan (B5). Frees the SLP's slot immediately.
+  # The account flips back to a no-login sandbox; the boards stay where
+  # they are. Used by the owner UI and the reclaim job.
+  def reclaim!(reason: "manual")
+    raise ArgumentError, "Only loaners can be reclaimed" unless loaner?
+    self.status = SANDBOX
+    self.passcode = nil
+    self.claim_token = nil
+    self.claim_token_sent_at = nil
+    self.reclaimed_at = Time.current
+    self.settings ||= {}
+    self.settings["reclaim_reason"] = reason
+    save!
+    self
+  end
+
+  class SlotFull < StandardError; end
 
   # Sandbox communicators are no-login scratch spaces. Guarded by
   # new_record?/passcode_changed? so we don't break legacy sandbox rows

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -106,6 +106,14 @@ class ChildAccount < ApplicationRecord
   scope :demo_accounts, -> { sandbox }
   scope :paid_accounts, -> { where.not(status: SANDBOX) }
 
+  # Soft-archive (issue #165). Archived sandboxes disappear from every
+  # default association/query (slot counters, communicator lists, status
+  # group-by) so a pro can stash a planning workspace without losing the
+  # boards. Use `.with_archived` or `.archived` to read past the scope.
+  scope :archived,     -> { unscope(where: :archived_at).where.not(archived_at: nil) }
+  scope :with_archived, -> { unscope(where: :archived_at) }
+  default_scope { where(archived_at: nil) }
+
   before_validation :set_status_from_is_demo, on: :create
   before_save :sync_is_demo_alias
   before_save :set_owner_if_missing, if: -> { owner.nil? && user.present? }
@@ -170,25 +178,41 @@ class ChildAccount < ApplicationRecord
     account
   end
 
-  # Promote a sandbox communicator to a loaner: provision a passcode if
-  # one wasn't supplied and lift the sandbox board cap so the full plan
-  # limit applies. Idempotent on a loaner; raises on active.
+  # Promote a sandbox or active communicator to a loaner.
+  #
+  # Sandbox → loaner: provisions a passcode (uses the caller's if
+  # supplied, otherwise mints one) and lifts the sandbox board cap.
+  #
+  # Active → loaner (issue #164): always rotates the passcode. The SLP
+  # knew the active's credentials; once the family takes over, the SLP
+  # shouldn't retain credential access. Caller-supplied `passcode:` is
+  # honored so an SLP can intentionally hand over a known password.
+  #
+  # Idempotent on a loaner.
   def promote_to_loaner!(passcode: nil)
-    case status
-    when LOANER
-      return self
-    when ACTIVE
-      raise ArgumentError, "Cannot promote an active communicator back to loaner"
-    end
+    return self if loaner?
+
+    from_active = active?
 
     self.status = LOANER
     self.loaner_started_at ||= Time.current
-    self.passcode = passcode if passcode.present?
-    self.passcode = SecureRandom.alphanumeric(8) if self.passcode.blank?
+
+    if passcode.present?
+      self.passcode = passcode
+    elsif self.passcode.blank? || from_active
+      # Mint a fresh passcode whenever sandbox lacks one, or always on
+      # active → loaner (the SLP forfeits their old credential access).
+      self.passcode = SecureRandom.alphanumeric(8)
+    end
+
     # Sandbox board cap was per-account in settings["demo_board_limit"];
     # remove it so the owner's plan board limit applies.
     self.settings ||= {}
     self.settings.delete("demo_board_limit")
+    # Clear the claimed_at watermark — if this active was previously
+    # claimed by the SLP themself, re-lending starts a fresh loan.
+    self.claimed_at = nil if from_active
+
     save!
     self
   end
@@ -264,6 +288,23 @@ class ChildAccount < ApplicationRecord
   end
 
   class SlotFull < StandardError; end
+
+  # Soft-archive a sandbox communicator (issue #165). Sandbox-only — the
+  # loaner/active paths have downstream effects (slot accounting, claim
+  # tokens, family ownership) that need their own flows (`end_loan`).
+  def archive!
+    raise ArgumentError, "Only sandbox communicators can be archived" unless sandbox?
+    return self if archived_at.present?
+    update!(archived_at: Time.current)
+    self
+  end
+
+  def unarchive!
+    update!(archived_at: nil)
+    self
+  end
+
+  def archived? = archived_at.present?
 
   # Surfaced on api_view so the frontend can render a countdown / "link
   # expires" copy without needing to know the reclaim job's cutoff.
@@ -381,6 +422,7 @@ class ChildAccount < ApplicationRecord
       layout: layout,
       status: status,
       is_demo: is_demo?,
+      archived_at: archived_at,
       claim_token: claim_token,
       claim_url: claim_link_url,
       loaned_at: loaner_started_at,
@@ -706,6 +748,7 @@ class ChildAccount < ApplicationRecord
       layout: layout,
       status: status,
       is_demo: is_demo?,
+      archived_at: archived_at,
       claim_token: claim_token,
       claim_url: claim_link_url,
       loaned_at: loaner_started_at,

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -26,12 +26,24 @@
 #  layout                 :jsonb
 #  owner_id               :bigint
 #  is_demo                :boolean          default(FALSE)
+#  status                 :string           default("sandbox"), not null
 #
 class ChildAccount < ApplicationRecord
   # devise :database_authenticatable, :trackable
   # devise :database_authenticatable, :registerable,
   #        :recoverable, :rememberable, :validatable,
   #        authentication_keys: [:username]
+
+  # Communicator lifecycle:
+  #   sandbox — no login, board-capped scratch space (old "demo")
+  #   loaner  — real login + full boards, owned by an SLP on a child's behalf;
+  #             counts against the owner's slot
+  #   active  — claimed/owned by the family; counts against their plan
+  STATUSES = %w[sandbox loaner active].freeze
+  SANDBOX = "sandbox".freeze
+  LOANER  = "loaner".freeze
+  ACTIVE  = "active".freeze
+
   DEMO_ACCOUNT_BOARD_LIMIT = 3
   # Board cap for the MySpeak demo communicator a Free user gets. Stored per
   # account in settings["demo_board_limit"]; Pro demo accounts keep the
@@ -58,8 +70,10 @@ class ChildAccount < ApplicationRecord
   # validates :passcode, length: { minimum: 6 }, on: :create
 
   validates :username, presence: true, uniqueness: true
-  # validate :demo_accounts_cannot_have_login
-  # validate :paid_accounts_must_have_login
+  validates :status, inclusion: { in: STATUSES }
+  # Repaired in B3 (#159):
+  # validate :sandbox_cannot_have_login
+  # validate :loaner_or_active_must_have_login
 
   delegate :display_docs_for_image, to: :user
 
@@ -83,9 +97,16 @@ class ChildAccount < ApplicationRecord
   scope :with_teams, -> { includes(teams: [:team_users]) }
   scope :created_today, -> { where("created_at >= ?", Time.zone.now.beginning_of_day) }
   scope :with_boards, -> { includes(child_boards: :board) }
-  scope :demo_accounts, -> { where(is_demo: true) }
-  scope :paid_accounts, -> { where(is_demo: false) }
+  # Lifecycle scopes. demo_accounts/paid_accounts are kept as thin aliases
+  # during the frontend cutover (F1) and removed when no callers remain.
+  scope :sandbox, -> { where(status: SANDBOX) }
+  scope :loaner,  -> { where(status: LOANER) }
+  scope :active,  -> { where(status: ACTIVE) }
+  scope :demo_accounts, -> { sandbox }
+  scope :paid_accounts, -> { where.not(status: SANDBOX) }
 
+  before_validation :set_status_from_is_demo, on: :create
+  before_save :sync_is_demo_alias
   before_save :set_owner_if_missing, if: -> { owner.nil? && user.present? }
   before_validation :set_username_if_missing, if: -> { username.blank? }
 
@@ -99,6 +120,47 @@ class ChildAccount < ApplicationRecord
 
   def set_owner_if_missing
     self.owner = user
+  end
+
+  # Lifecycle predicates
+  def sandbox? = status == SANDBOX
+  def loaner?  = status == LOANER
+  def active?  = status == ACTIVE
+
+  # `is_demo` is derived from status now. The DB column is retained until the
+  # frontend cutover (F1) is complete, then dropped. Writes to `is_demo` flow
+  # into `status` for backwards compatibility.
+  def is_demo
+    sandbox?
+  end
+
+  alias_method :is_demo?, :is_demo
+
+  def is_demo=(value)
+    truthy = ActiveModel::Type::Boolean.new.cast(value)
+    # Only flip from sandbox <-> active here. Loaner is set explicitly via the
+    # provisioning path (B3). Explicit writes to `is_demo` shouldn't silently
+    # demote a loaner.
+    if truthy
+      self.status = SANDBOX
+    elsif !loaner?
+      self.status = ACTIVE
+    end
+    super(truthy) if has_attribute?(:is_demo)
+  end
+
+  def set_status_from_is_demo
+    # New records that only set the legacy boolean still get a sensible status.
+    return if status_changed? || STATUSES.include?(status)
+    self.status = self[:is_demo] ? SANDBOX : ACTIVE
+  end
+
+  # Keep the legacy boolean in sync with status while the column lives, so
+  # any caller still reading the raw attribute sees a consistent value.
+  def sync_is_demo_alias
+    return unless has_attribute?(:is_demo)
+    desired = sandbox?
+    self[:is_demo] = desired if self[:is_demo] != desired
   end
 
   def self.valid_credentials?(username, password_to_set)
@@ -226,6 +288,7 @@ class ChildAccount < ApplicationRecord
       is_owner: viewing_user&.id == user_id,
       is_vendor: is_vendor,
       layout: layout,
+      status: status,
       is_demo: is_demo?,
       voice: voice,
       vendor: is_vendor ? cached_user.vendor.api_view(viewing_user) : nil,
@@ -545,6 +608,7 @@ class ChildAccount < ApplicationRecord
       is_owner: viewing_user&.id == user_id || viewing_user&.admin?,
       is_vendor: is_vendor,
       layout: layout,
+      status: status,
       is_demo: is_demo?,
       device_tag_url: device_tag_url,
       safety_id_url: safety_id_url,
@@ -656,6 +720,7 @@ class ChildAccount < ApplicationRecord
     current_board_list = current_board_list ? current_board_list.join(", ").truncate(150) : nil
     {
       id: id,
+      status: status,
       username: username,
       name: name,
       parent_name: user.display_name,

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -17,6 +17,19 @@ class TeamUser < ApplicationRecord
   belongs_to :team
 
   before_create :set_defaults
+  before_destroy :snapshot_shared_boards_to_family
+
+  # Safety net for the SLP→family hand-off (B6 — issue #162). When this
+  # membership is destroyed, copy any boards this user shared into the
+  # family's ownership so the communicator never loses access.
+  def snapshot_shared_boards_to_family
+    BoardSnapshotService.snapshot_for_removed_member(team: team, removed_user: user)
+  rescue => e
+    Rails.logger.error "[TeamUser##{id}] board snapshot on destroy failed: #{e.message}"
+    # Never block the membership removal — the family losing future
+    # access is worse than a missed snapshot, which can be re-run.
+    true
+  end
 
   def set_defaults
     self.role.blank? ? self.role = "member" : self.role

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,13 +98,36 @@ class User < ApplicationRecord
            foreign_key: "owner_id",
            dependent: :destroy
 
+  has_many :sandbox_communicator_accounts,
+           -> { where(status: ChildAccount::SANDBOX) },
+           class_name: "ChildAccount",
+           foreign_key: "owner_id"
+
+  has_many :loaner_communicator_accounts,
+           -> { where(status: ChildAccount::LOANER) },
+           class_name: "ChildAccount",
+           foreign_key: "owner_id"
+
+  has_many :active_communicator_accounts,
+           -> { where(status: ChildAccount::ACTIVE) },
+           class_name: "ChildAccount",
+           foreign_key: "owner_id"
+
+  # Owned loaner+active accounts — what counts against the slot limit.
+  has_many :slotted_communicator_accounts,
+           -> { where(status: [ChildAccount::LOANER, ChildAccount::ACTIVE]) },
+           class_name: "ChildAccount",
+           foreign_key: "owner_id"
+
+  # Legacy aliases kept during the frontend cutover (issue #157). They
+  # now resolve through status, not the legacy is_demo column.
   has_many :demo_communicator_accounts,
-           -> { where(is_demo: true) },
+           -> { where(status: ChildAccount::SANDBOX) },
            class_name: "ChildAccount",
            foreign_key: "owner_id"
 
   has_many :paid_communicator_accounts,
-           -> { where(is_demo: false) },
+           -> { where(status: [ChildAccount::LOANER, ChildAccount::ACTIVE]) },
            class_name: "ChildAccount",
            foreign_key: "owner_id"
 
@@ -211,13 +234,20 @@ class User < ApplicationRecord
     plan_type == "pro" ? 5 : 2
   end
 
-  # The MySpeak ID (a demo communicator + public profile) is a free feature:
-  # every Free user gets one demo communicator. ChildAccount::FREE_DEMO_BOARD_LIMIT
-  # caps how many boards that demo communicator can own.
+  # Communicator slot math after the loaner-lifecycle rework (issue #156):
+  #
+  #   paid_communicator_limit — total owned `loaner` + `active` slots.
+  #                             Free has 1 because they can host one
+  #                             *claimed* communicator (B4), even though
+  #                             they cannot self-create one.
+  #   demo_communicator_limit — sandbox (no-login, board-capped) slots.
+  #
+  # `Permissions::CommunicatorLimits.self_create_allowed?` gates whether a
+  # user may create a non-sandbox communicator themselves (paid plan only).
   FREE_PLAN_LIMITS = {
     "plan_type" => "free",
     "board_limit" => ENV.fetch("FREE_BOARD_LIMIT", 1).to_i,
-    "paid_communicator_limit" => ENV.fetch("FREE_PAID_COMMUNICATOR_LIMIT", 0).to_i,
+    "paid_communicator_limit" => ENV.fetch("FREE_PAID_COMMUNICATOR_LIMIT", 1).to_i,
     "demo_communicator_limit" => ENV.fetch("FREE_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
     "ai_monthly_limit" => ENV.fetch("FREE_AI_MONTHLY_LIMIT", 5).to_i,
   }.freeze
@@ -1149,9 +1179,7 @@ class User < ApplicationRecord
     myspeak_slug ||= settings["slug"] || email.split("@").first
     myspeak_name ||= display_name
     Rails.logger.info "Handling MySpeak setup for user #{email} with slug #{myspeak_slug} and name #{myspeak_name}"
-    @child_account = ChildAccount.new(username: myspeak_slug, name: myspeak_name)
-    # Type + ownership
-    @child_account.is_demo = true
+    @child_account = ChildAccount.new(username: myspeak_slug, name: myspeak_name, status: ChildAccount::SANDBOX)
     if free?
       @child_account.settings ||= {}
       @child_account.settings["demo_board_limit"] = ChildAccount::FREE_DEMO_BOARD_LIMIT

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1320,6 +1320,14 @@ class User < ApplicationRecord
     paid_comm_count = paid_communicator_accounts.length
     demo_comm_count = demo_communicator_accounts.length
 
+    # ---- Status-aware counts (loaner-lifecycle, issue #156) ----
+    # Single query, grouped by status, so we don't fire one query per
+    # association. Used by the dashboard slot counter + LoanerControls.
+    status_counts = communicator_accounts.group(:status).count
+    sandbox_count = status_counts.fetch(ChildAccount::SANDBOX, 0)
+    loaner_count  = status_counts.fetch(ChildAccount::LOANER, 0)
+    active_count  = status_counts.fetch(ChildAccount::ACTIVE, 0)
+
     # ---- Derived limits ----
     paid_comm_limit_total = comm_limit
 
@@ -1387,6 +1395,14 @@ class User < ApplicationRecord
       demo_comm_account_limit: demo_limit,
       demo_comm_account_limit_reached: demo_comm_account_limit_reached,
       demo_communicator_count: demo_comm_count,
+
+      # Lifecycle counts (loaner-lifecycle, issue #156). Active+loaner
+      # together count against comm_account_limit. Free hosts one
+      # claimed; claimed_communicator_count = active for Free users.
+      sandbox_communicator_count: sandbox_count,
+      loaner_communicator_count: loaner_count,
+      active_communicator_count: active_count,
+      claimed_communicator_count: active_count,
 
       # Other settings-driven limits
       supervisor_limit: settings["supervisor_limit"] || 0,

--- a/app/services/board_snapshot_service.rb
+++ b/app/services/board_snapshot_service.rb
@@ -1,0 +1,74 @@
+# Safety net for the SLP→family hand-off (B6 — issue #162).
+#
+# When an SLP is removed from a child's team, the boards she shared with
+# that team are snapshot-copied into the family's ownership so the
+# communicator keeps working. The SLP keeps her originals; the family
+# gets frozen copies attached as TeamBoards owned by the family.
+class BoardSnapshotService
+  Result = Struct.new(:snapshotted_count, :skipped_count, keyword_init: true)
+
+  def self.snapshot_for_removed_member(team:, removed_user:)
+    new(team: team, removed_user: removed_user).snapshot!
+  end
+
+  def initialize(team:, removed_user:)
+    @team = team
+    @removed_user = removed_user
+  end
+
+  def snapshot!
+    return Result.new(snapshotted_count: 0, skipped_count: 0) if @team.nil? || @removed_user.nil?
+
+    snapshotted = 0
+    skipped = 0
+
+    family_owner = team_family_owner
+    return Result.new(snapshotted_count: 0, skipped_count: 0) unless family_owner
+    return Result.new(snapshotted_count: 0, skipped_count: 0) if family_owner == @removed_user
+
+    shared_boards_added_by_removed_user.each do |team_board|
+      original = team_board.board
+      next if original.nil?
+
+      # Already-snapshotted check: avoid re-cloning if a snapshot copy
+      # for this team + original exists.
+      already = @team.team_boards.joins(:board)
+                     .where(boards: { user_id: family_owner.id, parent_id: original.id, parent_type: "Board" })
+                     .exists?
+      if already
+        skipped += 1
+        next
+      end
+
+      cloned = original.clone_with_images(family_owner.id, original.name)
+      if cloned.nil? || !cloned.persisted?
+        skipped += 1
+        next
+      end
+      cloned.update(parent_id: original.id, parent_type: "Board") if cloned.has_attribute?(:parent_id)
+
+      @team.team_boards.create!(board: cloned, created_by_id: family_owner.id)
+      snapshotted += 1
+    rescue => e
+      Rails.logger.error "[BoardSnapshotService] failed to snapshot board #{team_board.board_id} for team #{@team.id}: #{e.message}"
+      skipped += 1
+    end
+
+    Rails.logger.info "[BoardSnapshotService] team=#{@team.id} removed_user=#{@removed_user.id} snapshotted=#{snapshotted} skipped=#{skipped}"
+    Result.new(snapshotted_count: snapshotted, skipped_count: skipped)
+  end
+
+  private
+
+  # The "family owner" is the team's communicator account's current
+  # owner (parent after claim; SLP before). If multiple accounts are on
+  # the team, take the first — this is a small-N relationship.
+  def team_family_owner
+    account = @team.accounts.first
+    account&.owner
+  end
+
+  def shared_boards_added_by_removed_user
+    @team.team_boards.where(created_by_id: @removed_user.id).includes(:board)
+  end
+end

--- a/app/sidekiq/loaner_reclaim_job.rb
+++ b/app/sidekiq/loaner_reclaim_job.rb
@@ -1,0 +1,32 @@
+# Daily reclaim sweep for loaner communicators (B5 — issue #161).
+#
+# A loaner whose claim link was sent more than RECLAIM_AFTER ago without
+# being claimed is reclaimed: the account flips back to `sandbox`, the
+# passcode is cleared, and the SLP's slot is freed.
+#
+# The loaner_started_at fallback handles legacy loaners (or ones never
+# given a claim link) so a stranded loaner doesn't rot a slot forever.
+class LoanerReclaimJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 3
+
+  RECLAIM_AFTER = ENV.fetch("LOANER_RECLAIM_AFTER_DAYS", 90).to_i.days
+
+  def perform
+    cutoff = Time.current - RECLAIM_AFTER
+    reclaimed = 0
+
+    ChildAccount.loaner.where(claimed_at: nil).find_each do |account|
+      anchor = account.claim_token_sent_at || account.loaner_started_at || account.created_at
+      next if anchor.nil? || anchor > cutoff
+
+      account.reclaim!(reason: "expired_90d")
+      reclaimed += 1
+    rescue => e
+      Rails.logger.error "[LoanerReclaimJob] failed to reclaim ChildAccount #{account.id}: #{e.message}"
+    end
+
+    Rails.logger.info "[LoanerReclaimJob] reclaimed=#{reclaimed} cutoff=#{cutoff.iso8601}"
+    reclaimed
+  end
+end

--- a/app/views/communication_account_mailer/claim_link_email.html.erb
+++ b/app/views/communication_account_mailer/claim_link_email.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Claim your communicator</title>
+  <style>
+    body { background:#f0f0f0; font-family:Arial,sans-serif; margin:0; padding:20px; }
+    .container { background:#fff; margin:auto; max-width:600px; padding:24px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,.1); }
+    .header { font-size:22px; margin-bottom:16px; color:#1f2937; font-weight:700; }
+    .content { font-size:16px; color:#374151; line-height:1.6; }
+    .button { display:inline-block; margin-top:12px; padding:12px 22px; background:#10b981; color:#fff; text-decoration:none; border-radius:6px; font-weight:600; }
+    .muted { color:#6b7280; font-size:13px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">Make <%= @child_name.presence || "this" %> communicator yours</div>
+    <div class="content">
+      <p><%= @owner_name.presence || "Your therapist" %> set up a SpeakAnyWay communicator for <%= @child_name.presence || "your child" %> and is ready to hand it over.</p>
+      <p>Take ownership in a couple of taps. Your boards, your sign-in, your communicator — kept exactly as it is today.</p>
+      <p style="text-align:center;"><a href="<%= @claim_url %>" class="button">Claim the communicator</a></p>
+      <p class="muted">Free hosting for this one Communicator — no card needed. <%= @owner_name.presence || "Your therapist" %> stays linked as a supervisor; you can change that anytime.</p>
+      <p class="muted">If the button doesn't work, paste this link into your browser:<br><%= @claim_url %></p>
+      <p>Happy Communicating,<br>The SpeakAnyWay Team</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -36,5 +36,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Hourly root-disk check; emails an admin at 80% (warn) / 90% (critical). Skipped on staging.",
     },
+    "loaner_reclaim" => {
+      "cron" => "30 2 * * *",
+      "class" => "LoanerReclaimJob",
+      "queue" => "default",
+      "description" => "Daily reclaim sweep for loaner communicators unclaimed past LOANER_RECLAIM_AFTER_DAYS (default 90). Frees the SLP's slot.",
+    },
   })
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -314,7 +314,13 @@ Rails.application.routes.draw do
         post "assign_boards"
         post "send_setup_email"
         post "promote_to_loaner"
+        post "claim_link"
+        post "end_loan"
         delete "remove_board"
+      end
+      collection do
+        get "claim/:token", to: "child_accounts#claim_preview", as: :claim_preview
+        post "claim/:token", to: "child_accounts#claim", as: :claim
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,6 +313,7 @@ Rails.application.routes.draw do
       member do
         post "assign_boards"
         post "send_setup_email"
+        post "promote_to_loaner"
         delete "remove_board"
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,16 +313,22 @@ Rails.application.routes.draw do
       member do
         post "assign_boards"
         post "send_setup_email"
+        # B3: promote sandbox → loaner. `lend` is the frontend-facing alias.
         post "promote_to_loaner"
+        post "lend", to: "child_accounts#lend"
+        # B4: claim flow controls for the SLP side.
         post "claim_link"
+        post "send_claim_link"
         post "end_loan"
         delete "remove_board"
       end
-      collection do
-        get "claim/:token", to: "child_accounts#claim_preview", as: :claim_preview
-        post "claim/:token", to: "child_accounts#claim", as: :claim
-      end
     end
+
+    # B4: parent-facing claim endpoints — fetched without auth (preview)
+    # or with a signed-in parent (claim). Lives at its own namespace so
+    # the URLs read naturally.
+    get  "communicator_claims/:token", to: "child_accounts#claim_preview", as: :communicator_claim_preview
+    post "communicator_claims/:token/claim", to: "child_accounts#claim", as: :communicator_claim
 
     resources :profiles do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,9 @@ Rails.application.routes.draw do
         post "claim_link"
         post "send_claim_link"
         post "end_loan"
+        # #165: soft-archive sandbox communicators
+        post "archive"
+        post "unarchive"
         delete "remove_board"
       end
     end

--- a/db/migrate/20260523120000_add_status_to_child_accounts.rb
+++ b/db/migrate/20260523120000_add_status_to_child_accounts.rb
@@ -1,0 +1,18 @@
+class AddStatusToChildAccounts < ActiveRecord::Migration[7.1]
+  def up
+    add_column :child_accounts, :status, :string, default: "sandbox", null: false
+    add_index :child_accounts, :status
+
+    # Backfill: is_demo:true → sandbox, is_demo:false → active.
+    # is_demo column is kept for now; removed after frontend cutover (F1).
+    execute <<~SQL
+      UPDATE child_accounts SET status = 'sandbox' WHERE is_demo = TRUE;
+      UPDATE child_accounts SET status = 'active'  WHERE is_demo = FALSE;
+    SQL
+  end
+
+  def down
+    remove_index :child_accounts, :status
+    remove_column :child_accounts, :status
+  end
+end

--- a/db/migrate/20260523140000_add_claim_to_child_accounts.rb
+++ b/db/migrate/20260523140000_add_claim_to_child_accounts.rb
@@ -1,0 +1,12 @@
+class AddClaimToChildAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :child_accounts, :claim_token, :string
+    add_column :child_accounts, :claim_token_sent_at, :datetime
+    add_column :child_accounts, :claimed_at, :datetime
+    add_column :child_accounts, :loaner_started_at, :datetime
+    add_column :child_accounts, :reclaimed_at, :datetime
+
+    add_index :child_accounts, :claim_token, unique: true
+    add_index :child_accounts, :loaner_started_at
+  end
+end

--- a/db/migrate/20260523180000_add_archived_at_to_child_accounts.rb
+++ b/db/migrate/20260523180000_add_archived_at_to_child_accounts.rb
@@ -1,0 +1,6 @@
+class AddArchivedAtToChildAccounts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :child_accounts, :archived_at, :datetime
+    add_index :child_accounts, :archived_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_23_140000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_23_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -302,6 +302,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_23_140000) do
     t.datetime "claimed_at"
     t.datetime "loaner_started_at"
     t.datetime "reclaimed_at"
+    t.datetime "archived_at"
+    t.index ["archived_at"], name: "index_child_accounts_on_archived_at"
     t.index ["authentication_token"], name: "index_child_accounts_on_authentication_token", unique: true
     t.index ["claim_token"], name: "index_child_accounts_on_claim_token", unique: true
     t.index ["loaner_started_at"], name: "index_child_accounts_on_loaner_started_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_22_180000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -296,9 +296,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_22_180000) do
     t.jsonb "layout", default: {}
     t.bigint "owner_id"
     t.boolean "is_demo", default: false
+    t.string "status", default: "sandbox", null: false
     t.index ["authentication_token"], name: "index_child_accounts_on_authentication_token", unique: true
     t.index ["owner_id"], name: "index_child_accounts_on_owner_id"
     t.index ["reset_password_token"], name: "index_child_accounts_on_reset_password_token", unique: true
+    t.index ["status"], name: "index_child_accounts_on_status"
     t.index ["user_id"], name: "index_child_accounts_on_user_id"
     t.index ["username"], name: "index_child_accounts_on_username", unique: true
     t.index ["vendor_id"], name: "index_child_accounts_on_vendor_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_23_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_23_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -297,7 +297,14 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_23_120000) do
     t.bigint "owner_id"
     t.boolean "is_demo", default: false
     t.string "status", default: "sandbox", null: false
+    t.string "claim_token"
+    t.datetime "claim_token_sent_at"
+    t.datetime "claimed_at"
+    t.datetime "loaner_started_at"
+    t.datetime "reclaimed_at"
     t.index ["authentication_token"], name: "index_child_accounts_on_authentication_token", unique: true
+    t.index ["claim_token"], name: "index_child_accounts_on_claim_token", unique: true
+    t.index ["loaner_started_at"], name: "index_child_accounts_on_loaner_started_at"
     t.index ["owner_id"], name: "index_child_accounts_on_owner_id"
     t.index ["reset_password_token"], name: "index_child_accounts_on_reset_password_token", unique: true
     t.index ["status"], name: "index_child_accounts_on_status"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -76,6 +76,9 @@ FactoryBot.define do
   factory :child_account do
     association :user
     sequence(:username) { |n| "child_#{n}" }
+    status { ChildAccount::SANDBOX }
+    # Lifecycle (B3): sandbox = no login, loaner/active = login required.
+    passcode { status.to_s == ChildAccount::SANDBOX ? nil : SecureRandom.hex(4) }
   end
 
   factory(:user) do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -77,8 +77,6 @@ FactoryBot.define do
     association :user
     sequence(:username) { |n| "child_#{n}" }
     status { ChildAccount::SANDBOX }
-    # Lifecycle (B3): sandbox = no login, loaner/active = login required.
-    passcode { status.to_s == ChildAccount::SANDBOX ? nil : SecureRandom.hex(4) }
   end
 
   factory(:user) do

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -3,44 +3,113 @@
 require "rails_helper"
 
 RSpec.describe Permissions::CommunicatorLimits do
+  # Slot math after the loaner-lifecycle rework (issue #158):
+  #   Free  — 0 self-created; may host 1 claimed; +1 sandbox.
+  #   Basic — 2 self-created.
+  #   Pro   — 3 self-created, loaner-capable.
+
   describe ".can_create?" do
-    context "demo communicators (the MySpeak ID) on the free plan" do
-      # created_at outside the soft-trial window so the user stays on `free`
-      # (a fresh free user is flipped to basic_trial by set_soft_trial_plan).
+    context "free user requesting a sandbox communicator" do
+      # created_at outside the soft-trial window so the user stays on `free`.
       let(:user) { create(:user, created_at: 2.months.ago) }
 
-      before do
-        user.settings ||= {}
-        user.settings["demo_communicator_limit"] = 1
-        user.settings["paid_communicator_limit"] = 0
-        user.save!
-      end
+      before { user.setup_free_limits; user.save! }
 
-      it "allows the first MySpeak demo communicator" do
-        allowed, status, error = described_class.can_create?(user: user, is_demo: true)
+      it "allows the first sandbox communicator (the MySpeak ID)" do
+        allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::SANDBOX)
 
         expect(allowed).to be(true)
-        expect(status).to eq(:ok)
+        expect(http_status).to eq(:ok)
         expect(error).to be_nil
       end
 
-      it "blocks a second demo communicator once the slot is used" do
-        create(:child_account, user: user, owner: user, is_demo: true)
+      it "blocks a second sandbox once the slot is used" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::SANDBOX)
 
-        allowed, status, error = described_class.can_create?(user: user, is_demo: true)
+        allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::SANDBOX)
 
         expect(allowed).to be(false)
-        expect(status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_entity)
         expect(error).to match(/limit reached/i)
       end
 
-      it "still blocks paid communicators (free plan includes none)" do
-        allowed, status, error = described_class.can_create?(user: user, is_demo: false)
+      it "blocks self-creating an active communicator (Free can't self-create)" do
+        allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
 
         expect(allowed).to be(false)
-        expect(status).to eq(:forbidden)
-        expect(error).to match(/does not include/i)
+        expect(http_status).to eq(:forbidden)
+        expect(error).to match(/does not allow|does not include/i)
       end
+
+      it "still accepts the legacy is_demo:true shape" do
+        allowed, http_status, _error = described_class.can_create?(user: user, is_demo: true)
+        expect(allowed).to be(true)
+        expect(http_status).to eq(:ok)
+      end
+    end
+
+    context "basic user" do
+      let(:user) { create(:user, plan_type: "basic", created_at: 2.months.ago) }
+
+      it "allows up to two self-created communicators" do
+        2.times { create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE) }
+
+        allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
+
+        expect(allowed).to be(false)
+        expect(http_status).to eq(:unprocessable_entity)
+        expect(error).to match(/maximum.*reached/i)
+      end
+
+      it "allows the second one before the cap" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+
+        allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
+        expect(allowed).to be(true)
+        expect(http_status).to eq(:ok)
+      end
+
+      it "counts loaners against the same slot pool as active" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::LOANER)
+        create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+
+        allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::LOANER)
+        expect(allowed).to be(false)
+        expect(http_status).to eq(:unprocessable_entity)
+      end
+    end
+
+    context "pro user" do
+      let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+      it "allows up to three self-created communicators" do
+        3.times { create(:child_account, user: user, owner: user, status: ChildAccount::LOANER) }
+
+        allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::LOANER)
+        expect(allowed).to be(false)
+        expect(http_status).to eq(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe ".can_claim?" do
+    let(:user) { create(:user, created_at: 2.months.ago) }
+
+    before { user.setup_free_limits; user.save! }
+
+    it "lets a free user host one claimed communicator" do
+      allowed, http_status, _error = described_class.can_claim?(user: user)
+      expect(allowed).to be(true)
+      expect(http_status).to eq(:ok)
+    end
+
+    it "blocks a second claimed communicator once the free slot is used" do
+      create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+
+      allowed, http_status, error = described_class.can_claim?(user: user)
+      expect(allowed).to be(false)
+      expect(http_status).to eq(:unprocessable_entity)
+      expect(error).to match(/maximum/i)
     end
   end
 end

--- a/spec/lib/tasks/plans_rake_spec.rb
+++ b/spec/lib/tasks/plans_rake_spec.rb
@@ -32,11 +32,13 @@ RSpec.describe "plans rake task", type: :task do
       expect(myspeak_user.plan_status).to eq("active")
     end
 
-    it "applies free-plan limits, including the demo-communicator slot" do
+    it "applies free-plan limits, including the sandbox + claimable slots" do
       run_task
 
       settings = myspeak_user.reload.settings
       expect(settings["demo_communicator_limit"]).to eq(1)
+      # Free can host 1 claimed loaner/active (paid_communicator_limit=1).
+      expect(settings["paid_communicator_limit"]).to eq(1)
       expect(settings["board_limit"]).to eq(1)
       expect(settings["plan_nickname"]).to eq("free")
     end

--- a/spec/models/child_account_archive_spec.rb
+++ b/spec/models/child_account_archive_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #165 — soft-archive support for sandbox communicators. Archived
+# rows disappear from default-scoped queries, including the slot counts
+# that drive sandbox limits.
+RSpec.describe ChildAccount, "soft-archive", type: :model do
+  let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  describe "default scope" do
+    it "hides archived records from default queries" do
+      visible  = create(:child_account, user: user, owner: user, status: "sandbox")
+      archived = create(:child_account, user: user, owner: user, status: "sandbox")
+      archived.update!(archived_at: Time.current)
+
+      expect(ChildAccount.all).to include(visible)
+      expect(ChildAccount.all).not_to include(archived)
+    end
+
+    it "exposes archived rows through .archived and .with_archived" do
+      visible  = create(:child_account, user: user, owner: user, status: "sandbox")
+      archived = create(:child_account, user: user, owner: user, status: "sandbox")
+      archived.update!(archived_at: Time.current)
+
+      expect(ChildAccount.archived).to contain_exactly(archived)
+      expect(ChildAccount.with_archived).to include(visible, archived)
+    end
+  end
+
+  describe "association filtering" do
+    it "removes archived sandboxes from user.communicator_accounts" do
+      a = create(:child_account, user: user, owner: user, status: "sandbox")
+      b = create(:child_account, user: user, owner: user, status: "sandbox")
+      b.update!(archived_at: Time.current)
+
+      expect(user.communicator_accounts.reload).to contain_exactly(a)
+    end
+  end
+
+  describe "#archive!" do
+    it "stamps archived_at and stays a sandbox" do
+      account = create(:child_account, user: user, owner: user, status: "sandbox")
+      account.archive!
+      expect(account.archived_at).to be_within(5.seconds).of(Time.current)
+      expect(account.status).to eq("sandbox")
+    end
+
+    it "is idempotent on an already-archived row" do
+      account = create(:child_account, user: user, owner: user, status: "sandbox")
+      account.archive!
+      original = account.archived_at
+      account.archive!
+      expect(account.archived_at).to eq(original)
+    end
+
+    it "preserves boards/settings/details" do
+      account = create(:child_account, user: user, owner: user, status: "sandbox",
+                                       settings: { "voice" => { "name" => "polly:kevin" } },
+                                       details: { "school" => "Lincoln" })
+      board = create(:board, user: user)
+      create(:child_board, child_account: account, board: board)
+
+      account.archive!
+      account.reload
+      expect(account.settings["voice"]).to eq({ "name" => "polly:kevin" })
+      expect(account.details["school"]).to eq("Lincoln")
+      expect(account.child_boards.count).to eq(1)
+    end
+
+    it "refuses on a loaner" do
+      account = create(:child_account, user: user, owner: user, status: "loaner")
+      expect { account.archive! }.to raise_error(ArgumentError)
+    end
+
+    it "refuses on an active" do
+      account = create(:child_account, user: user, owner: user, status: "active")
+      expect { account.archive! }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#unarchive!" do
+    it "clears archived_at" do
+      account = create(:child_account, user: user, owner: user, status: "sandbox")
+      account.archive!
+      ChildAccount.with_archived.find(account.id).unarchive!
+      expect(account.reload.archived_at).to be_nil
+    end
+  end
+
+  describe "slot accounting" do
+    it "frees the sandbox limit (archived doesn't count toward sandbox_communicator_count)" do
+      user.setup_pro_limits
+      user.save!
+      create(:child_account, user: user, owner: user, status: "sandbox")
+      archived = create(:child_account, user: user, owner: user, status: "sandbox")
+      archived.update!(archived_at: Time.current)
+
+      view = user.api_view
+      expect(view[:sandbox_communicator_count]).to eq(1)
+    end
+  end
+end

--- a/spec/models/child_account_claim_spec.rb
+++ b/spec/models/child_account_claim_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #160 (B4) — SLP → parent claim hand-off.
+RSpec.describe ChildAccount, "claim flow", type: :model do
+  let(:slp) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:parent) do
+    u = create(:user, created_at: 2.months.ago)
+    u.setup_free_limits
+    u.save!
+    u
+  end
+  let!(:loaner) do
+    account = create(:child_account, user: slp, owner: slp, status: "loaner", passcode: "loaner01")
+    account.ensure_team!(creator: slp)
+    account
+  end
+
+  describe "#generate_claim_token!" do
+    it "issues a token and timestamp" do
+      token = loaner.generate_claim_token!
+      expect(token).to be_present
+      expect(loaner.claim_token).to eq(token)
+      expect(loaner.claim_token_sent_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "refuses on a sandbox" do
+      sandbox = create(:child_account, user: slp, owner: slp, status: "sandbox")
+      expect { sandbox.generate_claim_token! }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#claim_by!" do
+    it "transfers ownership, frees the SLP slot, keeps SLP as supervisor" do
+      loaner.claim_by!(user: parent)
+
+      expect(loaner.status).to eq("active")
+      expect(loaner.owner_id).to eq(parent.id)
+      expect(loaner.user_id).to eq(parent.id)
+      expect(loaner.claimed_at).to be_present
+      expect(loaner.claim_token).to be_nil
+
+      # SLP's slot freed
+      expect(slp.communicator_accounts.where(status: ["loaner", "active"]).count).to eq(0)
+      # Parent now holds it
+      expect(parent.communicator_accounts.where(status: "active").count).to eq(1)
+      # SLP still linked as supervisor on the team
+      team = loaner.reload.primary_team
+      slp_membership = team.team_users.find_by(user_id: slp.id)
+      expect(slp_membership.role).to eq("supervisor")
+    end
+
+    it "raises SlotFull when the parent has no claim slot" do
+      # Parent already hosts one — Free hosts exactly 1 claimed.
+      create(:child_account, user: parent, owner: parent, status: "active", passcode: "x", username: "first")
+
+      expect { loaner.claim_by!(user: parent) }.to raise_error(ChildAccount::SlotFull)
+      expect(loaner.reload.status).to eq("loaner")
+    end
+
+    it "refuses to claim a non-loaner" do
+      sandbox = create(:child_account, user: slp, owner: slp, status: "sandbox")
+      expect { sandbox.claim_by!(user: parent) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#reclaim!" do
+    it "flips loaner back to sandbox and clears the passcode" do
+      loaner.reclaim!
+      expect(loaner.status).to eq("sandbox")
+      expect(loaner.passcode).to be_nil
+      expect(loaner.reclaimed_at).to be_present
+    end
+
+    it "refuses on an active account" do
+      loaner.claim_by!(user: parent)
+      expect { loaner.reclaim! }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/child_account_promote_to_loaner_spec.rb
+++ b/spec/models/child_account_promote_to_loaner_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #159 (B3) — sandbox → loaner adds a working login and lifts the
+# sandbox board cap. Login validations are repaired against status.
+RSpec.describe ChildAccount, "loaner provisioning", type: :model do
+  let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  describe "login validations" do
+    it "rejects a new loaner without a passcode" do
+      account = build(:child_account, user: user, status: "loaner", passcode: nil)
+      expect(account).not_to be_valid
+      expect(account.errors[:passcode]).to be_present
+    end
+
+    it "rejects a new active without a passcode" do
+      account = build(:child_account, user: user, status: "active", passcode: nil)
+      expect(account).not_to be_valid
+    end
+
+    it "rejects setting a passcode on a brand-new sandbox" do
+      account = build(:child_account, user: user, status: "sandbox", passcode: "secret123")
+      expect(account).not_to be_valid
+      expect(account.errors[:passcode]).to be_present
+    end
+
+    it "leaves legacy sandbox-with-passcode rows alone until status is changed" do
+      account = create(:child_account, user: user, status: "sandbox", passcode: nil)
+      # Sneak a passcode into a legacy sandbox without going through the writer.
+      account.update_column(:passcode, "legacy123")
+      account.reload
+
+      account.name = "Edited"
+      expect(account).to be_valid
+    end
+  end
+
+  describe "#promote_to_loaner!" do
+    let(:account) { create(:child_account, user: user, status: "sandbox", passcode: nil) }
+
+    it "flips status to loaner and provisions a passcode" do
+      expect { account.promote_to_loaner! }.to change { account.status }.from("sandbox").to("loaner")
+      expect(account.passcode).to be_present
+    end
+
+    it "honors a caller-supplied passcode" do
+      account.promote_to_loaner!(passcode: "chosenpass")
+      expect(account.passcode).to eq("chosenpass")
+    end
+
+    it "lifts the sandbox board cap" do
+      account.update!(settings: { "demo_board_limit" => 1 })
+      account.promote_to_loaner!
+      expect(account.settings).not_to have_key("demo_board_limit")
+    end
+
+    it "is idempotent on a loaner" do
+      account.promote_to_loaner!
+      expect { account.promote_to_loaner! }.not_to change { account.reload.status }
+    end
+
+    it "refuses to demote an active back to loaner" do
+      account.update!(status: "loaner", passcode: "x")
+      account.update!(status: "active")
+      expect { account.promote_to_loaner! }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/child_account_promote_to_loaner_spec.rb
+++ b/spec/models/child_account_promote_to_loaner_spec.rb
@@ -50,10 +50,21 @@ RSpec.describe ChildAccount, "loaner provisioning", type: :model do
       expect { account.promote_to_loaner! }.not_to change { account.reload.status }
     end
 
-    it "refuses to demote an active back to loaner" do
-      account.update!(status: "loaner", passcode: "x")
-      account.update!(status: "active")
-      expect { account.promote_to_loaner! }.to raise_error(ArgumentError)
+    # Issue #164 — active → loaner is allowed (SLP relends a
+    # self-created active). Passcode is always rotated so the SLP's
+    # old credentials no longer work.
+    it "promotes active → loaner and rotates the passcode" do
+      account.update!(status: "active", passcode: "knownpass")
+      account.promote_to_loaner!
+      expect(account.status).to eq("loaner")
+      expect(account.passcode).to be_present
+      expect(account.passcode).not_to eq("knownpass")
+    end
+
+    it "honors a caller-supplied passcode on active → loaner" do
+      account.update!(status: "active", passcode: "knownpass")
+      account.promote_to_loaner!(passcode: "handoff42")
+      expect(account.passcode).to eq("handoff42")
     end
   end
 end

--- a/spec/models/child_account_promote_to_loaner_spec.rb
+++ b/spec/models/child_account_promote_to_loaner_spec.rb
@@ -2,36 +2,26 @@
 
 require "rails_helper"
 
-# Issue #159 (B3) — sandbox → loaner adds a working login and lifts the
-# sandbox board cap. Login validations are repaired against status.
+# Issue #159 (B3) — sandbox → loaner mints a passcode by default so a
+# child can sign in, but passcodes are optional at every status: callers
+# may create or save a loaner/active without one, and a sandbox may
+# carry one (no validation enforces either rule).
 RSpec.describe ChildAccount, "loaner provisioning", type: :model do
   let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
 
-  describe "login validations" do
-    it "rejects a new loaner without a passcode" do
+  describe "passcode is optional regardless of status" do
+    it "saves a loaner without a passcode" do
       account = build(:child_account, user: user, status: "loaner", passcode: nil)
-      expect(account).not_to be_valid
-      expect(account.errors[:passcode]).to be_present
+      expect(account).to be_valid
     end
 
-    it "rejects a new active without a passcode" do
+    it "saves an active without a passcode" do
       account = build(:child_account, user: user, status: "active", passcode: nil)
-      expect(account).not_to be_valid
+      expect(account).to be_valid
     end
 
-    it "rejects setting a passcode on a brand-new sandbox" do
-      account = build(:child_account, user: user, status: "sandbox", passcode: "secret123")
-      expect(account).not_to be_valid
-      expect(account.errors[:passcode]).to be_present
-    end
-
-    it "leaves legacy sandbox-with-passcode rows alone until status is changed" do
-      account = create(:child_account, user: user, status: "sandbox", passcode: nil)
-      # Sneak a passcode into a legacy sandbox without going through the writer.
-      account.update_column(:passcode, "legacy123")
-      account.reload
-
-      account.name = "Edited"
+    it "saves a sandbox with a passcode" do
+      account = build(:child_account, user: user, status: "sandbox", passcode: "anything")
       expect(account).to be_valid
     end
   end

--- a/spec/models/child_account_status_spec.rb
+++ b/spec/models/child_account_status_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ChildAccount, "status lifecycle", type: :model do
       account = FactoryBot.create(:child_account, user: user, status: "sandbox")
       expect(account[:is_demo]).to be(true)
 
-      account.update!(status: "loaner", passcode: "loaner01")
+      account.update!(status: "loaner")
       expect(account[:is_demo]).to be(false)
 
       account.update!(status: "active")

--- a/spec/models/child_account_status_spec.rb
+++ b/spec/models/child_account_status_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Lifecycle is `sandbox → loaner → active` (see issue #157 / #156).
+# The legacy `is_demo` boolean is kept as a derived alias during the
+# frontend cutover; sandbox accounts are the only ones that are "demo".
+RSpec.describe ChildAccount, "status lifecycle", type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
+  it "defaults a new account to sandbox" do
+    account = FactoryBot.create(:child_account, user: user)
+    expect(account.status).to eq("sandbox")
+    expect(account).to be_sandbox
+    expect(account).to be_is_demo
+  end
+
+  it "treats sandbox as the only demo status" do
+    sandbox = FactoryBot.create(:child_account, user: user, status: "sandbox")
+    loaner  = FactoryBot.create(:child_account, user: user, status: "loaner")
+    active  = FactoryBot.create(:child_account, user: user, status: "active")
+
+    expect(sandbox.is_demo?).to be(true)
+    expect(loaner.is_demo?).to be(false)
+    expect(active.is_demo?).to be(false)
+  end
+
+  it "rejects an unknown status" do
+    account = FactoryBot.build(:child_account, user: user, status: "graduated")
+    expect(account).not_to be_valid
+    expect(account.errors[:status]).to be_present
+  end
+
+  describe "scopes" do
+    let!(:sandbox) { FactoryBot.create(:child_account, user: user, status: "sandbox") }
+    let!(:loaner)  { FactoryBot.create(:child_account, user: user, status: "loaner") }
+    let!(:active)  { FactoryBot.create(:child_account, user: user, status: "active") }
+
+    it "filters by status" do
+      expect(ChildAccount.sandbox).to contain_exactly(sandbox)
+      expect(ChildAccount.loaner).to contain_exactly(loaner)
+      expect(ChildAccount.active).to contain_exactly(active)
+    end
+
+    it "keeps the legacy demo_accounts / paid_accounts aliases for the frontend cutover" do
+      expect(ChildAccount.demo_accounts).to contain_exactly(sandbox)
+      expect(ChildAccount.paid_accounts).to contain_exactly(loaner, active)
+    end
+  end
+
+  describe "legacy is_demo writer" do
+    it "flips sandbox <-> active" do
+      account = FactoryBot.create(:child_account, user: user, status: "active")
+      account.is_demo = true
+      expect(account.status).to eq("sandbox")
+      account.is_demo = false
+      expect(account.status).to eq("active")
+    end
+
+    it "does not silently demote a loaner" do
+      account = FactoryBot.create(:child_account, user: user, status: "loaner")
+      account.is_demo = false
+      expect(account.status).to eq("loaner")
+    end
+  end
+
+  describe "is_demo column sync" do
+    it "keeps the legacy boolean aligned with status on save" do
+      account = FactoryBot.create(:child_account, user: user, status: "sandbox")
+      expect(account[:is_demo]).to be(true)
+
+      account.update!(status: "loaner")
+      expect(account[:is_demo]).to be(false)
+
+      account.update!(status: "active")
+      expect(account[:is_demo]).to be(false)
+    end
+  end
+
+  describe "#api_view" do
+    it "emits status alongside the derived is_demo alias" do
+      account = FactoryBot.create(:child_account, user: user, status: "loaner")
+      view = account.api_view(user)
+      expect(view[:status]).to eq("loaner")
+      expect(view[:is_demo]).to be(false)
+    end
+  end
+
+  describe "#index_api_view" do
+    it "emits status" do
+      account = FactoryBot.create(:child_account, user: user, status: "loaner")
+      expect(account.index_api_view[:status]).to eq("loaner")
+    end
+  end
+end

--- a/spec/models/child_account_status_spec.rb
+++ b/spec/models/child_account_status_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ChildAccount, "status lifecycle", type: :model do
       account = FactoryBot.create(:child_account, user: user, status: "sandbox")
       expect(account[:is_demo]).to be(true)
 
-      account.update!(status: "loaner")
+      account.update!(status: "loaner", passcode: "loaner01")
       expect(account[:is_demo]).to be(false)
 
       account.update!(status: "active")

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe User, "plan limits", type: :model do
-  describe "demo communicator limits" do
-    # MySpeak (a demo communicator + public profile) is a free feature: every
-    # Free user gets one demo-communicator slot. Pro also gets one.
-    it "grants one demo communicator to Free and Pro, none to Basic" do
+  describe "sandbox (legacy demo) communicator limits" do
+    # Every Free user gets one sandbox communicator (the MySpeak ID).
+    # Pro also gets one. Basic has none.
+    it "grants one sandbox communicator to Free and Pro, none to Basic" do
       expect(User::FREE_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
       expect(User::BASIC_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
       expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
@@ -17,25 +17,37 @@ RSpec.describe User, "plan limits", type: :model do
     end
   end
 
+  # Per loaner-lifecycle issue #158:
+  #   Free  — 0 self-created, may HOST 1 claimed (slot pool = 1).
+  #   Basic — 2.
+  #   Pro   — 3.
+  describe "paid (loaner+active) communicator slot limits" do
+    it "matches the locked slot math from the spec" do
+      expect(User::FREE_PLAN_LIMITS["paid_communicator_limit"]).to eq(1)
+      expect(User::BASIC_PLAN_LIMITS["paid_communicator_limit"]).to eq(2)
+      expect(User::PRO_PLAN_LIMITS["paid_communicator_limit"]).to eq(3)
+    end
+  end
+
   describe "#setup_free_limits" do
-    it "gives a free user one demo-communicator slot (the MySpeak ID)" do
+    it "seeds the free-tier slot math (1 sandbox + 1 claimable)" do
       user = build(:user)
       user.setup_free_limits
 
       expect(user.settings["demo_communicator_limit"]).to eq(1)
       expect(user.settings["board_limit"]).to eq(1)
-      expect(user.settings["paid_communicator_limit"]).to eq(0)
+      expect(user.settings["paid_communicator_limit"]).to eq(1)
       expect(user.settings["ai_monthly_limit"]).to eq(5)
     end
   end
 
   describe "#has_myspeak_feature?" do
-    it "is true when the user has a demo-communicator slot" do
+    it "is true when the user has a sandbox communicator slot" do
       user = build(:user, settings: { "demo_communicator_limit" => 1 })
       expect(user.has_myspeak_feature?).to be(true)
     end
 
-    it "is false when the user has no demo-communicator slot" do
+    it "is false when the user has no sandbox communicator slot" do
       user = build(:user, settings: { "demo_communicator_limit" => 0 })
       expect(user.has_myspeak_feature?).to be(false)
     end

--- a/spec/requests/api/child_accounts_archive_spec.rb
+++ b/spec/requests/api/child_accounts_archive_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #165 — archive/unarchive endpoints for sandbox communicators.
+RSpec.describe "API::ChildAccounts archive", type: :request do
+  let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let!(:sandbox) { create(:child_account, user: user, owner: user, status: "sandbox") }
+
+  describe "POST /api/child_accounts/:id/archive" do
+    it "archives a sandbox and drops it from the default communicator list" do
+      post "/api/child_accounts/#{sandbox.id}/archive", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["archived_at"]).to be_present
+
+      get "/api/child_accounts", headers: auth_headers(user)
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).not_to include(sandbox.id)
+    end
+
+    it "rejects non-owners" do
+      other = create(:user)
+      post "/api/child_accounts/#{sandbox.id}/archive", headers: auth_headers(other)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "refuses on loaner" do
+      loaner = create(:child_account, user: user, owner: user, status: "loaner", username: "ln-#{SecureRandom.hex(2)}")
+      post "/api/child_accounts/#{loaner.id}/archive", headers: auth_headers(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "refuses on active" do
+      active = create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}")
+      post "/api/child_accounts/#{active.id}/archive", headers: auth_headers(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/unarchive" do
+    before { sandbox.archive! }
+
+    it "restores an archived sandbox" do
+      post "/api/child_accounts/#{sandbox.id}/unarchive", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["archived_at"]).to be_nil
+
+      get "/api/child_accounts", headers: auth_headers(user)
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).to include(sandbox.id)
+    end
+  end
+end

--- a/spec/requests/api/child_accounts_claim_spec.rb
+++ b/spec/requests/api/child_accounts_claim_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 # Issue #160 (B4) — claim hand-off through the API.
 RSpec.describe "API::ChildAccounts claim flow", type: :request do
+  include ActiveJob::TestHelper
+
   let(:slp) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
   let(:parent) do
     u = create(:user, created_at: 2.months.ago)
@@ -34,45 +36,123 @@ RSpec.describe "API::ChildAccounts claim flow", type: :request do
     end
   end
 
-  describe "GET /api/child_accounts/claim/:token (public preview)" do
+  describe "GET /api/communicator_claims/:token (public preview)" do
     before { loaner.generate_claim_token! }
 
-    it "returns minimal info without requiring auth" do
-      get "/api/child_accounts/claim/#{loaner.claim_token}"
+    it "returns the preview shape without requiring auth" do
+      get "/api/communicator_claims/#{loaner.claim_token}"
 
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
-      expect(body["name"]).to eq(loaner.display_name)
+      expect(body["child_name"]).to eq(loaner.display_name)
+      expect(body["communicator_name"]).to eq(loaner.display_name)
       expect(body["owner_name"]).to eq(slp.display_name)
+      expect(body["owner_email"]).to eq(slp.email)
+      expect(body["status"]).to eq("loaner")
+      expect(body["expired"]).to be(false)
+      expect(body["already_claimed"]).to be(false)
+    end
+
+    it "reports already_claimed once the loaner has been claimed" do
+      loaner.claim_by!(user: parent)
+      get "/api/communicator_claims/#{loaner.claim_token}"
+      # claim clears the token, so this 404s — caller should have a
+      # token from BEFORE the claim. Simulate by re-issuing one on the
+      # now-active account (the preview just inspects the row).
+      loaner.update_column(:claim_token, "preview-token")
+
+      get "/api/communicator_claims/preview-token"
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("claimed")
+      expect(body["already_claimed"]).to be(true)
     end
 
     it "404s on an unknown token" do
-      get "/api/child_accounts/claim/garbage"
+      get "/api/communicator_claims/garbage"
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  describe "POST /api/child_accounts/claim/:token" do
+  describe "POST /api/communicator_claims/:token/claim" do
     before { loaner.generate_claim_token! }
 
     it "lets the parent claim, transferring ownership" do
-      post "/api/child_accounts/claim/#{loaner.claim_token}", headers: auth_headers(parent)
+      post "/api/communicator_claims/#{loaner.claim_token}/claim", headers: auth_headers(parent)
 
       expect(response).to have_http_status(:ok)
-      loaner.reload
-      expect(loaner.status).to eq("active")
-      expect(loaner.owner_id).to eq(parent.id)
+      body = JSON.parse(response.body)
+      expect(body["account"]).to be_present
+      expect(body["account"]["status"]).to eq("active")
+      expect(loaner.reload.owner_id).to eq(parent.id)
     end
 
     it "returns slot_full when the parent has no room" do
       create(:child_account, user: parent, owner: parent, status: "active",
                              passcode: "x", username: "preclaimed-#{SecureRandom.hex(2)}")
 
-      post "/api/child_accounts/claim/#{loaner.claim_token}", headers: auth_headers(parent)
+      post "/api/communicator_claims/#{loaner.claim_token}/claim", headers: auth_headers(parent)
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(JSON.parse(response.body)["error"]).to eq("slot_full")
       expect(loaner.reload.status).to eq("loaner")
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/lend" do
+    let!(:sandbox) do
+      account = create(:child_account, user: slp, owner: slp, status: "sandbox", passcode: nil)
+      account.ensure_team!(creator: slp)
+      account
+    end
+
+    it "promotes sandbox → loaner and returns a claim_url in one round trip" do
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:ok)
+      sandbox.reload
+      expect(sandbox.status).to eq("loaner")
+      expect(sandbox.claim_token).to be_present
+      body = JSON.parse(response.body)
+      expect(body["claim_url"]).to include(sandbox.claim_token)
+      expect(body["loaned_at"]).to be_present
+    end
+
+    it "rotates the token when called again on a loaner" do
+      sandbox.promote_to_loaner!(passcode: "abc")
+      old_token = sandbox.generate_claim_token!
+
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(slp)
+      expect(response).to have_http_status(:ok)
+      expect(sandbox.reload.claim_token).not_to eq(old_token)
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/send_claim_link" do
+    before do
+      loaner.generate_claim_token!
+      ActionMailer::Base.deliveries.clear
+    end
+
+    it "delivers the claim link to the supplied email" do
+      perform_enqueued_jobs do
+        post "/api/child_accounts/#{loaner.id}/send_claim_link",
+          params: { email: "family@example.com" },
+          headers: auth_headers(slp)
+      end
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["ok"]).to be(true)
+      expect(body["claim_url"]).to include(loaner.reload.claim_token)
+      expect(ActionMailer::Base.deliveries.last.to).to eq(["family@example.com"])
+    end
+
+    it "rejects a bad email" do
+      post "/api/child_accounts/#{loaner.id}/send_claim_link",
+        params: { email: "not-an-email" },
+        headers: auth_headers(slp)
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 

--- a/spec/requests/api/child_accounts_claim_spec.rb
+++ b/spec/requests/api/child_accounts_claim_spec.rb
@@ -126,6 +126,48 @@ RSpec.describe "API::ChildAccounts claim flow", type: :request do
       expect(response).to have_http_status(:ok)
       expect(sandbox.reload.claim_token).not_to eq(old_token)
     end
+
+    # Issue #164 — an SLP can lend an active they self-created. The
+    # ownership guard is sufficient: by the time we get here, the
+    # caller IS the owner, which means no family ever claimed it.
+    context "when the SLP owns an active communicator (issue #164)" do
+      let!(:slp_active) do
+        account = create(:child_account, user: slp, owner: slp, status: "active",
+                                         passcode: "knownpass", username: "slp-active-#{SecureRandom.hex(2)}")
+        account.ensure_team!(creator: slp)
+        account
+      end
+
+      it "promotes active → loaner and rotates the passcode" do
+        post "/api/child_accounts/#{slp_active.id}/lend", headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:ok)
+        slp_active.reload
+        expect(slp_active.status).to eq("loaner")
+        expect(slp_active.passcode).not_to eq("knownpass")
+        expect(slp_active.passcode).to be_present
+        expect(slp_active.claim_token).to be_present
+      end
+
+      it "honors a caller-supplied passcode override" do
+        post "/api/child_accounts/#{slp_active.id}/lend",
+          params: { passcode: "handoff42" },
+          headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:ok)
+        expect(slp_active.reload.passcode).to eq("handoff42")
+      end
+
+      it "rejects with the family-claimed message when the caller doesn't own the active" do
+        slp_active.update!(owner: parent, user: parent, claimed_at: Time.current)
+
+        post "/api/child_accounts/#{slp_active.id}/lend", headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to match(/owned by someone else/i)
+        expect(slp_active.reload.status).to eq("active")
+      end
+    end
   end
 
   describe "POST /api/child_accounts/:id/send_claim_link" do

--- a/spec/requests/api/child_accounts_claim_spec.rb
+++ b/spec/requests/api/child_accounts_claim_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #160 (B4) — claim hand-off through the API.
+RSpec.describe "API::ChildAccounts claim flow", type: :request do
+  let(:slp) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:parent) do
+    u = create(:user, created_at: 2.months.ago)
+    u.setup_free_limits
+    u.save!
+    u
+  end
+  let!(:loaner) do
+    account = create(:child_account, user: slp, owner: slp, status: "loaner", passcode: "loaner01")
+    account.ensure_team!(creator: slp)
+    account
+  end
+
+  describe "POST /api/child_accounts/:id/claim_link" do
+    it "issues a claim link the SLP can share" do
+      post "/api/child_accounts/#{loaner.id}/claim_link", headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["claim_token"]).to be_present
+      expect(body["claim_url"]).to include(body["claim_token"])
+    end
+
+    it "rejects non-owners" do
+      other = create(:user)
+      post "/api/child_accounts/#{loaner.id}/claim_link", headers: auth_headers(other)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "GET /api/child_accounts/claim/:token (public preview)" do
+    before { loaner.generate_claim_token! }
+
+    it "returns minimal info without requiring auth" do
+      get "/api/child_accounts/claim/#{loaner.claim_token}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["name"]).to eq(loaner.display_name)
+      expect(body["owner_name"]).to eq(slp.display_name)
+    end
+
+    it "404s on an unknown token" do
+      get "/api/child_accounts/claim/garbage"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST /api/child_accounts/claim/:token" do
+    before { loaner.generate_claim_token! }
+
+    it "lets the parent claim, transferring ownership" do
+      post "/api/child_accounts/claim/#{loaner.claim_token}", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      loaner.reload
+      expect(loaner.status).to eq("active")
+      expect(loaner.owner_id).to eq(parent.id)
+    end
+
+    it "returns slot_full when the parent has no room" do
+      create(:child_account, user: parent, owner: parent, status: "active",
+                             passcode: "x", username: "preclaimed-#{SecureRandom.hex(2)}")
+
+      post "/api/child_accounts/claim/#{loaner.claim_token}", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("slot_full")
+      expect(loaner.reload.status).to eq("loaner")
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/end_loan" do
+    it "lets the SLP reclaim the slot" do
+      post "/api/child_accounts/#{loaner.id}/end_loan", headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:ok)
+      expect(loaner.reload.status).to eq("sandbox")
+    end
+
+    it "rejects non-owners" do
+      other = create(:user)
+      post "/api/child_accounts/#{loaner.id}/end_loan", headers: auth_headers(other)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "API::ChildAccounts demo (MySpeak) limits", type: :request do
+RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
   describe "POST /api/child_accounts" do
-    context "as a free user creating a MySpeak ID" do
+    context "as a free user creating a sandbox communicator" do
       let(:user) do
         u = create(:user, created_at: 2.months.ago)
         u.setup_free_limits
@@ -10,40 +10,88 @@ RSpec.describe "API::ChildAccounts demo (MySpeak) limits", type: :request do
         u
       end
 
-      it "creates the demo communicator capped at one board" do
+      it "creates the sandbox capped at one board" do
         post "/api/child_accounts",
-          params: { name: "My Kid", username: "my-kid-#{SecureRandom.hex(3)}", is_demo: true },
+          params: { name: "My Kid", username: "my-kid-#{SecureRandom.hex(3)}", status: "sandbox", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
         expect(response).to have_http_status(:created)
-        account = ChildAccount.find_by(owner_id: user.id, is_demo: true)
+        account = ChildAccount.find_by(owner_id: user.id, status: "sandbox")
         expect(account).to be_present
         expect(account.settings["demo_board_limit"]).to eq(ChildAccount::FREE_DEMO_BOARD_LIMIT)
         expect(account.settings["demo_board_limit"]).to eq(1)
       end
 
-      it "blocks a second demo communicator once the slot is used" do
-        create(:child_account, user: user, owner: user, is_demo: true)
+      it "blocks a second sandbox once the slot is used" do
+        create(:child_account, user: user, owner: user, status: "sandbox")
 
         post "/api/child_accounts",
-          params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", is_demo: true },
+          params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", status: "sandbox", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "rejects self-creating a non-sandbox communicator on Free" do
+        post "/api/child_accounts",
+          params: { name: "Real", username: "real-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "still accepts the legacy is_demo=true param for backwards compat" do
+        post "/api/child_accounts",
+          params: { name: "Legacy", username: "legacy-#{SecureRandom.hex(3)}", is_demo: true, password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:created)
+        expect(ChildAccount.where(owner_id: user.id, status: "sandbox").count).to eq(1)
       end
     end
 
     context "as a pro user" do
       let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
 
-      it "does not cap a Pro demo communicator at one board" do
+      it "does not cap a Pro sandbox at one board" do
         post "/api/child_accounts",
-          params: { name: "Pro Kid", username: "pro-kid-#{SecureRandom.hex(3)}", is_demo: true },
+          params: { name: "Pro Kid", username: "pro-kid-#{SecureRandom.hex(3)}", status: "sandbox", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
         expect(response).to have_http_status(:created)
-        account = ChildAccount.find_by(owner_id: user.id, is_demo: true)
+        account = ChildAccount.find_by(owner_id: user.id, status: "sandbox")
         expect(account.settings["demo_board_limit"]).to be_nil
+      end
+
+      it "allows up to three self-created loaner/active communicators, then 422s" do
+        3.times do |i|
+          create(:child_account, user: user, owner: user, status: "active",
+                                 username: "p#{i}-#{SecureRandom.hex(2)}")
+        end
+
+        post "/api/child_accounts",
+          params: { name: "Extra", username: "extra-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to match(/maximum/i)
+      end
+    end
+
+    context "as a basic user" do
+      let(:user) { create(:user, plan_type: "basic", created_at: 2.months.ago) }
+
+      it "enforces the 2-communicator cap" do
+        2.times do |i|
+          create(:child_account, user: user, owner: user, status: "active",
+                                 username: "b#{i}-#{SecureRandom.hex(2)}")
+        end
+
+        post "/api/child_accounts",
+          params: { name: "Third", username: "third-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      # Regression for PR #163 review: the pre-save valid? check fired
+      # before the controller assigned passcode, so every non-sandbox
+      # create 422'd with "Passcode is required..." regardless of the
+      # password the user typed.
+      it "actually creates a non-sandbox communicator when the password is supplied" do
+        post "/api/child_accounts",
+          params: { name: "First", username: "first-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:created), -> { response.body }
+        account = ChildAccount.find_by(owner_id: user.id, status: "active")
+        expect(account).to be_present
+        expect(account.passcode).to eq("abcdef")
+      end
     end
   end
 end

--- a/spec/requests/api/child_accounts_promote_spec.rb
+++ b/spec/requests/api/child_accounts_promote_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #159 (B3) — promote sandbox to loaner via the API.
+RSpec.describe "API::ChildAccounts promote_to_loaner", type: :request do
+  let(:user) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let!(:sandbox) { create(:child_account, user: user, owner: user, status: "sandbox", passcode: nil) }
+
+  it "promotes a sandbox to loaner" do
+    post "/api/child_accounts/#{sandbox.id}/promote_to_loaner",
+      params: { passcode: "rentme01" },
+      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(sandbox.reload.status).to eq("loaner")
+    expect(sandbox.passcode).to eq("rentme01")
+  end
+
+  it "rejects promotion when the owner is out of slots" do
+    3.times do |i|
+      create(:child_account, user: user, owner: user, status: "loaner",
+                             username: "p#{i}-#{SecureRandom.hex(2)}", passcode: "x#{i}")
+    end
+
+    post "/api/child_accounts/#{sandbox.id}/promote_to_loaner",
+      params: { passcode: "rentme01" },
+      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(sandbox.reload.status).to eq("sandbox")
+  end
+
+  it "refuses to promote a non-sandbox" do
+    sandbox.update!(status: "loaner", passcode: "existing01")
+
+    post "/api/child_accounts/#{sandbox.id}/promote_to_loaner",
+      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "rejects unauthorized users" do
+    other = create(:user)
+    post "/api/child_accounts/#{sandbox.id}/promote_to_loaner",
+      headers: auth_headers(other)
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/services/board_snapshot_service_spec.rb
+++ b/spec/services/board_snapshot_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #162 (B6) — snapshot shared boards into family ownership when
+# the SLP is removed from a child's team.
+RSpec.describe BoardSnapshotService, type: :service do
+  let(:slp) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:parent) do
+    u = create(:user, created_at: 2.months.ago)
+    u.setup_free_limits
+    u.save!
+    u
+  end
+  let!(:child) do
+    account = create(:child_account, user: parent, owner: parent, status: "active", passcode: "p")
+    account.ensure_team!(creator: parent)
+    account
+  end
+  let(:team) { child.primary_team }
+  let!(:slp_board) { create(:board, user: slp) }
+
+  before do
+    team.add_member!(parent, "admin")
+    team.add_member!(slp, "supervisor")
+    team.team_boards.create!(board: slp_board, created_by_id: slp.id)
+  end
+
+  it "copies the SLP's shared boards into the family's ownership" do
+    result = described_class.snapshot_for_removed_member(team: team, removed_user: slp)
+
+    expect(result.snapshotted_count).to eq(1)
+
+    snapshot = team.boards.where(user_id: parent.id).first
+    expect(snapshot).to be_present
+    expect(snapshot.name).to eq(slp_board.name)
+    expect(snapshot.id).not_to eq(slp_board.id)
+  end
+
+  it "doesn't snapshot boards added by other people" do
+    other_pro = create(:user)
+    other_board = create(:board, user: other_pro)
+    team.team_boards.create!(board: other_board, created_by_id: other_pro.id)
+
+    described_class.snapshot_for_removed_member(team: team, removed_user: slp)
+
+    family_boards = team.boards.where(user_id: parent.id)
+    expect(family_boards.count).to eq(1)
+    expect(family_boards.first.name).to eq(slp_board.name)
+  end
+
+  it "is idempotent — running twice does not create duplicate snapshots" do
+    described_class.snapshot_for_removed_member(team: team, removed_user: slp)
+    result = described_class.snapshot_for_removed_member(team: team, removed_user: slp)
+    expect(result.snapshotted_count).to eq(0)
+    expect(team.boards.where(user_id: parent.id).count).to eq(1)
+  end
+
+  it "leaves the SLP's originals untouched" do
+    described_class.snapshot_for_removed_member(team: team, removed_user: slp)
+    expect(slp_board.reload.user_id).to eq(slp.id)
+  end
+
+  describe "via TeamUser destruction" do
+    it "fires on team_user.destroy and the family keeps a copy" do
+      slp_team_user = team.team_users.find_by(user_id: slp.id)
+      expect { slp_team_user.destroy! }.to change { team.boards.where(user_id: parent.id).count }.from(0).to(1)
+    end
+  end
+end

--- a/spec/sidekiq/loaner_reclaim_job_spec.rb
+++ b/spec/sidekiq/loaner_reclaim_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #161 (B5) — 90-day auto-reclaim.
+RSpec.describe LoanerReclaimJob, type: :job do
+  let(:slp) { create(:user, plan_type: "pro", created_at: 6.months.ago) }
+
+  def loaner_with(claim_token_sent_at: nil, loaner_started_at: nil, status: "loaner", claimed_at: nil)
+    create(:child_account,
+           user: slp, owner: slp,
+           status: status, passcode: "x#{SecureRandom.hex(2)}",
+           username: "loan-#{SecureRandom.hex(3)}",
+           claim_token_sent_at: claim_token_sent_at,
+           loaner_started_at: loaner_started_at,
+           claimed_at: claimed_at)
+  end
+
+  it "reclaims a loaner whose claim link was sent over 90 days ago" do
+    stale = loaner_with(claim_token_sent_at: 95.days.ago)
+
+    described_class.new.perform
+
+    expect(stale.reload.status).to eq("sandbox")
+    expect(stale.passcode).to be_nil
+  end
+
+  it "leaves a loaner inside the 90-day window alone" do
+    fresh = loaner_with(claim_token_sent_at: 30.days.ago)
+
+    described_class.new.perform
+
+    expect(fresh.reload.status).to eq("loaner")
+  end
+
+  it "falls back to loaner_started_at when no claim link was sent" do
+    stale = loaner_with(claim_token_sent_at: nil, loaner_started_at: 100.days.ago)
+
+    described_class.new.perform
+
+    expect(stale.reload.status).to eq("sandbox")
+  end
+
+  it "doesn't touch claimed (active) accounts" do
+    parent = create(:user)
+    active = create(:child_account, user: parent, owner: parent, status: "active",
+                                    passcode: "p", username: "active-#{SecureRandom.hex(2)}",
+                                    claimed_at: 200.days.ago)
+
+    described_class.new.perform
+
+    expect(active.reload.status).to eq("active")
+  end
+
+  it "frees the SLP's slot on reclaim" do
+    loaner_with(claim_token_sent_at: 95.days.ago)
+    expect {
+      described_class.new.perform
+    }.to change { slp.communicator_accounts.where(status: ["loaner", "active"]).count }.from(1).to(0)
+  end
+end


### PR DESCRIPTION
Implements the loaner lifecycle epic ([#156](https://github.com/brittanyjohns/itty_bitty_boards/issues/156)) — replaces the `child_accounts.is_demo` boolean with a `sandbox → loaner → active` status lifecycle and ships the SLP → parent claim hand-off.

## Issues closed

- [#157](https://github.com/brittanyjohns/itty_bitty_boards/issues/157) — B1: status lifecycle on ChildAccount (retire is_demo)
- [#158](https://github.com/brittanyjohns/itty_bitty_boards/issues/158) — B2: status-aware communicator limits + slot math
- [#159](https://github.com/brittanyjohns/itty_bitty_boards/issues/159) — B3: loaner provisioning (sandbox → loaner adds login)
- [#160](https://github.com/brittanyjohns/itty_bitty_boards/issues/160) — B4: claim flow — ownership transfer SLP → parent
- [#161](https://github.com/brittanyjohns/itty_bitty_boards/issues/161) — B5: reclaim — 90-day expiry + manual end-loan
- [#162](https://github.com/brittanyjohns/itty_bitty_boards/issues/162) — B6: board snapshot on disconnect

## Summary

- **Lifecycle.** New `child_accounts.status` column (sandbox/loaner/active, default sandbox), backfilled from `is_demo`. `is_demo` column is kept and synced as a derived alias until the frontend cutover (F1) lands. New scopes (`sandbox`/`loaner`/`active`); old `demo_accounts`/`paid_accounts` aliases retained.
- **Slot math.** `Permissions::CommunicatorLimits.can_create?` / `.can_claim?` are status-aware. Free = 0 self-created + 1 claimable + 1 sandbox; Basic = 2; Pro = 3 (loaner-capable). `paid_communicator_limit` now means *total loaner+active owned*; self-create is gated by paid plan.
- **Provisioning.** `ChildAccount#promote_to_loaner!` flips sandbox → loaner, mints a passcode, lifts the sandbox board cap. Repaired sandbox/loaner login validations (guarded by `new_record?` / `passcode_changed?` so legacy rows aren't retroactively invalid).
- **Claim flow.** New columns: `claim_token` (+ unique index), `claim_token_sent_at`, `claimed_at`, `loaner_started_at`, `reclaimed_at`. `ChildAccount#claim_by!(user:)` transfers `owner_id` SLP → parent, sets status active, keeps SLP on the team as supervisor. Endpoints: `POST :id/claim_link`, `GET claim/:token` (public preview), `POST claim/:token` (parent-auth).
- **Reclaim.** `LoanerReclaimJob` runs daily 02:30 UTC, reclaims loaners unclaimed past `LOANER_RECLAIM_AFTER_DAYS` (default 90). Manual `POST :id/end_loan` shares the same `ChildAccount#reclaim!` path.
- **Board snapshot.** `BoardSnapshotService` + `TeamUser#before_destroy` copy the removed user's shared team boards into the family's ownership so a removed SLP never strands the child's boards. Idempotent.

## ENV change needed at deploy

`FREE_PAID_COMMUNICATOR_LIMIT` should be set to `1` (was `0`). Free now hosts one claimed loaner; with `0`, the claim flow would 403.

## Test plan

- [x] `bundle exec rspec` — 672 examples, 0 failures, 17 pending.
- [x] Added focused specs: ChildAccount status lifecycle, promote-to-loaner, claim flow, reclaim job, board snapshot service, plus updated `child_accounts_demo_limit_spec`, `user_plan_limits_spec`, `plans_rake_spec`, `communicator_limits_spec` for the new slot math.
- [ ] Frontend changes ([F1–F4 in itty-bitty-frontend](https://github.com/brittanyjohns/itty-bitty-frontend/issues/153)) are required to stop reading `is_demo` and surface the new `status` / claim UI; backwards-compatible aliases let backend ship first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)