### PR TITLE
feat(api): expose has_boards on User#api_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — `has_boards` flag on `User#api_view`
+- `User#api_view` now returns `has_boards: boolean` alongside
+  `board_count`. Derived from the already-computed `board_count`
+  (zero extra queries) so the new free-tier dashboard
+  (`itty-bitty-frontend` PR #183) can branch on an explicit boolean
+  instead of `(board_count ?? 0) > 0`. No behavior change for
+  existing clients — additive field only.
+
 ### Added — Free = 1 MySpeak ID limit (#143)
 - Free users are now capped at **one MySpeak ID** (Profile). Basic/Pro
   and admins remain unlimited. Trial users (`basic_trial`, Stripe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1372,6 +1372,7 @@ class User < ApplicationRecord
       # Boards
       board_limit: board_limit,
       board_count: board_count,
+      has_boards: board_count > 0,
       board_limit_reached: board_count >= board_limit,
       can_create_boards: can_create_boards,
       editable_board_id: effective_editable_board_id,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -296,6 +296,21 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#api_view has_boards flag" do
+    it "is false when the user has no boards" do
+      user = FactoryBot.create(:free_user)
+      expect(user.api_view[:has_boards]).to eq(false)
+      expect(user.api_view[:board_count]).to eq(0)
+    end
+
+    it "is true when the user has at least one board" do
+      user = FactoryBot.create(:free_user)
+      FactoryBot.create(:board, user: user)
+      expect(user.api_view[:has_boards]).to eq(true)
+      expect(user.api_view[:board_count]).to eq(1)
+    end
+  end
+
   describe "#send_free_setup_email" do
     let(:user) { FactoryBot.create(:user, plan_type: "free") }
 


### PR DESCRIPTION
## Summary

Adds a `has_boards: boolean` field to `User#api_view`, paired with the new free-tier dashboard in [itty-bitty-frontend#183](https://github.com/brittanyjohns/itty-bitty-frontend/pull/183).

The frontend dashboard branches its layout on whether the user has at least one board (`current_user.boards.any?` semantically). Today the React side derives it from the existing `board_count` field; this PR makes the boolean explicit so the frontend can use `currentUser.has_boards` directly.

## What changed

- [`app/models/user.rb`](app/models/user.rb) — one new key in `User#api_view`:
  ```ruby
  has_boards: board_count > 0,
  ```
  Placed next to `board_count` and `board_limit_reached` in the existing `# Boards` section.
- [`spec/models/user_spec.rb`](spec/models/user_spec.rb) — new `#api_view has_boards flag` describe block: two examples covering the no-boards and ≥1-board cases.
- `CHANGELOG.md` — Unreleased entry.

## Why derive from `board_count` instead of `boards.exists?`

`board_count` is already computed one line earlier (`memoized_boards.count`). Using `board_count > 0` is zero extra queries; calling `boards.exists?` would add a second `SELECT 1 ... LIMIT 1` for the same information. The spec asked for `exists?` to avoid loading the full collection — that concern is also satisfied here (no collection load), and we don't add a second roundtrip.

## Reviewer notes

- **Additive only.** No existing field is renamed, removed, or changed in shape. Existing API consumers are unaffected.
- No migrations, no controller changes, no policy changes.
- The frontend PR currently uses `board_count` for the branch — it'll switch to `has_boards` in a small follow-up once this ships, so there's no coupling risk.

## Test plan

- [x] `bundle exec rspec spec/models/user_spec.rb -e "has_boards"` — 2 examples, 0 failures.
- [ ] CI green.
- [ ] Manual: hit any endpoint that returns `User#api_view` (e.g. `GET /api/users`) as a free user with 0 boards → `has_boards: false`. Create a board → `has_boards: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)