### PR TITLE
feat(boards): retranslate images when board language changes

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -202,6 +202,12 @@ class Board < ApplicationRecord
 
   before_create :set_screen_sizes, :set_number_of_columns
   after_initialize :set_initial_layout, if: :layout_empty?
+  after_update_commit :retranslate_on_language_change
+
+  def retranslate_on_language_change
+    return unless saved_change_to_language?
+    schedule_translations_for(language)
+  end
 
   def run_generate_preview_job
     GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true }) # Generate PNG preview without header

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -299,6 +299,33 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "language change retranslation" do
+    let(:board) { FactoryBot.create(:board, language: "en") }
+
+    it "schedules translations when language changes" do
+      expect(board).to receive(:schedule_translations_for).with("es")
+      board.update!(language: "es")
+    end
+
+    it "does not schedule when language is unchanged" do
+      expect(board).not_to receive(:schedule_translations_for)
+      board.update!(name: "renamed")
+    end
+
+    it "enqueues TranslateBoardImagesJob on language change" do
+      allow(Rails.cache).to receive(:exist?).and_return(false)
+      allow(Rails.cache).to receive(:write)
+      expect(TranslateBoardImagesJob).to receive(:perform_async).with(board.id, "es")
+      board.update!(language: "es")
+    end
+
+    it "is a no-op when switching to English" do
+      board.update!(language: "es")
+      expect(TranslateBoardImagesJob).not_to receive(:perform_async)
+      board.update!(language: "en")
+    end
+  end
+
   describe "#api_view" do
     let(:user) { FactoryBot.create(:user) }
     let(:board) do


### PR DESCRIPTION
## Summary

When `board.language` is updated, schedule translation of all existing board images into the new language and generate localized audio. Previously only AI word suggestions (#177) reflected the language change — existing image labels and audio stayed in the old language until a viewer with a matching locale opened the board.

## What changed

- `Board` gets an `after_update_commit :retranslate_on_language_change` callback that delegates to the existing `schedule_translations_for(language)` when `saved_change_to_language?`.
- The existing pipeline does the rest: `TranslateBoardImagesJob` → per-image `TranslateImageJob` (fills `language_settings[lang]`) → `CreateAllAudioJob` (Polly audio in the new language).

## Behavior notes

- Idempotent: `TranslateImageJob` skips images that already have a translation in the target language, and `schedule_translations_for` debounces re-enqueues with a 1-hour cache key.
- **Switching to English is a no-op** — English labels on the underlying `Image` records are the source of truth. A separate "force regenerate" flow can be added later if we need to bust stale translations after a label edit.
- Bypasses the gate for English so existing behavior is preserved.

## Test plan

- [x] `bundle exec rspec spec/models/board_spec.rb spec/sidekiq/translate_board_images_job_spec.rb spec/sidekiq/translate_image_job_spec.rb` — 54 examples, 0 failures
- New specs cover: schedules on change, no-op on unrelated update, enqueues `TranslateBoardImagesJob`, no-op when switching to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)