### PR TITLE
feat(child_board): expose preview_image_url in api_view

### DIFF
--- a/app/models/child_board.rb
+++ b/app/models/child_board.rb
@@ -60,6 +60,10 @@ class ChildBoard < ApplicationRecord
     board.display_image_url
   end
 
+  def preview_image_url
+    board.preview_image_url
+  end
+
   def other_boards
     child_account.child_boards.where.not(id: id)
   end
@@ -108,7 +112,8 @@ class ChildBoard < ApplicationRecord
       child_account_id: child_account_id,
       status: status,
       settings: settings,
-      display_image_url: display_image_url,
+      display_image_url: display_image_url || preview_image_url,
+      preview_image_url: preview_image_url,
       board_type: board.board_type,
       published: published,
       favorite: favorite,


### PR DESCRIPTION
## Summary

- `ChildBoard#api_view` now returns `preview_image_url` (delegated to the underlying `board`) alongside `display_image_url`, using the same `display_image_url || preview_image_url` fallback that `Board#api_view` uses.
- The public profile endpoint `GET /api/profiles/public/:slug` renders `public_boards` from `ChildAccount#favorite_boards` (ChildBoard records). Before this change the items only carried `display_image_url`, while the `Board`-based shape returned both. The frontend needs both for the UI on the public page.

## Why

The `public_boards` array can hold either `Board` (when `profileable` is a `User`) or `ChildBoard` (when it's a `ChildAccount`). The two shapes were inconsistent — UI consumers can now rely on both keys regardless of which path produced the row.

## Test plan

- [ ] `bundle exec rspec spec/models/child_board_spec.rb`
- [ ] Hit `GET /api/profiles/public/:slug` for a profile whose communicator has favorite boards and confirm each item in `public_boards` has both `display_image_url` and `preview_image_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)