### PR TITLE
docs: document BetterStack /up monitor (#206)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,16 @@ backlog size (default 200).
   90% (critical). Alerts are debounced in Redis to once per severity per 6h.
   Skipped on staging, since staging shares the production EC2 box. Added
   after a disk-full outage wedged the box during a deploy.
+- **External `/up` monitor (BetterStack):** HTTP monitor hits
+  `https://670kd.hatchboxapp.com/up` (prod) every 3 min. Pages on failure
+  via SMS to the on-call number + email to `ADMIN_EMAIL`. No Rails code
+  backs this — `/up` is the stock `Rails::HealthController` route in
+  `config/routes.rb`. Catches failure modes the in-app jobs can't: wedged
+  puma (the 2026-05-30 outage), nginx/DNS/network, full-box down.
+  Configured in BetterStack's UI; nothing in this repo to change when
+  tuning the monitor. Staging is intentionally not monitored — it shares
+  the prod box, so a prod alert covers both. Added after the 2026-05-30
+  outage where puma was alive per systemd but all threads were wedged.
 
 ## Subscription model
 


### PR DESCRIPTION
## Summary

- Documents the new external healthcheck added in response to the 2026-05-30 outage (puma wedged but alive — `DiskSpaceAlertJob` couldn't catch it).
- BetterStack pings `https://670kd.hatchboxapp.com/up` every 3 min and pages via SMS + email on failure.
- Staging isn't monitored separately — it shares the prod EC2 box, so a prod alert covers both.

## Why

Closes #206. Direct fix for the "alive per systemd, all threads wedged, 38 min before anyone noticed" failure mode. SMS is the critical change — email alone failed on 2026-05-30.

## What's in the repo

CLAUDE.md only — one new bullet under "Monitoring / alerting". No Rails code change; `/up` is the stock `Rails::HealthController` route at `config/routes.rb:517`. The monitor itself lives in BetterStack's UI.

## Test plan

- [x] `git diff CLAUDE.md` — only the new bullet
- [x] BetterStack monitor configured and verified (smoke test via "Send test notification" — SMS + email both deliver)
- [ ] Real-fire test deferred to next opportunistic prod restart

Doc-only change; no specs added (per `~/.claude/CLAUDE.md`: doc-only changes can skip tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)