### PR TITLE
feat(obf): opt-in image binaries + private-by-default on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — OBF/OBZ import: opt-in for image binaries, private-by-default (#239)
+- `POST /api/boards/import_obf` no longer downloads or stores image
+  binaries from imported `.obz` / `.obf` files by default. Board
+  structure imports as before; tiles render with their label and the
+  user's existing matching images, but bundled symbol PNGs are not
+  pulled into S3 unless the client opts in.
+- Two new params:
+  - `include_images` (bool, default `false`) — when `true`, the importer
+    calls `Down.download` per OBF image entry and creates Docs.
+  - `image_license_acknowledged` (bool, default `false`) — required to
+    be `true` when `include_images=true`. Otherwise the request returns
+    **HTTP 400 `image_license_required`**.
+- Every `Image` row created via OBF/OBZ import is now `is_private: true`,
+  unconditionally. They never enter the `public_img` scope or other
+  users' search results. An admin can flip individual images public later.
+- `BoardGroup.settings["imported_from_obf"]` now records the audit trail
+  per import: `include_images`, `license_acknowledged`,
+  `acknowledged_by_user_id`, `acknowledged_at`, `imported_by_user_id`,
+  and the OBF root board's `license` block (if any).
+- **Why:** previously, importing a CoughDrop / TouchChat `.obz` with
+  proprietary symbol assets (e.g. SymbolStix) would land those PNGs in
+  S3 with `is_private=false`, exposing licensed artwork to every user
+  via `Image.searchable_images_for`.
+- **Frontend impact:** existing upload modal continues to succeed
+  without changes, but imports will be structure-only until the
+  frontend adds an "Import images" + "I have permission" pair of
+  checkboxes that send the new params.
+
 ### Changed — Pro plan now includes 5 Communicators (was 3)
 - `User::PRO_PLAN_LIMITS["paid_communicator_limit"]` default bumped
   from `3` → `5` in `app/models/user.rb`. Same `PRO_PAID_COMMUNICATOR_LIMIT`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,33 @@ Tasks:
   and `plan_credits_balance = 0`, then re-grants their tier allowance with
   `period_end = 30.days.from_now`.
 
+## OBF/OBZ import — copyright policy
+
+Imports via `POST /api/boards/import_obf` are gated to avoid silently
+pulling licensed symbol artwork (SymbolStix, etc.) into the public
+image pool:
+
+- **Default (no opt-in):** board structure imports, `Image` rows are
+  created **`is_private: true`**, but **no image binaries are downloaded
+  or attached to `Docs`**. The `attach_image_doc` step is skipped.
+- **With opt-in:** client must send `include_images=true` AND
+  `image_license_acknowledged=true`. Without the ack, the controller
+  returns **HTTP 400 `image_license_required`**. The importer then
+  calls `Down.download` per OBF image entry and attaches Docs.
+- **`is_private: true` is non-negotiable.** Set in
+  `Board.find_or_create_image_for_button` on every newly-created Image,
+  regardless of opt-in. Existing images matched by label are returned
+  as-is — we don't downgrade visibility on something the user already
+  owns. Admin can flip individual images public later via existing UI.
+- **Audit trail** lives on `BoardGroup.settings["imported_from_obf"]`:
+  `include_images`, `license_acknowledged`, `acknowledged_by_user_id`,
+  `acknowledged_at`, `imported_by_user_id`, and the OBF root board's
+  `license` block (author, source URL, license type) if present.
+- Plumbed through `ObzImporter#initialize(import_options:)`,
+  `Board.from_obf(... import_options:)`, and `ImportFromObfJob#perform`
+  (4th positional arg). All default to `{}` for backward compat with
+  callers that don't care.
+
 ## Do not
 
 - Do not install new gems without asking first

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -554,6 +554,16 @@ class API::BoardsController < API::ApplicationController
   end
 
   def import_obf
+    # Image binaries (e.g. licensed SymbolStix PNGs) are NEVER pulled in by
+    # default. The client must opt in with `include_images=true` AND confirm
+    # via `image_license_acknowledged=true`. Newly-created Images are always
+    # is_private (see Board.find_or_create_image_for_button).
+    import_options, ack_error = parse_obf_import_options
+    if ack_error
+      render json: ack_error, status: :bad_request
+      return
+    end
+
     if params[:file].present?
       uploaded_file = params[:file]
       file_name = uploaded_file.original_filename
@@ -566,6 +576,7 @@ class API::BoardsController < API::ApplicationController
           result = ObzImporter.new(
             uploaded_file.read, current_user,
             board_group: @board_group, import_all: true,
+            import_options: import_options,
           ).import!
         rescue => e
           Rails.logger.error "OBZ import failed: #{e.message}"
@@ -578,6 +589,7 @@ class API::BoardsController < API::ApplicationController
           message: "Imported OBZ file #{file_name}",
           board_group_id: @board_group.id,
           root_board_id: result[:root_board]&.id,
+          include_images: import_options[:include_images],
         }
       else
         render json: { error: "Unsupported file format" }, status: :unprocessable_entity
