### PR TITLE
fix(auth): ensure every signed-in user has 1+ communicator slot

### DIFF
--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -36,6 +36,7 @@ module API
           # user.send_welcome_email
           sign_in user
           user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
+          user.ensure_minimum_communicator_slot!
           if user.role == "partner"
             user.send_partner_welcome_email
           end
@@ -67,6 +68,7 @@ module API
           end
           sign_in user
           user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
+          user.ensure_minimum_communicator_slot!
           MailchimpEventJob.perform_async(user.id, "sign_in")
           render json: { token: user.authentication_token, user: user.api_view }
         else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,6 +398,22 @@ class User < ApplicationRecord
     settings["paid_communicator_limit"] || FREE_PLAN_LIMITS["paid_communicator_limit"]
   end
 
+  # Every signed-in user needs at least one communicator slot — otherwise
+  # the MySpeak wizard 403s on `Permissions::CommunicatorLimits.can_create?`
+  # ("Your plan does not include communicator accounts."). Older free
+  # accounts predate FREE_PLAN_LIMITS and have an explicit 0; new users
+  # whose settings haven't been initialized read as nil → 0 too. Bump to
+  # the free-plan default when below it; never lower an existing higher
+  # value.
+  def ensure_minimum_communicator_slot!
+    minimum = FREE_PLAN_LIMITS["paid_communicator_limit"]
+    self.settings ||= {}
+    current = settings["paid_communicator_limit"].to_i
+    return if current >= minimum
+    settings["paid_communicator_limit"] = minimum
+    save
+  end
+
   def get_stripe_subscriptions
     begin
       subscriptions = Stripe::Subscription.list({ customer: stripe_customer_id })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -311,6 +311,36 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#ensure_minimum_communicator_slot!" do
+    it "bumps a 0 limit up to the free-plan default" do
+      user = FactoryBot.create(:free_user)
+      user.update_columns(settings: { "paid_communicator_limit" => 0 })
+
+      expect { user.ensure_minimum_communicator_slot! }
+        .to change { user.reload.settings["paid_communicator_limit"] }
+        .from(0).to(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
+    end
+
+    it "initializes settings when paid_communicator_limit is missing" do
+      user = FactoryBot.create(:free_user)
+      user.update_columns(settings: {})
+
+      user.ensure_minimum_communicator_slot!
+
+      expect(user.reload.settings["paid_communicator_limit"])
+        .to eq(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
+    end
+
+    it "leaves higher limits alone (e.g. basic/pro)" do
+      user = FactoryBot.create(:free_user)
+      user.update_columns(settings: { "paid_communicator_limit" => 3 })
+
+      user.ensure_minimum_communicator_slot!
+
+      expect(user.reload.settings["paid_communicator_limit"]).to eq(3)
+    end
+  end
+
   describe "#send_free_setup_email" do
     let(:user) { FactoryBot.create(:user, plan_type: "free") }
 


### PR DESCRIPTION
## Summary
- Older free accounts have `settings["paid_communicator_limit"] == 0` (and brand-new users read as nil → 0), which trips `Permissions::CommunicatorLimits.can_create?` and returns 403 "Your plan does not include communicator accounts." on the MySpeak onboarding wizard.
- Adds `User#ensure_minimum_communicator_slot!` which bumps the limit to `FREE_PLAN_LIMITS["paid_communicator_limit"]` when below it; preserves any higher value (basic/pro).
- Calls it after `sign_in user` in `AuthsController#create` and `#sign_up`, so the limit self-heals on next login.

Repro on `main`: free user with `settings["paid_communicator_limit"] = 0` → POST `/api/v1/onboarding/myspeak` returns 403. After this change: next sign-in bumps the limit to 1 and the wizard completes.

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb -e "ensure_minimum_communicator_slot"` — 3 examples, 0 failures
  - bumps a 0 limit up to the free-plan default
  - initializes settings when paid_communicator_limit is missing
  - leaves higher limits alone (basic/pro)
- [ ] Sign out and back in as a user that previously 403'd on `/onboarding/myspeak`; confirm the wizard now POSTs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)