### PR TITLE
chore(team): rename add_member! to upsert_member!, fold creator-add into ensure_team!

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -362,20 +362,12 @@ class API::ChildAccountsController < API::ApplicationController
         end
       end
 
-      # Team setup
-      team_name = if @child_account.name.present?
-          "#{@child_account.name}'s Communication Team"
-        else
-          "Communication Team"
-        end
-
-      team = @child_account.teams.first
-      unless team
-        team = Team.create!(name: team_name, created_by: current_user)
-        TeamAccount.create!(team: team, account: @child_account)
-      end
-
-      team.add_member!(current_user, "admin")
+      # Team setup. `ensure_team!` adds the creator as admin; no
+      # follow-up call needed (issue #226).
+      team_name = @child_account.name.present? ?
+        "#{@child_account.name}'s Communication Team" :
+        "Communication Team"
+      @child_account.ensure_team!(creator: current_user, name: team_name)
 
       render json: @child_account.api_view(current_user), status: :created
     else

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -67,15 +67,11 @@ class API::TeamsController < API::ApplicationController
     unless @user
       return render json: { error: "User not invited. Something went wrong." }, status: :unprocessable_entity
     end
-    @team_user = @team.add_member!(@user, user_role) if @user
+    @team.upsert_member!(@user, user_role)
 
-    respond_to do |format|
-      if @team_user.save
-        format.json { render json: @team.show_api_view(current_user), status: :created }
-      else
-        format.json { render json: @team_user.errors, status: :unprocessable_entity }
-      end
-    end
+    render json: @team.show_api_view(current_user), status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors }, status: :unprocessable_entity
   end
 
   def remove_member
@@ -110,7 +106,7 @@ class API::TeamsController < API::ApplicationController
 
     respond_to do |format|
       if @team.save
-        @team.add_member!(current_user, "admin")
+        @team.upsert_member!(current_user, "admin")
         initial_account = current_user.communicator_accounts.find_by(id: account_id) if account_id.present?
         @team.add_communicator!(initial_account) if initial_account
 

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -202,13 +202,10 @@ module API
         # Mirrors API::ChildAccountsController#create — every new
         # communicator gets a Team with the creator as admin, so team
         # permission checks have something to anchor on later.
+        # `ChildAccount#ensure_team!` does the admin-add (issue #226).
         def ensure_team_for(child)
-          return if child.teams.exists?
-
           team_name = child.name.present? ? "#{child.name}'s Communication Team" : "Communication Team"
-          team = Team.create!(name: team_name, created_by: current_user)
-          TeamAccount.create!(team: team, account: child)
-          team.add_member!(current_user, "admin")
+          child.ensure_team!(creator: current_user, name: team_name)
         end
       end
     end

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -271,8 +271,8 @@ class ChildAccount < ApplicationRecord
 
       if previous_owner && previous_owner != user
         team = primary_team || ensure_team!(creator: user)
-        team.add_member!(previous_owner, "supervisor")
-        team.add_member!(user, "admin")
+        team.upsert_member!(previous_owner, "supervisor")
+        team.upsert_member!(user, "admin")
       end
     end
 
@@ -328,11 +328,21 @@ class ChildAccount < ApplicationRecord
     teams.first
   end
 
-  def ensure_team!(creator:)
+  # Ensure this communicator has a team. If it already does, return
+  # it as-is. Otherwise create one with `creator` as the team-creator
+  # AND as an `admin` team_user — i.e. the caller never has to follow
+  # up with `team.upsert_member!(creator, "admin")`. Issue #226.
+  #
+  # `name:` lets callers override the default "<communicator>'s Team"
+  # (e.g. the API controllers use "<communicator>'s Communication
+  # Team"). Passing nil falls back to the default.
+  def ensure_team!(creator:, name: nil)
     return primary_team if primary_team.present?
 
-    team = Team.create!(name: "#{name || "Communicator"}'s Team", created_by: creator)
+    team_name = name.presence || "#{self.name || "Communicator"}'s Team"
+    team = Team.create!(name: team_name, created_by: creator)
     TeamAccount.create!(team: team, account: self)
+    team.upsert_member!(creator, "admin") if creator
     team
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -33,28 +33,19 @@ class Team < ApplicationRecord
     end
   end
 
-  def add_member!(user, role = "member")
+  # Upsert a team membership: add `user` at `role`, or update an
+  # existing membership's role if it differs. Raises on validation
+  # failure (e.g. role outside `TeamUser::ROLES`). Returns the
+  # persisted TeamUser. Returns nil only when `user` is nil.
+  #
+  # Named `upsert_member!` rather than `add_member!` because the
+  # silent-role-overwrite behavior was a footgun under the old name
+  # (issue #226).
+  def upsert_member!(user, role = "member")
     return nil if user.nil?
