### PR TITLE
feat(child_accounts): allow owners to archive active communicators (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Owners can archive active communicators (issue #237)
+- `ChildAccount#archive!` now allows archiving owner-controlled active
+  communicators in addition to sandboxes. Loaner is still excluded —
+  callers get an `ArgumentError` pointing at `end_loan` / `reclaim!`.
+- Archive stamps `settings["archive_reason"]` and
+  `settings["archived_status"]` so support has an audit trail and
+  `unarchive!` can restore the original status cleanly.
+- `ChildAccount#unarchive!` re-checks the owner's slot limit when
+  restoring a previously-active record (archive frees the slot via the
+  default scope; the owner may have filled it). Raises
+  `ChildAccount::SlotFull` when at-cap.
+- `POST /api/child_accounts/:id/archive` now returns 200 for an active
+  owner, 422 (`End the loan first via end_loan.`) for a loaner, and
+  401 for non-owners. `POST /:id/unarchive` returns 422 with the slot
+  message when the owner is at-cap.
+- Frontend `LoanerControls.tsx` work is tracked separately in
+  `rally25rs/itty-bitty-frontend`.
+
 ### Changed — Pro plan now includes 5 Communicators (was 3)
 - `User::PRO_PLAN_LIMITS["paid_communicator_limit"]` default bumped
   from `3` → `5` in `app/models/user.rb`. Same `PRO_PAID_COMMUNICATOR_LIMIT`

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -258,42 +258,41 @@ class API::ChildAccountsController < API::ApplicationController
   end
 
   # POST /api/child_accounts/:id/archive
-  # Soft-archive a sandbox communicator (issue #165). The record stays
-  # in the database with all its boards/settings/history — it just
-  # drops out of the default-scoped lists and stops counting against
-  # the sandbox limit. Sandbox-only; loaner/active have downstream
-  # effects (slot accounting, claim tokens) that need their own paths.
+  # Soft-archive a communicator (issues #165, #237). The record stays in
+  # the database with all its boards/settings/history — it just drops out
+  # of the default-scoped lists. Allowed for sandbox and owner-controlled
+  # active. Loaner is excluded — use end_loan first to clear the claim
+  # token and slot accounting.
   def archive
     unless @child_account.owner_id == current_user.id || current_user.admin?
       render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
-    unless @child_account.sandbox?
-      render json: account_error_payload("Only sandbox communicators can be archived"), status: :unprocessable_entity
+    if @child_account.loaner?
+      render json: account_error_payload("End the loan first via end_loan."), status: :unprocessable_entity
       return
     end
 
-    @child_account.archive!
+    @child_account.archive!(reason: "owner_request")
     render json: @child_account.api_view(current_user), status: :ok
   end
 
   # POST /api/child_accounts/:id/unarchive
-  # Restore a previously-archived sandbox. Sandbox-only (loaner/active
-  # can't get into the archived state in the first place).
+  # Restore a previously-archived communicator. Sandbox restores as a
+  # sandbox; active restores as active, but only if the owner still has
+  # a free slot (archiving freed it, and the owner may have filled it).
   def unarchive
     unless @child_account.owner_id == current_user.id || current_user.admin?
       render json: account_error_payload("Unauthorized"), status: :unauthorized
       return
     end
 
-    unless @child_account.sandbox?
-      render json: account_error_payload("Only sandbox communicators can be unarchived"), status: :unprocessable_entity
-      return
-    end
-
     @child_account.unarchive!
     render json: @child_account.api_view(current_user), status: :ok
+  rescue ChildAccount::SlotFull => e
+    render json: account_error_payload(e.message.presence || "At your communicator slot limit. Free a slot before restoring."),
+           status: :unprocessable_entity
   end
 
   # POST /child_accounts

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -297,18 +297,46 @@ class ChildAccount < ApplicationRecord
 
   class SlotFull < StandardError; end
 
-  # Soft-archive a sandbox communicator (issue #165). Sandbox-only — the
-  # loaner/active paths have downstream effects (slot accounting, claim
-  # tokens, family ownership) that need their own flows (`end_loan`).
-  def archive!
-    raise ArgumentError, "Only sandbox communicators can be archived" unless sandbox?
+  # Soft-archive a communicator (issues #165, #237). Allowed for sandbox
+  # and active (owner-controlled) accounts. Loaner is excluded — it has
+  # downstream effects (slot accounting, claim tokens, family ownership)
+  # that need their own flow via `end_loan` / `reclaim!`.
+  #
+  # Archiving an active frees the owner's slot via the default scope,
+  # matching how archived sandboxes drop out of the sandbox count. The
+  # status field is preserved so unarchive can restore the original state;
+  # we also stamp the pre-archive status in settings as an audit trail.
+  def archive!(reason: "owner_request")
+    if loaner?
+      raise ArgumentError, "Loaner communicators must end the loan first (see end_loan / reclaim!)"
+    end
     return self if archived_at.present?
-    update!(archived_at: Time.current)
+
+    self.settings ||= {}
+    self.settings["archive_reason"] = reason
+    self.settings["archived_status"] = status
+    self.archived_at = Time.current
+    save!
     self
   end
 
+  # Restore an archived communicator. If it was an active when archived,
+  # re-check the owner's slot limit before un-archiving — archiving freed
+  # the slot, so the owner may have filled it in the meantime.
   def unarchive!
-    update!(archived_at: nil)
+    archived_status = settings&.dig("archived_status") || status
+
+    if archived_status == ACTIVE && owner.present?
+      allowed, _http_status, error =
+        Permissions::CommunicatorLimits.can_create?(user: owner, status: ACTIVE)
+      raise SlotFull, (error || "Maximum number of communicator accounts reached.") unless allowed
+    end
+
+    self.settings ||= {}
+    self.settings.delete("archive_reason")
+    self.settings.delete("archived_status")
+    self.archived_at = nil
+    save!
     self
   end
 

--- a/spec/models/child_account_archive_spec.rb
+++ b/spec/models/child_account_archive_spec.rb
@@ -68,23 +68,61 @@ RSpec.describe ChildAccount, "soft-archive", type: :model do
       expect(account.child_boards.count).to eq(1)
     end
 
-    it "refuses on a loaner" do
+    it "refuses on a loaner with end_loan guidance" do
       account = create(:child_account, user: user, owner: user, status: "loaner")
-      expect { account.archive! }.to raise_error(ArgumentError)
+      expect { account.archive! }.to raise_error(ArgumentError, /end_loan|reclaim/i)
     end
 
-    it "refuses on an active" do
+    it "allows an active owner to archive (issue #237)" do
       account = create(:child_account, user: user, owner: user, status: "active")
-      expect { account.archive! }.to raise_error(ArgumentError)
+      account.archive!
+      expect(account.archived_at).to be_within(5.seconds).of(Time.current)
+      expect(account.status).to eq("active")
+    end
+
+    it "writes archive_reason and archived_status to settings on active archive" do
+      account = create(:child_account, user: user, owner: user, status: "active")
+      account.archive!(reason: "owner_request")
+      expect(account.settings["archive_reason"]).to eq("owner_request")
+      expect(account.settings["archived_status"]).to eq("active")
     end
   end
 
   describe "#unarchive!" do
-    it "clears archived_at" do
+    it "clears archived_at on a sandbox" do
       account = create(:child_account, user: user, owner: user, status: "sandbox")
       account.archive!
       ChildAccount.with_archived.find(account.id).unarchive!
       expect(account.reload.archived_at).to be_nil
+    end
+
+    it "restores an archived active as active when the owner has a free slot" do
+      user.setup_pro_limits
+      user.save!
+      account = create(:child_account, user: user, owner: user, status: "active")
+      account.archive!
+
+      ChildAccount.with_archived.find(account.id).unarchive!
+      account.reload
+      expect(account.archived_at).to be_nil
+      expect(account.status).to eq("active")
+      expect(account.settings["archive_reason"]).to be_nil
+      expect(account.settings["archived_status"]).to be_nil
+    end
+
+    it "raises SlotFull when the owner is at the slot cap" do
+      user.setup_pro_limits
+      user.save!
+      pro_limit = user.settings["paid_communicator_limit"]
+
+      account = create(:child_account, user: user, owner: user, status: "active")
+      account.archive!
+
+      # Fill every paid slot so unarchive has nowhere to land.
+      pro_limit.times { create(:child_account, user: user, owner: user, status: "active") }
+
+      target = ChildAccount.with_archived.find(account.id)
+      expect { target.unarchive! }.to raise_error(ChildAccount::SlotFull)
     end
   end
 
@@ -98,6 +136,28 @@ RSpec.describe ChildAccount, "soft-archive", type: :model do
 
       view = user.api_view
       expect(view[:sandbox_communicator_count]).to eq(1)
+    end
+
+    it "frees the paid slot when an active is archived (issue #237)" do
+      user.setup_pro_limits
+      user.save!
+      create(:child_account, user: user, owner: user, status: "active")
+      archived = create(:child_account, user: user, owner: user, status: "active")
+      archived.archive!
+
+      expect(user.paid_communicator_accounts.reload.count).to eq(1)
+      expect(user.api_view[:active_communicator_count]).to eq(1)
+    end
+  end
+
+  describe "team visibility" do
+    it "hides an archived active from team_accounts joins" do
+      account = create(:child_account, user: user, owner: user, status: "active")
+      team = account.ensure_team!(creator: user)
+      expect(team.accounts.reload).to include(account)
+
+      account.archive!
+      expect(team.accounts.reload).not_to include(account)
     end
   end
 end

--- a/spec/requests/api/child_accounts_archive_spec.rb
+++ b/spec/requests/api/child_accounts_archive_spec.rb
@@ -25,23 +25,38 @@ RSpec.describe "API::ChildAccounts archive", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it "refuses on loaner" do
+    it "refuses on loaner with end_loan guidance" do
       loaner = create(:child_account, user: user, owner: user, status: "loaner", username: "ln-#{SecureRandom.hex(2)}")
       post "/api/child_accounts/#{loaner.id}/archive", headers: auth_headers(user)
       expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/end_loan/i)
     end
 
-    it "refuses on active" do
+    it "archives an active owner-controlled communicator (issue #237)" do
       active = create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}")
       post "/api/child_accounts/#{active.id}/archive", headers: auth_headers(user)
