### PR TITLE
test(board): deflake Board#display_image_url preview specs

### DIFF
--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -394,12 +394,17 @@ RSpec.describe Board, type: :model do
         board.update!(settings: board.settings.merge("display_follows_preview" => true))
       end
 
+      # Active Storage signed URLs embed an `expires_at` derived from
+      # `Time.current`, so two `.url` calls a millisecond apart produce
+      # different strings. Freeze time so both calls share an expiry.
       it "returns the live preview URL" do
-        expect(board.display_image_url).to eq(board.preview_image_url)
+        freeze_time do
+          expect(board.display_image_url).to eq(board.preview_image_url)
+        end
       end
 
       it "resolves to the new URL after the preview regenerates" do
-        original_url = board.display_image_url
+        original_url = freeze_time { board.display_image_url }
         board.preview_image.purge
         board.preview_image.attach(
           io: StringIO.new("new-png-bytes"),
@@ -407,8 +412,10 @@ RSpec.describe Board, type: :model do
           content_type: "image/png",
         )
 
-        expect(board.display_image_url).to eq(board.preview_image_url)
-        expect(board.display_image_url).not_to eq(original_url) if board.preview_image_url != original_url
+        freeze_time do
+          expect(board.display_image_url).to eq(board.preview_image_url)
+          expect(board.display_image_url).not_to eq(original_url) if board.preview_image_url != original_url
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Wrap the `display_image_url` vs `preview_image_url` comparisons in `freeze_time` so both signed URLs use the same `expires_at`.

Active Storage signed URLs embed an `expires_at` derived from `Time.current`. When the spec called `board.display_image_url` and `board.preview_image_url` back-to-back, a sub-millisecond gap occasionally produced different URL strings, causing intermittent failures in [spec/models/board_spec.rb:397](spec/models/board_spec.rb:397) and [spec/models/board_spec.rb:401](spec/models/board_spec.rb:401).

## Test plan
- [x] `bundle exec rspec spec/models/board_spec.rb -e "display_image_url with display_follows_preview flag"` — 4 examples, 0 failures
- [x] Looped the previously flaky example 10x in a row — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)