-    if user && !users.include?(user)
-      team_user = team_users.new(user: user, role: role)
-      Rails.logger.debug "Adding user #{user.id} to team #{id} with role #{role}"
-      team_user.save
-    else
-      team_user = team_users.find_by(user_id: user.id)
-      Rails.logger.debug "Team user found: #{team_user.id} with role #{team_user.role}"
-      unless team_user
-        team_user = team_users.new(user: user, role: role)
-        team_user.save
-      end
-      if role != team_user.role
-        team_user.role = role
-        Rails.logger.debug "Updating user #{user.id} role to #{role} in team #{id}"
-        team_user.save
-      end
-    end
-    unless team_user.persisted?
-      Rails.logger.error "Could not add user #{user.id} to team #{id}: #{team_user.errors.full_messages.join(", ")}"
-    end
+    team_user = team_users.find_or_initialize_by(user_id: user.id)
+    team_user.role = role
+    team_user.save!
     team_user
   end
 

--- a/spec/models/child_account_editable_by_spec.rb
+++ b/spec/models/child_account_editable_by_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ChildAccount, "#editable_by?", type: :model do
   let!(:account) do
     acct = create(:child_account, user: owner, owner: owner, status: "active")
     team = acct.ensure_team!(creator: owner)
-    team.add_member!(supervisor, "supervisor")
+    team.upsert_member!(supervisor, "supervisor")
     acct
   end
 

--- a/spec/models/child_account_ensure_team_spec.rb
+++ b/spec/models/child_account_ensure_team_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #226 — `ChildAccount#ensure_team!` adds the creator as an
+# admin team_user automatically. Callers used to have to follow up
+# with an explicit `add_member!` call; this guarantees the team is
+# never left without an admin row backing the team-creator semantic.
+RSpec.describe ChildAccount, "#ensure_team!", type: :model do
+  let(:creator) { create(:user, created_at: 2.months.ago) }
+  let(:account) { create(:child_account, user: creator, owner: creator) }
+
+  context "when no team exists yet" do
+    it "creates a team and pins the creator as admin" do
+      team = account.ensure_team!(creator: creator)
+
+      expect(team).to be_persisted
+      expect(team.created_by_id).to eq(creator.id)
+      tu = team.team_users.find_by(user_id: creator.id)
+      expect(tu).to be_present
+      expect(tu.role).to eq("admin")
+    end
+
+    it "uses the default '<communicator>'s Team' name when no override is given" do
+      team = account.ensure_team!(creator: creator)
+      expect(team.name).to end_with("'s Team")
+    end
+
+    it "uses the override name when one is provided" do
+      team = account.ensure_team!(creator: creator, name: "My Custom Team")
+      expect(team.name).to eq("My Custom Team")
+    end
+  end
+
+  context "when a team already exists" do
+    it "is idempotent — returns the existing team without touching team_users" do
+      first = account.ensure_team!(creator: creator)
+      tu_count_before = first.team_users.count
+
+      second = account.ensure_team!(creator: creator)
+
+      expect(second).to eq(first)
+      expect(first.team_users.count).to eq(tu_count_before)
+    end
+  end
+end

