### PR TITLE
feat(seeds): populate MySpeak starter boards with 6 tiles + myspeak tag (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — MySpeak starter-board seed populates tiles + tags `myspeak` (#204)
+- `db/seeds/myspeak_starter_boards.rb` now creates **5** starter boards
+  (`myspeak-basics`, `myspeak-feelings`, `myspeak-social`,
+  `myspeak-food`, `myspeak-school`), tags each with `myspeak` so they
+  appear in `Board.myspeak_public_boards`, and seeds **6 starter tiles**
+  per board via `Board#find_or_create_images_from_word_list`.
+- Net effect: the MySpeak onboarding picker
+  (`GET /api/public_boards?myspeak=true`) renders 5 cards with real
+  tile previews instead of one empty card.
+- Idempotent: per-board tile add is gated by an existing-label check,
+  so re-running the seed will not duplicate `board_images`.
+- Run after deploy: `bin/rails runner db/seeds/myspeak_starter_boards.rb`.
+  Adding new tiles enqueues `GenerateImagesJob` for any image without an
+  existing display doc — let Sidekiq drain before verifying the picker.
+
 ### Added — `has_boards` flag on `User#api_view`
 - `User#api_view` now returns `has_boards: boolean` alongside
   `board_count`. Derived from the already-computed `board_count`

--- a/db/seeds/myspeak_starter_boards.rb
+++ b/db/seeds/myspeak_starter_boards.rb
@@ -1,6 +1,20 @@
-# Seed the three starter boards used by the MySpeak onboarding wizard
-# (POST /api/v1/onboarding/myspeak). Idempotent — safe to re-run. Image
-# tiles are not seeded here; admin can populate via the editor.
+# Seed the starter boards used by the MySpeak onboarding wizard
+# (POST /api/v1/onboarding/myspeak) and the board picker fed by
+# GET /api/public_boards?myspeak=true.
+#
+# Each board is tagged "myspeak" so it shows up in
+# Board.myspeak_public_boards, and is populated with a starter set of
+# tiles so the picker grid in the wizard renders real previews.
+#
+# Idempotent — safe to re-run. Per-board:
+#   * upserts by slug
+#   * ensures the "myspeak" tag is present
+#   * adds any starter tile labels that aren't already on the board
+#
+# Adding tiles enqueues GenerateImagesJob for any tiles whose Image
+# doesn't yet have a display doc, so run this in an environment where
+# Sidekiq workers can drain (or expect the jobs to queue up). See
+# Board#find_or_create_images_from_word_list.
 #
 # Run:
 #   bin/rails runner db/seeds/myspeak_starter_boards.rb
@@ -11,28 +25,45 @@
 admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || User.where(role: "admin").order(:id).first
 abort "No admin user found (User::DEFAULT_ADMIN_ID=#{User::DEFAULT_ADMIN_ID})." unless admin
 
-STARTERS = [
+starters = [
   {
     slug: "myspeak-basics",
-    name: "Basic needs",
-    description: "Core daily words: yes, no, more, all done, help, hurt.",
+    name: "Basic Needs",
+    description: "Core daily words: yes, no, more, help, hurt, all done.",
     category: "welcome",
+    tiles: ["Yes", "No", "More", "Help", "Hurt", "All done"],
   },
   {
     slug: "myspeak-feelings",
-    name: "Feelings & needs",
-    description: "Quick feeling and need words: happy, sad, hungry, thirsty, tired, scared.",
+    name: "Feelings",
+    description: "Quick feeling words: happy, sad, mad, scared, tired, calm.",
     category: "welcome",
+    tiles: ["Happy", "Sad", "Mad", "Scared", "Tired", "Calm"],
   },
   {
     slug: "myspeak-social",
-    name: "Out & about",
+    name: "Out & About",
     description: "Out-and-about words: hi, bye, please, thank you, my name is, I need.",
     category: "welcome",
+    tiles: ["Hi", "Bye", "Please", "Thank you", "My name is", "I need"],
   },
-].freeze
+  {
+    slug: "myspeak-food",
+    name: "Food & Drink",
+    description: "Meal-time words: hungry, thirsty, snack, water, milk, done.",
+    category: "welcome",
+    tiles: ["Hungry", "Thirsty", "Snack", "Water", "Milk", "Done"],
+  },
+  {
+    slug: "myspeak-school",
+    name: "School Day",
+    description: "School-day words: bathroom, break, finished, question, help, ready.",
+    category: "welcome",
+    tiles: ["Bathroom", "Break", "Finished", "Question", "Help", "Ready"],
+  },
+]
 
-STARTERS.each do |attrs|
+starters.each do |attrs|
   board = Board.find_by(slug: attrs[:slug]) || Board.new(slug: attrs[:slug])
   board.assign_attributes(
     name: attrs[:name],
@@ -46,6 +77,15 @@ STARTERS.each do |attrs|
     sub_board: false,
     board_type: "board",
   )
+  board.add_tag("myspeak")
   board.save!
-  puts "[myspeak-starter] #{board.persisted? ? 'ok' : 'failed'}: #{board.slug} (id=#{board.id})"
+
+  existing_labels = board.board_images.pluck(:label).compact.map(&:downcase)
+  missing_tiles = attrs[:tiles].reject { |t| existing_labels.include?(t.downcase) }
+
+  if missing_tiles.any?
+    board.find_or_create_images_from_word_list(missing_tiles)
+  end
+
+  puts "[myspeak-starter] ok: #{board.slug} (id=#{board.id}, tiles=#{board.board_images.count}, tags=#{board.tags.inspect})"
 end

--- a/spec/db/seeds/myspeak_starter_boards_seed_spec.rb
+++ b/spec/db/seeds/myspeak_starter_boards_seed_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "db/seeds/myspeak_starter_boards.rb", type: :model do
+  let(:seed_path) { Rails.root.join("db/seeds/myspeak_starter_boards.rb") }
+
+  def run_seed
+    load seed_path.to_s
+  end
+
+  before do
+    FactoryBot.create(:user, id: User::DEFAULT_ADMIN_ID)
+    allow(AacWordCategorizer).to receive(:categorize).and_return("noun")
+    allow(SaveAudioJob).to receive(:perform_async)
+    allow(GenerateImagesJob).to receive(:perform_async)
+  end
+
+  it "creates 5 myspeak-tagged public boards each with >= 6 tiles" do
+    run_seed
+
+    boards = Board.myspeak_public_boards
+    expect(boards.count).to eq(5)
+
+    expected_slugs = %w[myspeak-basics myspeak-feelings myspeak-social myspeak-food myspeak-school]
+    expect(boards.pluck(:slug)).to match_array(expected_slugs)
+
+    boards.each do |b|
+      expect(b.tags).to include("myspeak")
+      expect(b.predefined).to be(true)
+      expect(b.published).to be(true)
+      expect(b.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      expect(b.board_images.count).to be >= 6
+    end
+  end
+
+  it "is idempotent — re-running does not duplicate boards or tiles" do
+    run_seed
+    counts_before = Board.myspeak_public_boards.map { |b| [b.slug, b.board_images.count] }.to_h
+
+    run_seed
+    counts_after = Board.myspeak_public_boards.map { |b| [b.slug, b.board_images.count] }.to_h
+
+    expect(Board.myspeak_public_boards.count).to eq(5)
+    expect(counts_after).to eq(counts_before)
+  end
+
+  it "tags each board so it appears in GET /api/public_boards?myspeak=true scope" do
+    run_seed
+    expect(Board.myspeak_public_boards.pluck(:slug)).to include(
+      "myspeak-basics", "myspeak-feelings", "myspeak-social",
+      "myspeak-food", "myspeak-school"
+    )
+  end
+end


### PR DESCRIPTION
Closes #204.

## Summary
- Expand `db/seeds/myspeak_starter_boards.rb` to seed **5** starter boards (`myspeak-basics`, `myspeak-feelings`, `myspeak-social`, `myspeak-food`, `myspeak-school`) matching the issue's target set.
- Tag each board with `"myspeak"` via `Board#add_tag` so they appear in `Board.myspeak_public_boards` (the scope behind `GET /api/public_boards?myspeak=true`).
- Seed **6 starter tiles** per board via `Board#find_or_create_images_from_word_list`. Per-board add is gated by an existing-label check so re-runs do not duplicate `board_images`.
- Add a focused seed spec (`spec/db/seeds/myspeak_starter_boards_seed_spec.rb`) that stubs `GenerateImagesJob`/`SaveAudioJob`/`AacWordCategorizer` so the seed runs cleanly under RSpec.

## Acceptance criteria from the issue
- [x] `Board.myspeak_public_boards.count >= 3` after running the seed (5 in test).
- [x] Each starter has `board_images.count >= 6`.
- [x] `GET /api/public_boards?myspeak=true` will return 3–5 boards — `Board.myspeak_public_boards` includes all 5 starters once seeded.
- [ ] Verified on `/onboarding/myspeak` step 2 — needs the post-deploy `bin/rails runner db/seeds/myspeak_starter_boards.rb` run and Sidekiq drain for image-gen before tile thumbnails appear.

## Deploy / run
After deploying, run once in the target environment so the boards get tagged and tiles get queued for image-gen:
```
bin/rails runner db/seeds/myspeak_starter_boards.rb
```
Let Sidekiq drain `GenerateImagesJob` before announcing — fresh `Image` rows without a display doc are enqueued for OpenAI image gen (skipped on staging per `AppEnv.staging?` gate).

## Test plan
- [x] `bundle exec rspec spec/db/seeds/myspeak_starter_boards_seed_spec.rb` — 3 examples, 0 failures (creates 5 boards × 6 tiles; idempotent on re-run; all carry the `myspeak` tag).
- [x] `bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb` — 13 examples, 0 failures (regression check on the related onboarding endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)