### PR TITLE
feat(onboarding): MySpeak setup wizard endpoint

### DIFF
--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -1,0 +1,158 @@
+module API
+  module V1
+    module Onboarding
+      class MyspeakController < API::ApplicationController
+        STARTER_BOARD_SLUGS = {
+          "basics"   => "myspeak-basics",
+          "feelings" => "myspeak-feelings",
+          "social"   => "myspeak-social",
+        }.freeze
+
+        MAX_SLUG_TRIES = 50
+
+        def create
+          unless current_user.can_create_myspeak_id?
+            limit = current_user.myspeak_id_limit
+            render json: {
+              error: "myspeak_id_limit_reached",
+              message: "Free accounts are limited to #{limit} MySpeak ID. Upgrade to Basic or Pro to add more.",
+              limit: limit,
+              count: current_user.myspeak_id_count,
+            }, status: :forbidden
+            return
+          end
+
+          name = params[:name].to_s.strip
+          if name.blank?
+            render json: { error: "Onboarding failed", details: ["Name can't be blank"] },
+                   status: :unprocessable_entity
+            return
+          end
+
+          pronouns       = params[:pronouns].to_s.strip
+          care_notes     = params[:care_notes].to_s
+          board_id       = params[:board_id].to_s
+          photo_data_url = params[:photo_data_url].to_s
+          contacts       = Array(params[:contacts])
+
+          base_slug = name.parameterize.presence || "communicator-#{SecureRandom.hex(3)}"
+          unique = unique_slug_for(base_slug)
+
+          profile = nil
+
+          ActiveRecord::Base.transaction do
+            # `communicator_accounts` uses `owner_id` as the FK; set `user`
+            # explicitly so downstream `api_view`s (which read
+            # `child.user.pro?` etc.) don't see a nil user.
+            child = current_user.communicator_accounts.create!(
+              name: name,
+              username: unique,
+              user: current_user,
+            )
+
+            profile = Profile.new(
+              profileable: child,
+              profile_kind: "safety",
+              username: unique,
+              slug: unique,
+              bio: care_notes,
+              settings: build_settings(pronouns: pronouns, contacts: contacts),
+            )
+
+            attach_photo(profile, photo_data_url, unique) if photo_data_url.present?
+
+            profile.save!
+
+            attach_starter_board(child, board_id)
+          end
+
+          profile.generate_attachments! if profile.safety?
+          render json: profile.safety_view, status: :created
+        rescue ActiveRecord::RecordInvalid => e
+          Rails.logger.warn "[Onboarding::Myspeak#create] #{e.record.class}: #{e.record.errors.full_messages.join(", ")}"
+          render json: {
+            error: "Onboarding failed",
+            details: e.record.errors.full_messages,
+          }, status: :unprocessable_entity
+        end
+
+        private
+
+        def build_settings(pronouns:, contacts:)
+          settings = {}
+          settings["pronouns"] = pronouns if pronouns.present?
+
+          slot = 1
+          contacts.each do |c|
+            attrs = c.respond_to?(:to_unsafe_h) ? c.to_unsafe_h : c.to_h
+            name  = attrs["name"].to_s.strip
+            phone = attrs["phone"].to_s.strip
+            rel   = attrs["relationship"].to_s.strip
+            next if name.blank? && phone.blank?
+
+            settings["ice_contact_#{slot}"] = {
+              "name" => name,
+              "relationship" => rel,
+              "phone" => phone,
+            }
+            slot += 1
+            break if slot > 5
+          end
+
+          settings
+        end
+
+        def attach_photo(profile, data_url, slug)
+          match = data_url.match(/\Adata:(?<ct>[\w\/+\-.]+);base64,(?<b64>.+)\z/m)
+          return unless match
+
+          content_type = match[:ct]
+          bytes = Base64.decode64(match[:b64])
+          return if bytes.blank?
+
+          ext = content_type.split("/").last.split("+").first
+          ext = "png" if ext.blank?
+
+          profile.avatar.attach(
+            io: StringIO.new(bytes),
+            filename: "#{slug}.#{ext}",
+            content_type: content_type,
+          )
+        end
+
+        def attach_starter_board(child, board_id)
+          slug = STARTER_BOARD_SLUGS[board_id]
+          return unless slug
+
+          board = Board.find_by(slug: slug)
+          unless board
+            Rails.logger.warn "[Onboarding::Myspeak] starter board #{slug.inspect} missing — skipping attachment"
+            return
+          end
+
+          ChildBoard.create!(
+            board: board,
+            child_account: child,
+            created_by: current_user,
+            favorite: true,
+          )
+        end
+
+        def unique_slug_for(base)
+          candidate = base
+          (1..MAX_SLUG_TRIES).each do |i|
+            candidate = (i == 1 ? base : "#{base}-#{i}")
+            return candidate unless slug_or_username_taken?(candidate)
+          end
+          "#{base}-#{SecureRandom.hex(3)}"
+        end
+
+        def slug_or_username_taken?(value)
+          Profile.exists?(slug: value) ||
+            Profile.exists?(username: value) ||
+            ChildAccount.exists?(username: value)
+        end
+      end
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -350,6 +350,7 @@ class Profile < ApplicationRecord
 
   # --- Public settings whitelist ---
   SAFETY_PUBLIC_KEYS = %w[
+    pronouns
     allergies
     medical_conditions
     medications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -384,6 +384,10 @@ Rails.application.routes.draw do
     end
 
     namespace :v1 do
+      namespace :onboarding do
+        post :myspeak, to: "myspeak#create"
+      end
+
       resource :auth, only: [:create, :destroy]
       delete "/child_accounts/logout", to: "child_auths#destroy"
       post "/child_accounts/login", to: "child_auths#create"

--- a/db/seeds/myspeak_starter_boards.rb
+++ b/db/seeds/myspeak_starter_boards.rb
@@ -1,0 +1,51 @@
+# Seed the three starter boards used by the MySpeak onboarding wizard
+# (POST /api/v1/onboarding/myspeak). Idempotent — safe to re-run. Image
+# tiles are not seeded here; admin can populate via the editor.
+#
+# Run:
+#   bin/rails runner db/seeds/myspeak_starter_boards.rb
+#
+# Or load from db/seeds.rb:
+#   load Rails.root.join("db/seeds/myspeak_starter_boards.rb")
+
+admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || User.where(role: "admin").order(:id).first
+abort "No admin user found (User::DEFAULT_ADMIN_ID=#{User::DEFAULT_ADMIN_ID})." unless admin
+
+STARTERS = [
+  {
+    slug: "myspeak-basics",
+    name: "Basic needs",
+    description: "Core daily words: yes, no, more, all done, help, hurt.",
+    category: "welcome",
+  },
+  {
+    slug: "myspeak-feelings",
+    name: "Feelings & needs",
+    description: "Quick feeling and need words: happy, sad, hungry, thirsty, tired, scared.",
+    category: "welcome",
+  },
+  {
+    slug: "myspeak-social",
+    name: "Out & about",
+    description: "Out-and-about words: hi, bye, please, thank you, my name is, I need.",
+    category: "welcome",
+  },
+].freeze
+
+STARTERS.each do |attrs|
+  board = Board.find_by(slug: attrs[:slug]) || Board.new(slug: attrs[:slug])
+  board.assign_attributes(
+    name: attrs[:name],
+    description: attrs[:description],
+    category: attrs[:category],
+    user: admin,
+    parent: admin,
+    predefined: true,
+    published: true,
+    is_template: false,
+    sub_board: false,
+    board_type: "board",
+  )
+  board.save!
+  puts "[myspeak-starter] #{board.persisted? ? 'ok' : 'failed'}: #{board.slug} (id=#{board.id})"
+end

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -1,0 +1,177 @@
+require "rails_helper"
+
+RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
+  # 1x1 transparent PNG
+  PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=".freeze
+
+  let(:user) do
+    u = FactoryBot.create(:user)
+    # Pull out of the soft-trial window so paid_plan? is false and we can test
+    # the genuine Free state.
+    u.update_columns(plan_type: "free", created_at: 60.days.ago)
+    u
+  end
+
+  let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
+
+  let(:base_payload) do
+    {
+      name: "River Stone",
+      pronouns: "they/them",
+      photo_data_url: PNG_DATA_URL,
+      board_id: "later",
+      care_notes: "Loves big hugs. Use a calm voice when overwhelmed.",
+      contacts: [
+        { name: "Sam Stone", relationship: "Parent", phone: "555-0101" },
+        { name: "Kit Stone", relationship: "Aunt",   phone: "555-0102" },
+        { name: "Jo Stone",  relationship: "Friend", phone: "555-0103" },
+      ],
+    }
+  end
+
+  before do
+    # The synchronous PDF/PNG generation in Profile#generate_attachments! is
+    # heavy (Grover-style HTML rendering) and not what these specs are about.
+    allow_any_instance_of(Profile).to receive(:generate_attachments!).and_return(true)
+  end
+
+  describe "POST /api/v1/onboarding/myspeak" do
+    context "without auth" do
+      it "returns 401" do
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json,
+             headers: { "Content-Type" => "application/json" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "happy path" do
+      it "creates a child account + safety profile, attaches avatar, writes settings" do
+        expect {
+          post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+        }.to change { user.communicator_accounts.count }.by(1)
+         .and change { Profile.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+
+        child = user.communicator_accounts.order(:created_at).last
+        expect(child.name).to eq("River Stone")
+        expect(child.username).to eq("river-stone")
+
+        profile = child.profile
+        expect(profile.profile_kind).to eq("safety")
+        expect(profile.slug).to eq("river-stone")
+        expect(profile.username).to eq("river-stone")
+        expect(profile.bio).to include("Loves big hugs")
+        expect(profile.avatar).to be_attached
+        expect(profile.settings["pronouns"]).to eq("they/them")
+        expect(profile.settings["ice_contact_1"]).to eq(
+          "name" => "Sam Stone", "relationship" => "Parent", "phone" => "555-0101",
+        )
+        expect(profile.settings["ice_contact_2"]["name"]).to eq("Kit Stone")
+        expect(profile.settings["ice_contact_3"]["name"]).to eq("Jo Stone")
+
+        body = JSON.parse(response.body)
+        expect(body["slug"]).to eq("river-stone")
+        expect(body["profile_kind"]).to eq("safety")
+        expect(body["settings"]["pronouns"]).to eq("they/them")
+        expect(body["settings"]["ice_contact_1"]["phone"]).to eq("555-0101")
+      end
+    end
+
+    context "missing name" do
+      it "returns 422" do
+        post "/api/v1/onboarding/myspeak",
+             params: base_payload.merge(name: "").to_json, headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["details"]).to include(/Name/)
+      end
+    end
+
+    context "slug collision" do
+      it "appends -2 to the slug" do
+        Profile.create!(
+          username: "river-stone",
+          slug: "river-stone",
+          bio: "x",
+          intro: "y",
+        )
+
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        new_profile = user.communicator_accounts.last.profile
+        expect(new_profile.slug).to eq("river-stone-2")
+        expect(new_profile.username).to eq("river-stone-2")
+      end
+    end
+
+    context "board_id 'later'" do
+      it "does not create a ChildBoard" do
+        expect {
+          post "/api/v1/onboarding/myspeak",
+               params: base_payload.merge(board_id: "later").to_json, headers: headers
+        }.not_to change { ChildBoard.count }
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "board_id matches a seeded starter board" do
+      it "favorites it on the new communicator" do
+        admin = FactoryBot.create(:admin_user)
+        starter = Board.create!(
+          slug: "myspeak-basics",
+          name: "Basic needs",
+          user: admin,
+          parent: admin,
+          predefined: true,
+          published: true,
+          board_type: "board",
+        )
+
+        post "/api/v1/onboarding/myspeak",
+             params: base_payload.merge(board_id: "basics").to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        child = user.communicator_accounts.last
+        cb = child.child_boards.find_by(board: starter)
+        expect(cb).to be_present
+        expect(cb.favorite).to eq(true)
+        expect(cb.created_by_id).to eq(user.id)
+      end
+    end
+
+    context "blank contacts are filtered" do
+      it "only persists non-empty contacts and numbers them sequentially" do
+        payload = base_payload.merge(contacts: [
+          { name: "Sam", relationship: "Parent", phone: "555-1" },
+          { name: "",    relationship: "",       phone: "" },
+          { name: "Kit", relationship: "Aunt",   phone: "555-2" },
+        ])
+        post "/api/v1/onboarding/myspeak", params: payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        s = user.communicator_accounts.last.profile.settings
+        expect(s["ice_contact_1"]["name"]).to eq("Sam")
+        expect(s["ice_contact_2"]["name"]).to eq("Kit")
+        expect(s["ice_contact_3"]).to be_nil
+      end
+    end
+
+    context "free user already at the MySpeak ID limit" do
+      it "returns 403 myspeak_id_limit_reached" do
+        Profile.create!(
+          profileable: user,
+          username: "first-#{SecureRandom.hex(2)}",
+          slug: "first-#{SecureRandom.hex(2)}",
+        )
+
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:forbidden)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("myspeak_id_limit_reached")
+        expect(body["limit"]).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New endpoint **`POST /api/v1/onboarding/myspeak`** that creates a communicator's safety profile in one round-trip — child account + safety `Profile` + avatar + pronouns + ICE contacts + optional favorited starter board, all in one transaction.
- Adds `pronouns` to `Profile::SAFETY_PUBLIC_KEYS` so it surfaces on the public safety view.
- Enforces existing Free-tier MySpeak ID cap (returns **403 `myspeak_id_limit_reached`**); slug collisions get `-2`, `-3`, … fallback.
- Idempotent seed at `db/seeds/myspeak_starter_boards.rb` that creates the three boards the wizard picker maps to (`myspeak-basics`, `myspeak-feelings`, `myspeak-social`). Tile contents intentionally left empty for admin to populate later.
- No schema migrations.

## Notes / trade-offs

- `current_user.communicator_accounts` uses `owner_id` as its FK; the controller sets `user:` explicitly so downstream `api_view`s don't see a nil user. Pre-existing latent issue in `Profile.generate_with_username` — out of scope here.
- The synchronous `Profile#generate_attachments!` (PDF/PNG render) is stubbed in specs but runs in production, matching the existing `ProfilesController#create` pattern.
- Frontend wizard lives in `itty-bitty-frontend` — separate PR.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb` — 8 examples, all green
- [x] `bundle exec rspec spec/requests/api/profiles_spec.rb` — 5 examples, all green (no regression)
- [x] `bin/rails runner db/seeds/myspeak_starter_boards.rb` — created 3 boards locally, idempotent on re-run
- [ ] **End-to-end with the frontend wizard** — pending the FE PR being deployed somewhere

## Spec coverage

- Happy path: child account + safety profile created, avatar attached, contacts in `ice_contact_N`, response is `safety_view`
- Unauthenticated → 401
- Missing name → 422
- Slug collision → `-2` suffix
- `board_id: "later"` → no `ChildBoard` created
- `board_id: "basics"` with seeded board → favorited `ChildBoard` row
- Blank contacts filtered out, numbering stays sequential
- Free user already at limit → 403 `myspeak_id_limit_reached`

🤖 Generated with [Claude Code](https://claude.com/claude-code)