### PR TITLE
feat(handoff): expose can_edit_communicator on child_account api_view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,25 @@ A real **transfer ownership** flow doesn't exist yet — it's out of scope
 for #166 and will get its own endpoint (touches `child_account.owner_id`,
 not just team membership).
 
+### Editing the communicator object itself
+
+`ChildAccount#editable_by?(user)` returns true iff the user is the
+`owner_id` or a system admin. It's the helper that drives the
+`can_edit_communicator` flag on both `api_view` and `vendor_api_view`
+(issue #215). The frontend uses that flag to gate the Edit tab/form on a
+communicator — i.e. who can change name, username, voice, layout, and
+the safety profile.
+
+`can_edit_communicator` is **distinct from `can_edit`** in the same
+payload: `can_edit` answers "can this user curate boards on this
+communicator" (board sharers, including team members on a paid plan).
+`can_edit_communicator` answers "can this user mutate the communicator
+object itself" (owner-only by default). Keep both — they back different
+UI affordances.
+
+Full permissions matrix and the rationale for the split lives in
+`../speakanyway/marketing/.claude-notes/handoff-workflow.md`.
+
 ## AI gating: credit ledger (source of truth)
 
 - AI features are gated by **weighted credits** held in two balances on `users`:

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -136,6 +136,14 @@ class ChildAccount < ApplicationRecord
   def loaner?  = status == LOANER
   def active?  = status == ACTIVE
 
+  # Can `user` edit the communicator object itself (name, username, voice,
+  # layout, safety info)? Distinct from `can_edit` in api_view, which
+  # answers "can this user curate boards on this communicator." Spec:
+  # marketing/.claude-notes/handoff-workflow.md (Permissions matrix).
+  def editable_by?(user)
+    user.present? && (user.id == owner_id || user.admin?)
+  end
+
   # `is_demo` is derived from status now. The DB column is retained until the
   # frontend cutover (F1) is complete, then dropped. Writes to `is_demo` flow
   # into `status` for backwards compatibility.
@@ -417,6 +425,7 @@ class ChildAccount < ApplicationRecord
       sign_in_count: sign_in_count,
       board_week_chart: board_week_chart,
       can_edit: viewing_user&.can_add_boards_to_account?([id]),
+      can_edit_communicator: editable_by?(viewing_user),
       is_owner: viewing_user&.id == user_id,
       is_vendor: is_vendor,
       layout: layout,
@@ -743,6 +752,7 @@ class ChildAccount < ApplicationRecord
       created_at: created_at,
       sign_in_count: sign_in_count,
       can_edit: viewing_user&.can_add_boards_to_account?([id]),
+      can_edit_communicator: editable_by?(viewing_user),
       is_owner: viewing_user&.id == user_id || viewing_user&.admin?,
       is_vendor: is_vendor,
       layout: layout,

--- a/spec/models/child_account_editable_by_spec.rb
+++ b/spec/models/child_account_editable_by_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #215 — helper that drives `can_edit_communicator` in api_view.
+# Spec: marketing/.claude-notes/handoff-workflow.md (Permissions matrix).
+RSpec.describe ChildAccount, "#editable_by?", type: :model do
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:supervisor) { create(:user, created_at: 2.months.ago) }
+  let(:admin) { create(:admin_user) }
+  let!(:account) do
+    acct = create(:child_account, user: owner, owner: owner, status: "active")
+    team = acct.ensure_team!(creator: owner)
+    team.add_member!(supervisor, "supervisor")
+    acct
+  end
+
+  it "is true for the owner" do
+    expect(account.editable_by?(owner)).to be true
+  end
+
+  it "is true for a system admin" do
+    expect(account.editable_by?(admin)).to be true
+  end
+
+  it "is false for a supervisor on the team" do
+    expect(account.editable_by?(supervisor)).to be false
+  end
+
+  it "is false for nil" do
+    expect(account.editable_by?(nil)).to be false
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `ChildAccount#editable_by?(user)` — true iff the user is the `owner_id` or a system admin. Small helper several upcoming handoff PRs will key off (issues #210–#214).
- Surfaces it as `can_edit_communicator` on both `api_view` and `vendor_api_view`. Leaves the existing `can_edit` flag alone — it answers a different question (boards curation).
- CLAUDE.md "Team permissions" gains a short subsection explaining the two flags side-by-side and points at `marketing/.claude-notes/handoff-workflow.md` for the full permissions matrix.

The matching frontend issue ([itty-bitty-frontend#225](https://github.com/brittanyjohns/itty-bitty-frontend/issues/225)) will flip the Edit tab gate from `is_owner` to `can_edit_communicator` so admin-tier team members other than the owner can be granted edit access later without another backend release.

Closes #215.

## Test plan

- New model spec `spec/models/child_account_editable_by_spec.rb` covers owner → true, system admin → true, supervisor on the team → false, nil → false. Mirrors the style of `spec/models/child_account_claim_spec.rb`.
- `bundle exec rspec spec/models/child_account_claim_spec.rb spec/models/child_account_editable_by_spec.rb` → 11 examples, 0 failures.