### PR TITLE
feat(teams): protect communicator owner from removal and demotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Team owner can't be removed or demoted by other team members
+
+- After the SLP→parent claim hand-off, the parent (new owner) is protected on the communicator's team. An SLP supervisor — or any non-owner team member — can no longer remove the parent owner via `DELETE /api/teams/:id/remove_member`, demote the owner via the invite endpoint, or self-promote themselves to admin. Attempts return HTTP 403 with structured errors (`cannot_remove_owner`, `cannot_change_owner_role`, `cannot_self_promote`). The owner can still remove themselves; system admins retain an escape hatch.
+- Team `show`/`index` `api_view` now exposes `account_owner_ids` and per-member `is_account_owner` so the frontend can hide destructive controls on the owner row.
+
 ### Changed — Downgraded users keep their boards (read-only, never deleted)
 - When a paid user (Basic/Pro) cancels and lands back on Free, their existing boards are no longer all fully editable. Boards beyond the Free limit (1) become **read-only**: they still open, cells still tap, audio still plays — so a non-speaking user's communication never breaks — but content-editing (renaming, layout changes, image swaps, audio uploads) is blocked behind an upgrade prompt. Previously, a Pro user with dozens of boards who cancelled kept full edit access to every one of them forever; only *creating* a new board was blocked.
 - Users pick which single board keeps full edit access via `PATCH /api/boards/:id/make_editable`. On downgrade the backend pins a sensible default (favorite or most-recent) so they're never fully locked out before they choose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,32 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   frees one board. If the ENV is ever raised above 1, revisit this to a
   per-board flag or join table.
 
+## Team permissions — owner protection
+
+Communicators (`child_account`) have an `owner_id` (the family/parent
+post-claim, or the SLP pre-claim). That user is "**owner-pinned**" on the
+communicator's team: they cannot be removed or have their role changed by
+any non-owner. Full matrix in issue #166. Server-side rules:
+
+- `ChildAccount#claim_by!` auto-adds the new owner to the team.
+- `DELETE /api/teams/:id/remove_member` returns **HTTP 403
+  `cannot_remove_owner`** if the target is owner-pinned and the caller is
+  neither that user nor a system admin. The owner can remove themselves.
+- `POST /api/teams/:id/invite`, when it would change an *existing*
+  membership's role, returns **HTTP 403 `cannot_change_owner_role`** if
+  the target is owner-pinned (and the caller isn't that user). It also
+  returns **HTTP 403 `cannot_self_promote`** if a non-owner non-admin
+  caller tries to set their own role to `admin`.
+- Owner-pinned-ness is computed, not stored:
+  `Team#account_owner_ids` / `Team#account_owner?(user)` and
+  `TeamUser#account_owner?`. Team `show`/`index` `api_view` expose
+  `account_owner_ids` and per-member `is_account_owner` so the frontend
+  can hide destructive controls.
+
+A real **transfer ownership** flow doesn't exist yet — it's out of scope
+for #166 and will get its own endpoint (touches `child_account.owner_id`,
+not just team membership).
+
 ## AI gating: credit ledger (source of truth)
 
 - AI features are gated by **weighted credits** held in two balances on `users`:

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -43,16 +43,26 @@ class API::TeamsController < API::ApplicationController
     user_email = team_user_params[:email]
     user_role = invite_role
     @team = Team.find(params[:id])
-    # @user = User.find_by(email: user_email)
-    # if @user
-    #   Rails.logger.info "Inviting existing user #{@user.id} to team #{@team.id}"
-    #   @user.invite_to_team!(@team, current_user, user_role)
-    # else
+
+    # Block role-change of an existing owner-pinned member, and block
+    # self-promotion to admin by non-owners. See issue #166.
+    existing_user = User.find_by(email: user_email)
+    if existing_user
+      existing_membership = TeamUser.find_by(user_id: existing_user.id, team_id: @team.id)
+      if existing_membership && existing_membership.role != user_role
+        if @team.account_owner?(existing_user) && existing_user != current_user
+          return render_team_permission_error("cannot_change_owner_role",
+                                              "You cannot change the role of the communicator's owner.")
+        end
+        if existing_user == current_user && user_role == "admin" &&
+           !current_user.admin? && !@team.account_owner?(current_user)
+          return render_team_permission_error("cannot_self_promote",
+                                              "You cannot promote yourself to admin.")
+        end
+      end
+    end
+
     @user = User.invite_new_user_to_team!(user_email, current_user, @team, user_role)
-    #   Rails.logger.info "Inviting new user #{@user.id} to team #{@team.id}"
-    #   # @user = User.create_from_email(user_email, nil, current_user.id)
-    # end
-    # @user = User.find_by(email: user_email) unless @user && @user.persisted?
     unless @user
       return render json: { error: "User not invited. Something went wrong." }, status: :unprocessable_entity
     end
@@ -70,7 +80,20 @@ class API::TeamsController < API::ApplicationController
   def remove_member
     @team = Team.find(params[:id])
     @user = User.find_by(email: params[:email])
