### PR TITLE
feat(profiles): Free = 1 MySpeak ID limit (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Free = 1 MySpeak ID limit (#143)
+- Free users are now capped at **one MySpeak ID** (Profile). Basic/Pro
+  and admins remain unlimited. Trial users (`basic_trial`, Stripe
+  `trialing`) are treated as paid by `User#paid_plan?` and the gate
+  doesn't trigger.
+- "MySpeak ID" counts a Profile attached to the user directly *or* to
+  one of their `communicator_accounts`.
+- `POST /api/profiles` returns **HTTP 403** with
+  `{ error: "myspeak_id_limit_reached", message, limit, count }` when a
+  Free user is already at the cap.
+- Limit env-tunable via `FREE_MYSPEAK_ID_LIMIT` (default `1`).
+- New helpers on `User`: `#myspeak_id_limit`, `#myspeak_id_count`,
+  `#can_create_myspeak_id?`.
+
 ### Changed — CommunicationAccountMailer per-recipient i18n (#175)
 - `CommunicationAccountMailer` now extends `BaseMailer` (was
   `ApplicationMailer`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,20 @@ backlog size (default 200).
 - Premium features (Menu Board Creator, AI image generation) require active subscription
 - Subscription managed via Stripe/RevenueCat — check status before allowing access to premium endpoints
 
+### MySpeak ID limit (Free = 1)
+
+Free users are capped at **one MySpeak ID** (Profile). Basic/Pro/admin
+are unlimited. A "MySpeak ID" counts a Profile attached to the user
+directly *or* to one of their `communicator_accounts`. Implemented in
+`User#myspeak_id_limit` / `#myspeak_id_count` / `#can_create_myspeak_id?`,
+with limit env-tunable via `FREE_MYSPEAK_ID_LIMIT` (default `1`).
+
+`POST /api/profiles` is gated up front and returns **HTTP 403** with
+`{ error: "myspeak_id_limit_reached", message, limit, count }` when a
+Free user is already at the cap. Trial users (`basic_trial`, Stripe
+`trialing`) are treated as paid by `paid_plan?` and the gate doesn't
+trigger — consistent with how credit gates work.
+
 ### Board access on downgrade (read-only rule)
 
 When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -58,6 +58,18 @@ class API::ProfilesController < API::ApplicationController
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
+
+    unless current_user.can_create_myspeak_id?
+      limit = current_user.myspeak_id_limit
+      render json: {
+        error: "myspeak_id_limit_reached",
+        message: "Free accounts are limited to #{limit} MySpeak ID. Upgrade to Basic or Pro to add more.",
+        limit: limit,
+        count: current_user.myspeak_id_count,
+      }, status: :forbidden
+      return
+    end
+
     profile = Profile.new(profile_params)
     profile.profileable = current_user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1271,6 +1271,28 @@ class User < ApplicationRecord
   EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS =
     ENV.fetch("EDITABLE_BOARD_SWITCH_COOLDOWN_DAYS", 14).to_i
 
+  # Free users get one MySpeak ID; Basic/Pro keep current (unlimited) behavior.
+  # A MySpeak ID = a Profile owned by the user directly or by one of their
+  # communicator accounts.
+  FREE_MYSPEAK_ID_LIMIT = ENV.fetch("FREE_MYSPEAK_ID_LIMIT", 1).to_i
+
+  def myspeak_id_limit
+    return nil if admin? || paid_plan?
+    FREE_MYSPEAK_ID_LIMIT
+  end
+
+  def myspeak_id_count
+    user_owned = Profile.where(profileable_type: "User", profileable_id: id).count
+    child_owned = Profile.where(profileable_type: "ChildAccount", profileable_id: communicator_accounts.select(:id)).count
+    user_owned + child_owned
+  end
+
+  def can_create_myspeak_id?
+    limit = myspeak_id_limit
+    return true if limit.nil?
+    myspeak_id_count < limit
+  end
+
   # When the next make_editable call is permitted. Nil if no prior explicit
   # pick (so the user can pick immediately) or if the cooldown has passed.
   def editable_board_switch_available_at

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -1,7 +1,90 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "API::Profiles", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /api/profiles (MySpeak ID limit)" do
+    # New users within TRAIL_PERIOD (14 days) get auto-bumped to basic_trial,
+    # which `paid_plan?` treats as paid. To test the true Free state, bypass
+    # callbacks with update_columns so plan_type stays "free".
+    let(:free_user) do
+      user = FactoryBot.create(:user)
+      user.update_columns(plan_type: "free", created_at: 30.days.ago)
+      user
+    end
+    let(:pro_user) { FactoryBot.create(:user, plan_type: "pro") }
+
+    let(:create_params) do
+      { profile: { username: "pat-#{SecureRandom.hex(2)}" } }
+    end
+
+    context "as a Free user" do
+      it "allows creating the first MySpeak ID" do
+        expect {
+          post "/api/profiles", params: create_params, headers: auth_headers(free_user)
+        }.to change { Profile.where(profileable: free_user).count }.by(1)
+        expect(response).to have_http_status(:created)
+      end
+
+      it "rejects the second MySpeak ID with 403 and a clear error code" do
+        Profile.create!(
+          profileable: free_user,
+          username: "first-#{SecureRandom.hex(2)}",
+          slug: "first-#{SecureRandom.hex(2)}",
+        )
+
+        post "/api/profiles", params: create_params, headers: auth_headers(free_user)
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("myspeak_id_limit_reached")
+        expect(body["limit"]).to eq(1)
+        expect(body["count"]).to eq(1)
+        expect(body["message"]).to include("Free")
+      end
+
+      it "counts a Profile attached to one of the user's communicator accounts toward the limit" do
+        child = FactoryBot.create(:child_account, user: free_user, owner: free_user)
+        Profile.create!(
+          profileable: child,
+          username: "child-#{SecureRandom.hex(2)}",
+          slug: "child-#{SecureRandom.hex(2)}",
+        )
+
+        post "/api/profiles", params: create_params, headers: auth_headers(free_user)
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("myspeak_id_limit_reached")
+      end
+    end
+
+    context "as a Pro user" do
+      it "is not limited" do
+        Profile.create!(
+          profileable: pro_user,
+          username: "first-#{SecureRandom.hex(2)}",
+          slug: "first-#{SecureRandom.hex(2)}",
+        )
+
+        expect {
+          post "/api/profiles", params: create_params, headers: auth_headers(pro_user)
+        }.to change { Profile.where(profileable: pro_user).count }.by(1)
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as an admin on the Free plan" do
+      it "bypasses the limit" do
+        admin = FactoryBot.create(:user, role: "admin")
+        admin.update_columns(plan_type: "free", created_at: 30.days.ago)
+        Profile.create!(
+          profileable: admin,
+          username: "first-#{SecureRandom.hex(2)}",
+          slug: "first-#{SecureRandom.hex(2)}",
+        )
+
+        expect {
+          post "/api/profiles", params: create_params, headers: auth_headers(admin)
+        }.to change { Profile.where(profileable: admin).count }.by(1)
+        expect(response).to have_http_status(:created)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Closes #143. Part of the MySpeak-goes-free rollout (alongside #142, #144).

- Free users are capped at **one MySpeak ID** (Profile). Basic/Pro and
  admins remain unlimited.
- Trial users (`basic_trial`, Stripe `trialing`) are treated as paid by
  `User#paid_plan?` so the gate doesn't trigger during trial — consistent
  with how credit gates work.
- \"MySpeak ID\" counts a Profile attached to the user directly **or** to
  one of their `communicator_accounts` (the rollout plan: \"Free is 0
  communicators, so one ID = the parent's child by default\").

## API behavior

`POST /api/profiles` now returns **HTTP 403** with a clear error code
when a Free user is already at the cap:

\`\`\`json
{
  \"error\": \"myspeak_id_limit_reached\",
  \"message\": \"Free accounts are limited to 1 MySpeak ID. Upgrade to Basic or Pro to add more.\",
  \"limit\": 1,
  \"count\": 1
}
\`\`\`

Frontend can key off `error: \"myspeak_id_limit_reached\"` to surface an
upgrade prompt.

## Configuration

`FREE_MYSPEAK_ID_LIMIT` ENV (default `1`) — env-tunable in case the
rollout plan changes the cap later.

## Implementation

- `User::FREE_MYSPEAK_ID_LIMIT` constant
- `User#myspeak_id_limit` — `nil` (unlimited) for paid/admin, `1` for Free
- `User#myspeak_id_count` — sums User-attached + ChildAccount-attached Profiles
- `User#can_create_myspeak_id?`
- Gate added in `API::ProfilesController#create` immediately after the auth check
- CLAUDE.md gets a new \"MySpeak ID limit (Free = 1)\" section under Subscription model

## Test plan

- [x] `bundle exec rspec spec/requests/api/profiles_spec.rb` — 5 examples, 0 failures
  - Free user: first MySpeak ID allowed
  - Free user: second rejected with 403 + correct error code
  - Free user: child-account-attached Profile counts toward the limit
  - Pro user: not limited
  - Admin on Free: bypasses the limit
- [x] `bundle exec rspec spec/models/user_spec.rb spec/models/profile_spec.rb spec/requests/api/profiles_spec.rb` — 40 examples, 0 failures, 1 pre-existing pending
- [ ] Manual: as a Free user (post-trial, `plan_type=\"free\"`), try creating a second profile via the UI, confirm 403 with friendly error

## Notes for reviewer

- New users within the 14-day `TRAIL_PERIOD` get auto-bumped to
  `basic_trial` via a `before_save` callback, so my specs use
  `update_columns` to set a true `plan_type=\"free\"` state. Called out
  in a comment.
- This is enforced at the most direct user-facing path
  (`ProfilesController#create`). Internal setup paths
  (`Profile.create_for_user`, `User#handle_myspeak_setup`,
  `ChildAccount#some_method`, etc.) are not gated — they're bootstrap
  flows already controlled by their own logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)