### PR TITLE
chore(team_roles): normalize team_users.role to admin/supervisor/member

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -375,8 +375,7 @@ class API::ChildAccountsController < API::ApplicationController
         TeamAccount.create!(team: team, account: @child_account)
       end
 
-      team_role = current_user.professional? ? "professional" : "admin"
-      team.add_member!(current_user, team_role)
+      team.add_member!(current_user, "admin")
 
       render json: @child_account.api_view(current_user), status: :created
     else

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,5 +1,6 @@
 class API::TeamsController < API::ApplicationController
   before_action :set_team, only: %i[ show edit update destroy remove_board invite ]
+  before_action :authorize_team_member!, only: %i[ create_board ]
   # after_action :verify_policy_scoped, only: :index
 
   # GET /teams or /teams.json
@@ -134,7 +135,6 @@ class API::TeamsController < API::ApplicationController
   end
 
   def create_board
-    @team = Team.find(params[:id])
     @board = Board.find(params[:board_id])
     @team_board = @team.add_board!(@board, current_user.id)
     if @team_board.save
@@ -185,13 +185,25 @@ class API::TeamsController < API::ApplicationController
     @team = Team.with_artifacts.find(params[:id])
   end
 
+  # Any team member (admin, supervisor, member) — or a system admin —
+  # may add boards to the team's library. Non-members get 403. Issue
+  # #216 — closes the gap where any signed-in user could write to any
+  # team's `team_boards`.
+  def authorize_team_member!
+    @team = Team.with_artifacts.find(params[:id])
+    return if current_user.admin?
+    return if @team.team_users.where(user_id: current_user.id, role: TeamUser::ROLES).exists?
+    render_team_permission_error("not_a_team_member",
+                                 "You must be on this team to add boards to it.")
+  end
+
   def team_user_params
     params.require(:team_user).permit(:email)
   end
 
   def invite_role
     role = params.dig(:team_user, :role).to_s
-    %w[admin member].include?(role) ? role : "member"
+    TeamUser::ROLES.include?(role) ? role : "member"
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -208,7 +208,7 @@ module API
           team_name = child.name.present? ? "#{child.name}'s Communication Team" : "Communication Team"
           team = Team.create!(name: team_name, created_by: current_user)
           TeamAccount.create!(team: team, account: child)
-          team.add_member!(current_user, current_user.professional? ? "professional" : "admin")
+          team.add_member!(current_user, "admin")
         end
       end
     end

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -642,12 +642,18 @@ class ChildAccount < ApplicationRecord
              .where.not(board_id: used_ids)
   end
 
+  # Read-only team members across all of this account's teams. Named
+  # for backward-compat with the `supporters` field in `api_view`; new
+  # canonical role set is just `member`. Issue #216.
   def supporters
-    team_users.includes(:user).where(role: ["supporter", "member", "restricted"]).distinct.map(&:user)
+    team_users.includes(:user).where(role: "member").distinct.map(&:user)
   end
 
+  # Curators across all of this account's teams. `admin` is the
+  # account owner, `supervisor` is the SLP / power collaborator.
+  # Surfaced in `api_view` under the `supervisors` key. Issue #216.
   def supervisors
-    team_users.includes(:user).where(role: ["supervisor", "admin"]).distinct.map(&:user)
+    team_users.includes(:user).where(role: %w[admin supervisor]).distinct.map(&:user)
   end
 
   def startup_url

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -33,23 +33,7 @@ class Team < ApplicationRecord
     end
   end
 
-  def primary_supporter
-    team_users.find_by(role: "admin")&.user
-  end
-
-  def professionals
-    team_users.where(role: "professional").includes(:user).map(&:user)
-  end
-
-  def all_supporters
-    team_users.where(role: ["admin", "supporter", "member"]).includes(:user).map(&:user)
-  end
-
-  def supporters
-    team_users.where(role: ["supporter", "member", "restricted"]).includes(:user)
-  end
-
-  def add_member!(user, role = "supporter")
+  def add_member!(user, role = "member")
     return nil if user.nil?
     if user && !users.include?(user)
       team_user = team_users.new(user: user, role: role)

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -13,10 +13,21 @@
 #  can_edit               :boolean          default(FALSE)
 #
 class TeamUser < ApplicationRecord
