### PR TITLE
fix(boards): include OBF-imported boards in user's own index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   without changes, but imports will be structure-only until the
   frontend adds an "Import images" + "I have permission" pair of
   checkboxes that send the new params.
+- **Fixed alongside:** `GET /api/boards` (user's own listing) used to
+  silently drop OBF-imported boards via `where(obf_id: nil)`, so
+  `board_count` and the visible list disagreed (e.g. 6 vs 4).
+  The filter belongs on cross-user discovery scopes
+  (`Board.searchable`, `Board.public_boards`), not on a user's own
+  index. Removed there; kept on the discovery scopes.
 ### Changed — Owners can archive active communicators (issue #237)
 - `ChildAccount#archive!` now allows archiving owner-controlled active
   communicators in addition to sandboxes. Loaner is still excluded —

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -130,7 +130,14 @@ class API::BoardsController < API::ApplicationController
     # ---------------------------
     # 3. NORMAL MODE (no search)
     # ---------------------------
-    base_scope = current_user.boards.where(obf_id: nil)
+    # NOTE: deliberately no `where(obf_id: nil)` here. That filter belongs
+    # on cross-user discovery scopes (Board.searchable, Board.public_boards)
+    # — it keeps a user's imports out of OTHER users' search results. On a
+    # user's OWN index, we have to show their imports too; otherwise
+    # `boards.count` (which exposes board_count in api_view) reports 6 while
+    # this listing renders 4, and imported boards become unreachable from
+    # the boards page.
+    base_scope = current_user.boards
     filtered_scope = apply_filter(base_scope, filter)
     filtered_scope = filtered_scope.with_any_tags(selected_tags) if selected_tags.present?
 

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe "API::Boards", type: :request do
           headers: auth_headers(user)
       expect(response).to have_http_status(:ok)
     end
+
+    # Regression: an OBF/OBZ import sets boards.obf_id, and the index used
+    # to silently drop them via `where(obf_id: nil)`. User-visible symptom
+    # was board_count=6 but the listing returning 4 boards. The filter
+    # belongs on cross-user discovery, not on a user's own index.
+    it "includes the user's OBF-imported boards in the listing" do
+      create(:board, user: user, name: "Imported Greetings", obf_id: "greetings")
+      get "/api/boards",
+          params: { per_page: 50 },
+          headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      names = JSON.parse(response.body).fetch("boards").map { |b| b["name"] }
+      expect(names).to include("Imported Greetings")
+    end
   end
 
   describe "POST /api/boards" do


### PR DESCRIPTION
Follow-up to #240, surfaced while testing the opt-in import flow on staging.

## Symptom

- \`user.board_count\` (== \`boards.count\`) reads 6.
- \`GET /api/boards\` returns 4.
- Net effect: a user imports a \`.obz\`, the import succeeds (200, audit log written, boards created in DB), but the new boards never appear in the \"My Boards\" listing — they look lost.

## Cause

\`API::BoardsController#index\` normal-mode (no search) used:

\`\`\`ruby
base_scope = current_user.boards.where(obf_id: nil)
\`\`\`

Every OBF/OBZ-imported board has \`obf_id\` set, so the filter silently dropped them.

That \`obf_id IS NULL\` filter belongs on **cross-user discovery scopes** (\`Board.searchable\`, \`Board.public_boards\`) — those keep one user's imports out of OTHER users' search results, which is correct. But on a user's **own** \`/api/boards\` listing, we have to show everything they own; otherwise \`board_count\` and the visible list lie to each other and there's no path to reach the imported board from the boards page.

## Fix

- Removed the \`where(obf_id: nil)\` from the controller's normal-mode \`base_scope\`. Discovery scopes untouched.
- Comment block on the line explaining why so we don't accidentally re-add it.
- Regression spec in \`spec/requests/api/boards_spec.rb\`: a board with \`obf_id\` set must appear in \`/api/boards\` for its owner.

## Test plan

- [x] \`bundle exec rspec spec/requests/api/boards_spec.rb spec/requests/api/boards/import_export_spec.rb spec/models/board_spec.rb\` — **98 examples, 0 failures**.
- [ ] Manual on staging: re-upload \`speakanyway-test.obz\`, confirm \"Greetings\" appears in /boards and \`board_count\` matches the visible row count.

## Note on cross-user search

Sanity checks I ran while writing this:

- \`Board.searchable\` (line 109) still has \`where(obf_id: nil)\` — good.
- \`Board.public_boards\` (line 130) still has \`where.not(parent_type: \"Menu\").where(obf_id: nil)\` — good.
- Public-boards lookup paths in this controller (lines ~50, 52) still filter — good.

So another user can't suddenly search up your imported \"Greetings\" board. The only behavior change is that you can see your own imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)