### PR TITLE
feat(images): language-aware image lookup when adding words

### DIFF
--- a/app/controllers/api/account/images_controller.rb
+++ b/app/controllers/api/account/images_controller.rb
@@ -14,12 +14,27 @@ class API::Account::ImagesController < API::Account::ApplicationController
     label = image_params["label"]
 
     is_private = image_params["private"] || false
-    @image = Image.find_by(label: label, user_id: @user.id)
-    @image = Image.public_img.find_by(label: label) unless @image
-    @found_image = @image
-    @image = Image.create(label: label, private: is_private, user_id: @user.id, image_prompt: image_params[:image_prompt], image_type: "User") unless @image || (@found_image && duplicate_image)
-
     @board = Board.find_by(id: image_params[:board_id]) unless image_params[:board_id].blank?
+    language = @board&.language.presence || @user.i18n_locale.to_s.presence || "en"
+
+    @found_image = Image.lookup_by_normalized_label(
+      Image.normalize_label(label),
+      language: language,
+      user: @user,
+    )
+    if @found_image
+      @image = @found_image
+      Image.record_localized_label!(@image, language, label) if language != "en"
+    else
+      @image = Image.find_or_create_for_label(label, language: language, user: @user)
+      if @image && @image.previously_new_record?
+        @image.update(
+          private: is_private,
+          image_prompt: image_params[:image_prompt],
+          image_type: "User",
+        )
+      end
+    end
     if @board.nil? && duplicate_image && !generate_image && !@image.blank?
       return render json: @image.api_view(@user), status: :ok
     end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -705,17 +705,12 @@ class API::BoardsController < API::ApplicationController
   def add_image
     set_board
     # @board = Board.with_artifacts.find(params[:id])
-    @found_image = Image.find_by(label: image_params[:label], user_id: current_user.id, private: true)
-    @found_image ||= Image.find_by(label: image_params[:label])
-    if @found_image
-      @image = @found_image
-      img_saved = true
-    else
-      @image = Image.new
-      @image.user = current_user
-      @image.label = image_params[:label]
-      img_saved = @image.save!
-    end
+    @image = Image.find_or_create_for_label(
+      image_params[:label],
+      language: @board&.language.presence || "en",
+      user: current_user,
+    )
+    img_saved = @image&.persisted?
 
     new_doc = nil
     if (image_params[:docs].present?)

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -72,10 +72,8 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     if p[:image_id].present?
       Image.find_by(id: p[:image_id])
     elsif p[:label].present?
-      label = p[:label].to_s.strip
-      Image.find_by(label: label, user_id: current_user.id) ||
-        Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil]) ||
-        Image.create(label: label, user_id: current_user.id)
+      language = p[:language].presence || @board&.language.presence || "en"
+      Image.find_or_create_for_label(p[:label], language: language, user: current_user)
     end
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -562,6 +562,118 @@ class Image < ApplicationRecord
     ["en", "es", "fr", "de", "it", "ja", "ko", "nl", "pl", "pt", "ru", "zh"]
   end
 
