### PR TITLE
feat(onboarding/myspeak): clone selected public board instead of attaching seeded master

### DIFF
--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -2,12 +2,6 @@ module API
   module V1
     module Onboarding
       class MyspeakController < API::ApplicationController
-        STARTER_BOARD_SLUGS = {
-          "basics"   => "myspeak-basics",
-          "feelings" => "myspeak-feelings",
-          "social"   => "myspeak-social",
-        }.freeze
-
         MAX_SLUG_TRIES = 50
 
         def create
@@ -45,7 +39,7 @@ module API
 
           pronouns       = params[:pronouns].to_s.strip
           care_notes     = params[:care_notes].to_s
-          board_id       = params[:board_id].to_s
+          board_id       = params[:board_id]
           photo_data_url = params[:photo_data_url].to_s
           contacts       = Array(params[:contacts])
 
@@ -141,22 +135,43 @@ module API
           )
         end
 
+        # The frontend sends a Board#id (integer) for the picked public
+        # starter, "later" / nil to skip, or the string form of either. We
+        # clone the picked board for current_user so admin edits to the
+        # master never leak into a family's communicator, then favorite the
+        # ChildBoard that clone_with_images creates.
+        #
+        # Anything unparseable, unknown, or not in Board.public_boards is
+        # logged and skipped — the board step must never block setup.
         def attach_starter_board(child, board_id)
-          slug = STARTER_BOARD_SLUGS[board_id]
-          return unless slug
+          return if board_id.blank?
+          return if board_id.to_s == "later"
 
-          board = Board.find_by(slug: slug)
+          board = Board.find_by(id: board_id.to_i)
           unless board
-            Rails.logger.warn "[Onboarding::Myspeak] starter board #{slug.inspect} missing — skipping attachment"
+            Rails.logger.warn "[Onboarding::Myspeak] board id #{board_id.inspect} not found — skipping"
             return
           end
 
-          ChildBoard.create!(
-            board: board,
-            child_account: child,
-            created_by: current_user,
-            favorite: true,
-          )
+          # Allowlist against the picker's own scope. clone_with_images
+          # doesn't enforce ownership, so without this guard a client could
+          # send any id and clone a stranger's private board.
+          unless Board.public_boards.exists?(id: board.id)
+            Rails.logger.warn "[Onboarding::Myspeak] board #{board.id} is not a public board — skipping"
+            return
+          end
+
+          cloned = board.clone_with_images(current_user.id, board.name, child.voice, child)
+          unless cloned&.persisted?
+            Rails.logger.warn "[Onboarding::Myspeak] clone failed for board #{board.id}"
+            return
+          end
+
+          # clone_with_images creates the ChildBoard join row. Mark it the
+          # communicator's favorite to match the old behavior (the wizard's
+          # pick is the home board).
+          child_board = ChildBoard.find_by(child_account: child, board: cloned)
+          child_board&.update(favorite: true)
         end
 
         def unique_slug_for(base)

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -128,28 +128,94 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
       end
     end
 
-    context "board_id matches a seeded starter board" do
-      it "favorites it on the new communicator" do
-        admin = FactoryBot.create(:admin_user)
-        starter = Board.create!(
-          slug: "myspeak-basics",
+    context "board_id matches a public starter board" do
+      let(:admin) do
+        a = FactoryBot.create(:admin_user)
+        # Board.public_boards is anchored on User::DEFAULT_ADMIN_ID, so
+        # force the admin factory's row to that id rather than depending on
+        # the test db being clean.
+        a.update_columns(id: User::DEFAULT_ADMIN_ID) unless a.id == User::DEFAULT_ADMIN_ID
+        a
+      end
+
+      let(:starter) do
+        Board.create!(
           name: "Basic needs",
-          user: admin,
+          user_id: User::DEFAULT_ADMIN_ID,
           parent: admin,
           predefined: true,
           published: true,
           board_type: "board",
         )
+      end
+
+      it "clones the public board, attaches the clone as a favorited ChildBoard, and assigns ownership to current_user" do
+        starter # force creation
+
+        expect {
+          post "/api/v1/onboarding/myspeak",
+               params: base_payload.merge(board_id: starter.id).to_json, headers: headers
+        }.to change { Board.count }.by(1)
+         .and change { ChildBoard.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+
+        child = user.communicator_accounts.last
+        cb = child.child_boards.last
+        expect(cb.favorite).to eq(true)
+        # The attached board is the *clone*, not the master.
+        expect(cb.board_id).not_to eq(starter.id)
+        expect(cb.board.user_id).to eq(user.id)
+        expect(cb.board.name).to eq(starter.name)
+        # Master untouched.
+        expect(starter.reload.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      end
+
+      it "accepts board_id as a string (JSON normally sends integers, but be defensive)" do
+        starter
 
         post "/api/v1/onboarding/myspeak",
-             params: base_payload.merge(board_id: "basics").to_json, headers: headers
+             params: base_payload.merge(board_id: starter.id.to_s).to_json, headers: headers
 
         expect(response).to have_http_status(:created)
         child = user.communicator_accounts.last
-        cb = child.child_boards.find_by(board: starter)
-        expect(cb).to be_present
-        expect(cb.favorite).to eq(true)
-        expect(cb.created_by_id).to eq(user.id)
+        expect(child.child_boards.count).to eq(1)
+      end
+
+      it "silently skips when board_id references a board outside the public picker" do
+        private_board = Board.create!(
+          name: "Private board",
+          user: user, # not admin → not in Board.public_boards
+          parent: user,
+          predefined: false,
+          published: false,
+          board_type: "board",
+        )
+
+        expect {
+          post "/api/v1/onboarding/myspeak",
+               params: base_payload.merge(board_id: private_board.id).to_json, headers: headers
+        }.not_to change { ChildBoard.count }
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it "silently skips when board_id is unknown" do
+        expect {
+          post "/api/v1/onboarding/myspeak",
+               params: base_payload.merge(board_id: 999_999).to_json, headers: headers
+        }.not_to change { ChildBoard.count }
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it "silently skips when board_id is nil" do
+        expect {
+          post "/api/v1/onboarding/myspeak",
+               params: base_payload.merge(board_id: nil).to_json, headers: headers
+        }.not_to change { ChildBoard.count }
+
+        expect(response).to have_http_status(:created)
       end
     end
 


### PR DESCRIPTION
Closes #201.

## Summary

- `attach_starter_board` now takes an integer `Board#id`, allowlists it against `Board.public_boards`, calls `Board#clone_with_images(current_user.id, ...)`, and favorites the `ChildBoard` the helper creates. Master boards are no longer shared mutable state across families.
- Dropped `STARTER_BOARD_SLUGS` — the wizard hands us a real id now.
- `nil`, blank, `"later"`, unknown ids, and ids outside `Board.public_boards` are logged and skipped. No 4xx — the board step must never block setup completion.
- Allowlisting against `Board.public_boards` is the security boundary: `clone_with_images` doesn't enforce ownership, so without the check a client could send any id and clone a stranger's private board.

Companion frontend PR: brittanyjohns/itty-bitty-frontend#218. **Merge this one first** — the frontend now sends integer ids; if it ships against the old slug-based controller, every wizard run will silently skip the board.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb` → 13 examples, 0 failures.
- [x] New examples cover: clone ownership goes to `current_user`, master is untouched, `ChildBoard.favorite == true`, string-form `board_id` accepted, non-public/unknown/nil ids all 201 with no `ChildBoard` created.
- [ ] After frontend ships to staging: end-to-end smoke through the wizard, verify the new communicator's board has `user_id == current_user.id` and editing a tile doesn't touch the master.