### PR TITLE
feat(handoff): gate child_account mutations on the owner

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,5 +1,6 @@
 class API::ChildAccountsController < API::ApplicationController
-  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan archive unarchive ]
+  before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan archive unarchive assign_boards send_setup_email ]
+  before_action :authorize_communicator_edit!, only: %i[ update assign_boards send_setup_email ]
   # Claim preview is the parent's "this is what you're about to claim"
   # page — they may not be signed in yet, so it runs token-only.
   skip_before_action :authenticate_token!, only: %i[ claim_preview ]
@@ -22,7 +23,6 @@ class API::ChildAccountsController < API::ApplicationController
   end
 
   def send_setup_email
-    @child_account = ChildAccount.find(params[:id])
     @child_account.send_setup_email(current_user)
     render json: { success: true }
   end
@@ -450,7 +450,6 @@ class API::ChildAccountsController < API::ApplicationController
   end
 
   def assign_boards
-    @child_account = ChildAccount.find(params[:id])
     board_ids = params[:board_ids]
     total_boards = @child_account.child_boards.count + board_ids.size
     if @child_account.sandbox?
@@ -498,6 +497,24 @@ class API::ChildAccountsController < API::ApplicationController
   # Only allow a list of trusted parameters through.
   def child_account_params
     params.require(:child_account).permit(:user_id, :username, :name)