+  # Strip + downcase + transliterate accents. Used for case- and
+  # diacritic-insensitive matching against the DB's `unaccent(lower(...))`.
+  def self.normalize_label(str)
+    return "" if str.blank?
+    ActiveSupport::Inflector.transliterate(str.to_s.strip.downcase)
+  end
+
+  # Returns an Image whose canonical (English) `label` corresponds to the
+  # user's `input_label`, honoring the requesting board/user's `language`.
+  #
+  # Identity model is English-canonical: `Image#label` is always English,
+  # and `Image#language_settings[<lang>] = { "label" => ..., "display_label"
+  # => ... }` holds the localized form. On a Spanish board, "perro" resolves
+  # to the existing "dog" image via its stored es translation; if no match
+  # exists, we translate "perro" → English ("dog") and find_or_create on
+  # the English term, then record the user's original Spanish input in
+  # language_settings.
+  #
+  # Args:
+  #   input_label - raw user-entered string
+  #   language    - the board's language (defaults to "en")
+  #   user        - optional User whose private images get lookup priority
+  #
+  # Returns a persisted Image, or nil if input is blank.
+  def self.find_or_create_for_label(input_label, language: "en", user: nil)
+    return nil if input_label.blank?
+
+    language = language.to_s.presence || "en"
+    language = "en" unless languages.include?(language)
+    norm = normalize_label(input_label)
+    return nil if norm.blank?
+
+    image = lookup_by_normalized_label(norm, language: language, user: user)
+
+    english_label = nil
+    if image.nil? && language != "en"
+      english_label = translate_to_english(input_label, language)
+      if english_label.present?
+        english_norm = normalize_label(english_label)
+        image = lookup_by_normalized_label(english_norm, language: "en", user: user)
+      end
+    end
+
+    if image.nil?
+      # Translation succeeded → create canonical English image.
+      # Translation failed or input was already English → create with the raw
+      # input and let the existing TranslateImageJob backfill translations.
+      if english_label.present?
+        image = create!(label: english_label.to_s.strip, language: "en", user_id: user&.id)
+      else
+        image = create!(label: input_label.to_s.strip, language: language, user_id: user&.id)
+      end
+    end
+
+    record_localized_label!(image, language, input_label) if language != "en"
+
+    image
+  end
+
+  # Lookup an image whose canonical label OR stored translation for `language`
+  # matches `norm` (a pre-normalized string). Returns the user's private match
+  # first, then a public match, or nil.
+  def self.lookup_by_normalized_label(norm, language:, user:)
+    return nil if norm.blank?
+
+    base = where(
+      "unaccent(lower(label)) = ? OR unaccent(lower(coalesce(language_settings -> ? ->> 'label', ''))) = ?",
+      norm, language, norm,
+    )
+
+    if user
+      owned = base.where(user_id: user.id).first
+      return owned if owned
+    end
+
+    base.public_img.first || base.first
+  end
+
+  # Records the user-entered localized form on the image so future lookups
+  # in this language find it instantly. Skipped for English (label already
+  # holds the canonical form).
+  def self.record_localized_label!(image, language, input_label)
+    return if language == "en"
+    return if image.nil? || input_label.blank?
+
+    settings = image.language_settings.is_a?(Hash) ? image.language_settings.deep_dup : {}
+    entry = settings[language].is_a?(Hash) ? settings[language] : {}
+
+    cleaned = input_label.to_s.strip
+    return if entry["label"].to_s == cleaned && entry["display_label"].present?
+
+    entry["label"] = cleaned if entry["label"].blank?
+    entry["display_label"] = cleaned.titleize if entry["display_label"].blank?
+    settings[language] = entry
+
+    image.update_column(:language_settings, settings)
+  end
+
+  # Synchronously translates `input` from `from_language` to English using
+  # OpenAiClient. Returns nil on failure (caller falls back to creating with
+  # the original input).
+  def self.translate_to_english(input, from_language)
+    return nil if input.blank? || from_language.to_s == "en"
+    return nil if Rails.env.test? # OpenAiClient.translate_text is a no-op in test
+
+    client = OpenAiClient.new({ prompt: input.to_s })
+    client.translate_text(input.to_s, from_language.to_s, "en")
+  rescue => e
+    Rails.logger.warn("Image.translate_to_english failed for #{input.inspect} (#{from_language}): #{e.class} #{e.message}")
+    nil
+  end
+
   def core_words
     ["yes", "no", "more", "stop", "go", "help", "please", "thank you", "sorry", "i want", "i feel", "bathroom", "thirsty", "hungry", "tired", "hurt", "happy", "sad", "play", "all done"]
   end

--- a/db/migrate/20260526120000_enable_unaccent_and_index_language_settings.rb
+++ b/db/migrate/20260526120000_enable_unaccent_and_index_language_settings.rb
@@ -1,0 +1,18 @@
+class EnableUnaccentAndIndexLanguageSettings < ActiveRecord::Migration[7.0]
+  def up
+    enable_extension "unaccent" unless extension_enabled?("unaccent")
+
+    return if index_exists?(:images, :language_settings, name: "index_images_on_language_settings_gin")
+
+    add_index :images,
+              :language_settings,
+              using: :gin,
+              name: "index_images_on_language_settings_gin"
+  end
+
+  def down
+    if index_exists?(:images, :language_settings, name: "index_images_on_language_settings_gin")
+      remove_index :images, name: "index_images_on_language_settings_gin"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_23_180000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -480,6 +481,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_23_180000) do
     t.jsonb "language_settings", default: {}
     t.string "language", default: "en"
     t.index ["category"], name: "index_images_on_category"