@@ -597,11 +609,38 @@ class API::BoardsController < API::ApplicationController
       end
       board_name = json_data["name"] || "Imported Board"
 
-      ImportFromObfJob.perform_async(json_data, current_user.id, board_group&.id)
-      render json: { status: "ok", message: "Importing OBF data for board #{board_name}" }
+      # Sidekiq serializes args to JSON — pass string-keyed hash.
+      ImportFromObfJob.perform_async(json_data, current_user.id, board_group&.id, import_options.stringify_keys)
+      render json: {
+        status: "ok",
+        message: "Importing OBF data for board #{board_name}",
+        include_images: import_options[:include_images],
+      }
     else
       render json: { error: "No file or data provided" }, status: :unprocessable_entity
     end
+  end
+
+  # Pulls the three opt-in params off the request and validates that
+  # `image_license_acknowledged` accompanies `include_images=true`. Returns
+  # [options_hash, error_response_or_nil].
+  def parse_obf_import_options
+    include_images = ActiveModel::Type::Boolean.new.cast(params[:include_images]) || false
+    ack = ActiveModel::Type::Boolean.new.cast(params[:image_license_acknowledged]) || false
+
+    if include_images && !ack
+      return [nil, {
+        error: "image_license_required",
+        message: "include_images=true requires image_license_acknowledged=true. " \
+                 "Imports must confirm permission to use the bundled images.",
+      }]
+    end
+
+    [{
+      include_images: include_images,
+      license_acknowledged: ack,
+      acknowledged_by_user_id: ack ? current_user.id : nil,
+    }, nil]
   end
 
   def additional_words

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2428,9 +2428,20 @@ class Board < ApplicationRecord
     end
   end
 
-  def self.from_obf(data, current_user, board_group = nil, board_id = nil)
+  # import_options controls copyright-sensitive behavior during OBF/OBZ import.
+  # Keys (all optional, all default to safe values):
+  #   include_images:           Boolean. When false (default), imported Image
+  #                             records are created (always is_private: true),
+  #                             but NO image binaries are downloaded or attached
+  #                             to Docs. When true, attach_image_doc runs.
+  #   license_acknowledged:     Boolean. Audit-only; recorded by ObzImporter on
+  #                             BoardGroup.settings. Must be true to set
+  #                             include_images: true (enforced by controller).
+  #   acknowledged_by_user_id:  Integer. Audit-only.
+  def self.from_obf(data, current_user, board_group = nil, board_id = nil, import_options: {})
     obj = parse_obf_input(data)
     raise ArgumentError, "OBF data must be a Hash" unless obj.is_a?(Hash)
+    import_options = (import_options || {}).symbolize_keys
 
     obf_id = obj["id"].to_s
     is_root = board_group && board_group.original_obf_root_id == obf_id
@@ -2465,7 +2476,7 @@ class Board < ApplicationRecord
       next unless image
 
       doc_data = images_by_obf_id[item["image_id"].to_s]
