### PR TITLE
fix(audio): handle Polly throttling on bulk audio fan-out

### DIFF
--- a/app/sidekiq/create_all_audio_job.rb
+++ b/app/sidekiq/create_all_audio_job.rb
@@ -1,6 +1,17 @@
 class CreateAllAudioJob
   include Sidekiq::Job
-  sidekiq_options queue: :audio, retry: 2
+  sidekiq_options queue: :audio, retry: 5
+
+  # Polly enforces per-region TPS limits. When a burst (e.g. a board language
+  # change fanning out across many images) exceeds them, Polly raises
+  # ThrottlingException. Back off well past Sidekiq's default a few seconds
+  # so the queue actually drains instead of retrying into the same throttle.
+  sidekiq_retry_in do |count, exception|
+    case exception
+    when Aws::Polly::Errors::ThrottlingException
+      (30 * (count + 1)) + rand(15) # 30s, 60s, 90s, 120s, 150s (+ jitter)
+    end
+  end
 
   def perform(image_id, language = "en", scope = "all")
     image = Image.find_by(id: image_id)

--- a/app/sidekiq/translate_board_images_job.rb
+++ b/app/sidekiq/translate_board_images_job.rb
@@ -2,6 +2,11 @@ class TranslateBoardImagesJob
   include Sidekiq::Job
   sidekiq_options queue: :default, retry: 2
 
+  # Stagger per-image jobs so the downstream Polly audio calls don't all hit
+  # AWS at once. A single board with dozens of images previously triggered
+  # `Aws::Polly::Errors::ThrottlingException`.
+  PER_IMAGE_DELAY_SECONDS = 2
+
   # Walks every image on a board and queues a TranslateImageJob for any whose
   # `language_settings` is missing the requested language. Splitting per-image
   # keeps each OpenAI call retryable and bounded.
@@ -13,6 +18,7 @@ class TranslateBoardImagesJob
     return if language.blank? || language == "en"
     return unless Image.languages.include?(language)
 
+    offset = 0
     board.board_images.includes(:image).find_each do |bi|
       image = bi.image
       next unless image && image.label.present?
@@ -20,7 +26,8 @@ class TranslateBoardImagesJob
       existing = (image.language_settings || {})[language]
       next if existing.is_a?(Hash) && (existing["label"] || existing[:label]).to_s.strip.present?
 
-      TranslateImageJob.perform_async(image.id, language)
+      TranslateImageJob.perform_in(offset.seconds, image.id, language)
+      offset += PER_IMAGE_DELAY_SECONDS
     end
   end
 end

--- a/spec/sidekiq/create_all_audio_job_spec.rb
+++ b/spec/sidekiq/create_all_audio_job_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe CreateAllAudioJob, type: :job do
+  describe "retry backoff" do
+    let(:retry_block) { described_class.sidekiq_retry_in_block }
+
+    it "backs off 30s+ on Polly throttling so the queue can drain" do
+      err = Aws::Polly::Errors::ThrottlingException.new(nil, "Rate exceeded")
+      delay = retry_block.call(0, err)
+      expect(delay).to be >= 30
+      expect(delay).to be < 60
+    end
+
+    it "increases the backoff on later attempts" do
+      err = Aws::Polly::Errors::ThrottlingException.new(nil, "Rate exceeded")
+      first = retry_block.call(0, err)
+      later = retry_block.call(3, err)
+      expect(later).to be > first
+    end
+
+    it "falls back to Sidekiq default for unrelated errors" do
+      expect(retry_block.call(0, StandardError.new("boom"))).to be_nil
+    end
+  end
+end

--- a/spec/sidekiq/translate_board_images_job_spec.rb
+++ b/spec/sidekiq/translate_board_images_job_spec.rb
@@ -9,31 +9,31 @@ RSpec.describe TranslateBoardImagesJob, type: :job do
   let!(:bi_b) { FactoryBot.create(:board_image, board: board, image: image_b) }
 
   it "skips when board is missing" do
-    expect(TranslateImageJob).not_to receive(:perform_async)
+    expect(TranslateImageJob).not_to receive(:perform_in)
     described_class.new.perform(0, "es")
   end
 
   it "skips when language is blank or 'en'" do
-    expect(TranslateImageJob).not_to receive(:perform_async)
+    expect(TranslateImageJob).not_to receive(:perform_in)
     described_class.new.perform(board.id, "en")
     described_class.new.perform(board.id, "")
   end
 
   it "skips when language is unsupported" do
-    expect(TranslateImageJob).not_to receive(:perform_async)
+    expect(TranslateImageJob).not_to receive(:perform_in)
     described_class.new.perform(board.id, "xx")
   end
 
-  it "queues a TranslateImageJob for each image missing the translation" do
-    expect(TranslateImageJob).to receive(:perform_async).with(image_a.id, "es")
-    expect(TranslateImageJob).to receive(:perform_async).with(image_b.id, "es")
+  it "queues a TranslateImageJob for each image missing the translation, staggered" do
+    expect(TranslateImageJob).to receive(:perform_in).with(0.seconds, image_a.id, "es")
+    expect(TranslateImageJob).to receive(:perform_in).with(2.seconds, image_b.id, "es")
     described_class.new.perform(board.id, "es")
   end
 
   it "skips images that already have the translation" do
     image_a.update!(language_settings: { "es" => { "label" => "hola" } })
-    expect(TranslateImageJob).not_to receive(:perform_async).with(image_a.id, "es")
-    expect(TranslateImageJob).to receive(:perform_async).with(image_b.id, "es")
+    expect(TranslateImageJob).not_to receive(:perform_in).with(anything, image_a.id, "es")
+    expect(TranslateImageJob).to receive(:perform_in).with(0.seconds, image_b.id, "es")
     described_class.new.perform(board.id, "es")
   end
 end


### PR DESCRIPTION
## Context

After #184 shipped, staging started reporting `Aws::Polly::Errors::ThrottlingException: Rate exceeded`. Each board language change calls `TranslateBoardImagesJob`, which fires `TranslateImageJob` per image; each of those queues `CreateAllAudioJob` which makes 2–3 Polly requests per voice. A board with 50 images can issue 100+ Polly calls in seconds, well past the per-region TPS limit.

## What changed

1. **`CreateAllAudioJob` retry backoff** — added a `sidekiq_retry_in` that returns 30–150s (+jitter) specifically for `Aws::Polly::Errors::ThrottlingException`. Sidekiq's default ~5s backoff just retries straight back into the throttle. Retry count bumped 2 → 5 so jobs can outlast a real burst.
2. **`TranslateBoardImagesJob` stagger** — switched per-image enqueues from `perform_async` to `perform_in(offset.seconds, …)` with a 2s offset per image, so one language change spreads its Polly load over time.

Non-throttling errors keep Sidekiq's default backoff (block returns `nil`).

## Test plan

- [x] `bundle exec rspec spec/sidekiq/translate_board_images_job_spec.rb spec/sidekiq/create_all_audio_job_spec.rb` — 12 examples, 0 failures
- New specs cover: throttling backoff is ≥30s, grows on later attempts, and falls back to Sidekiq default for unrelated errors; stagger schedules images at 0s, 2s, 4s …

🤖 Generated with [Claude Code](https://claude.com/claude-code)