### PR TITLE
feat(boards): accept bw and qr params on board PDF endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — B&W and QR options for board PDF downloads
+
+- `GET /api/boards/:id/pdf` now accepts `bw=1` for a copier-friendly black-and-white render (no tile backgrounds, grayscale images, black borders) and `qr=0` to suppress the QR code in the header. Defaults preserve existing behavior: color render with QR included. Variants are streamed but not stored on the board's cached `pdf_file` attachment, so the default PDF stays canonical. B&W downloads are named `<slug>-board-bw.pdf` to disambiguate.
+
 ### Fixed — Team owner can't be removed or demoted by other team members
 
 - After the SLP→parent claim hand-off, the parent (new owner) is protected on the communicator's team. An SLP supervisor — or any non-owner team member — can no longer remove the parent owner via `DELETE /api/teams/:id/remove_member`, demote the owner via the invite endpoint, or self-promote themselves to admin. Attempts return HTTP 403 with structured errors (`cannot_remove_owner`, `cannot_change_owner_role`, `cannot_self_promote`). The owner can still remove themselves; system admins retain an escape hatch.

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -954,12 +954,18 @@ class API::BoardsController < API::ApplicationController
   end
 
   def pdf
+    bw_requested = ActiveModel::Type::Boolean.new.cast(params[:bw])
+    qr_param = params[:qr]
+    qr_requested = qr_param.nil? ? true : ActiveModel::Type::Boolean.new.cast(qr_param)
+    @bw = bw_requested
+
     render_data = Boards::RenderAssetData.new(
       board: @board,
       screen_size: params[:screen_size] || "lg",
-      hide_colors: params[:hide_colors] == "1",
+      hide_colors: bw_requested || params[:hide_colors] == "1",
       hide_header: params[:hide_header] == "1",
       routes: Rails.application.routes.url_helpers,
+      include_qr: qr_requested,
     ).call
 
     render_data.each do |key, value|
@@ -989,7 +995,8 @@ class API::BoardsController < API::ApplicationController
 
     file_data = Grover.new(html, **grover_options).to_pdf
 
-    unless @board.pdf_file.attached?
+    default_variant = !bw_requested && qr_requested
+    if default_variant && !@board.pdf_file.attached?
       @board.pdf_file.attach(
         io: StringIO.new(file_data),
         filename: "#{@board.slug}-board.pdf",
@@ -997,8 +1004,9 @@ class API::BoardsController < API::ApplicationController
       )
     end
 
+    filename_suffix = bw_requested ? "-bw" : ""
     send_data file_data,
-      filename: "#{@board.slug}-board.pdf",
+      filename: "#{@board.slug}-board#{filename_suffix}.pdf",
       type: "application/pdf",
       disposition: disp
   end

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -205,10 +205,25 @@
       .gray   { background-color: #808080d9; }
       .pink   { background-color: #ffc0e4; }
       .teal   { background-color: #18ddda; }
+
+      body.bw .tile {
+        border-color: #000 !important;
+        background: #fff !important;
+      }
+
+      body.bw .tile img,
+      body.bw .qr-small img {
+        filter: grayscale(100%);
+      }
+
+      body.bw .label {
+        background: #fff !important;
+        color: #000 !important;
+      }
     </style>
   </head>
 
-  <body>
+  <body class="<%= 'bw' if @bw %>">
     <div class="page">
       <%= yield %>
     </div>

--- a/spec/requests/api/board_pdf_spec.rb
+++ b/spec/requests/api/board_pdf_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "API::Boards#pdf", type: :request do
+  let!(:user)  { create(:user) }
+  let!(:board) { create(:board, user: user, name: "PDF Board") }
+
+  before do
+    fake_grover = instance_double(Grover, to_pdf: "%PDF-fake")
+    allow(Grover).to receive(:new).and_return(fake_grover)
+    allow_any_instance_of(API::BoardsController)
+      .to receive(:render_to_string).and_return("<html></html>")
+  end
+
+  describe "GET /api/boards/:id/pdf" do
+    it "defaults to color with QR code included" do
+      expect(Boards::RenderAssetData).to receive(:new).with(
+        hash_including(board: board, hide_colors: false, include_qr: true),
+      ).and_call_original
+
+      get "/api/boards/#{board.id}/pdf", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+      expect(response.headers["Content-Disposition"]).to include("#{board.slug}-board.pdf")
+    end
+
+    it "renders black-and-white when bw=1" do
+      expect(Boards::RenderAssetData).to receive(:new).with(
+        hash_including(hide_colors: true, include_qr: true),
+      ).and_call_original
+
+      get "/api/boards/#{board.id}/pdf", params: { bw: "1" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Content-Disposition"]).to include("#{board.slug}-board-bw.pdf")
+    end
+
+    it "omits the QR code when qr=0" do
+      expect(Boards::RenderAssetData).to receive(:new).with(
+        hash_including(include_qr: false),
+      ).and_call_original
+
+      get "/api/boards/#{board.id}/pdf", params: { qr: "0" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not cache the attachment when a non-default variant is requested" do
+      expect {
+        get "/api/boards/#{board.id}/pdf", params: { bw: "1" }, headers: auth_headers(user)
+      }.not_to change { board.reload.pdf_file.attached? }.from(false)
+    end
+
+    it "caches the attachment on the default variant" do
+      expect {
+        get "/api/boards/#{board.id}/pdf", headers: auth_headers(user)
+      }.to change { board.reload.pdf_file.attached? }.from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of [brittanyjohns/itty-bitty-frontend#161](https://github.com/brittanyjohns/itty-bitty-frontend/issues/161): the teachers landing page promises print-ready boards in B&W and with QR codes, but `GET /api/boards/:id/pdf` only emits the default color+QR variant.

This PR adds two query params:

- `bw=1` — grayscale, copier-friendly render. Tile backgrounds drop, borders go black, images get `filter: grayscale(100%)`, labels render white-on-black-text.
- `qr=0` — suppress the QR code in the header. Default is `qr=1` so existing callers keep their QR.

Defaults match today's behavior, so the existing single `Download PDF` button keeps working unchanged.

## What changed

- `app/controllers/api/boards_controller.rb#pdf` — parses `bw` and `qr`, plumbs through to `Boards::RenderAssetData` (`hide_colors:` + `include_qr:`), sets `@bw` for the layout. Filename gets a `-bw` suffix when B&W is requested.
- `app/views/layouts/pdf.html.erb` — `body.bw` CSS rules: grayscale images, white tile bgs, black borders, white labels.
- `spec/requests/api/board_pdf_spec.rb` — 5 new specs.
- `CHANGELOG.md` — Unreleased entry.

## Non-default variants don't poison the cache

The existing endpoint attaches the rendered PDF to `board.pdf_file` as a cached canonical copy. We only do that on the default variant (`bw=0` + `qr=1`) — `bw=1` and `qr=0` are streamed but never written to the attachment, so the canonical PDF stays color+QR.

## Test plan

- [x] `bundle exec rspec spec/requests/api/board_pdf_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec rspec spec/requests/api/internal/board_pdf_export_spec.rb spec/requests/api/boards_spec.rb` — 32 examples, 0 failures (no regressions in adjacent specs)
- [ ] Frontend PR adds the toggles to BoardSubHeader and passes the new params

🤖 Generated with [Claude Code](https://claude.com/claude-code)