+  # Canonical role set (issue #216). Permissions matrix lives in
+  # marketing/.claude-notes/handoff-workflow.md:
+  #   admin      — account owner; full curation + member management.
+  #   supervisor — power collaborator (SLP). Can curate boards on the
+  #                communicator but cannot edit the communicator object
+  #                or delete the account.
+  #   member     — read-only on the communicator; can add boards to the
+  #                team library but cannot assign them.
+  ROLES = %w[admin supervisor member].freeze
+
   belongs_to :user
   belongs_to :team
 
-  before_create :set_defaults
+  before_validation :set_defaults, on: :create
+  validates :role, inclusion: { in: ROLES, message: "must be admin, supervisor, or member" }
   before_destroy :snapshot_shared_boards_to_family
 
   # Safety net for the SLP→family hand-off (B6 — issue #162). When this
@@ -49,7 +60,7 @@ class TeamUser < ApplicationRecord
   end
 
   def self.roles
-    { "admin" => "Admin", "member" => "Member" }
+    { "admin" => "Admin", "supervisor" => "Supervisor", "member" => "Member" }
   end
 
   # True if this user is the owner of any child_account on the team. Used

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -621,11 +621,7 @@ class User < ApplicationRecord
     return false unless account
     return true if account.user_id == id
     return true if admin?
-    return true if account.team_users.where(user_id: id, role: "admin").exists?
-    return true if account.team_users.where(user_id: id, role: "member").exists?
-    return true if account.team_users.where(user_id: id, role: "supporter").exists?
-    return true if account.team_users.where(user_id: id, role: "restricted").exists?
-    false
+    account.team_users.where(user_id: id, role: TeamUser::ROLES).exists?
   end
 
   def can_edit_profile?(profile_id, profileable_type = "User")
@@ -645,6 +641,13 @@ class User < ApplicationRecord
     false
   end
 
+  # Can the user curate boards on the communicator? Issue #216 — only
+  # admin (account owner) and supervisor (SLP power-collaborator) can
+  # assign/reorder/favorite boards on the communicator. `member` is
+  # read-only on the communicator; they can add boards to the team
+  # library but cannot push them onto the communicator.
+  CURATE_ROLES = %w[admin supervisor].freeze
+
   def can_add_boards_to_account?(account_ids)
     return false unless account_ids
     account_id = account_ids.first
@@ -653,11 +656,7 @@ class User < ApplicationRecord
     return false unless account
     return true if account.user_id == id
     return true if admin?
-    return true if account.team_users.where(user_id: id, role: "admin").exists?
-    return true if account.team_users.where(user_id: id, role: "member").exists?
-    return true if account.team_users.where(user_id: id, role: "supporter").exists?
-    return false if account.team_users.where(user_id: id, role: "restricted").exists?
-    false
+    account.team_users.where(user_id: id, role: CURATE_ROLES).exists?
   end
 
   def can_favorite?(model)
@@ -1171,10 +1170,8 @@ class User < ApplicationRecord
   end
 
   def teams_with_read_access
-    # teams = Team.where(id: team_users.select(:team_id)).where.not(created_by_id: id)
-    # team_users.includes(:team).where(role: ["supporter", "member", "restricted"]).map(&:team).uniq
     teams.joins(:team_users)
-         .where(team_users: { role: ["supporter", "member", "restricted"] })
+         .where(team_users: { user_id: id, role: %w[supervisor member] })
          .where.not(teams: { created_by_id: id })
          .distinct
   end