--- a/spec/models/team_upsert_member_spec.rb
+++ b/spec/models/team_upsert_member_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #226 — `Team#upsert_member!` replaced the old `add_member!`.
+# Behavior: add the membership if missing, update the role if the
+# user is already on the team, raise on validation failure.
+RSpec.describe Team, "#upsert_member!", type: :model do
+  let(:owner) { create(:user, created_at: 2.months.ago) }
+  let(:account) { create(:child_account, user: owner, owner: owner) }
+  let(:team) { account.ensure_team!(creator: owner) }
+  let(:user) { create(:user, created_at: 2.months.ago) }
+
+  it "creates a new team_user with the given role" do
+    expect {
+      team.upsert_member!(user, "supervisor")
+    }.to change { team.team_users.count }.by(1)
+
+    tu = team.team_users.find_by(user_id: user.id)
+    expect(tu.role).to eq("supervisor")
+  end
+
+  it "updates the role when the user is already on the team" do
+    team.upsert_member!(user, "member")
+
+    expect {
+      team.upsert_member!(user, "admin")
+    }.not_to change { team.team_users.count }
+
+    expect(team.team_users.find_by(user_id: user.id).role).to eq("admin")
+  end
+
+  it "returns the persisted team_user" do
+    result = team.upsert_member!(user, "member")
+    expect(result).to be_persisted
+    expect(result).to eq(team.team_users.find_by(user_id: user.id))
+  end
+
+  it "returns nil when user is nil (no-op)" do
+    expect(team.upsert_member!(nil)).to be_nil
+  end
+
+  it "raises ActiveRecord::RecordInvalid when role is outside the canonical set" do
+    expect {
+      team.upsert_member!(user, "bogus")
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it "defaults to role 'member' when none is given" do
+    team.upsert_member!(user)
+    expect(team.team_users.find_by(user_id: user.id).role).to eq("member")
+  end
+end

--- a/spec/models/user_curate_spec.rb
+++ b/spec/models/user_curate_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe User, "#can_add_boards_to_account?", type: :model do
 
   it "is true for a team member with role 'admin'" do
     user = create(:user, created_at: 2.months.ago)
-    team.add_member!(user, "admin")
+    team.upsert_member!(user, "admin")
     expect(user.can_add_boards_to_account?([account.id])).to be true
   end
 
   it "is true for a team member with role 'supervisor'" do
     user = create(:user, created_at: 2.months.ago)
-    team.add_member!(user, "supervisor")
+    team.upsert_member!(user, "supervisor")
     expect(user.can_add_boards_to_account?([account.id])).to be true
   end
 
   it "is false for a team member with role 'member' (read-only on the communicator)" do
     user = create(:user, created_at: 2.months.ago)
-    team.add_member!(user, "member")
+    team.upsert_member!(user, "member")
     expect(user.can_add_boards_to_account?([account.id])).to be false
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -195,11 +195,11 @@ RSpec.describe User, type: :model do
     subject(:invite_new_user_to_team!) do
       # current_user.invite_new_user_to_team!(user_to_invite_email, team)
       @user = User.create_from_email(user_to_invite_email, nil, current_user.id)
-      team.add_member!(@user) if @user
+      team.upsert_member!(@user) if @user
     end
     before do
       # Create a team and add the current user to it
-      team.add_member!(current_user, "admin")
+      team.upsert_member!(current_user, "admin")
       allow(User).to receive(:create_stripe_customer).and_return("cus_test_#{SecureRandom.hex(4)}")
     end
     it "adds the invited user to the team" do

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
   end
   let!(:team) do
     t = account.ensure_team!(creator: slp)
-    t.add_member!(parent, "admin")
-    t.add_member!(slp, "supervisor")
+    t.upsert_member!(parent, "admin")
+    t.upsert_member!(slp, "supervisor")
     t
   end
 

--- a/spec/requests/api/child_boards_owner_protection_spec.rb
+++ b/spec/requests/api/child_boards_owner_protection_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "API::ChildBoards owner protection", type: :request do
   end
   let!(:team) do
     t = child_account.ensure_team!(creator: slp)
-    t.add_member!(parent, "admin")
-    t.add_member!(slp, "supervisor")
+    t.upsert_member!(parent, "admin")
+    t.upsert_member!(slp, "supervisor")
     t
   end
   let(:slp_board) { create(:board, user: slp, name: "Shared by SLP") }
@@ -73,7 +73,7 @@ RSpec.describe "API::ChildBoards owner protection", type: :request do
     let(:admin_member) { create(:user, plan_type: "pro", created_at: 2.months.ago, stripe_customer_id: "cus_admin_member_stub") }
 
     before do
-      team.add_member!(admin_member, "admin")
+      team.upsert_member!(admin_member, "admin")
     end
 
     it "lets the communicator owner toggle favorite" do
@@ -105,7 +105,7 @@ RSpec.describe "API::ChildBoards owner protection", type: :request do
 
     it "blocks a plain `member` from toggling favorite (read-only, issue #216)" do
       plain_member = create(:user, created_at: 2.months.ago)
-      team.add_member!(plain_member, "member")
+      team.upsert_member!(plain_member, "member")
       patch "/api/child_boards/#{child_board.id}",
             params: { child_board: { favorite: true } },
             headers: auth_headers(plain_member)

--- a/spec/requests/api/profiles_owner_protection_spec.rb
+++ b/spec/requests/api/profiles_owner_protection_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "API::Profiles owner protection", type: :request do
   end
   let!(:team) do
     t = account.ensure_team!(creator: slp)
-    t.add_member!(parent, "admin")
-    t.add_member!(slp, "supervisor")
+    t.upsert_member!(parent, "admin")
+    t.upsert_member!(slp, "supervisor")
     t
   end
   let!(:child_profile) do

--- a/spec/requests/api/team_permissions_spec.rb
+++ b/spec/requests/api/team_permissions_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "API::Teams owner protection", type: :request do
   end
   let!(:team) do
     t = account.ensure_team!(creator: slp)
-    t.add_member!(parent, "admin")
-    t.add_member!(slp, "supervisor")
+    t.upsert_member!(parent, "admin")
+    t.upsert_member!(slp, "supervisor")
     t
   end
 

--- a/spec/requests/api/teams_create_board_spec.rb
+++ b/spec/requests/api/teams_create_board_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "API::Teams#create_board membership gate", type: :request do
     # Mirror the production shape: controllers always add the creator
     # as the admin team_user when ensuring a team for a child_account.
     t = account.ensure_team!(creator: owner)
-    t.add_member!(owner, "admin")
+    t.upsert_member!(owner, "admin")
     t
   end
   let(:board) { create(:board, user: owner) }
@@ -32,14 +32,14 @@ RSpec.describe "API::Teams#create_board membership gate", type: :request do
 
   it "lets a supervisor add a board" do
     user = create(:user, created_at: 2.months.ago)
-    team.add_member!(user, "supervisor")
+    team.upsert_member!(user, "supervisor")
     post_create_board(user)
     expect(response).to have_http_status(:ok)
   end
 
   it "lets a plain member add a board to the team library" do
     user = create(:user, created_at: 2.months.ago)
-    team.add_member!(user, "member")
+    team.upsert_member!(user, "member")
     post_create_board(user)
     expect(response).to have_http_status(:ok)
   end

--- a/spec/services/board_snapshot_service_spec.rb
+++ b/spec/services/board_snapshot_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe BoardSnapshotService, type: :service do
   let!(:slp_board) { create(:board, user: slp) }
 
   before do
-    team.add_member!(parent, "admin")
-    team.add_member!(slp, "supervisor")
+    team.upsert_member!(parent, "admin")
+    team.upsert_member!(slp, "supervisor")
     team.team_boards.create!(board: slp_board, created_by_id: slp.id)
   end
 


### PR DESCRIPTION
## Summary

Two adjacent cleanups bundled into one PR (issue #226):

1. **`Team#add_member!` → `Team#upsert_member!`** — name signals the upsert behavior; bang now actually raises (`save!`).
2. **`ChildAccount#ensure_team!`** now adds the creator as an `admin` team_user automatically — callers no longer have to remember the follow-up `add_member!` call.

Closes #226.

## Why

`Team#add_member!`:
- Bang-named but called `save`, not `save!` — swallowed failures.
- Silently overwrote the role on every call when the user already existed at a different role. With `claim_by!` writing `"admin"`, a stray call to `add_member!(owner, "member")` would have demoted the owner without a signal. No prod caller does that today, but it's a footgun.
- Triggered an `users.include?(user)` membership check that was redundant given the immediate `team_users.find_by(user_id:)` lookup in the else branch.

`ChildAccount#ensure_team!` created the team and `TeamAccount` but didn't add the creator as a team_user. Every caller compensated with a follow-up `team.add_member!(creator, "admin")`. A new caller that forgot would land a team with no admin row, and the membership gate added in [#225](https://github.com/brittanyjohns/itty_bitty_boards/pull/225) would reject the creator. Folding it into `ensure_team!` makes the seam the single source of truth.

## Notable

- `ensure_team!` gained an optional `name:` kwarg. `API::ChildAccountsController#create` and `MyspeakController#ensure_team_for` both used `"<communicator>'s Communication Team"` (vs. the default `"<communicator>'s Team"`); the kwarg preserves their naming without forcing a global rename.
- `ChildAccount#claim_by!` already used `ensure_team!`. Its post-claim `upsert_member!(user, "admin")` becomes a benign no-op when `ensure_team!` just created the team for the same user, and the real-work path when it didn't. Left it explicit for readability.
- `API::TeamsController#invite` simplified: dropped the redundant second `@team_user.save` and added a `rescue ActiveRecord::RecordInvalid` for the 422 path.

## Test plan

- [x] `bundle exec rspec` — 1004 examples, 0 failures, 12 pending.
- [x] `spec/models/team_upsert_member_spec.rb` — create vs. update branch, nil-user no-op, raises on bogus role, default role is "member".
- [x] `spec/models/child_account_ensure_team_spec.rb` — creator pinned as admin on create, idempotent on re-call, name override applied when given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)