### PR TITLE
feat(boards): accept topic + word_list together on create, clamp word_count (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Board create accepts topic + word_list together (#246)
+- `POST /api/boards` now accepts a situation (`topic`/`prompt`) and seed
+  words (`word_list`) in the same request. The redesigned `/boards/new`
+  merges "Create from Scratch" and "Create from Scenario" into one
+  "Build a board" form; the `default` and `scenario` creation types now
+  share a single code path in `API::BoardsController#create`.
+- `word_count` is clamped server-side to `1..50` (accepts either
+  `wordCount` or `word_count`), so an oversized client value can't drive
+  a huge AI prompt.
+- `age_range` (`ageRange`/`age_range`) is optional on both paths —
+  `GenerateBoardJob` falls back to its own default when blank.
+- `GenerateBoardJob`'s `default`/`scenario` strategy now combines the
+  seed `word_list` with topic-generated words (deduped). A board with
+  seed words but no topic just keeps the seed words.
+- Affected files: `app/controllers/api/boards_controller.rb`,
+  `app/sidekiq/generate_board_job.rb`.
+
 ### Changed — Background-queue all user-lifecycle emails (#207, phase 2)
 - Every inline `deliver_now` in request and lifecycle paths is now
   `deliver_later`. Welcome, plan-change, team invitation, claim-link,

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -343,17 +343,30 @@ class API::BoardsController < API::ApplicationController
 
     respond_to do |format|
       if @board.save
-        word_count = params[:wordCount].presence || params[:word_count].presence.to_i || 12
+        # Clamp word_count server-side so a malicious/oversized client value
+        # can't drive a huge AI prompt. The merged "Build a board" form sends
+        # either camelCase (wordCount) or snake_case (word_count).
+        word_count = (params[:wordCount].presence || params[:word_count].presence || 12).to_i.clamp(1, 50)
         case creation_type
-        when "default"
+        when "default", "scenario"
+          # The redesigned /boards/new merges "from scratch" and "from
+          # scenario" into one form, so topic (situation) and word_list (seed
+          # words) can arrive together. The frontend picks the creation_type;
+          # both paths share the same job args. age_range is optional —
+          # GenerateBoardJob falls back to its own default when it's blank.
           word_list = params[:word_list]&.compact
-          if word_list.present?
-            GenerateBoardJob.perform_async(@board.id, creation_type, { "word_list" => word_list })
-          end
-        when "scenario"
-          topic = params[:topic] || params[:prompt] || @board.name
+          topic     = params[:topic] || params[:prompt] || @board.name
           age_range = params[:ageRange].presence || params[:age_range].presence
-          GenerateBoardJob.perform_async(@board.id, creation_type, { "topic" => topic, "age_range" => age_range, "word_count" => word_count, "profile" => communicator_profile_params })
+
+          job_args = {
+            "topic"      => topic,
+            "age_range"  => age_range,
+            "word_count" => word_count,
+            "profile"    => communicator_profile_params,
+          }
+          job_args["word_list"] = word_list if word_list.present?
+
+          GenerateBoardJob.perform_async(@board.id, creation_type, job_args)
         else
           GenerateBoardJob.perform_async(@board.id, creation_type, { "word_count" => word_count, "profile" => communicator_profile_params })
         end

--- a/app/sidekiq/generate_board_job.rb
+++ b/app/sidekiq/generate_board_job.rb
@@ -12,20 +12,28 @@ class GenerateBoardJob
         board.update_column(:status, "generating_words")
         profile = CommunicatorProfile.from_params(options["profile"] || {})
         case board_creation_type
-        when "default"
-          words = options["word_list"] || options["wordList"] || []
-        when "scenario"
+        when "default", "scenario"
+          # The merged "Build a board" form can send seed words (word_list)
+          # and a topic together. Seed words are used as-is; when a topic is
+          # present we also generate scenario words and combine them. A board
+          # with seed words but no topic just keeps the seed words.
+          seed_words = (options["word_list"] || options["wordList"] || []).compact
           topic = options["topic"].to_s.strip
           age_range = options["age_range"].presence || options["ageRange"].presence
-          if word_count <= 0 || word_count > 80
-            Rails.logger.warn "Word count of #{word_count} is out of bounds for Board ID #{board.id}."
-            # `|| 6` doesn't fire on 0 (truthy in Ruby), which mattered when
-            # api/internal/boards#create coerced missing columns to 0. Guard
-            # against any caller that still produces a zero column count.
-            lrg_cols = board.large_screen_columns.to_i.positive? ? board.large_screen_columns : 6
-            word_count = lrg_cols * 4
+
+          generated = []
+          if topic.present?
+            if word_count <= 0 || word_count > 80
+              Rails.logger.warn "Word count of #{word_count} is out of bounds for Board ID #{board.id}."
+              # `|| 6` doesn't fire on 0 (truthy in Ruby), which mattered when
+              # api/internal/boards#create coerced missing columns to 0. Guard
+              # against any caller that still produces a zero column count.
+              lrg_cols = board.large_screen_columns.to_i.positive? ? board.large_screen_columns : 6
+              word_count = lrg_cols * 4
+            end
+            generated = board.get_words_for_scenario(topic, age_range, word_count, profile: profile) || []
           end
-          words = board.get_words_for_scenario(topic, age_range, word_count, profile: profile)
+          words = (seed_words + generated).uniq
         when "menu"
           # Placeholder for future menu-based word generation logic
           words = []

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -174,6 +174,95 @@ RSpec.describe "API::Boards", type: :request do
             expect(opts["profile"]).to be_empty
           end
         end
+
+        it "passes topic + word_list together for default creation" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Build A Board" },
+                 board_creation_type: "default",
+                 topic: "morning routine",
+                 word_list: %w[wake brush eat],
+                 wordCount: 12,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, type, opts|
+            expect(type).to eq("default")
+            expect(opts["topic"]).to eq("morning routine")
+            expect(opts["word_list"]).to eq(%w[wake brush eat])
+            expect(opts["word_count"]).to eq(12)
+          end
+        end
+
+        it "passes topic + word_list together for scenario creation" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Coffee Shop" },
+                 board_creation_type: "scenario",
+                 topic: "ordering coffee",
+                 word_list: %w[latte size],
+                 ageRange: "10-15",
+                 wordCount: 8,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, type, opts|
+            expect(type).to eq("scenario")
+            expect(opts["topic"]).to eq("ordering coffee")
+            expect(opts["word_list"]).to eq(%w[latte size])
+            expect(opts["age_range"]).to eq("10-15")
+          end
+        end
+
+        it "clamps word_count above 50 down to 50" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Too Many Words" },
+                 board_creation_type: "default",
+                 topic: "animals",
+                 wordCount: 999,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts["word_count"]).to eq(50)
+          end
+        end
+
+        it "clamps word_count below 1 up to 1" do
+          post "/api/boards",
+               params: {
+                 board: { name: "No Words" },
+                 board_creation_type: "default",
+                 topic: "animals",
+                 wordCount: 0,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts["word_count"]).to eq(1)
+          end
+        end
+
+        it "does not error when age_range is omitted" do
+          post "/api/boards",
+               params: {
+                 board: { name: "No Age Range" },
+                 board_creation_type: "scenario",
+                 topic: "going to the park",
+                 wordCount: 12,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts["age_range"]).to be_nil
+          end
+        end
       end
     end
   end

--- a/spec/sidekiq/generate_board_job_spec.rb
+++ b/spec/sidekiq/generate_board_job_spec.rb
@@ -107,4 +107,51 @@ RSpec.describe GenerateBoardJob, type: :job do
       )
     end
   end
