### PR TITLE
feat(communicators): let Free users self-create their 1 communicator slot

### DIFF
--- a/app/helpers/permissions/communicator_limits.rb
+++ b/app/helpers/permissions/communicator_limits.rb
@@ -2,10 +2,10 @@ module Permissions
   module CommunicatorLimits
     extend self
 
-    # Slot math (per the loaner-lifecycle spec — issue #158):
+    # Slot math:
     #
-    #   Free  — 0 self-created (loaner/active). May host 1 *claimed* (a loaner
-    #           handed off SLP → parent). Plus the no-login sandbox.
+    #   Free  — 1 communicator (self-created or claimed). Plus the no-login
+    #           sandbox.
     #   Basic — 2 communicators (loaner + active total).
     #   Pro   — 3 communicators, loaner-capable, recycling.
     #
@@ -61,7 +61,7 @@ module Permissions
 
     def self_create_allowed?(user)
       return true if user.admin?
-      user.paid_plan?
+      slot_limit_for(user.settings || {}) > 0
     end
 
     private
@@ -77,10 +77,6 @@ module Permissions
     end
 
     def check_slot_self_create(user, settings)
-      unless self_create_allowed?(user)
-        return [false, :forbidden, "Your plan does not allow creating communicator accounts. Upgrade to Basic or Pro, or have one handed to you."]
-      end
-
       limit = slot_limit_for(settings)
       count = owned_slot_count(user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,16 +234,15 @@ class User < ApplicationRecord
     plan_type == "pro" ? 5 : 2
   end
 
-  # Communicator slot math after the loaner-lifecycle rework (issue #156):
+  # Communicator slot math:
   #
   #   paid_communicator_limit — total owned `loaner` + `active` slots.
-  #                             Free has 1 because they can host one
-  #                             *claimed* communicator (B4), even though
-  #                             they cannot self-create one.
+  #                             Free has 1 (self-created or claimed).
   #   demo_communicator_limit — sandbox (no-login, board-capped) slots.
   #
-  # `Permissions::CommunicatorLimits.self_create_allowed?` gates whether a
-  # user may create a non-sandbox communicator themselves (paid plan only).
+  # `Permissions::CommunicatorLimits.self_create_allowed?` returns true
+  # whenever the user has any non-zero slot limit (i.e. has at least one
+  # slot to spend).
   FREE_PLAN_LIMITS = {
     "plan_type" => "free",
     "board_limit" => ENV.fetch("FREE_BOARD_LIMIT", 1).to_i,

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Permissions::CommunicatorLimits do
-  # Slot math after the loaner-lifecycle rework (issue #158):
-  #   Free  — 0 self-created; may host 1 claimed; +1 sandbox.
+  # Slot math:
+  #   Free  — 1 communicator (self-created or claimed); +1 sandbox.
   #   Basic — 2 self-created.
   #   Pro   — 3 self-created, loaner-capable.
 
@@ -33,12 +33,22 @@ RSpec.describe Permissions::CommunicatorLimits do
         expect(error).to match(/limit reached/i)
       end
 
-      it "blocks self-creating an active communicator (Free can't self-create)" do
+      it "allows self-creating one active communicator (Free gets 1 slot)" do
+        allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
+
+        expect(allowed).to be(true)
+        expect(http_status).to eq(:ok)
+        expect(error).to be_nil
+      end
+
+      it "blocks a second active once the free slot is used" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+
         allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
 
         expect(allowed).to be(false)
-        expect(http_status).to eq(:forbidden)
-        expect(error).to match(/does not allow|does not include/i)
+        expect(http_status).to eq(:unprocessable_entity)
+        expect(error).to match(/maximum.*reached/i)
       end
 
       it "still accepts the legacy is_demo:true shape" do

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe User, "plan limits", type: :model do
     end
   end
 
-  # Per loaner-lifecycle issue #158:
-  #   Free  — 0 self-created, may HOST 1 claimed (slot pool = 1).
+  # Slot pool sizes (self-created or claimed):
+  #   Free  — 1.
   #   Basic — 2.
   #   Pro   — 3.
   describe "paid (loaner+active) communicator slot limits" do

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -32,12 +32,22 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it "rejects self-creating a non-sandbox communicator on Free" do
+      it "allows self-creating one non-sandbox communicator on Free" do
         post "/api/child_accounts",
           params: { name: "Real", username: "real-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:created)
+      end
+
+      it "blocks a second non-sandbox communicator once the Free slot is used" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+
+        post "/api/child_accounts",
+          params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it "still accepts the legacy is_demo=true param for backwards compat" do


### PR DESCRIPTION
## Summary

Free users hitting `/communicator-accounts/new` were getting a 403 "Your plan does not allow creating communicator accounts. Upgrade to Basic or Pro, or have one handed to you." — even though `FREE_PLAN_LIMITS["paid_communicator_limit"]` is already `1`.

The 1-slot allowance was originally intended for *hosting a claimed loaner* (SLP → parent hand-off), but `Permissions::CommunicatorLimits.self_create_allowed?` short-circuited self-create with a paid-plan paywall, so the slot was unreachable by self-create.

This PR removes the paid-plan gate and lets the existing slot-limit check enforce the cap. Free users can now self-create their 1 communicator; the 2nd attempt is still blocked with the existing 422 "Maximum number of communicator accounts reached." Basic (2) and Pro (3) caps are unchanged.

## What changed

- `app/helpers/permissions/communicator_limits.rb` — `check_slot_self_create` no longer calls the paid-plan paywall; `self_create_allowed?` now reflects "has any slot > 0" so external callers see the truth.
- `app/models/user.rb` — comment refresh on the slot-math block.
- Specs updated to assert the new behavior:
  - `spec/helpers/permissions/communicator_limits_spec.rb` — Free can self-create one ACTIVE, second is rejected.
  - `spec/requests/api/child_accounts_demo_limit_spec.rb` — same flip at the request level.
  - `spec/models/user_plan_limits_spec.rb` — comment refresh.

## Test plan

- [x] `rspec spec/helpers/permissions/communicator_limits_spec.rb` — 11 examples, 0 failures
- [x] `rspec spec/requests/api/child_accounts_demo_limit_spec.rb` — 9 examples, 0 failures
- [x] `rspec spec/models/user_plan_limits_spec.rb` — 6 examples, 0 failures
- [x] `rspec spec/lib/tasks/plans_rake_spec.rb` — 10 examples, 0 failures
- [ ] Manually confirm on staging: Free user with 0 communicators can `POST /api/child_accounts` with `status: "active"` and get a 201; a 2nd attempt returns 422.

## Notes for reviewer

- This intentionally widens the Free policy compared to the original loaner-lifecycle spec (#163), which had Free at "0 self-created, may host 1 claimed." The new policy treats the 1 slot as a generic communicator slot — self-created *or* claimed — which matches the UI expectation and the existing `FREE_PAID_COMMUNICATOR_LIMIT=1` default.
- Loaner / claim flows are unaffected: `can_claim?` and the loaner promotion paths still consult the same slot pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)