-      temp_display_image = attach_image_doc(image, doc_data, current_user) || temp_display_image
+      temp_display_image = attach_image_doc(image, doc_data, current_user, import_options: import_options) || temp_display_image
 
       coords = coords_by_button_id[item["id"].to_s]
       reset_layouts_after_import ||= coords.nil?
@@ -2540,6 +2551,10 @@ class Board < ApplicationRecord
   end
   private_class_method :find_or_init_board_for_import
 
+  # Newly-created Images from OBF/OBZ import are ALWAYS is_private: true.
+  # An admin can flip the flag later via the admin UI. Existing matches are
+  # returned as-is — we don't downgrade visibility on something the user
+  # already owns.
   def self.find_or_create_image_for_button(item, user)
     label = item["label"]
     image = nil
@@ -2548,13 +2563,18 @@ class Board < ApplicationRecord
     end
     image ||= Image.find_by(user_id: user.id, label: label, obf_id: item["image_id"])
     image ||= Image.find_by(user_id: user.id, label: label)
-    image ||= Image.create!(label: label, user_id: user.id, obf_id: item["image_id"])
+    image ||= Image.create!(label: label, user_id: user.id, obf_id: item["image_id"], is_private: true)
     image
   end
   private_class_method :find_or_create_image_for_button
 
-  def self.attach_image_doc(image, doc_meta, current_user)
+  # Downloads / attaches an image binary from an OBF image entry to a Doc on
+  # the SpeakAnyWay Image. Copyright-sensitive: gated behind
+  # import_options[:include_images]. When the user hasn't opted in, returns
+  # nil and the tile renders with a label-only Image (no symbol binary).
+  def self.attach_image_doc(image, doc_meta, current_user, import_options: {})
     return nil unless doc_meta
+    return nil unless (import_options || {}).symbolize_keys[:include_images]
 
     url = doc_meta["url"]
     inline = doc_meta["data"]

--- a/app/models/obz_importer.rb
+++ b/app/models/obz_importer.rb
@@ -11,7 +11,11 @@ require "set"
 class ObzImporter
   class ImportError < StandardError; end
 
-  def initialize(file_or_bytes, current_user, board_group: nil, board_id: nil, import_all: true)
+  # import_options forwards to Board.from_obf — see that method for keys.
+  # ObzImporter additionally persists an "imported_from_obf" audit block on
+  # the BoardGroup's settings JSONB so we always know whether image binaries
+  # were pulled in, and who acknowledged the license.
+  def initialize(file_or_bytes, current_user, board_group: nil, board_id: nil, import_all: true, import_options: {})
     @file_or_bytes = file_or_bytes
     @current_user = current_user
     @board_group = board_group
@@ -20,10 +24,12 @@ class ObzImporter
     end
     @board_id = board_id
     @import_all = import_all
+    @import_options = (import_options || {}).symbolize_keys
 
     @entries = {}  # original_path => raw_bytes
     @path_index = {}  # normalized_path => original_path
     @manifest_dir = ""  # directory (normalized) where manifest.json was found
+    @root_license = nil
   end
 
   def import!
@@ -59,8 +65,12 @@ class ObzImporter
         @board_group.update(original_obf_root_id: obf_json["id"].to_s) rescue nil
       end
 
+      if same_norm_path?(path, root_obf_path)
+        @root_license = obf_json["license"]
+      end
+
       begin
-        board, dynamic_data = Board.from_obf(obf_json, @current_user, @board_group, @board_id)
+        board, dynamic_data = Board.from_obf(obf_json, @current_user, @board_group, @board_id, import_options: @import_options)
       rescue StandardError => e
         Rails.logger.error "[ObzImporter] Skipping #{path}: #{e.class}: #{e.message}"
         next
@@ -85,6 +95,8 @@ class ObzImporter
 
     link_dynamic_boards!(dynamic_data_rows, boards_by_obf_id, obf_id_by_path, root_board)
 
+    persist_import_audit!
+
     { boards: boards_by_obf_id, root_board: root_board, dynamic_data: dynamic_data_rows }
   rescue ImportError => e
     Rails.logger.error "[ObzImporter] Import error: #{e.message}"
