### PR TITLE
fix(onboarding): MySpeak wizard creates active communicator + team

### DIFF
--- a/.claude-notes/myspeak-onboarding.md
+++ b/.claude-notes/myspeak-onboarding.md
@@ -53,20 +53,35 @@ by `API::ApplicationController#authenticate_token!`)
 | 201    | `Profile#safety_view` hash (same payload the public `/my/:slug` returns)  | success                           |
 | 401    | `{ error: "Unauthorized" }`                                               | no/bad bearer token               |
 | 403    | `{ error: "myspeak_id_limit_reached", limit, count, message }`            | Free user at the 1-profile cap    |
+| 403    | `{ error: "communicator_slot_unavailable", message }`                     | plan has 0 communicator slots     |
+| 422    | `{ error: "communicator_slot_unavailable", message }`                     | all communicator slots in use     |
 | 422    | `{ error: "Onboarding failed", details: [...] }`                          | blank `name`, validation errors   |
 
 **Not 402.** 402 is reserved for credit exhaustion in this codebase.
 
 ## Transactional shape
 
-Everything happens inside `ActiveRecord::Base.transaction`:
+**Pre-transaction gates** (in order):
+
+1. `User#can_create_myspeak_id?` — Profile-count cap (Free = 1).
+   Returns **403 `myspeak_id_limit_reached`** if hit.
+2. `Permissions::CommunicatorLimits.can_create?(user:, status: ACTIVE)`
+   — slot cap from `user.settings["paid_communicator_limit"]`.
+   Returns **403/422 `communicator_slot_unavailable`** if hit.
+3. `name.present?` — **422** if blank.
+
+**Inside `ActiveRecord::Base.transaction`:**
 
 1. Compute a unique slug from `name.parameterize`, falling back to
    `<base>-2`, `<base>-3`, … up to 50 tries, then a random suffix.
    Checks `Profile.slug`, `Profile.username`, AND
    `ChildAccount.username`.
-2. `current_user.communicator_accounts.create!(name:, username:, user: current_user)`
-   — note `user:` is set explicitly (see footgun below).
+2. `current_user.communicator_accounts.create!(name:, username:, user: current_user, status: ChildAccount::ACTIVE)`
+   — note `user:` is explicit (see footgun below), and **`status:`
+   must be `ACTIVE`** so the communicator appears on the family
+   dashboard. The model default is `sandbox`, which is the Pro
+   no-login scratch space — sandbox communicators are filtered out
+   of the standard dashboard view.
 3. `Profile.new(profileable: child, profile_kind: "safety", username:, slug:, bio: care_notes, settings: ...)`.
 4. If `photo_data_url` matches `data:<ct>;base64,<payload>`, decode
    and `avatar.attach`.
@@ -75,6 +90,10 @@ Everything happens inside `ActiveRecord::Base.transaction`:
    `Board.find_by(slug: "myspeak-#{board_id}")` and create a favorited
    `ChildBoard`. **Silently skipped** if the board isn't seeded —
    logs a `Rails.logger.warn`, doesn't 422.
+7. `ensure_team_for(child)` — mirrors `API::ChildAccountsController#create`:
+   creates a `Team` named `"<name>'s Communication Team"`, attaches
+   the child via `TeamAccount`, and adds `current_user` as admin
+   (or `"professional"` if `current_user.professional?`).
 
 After the transaction commits, `profile.generate_attachments!` runs
 synchronously (Grover-based PDF/PNG generation) — same as

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -22,6 +22,20 @@ module API
             return
           end
 
+          # Slot check — the wizard creates a real owned (active) communicator,
+          # not a Pro-only sandbox scratch space. Free has 1 slot by default
+          # (FREE_PAID_COMMUNICATOR_LIMIT); over-cap is 422.
+          allowed, http_status, slot_error =
+            Permissions::CommunicatorLimits.can_create?(
+              user: current_user,
+              status: ChildAccount::ACTIVE,
+            )
+          unless allowed
+            render json: { error: "communicator_slot_unavailable", message: slot_error },
+                   status: http_status
+            return
+          end
+
           name = params[:name].to_s.strip
           if name.blank?
             render json: { error: "Onboarding failed", details: ["Name can't be blank"] },
@@ -39,15 +53,21 @@ module API
           unique = unique_slug_for(base_slug)
 
           profile = nil
+          child = nil
 
           ActiveRecord::Base.transaction do
             # `communicator_accounts` uses `owner_id` as the FK; set `user`
             # explicitly so downstream `api_view`s (which read
             # `child.user.pro?` etc.) don't see a nil user.
