### PR TITLE
chore(user): remove orphaned handle_myspeak_setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Removed
+- `User#handle_myspeak_setup` — orphaned method from an earlier MySpeak
+  signup path with no callers anywhere in the codebase. Spotted while
+  closing the MySpeak-goes-free rollout audit (#144).
+
 ### Added — Free = 1 MySpeak ID limit (#143)
 - Free users are now capped at **one MySpeak ID** (Profile). Basic/Pro
   and admins remain unlimited. Trial users (`basic_trial`, Stripe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1175,33 +1175,6 @@ class User < ApplicationRecord
     true
   end
 
-  def handle_myspeak_setup(myspeak_name: nil, myspeak_slug: nil)
-    myspeak_slug ||= settings["slug"] || email.split("@").first
-    myspeak_name ||= display_name
-    Rails.logger.info "Handling MySpeak setup for user #{email} with slug #{myspeak_slug} and name #{myspeak_name}"
-    @child_account = ChildAccount.new(username: myspeak_slug, name: myspeak_name, status: ChildAccount::SANDBOX)
-    if free?
-      @child_account.settings ||= {}
-      @child_account.settings["demo_board_limit"] = ChildAccount::FREE_DEMO_BOARD_LIMIT
-    end
-    @child_account.owner = self
-    @child_account.user = self if @child_account.respond_to?(:user=) # legacy (optional)
-
-    # Validate basic fields first
-    unless @child_account.valid?
-      Rails.logger.error "Child account validation failed: #{@child_account.errors.full_messages.join(", ")}"
-      return nil
-    end
-    if @child_account.save
-      Rails.logger.info "Child account created with ID #{@child_account.id} for MySpeak setup"
-      @child_account.create_profile!
-      Rails.logger.info "Profile created with slug #{myspeak_slug} for MySpeak setup"
-    else
-      Rails.logger.error "Failed to save child account for MySpeak setup: #{@child_account.errors.full_messages.join(", ")}"
-    end
-    @child_account
-  end
-
   def reset_ai_limits!
     current_user = self
     feature_key = "ai_action"


### PR DESCRIPTION
## Summary

- Deletes `User#handle_myspeak_setup` from `app/models/user.rb`. Verified zero callers anywhere in `app/`, `config/`, `lib/`, or `spec/` via `grep -rn "handle_myspeak_setup"`.
- The method was dead code from an earlier MySpeak signup path that no longer exists — it created a `ChildAccount` + `Profile` for a flow that's been replaced.
- Adds a "Removed" entry under `[Unreleased]` in `CHANGELOG.md`.

## Why

Spotted while closing the MySpeak-goes-free rollout audit (#144). The audit confirmed no `plan_type='myspeak'` references in app code, and this orphaned method came up as a separate observation worth cleaning up.

## Test plan

- [x] `grep -rn "handle_myspeak_setup" .` → only the (now-removed) definition matched.
- [x] `ruby -c app/models/user.rb` → Syntax OK.
- [ ] No new behavior to test; pure dead-code removal. CI should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)