### PR TITLE
fix(reliability): timeouts on outbound calls + puma cluster mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Harden production puma against silent outbound-call wedges (#207)
+- **Puma cluster mode in production.** `config/puma.rb` now sets `workers 2`
+  (overridable via `WEB_CONCURRENCY`), `worker_timeout 30`, and
+  `preload_app!` for production. A worker that wedges no longer takes the
+  whole site down — the other worker keeps serving at 50% capacity.
+- **SMTP timeouts.** `config/environments/production.rb` `smtp_settings`
+  now sets `open_timeout: 10` and `read_timeout: 20`. Previously a stalled
+  Gmail SMTP session could hang a puma thread for the Net::SMTP default
+  (much longer); on 2026-05-30 this contributed to a 38-minute outage where
+  all 8 single-mode threads silently wedged after a deploy.
+- **OpenAI request_timeout.** `OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS`
+  (defaults to 60s, overridable via `OPENAI_REQUEST_TIMEOUT`) is now passed
+  to every `OpenAI::Client.new` — the central wrapper and the nine direct
+  call sites in `app/services/*` and `app/controllers/api/scenarios_controller.rb`.
+- No user-facing behavior change; reliability/SLO improvement only.
+- Net effect: a future hang in SMTP or OpenAI raises an exception after the
+  cap instead of holding a thread; with cluster mode, even a deadlock that
+  the timeouts don't catch only halves capacity instead of taking the site
+  fully offline.
+
 ### Changed — MySpeak starter-board seed populates tiles + tags `myspeak` (#204)
 - `db/seeds/myspeak_starter_boards.rb` now creates **5** starter boards
   (`myspeak-basics`, `myspeak-feelings`, `myspeak-social`,

--- a/app/controllers/api/scenarios_controller.rb
+++ b/app/controllers/api/scenarios_controller.rb
@@ -196,7 +196,10 @@ class API::ScenariosController < API::ApplicationController
   def generate_first_question(scenario)
     initial_scenario = scenario.initial_description
     age_range = scenario.age_range
-    client = OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    client = OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
 
     prompt = <<~PROMPT
       The scenario is name: #{scenario.name} and was described as: #{initial_scenario}. The age range of the person in the given scenario is: #{age_range}.
@@ -225,7 +228,10 @@ class API::ScenariosController < API::ApplicationController
     question_1 = scenario.questions["question_1"]
     name = scenario.name
 
-    client = OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    client = OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
 
     prompt = <<~PROMPT
       The scenario is name: #{scenario.name} and is described as: #{initial_scenario}. The age range is: #{age_range}.
@@ -259,7 +265,10 @@ class API::ScenariosController < API::ApplicationController
     question_2 = scenario.questions["question_2"]
     answer_2 = scenario.answers["question_2"]
 
-    client = OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    client = OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
 
     prompt = <<~PROMPT
       The scenario is: #{initial_scenario}. The age range is: #{age_range}.
@@ -285,7 +294,10 @@ class API::ScenariosController < API::ApplicationController
   end
 
   def generate_scenario_description(name, age_range, language: "en")
-    client = OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    client = OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
 
     # prompt = <<~PROMPT
     #   Please generate a brief description of a scenario for a person named #{name} who is #{age_range} years old.

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -15,12 +15,25 @@ class OpenAiClient
     @prompt = @opts[:prompt] || "backup"
   end
 
+  # Default request timeout for OpenAI calls. ruby-openai's own default is 120s
+  # but several failure modes (TLS half-open, idle keep-alive) can stall longer.
+  # Explicit cap prevents a hung OpenAI request from holding a puma thread.
+  OPENAI_REQUEST_TIMEOUT_SECONDS = Integer(ENV.fetch("OPENAI_REQUEST_TIMEOUT", 60))
+
   def self.openai_client
-    @openai_client ||= OpenAI::Client.new(access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"), log_errors: true)
+    @openai_client ||= OpenAI::Client.new(
+      access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
+      log_errors: true,
+      request_timeout: OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def openai_client
-    @openai_client ||= OpenAI::Client.new(access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"), log_errors: true)
+    @openai_client ||= OpenAI::Client.new(
+      access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
+      log_errors: true,
+      request_timeout: OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def specific_image_prompt(img_prompt)

--- a/app/services/board_screenshot_vision_service.rb
+++ b/app/services/board_screenshot_vision_service.rb
@@ -206,7 +206,10 @@ class BoardScreenshotVisionService
   end
 
   def default_openai_client
-    OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def default_logger

--- a/app/services/coaching_prompt_generator.rb
+++ b/app/services/coaching_prompt_generator.rb
@@ -152,7 +152,11 @@ class CoachingPromptGenerator
     end
 
     def openai_client
-      OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"], log_errors: true)
+      OpenAI::Client.new(
+        access_token: ENV["OPENAI_ACCESS_TOKEN"],
+        log_errors: true,
+        request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+      )
     end
 
     # The fallback row is upserted by db/seeds.rb and is therefore expected to

--- a/app/services/image_edit_service.rb
+++ b/app/services/image_edit_service.rb
@@ -146,7 +146,10 @@ class ImageEditService
   end
 
   def default_openai_client
-    OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def default_logger

--- a/app/services/image_variation_service.rb
+++ b/app/services/image_variation_service.rb
@@ -130,7 +130,10 @@ class ImageVariationService
   end
 
   def default_openai_client
-    OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def default_logger

--- a/app/services/menu_vision_service.rb
+++ b/app/services/menu_vision_service.rb
@@ -122,7 +122,10 @@ class MenuVisionService
   end
 
   def default_openai_client
-    OpenAI::Client.new(access_token: ENV["OPENAI_ACCESS_TOKEN"])
+    OpenAI::Client.new(
+      access_token: ENV["OPENAI_ACCESS_TOKEN"],
+      request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS,
+    )
   end
 
   def default_logger

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -152,5 +152,10 @@ Rails.application.configure do
     user_name: smtp_username,
     password: smtp_password,
     authentication: smtp_username ? :plain : nil,
+    # Explicit timeouts so a stalled Gmail SMTP session can't wedge a puma thread
+    # indefinitely. Without these, Net::SMTP uses generous defaults that contributed
+    # to the 2026-05-30 outage where all 8 threads stalled for 38 minutes.
+    open_timeout: 10,
+    read_timeout: 20,
   }
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,15 +11,35 @@ max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 8 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies that the worker count should equal the number of processors in production.
+# Cluster mode in production: multiple workers + worker_timeout for resilience.
+# Set after the 2026-05-30 outage where puma in single mode silently wedged all
+# 8 threads on hung outbound calls (likely SMTP / OpenAI without timeouts) and
+# stopped serving requests for 38 minutes. With 2 workers, a single wedged worker
+# only halves capacity instead of taking the site down entirely.
+#
+# WEB_CONCURRENCY=2 default fits a t3.medium (2 vCPU, 3.8 GiB RAM): current
+# memory footprint ~165 MB single-mode, so 2 workers ≈ 350 MB — well within budget.
+#
+# worker_timeout 30 is a backstop for a Ruby-VM-level deadlock; it does NOT fire
+# when worker threads are merely blocked on IO (the heartbeat thread keeps running
+# while request threads block on socket recv). The real defense against IO wedges
+# is explicit timeouts on outbound calls (SMTP, OpenAI, etc.) — see
+# config/environments/production.rb smtp_settings and app/models/open_ai_client.rb.
 if ENV["RAILS_ENV"] == "production"
-  require "concurrent-ruby"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
-  workers worker_count if worker_count > 1
+  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY", 2))
+  workers worker_count
+  worker_timeout 30
+  preload_app!
+
+  # In cluster mode with preload_app!, the master loads the app once and forks
+  # workers. Forked workers must re-establish their own ActiveRecord connection
+  # pool — otherwise they share the master's connection and corrupt it.
+  on_worker_boot do
+    ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+  end
 end
 
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
+# In development, prevent worker_timeout from interrupting debugger pauses.
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,7 +26,12 @@ threads min_threads_count, max_threads_count
 # is explicit timeouts on outbound calls (SMTP, OpenAI, etc.) — see
 # config/environments/production.rb smtp_settings and app/models/open_ai_client.rb.
 if ENV["RAILS_ENV"] == "production"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY", 2))
+  # Hatchbox sets WEB_CONCURRENCY=0 by default on these apps, which would force
+  # puma into single mode and defeat the post-incident hardening. Treat 0
+  # (or unset / empty) as "use the safe default of 2"; honor any explicit
+  # positive override (e.g. WEB_CONCURRENCY=4 on a bigger box).
+  configured_concurrency = ENV["WEB_CONCURRENCY"].to_i
+  worker_count = configured_concurrency > 0 ? configured_concurrency : 2
   workers worker_count
   worker_timeout 30
   preload_app!

--- a/spec/config/production_smtp_timeouts_spec.rb
+++ b/spec/config/production_smtp_timeouts_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+# Regression coverage for the 2026-05-30 production outage (see issue #207):
+# the Gmail SMTP `smtp_settings` hash in config/environments/production.rb was
+# missing both `open_timeout` and `read_timeout`, so a stalled SMTP session
+# during a synchronous mailer call could wedge a puma thread indefinitely.
+#
+# Rails only loads `config/environments/production.rb` when `Rails.env` is
+# production, so we re-evaluate the file in an isolated context instead of
+# trying to flip the environment under the test runner.
+RSpec.describe "config/environments/production.rb SMTP timeouts" do
+  let(:production_env_path) { Rails.root.join("config/environments/production.rb") }
+
+  it "exists at the expected path" do
+    expect(File.exist?(production_env_path)).to be true
+  end
+
+  it "includes an explicit open_timeout in smtp_settings" do
+    expect(File.read(production_env_path)).to match(/open_timeout:\s*\d+/)
+  end
+
+  it "includes an explicit read_timeout in smtp_settings" do
+    expect(File.read(production_env_path)).to match(/read_timeout:\s*\d+/)
+  end
+
+  it "caps open_timeout at no more than 30 seconds" do
+    match = File.read(production_env_path).match(/open_timeout:\s*(\d+)/)
+    expect(match).not_to be_nil, "expected open_timeout to be set"
+    expect(Integer(match[1])).to be <= 30
+  end
+
+  it "caps read_timeout at no more than 60 seconds" do
+    match = File.read(production_env_path).match(/read_timeout:\s*(\d+)/)
+    expect(match).not_to be_nil, "expected read_timeout to be set"
+    expect(Integer(match[1])).to be <= 60
+  end
+end

--- a/spec/models/open_ai_client_spec.rb
+++ b/spec/models/open_ai_client_spec.rb
@@ -144,4 +144,42 @@ RSpec.describe OpenAiClient do
       end
     end
   end
+
+  # Regression coverage for the 2026-05-30 production outage (see issue #207):
+  # OpenAI clients constructed without a request_timeout could stall a puma
+  # thread for the full ruby-openai default of 120s — or longer on TLS half-
+  # open conditions. We now pass an explicit cap.
+  describe "request_timeout" do
+    let(:fake_openai_client) { instance_double(OpenAI::Client) }
+
+    around do |example|
+      # Memoization on the class means a prior spec may have cached a client
+      # built without the kwarg. Clear both class- and instance-level caches.
+      described_class.instance_variable_set(:@openai_client, nil)
+      original_token = ENV["OPENAI_ACCESS_TOKEN"]
+      ENV["OPENAI_ACCESS_TOKEN"] = "test-token-not-used"
+      example.run
+    ensure
+      ENV["OPENAI_ACCESS_TOKEN"] = original_token
+      described_class.instance_variable_set(:@openai_client, nil)
+    end
+
+    it "passes request_timeout to OpenAI::Client.new from the class-level accessor" do
+      expect(OpenAI::Client).to receive(:new).with(
+        hash_including(request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS),
+      ).and_return(fake_openai_client)
+      expect(described_class.openai_client).to eq(fake_openai_client)
+    end
+
+    it "passes request_timeout to OpenAI::Client.new from the instance accessor" do
+      expect(OpenAI::Client).to receive(:new).with(
+        hash_including(request_timeout: OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS),
+      ).and_return(fake_openai_client)
+      expect(described_class.new({}).openai_client).to eq(fake_openai_client)
+    end
+
+    it "defaults the timeout to 60 seconds" do
+      expect(OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS).to eq(60)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Hardens production against the silent puma-thread-wedge failure mode that caused the **2026-05-30 38-minute outage** (#207). All 8 threads on a single-mode puma silently stalled on outbound calls without timeouts; the act of hot-reloading puma after a deploy made it visible but didn't recover. The fix has three parts, ordered by leverage:

1. **`config/puma.rb` — production cluster mode.** `workers 2` (overridable via `WEB_CONCURRENCY`), `worker_timeout 30`, `preload_app!`, plus an `on_worker_boot` DB reconnect. Damage limiter: a wedged worker no longer takes the whole site down — the other worker keeps serving at 50% capacity.
2. **`config/environments/production.rb` — SMTP timeouts.** Adds `open_timeout: 10` and `read_timeout: 20` to Gmail `smtp_settings`. Without these, Net::SMTP could hold a puma thread for many minutes on a stalled session — the most plausible culprit for the 2026-05-30 wedge.
3. **`OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS`** (default 60s, env-tunable via `OPENAI_REQUEST_TIMEOUT`) — passed to every `OpenAI::Client.new`: the central wrapper plus the 9 direct call sites in `app/services/*` and `api/scenarios_controller.rb`.

### Honest caveat on cluster mode

`worker_timeout 30` does **not** fire when worker threads are merely blocked on IO. Puma's heartbeat runs on a separate thread that keeps getting scheduled while request threads sit in `recv()` with the GVL released. The real defense against IO wedges is the explicit timeouts (#2 and #3); cluster mode is the damage limiter, not an auto-heal. With cluster mode + 2 workers, today's outage would have been a 50% capacity blip instead of a full outage — combined with the timeouts, the wedge would have unwound itself.

## Test plan

- [x] `spec/config/production_smtp_timeouts_spec.rb` — new regression coverage that `open_timeout`/`read_timeout` are set and capped in `production.rb`. 5/5 pass.
- [x] `spec/models/open_ai_client_spec.rb` — extended with 3 new tests verifying `request_timeout` is passed to `OpenAI::Client.new` from both the class- and instance-level accessors, and that the constant defaults to 60. 23/23 pass (existing + new).
- [x] Adjacent specs unchanged: `menu_vision_service_spec`, `image_edit_service_spec`, `image_variation_service_spec`, `coaching_prompt_generator_spec`, `requests/api/scenarios_spec` — 18/18 pass.
- [x] Full suite: **861 examples, 1 failure, 13 pending.** The single failure is `Board#display_image_url with display_follows_preview flag`. **Pre-existing flake unrelated to this PR** — the test compares two signed ActiveStorage URLs generated 1ms apart (`22:29:09.282Z` vs `22:29:09.281Z`); reproduces in isolation on this branch and on `main`. Not introduced here.
- [ ] **Staging soak** — labeled `deploy-to-staging`. After staging deploys, verify:
  - `journalctl --user -u staging-speakanyway-server.service` shows `workers 2` not `single mode`
  - `/up` returns 200 from `https://ypk9e.hatchboxapp.com`
  - Trigger a Stripe webhook welcome email path and confirm response stays under ~500ms (mail goes inline today; a slow SMTP send should now raise after 20s instead of holding the thread)
  - `bin/staging-logs` shows no startup errors from the puma config change

## Not in this PR (deliberate)

- Moving 23 inline `deliver_now` calls to `deliver_later`. Bigger change, separate PR. Phase 1 of #207's plan covers what's here; the `deliver_later` migration is Phase 2.
- External healthcheck monitor — that's #206, separate concern.

## Refs

- Closes the Phase 1 portion of #207
- Outage incident: 2026-05-30, 14:54 → 15:33 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)