-      expect(response).to have_http_status(:unprocessable_entity)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["archived_at"]).to be_present
+      expect(body["status"]).to eq("active")
+
+      get "/api/child_accounts", headers: auth_headers(user)
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).not_to include(active.id)
+    end
+
+    it "rejects a non-owner trying to archive an active" do
+      active = create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}")
+      other = create(:user, plan_type: "pro")
+      post "/api/child_accounts/#{active.id}/archive", headers: auth_headers(other)
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
   describe "POST /api/child_accounts/:id/unarchive" do
-    before { sandbox.archive! }
-
     it "restores an archived sandbox" do
+      sandbox.archive!
       post "/api/child_accounts/#{sandbox.id}/unarchive", headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
@@ -50,6 +65,33 @@ RSpec.describe "API::ChildAccounts archive", type: :request do
       get "/api/child_accounts", headers: auth_headers(user)
       ids = JSON.parse(response.body).map { |a| a["id"] }
       expect(ids).to include(sandbox.id)
+    end
+
+    it "restores an archived active when the owner has slot capacity" do
+      user.setup_pro_limits
+      user.save!
+      active = create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}")
+      active.archive!
+
+      post "/api/child_accounts/#{active.id}/unarchive", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["archived_at"]).to be_nil
+      expect(body["status"]).to eq("active")
+    end
+
+    it "returns 422 when restoring an active would exceed the slot cap" do
+      user.setup_pro_limits
+      user.save!
+      pro_limit = user.settings["paid_communicator_limit"]
+      active = create(:child_account, user: user, owner: user, status: "active", username: "ac-#{SecureRandom.hex(2)}")
+      active.archive!
+      pro_limit.times { create(:child_account, user: user, owner: user, status: "active") }
+
+      post "/api/child_accounts/#{active.id}/unarchive", headers: auth_headers(user)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/communicator/i)
     end
   end
 