+    return render json: { error: "User not found" }, status: :not_found unless @user
+
     @team_user = TeamUser.find_by(user_id: @user.id, team_id: @team.id)
+    return render json: { error: "Not a team member" }, status: :not_found unless @team_user
+
+    # Owner of any child_account on this team is owner-pinned: only the
+    # owner themselves (or a system admin) can remove them. Issue #166 —
+    # prevents an SLP supervisor from removing the parent owner after the
+    # claim hand-off.
+    if @team.account_owner?(@user) && @user != current_user && !current_user.admin?
+      return render_team_permission_error("cannot_remove_owner",
+                                          "You cannot remove the communicator's owner from the team.")
+    end
+
     @team_user.destroy!
     render json: @team.show_api_view(current_user)
   end
@@ -151,6 +174,10 @@ class API::TeamsController < API::ApplicationController
   end
 
   private
+
+  def render_team_permission_error(error_key, message)
+    render json: { error: error_key, message: message }, status: :forbidden
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_team

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -101,18 +101,34 @@ class Team < ApplicationRecord
     team_board.destroy if team_board
   end
 
+  # User ids of the owners of any child_account on this team. These users
+  # are "owner-pinned" — they cannot be removed or have their role changed
+  # by anyone other than themselves (or a system admin). The frontend reads
+  # this to hide destructive controls on the owner row.
+  def account_owner_ids
+    accounts.pluck(:owner_id).compact.uniq
+  end
+
+  def account_owner?(user)
+    return false unless user
+    account_owner_ids.include?(user.id)
+  end
+
   def index_api_view(viewing_user = nil)
