### PR TITLE
chore(plans): rake task to backfill per-tier communicator limits

### DIFF
--- a/lib/tasks/plans.rake
+++ b/lib/tasks/plans.rake
@@ -1,4 +1,82 @@
 namespace :plans do
+  # Map plan_type → the PLAN_LIMITS constant on User that defines the
+  # current per-tier defaults. partner_pro and basic_trial inherit
+  # their paid tier's slot math (matches User#setup_limits).
+  BACKFILL_LIMITS_BY_PLAN = {
+    "free"         => User::FREE_PLAN_LIMITS,
+    "basic"        => User::BASIC_PLAN_LIMITS,
+    "basic_yearly" => User::BASIC_PLAN_LIMITS,
+    "basic_trial"  => User::BASIC_PLAN_LIMITS,
+    "pro"          => User::PRO_PLAN_LIMITS,
+    "pro_yearly"   => User::PRO_PLAN_LIMITS,
+    "partner_pro"  => User::PRO_PLAN_LIMITS,
+  }.freeze
+
+  BACKFILL_LIMIT_KEYS = %w[paid_communicator_limit demo_communicator_limit board_limit ai_monthly_limit].freeze
+
+  desc "Backfill per-tier limits onto user.settings, filling missing/zero values without clobbering admin-tuned higher values"
+  task backfill_communicator_limits: :environment do
+    dry_run = ENV["DRY_RUN"] == "true"
+    only_plans = ENV["PLANS"]&.split(",")&.map(&:strip)
+    updated = 0
+    unchanged = 0
+    skipped = 0
+    by_plan = Hash.new(0)
+
+    scope = User.all
+    scope = scope.where(plan_type: only_plans) if only_plans
+
+    puts "[backfill_communicator_limits] starting (dry_run=#{dry_run} plans=#{only_plans || "all"})"
+
+    scope.find_each(batch_size: 200) do |user|
+      defaults = BACKFILL_LIMITS_BY_PLAN[user.plan_type]
+      unless defaults
+        skipped += 1
+        next
+      end
+
+      user.settings ||= {}
+      changes = {}
+
+      BACKFILL_LIMIT_KEYS.each do |key|
+        current = user.settings[key].to_i
+        # Fill when missing or explicitly 0 — never clobber a higher
+        # value an admin set intentionally.
+        if current <= 0 && defaults[key].to_i > 0
+          changes[key] = defaults[key]
+        end
+      end
+
+      if changes.empty?
+        unchanged += 1
+        next
+      end
+
+      by_plan[user.plan_type] += 1
+
+      if dry_run
+        puts "  would update user=#{user.id} plan=#{user.plan_type} changes=#{changes.inspect}"
+        updated += 1
+      else
+        user.settings.merge!(changes)
+        # update_columns to skip callbacks — the plan_type isn't
+        # changing, and we don't want before_save :setup_limits to
+        # also run and overwrite ai_monthly_limit etc.
+        user.update_columns(settings: user.settings, updated_at: Time.current)
+        updated += 1
+        print "." if updated % 100 == 0
+      end
+    rescue => e
+      skipped += 1
+      warn "[plans:backfill_communicator_limits] user #{user.id} failed: #{e.message}"
+    end
+
+    puts
+    puts "[backfill_communicator_limits] done. updated=#{updated} unchanged=#{unchanged} skipped=#{skipped}"
+    by_plan.sort.each { |plan, count| puts "  #{plan}: #{count}" }
+    puts "(dry run — no rows were written)" if dry_run
+  end
+
   desc "Migrate users on the retired MySpeak plan tier to the free plan"
   task migrate_myspeak_to_free: :environment do
     migrated = 0

--- a/spec/lib/tasks/plans_rake_spec.rb
+++ b/spec/lib/tasks/plans_rake_spec.rb
@@ -55,4 +55,81 @@ RSpec.describe "plans rake task", type: :task do
       expect(myspeak_user.reload.plan_type).to eq("free")
     end
   end
