### PR TITLE
test: fix flaky team-invite dispatch spec (stub Stripe)

### DIFF
--- a/spec/models/user_mailer_dispatch_spec.rb
+++ b/spec/models/user_mailer_dispatch_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe "User lifecycle mailers enqueue instead of delivering inline" do
     }.to have_enqueued_mail(BaseMailer, :team_invitation_email)
   end
 
+  it "enqueues the team invitation email from invite_new_user_to_team!" do
+    inviter = FactoryBot.create(:user)
+    team = FactoryBot.create(:team)
+    # Like invite_to_team!, this path lazily provisions a Stripe customer for
+    # the (possibly brand-new) invitee; stub it to keep the test on dispatch.
+    allow(User).to receive(:create_stripe_customer).and_return("cus_test_#{SecureRandom.hex(4)}")
+    expect {
+      User.invite_new_user_to_team!("invitee-#{SecureRandom.hex(4)}@example.com", inviter, team, "member")
+    }.to have_enqueued_mail(BaseMailer, :team_invitation_email)
+  end
+
   it "enqueues the partner welcome email" do
     expect {
       user.send_partner_welcome_email

--- a/spec/models/user_mailer_dispatch_spec.rb
+++ b/spec/models/user_mailer_dispatch_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe "User lifecycle mailers enqueue instead of delivering inline" do
   it "enqueues the team invitation email from invite_to_team!" do
     inviter = FactoryBot.create(:user)
     team = FactoryBot.create(:team)
+    # invite_to_team! also lazily provisions a Stripe customer; stub it so the
+    # test stays focused on mailer dispatch and doesn't hit the real Stripe API.
+    allow(User).to receive(:create_stripe_customer).and_return("cus_test_#{SecureRandom.hex(4)}")
     expect {
       user.invite_to_team!(team, inviter, "member")
     }.to have_enqueued_mail(BaseMailer, :team_invitation_email)


### PR DESCRIPTION
## Summary

CI on `main` is red: `spec/models/user_mailer_dispatch_spec.rb:31` ("enqueues the team invitation email from invite_to_team!") fails with `Stripe::AuthenticationError: No API key provided`.

`User#invite_to_team!` enqueues the mailer (the thing under test) and then lazily provisions a Stripe customer via `User.create_stripe_customer`, which hit the real Stripe API. CI has no Stripe key, so the call raised before the `have_enqueued_mail` expectation could pass. The test was added in #245 (issue #207 phase 2) without stubbing that side effect.

Fix: stub `User.create_stripe_customer` in that example, matching the existing pattern in `spec/models/user_spec.rb:205`. Test-only change — no production behavior touched.

## Test plan

- `bundle exec rspec spec/models/user_mailer_dispatch_spec.rb` → 8 examples, 0 failures (was 1 failure).