@@ -96,6 +108,32 @@ class ObzImporter
   end
 
   private
+
+  # --------------------------
+  # Audit log on BoardGroup
+  # --------------------------
+
+  # Stamp BoardGroup.settings["imported_from_obf"] with what we did and who
+  # acknowledged it. Captured every import (with or without opt-in) so we
+  # can answer "did this group pull in binaries?" later.
+  def persist_import_audit!
+    return unless @board_group
+
+    audit = {
+      "include_images" => @import_options[:include_images] ? true : false,
+      "license_acknowledged" => @import_options[:license_acknowledged] ? true : false,
+      "acknowledged_by_user_id" => @import_options[:acknowledged_by_user_id],
+      "acknowledged_at" => @import_options[:license_acknowledged] ? Time.current.iso8601 : nil,
+      "imported_by_user_id" => @current_user&.id,
+      "root_license" => @root_license,
+    }
+
+    settings = @board_group.settings.is_a?(Hash) ? @board_group.settings.dup : {}
+    settings["imported_from_obf"] = audit
+    @board_group.update(settings: settings)
+  rescue StandardError => e
+    Rails.logger.warn "[ObzImporter] Failed to persist import audit: #{e.message}"
+  end
 
   # --------------------------
   # Post-import linking

--- a/app/sidekiq/import_from_obf_job.rb
+++ b/app/sidekiq/import_from_obf_job.rb
@@ -1,7 +1,7 @@
 class ImportFromObfJob
   include Sidekiq::Job
 
-  def perform(board_data, user_id, board_group_id = nil)
+  def perform(board_data, user_id, board_group_id = nil, import_options = {})
     current_user = User.find_by(id: user_id)
     return unless current_user
     unless board_data.is_a?(Hash)
@@ -18,7 +18,7 @@ class ImportFromObfJob
       return
     end
     Rails.logger.debug "Created new board with ID #{@board.id} for import"
-    @board, _data = Board.from_obf(board_data, current_user, board_group, @board.id)
+    @board, _data = Board.from_obf(board_data, current_user, board_group, @board.id, import_options: import_options || {})
     if @board
       @board.update(status: "active")
       Rails.logger.debug "Board import completed successfully for board ID #{@board.id}"

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -467,6 +467,75 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe ".from_obf — image policy (private + opt-in for binaries)" do
+    let(:user) { create(:user) }
+
+    let(:obf_with_image_url) do
+      {
+        "format" => "open-board-0.1",
+        "id" => "imgtest",
+        "name" => "ImgTest",
+        "grid" => { "rows" => 1, "columns" => 1, "order" => [["b1"]] },
+        "buttons" => [{ "id" => "b1", "label" => "hi", "image_id" => "i1" }],
+        "images" => [{
+          "id" => "i1",
+          "url" => "https://example.test/symbol.png",
+          "width" => 1, "height" => 1, "content_type" => "image/png",
+        }],
+        "sounds" => [],
+      }
+    end
+
+    before do
+      # Don't trigger downstream variant preprocessing during unit specs.
+      allow(PreprocessDocTileVariantJob).to receive(:perform_async)
+    end
+
+    context "by default (include_images not set)" do
+      it "creates Image rows as is_private: true" do
+        # Down.download should never even be called.
+        expect(Down).not_to receive(:download)
+        described_class.from_obf(obf_with_image_url, user)
+        image = Image.find_by(user: user, label: "hi")
+        expect(image).to be_present
+        expect(image.is_private).to eq(true)
+      end
+
+      it "does NOT attach a Doc for an OBF image entry — binary opt-in is off" do
+        allow(Down).to receive(:download)  # safety; should not be called
+        expect {
+          described_class.from_obf(obf_with_image_url, user)
+        }.not_to change { Doc.count }
+      end
+    end
+
+    context "with import_options include_images: true" do
+      # We stub Down.download => nil to short-circuit attach_image_doc cleanly
+      # (existing code: nil download → return nil before any Active Storage work).
+      # The point of these specs is the GATE — that opt-in flips the call from
+      # blocked to attempted — not the downstream attach/storage stack.
+      before { allow(Down).to receive(:download).and_return(nil) }
+
+      it "still marks Image rows is_private: true (non-negotiable)" do
+        described_class.from_obf(obf_with_image_url, user, nil, nil,
+                                 import_options: { include_images: true })
+        expect(Image.find_by(user: user, label: "hi").is_private).to eq(true)
+      end
+
+      it "calls Down.download for the URL (gate is open)" do
+        expect(Down).to receive(:download).with("https://example.test/symbol.png")
+        described_class.from_obf(obf_with_image_url, user, nil, nil,
+                                 import_options: { include_images: true })
+      end
+    end
+
+    it "does NOT downgrade an existing public Image found by label match" do
+      existing = create(:image, label: "hi", user: user, is_private: false)
+      described_class.from_obf(obf_with_image_url, user)
+      expect(existing.reload.is_private).to eq(false)
+    end
+  end
+
   describe "#to_obf (export)" do
     let(:user) { create(:user) }
     let(:linked_board) { create(:board, user: user, name: "Drinks", obf_id: "drinks-123") }