+  end
+
+  # Issues #210 / #211 — content-mutating endpoints on the communicator
+  # itself (name, username, passcode, voice, settings, layout, boards
+  # roster, setup email) must be owner-only. SLP supervisors and other
+  # team members are read-only on the communicator object; they share
+  # boards via the team instead. System admins bypass.
+  #
+  # The inline ownership checks in `lend`, `end_loan`, `archive`,
+  # `unarchive`, `promote_to_loaner`, `claim_link`, and `send_claim_link`
+  # haven't been folded in here yet — each has its own error message /
+  # status nuance. Tracked as a follow-up.
+  def authorize_communicator_edit!
+    return if @child_account.editable_by?(current_user)
+
+    render json: account_error_payload("not_owner").merge(
+      message: "Only the owner can edit this communicator.",
+    ), status: :forbidden
   end
 
   # Mutation endpoints (lend, end_loan, etc.) return the current account

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issues #210 / #211 — owner-protection on the content-mutating
+# communicator endpoints. After the SLP→parent claim hand-off, the SLP
+# stays on the team as a supervisor (board-sharer only). Direct edits
+# to the communicator object — name/passcode/voice/settings/layout, the
+# boards roster, and the setup email — must be owner-only. Mirrors the
+# shape of spec/requests/api/team_permissions_spec.rb.
+RSpec.describe "API::ChildAccounts owner protection", type: :request do
+  let(:slp)    { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_slp_stub") }
+  let(:parent) { create(:user, created_at: 2.months.ago, stripe_customer_id: "cus_parent_stub") }
+  let(:admin)  { create(:admin_user) }
+
+  # Mirror the post-claim shape: the parent is the owner, the SLP is on
+  # the team as a supervisor.
+  let!(:account) do
+    create(:child_account,
+           user: parent,
+           owner: parent,
+           status: ChildAccount::ACTIVE,
+           passcode: "ownerpw1")
+  end
+  let!(:team) do
+    t = account.ensure_team!(creator: slp)
+    t.add_member!(parent, "admin")
+    t.add_member!(slp, "supervisor")
+    t
+  end
+
+  describe "PATCH /api/child_accounts/:id" do
+    let(:rename_params) { { name: "New Name" } }
+
+    it "lets the parent owner rename the communicator" do
+      patch "/api/child_accounts/#{account.id}",
+            params: rename_params,
+            headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(account.reload.name).to eq("New Name")
+    end
+
+    it "blocks an SLP supervisor (403 not_owner)" do
+      patch "/api/child_accounts/#{account.id}",
+            params: rename_params,
+            headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(account.reload.name).not_to eq("New Name")
+    end
+
+    it "lets a system admin through (escape hatch)" do
+      patch "/api/child_accounts/#{account.id}",
+            params: rename_params,
+            headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(account.reload.name).to eq("New Name")
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/assign_boards" do
+    let!(:board) { Board.create!(user: parent, name: "Shared Board", number_of_columns: 3) }
+
+    it "lets the parent owner assign a board" do
+      expect {
+        post "/api/child_accounts/#{account.id}/assign_boards",
+             params: { board_ids: [board.id] },
+             headers: auth_headers(parent)
+      }.to change { account.reload.child_boards.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "blocks an SLP supervisor (403 not_owner)" do
+      expect {
+        post "/api/child_accounts/#{account.id}/assign_boards",
+             params: { board_ids: [board.id] },
+             headers: auth_headers(slp)
+      }.not_to change { account.reload.child_boards.count }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+    end
+
+    it "lets a system admin through (escape hatch)" do
+      expect {
+        post "/api/child_accounts/#{account.id}/assign_boards",
+             params: { board_ids: [board.id] },
+             headers: auth_headers(admin)
+      }.to change { account.reload.child_boards.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/child_accounts/:id/send_setup_email" do
+    before do
+      mailer = double("CommunicationAccountMailer", deliver_now: true)
+      allow(CommunicationAccountMailer).to receive(:setup_email).and_return(mailer)
+    end
+
+    it "lets the parent owner send the setup email" do
+      post "/api/child_accounts/#{account.id}/send_setup_email",
+           headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(CommunicationAccountMailer).to have_received(:setup_email).with(account, parent)
+    end
+
+    it "blocks an SLP supervisor (403 not_owner)" do
+      post "/api/child_accounts/#{account.id}/send_setup_email",
+           headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(CommunicationAccountMailer).not_to have_received(:setup_email)
+    end
+
+    it "lets a system admin through (escape hatch)" do
+      post "/api/child_accounts/#{account.id}/send_setup_email",
+           headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(CommunicationAccountMailer).to have_received(:setup_email).with(account, admin)
+    end
+  end
+end


### PR DESCRIPTION
Closes #210 and #211.

## Summary

- Adds `authorize_communicator_edit!` `before_action` on `API::ChildAccountsController`, applied to `update`, `assign_boards`, and `send_setup_email`. It runs `ChildAccount#editable_by?` (added in #219) and renders HTTP 403 `{ error: "not_owner", message: "Only the owner can edit this communicator." }` for non-owner, non-admin callers. Uses `account_error_payload` so the response shape matches the other mutation endpoints (current account view + error).
- Folds `assign_boards` and `send_setup_email` into the existing `set_child_account` before_action so the new filter has `@child_account` to look at, and drops the duplicate `ChildAccount.find(params[:id])` calls.
- Inline ownership checks on `lend`, `end_loan`, `archive`, `unarchive`, `promote_to_loaner`, `claim_link`, and `send_claim_link` are intentionally left alone — each has its own error-message / status nuance (e.g. `lend`'s `active`-branch message). Tracked as a follow-up.

Spec: [`marketing/.claude-notes/handoff-workflow.md`](https://github.com/brittanyjohns/speakanyway/blob/main/marketing/.claude-notes/handoff-workflow.md) — "Permissions matrix" + "Known gaps" #1 and #2.

## Test plan

- [x] New `spec/requests/api/child_accounts_owner_protection_spec.rb` mirrors `spec/requests/api/team_permissions_spec.rb`. Three describe blocks (`PATCH /update`, `POST /assign_boards`, `POST /send_setup_email`), each covering: owner → 200/ok, SLP supervisor → 403 with `body["error"] == "not_owner"`, system admin → 200/ok. 9 examples, all green.
- [x] Full `spec/requests/api/child_accounts*_spec.rb` set (archive, claim, demo_limit, promote, owner_protection) — 43 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)