--- a/db/migrate/20260601120000_normalize_team_users_role.rb
+++ b/db/migrate/20260601120000_normalize_team_users_role.rb
@@ -1,0 +1,42 @@
+class NormalizeTeamUsersRole < ActiveRecord::Migration[7.1]
+  # Canonical set is admin/supervisor/member. See issue #216 and
+  # marketing/drafts/role-normalization-notes.md. Same fold map as
+  # lib/tasks/team_roles.rake — duplicated here to keep the migration
+  # self-contained (rake constants aren't loaded reliably in migrations).
+  FOLD = {
+    "professional" => "admin",
+    "supporter"    => "member",
+    "restricted"   => "member",
+  }.freeze
+  CANONICAL = %w[admin supervisor member].freeze
+
+  def up
+    say_with_time "Normalizing team_users.role values" do
+      total = 0
+      FOLD.each do |from, to|
+        count = execute(
+          ActiveRecord::Base.send(:sanitize_sql_array,
+                                  ["UPDATE team_users SET role = ?, updated_at = NOW() WHERE role = ?", to, from])
+        ).cmd_tuples
+        say "#{from.inspect} -> #{to.inspect}: #{count}", true
+        total += count
+      end
+
+      # Defensive: anything still out of the canonical set falls back
+      # to "member". This catches NULLs and any unanticipated string
+      # so the upcoming inclusion validation won't trip on legacy data.
+      defensive = execute(
+        ActiveRecord::Base.send(:sanitize_sql_array,
+                                ["UPDATE team_users SET role = ?, updated_at = NOW() WHERE role IS NULL OR role NOT IN (?)",
+                                 "member", CANONICAL])
+      ).cmd_tuples
+      say "defensive (NULL/unknown -> \"member\"): #{defensive}", true
+      total += defensive
+      say "Total rows updated: #{total}", true
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_23_180000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"

--- a/lib/tasks/team_roles.rake
+++ b/lib/tasks/team_roles.rake
@@ -1,0 +1,56 @@
+namespace :team_roles do
+  # Mapping for non-canonical role strings. Anything not in
+  # TeamUser::ROLES and not in this map falls back to "member" so a
+  # surprise value never blocks the inclusion validation.
+  #
+  # See issue #216 and marketing/drafts/role-normalization-notes.md
+  # for the reasoning behind each fold.
+  ROLE_FOLD = {
+    "professional" => "admin",     # creator-add path; always the account owner
+    "supporter"    => "member",    # never landed in prod (default arg for add_member!)
+    "restricted"   => "member",    # read access preserved; curate access dropped
+  }.freeze
+
+  desc "Print every team_users row that would be rewritten by team_roles:normalize"
+  task normalize_dry_run: :environment do
+    rows = stale_rows
+    if rows.empty?
+      puts "No team_users rows need normalization. All values already in TeamUser::ROLES."
+      next
+    end
+
+    puts "Would update #{rows.count} team_users row(s):"
+    rows.each do |row|
+      target = target_role_for(row.role)
+      puts "  ##{row.id} team=#{row.team_id} user=#{row.user_id}: " \
+           "#{row.role.inspect} -> #{target.inspect}"
+    end
+    puts ""
+    summary = rows.group_by(&:role).transform_values(&:count)
+    puts "By source role: #{summary.inspect}"
+  end
+
+  desc "Rewrite stale team_users.role values to the canonical set (admin/supervisor/member)"
+  task normalize: :environment do
+    updated = 0
+    skipped = 0
+    stale_rows.each do |row|
+      target = target_role_for(row.role)
+      if row.role == target
+        skipped += 1
+        next
+      end
+      row.update_columns(role: target, updated_at: Time.current)
+      updated += 1
+    end
+    puts "team_roles:normalize complete. updated=#{updated} skipped=#{skipped}"
+  end
+
+  def stale_rows
+    TeamUser.where.not(role: TeamUser::ROLES).order(:id)
+  end
+
+  def target_role_for(role)
+    ROLE_FOLD[role.to_s] || "member"
+  end
+end