--- a/spec/models/obz_importer_spec.rb
+++ b/spec/models/obz_importer_spec.rb
@@ -68,6 +68,44 @@ RSpec.describe ObzImporter, type: :model do
     end
   end
 
+  describe "#import! — image policy audit on BoardGroup.settings" do
+    it "stamps imported_from_obf with include_images=false by default" do
+      described_class.new(fixture_bytes("simple.obz"), user, board_group: board_group).import!
+      audit = board_group.reload.settings["imported_from_obf"]
+      expect(audit).to include(
+        "include_images" => false,
+        "license_acknowledged" => false,
+        "imported_by_user_id" => user.id,
+      )
+      expect(audit["acknowledged_at"]).to be_nil
+    end
+
+    it "records the acknowledgment timestamp + acknowledger when opted in" do
+      described_class.new(
+        fixture_bytes("simple.obz"), user, board_group: board_group,
+        import_options: {
+          include_images: true,
+          license_acknowledged: true,
+          acknowledged_by_user_id: user.id,
+        }
+      ).import!
+      audit = board_group.reload.settings["imported_from_obf"]
+      expect(audit).to include(
+        "include_images" => true,
+        "license_acknowledged" => true,
+        "acknowledged_by_user_id" => user.id,
+      )
+      expect(audit["acknowledged_at"]).to be_present
+    end
+
+    it "marks freshly-created Images is_private: true regardless of opt-in" do
+      described_class.new(fixture_bytes("simple.obz"), user, board_group: board_group).import!
+      imported = user.images.where(label: ["happy", "sad"])
+      expect(imported.count).to eq(2)
+      expect(imported.pluck(:is_private)).to all(eq(true))
+    end
+  end
+
   describe "#import! with a malformed archive" do
     it "raises ObzImporter::ImportError when the zip has no .obf entries" do
       empty_zip = StringIO.new

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -35,6 +35,55 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(JSON.parse(response.body)["error"]).to match(/unsupported/i)
     end
+
+    context "image opt-in policy" do
+      def fresh_upload
+        Rack::Test::UploadedFile.new(obz_path, "application/zip")
+      end
+
+      it "succeeds without opt-in and reports include_images=false" do
+        post "/api/boards/import_obf",
+             params: { file: fresh_upload },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["include_images"]).to eq(false)
+      end
+
+      it "marks all newly-created Images as is_private" do
+        post "/api/boards/import_obf",
+             params: { file: fresh_upload },
+             headers: auth_headers(user)
+        expect(user.images.where(label: ["happy", "sad"]).pluck(:is_private)).to all(eq(true))
+      end
+
+      it "returns 400 image_license_required when include_images=true without ack" do
+        post "/api/boards/import_obf",
+             params: { file: fresh_upload, include_images: "true" },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)["error"]).to eq("image_license_required")
+      end
+
+      it "succeeds and persists the audit when include_images=true with ack" do
+        post "/api/boards/import_obf",
+             params: {
+               file: fresh_upload,
+               include_images: "true",
+               image_license_acknowledged: "true",
+             },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["include_images"]).to eq(true)
+
+        bg = BoardGroup.find(body["board_group_id"])
+        expect(bg.settings["imported_from_obf"]).to include(
+          "include_images" => true,
+          "license_acknowledged" => true,
+          "acknowledged_by_user_id" => user.id,
+        )
+      end
+    end
   end
 
   describe "GET /api/boards/:id/download_obf" do