+
+  describe "default creation with both seed words and a topic" do
+    let(:board) do
+      create(:board, user: user, name: "Morning Routine", board_type: "default", large_screen_columns: 5)
+    end
+
+    before do
+      allow_any_instance_of(Board).to receive(:find_or_create_images_from_word_list)
+      allow_any_instance_of(Board).to receive(:reset_layouts)
+      allow_any_instance_of(Board).to receive(:generate_previews)
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
+
+    it "combines the seed word_list with topic-generated words (deduped)" do
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+      expect(board).to receive(:get_words_for_scenario)
+        .with("morning routine", nil, 5, profile: nil)
+        .and_return(%w[wake eat])
+
+      captured = nil
+      allow(board).to receive(:find_or_create_images_from_word_list) { |w| captured = w }
+
+      described_class.new.perform(
+        board.id,
+        "default",
+        { "topic" => "morning routine", "word_list" => %w[wake brush], "word_count" => 5 },
+      )
+
+      expect(captured).to eq(%w[wake brush eat])
+    end
+
+    it "uses the seed words alone when no topic is given" do
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+      expect(board).not_to receive(:get_words_for_scenario)
+
+      captured = nil
+      allow(board).to receive(:find_or_create_images_from_word_list) { |w| captured = w }
+
+      described_class.new.perform(
+        board.id,
+        "default",
+        { "word_list" => %w[apple banana], "word_count" => 5 },
+      )
+
+      expect(captured).to eq(%w[apple banana])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements #246. The redesigned `/boards/new` (frontend [itty-bitty-frontend#260](https://github.com/brittanyjohns/itty-bitty-frontend/pull/260)) merges "Create from Scratch" and "Create from Scenario" into one "Build a board" form that can send a situation (`topic`/`prompt`) and seed words (`word_list`) together.

### `API::BoardsController#create`
- Merged `default` and `scenario` into a single `when` branch sharing one set of job args.
- `word_count` clamped server-side to `1..50` (accepts `wordCount` or `word_count`).
- `age_range` (`ageRange`/`age_range`) optional on both paths — blank falls back to the job's default.
- `topic` + `word_list` accepted together; `menu`/`import_screenshot`/etc. still fall through to the `else` branch unchanged.

### `GenerateBoardJob`
- `default`/`scenario` strategy now combines the seed `word_list` with topic-generated words (deduped). A board with seed words but no topic keeps just the seed words. The out-of-bounds `word_count` fallback (`<=0` / `>80`) is preserved for other callers (e.g. internal boards) that pass `0`.

## Test plan
Ran locally, all green:
- `spec/sidekiq/generate_board_job_spec.rb` (5 examples) — added 2 covering default-path seed+topic combine and seed-only.
- `spec/requests/api/boards_spec.rb` (45 examples) — added 5 covering default+both, scenario+both, word_count clamp high/low, and omitted age_range.
- `spec/requests/api/internal/boards_spec.rb` + `generated_boards_spec.rb` (18 examples) — no regressions.

## Acceptance
- [x] `default` + `word_list` + `topic` creates a board using both
- [x] `scenario` + `word_list` + `topic` creates a board using both
- [x] `word_count` > 50 clamped to 50; < 1 clamped to 1
- [x] Omitting `age_range` does not error

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)