### PR TITLE
feat(child_boards): gate destroy and favorite toggle by role (#212, #213)

### DIFF
--- a/app/controllers/api/child_boards_controller.rb
+++ b/app/controllers/api/child_boards_controller.rb
@@ -3,6 +3,9 @@ class API::ChildBoardsController < API::ApplicationController
   respond_to :json
   skip_before_action :authenticate_token!, only: %i[show current]
   before_action :authenticate_child_token!, only: %i[show current]
+  before_action :load_child_board, only: %i[toggle_favorite update destroy]
+  before_action :authorize_curate!, only: %i[toggle_favorite update]
+  before_action :authorize_detach!, only: %i[destroy]
 
   # GET /boards/1 or /boards/1.json
   def show
@@ -27,10 +30,7 @@ class API::ChildBoardsController < API::ApplicationController
   end
 
   def toggle_favorite
-    @child_board = ChildBoard.find(params[:id])
-
     result = @child_board.toggle_favorite
-    # render json: @child_board.api_view
     unless result
       render json: { error: "You can only favorite 80 boards" }, status: :unprocessable_entity
       return
@@ -40,7 +40,6 @@ class API::ChildBoardsController < API::ApplicationController
   end
 
   def update
-    @child_board = ChildBoard.find(params[:id])
     if @child_board.update(board_params)
       render json: @child_board.api_view
     else
@@ -50,14 +49,8 @@ class API::ChildBoardsController < API::ApplicationController
 
   def destroy
     Rails.logger.info "Deleting child board with ID: #{params[:id]}"
-
-    @child_board = ChildBoard.find(params[:id])
     @board = @child_board.board
-    unless @board.user_id == current_user.id
-      Rails.logger.warn "Unauthorized attempt to delete child board ID: #{params[:id]} by user ID: #{current_user.id}"
-      render json: { error: "Unauthorized" }, status: :unauthorized
-      return
-    end
+
     if @board.is_template
       Rails.logger.info "Deleting associated board ID: #{@board.id}"
       @child_board.destroy
@@ -71,6 +64,32 @@ class API::ChildBoardsController < API::ApplicationController
   end
 
   private
+
+  def load_child_board
+    @child_board = ChildBoard.find(params[:id])
+  end
+
+  # Curation tier: owner, admin, or any team member with
+  # admin/member/supporter role on the communicator. Backs the favorite
+  # toggle and any other curation-only field on the join row.
+  def authorize_curate!
+    return if @child_board.curatable_by?(current_user)
+
+    Rails.logger.warn "Unauthorized curation attempt on child_board ID: #{@child_board.id} by user ID: #{current_user&.id}"
+    render json: { error: "Unauthorized" }, status: :forbidden
+  end
+
+  # Detach (destroy) is owner-only. Letting a supervisor unshare a board
+  # via this endpoint would bypass `TeamUser#before_destroy`'s snapshot
+  # safety net — the family would lose access to a board they were
+  # relying on. If an SLP wants to stop sharing, she removes herself
+  # from the team, which triggers the snapshot copy.
+  def authorize_detach!
+    return if @child_board.child_account.editable_by?(current_user)
+
+    Rails.logger.warn "Unauthorized detach attempt on child_board ID: #{@child_board.id} by user ID: #{current_user&.id}"
+    render json: { error: "Unauthorized" }, status: :forbidden
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_child_board

--- a/app/models/child_board.rb
+++ b/app/models/child_board.rb
@@ -87,6 +87,17 @@ class ChildBoard < ApplicationRecord
     board.board_type
   end
 
+  # Can `user` curate this child_board (toggle favorite, reorder, etc.)?
+  # Uses the curation tier — owner, system admin, or anyone on the
+  # communicator's team with admin/member/supporter role. Same shape as
+  # `assign_boards`. Detach (#destroy) is stricter — owner-only — because
+  # it bypasses the supervisor-removal snapshot safety net. Spec:
+  # marketing/.claude-notes/handoff-workflow.md (Permissions matrix).
+  def curatable_by?(user)
+    return false unless user
+    user.can_add_boards_to_account?([child_account_id])
+  end
+
   def api_view
     {
       id: id,

--- a/spec/requests/api/child_boards_owner_protection_spec.rb
+++ b/spec/requests/api/child_boards_owner_protection_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issues #212 and #213 — authorization on `/api/child_boards/:id`.
+#
+# Two different rules apply to the two mutating actions:
+#
+# - **#destroy** (detach a board from the communicator) is **owner-only**.
+#   An SLP supervisor who shared a board can NOT detach it directly,
+#   because that bypasses `TeamUser#before_destroy`'s snapshot safety net.
+#   To stop sharing, the supervisor removes herself from the team, which
+#   triggers the snapshot copy onto the family.
+#
+# - **#update / #toggle_favorite** (the favorite flag, plus any other
+#   curation-tier field on the join row) follow the **curation rule** —
+#   anyone with admin/member/supporter on the communicator's team, plus
+#   the owner and system admins. Same rule as `assign_boards`.
+#
+# Full matrix: marketing/.claude-notes/handoff-workflow.md
+RSpec.describe "API::ChildBoards owner protection", type: :request do
+  let(:parent) { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_parent_stub") }
+  let(:slp)    { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_slp_stub") }
+
+  # Post-claim shape: the parent owns the communicator. The SLP is on
+  # the team as a supervisor. The board that's attached to the
+  # communicator is owned by the SLP — i.e. a board she's sharing in.
+  let!(:child_account) do
+    create(:child_account,
+           user: parent,
+           owner: parent,
+           status: ChildAccount::ACTIVE,
+           passcode: "ownerpw1")
+  end
+  let!(:team) do
+    t = child_account.ensure_team!(creator: slp)
+    t.add_member!(parent, "admin")
+    t.add_member!(slp, "supervisor")
+    t
+  end
+  let(:slp_board) { create(:board, user: slp, name: "Shared by SLP") }
+  let!(:child_board) { create(:child_board, board: slp_board, child_account: child_account) }
+
+  describe "DELETE /api/child_boards/:id (detach)" do
+    it "lets the communicator owner detach the board" do
+      expect {
+        delete "/api/child_boards/#{child_board.id}", headers: auth_headers(parent)
+      }.to change { ChildBoard.where(id: child_board.id).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "blocks the SLP supervisor from detaching the board she shared (403)" do
+      expect {
+        delete "/api/child_boards/#{child_board.id}", headers: auth_headers(slp)
+      }.not_to change { ChildBoard.where(id: child_board.id).count }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "lets a system admin detach (escape hatch)" do
+      admin = create(:admin_user)
+      expect {
+        delete "/api/child_boards/#{child_board.id}", headers: auth_headers(admin)
+      }.to change { ChildBoard.where(id: child_board.id).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /api/child_boards/:id (favorite toggle)" do
+    let(:admin_member) { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_admin_member_stub") }
+
+    before do
+      team.add_member!(admin_member, "admin")
+    end
+
+    it "lets the communicator owner toggle favorite" do
+      patch "/api/child_boards/#{child_board.id}",
+            params: { child_board: { favorite: true } },
+            headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(child_board.reload.favorite).to eq(true)
+    end
+
+    it "lets a team admin (non-owner) toggle favorite" do
+      patch "/api/child_boards/#{child_board.id}",
+            params: { child_board: { favorite: true } },
+            headers: auth_headers(admin_member)
+
+      expect(response).to have_http_status(:ok)
+      expect(child_board.reload.favorite).to eq(true)
+    end
+
+    it "blocks the SLP supervisor from toggling favorite (403)" do
+      patch "/api/child_boards/#{child_board.id}",
+            params: { child_board: { favorite: true } },
+            headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(child_board.reload.favorite).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #212 and #213.

## Summary

- **`DELETE /api/child_boards/:id`** was checking `@board.user_id == current_user.id` — the board owner. That's the wrong gate post-claim: an SLP whose board is shared on a family's communicator could detach it via the API, bypassing the snapshot safety net in `TeamUser#before_destroy`. Switched to `child_account.editable_by?(current_user)` so detach is **owner-only** (or system admin). Supervisors who want to stop sharing remove themselves from the team — that's the path that triggers the snapshot copy.
- **`PATCH /api/child_boards/:id`** and **`PUT /api/child_boards/:id/toggle_favorite`** had no permission check at all. Added `ChildBoard#curatable_by?(user)` (wraps `User#can_add_boards_to_account?`) and gate both actions with it — same **curation tier** as `assign_boards` (owner, system admin, or admin/member/supporter on the team).
- Both unauthorized paths now return **HTTP 403** (previously 401).
- Permissions matrix updated in `marketing/.claude-notes/handoff-workflow.md` to record the favorite-toggle decision (curation tier) and call out why destroy is stricter.

## Permission split (matches the matrix)

| Action | Rule | Helper |
|---|---|---|
| `#destroy` (detach board) | Owner-only | `ChildAccount#editable_by?` |
| `#update` (favorite, etc.) | Curation tier | `ChildBoard#curatable_by?` |
| `#toggle_favorite` | Curation tier | `ChildBoard#curatable_by?` |

## Test plan

- [x] `bundle exec rspec spec/requests/api/child_boards_owner_protection_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rspec spec/models/child_board_spec.rb` — passes (1 pending placeholder, unchanged)
- [x] Destroy: owner → 200, SLP supervisor (board owner) → 403, system admin → 200
- [x] Update favorite: owner → 200, team admin (non-owner) → 200, SLP supervisor → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)