### PR DESCRIPTION
## Summary

- Relaxes `ChildAccount#archive!` to allow owner-controlled **active** communicators in addition to sandboxes. Loaner stays excluded — callers get an `ArgumentError` pointing at `end_loan` / `reclaim!`.
- `archive!` stamps `settings["archive_reason"]` (default `"owner_request"`) and `settings["archived_status"]` so support has an audit trail and `unarchive!` can restore the right state.
- `unarchive!` re-checks the owner's slot via `Permissions::CommunicatorLimits.can_create?` when the row was an active (archive frees the slot via the default scope; the owner may have filled it). Raises `ChildAccount::SlotFull` if at-cap.
- `POST /api/child_accounts/:id/archive` returns 200 for an active owner, 422 (`End the loan first via end_loan.`) for a loaner, 401 for non-owners.
- `POST /:id/unarchive` returns 422 with the slot-cap message when restoring would exceed the limit.

Frontend `LoanerControls.tsx` work is a separate ticket in `rally25rs/itty-bitty-frontend`.

Closes #237.

## Why

Archive was sandbox-only since #165. The only way an owner could archive an active communicator was to flip the Sandbox toggle ON to make the archive button appear — no real user discovers that path. The other option, deletion, loses boards/history. Real cases:

- Parent's child outgrew AAC and they want to tidy their dashboard.
- SLP retiring an active from their caseload but keeping the records.
- Duplicate active accidentally created.

## Design decisions

- **Slot frees on archive.** Default scope already excludes archived rows from `paid_communicator_accounts` — same behavior as archived sandbox freeing the sandbox limit today. Trade-off: `unarchive!` of an active has to re-check the slot.
- **Audit reason in settings**, mirroring `reclaim!`. Cleared on unarchive.
- **Team visibility:** default scope already hides archived rows from `ChildAccountTeam` joins; locked in by a spec.

## Test plan

- [x] `bundle exec rspec spec/models/child_account_archive_spec.rb` — 15 examples, 0 failures
- [x] `bundle exec rspec spec/requests/api/child_accounts_archive_spec.rb` — 11 examples, 0 failures
- [x] Regression: `child_account_spec.rb` + `child_accounts_{claim,demo_limit,owner_protection,promote}_spec.rb` — 46 examples, 0 failures

New cases cover: active archive happy path, settings audit trail, loaner refusal with `end_loan` guidance, active unarchive when slot is free, active unarchive at-cap raises `SlotFull`, paid-slot count drops on active archive, team-accounts join hides archived active, non-owner gets 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)