### PR TITLE
fix(reliability): background-queue user-lifecycle emails (#207 phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Background-queue all user-lifecycle emails (#207, phase 2)
+- Every inline `deliver_now` in request and lifecycle paths is now
+  `deliver_later`. Welcome, plan-change, team invitation, claim-link,
+  setup, confirm-email-update, message notification, and admin
+  feedback emails all enqueue to Sidekiq instead of blocking the
+  request thread on SMTP.
+- Affected files: `app/models/user.rb` (17 sites),
+  `app/controllers/api/users_controller.rb` (2 sites),
+  `app/models/message.rb`, `app/models/feedback_item.rb`,
+  `app/models/child_account.rb`. `DiskSpaceAlertJob` still uses
+  `deliver_now` — it already runs inside Sidekiq.
+- Closes the last hot-path SMTP risk identified in the 2026-05-30
+  outage (#207). Pairs with PR #208 (SMTP timeouts, OpenAI timeouts,
+  puma cluster mode).
+- User-visible: faster HTTP responses on signup, plan change, team
+  invites, email-change confirmation. Email arrival time unchanged
+  (Gmail-side delivery dominates).
+- Added `spec/lib/no_inline_mailer_delivery_spec.rb` as a regression
+  guard so a new `deliver_now` outside `app/sidekiq/` fails CI.
+
 ### Changed — OBF/OBZ import: opt-in for image binaries, private-by-default (#239)
 - `POST /api/boards/import_obf` no longer downloads or stores image
   binaries from imported `.obz` / `.obf` files by default. Board

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -78,7 +78,7 @@ class API::UsersController < API::ApplicationController
     if current_user.update(unconfirmed_email: new_email)
       token = SecureRandom.hex(16)
       if current_user.update(confirmation_token: token, confirmation_sent_at: Time.current)
-        UserMailer.confirm_update_email(current_user).deliver_now
+        UserMailer.confirm_update_email(current_user).deliver_later
         render json: {
                  message: "Confirmation email sent to #{new_email}. Your current email will stay active until you confirm.",
                  current_email: current_user.email,
@@ -122,7 +122,7 @@ class API::UsersController < API::ApplicationController
       token = SecureRandom.hex(16)
       current_user.update(confirmation_token: token, confirmation_sent_at: Time.current)
     end
-    UserMailer.confirm_update_email(current_user).deliver_now
+    UserMailer.confirm_update_email(current_user).deliver_later
 
     render json: {
       message: "Confirmation email resent to #{pending_email}.",

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -582,7 +582,7 @@ class ChildAccount < ApplicationRecord
   end
 
   def send_setup_email(sending_user)
-    CommunicationAccountMailer.setup_email(self, sending_user).deliver_now
+    CommunicationAccountMailer.setup_email(self, sending_user).deliver_later
   end
 
   def create_profile!

--- a/app/models/feedback_item.rb
+++ b/app/models/feedback_item.rb
@@ -59,6 +59,6 @@ class FeedbackItem < ApplicationRecord
   private
 
   def send_admin_notification
-    AdminMailer.new_feedback_email(self).deliver_now
+    AdminMailer.new_feedback_email(self).deliver_later
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -58,10 +58,9 @@ class Message < ApplicationRecord
   def notify_recipient
     if recipient.should_receive_notifications?
       begin
-        UserMailer.message_notification_email(self).deliver_now
-      rescue Net::SMTPFatalError => e
-        Rails.logger.error "Failed to send email: #{e.message}"
-        puts "Failed to send email: #{e.message}"
+        UserMailer.message_notification_email(self).deliver_later
+      rescue => e
+        Rails.logger.error "Failed to enqueue notification email: #{e.message}"
       end
       recipient.set_recently_notified!
       puts "Notification sent to #{recipient.email} about new message from #{sender.email}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -731,7 +731,7 @@ class User < ApplicationRecord
   end
 
   def invite_to_team!(team, inviter, role = "member")
-    BaseMailer.team_invitation_email(self, inviter, team, role).deliver_now
+    BaseMailer.team_invitation_email(self, inviter, team, role).deliver_later
     if stripe_customer_id.nil?
       stripe_customer_id = User.create_stripe_customer(email)
       update!(stripe_customer_id: stripe_customer_id)
@@ -746,7 +746,7 @@ class User < ApplicationRecord
         u.skip_invitation = true
       end
     end
-    BaseMailer.team_invitation_email(@user, inviter, team, role).deliver_now
+    BaseMailer.team_invitation_email(@user, inviter, team, role).deliver_later
     if @user.stripe_customer_id.nil?
       stripe_customer_id = User.create_stripe_customer(new_user_email)
       @user.update!(stripe_customer_id: stripe_customer_id)
@@ -757,7 +757,7 @@ class User < ApplicationRecord
   def send_partner_welcome_email
     Rails.logger.info "Sending partner welcome email to #{email}"
     begin
-      PartnerMailer.welcome_email(self).deliver_now
+      PartnerMailer.welcome_email(self).deliver_later
       Rails.logger.info "Partner welcome email sent to #{email}"
     rescue => e
       Rails.logger.error("Error sending partner welcome email: #{e.message}")
@@ -768,7 +768,7 @@ class User < ApplicationRecord
     Rails.logger.info "Sending temporary login email to #{email}"
     begin
       TempLoginService.issue_for!(self)
-      UserMailer.temporary_login_email(self, User::TEMP_LOGIN_TOKEN_EXPIRY_HOURS).deliver_now
+      UserMailer.temporary_login_email(self, User::TEMP_LOGIN_TOKEN_EXPIRY_HOURS).deliver_later
       Rails.logger.info "Temporary login email sent to #{email}"
     rescue => e
       Rails.logger.error("Error sending temporary login email: #{e.message}")
@@ -778,27 +778,27 @@ class User < ApplicationRecord
   def send_general_welcome_email
     Rails.logger.info "Preparing to send welcome email to #{email}"
     begin
-      UserMailer.welcome_email(self).deliver_now
+      UserMailer.welcome_email(self).deliver_later
       self.settings["welcome_email_sent"] = true
       self.save
-      AdminMailer.new_user_email(self).deliver_now
+      AdminMailer.new_user_email(self).deliver_later
       update_mailchimp_subscription
     end
   end
 
   def send_welcome_email_free
     Rails.logger.info "Sending free welcome email to #{email}"
-    UserMailer.welcome_free_email(self).deliver_now
+    UserMailer.welcome_free_email(self).deliver_later
   end
 
   def send_welcome_email_basic
     Rails.logger.info "Sending basic welcome email to #{email}"
-    UserMailer.welcome_basic_email(self).deliver_now
+    UserMailer.welcome_basic_email(self).deliver_later
   end
 
   def send_welcome_email_pro
     Rails.logger.info "Sending pro welcome email to #{email}"
-    UserMailer.welcome_pro_email(self).deliver_now
+    UserMailer.welcome_pro_email(self).deliver_later
   end
 
   def send_welcome_email(plan_nickname = nil, slug = nil)
@@ -818,7 +818,7 @@ class User < ApplicationRecord
       end
       self.settings["welcome_email_sent"] = true
       self.save
-      AdminMailer.new_user_email(self).deliver_now
+      AdminMailer.new_user_email(self).deliver_later
       update_mailchimp_subscription
 
       Rails.logger.info "Welcome email sent to #{email}"
@@ -830,7 +830,7 @@ class User < ApplicationRecord
   def send_pro_setup_email
     Rails.logger.info "Sending pro setup email to #{email}"
     begin
-      SetupMailer.pro_setup_email(self).deliver_now
+      SetupMailer.pro_setup_email(self).deliver_later
       Rails.logger.info "Pro setup email sent to #{email}"
     rescue => e
       Rails.logger.error("Error sending pro setup email: #{e.message}")
@@ -840,7 +840,7 @@ class User < ApplicationRecord
   def send_free_setup_email
     Rails.logger.info "Sending free setup email to #{email}"
     begin
-      UserMailer.welcome_free_email(self).deliver_now
+      UserMailer.welcome_free_email(self).deliver_later
       Rails.logger.info "Free setup email sent to #{email}"
     rescue => e
       Rails.logger.error("Error sending free setup email: #{e.message}")
@@ -850,7 +850,7 @@ class User < ApplicationRecord
   def send_vendor_setup_email
     Rails.logger.info "Sending vendor setup email to #{email}"
     begin
-      SetupMailer.vendor_setup_email(self).deliver_now
+      SetupMailer.vendor_setup_email(self).deliver_later
       Rails.logger.info "Vendor setup email sent to #{email}"
     rescue => e
       Rails.logger.error("Error sending vendor setup email: #{e.message}")
@@ -876,8 +876,8 @@ class User < ApplicationRecord
   def send_welcome_invitation_email(inviter_id)
     Rails.logger.info "Sending welcome invitation email to #{email} from user ID #{inviter_id}"
     begin
-      UserMailer.welcome_invitation_email(self, inviter_id).deliver_now
-      # AdminMailer.new_user_email(self).deliver_now
+      UserMailer.welcome_invitation_email(self, inviter_id).deliver_later
+      # AdminMailer.new_user_email(self).deliver_later
     rescue => e
       Rails.logger.error("Error sending welcome invitation email: #{e.message}")
     end
@@ -887,7 +887,7 @@ class User < ApplicationRecord
     business_name = vendor.business_name
     Rails.logger.info "Sending welcome new vendor email to #{email} for business #{business_name}"
     begin
-      UserMailer.welcome_new_vendor_email(self, vendor).deliver_now
+      UserMailer.welcome_new_vendor_email(self, vendor).deliver_later
     rescue => e
       Rails.logger.error("Error sending welcome new vendor email: #{e.message}")
     end
@@ -896,7 +896,7 @@ class User < ApplicationRecord
   def send_welcome_to_organization_email(inviter_id)
     Rails.logger.info "Sending welcome to organization email to #{email} from user ID #{inviter_id}"
     begin
-      UserMailer.welcome_to_organization_email(self, inviter_id).deliver_now
+      UserMailer.welcome_to_organization_email(self, inviter_id).deliver_later
     rescue => e
       Rails.logger.error("Error sending welcome to organization email: #{e.message}")
     end
@@ -905,7 +905,7 @@ class User < ApplicationRecord
   def send_welcome_with_claim_link_email(slug)
     Rails.logger.info "Sending welcome with claim link email to #{email} with slug #{slug}"
     begin
-      UserMailer.welcome_with_claim_link_email(self, slug).deliver_now
+      UserMailer.welcome_with_claim_link_email(self, slug).deliver_later
     rescue => e
       Rails.logger.error("Error sending welcome with claim link email: #{e.message}")
     end

--- a/spec/lib/no_inline_mailer_delivery_spec.rb
+++ b/spec/lib/no_inline_mailer_delivery_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+# Regression coverage for the 2026-05-30 production outage (see issue #207):
+# inline `deliver_now` calls in request and lifecycle paths can wedge puma
+# threads when SMTP stalls. Phase 2 of #207 moved every such call to
+# `deliver_later`. This guard fails the suite if a `deliver_now` reappears
+# in any non-Sidekiq app path.
+#
+# Allowed exception: mailer sends that already run inside a Sidekiq job —
+# they're off the request thread, so blocking on SMTP is fine.
+RSpec.describe "inline mailer delivery regression guard" do
+  ALLOWED_DELIVER_NOW_PATHS = [
+    "app/sidekiq/",
+  ].freeze
+
+  it "has no `deliver_now` calls outside Sidekiq jobs" do
+    offenders = []
+
+    Dir.glob(Rails.root.join("app/**/*.rb")).each do |path|
+      rel = Pathname.new(path).relative_path_from(Rails.root).to_s
+      next if ALLOWED_DELIVER_NOW_PATHS.any? { |allowed| rel.start_with?(allowed) }
+
+      File.foreach(path).with_index(1) do |line, lineno|
+        # Skip comment-only lines.
+        next if line.strip.start_with?("#")
+        offenders << "#{rel}:#{lineno}: #{line.strip}" if line.include?("deliver_now")
+      end
+    end
+
+    expect(offenders).to be_empty, <<~MSG
+      Found inline `deliver_now` calls outside Sidekiq. Use `deliver_later` so
+      a stalled SMTP session can't wedge a puma thread (see issue #207):
+
+      #{offenders.join("\n")}
+    MSG
+  end
+end

--- a/spec/models/user_mailer_dispatch_spec.rb
+++ b/spec/models/user_mailer_dispatch_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+# Dispatch coverage for issue #207 Phase 2: every user-lifecycle mailer must
+# enqueue via ActiveJob (`deliver_later`) instead of blocking the request
+# thread with `deliver_now`. We test one representative for each grouping
+# rather than all 17 sites — the regression guard
+# (spec/lib/no_inline_mailer_delivery_spec.rb) covers the rest.
+RSpec.describe "User lifecycle mailers enqueue instead of delivering inline" do
+  include ActiveJob::TestHelper
+
+  let(:user) { FactoryBot.create(:user) }
+
+  it "enqueues the welcome (free) email" do
+    expect {
+      user.send_welcome_email_free
+    }.to have_enqueued_mail(UserMailer, :welcome_free_email).with(user)
+  end
+
+  it "enqueues the welcome (basic) email" do
+    expect {
+      user.send_welcome_email_basic
+    }.to have_enqueued_mail(UserMailer, :welcome_basic_email).with(user)
+  end
+
+  it "enqueues the welcome (pro) email" do
+    expect {
+      user.send_welcome_email_pro
+    }.to have_enqueued_mail(UserMailer, :welcome_pro_email).with(user)
+  end
+
+  it "enqueues the team invitation email from invite_to_team!" do
+    inviter = FactoryBot.create(:user)
+    team = FactoryBot.create(:team)
+    expect {
+      user.invite_to_team!(team, inviter, "member")
+    }.to have_enqueued_mail(BaseMailer, :team_invitation_email)
+  end
+
+  it "enqueues the partner welcome email" do
+    expect {
+      user.send_partner_welcome_email
+    }.to have_enqueued_mail(PartnerMailer, :welcome_email).with(user)
+  end
+
+  it "enqueues the pro setup email" do
+    expect {
+      user.send_pro_setup_email
+    }.to have_enqueued_mail(SetupMailer, :pro_setup_email).with(user)
+  end
+
+  it "enqueues the vendor setup email" do
+    expect {
+      user.send_vendor_setup_email
+    }.to have_enqueued_mail(SetupMailer, :vendor_setup_email).with(user)
+  end
+
+  it "enqueues the welcome-with-claim-link email" do
+    expect {
+      user.send_welcome_with_claim_link_email("some-slug")
+    }.to have_enqueued_mail(UserMailer, :welcome_with_claim_link_email)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,6 +60,8 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  include ActiveJob::TestHelper
+
   after(:all) do
     Team.destroy_all
     User.destroy_all
@@ -216,7 +218,9 @@ RSpec.describe User, type: :model do
     end
 
     it "sends an invitation email to the invited user" do
-      expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect {
+        perform_enqueued_jobs { subject }
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
       last_email = ActionMailer::Base.deliveries.last
       expect(last_email.to).to include(user_to_invite_email)
       expect(last_email.subject).to include("You have been invited to join SpeakAnyWay AAC!")
@@ -346,7 +350,7 @@ RSpec.describe User, type: :model do
 
     it "delivers UserMailer#welcome_free_email" do
       expect {
-        user.send_free_setup_email
+        perform_enqueued_jobs { user.send_free_setup_email }
       }.to change { ActionMailer::Base.deliveries.size }.by(1)
 
       mail = ActionMailer::Base.deliveries.last

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
 
   describe "POST /api/child_accounts/:id/send_setup_email" do
     before do
-      mailer = double("CommunicationAccountMailer", deliver_now: true)
+      mailer = double("CommunicationAccountMailer", deliver_later: true)
       allow(CommunicationAccountMailer).to receive(:setup_email).and_return(mailer)
     end
 


### PR DESCRIPTION
## Summary

- Move every inline `deliver_now` in request/lifecycle paths to `deliver_later`. Welcome, plan-change, team invitation, claim-link, setup, confirm-email-update, message notification, and admin feedback emails all enqueue to Sidekiq now instead of blocking the request thread on SMTP.
- Closes the last hot-path SMTP risk identified in the 2026-05-30 outage (#207). Pairs with #208 (SMTP timeouts, OpenAI timeouts, puma cluster mode).
- User-visible effect: faster HTTP responses on signup, plan change, team invites, and email-change confirmation. Email arrival time unchanged (Gmail-side delivery dominates).

Closes #207.

## What changed

**Flipped to `deliver_later` (22 sites):**
- `app/models/user.rb` — 17 sites (welcome free/basic/pro, plan-change, claim, team invitation, partner, temp-login, setup, vendor, organization, admin new-user)
- `app/controllers/api/users_controller.rb` — 2 sites (`confirm_update_email`)
- `app/models/message.rb` — `message_notification_email` (also dropped the now-unreachable `Net::SMTPFatalError` rescue for a generic enqueue rescue)
- `app/models/feedback_item.rb` — `new_feedback_email`
- `app/models/child_account.rb` — `setup_email`

**Stays as `deliver_now`:**
- `app/sidekiq/disk_space_alert_job.rb:28` — already runs inside Sidekiq; nesting `deliver_later` is wasted hops.

The `rescue => e` blocks in `app/models/user.rb` are kept. They previously caught Net::SMTP errors; after this PR they catch the (rare) ActiveJob enqueue failure if Redis hiccups during user creation. Cheap and useful.

## Why this is safe

- All mailer args are GlobalID-able AR records (`User`, `Team`, `ChildAccount`, `Message`, `FeedbackItem`) or integer ids / strings.
- Token-before-send ordering: `confirm_update_email` and `temporary_login_email` persist the token before enqueueing, so the deferred send picks up persisted state.
- SMTP errors now happen inside Sidekiq, which has built-in retries with backoff — strictly better than the old behavior where a Stripe webhook could 500 on a slow SMTP session.

## Tests

- **New regression guard:** `spec/lib/no_inline_mailer_delivery_spec.rb` — fails CI if `deliver_now` reappears outside `app/sidekiq/`.
- **New dispatch coverage:** `spec/models/user_mailer_dispatch_spec.rb` — asserts `have_enqueued_mail` for one representative of each grouping (welcome free/basic/pro, team invite, partner, pro/vendor setup, claim-link). The regression guard handles the other sites.
- **Updated existing:**
  - `spec/models/user_spec.rb` — wrapped two `ActionMailer::Base.deliveries` assertions in `perform_enqueued_jobs`. Added `include ActiveJob::TestHelper`.
  - `spec/requests/api/child_accounts_owner_protection_spec.rb` — swapped the `setup_email` mailer-double from `deliver_now` to `deliver_later`.

## Test plan

- [x] `bundle exec rspec spec/lib/no_inline_mailer_delivery_spec.rb spec/models/user_mailer_dispatch_spec.rb spec/requests/api/child_accounts_owner_protection_spec.rb` — 18/18 pass.
- [x] `bundle exec rspec spec/models/user_spec.rb spec/models/child_account_spec.rb spec/mailers/` plus the above — 117/117 pass.
- [x] Full suite: `bundle exec rspec` — **1044 examples, 2 failures, 12 pending**. Both failures are pre-existing on `main` (verified by re-running the same two against `git stash`):
  - `spec/models/user_plan_limits_spec.rb:25`
  - `spec/sidekiq/generate_board_preview_job_spec.rb:17` (the ActiveStorage URL flake also called out in #208)
- [ ] Manual smoke after deploy to staging: trigger Stripe webhook (welcome_free_email path), confirm HTTP response in <500ms and email arrives via Sidekiq.

## Related

- #207 — original issue (Phase 1 was #208; this is Phase 2)
- #208 — SMTP timeouts, OpenAI timeouts, puma cluster mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)