+    t.index ["language_settings"], name: "index_images_on_language_settings_gin", using: :gin
     t.index ["obf_id"], name: "index_images_on_obf_id"
     t.index ["use_custom_audio"], name: "index_images_on_use_custom_audio"
     t.index ["voice"], name: "index_images_on_voice"

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -174,4 +174,115 @@ RSpec.describe Image, type: :model do
       expect(image.text_for_audio("fr")).to eq("hello")
     end
   end
+
+  describe ".normalize_label" do
+    it "lowercases, strips, and removes diacritics" do
+      expect(Image.normalize_label("  Perró  ")).to eq("perro")
+    end
+
+    it "returns empty string for blank input" do
+      expect(Image.normalize_label(nil)).to eq("")
+      expect(Image.normalize_label("")).to eq("")
+    end
+  end
+
+  describe ".find_or_create_for_label" do
+    let(:user) { FactoryBot.create(:user) }
+
+    context "with English input" do
+      it "returns the user's existing image when label matches" do
+        owned = FactoryBot.create(:image, label: "dog", user_id: user.id)
+        FactoryBot.create(:image, label: "dog", user_id: nil, is_private: false)
+        result = Image.find_or_create_for_label("dog", language: "en", user: user)
+        expect(result).to eq(owned)
+      end
+
+      it "falls back to a public image when the user has none" do
+        public_image = FactoryBot.create(:image, label: "dog", user_id: nil, is_private: false)
+        result = Image.find_or_create_for_label("dog", language: "en", user: user)
+        expect(result).to eq(public_image)
+      end
+
+      it "creates a new English-canonical image when none exists" do
+        expect {
+          @image = Image.find_or_create_for_label("dog", language: "en", user: user)
+        }.to change { Image.count }.by(1)
+        expect(@image.label).to eq("dog")
+        expect(@image.language).to eq("en")
+        expect(@image.user_id).to eq(user.id)
+      end
+    end
+
+    context "with Spanish input" do
+      it "matches an existing image by its stored Spanish translation" do
+        dog = FactoryBot.create(
+          :image,
+          label: "dog",
+          user_id: nil,
+          is_private: false,
+          language_settings: { "es" => { "label" => "perro", "display_label" => "Perro" } },
+        )
+        result = Image.find_or_create_for_label("perro", language: "es", user: user)
+        expect(result).to eq(dog)
+      end
+
+      it "matches case- and diacritic-insensitively" do
+        dog = FactoryBot.create(
+          :image,
+          label: "dog",
+          user_id: nil,
+          is_private: false,
+          language_settings: { "es" => { "label" => "perro", "display_label" => "Perro" } },
+        )
+        result = Image.find_or_create_for_label("Perró", language: "es", user: user)
+        expect(result).to eq(dog)
+      end
+
+      it "translates input to English and matches on the canonical label" do
+        cat = FactoryBot.create(:image, label: "cat", user_id: nil, is_private: false)
+        allow(Image).to receive(:translate_to_english).with("gato", "es").and_return("cat")
+        result = Image.find_or_create_for_label("gato", language: "es", user: user)
+        expect(result).to eq(cat)
+        expect(result.reload.language_settings.dig("es", "label")).to eq("gato")
+      end
+
+      it "creates a canonical English image when translation succeeds but no match exists" do
+        allow(Image).to receive(:translate_to_english).with("gato", "es").and_return("cat")
+        expect {
+          @image = Image.find_or_create_for_label("gato", language: "es", user: user)
+        }.to change { Image.count }.by(1)
+        expect(@image.label).to eq("cat")
+        expect(@image.language).to eq("en")
+        expect(@image.language_settings.dig("es", "label")).to eq("gato")
+      end
+
+      it "falls back to creating with the raw input when translation fails" do
+        allow(Image).to receive(:translate_to_english).with("gato", "es").and_return(nil)
+        expect {
+          @image = Image.find_or_create_for_label("gato", language: "es", user: user)
+        }.to change { Image.count }.by(1)
+        expect(@image.label).to eq("gato")
+        expect(@image.language).to eq("es")
+      end
+
+      it "records the user's Spanish input on a match that lacked it" do
+        cat = FactoryBot.create(:image, label: "cat", user_id: nil, is_private: false)
+        allow(Image).to receive(:translate_to_english).with("gato", "es").and_return("cat")
+        Image.find_or_create_for_label("gato", language: "es", user: user)
+        expect(cat.reload.language_settings.dig("es", "label")).to eq("gato")
+        expect(cat.language_settings.dig("es", "display_label")).to eq("Gato")
+      end
+    end
+
+    it "returns nil for blank input" do
+      expect(Image.find_or_create_for_label(nil, language: "es", user: user)).to be_nil
+      expect(Image.find_or_create_for_label("   ", language: "es", user: user)).to be_nil
+    end
+
+    it "treats unknown languages as English" do
+      FactoryBot.create(:image, label: "dog", user_id: nil, is_private: false)
+      result = Image.find_or_create_for_label("dog", language: "xx", user: user)
+      expect(result.label).to eq("dog")
+    end
+  end
 end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -458,5 +458,40 @@ RSpec.describe "API::Boards", type: :request do
       board_image = board.board_images.find_by(image_id: foreign_image.id)
       expect(board_image.display_image_url).to eq(new_doc.tile_url)
     end