+
+  describe "plans:backfill_communicator_limits" do
+    let(:task) { Rake::Task["plans:backfill_communicator_limits"] }
+
+    def zero_settings(plan)
+      {
+        "paid_communicator_limit" => 0,
+        "demo_communicator_limit" => 0,
+        "board_limit" => 0,
+        "ai_monthly_limit" => 0,
+        "plan_nickname" => plan,
+      }
+    end
+
+    it "fills zero/missing limits for a Pro user without clobbering higher values" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago, settings: zero_settings("pro"))
+      # Admin-bumped slot we must preserve.
+      pro.update!(settings: pro.settings.merge("paid_communicator_limit" => 10))
+
+      run_task
+
+      settings = pro.reload.settings
+      expect(settings["paid_communicator_limit"]).to eq(10) # preserved
+      expect(settings["demo_communicator_limit"]).to eq(User::PRO_PLAN_LIMITS["demo_communicator_limit"])
+      expect(settings["board_limit"]).to eq(User::PRO_PLAN_LIMITS["board_limit"])
+      expect(settings["ai_monthly_limit"]).to eq(User::PRO_PLAN_LIMITS["ai_monthly_limit"])
+    end
+
+    it "fills the new Free paid_communicator_limit=1 onto legacy Free users" do
+      free = create(:user, plan_type: "free", created_at: 1.year.ago)
+      free.update!(settings: free.settings.merge("paid_communicator_limit" => 0))
+
+      run_task
+
+      expect(free.reload.settings["paid_communicator_limit"]).to eq(1)
+    end
+
+    it "applies Pro defaults to partner_pro users" do
+      partner = create(:user, plan_type: "partner_pro", created_at: 2.months.ago, settings: zero_settings("partner_pro"))
+
+      run_task
+
+      settings = partner.reload.settings
+      expect(settings["paid_communicator_limit"]).to eq(User::PRO_PLAN_LIMITS["paid_communicator_limit"])
+      expect(settings["demo_communicator_limit"]).to eq(User::PRO_PLAN_LIMITS["demo_communicator_limit"])
+    end
+
+    it "is idempotent — second run makes no further changes" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago, settings: zero_settings("pro"))
+
+      run_task
+      first = pro.reload.settings.dup
+
+      task.reenable
+      task.invoke
+      expect(pro.reload.settings).to eq(first)
+    end
+
+    it "honors DRY_RUN by reporting but not writing" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago, settings: zero_settings("pro"))
+
+      ENV["DRY_RUN"] = "true"
+      begin
+        expect { run_task }.not_to(change { pro.reload.settings["paid_communicator_limit"] })
+      ensure
+        ENV.delete("DRY_RUN")
+      end
+    end
+
+    it "skips users on an unknown plan_type" do
+      mystery = create(:user, plan_type: "experimental_x", created_at: 2.months.ago, settings: zero_settings("experimental_x"))
+
+      run_task
+
+      expect(mystery.reload.settings["paid_communicator_limit"]).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to [#163](https://github.com/brittanyjohns/itty_bitty_boards/pull/163). Existing users whose `settings["paid_communicator_limit"]` / `demo_communicator_limit` / `board_limit` / `ai_monthly_limit` are missing or `0` (legacy accounts that pre-date the loaner-lifecycle defaults) silently hit "Your plan does not include communicator accounts" on the lend flow. This task is the recovery path.

`bin/rails plans:backfill_communicator_limits` walks every user, fills the four limit keys from the matching `User::*_PLAN_LIMITS`, and **never clobbers a higher value** an admin set intentionally. Uses `update_columns` so `before_save :setup_limits` doesn't fire and overwrite anything.

- Plans covered: free, basic, basic_yearly, basic_trial, pro, pro_yearly, partner_pro. Unknown plans are skipped and counted.
- `DRY_RUN=true` prints every proposed change without writing.
- `PLANS=pro,pro_yearly` scopes to specific plan_types.
- Per-plan summary at the end.

## Test plan

- [x] `bundle exec rspec spec/lib/tasks/plans_rake_spec.rb` — 10/10
  - preserves admin-bumped values
  - backfills legacy Free users to `paid_communicator_limit=1`
  - `partner_pro` inherits Pro defaults
  - idempotent
  - `DRY_RUN=true` writes nothing
  - unknown plan_type is skipped
- [ ] On staging: `DRY_RUN=true bin/rails plans:backfill_communicator_limits`, eyeball the diff, then re-run without `DRY_RUN`.
- [ ] On prod: same dry-run-first sequence after the new code is rolled out and `FREE_PAID_COMMUNICATOR_LIMIT=1` is set in Hatchbox env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)