--- a/spec/lib/tasks/team_roles_rake_spec.rb
+++ b/spec/lib/tasks/team_roles_rake_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# Issue #216 — operator can preview the role-normalization fold with
+# `team_roles:normalize_dry_run` before running `team_roles:normalize`.
+# The migration (db/migrate/...normalize_team_users_role.rb) does the
+# same work on deploy; the rake task is the dress-rehearsal.
+RSpec.describe "team_roles rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:dry_run) { Rake::Task["team_roles:normalize_dry_run"] }
+  let(:normalize) { Rake::Task["team_roles:normalize"] }
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:account) { create(:child_account, user: owner, owner: owner) }
+  let!(:team) { account.ensure_team!(creator: owner) }
+
+  after do
+    dry_run.reenable
+    normalize.reenable
+  end
+
+  def insert_team_user_with_role(role)
+    user = create(:user, created_at: 2.months.ago)
+    # Bypass the inclusion validation so we can simulate legacy rows.
+    TeamUser.new(team: team, user: user, role: role).save(validate: false)
+    TeamUser.where(team: team, user: user).first
+  end
+
+  describe "team_roles:normalize_dry_run" do
+    it "doesn't mutate anything" do
+      tu = insert_team_user_with_role("professional")
+      expect { silent { dry_run.invoke } }.not_to(change { tu.reload.role })
+    end
+
+    it "prints the no-op message when every row is already canonical" do
+      output = capture_stdout { dry_run.invoke }
+      expect(output).to match(/No team_users rows need normalization/)
+    end
+  end
+
+  describe "team_roles:normalize" do
+    it "rewrites professional -> admin" do
+      tu = insert_team_user_with_role("professional")
+      silent { normalize.invoke }
+      expect(tu.reload.role).to eq("admin")
+    end
+
+    it "rewrites supporter -> member" do
+      tu = insert_team_user_with_role("supporter")
+      silent { normalize.invoke }
+      expect(tu.reload.role).to eq("member")
+    end
+
+    it "rewrites restricted -> member" do
+      tu = insert_team_user_with_role("restricted")
+      silent { normalize.invoke }
+      expect(tu.reload.role).to eq("member")
+    end
+
+    it "rewrites unknown values -> member (defensive)" do
+      tu = insert_team_user_with_role("slp")
+      silent { normalize.invoke }
+      expect(tu.reload.role).to eq("member")
+    end
+
+    it "leaves canonical roles untouched" do
+      tu_admin      = insert_team_user_with_role("admin")
+      tu_supervisor = insert_team_user_with_role("supervisor")
+      tu_member     = insert_team_user_with_role("member")
+
+      silent { normalize.invoke }
+
+      expect(tu_admin.reload.role).to eq("admin")
+      expect(tu_supervisor.reload.role).to eq("supervisor")
+      expect(tu_member.reload.role).to eq("member")
+    end
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  def silent
+    capture_stdout { yield }
+  end
+end

--- a/spec/models/team_user_spec.rb
+++ b/spec/models/team_user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #216 — `team_users.role` is locked to the canonical set
+# `%w[admin supervisor member]`. Permissions matrix:
+# marketing/.claude-notes/handoff-workflow.md.
+RSpec.describe TeamUser, type: :model do
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:account) { create(:child_account, user: owner, owner: owner) }
+  let(:team) { account.ensure_team!(creator: owner) }
+
+  describe "role inclusion validation" do
+    TeamUser::ROLES.each do |role|
+      it "accepts #{role.inspect}" do
+        user = create(:user, created_at: 2.months.ago)
+        tu = TeamUser.new(team: team, user: user, role: role)
+        expect(tu).to be_valid
+      end
+    end
+
+    %w[professional supporter restricted slp parent foo].each do |stale|
+      it "rejects #{stale.inspect}" do
+        user = create(:user, created_at: 2.months.ago)
+        tu = TeamUser.new(team: team, user: user, role: stale)
+        expect(tu).not_to be_valid
+        expect(tu.errors[:role]).to be_present
+      end
+    end
+
+    it "fills the default ('member') when role is blank on create" do
+      user = create(:user, created_at: 2.months.ago)
+      tu = TeamUser.create!(team: team, user: user)
+      expect(tu.role).to eq("member")
+    end
+  end
+
+  describe ".roles" do
+    it "lists every canonical role" do
+      expect(TeamUser.roles.keys).to match_array(TeamUser::ROLES)
+    end
+  end
+end