+
+    context "when the board is in a non-English language" do
+      let!(:spanish_board) { create(:board, user: user, name: "Tablero", language: "es") }
+
+      it "reuses an existing English image when the user enters its Spanish translation" do
+        dog = create(
+          :image,
+          label: "dog",
+          user_id: nil,
+          is_private: false,
+          language_settings: { "es" => { "label" => "perro", "display_label" => "Perro" } },
+        )
+
+        expect {
+          post "/api/boards/#{spanish_board.id}/add_image",
+               params: { image: { label: "perro" } },
+               headers: auth_headers(user)
+        }.not_to change(Image, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(spanish_board.reload.images).to include(dog)
+      end
+
+      it "records the user's Spanish input on the matched image's language_settings" do
+        cat = create(:image, label: "cat", user_id: nil, is_private: false)
+        allow(Image).to receive(:translate_to_english).with("gato", "es").and_return("cat")
+
+        post "/api/boards/#{spanish_board.id}/add_image",
+             params: { image: { label: "gato" } },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(cat.reload.language_settings.dig("es", "label")).to eq("gato")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the case where adding **"perro"** to a Spanish board would `find_or_create_by(label: "perro")` and create a duplicate Image, ignoring the existing **"dog"** image whose `language_settings.es.label` was already "perro".

The lookup is now language-aware:
1. Match against `label` OR `language_settings.<lang>.label` (case- and diacritic-insensitive via Postgres `unaccent` + `lower`).
2. On miss for non-English input, translate input → English via OpenAI and retry the lookup on the canonical English label.
3. Only create a new Image if both steps miss. The user's original term is always recorded into `language_settings[<lang>]`.

Identity stays **English-canonical**: `Image#label` is always English, localized forms live in `language_settings`.

## What changed

- New helpers on `Image`: `find_or_create_for_label`, `normalize_label`, `lookup_by_normalized_label`, `record_localized_label!`, `translate_to_english`.
- Migration enables the `unaccent` Postgres extension and adds a GIN index on `images.language_settings`.
- Migrated user-facing add-word callers:
  - `API::BoardsController#add_image`
  - `API::Internal::BoardImagesController#resolve_image_from`
  - `API::Account::ImagesController#find_or_create`
- Bespoke admin/generation paths (`ImagesController#crop`/`#generate`, `Internal::ImagesController#create`, `DocsController#find_or_create_image`, audit lookups) are intentionally left alone — they don't share the user-adding-a-word intent.

## Reviewer notes

- The new normalized SQL comparison (`unaccent(lower(...))`) won't use the GIN index — that index is for jsonb containment queries elsewhere. Per-language expression indexes are a follow-up if profiling shows scans.
- Ambiguity guard: we strict-match on the stored translation, then translate-to-English for canonical lookup. We do **not** loosely collapse different concepts that happen to share an English translation (e.g. "tú" vs "usted").
- A backfill rake task to merge already-duplicated images from the old path is **out of scope** for this PR.

## Test plan

- [x] \`bin/rails db:migrate\` runs cleanly (unaccent + GIN index)
- [x] \`bundle exec rspec spec/models/image_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/internal/board_images_spec.rb\` — 85 examples, 0 failures
- [x] 13 new model specs: English/Spanish/translate-on-miss/diacritic match/blank input/unknown language
- [x] 2 new boards request specs: Spanish-board add reuses existing English image; localized label is recorded
- [ ] Full \`bundle exec rspec\` (was interrupted in-session — please run before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)