### PR DESCRIPTION
Closes #239.

## What

OBF/OBZ imports no longer silently pull licensed symbol artwork (e.g. SymbolStix from a CoughDrop \`.obz\`) into the public image pool.

### Before
- \`POST /api/boards/import_obf\` always downloaded every image URL in the OBF and attached the binary to a \`Doc\` on a new \`Image\` row.
- New \`Image\` rows defaulted to \`is_private = false\`.
- Result: imported SymbolStix PNGs ended up in S3 and surfaced to every user via \`Image.searchable_images_for\` / \`Image.public_img\`.

### After
- Image binary download is **opt-in**. New params on \`/import_obf\`:
  - \`include_images\` (bool, default \`false\`) — when \`true\`, the importer calls \`Down.download\` per OBF image entry and attaches Docs.
  - \`image_license_acknowledged\` (bool, default \`false\`) — required when \`include_images=true\`. Missing/false → **HTTP 400 \`image_license_required\`**.
- Every \`Image\` row created via OBF/OBZ import is \`is_private: true\`, unconditionally. Never enters \`Image.public_img\` scope. Existing images matched by label are **not** downgraded — we don't touch user-owned visibility.
- Audit trail on \`BoardGroup.settings[\"imported_from_obf\"]\`: \`include_images\`, \`license_acknowledged\`, \`acknowledged_by_user_id\`, \`acknowledged_at\`, \`imported_by_user_id\`, \`root_license\`.

## How it threads through

\`\`\`
controller#import_obf
  ├─ parse_obf_import_options (new) — validates ack, builds hash
  ├─ ObzImporter.new(..., import_options:)             (.obz branch)
  │    └─ Board.from_obf(..., import_options:)
  │         ├─ find_or_create_image_for_button → is_private: true
  │         └─ attach_image_doc(import_options:) — gates Down.download
  └─ ImportFromObfJob.perform_async(..., options.stringify_keys)  (JSON branch)
       └─ Board.from_obf(..., import_options:)
\`\`\`

All four signatures accept \`import_options: {}\` as a keyword default so existing callers / Sidekiq retries from before this change keep working.

## Test plan

- [x] \`bundle exec rspec\` — **1025 examples, 0 failures, 12 pending** (unchanged from main).
- [x] New unit specs in \`spec/models/board_spec.rb\`: default import marks \`Image.is_private = true\` + no \`Doc\` created; \`include_images: true\` opens the \`Down.download\` gate; existing public Image matched by label is NOT downgraded.
- [x] \`spec/models/obz_importer_spec.rb\`: audit log stamped on \`BoardGroup.settings\` for both default and opt-in paths; freshly-created Images private regardless.
- [x] \`spec/requests/api/boards/import_export_spec.rb\`: 400 when \`include_images=true\` w/o ack; success + audit persisted with ack; default import marks new images private.

## Docs

- \`CHANGELOG.md\` — Unreleased entry.
- \`CLAUDE.md\` — new \"OBF/OBZ import — copyright policy\" section so future agents know the contract.

## Not in scope

- **Frontend.** Existing upload modal continues to succeed unchanged, but imports will be structure-only until the frontend adds an \"Import images\" + \"I have permission\" checkbox pair that sends the new params. Filing a separate frontend issue.
- **Backfill.** Existing \`is_private = false\` images imported via OBF before this PR are not flipped private retroactively. Worth a one-off rake task in a follow-up if there are any in prod (\`docs.source_type = 'ObfImport'\` is the marker).
- The OBF duplicate-code cleanup from #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)