### PR TITLE
fix(child_accounts): honor ?archived=true on index endpoint

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -7,8 +7,15 @@ class API::ChildAccountsController < API::ApplicationController
 
   # GET /child_accounts
   # GET /child_accounts.json
+  #
+  # `?archived=true` returns the caller's soft-archived sandboxes (issue
+  # #165). Default scope hides archived rows; the `.archived` scope
+  # unscopes `archived_at` and filters to non-null. Without the param,
+  # behavior is unchanged.
   def index
-    @child_accounts = ChildAccount.with_boards.where(user_id: current_user.id).order(name: :asc)
+    scope = ChildAccount.with_boards.where(user_id: current_user.id)
+    scope = scope.archived if ActiveModel::Type::Boolean.new.cast(params[:archived])
+    @child_accounts = scope.order(name: :asc)
     render json: @child_accounts.map(&:index_api_view)
   end
 

--- a/spec/requests/api/child_accounts_archive_spec.rb
+++ b/spec/requests/api/child_accounts_archive_spec.rb
@@ -52,4 +52,41 @@ RSpec.describe "API::ChildAccounts archive", type: :request do
       expect(ids).to include(sandbox.id)
     end
   end
+
+  describe "GET /api/child_accounts?archived=true" do
+    let!(:active) { create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}") }
+    let!(:archived_sandbox) do
+      sb = create(:child_account, user: user, owner: user, status: "sandbox", username: "sb-#{SecureRandom.hex(2)}")
+      sb.archive!
+      sb
+    end
+
+    it "returns only the caller's archived records" do
+      get "/api/child_accounts?archived=true", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).to include(archived_sandbox.id)
+      expect(ids).not_to include(sandbox.id, active.id)
+    end
+
+    it "does not leak other users' archived records" do
+      other = create(:user)
+      other_sandbox = create(:child_account, user: other, owner: other, status: "sandbox", username: "ot-#{SecureRandom.hex(2)}")
+      other_sandbox.archive!
+
+      get "/api/child_accounts?archived=true", headers: auth_headers(user)
+
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).not_to include(other_sandbox.id)
+    end
+
+    it "default list still excludes archived records" do
+      get "/api/child_accounts", headers: auth_headers(user)
+
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).to include(sandbox.id, active.id)
+      expect(ids).not_to include(archived_sandbox.id)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `GET /api/child_accounts` now honors `?archived=true` and returns the caller's soft-archived sandboxes via the existing `.archived` scope. Default behavior unchanged.

## Why

The frontend's **Archived** tab (`getArchivedCommunicatorAccounts` in `itty-bitty-frontend/src/data/communicator_accounts.ts`) calls `GET /api/child_accounts?archived=true`, but the controller ignored the param. Because `ChildAccount.default_scope` is `where(archived_at: nil)`, both tabs received the *same list of active accounts*. When a user clicked "Restore" on one of those rows, the `unarchive` action's `sandbox?` guard correctly rejected it (the record was `status="active"`, not a sandbox) and returned **HTTP 422**.

Symptoms reported:

1. Unarchive endpoint returns 422.
2. Active accounts appear under the Archived tab.

Both fall out of the same root cause — backend `index` was a no-op on the `archived` param. Data was never corrupted; `archive!` still raises unless `sandbox?`.

## Change

```ruby
def index
  scope = ChildAccount.with_boards.where(user_id: current_user.id)
  scope = scope.archived if ActiveModel::Type::Boolean.new.cast(params[:archived])
  @child_accounts = scope.order(name: :asc)
  render json: @child_accounts.map(&:index_api_view)
end
```

`ChildAccount.archived` already `unscope`s `archived_at`, so it bypasses the default scope correctly. `ActiveModel::Type::Boolean` is consistent with how the rest of the controller parses query-string booleans.

No frontend changes required.

## Test plan

- [x] `bundle exec rspec spec/requests/api/child_accounts_archive_spec.rb` — 8/8 pass (3 new + 5 existing)
- [ ] Manual smoke on staging:
  - [ ] Create a sandbox communicator, archive it → disappears from Active, appears in Archived.
  - [ ] Click Restore → 200, moves back to Active.
  - [ ] Active/loaner accounts never appear in the Archived tab.

## Out of scope

- Migrating the index auth predicate from `user_id` to `owner_id`.
- Any production data audit (none expected — `archive!` raises unless `sandbox?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)