### PR TITLE
fix(obf): enqueue tile audio on import so labels can be spoken

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2615,7 +2615,12 @@ class Board < ApplicationRecord
       board_image = board.board_images.new(image_id: image.id, voice: board.voice,
                                            position: board.board_images_count,
                                            display_image_url: display_url)
-      board_image.skip_create_voice_audio = true
+      # Let BoardImage's after_create :create_voice_audio_after_create
+      # fire — that's the canonical hook for enqueuing SaveAudioJob, and
+      # an existing pre-rendered Polly file (same image+voice+language)
+      # is reused, so the job is cheap when there is one to reuse.
+      # Previously skipped here; result was imported tiles had no audio
+      # at all because nothing else compensated.
       board_image.save!
     end
 
@@ -2626,6 +2631,9 @@ class Board < ApplicationRecord
       board_image.layout["sm"] = layout
       board_image.data ||= {}
       board_image.data["obf_id"] = item["image_id"]
+      # Skip on update — after_create doesn't fire on save here anyway,
+      # this just keeps the flag explicit so future readers don't think
+      # we want re-enqueue on every layout tweak.
       board_image.skip_create_voice_audio = true
       board_image.save!
     end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -465,6 +465,20 @@ RSpec.describe Board, type: :model do
       json = obf_hash.to_json
       expect(described_class.from_obf(json, user).first).to be_persisted
     end
+
+    # Regression: imported tiles used to set skip_create_voice_audio=true,
+    # which silenced BoardImage's after_create audio hook. Result: tapping
+    # an imported tile produced no sound. Audio should enqueue exactly the
+    # same way as boards created any other way.
+    it "enqueues SaveAudioJob for each imported BoardImage so tile audio works" do
+      Sidekiq::Testing.fake! do
+        SaveAudioJob.clear
+        described_class.from_obf(obf_hash, user)
+        expect(SaveAudioJob.jobs.size).to eq(2)
+        voices = SaveAudioJob.jobs.map { |j| j["args"][1] }
+        expect(voices).to all(be_present)
+      end
+    end
   end
 
   describe ".from_obf — image policy (private + opt-in for binaries)" do


### PR DESCRIPTION
Follow-up to #240 / #242, found while testing on staging.

## Symptom

Imported tiles had no audio. Tapping \"hello\" on the test \`.obz\` produced no sound — neither pre-rendered Polly nor a fallback. Other (non-imported) tiles in the same account played their audio fine.

## Cause

\`Board.upsert_board_image\` set \`skip_create_voice_audio = true\` on the initial \`save!\` of a new \`BoardImage\`:

\`\`\`ruby
board_image = board.board_images.new(image_id: ..., voice: board.voice, ...)
board_image.skip_create_voice_audio = true   # ← silences after_create
board_image.save!
\`\`\`

That flag suppresses \`BoardImage\`'s \`after_create :create_voice_audio_after_create\` hook — the canonical place where \`SaveAudioJob.perform_async(image_id, voice, id)\` is enqueued for Polly rendering. Nothing else compensated, so imported tiles stayed silent forever.

The comment at \`board.rb:964\` already calls out the contract: \"Audio generation is enqueued by BoardImage's after_create callback. Don't enqueue SaveAudioJob a second time here.\" The import path was bypassing the callback and then never queuing.

## Fix

- Removed the \`skip_create_voice_audio = true\` from the initial create in \`Board.upsert_board_image\`. The standard \`after_create\` hook now fires per imported tile, queuing \`SaveAudioJob\` exactly once (cheap — a Polly file for the same image+voice+language is reused server-side when one exists).
- Left the flag on the subsequent layout-update \`save!\` for documentation: \`after_create\` doesn't re-fire on update, so the flag is a no-op there, but it signals intent for future readers.
- Comment block added on the new lines explaining why.

## Test plan

- [x] New regression spec in \`spec/models/board_spec.rb\` (\`.from_obf\` describe block): \`Board.from_obf\` with two buttons enqueues exactly two \`SaveAudioJob\`s.
- [x] Existing \"enqueues SaveAudioJob exactly once for the new board image\" spec on \`Board#add_image\` continues to pass — this isn't double-enqueuing through some other path.
- [x] \`bundle exec rspec spec/models/board_spec.rb spec/models/obz_importer_spec.rb spec/requests/api/boards/import_export_spec.rb spec/requests/api/boards_spec.rb\` — **108 examples, 0 failures**.
- [ ] Manual on staging: re-import \`speakanyway-test.obz\`, wait for Sidekiq to drain SaveAudioJob, tap a tile, hear Polly speak the label.

## Not in scope

- Imported boards from before this PR will still have no audio. A one-off rake task could iterate \`BoardImage\` rows where \`audio_url IS NULL\` and call \`create_voice_audio\` to retroactively queue. Easy to add if there are real imports in prod that need it — flag if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)