### PR TITLE
feat(credits): add GET /api/credits/feature_costs

### DIFF
--- a/app/controllers/api/credits_controller.rb
+++ b/app/controllers/api/credits_controller.rb
@@ -1,0 +1,10 @@
+class API::CreditsController < API::ApplicationController
+  skip_before_action :authenticate_token!, only: %i[feature_costs]
+
+  # GET /api/credits/feature_costs
+  # Public endpoint that mirrors CreditService::FEATURE_COSTS so the frontend
+  # /upgrade page can render server-truth costs without a duplicated TS constant.
+  def feature_costs
+    render json: { feature_costs: CreditService::FEATURE_COSTS.except("ai_action") }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
     get "me/page_followers", to: "me#page_followers"
     get "me/credits", to: "me#credits"
     get "me/credit_transactions", to: "me#credit_transactions"
+    get "credits/feature_costs", to: "credits#feature_costs"
 
     post "word_click", to: "audits#word_click"
     post "public_word_click", to: "audits#public_word_click"

--- a/spec/requests/api/credits_feature_costs_spec.rb
+++ b/spec/requests/api/credits_feature_costs_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/credits/feature_costs", type: :request do
+  it "returns 200 without authentication" do
+    get "/api/credits/feature_costs"
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "returns feature_costs mirroring CreditService::FEATURE_COSTS (minus the legacy ai_action key)" do
+    get "/api/credits/feature_costs"
+    body = JSON.parse(response.body)
+
+    expect(body).to have_key("feature_costs")
+    expected = CreditService::FEATURE_COSTS.except("ai_action")
+    expect(body["feature_costs"]).to eq(expected)
+  end
+
+  it "does not expose the legacy ai_action shadow-mode key" do
+    get "/api/credits/feature_costs"
+    body = JSON.parse(response.body)
+    expect(body["feature_costs"]).not_to have_key("ai_action")
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a public, unauthenticated `GET /api/credits/feature_costs` endpoint that returns `CreditService::FEATURE_COSTS` as JSON.
- Lets the frontend `/upgrade` page (itty-bitty-frontend#236) render server-truth costs instead of mirroring the Ruby constant in TS.
- Strips the legacy `"ai_action"` shadow-mode key before serializing — it's not user-facing.
- New `API::CreditsController` (separate from the auth-gated `MeController`), route added next to the existing `me/credits` routes.

Frontend follow-up tracked in itty-bitty-frontend#237.

Closes #231

## Test plan

- [x] New request spec: `spec/requests/api/credits_feature_costs_spec.rb`
  - 200 without auth headers
  - Body matches `CreditService::FEATURE_COSTS.except("ai_action")`
  - `ai_action` key not exposed
- [x] Full suite: `bundle exec rspec` → **1010 examples, 0 failures, 12 pending** (pre-existing unrelated scaffold specs)
- [x] `bin/rails routes | grep feature_costs` confirms `api_credits_feature_costs GET /api/credits/feature_costs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)