--- a/spec/models/user_curate_spec.rb
+++ b/spec/models/user_curate_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #216 — `can_add_boards_to_account?` is the "curate boards on
+# the communicator" gate. Only admin (account owner) and supervisor
+# (power collaborator) curate. `member` is read-only on the
+# communicator; they can add boards to the team library but cannot
+# push them onto the communicator. Full matrix in
+# marketing/.claude-notes/handoff-workflow.md.
+RSpec.describe User, "#can_add_boards_to_account?", type: :model do
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:account) do
+    create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE)
+  end
+  let!(:team) { account.ensure_team!(creator: owner) }
+
+  it "is true for the account owner" do
+    expect(owner.can_add_boards_to_account?([account.id])).to be true
+  end
+
+  it "is true for a system admin" do
+    sys_admin = create(:admin_user)
+    expect(sys_admin.can_add_boards_to_account?([account.id])).to be true
+  end
+
+  it "is true for a team member with role 'admin'" do
+    user = create(:user, created_at: 2.months.ago)
+    team.add_member!(user, "admin")
+    expect(user.can_add_boards_to_account?([account.id])).to be true
+  end
+
+  it "is true for a team member with role 'supervisor'" do
+    user = create(:user, created_at: 2.months.ago)
+    team.add_member!(user, "supervisor")
+    expect(user.can_add_boards_to_account?([account.id])).to be true
+  end
+
+  it "is false for a team member with role 'member' (read-only on the communicator)" do
+    user = create(:user, created_at: 2.months.ago)
+    team.add_member!(user, "member")
+    expect(user.can_add_boards_to_account?([account.id])).to be false
+  end
+
+  it "is false for a stranger who isn't on any team for the account" do
+    stranger = create(:user, created_at: 2.months.ago)
+    expect(stranger.can_add_boards_to_account?([account.id])).to be false
+  end
+end

--- a/spec/requests/api/child_boards_owner_protection_spec.rb
+++ b/spec/requests/api/child_boards_owner_protection_spec.rb
@@ -14,8 +14,9 @@ require "rails_helper"
 #
 # - **#update / #toggle_favorite** (the favorite flag, plus any other
 #   curation-tier field on the join row) follow the **curation rule** —
-#   anyone with admin/member/supporter on the communicator's team, plus
-#   the owner and system admins. Same rule as `assign_boards`.
+#   the account owner, anyone with admin/supervisor on the team, and
+#   system admins. Same rule as `assign_boards`. Plain `member` is
+#   read-only on the communicator and is rejected (issue #216).
 #
 # Full matrix: marketing/.claude-notes/handoff-workflow.md
 RSpec.describe "API::ChildBoards owner protection", type: :request do
@@ -93,10 +94,21 @@ RSpec.describe "API::ChildBoards owner protection", type: :request do
       expect(child_board.reload.favorite).to eq(true)
     end
 
-    it "blocks the SLP supervisor from toggling favorite (403)" do
+    it "lets the SLP supervisor toggle favorite (curation tier, issue #216)" do
       patch "/api/child_boards/#{child_board.id}",
             params: { child_board: { favorite: true } },
             headers: auth_headers(slp)
+
+      expect(response).to have_http_status(:ok)
+      expect(child_board.reload.favorite).to eq(true)
+    end
+
+    it "blocks a plain `member` from toggling favorite (read-only, issue #216)" do
+      plain_member = create(:user, created_at: 2.months.ago)
+      team.add_member!(plain_member, "member")
+      patch "/api/child_boards/#{child_board.id}",
+            params: { child_board: { favorite: true } },
+            headers: auth_headers(plain_member)
 
       expect(response).to have_http_status(:forbidden)
       expect(child_board.reload.favorite).to eq(false)