+    owner_ids = account_owner_ids
     {
       id: id,
       name: name,
       created_by_id: created_by_id,
       created_by_name: created_by&.name,
       created_by_email: created_by&.email,
+      account_owner_ids: owner_ids,
       members: team_users.includes(:user).map { |tu|
-        { id: tu.id, name: tu.user.name, email: tu.user.email,
-          role: tu.role, plan_type: tu.user.plan_type }
+        { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
+          role: tu.role, plan_type: tu.user.plan_type,
+          is_account_owner: owner_ids.include?(tu.user_id) }
       },
-      accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
+      accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, owner_id: a.owner_id, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
 
       created_at: created_at.strftime("%Y-%m-%d %H:%M:%S"),
       updated_at: updated_at.strftime("%Y-%m-%d %H:%M:%S"),
@@ -120,6 +136,7 @@ class Team < ApplicationRecord
   end
 
   def show_api_view(viewing_user = nil)
+    owner_ids = account_owner_ids
     {
       id: id,
       name: name,
@@ -129,10 +146,12 @@ class Team < ApplicationRecord
       created_by_id: created_by_id,
       created_by_name: created_by&.name,
       created_by_email: created_by&.email,
-      accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
+      account_owner_ids: owner_ids,
+      accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, owner_id: a.owner_id, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
       members: team_users.includes(:user).map { |tu|
-        { id: tu.id, name: tu.user.name, email: tu.user.email,
-          role: tu.role, plan_type: tu.user.plan_type }
+        { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
+          role: tu.role, plan_type: tu.user.plan_type,
+          is_account_owner: owner_ids.include?(tu.user_id) }
       },
       boards: team_boards.includes(board: :user).map { |tb| { id: tb.board_id, name: tb.board.name, board_type: tb.board.board_type, display_image_url: tb.board.display_image_url, added_by_id: tb.created_by_id, board_owner_name: tb.board.user&.display_name, board_owner_id: tb.board.user_id } },
       created_at: created_at.strftime("%Y-%m-%d %H:%M:%S"),

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -52,6 +52,13 @@ class TeamUser < ApplicationRecord
     { "admin" => "Admin", "member" => "Member" }
   end
 
+  # True if this user is the owner of any child_account on the team. Used
+  # by `API::TeamsController` to block removal / role-change of the owner
+  # by anyone other than themselves (issue #166).
+  def account_owner?
+    team.account_owner?(user)
+  end
+
   def api_view
     {
       id: id,
@@ -59,6 +66,7 @@ class TeamUser < ApplicationRecord
       name: name,
       role: role,
       can_edit: user.can_add_boards_to_account?(team.account_ids),
+      is_account_owner: account_owner?,
       invitation_accepted_at: invitation_accepted_at,
       user_id: user_id,
       team_id: team_id,

--- a/spec/requests/api/team_permissions_spec.rb
+++ b/spec/requests/api/team_permissions_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #166 — owner-protection rules on team membership endpoints.
+# After the SLP→parent claim hand-off, the SLP remains on the team as a
+# supervisor while the parent is the new owner. These specs lock in the
+# rule that the owner cannot be removed or demoted by anyone other than
+# themselves (or a system admin).
+RSpec.describe "API::Teams owner protection", type: :request do
+  let(:slp)    { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_slp_stub") }
+  let(:parent) { create(:user, created_at: 2.months.ago, stripe_customer_id: "cus_parent_stub") }
+
+  # Mirror the post-claim shape: the parent is the owner of the account,
+  # the SLP is the previous owner who stays on the team as a supervisor.
+  let!(:account) do
+    create(:child_account,
+           user: parent,
+           owner: parent,
+           status: ChildAccount::ACTIVE,
+           passcode: "ownerpw1")
+  end
+  let!(:team) do
+    t = account.ensure_team!(creator: slp)
+    t.add_member!(parent, "admin")
+    t.add_member!(slp, "supervisor")
+    t
+  end
+
+  describe "DELETE /api/teams/:id/remove_member" do
+    it "blocks an SLP supervisor from removing the parent owner (403)" do
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: parent.email },
+               headers: auth_headers(slp)
+      }.not_to change { TeamUser.where(team: team).count }
+
+      expect(response).to have_http_status(:forbidden)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("cannot_remove_owner")
+    end
+
+    it "lets the parent owner remove the SLP supervisor" do
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: slp.email },
+               headers: auth_headers(parent)
+      }.to change { TeamUser.where(team: team, user: slp).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lets the owner remove themselves (single allowed self-action)" do
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: parent.email },
+               headers: auth_headers(parent)
+      }.to change { TeamUser.where(team: team, user: parent).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lets a system admin remove the owner (escape hatch)" do
+      admin = create(:admin_user)
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: parent.email },
+               headers: auth_headers(admin)
+      }.to change { TeamUser.where(team: team, user: parent).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/teams/:id/invite (role change path)" do
+    it "blocks an SLP supervisor from demoting the parent owner (403)" do
+      post "/api/teams/#{team.id}/invite",
+           params: { team_user: { email: parent.email, role: "member" } },
+           headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("cannot_change_owner_role")
+
+      expect(TeamUser.find_by(team: team, user: parent).role).to eq("admin")
+    end
+
+    it "blocks an SLP supervisor from changing the owner's role to admin (a no-op for owner, still rejected)" do
+      # Start parent at "member" (legacy data) and confirm SLP cannot
+      # touch the owner row even when the change would be benign.
+      TeamUser.find_by(team: team, user: parent).update!(role: "member")
+
+      post "/api/teams/#{team.id}/invite",
+           params: { team_user: { email: parent.email, role: "admin" } },
+           headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("cannot_change_owner_role")
+    end
+
+    it "blocks an SLP supervisor from self-promoting to admin (403)" do
+      post "/api/teams/#{team.id}/invite",
+           params: { team_user: { email: slp.email, role: "admin" } },
+           headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("cannot_self_promote")
+
+      expect(TeamUser.find_by(team: team, user: slp).role).to eq("supervisor")
+    end
+
+    it "lets the parent owner change the SLP's role" do
+      post "/api/teams/#{team.id}/invite",
+           params: { team_user: { email: slp.email, role: "member" } },
+           headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:created)
+      expect(TeamUser.find_by(team: team, user: slp).role).to eq("member")
+    end
+  end
+
+  describe "GET /api/teams/:id (api_view)" do
+    it "exposes account_owner_ids and per-member is_account_owner" do
+      get "/api/teams/#{team.id}", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["account_owner_ids"]).to eq([parent.id])
+
+      parent_member = body["members"].find { |m| m["user_id"] == parent.id }
+      slp_member    = body["members"].find { |m| m["user_id"] == slp.id }
+      expect(parent_member["is_account_owner"]).to eq(true)
+      expect(slp_member["is_account_owner"]).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #166. Hardens team-membership permissions so a non-owner team member (notably an SLP supervisor after the parent claim hand-off) can no longer remove or demote the communicator's owner.

- `DELETE /api/teams/:id/remove_member` now returns **HTTP 403 `cannot_remove_owner`** when the target user is owner-pinned and the caller is neither that user nor a system admin. The owner can still remove themselves; admins keep an escape hatch.
- `POST /api/teams/:id/invite`, when it would change an *existing* membership's role, returns **HTTP 403 `cannot_change_owner_role`** if the target is owner-pinned (and the caller isn't them). It also returns **HTTP 403 `cannot_self_promote`** if a non-owner non-admin caller tries to set their own role to `admin`.
- "Owner-pinned" = the user is the `owner_id` of any `child_account` on the team. Computed, not stored — see `Team#account_owner_ids` / `Team#account_owner?` / `TeamUser#account_owner?`.
- Team `show`/`index` `api_view` now expose `account_owner_ids` and per-member `is_account_owner` so the frontend can hide destructive controls on the owner row. Pairs with [itty-bitty-frontend#159](https://github.com/brittanyjohns/itty-bitty-frontend/issues/159) (frontend PR coming next).

A real **transfer ownership** flow is intentionally out of scope here (separate issue).

## Test plan

- [x] `bundle exec rspec spec/requests/api/team_permissions_spec.rb` — 9 examples, 0 failures
- [x] `bundle exec rspec` — 705 examples, 0 failures, 17 pre-existing pending
- [x] CHANGELOG entry added
- [x] CLAUDE.md "Team permissions — owner protection" section added

🤖 Generated with [Claude Code](https://claude.com/claude-code)