+            #
+            # Status MUST be ACTIVE — sandbox is the no-login Pro scratch
+            # space and is filtered out of the family dashboard. The
+            # MySpeak wizard is the family's first real communicator.
             child = current_user.communicator_accounts.create!(
               name: name,
               username: unique,
               user: current_user,
+              status: ChildAccount::ACTIVE,
             )
 
             profile = Profile.new(
@@ -64,6 +84,7 @@ module API
             profile.save!
 
             attach_starter_board(child, board_id)
+            ensure_team_for(child)
           end
 
           profile.generate_attachments! if profile.safety?
@@ -151,6 +172,18 @@ module API
           Profile.exists?(slug: value) ||
             Profile.exists?(username: value) ||
             ChildAccount.exists?(username: value)
+        end
+
+        # Mirrors API::ChildAccountsController#create — every new
+        # communicator gets a Team with the creator as admin, so team
+        # permission checks have something to anchor on later.
+        def ensure_team_for(child)
+          return if child.teams.exists?
+
+          team_name = child.name.present? ? "#{child.name}'s Communication Team" : "Communication Team"
+          team = Team.create!(name: team_name, created_by: current_user)
+          TeamAccount.create!(team: team, account: child)
+          team.add_member!(current_user, current_user.professional? ? "professional" : "admin")
         end
       end
     end

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -6,9 +6,16 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
 
   let(:user) do
     u = FactoryBot.create(:user)
-    # Pull out of the soft-trial window so paid_plan? is false and we can test
-    # the genuine Free state.
-    u.update_columns(plan_type: "free", created_at: 60.days.ago)
+    # Pull out of the soft-trial window so paid_plan? is false. The factory
+    # user gets seeded with Basic-tier limits via the soft-trial callback;
+    # overwrite the slot limits to match production Free state
+    # (paid_communicator_limit = 1, demo_communicator_limit = 1).
+    free_settings = u.settings.merge(
+      "paid_communicator_limit" => 1,
+      "demo_communicator_limit" => 1,
+      "board_limit" => 1,
+    )
+    u.update_columns(plan_type: "free", created_at: 60.days.ago, settings: free_settings)
     u
   end
 
@@ -45,7 +52,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
     end
 
     context "happy path" do
-      it "creates a child account + safety profile, attaches avatar, writes settings" do
+      it "creates an active child account + safety profile, attaches avatar, writes settings, sets up a team" do
         expect {
           post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
         }.to change { user.communicator_accounts.count }.by(1)
@@ -56,6 +63,12 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         child = user.communicator_accounts.order(:created_at).last
         expect(child.name).to eq("River Stone")
         expect(child.username).to eq("river-stone")
+        expect(child.status).to eq(ChildAccount::ACTIVE)
+
+        team = child.teams.first
+        expect(team).to be_present
+        expect(team.name).to eq("River Stone's Communication Team")
+        expect(team.team_users.where(user: user, role: "admin")).to exist
 
         profile = child.profile
         expect(profile.profile_kind).to eq("safety")
@@ -154,6 +167,24 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(s["ice_contact_1"]["name"]).to eq("Sam")
         expect(s["ice_contact_2"]["name"]).to eq("Kit")
         expect(s["ice_contact_3"]).to be_nil
+      end
+    end
+
+    context "free user has no available communicator slot" do
+      it "returns 422 communicator_slot_unavailable" do
+        # Free's default paid_communicator_limit is 1. Take it.
+        FactoryBot.create(
+          :child_account,
+          user: user,
+          owner: user,
+          status: ChildAccount::ACTIVE,
+        )
+
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("communicator_slot_unavailable")
       end
     end
 


### PR DESCRIPTION
## Summary

The MySpeak wizard (#190) was creating ChildAccounts with the model's default `sandbox` status. Sandbox is the Pro no-login scratch space — those rows are filtered out of the family dashboard view, so users completing the wizard saw "nothing happened" even though the data was saved.

This PR makes the wizard create a real `active` communicator with a team, matching what `API::ChildAccountsController#create` does for every other create path.

## Changes

- `app/controllers/api/v1/onboarding/myspeak_controller.rb`
  - Pass `status: ChildAccount::ACTIVE` on `ChildAccount` create so it shows up on the dashboard.
  - Add `Permissions::CommunicatorLimits.can_create?` gate. Returns `403`/`422 communicator_slot_unavailable` based on whether the plan supports communicators at all vs. all slots filled.
  - New `ensure_team_for(child)` helper: creates `"<name>'s Communication Team"`, attaches via `TeamAccount`, adds `current_user` as `admin` (or `professional`). Mirrors the existing pattern.
- `spec/requests/api/v1/onboarding/myspeak_spec.rb`
  - `let(:user)` now overrides settings to match production Free state (`paid_communicator_limit: 1`, etc) — the factory user otherwise inherits Basic-tier settings via the soft-trial callback, which masked the slot check.
  - Happy-path asserts `status == ACTIVE` and that a Team was created with the user as admin.
  - New spec covers `communicator_slot_unavailable` when the slot is full.
- `.claude-notes/myspeak-onboarding.md` — gate list, team step, ACTIVE rationale added.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb` — 9 examples, all green
- [ ] Sign in as Free user → walk the wizard → confirm new communicator appears on the dashboard at `/dashboard` (the bug Brittany reported)
- [ ] Re-run the wizard with the slot already filled → 422 surfaces in the rose error box on the preview step

## Notes

- The status flip + team setup also bring the wizard into line with the `paid_communicator_limit` accounting used everywhere else (PR #189). Free's "1 MySpeak ID" cap (#185-ish) and "1 communicator slot" cap (#189) now sit on the same record instead of accidentally double-counting.
- Sandbox-only is still possible via `API::ChildAccountsController#create` with `is_demo=true` — this PR doesn't change that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)