--- a/spec/requests/api/teams_create_board_spec.rb
+++ b/spec/requests/api/teams_create_board_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #216 — `POST /api/teams/:id/create_board` now requires the
+# caller to be on the team (any role) or a system admin. Closes the
+# gap where any signed-in user could write to any team's `team_boards`.
+RSpec.describe "API::Teams#create_board membership gate", type: :request do
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:account) do
+    create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE)
+  end
+  let!(:team) do
+    # Mirror the production shape: controllers always add the creator
+    # as the admin team_user when ensuring a team for a child_account.
+    t = account.ensure_team!(creator: owner)
+    t.add_member!(owner, "admin")
+    t
+  end
+  let(:board) { create(:board, user: owner) }
+
+  def post_create_board(user)
+    post "/api/teams/#{team.id}/create_board",
+         params: { board_id: board.id },
+         headers: auth_headers(user)
+  end
+
+  it "lets the team owner (admin) add a board" do
+    post_create_board(owner)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "lets a supervisor add a board" do
+    user = create(:user, created_at: 2.months.ago)
+    team.add_member!(user, "supervisor")
+    post_create_board(user)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "lets a plain member add a board to the team library" do
+    user = create(:user, created_at: 2.months.ago)
+    team.add_member!(user, "member")
+    post_create_board(user)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "rejects a stranger who isn't on the team (403)" do
+    stranger = create(:user, created_at: 2.months.ago)
+    expect {
+      post_create_board(stranger)
+    }.not_to change { team.team_boards.count }
+    expect(response).to have_http_status(:forbidden)
+    expect(JSON.parse(response.body)["error"]).to eq("not_a_team_member")
+  end
+
+  it "lets a system admin add a board even when not on the team" do
+    sys_admin = create(:admin_user)
+    post_create_board(sys_admin)
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Summary

- Locks `team_users.role` to a canonical 3-value set: `admin`, `supervisor`, `member`. Adds inclusion validation, a backfill migration, and a dry-run rake task.
- Aligns the gates: only `admin` (owner) and `supervisor` (SLP / power collaborator) can curate boards on the communicator. `member` is read-only on the communicator; can add to the team library, can't assign.
- Closes the gap where any signed-in user could write to any team's `team_boards` via `POST /api/teams/:id/create_board` — now requires the caller to be on the team.

Closes #216.

## Why

`team_users.role` was free-text. Six values lived in code (`admin/member/supervisor/professional/supporter/restricted`); the read/write whitelists in `User#can_add_boards_to_account?`, `Team#all_supporters`, `Team#supporters`, `Team#professionals`, and `TeamUser.roles` did not agree. Worked today only because the rules are deny-by-default — brittle and load-bearing for the SLP→parent handoff. Pre-implementation audit + production data is in `marketing/drafts/role-normalization-notes.md`.

## Semantics (matches the handoff-workflow permissions matrix)

| Role | Curate boards on communicator | Add to team library | Edit communicator | Delete account |
| --- | --- | --- | --- | --- |
| admin | ✅ | ✅ | ✅ | ✅ |
| supervisor | ✅ | ✅ | ❌ | ❌ |
| member | ❌ | ✅ | ❌ | ❌ |

## Backfill fold (13 prod rows; all `professional`)

- `professional` → `admin`
- `supporter` → `member`
- `restricted` → `member`
- any other / NULL → `member` (defensive)

Migration runs on deploy. `bin/rails team_roles:normalize_dry_run` previews before; `team_roles:normalize` applies the same logic for operator visibility.

## Notable changes worth a closer look

- `User#teams_with_read_access` had a latent bug — its role filter wasn't scoped to the current user's own row, so admin-only teams with any member on them appeared in unrelated users' "shared with me" lists. Fixed.
- `User#can_view_account?` collapsed the 4 explicit role branches into a single `where(role: TeamUser::ROLES)` check. Strictly broader than before for the "any team member can view" case — intentional under the new model.
- `Team#primary_supporter`, `#professionals`, `#all_supporters`, `#supporters` were dead. Deleted. `ChildAccount#supporters` and `#supervisors` are used by `api_view` so they're kept but rewritten against the canonical set (`supporters` = members, `supervisors` = admin + supervisor).
- `child_boards_owner_protection_spec.rb` was flipping a supervisor to 403 on favorite toggle. Under the new semantic, supervisor curates — flipped that example and added a `member`-403 example.

## Test plan

- [x] `bundle exec rspec` — 994 examples, 0 failures, 12 pending.
- [x] Migration runs clean against the test DB.
- [x] `team_roles:normalize` / `:normalize_dry_run` covered in `spec/lib/tasks/team_roles_rake_spec.rb`.
- [x] New gate on `POST /api/teams/:id/create_board` covered in `spec/requests/api/teams_create_board_spec.rb` (stranger 403; member/supervisor/admin/sysadmin pass).
- [x] Inclusion validation matrix in `spec/models/team_user_spec.rb`.
- [x] Curate gate matrix in `spec/models/user_curate_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)