### PR TITLE
fix(plans): defer User::*_PLAN_LIMITS lookup so deploy doesn't NameError

### DIFF
--- a/lib/tasks/plans.rake
+++ b/lib/tasks/plans.rake
@@ -1,21 +1,25 @@
 namespace :plans do
-  # Map plan_type → the PLAN_LIMITS constant on User that defines the
-  # current per-tier defaults. partner_pro and basic_trial inherit
-  # their paid tier's slot math (matches User#setup_limits).
-  BACKFILL_LIMITS_BY_PLAN = {
-    "free"         => User::FREE_PLAN_LIMITS,
-    "basic"        => User::BASIC_PLAN_LIMITS,
-    "basic_yearly" => User::BASIC_PLAN_LIMITS,
-    "basic_trial"  => User::BASIC_PLAN_LIMITS,
-    "pro"          => User::PRO_PLAN_LIMITS,
-    "pro_yearly"   => User::PRO_PLAN_LIMITS,
-    "partner_pro"  => User::PRO_PLAN_LIMITS,
-  }.freeze
-
+  # Keep ALL references to autoloaded constants (User::*_PLAN_LIMITS)
+  # inside the task body. Rakefiles get loaded during asset precompile
+  # before Rails boots — a top-level `User::FREE_PLAN_LIMITS` raises
+  # `NameError: uninitialized constant User` during deploy.
   BACKFILL_LIMIT_KEYS = %w[paid_communicator_limit demo_communicator_limit board_limit ai_monthly_limit].freeze
 
   desc "Backfill per-tier limits onto user.settings, filling missing/zero values without clobbering admin-tuned higher values"
   task backfill_communicator_limits: :environment do
+    # Built at task-execution time (after :environment), so User is
+    # available. partner_pro and basic_trial inherit their paid tier's
+    # slot math (matches User#setup_limits).
+    limits_by_plan = {
+      "free"         => User::FREE_PLAN_LIMITS,
+      "basic"        => User::BASIC_PLAN_LIMITS,
+      "basic_yearly" => User::BASIC_PLAN_LIMITS,
+      "basic_trial"  => User::BASIC_PLAN_LIMITS,
+      "pro"          => User::PRO_PLAN_LIMITS,
+      "pro_yearly"   => User::PRO_PLAN_LIMITS,
+      "partner_pro"  => User::PRO_PLAN_LIMITS,
+    }.freeze
+
     dry_run = ENV["DRY_RUN"] == "true"
     only_plans = ENV["PLANS"]&.split(",")&.map(&:strip)
     updated = 0
@@ -29,7 +33,7 @@ namespace :plans do
     puts "[backfill_communicator_limits] starting (dry_run=#{dry_run} plans=#{only_plans || "all"})"
 
     scope.find_each(batch_size: 200) do |user|
-      defaults = BACKFILL_LIMITS_BY_PLAN[user.plan_type]
+      defaults = limits_by_plan[user.plan_type]
       unless defaults
         skipped += 1
         next


### PR DESCRIPTION
## Summary

Hot-fix for the Hatchbox deploy failure on main:

\`\`\`
rake aborted!
NameError: uninitialized constant User
    \"free\"         => User::FREE_PLAN_LIMITS,
                      ^^^^
lib/tasks/plans.rake:6:in \`block in <main>\`
\`\`\`

Rakefiles are loaded during \`bundle exec rake assets:precompile\` *before* Rails boots, so [#167](https://github.com/brittanyjohns/itty_bitty_boards/pull/167)'s top-level \`User::FREE_PLAN_LIMITS\` reference wedged every deploy. Moved the plan_type → limits map inside the task body — it now evaluates at task-execution time, after \`:environment\` loads.

## Test plan

- [x] Loads without Rails: \`ruby -e 'load "lib/tasks/plans.rake"'\` → \`loaded OK\`
- [x] \`bundle exec rspec spec/lib/tasks/plans_rake_spec.rb\` — 10/10
- [ ] Watch the next Hatchbox deploy succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)