### PR TITLE
feat(plans): drop no-CC basic_trial soft trial; new signups start on Free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Drop the no-CC `basic_trial` soft trial (Option A)
+- Every new signup now starts on **Free** (5 credits, Free-tier limits)
+  instead of the 14-day no-credit-card `basic_trial`. The credit-card
+  Stripe trial is unchanged. This closes the loophole where a signup could
+  stack ~28 days of premium-level access (no-CC trial + CC Stripe trial)
+  before the first charge.
+- Removed the `before_create :set_soft_trial_plan` callback (replaced with
+  `setup_new_user_free_plan`, which applies Free limits on create) and the
+  login-time re-apply in `API::V1::AuthsController#create`.
+- Existing `basic_trial` users are migrated to Free via the one-off
+  `bin/rails plans:migrate_basic_trial_to_free` task (run on production
+  after deploy). The remaining `basic_trial` plumbing
+  (`CreditService`, `setup_limits`, `RefreshFreeTierCreditsJob`,
+  `DowngradeSoftTrialJob`) is kept as a harmless fallback.
+
 ### Changed — Board create accepts topic + word_list together (#246)
 - `POST /api/boards` now accepts a situation (`topic`/`prompt`) and seed
   words (`word_list`) in the same request. The redesigned `/boards/new`

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -61,11 +61,6 @@ module API
               user.save!
             end
           end
-          if user.free_trial? && user.plan_type != "basic_trial"
-            user.set_soft_trial_plan
-            Rails.logger.info "User #{user.email} is eligible for soft trial. Setting plan_type to #{user.plan_type} and resetting limits."
-            user.save!
-          end
           sign_in user
           user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
           user.ensure_minimum_communicator_slot!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,11 +166,14 @@ class User < ApplicationRecord
   before_destroy :delete_stripe_customer
   before_destroy :unassign_vendor
 
-  # Only run on create — running on every save would bounce a user back to
-  # basic_trial any time they were deliberately set to "free" within the
-  # 14-day signup window (Stripe cancellation, checkout "Free" pick, etc.).
-  # The auths controller calls set_soft_trial_plan explicitly when needed.
-  before_create :set_soft_trial_plan, if: :free_trial?
+  # Every new signup lands on Free — the no-CC `basic_trial` soft trial was
+  # removed (drafts/drop-basic-trial-option-a.md). The `plan_type` column
+  # already defaults to "free"; this callback just applies the Free-tier
+  # limits in-memory on create so the account has a board slot, a communicator
+  # slot, and the AI monthly limit set from the start. The 5-credit initial
+  # grant is handled by after_create :grant_initial_plan_credits, which reads
+  # the user's plan_type ("free").
+  before_create :setup_new_user_free_plan
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
 
@@ -201,6 +204,24 @@ class User < ApplicationRecord
 
   attr_accessor :skip_plan_setup
 
+  # before_create hook: put new signups on Free with the correct limits.
+  # Mutates settings in-memory only (no save) since the record isn't
+  # persisted yet. setup_free_limits sets paid_communicator_limit to the
+  # FREE default, which already satisfies ensure_minimum_communicator_slot!.
+  #
+  # Only applies Free limits when the account is actually Free. Accounts
+  # created with an explicit paid/basic_trial plan_type get their limits from
+  # before_save :setup_limits (which fires on plan_type_changed?) — don't
+  # clobber those here.
+  def setup_new_user_free_plan
+    self.plan_type = "free" if plan_type.blank?
+    setup_free_limits if plan_type == "free"
+  end
+
+  # DEPRECATED: the no-CC soft trial was removed
+  # (drafts/drop-basic-trial-option-a.md). No longer wired to any callback or
+  # controller — kept defined as harmless fallback during the cutover. Safe to
+  # delete once the basic_trial cohort is confirmed empty.
   def set_soft_trial_plan
     # A non-blank paid_plan_type means the user has previously been on a paid
     # plan (set by apply_free_plan on cancel/pause and by the soft-trial

--- a/lib/tasks/plans.rake
+++ b/lib/tasks/plans.rake
@@ -160,4 +160,42 @@ namespace :plans do
            "so RefreshFreeTierCreditsJob (daily) re-grants the free-tier allowance."
     end
   end
+
+  desc "Migrate users on the retired basic_trial soft-trial tier to the free plan " \
+       "(drafts/drop-basic-trial-option-a.md). Mirrors DowngradeSoftTrialJob so " \
+       "credits/limits/boards land cleanly."
+  task migrate_basic_trial_to_free: :environment do
+    migrated = 0
+    skipped = 0
+
+    User.where(plan_type: "basic_trial").find_each do |user|
+      user.setup_free_limits
+      user.plan_type = "free"
+      user.plan_status = "active"
+      user.plan_expires_at = nil
+      user.settings ||= {}
+      user.settings["plan_nickname"] = "free"
+      user.save!
+
+      # Re-grant the free-tier allowance so they don't see balance=0 after
+      # losing the 400-credit trial grant (mirrors DowngradeSoftTrialJob).
+      CreditService.grant_plan!(
+        user,
+        amount: CreditService.monthly_credits_for("free"),
+        period_end: CreditService.initial_period_end_for("free"),
+        metadata: { source: "basic_trial_migration" },
+      )
+
+      # Pin a default editable board so over-limit boards have a deterministic
+      # editable slot (matches DowngradeSoftTrialJob / apply_free_plan).
+      user.pin_default_editable_board!
+      migrated += 1
+      print "." if migrated % 100 == 0
+    rescue => e
+      skipped += 1
+      warn "[plans:migrate_basic_trial_to_free] user #{user.id} failed: #{e.message}"
+    end
+
+    puts "\nMigration complete. migrated=#{migrated} skipped=#{skipped}"
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -91,9 +91,11 @@ FactoryBot.define do
     role { "admin" }
   end
 
-  # A real Free user (no longer in the soft-trial window). User#set_soft_trial_plan
-  # flips plan_type="free" to "basic_trial" when created_at is within the
-  # 14-day trial period, so we backdate created_at to stay genuinely free.
+  # An explicit Free user. As of drafts/drop-basic-trial-option-a.md every new
+  # signup already lands on Free (the no-CC basic_trial soft trial was removed),
+  # so the base :user factory is also Free. This factory just makes the intent
+  # explicit; the backdated created_at is kept for specs that assert a user is
+  # past any trial window.
   factory(:free_user, class: "User") do
     sequence(:email) { |n| "free#{n}@example.com" }
     password { "password123" }

--- a/spec/models/user_lifecycle_spec.rb
+++ b/spec/models/user_lifecycle_spec.rb
@@ -6,17 +6,20 @@ require "rails_helper"
 #   - spec/requests/api/webhooks_plan_type_spec.rb (webhook-driven mutations)
 #   - spec/sidekiq/downgrade_soft_trial_job_spec.rb (job-driven downgrade)
 RSpec.describe User, type: :model do
-  describe "#set_soft_trial_plan" do
-    it "promotes a blank plan_type to basic_trial on create" do
+  # The no-CC basic_trial soft trial was removed
+  # (drafts/drop-basic-trial-option-a.md). Every new signup lands on Free.
+  describe "signup plan defaults (#setup_new_user_free_plan)" do
+    it "puts a blank plan_type on free with Free limits on create" do
       user = User.new(email: "a@example.com", password: "password123", plan_type: nil)
       user.save!
-      expect(user.plan_type).to eq("basic_trial")
+      expect(user.plan_type).to eq("free")
+      expect(user.settings["board_limit"]).to eq(User::FREE_PLAN_LIMITS["board_limit"])
     end
 
-    it "promotes plan_type='free' to basic_trial when within the trial window" do
+    it "keeps a fresh free user on free even within the old trial window" do
       user = User.new(email: "b@example.com", password: "password123", plan_type: "free")
       user.save!
-      expect(user.plan_type).to eq("basic_trial")
+      expect(user.plan_type).to eq("free")
     end
 
     it "does NOT overwrite an explicit 'basic' plan on create" do
@@ -31,12 +34,8 @@ RSpec.describe User, type: :model do
       expect(user.plan_type).to eq("pro")
     end
 
-    # Regression for bug 3 (downgrade-then-save inside trial window).
-    it "does NOT re-promote a user who has been deliberately downgraded (paid_plan_type set)" do
-      user = FactoryBot.create(:user) # basic_trial inside window
-      user.update!(plan_type: "free", paid_plan_type: "basic")
-      # Trigger any save — without the paid_plan_type guard, the before_save
-      # callback would bounce them back to basic_trial.
+    it "does NOT re-promote a free user on subsequent saves" do
+      user = FactoryBot.create(:user) # free
       user.touch
       expect(user.reload.plan_type).to eq("free")
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,9 +80,17 @@ RSpec.describe User, type: :model do
     end
   end
   context "plan_type checks" do
-    it "defaults to basic_trial plan (soft trial) on signup" do
+    it "defaults to free plan on signup (no-CC soft trial removed)" do
       user = FactoryBot.create(:user)
-      expect(user.plan_type).to eq("basic_trial")
+      expect(user.plan_type).to eq("free")
+    end
+
+    it "applies Free-tier limits on signup" do
+      user = FactoryBot.create(:user)
+      expect(user.settings["board_limit"]).to eq(User::FREE_PLAN_LIMITS["board_limit"])
+      expect(user.settings["paid_communicator_limit"]).to eq(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
+      expect(user.settings["demo_communicator_limit"]).to eq(User::FREE_PLAN_LIMITS["demo_communicator_limit"])
+      expect(user.settings["ai_monthly_limit"]).to eq(User::FREE_PLAN_LIMITS["ai_monthly_limit"])
     end
 
     it "does not override an explicitly set plan_type on create" do
@@ -93,7 +101,7 @@ RSpec.describe User, type: :model do
     it "does not change plan_type on subsequent saves" do
       user = FactoryBot.create(:user)
       user.update!(name: "Updated")
-      expect(user.plan_type).to eq("basic_trial")
+      expect(user.plan_type).to eq("free")
     end
 
     it "recognizes pro plan" do
@@ -119,21 +127,11 @@ RSpec.describe User, type: :model do
   end
 
   context "initial plan-credit grant on signup" do
-    it "grants the basic_trial allowance (400) by default since new users land in basic_trial" do
+    it "grants the free allowance (5) by default since new users land on free" do
       user = FactoryBot.create(:user)
-      expect(user.plan_type).to eq("basic_trial")
-      expect(user.plan_credits_balance).to eq(400)
-      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
-    end
-
-    # NOTE: User#set_soft_trial_plan (before_save) flips plan_type "free" → "basic_trial"
-    # for any user inside their 14-day free trial window. To test the "free" path,
-    # explicitly age the user past the trial window before the after_create grant.
-    it "grants the free allowance (5) when the user is post-trial (free)" do
-      user = FactoryBot.build(:user, plan_type: "free", created_at: 30.days.ago)
-      user.save!
       expect(user.plan_type).to eq("free")
       expect(user.plan_credits_balance).to eq(5)
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
 
     it "grants the basic allowance (400) when plan_type is explicitly basic" do
@@ -146,14 +144,8 @@ RSpec.describe User, type: :model do
       expect(user.plan_credits_balance).to eq(1500)
     end
 
-    it "sets plan_credits_reset_at = 14 days from now for basic_trial users" do
+    it "sets plan_credits_reset_at = 30 days from now for free users (default)" do
       user = FactoryBot.create(:user)
-      expect(user.plan_credits_reset_at).to be_within(5.seconds).of(14.days.from_now)
-    end
-
-    it "sets plan_credits_reset_at = 30 days from now for post-trial free users" do
-      user = FactoryBot.build(:user, plan_type: "free", created_at: 30.days.ago)
-      user.save!
       expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
     end
 
@@ -161,6 +153,26 @@ RSpec.describe User, type: :model do
       admin = FactoryBot.create(:admin_user)
       expect(admin.plan_credits_balance).to eq(0)
       expect(admin.credit_transactions.where(kind: "plan_grant")).to be_empty
+    end
+  end
+
+  # Regression guard for drafts/drop-basic-trial-option-a.md: the no-CC
+  # basic_trial soft trial was removed, so every brand-new signup must land on
+  # Free with Free limits and the 5-credit initial grant — no 400-credit trial.
+  context "fresh signup (no-CC soft trial removed)" do
+    it "lands on free with Free limits, a communicator slot, and a 5-credit grant" do
+      user = FactoryBot.create(:user)
+
+      expect(user.plan_type).to eq("free")
+      expect(user.settings["board_limit"]).to eq(User::FREE_PLAN_LIMITS["board_limit"])
+      expect(user.settings["ai_monthly_limit"]).to eq(User::FREE_PLAN_LIMITS["ai_monthly_limit"])
+      # At least the Free-tier communicator slot so the MySpeak wizard doesn't 403.
+      expect(user.settings["paid_communicator_limit"])
+        .to eq(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
+      expect(user.settings["paid_communicator_limit"].to_i).to be >= 1
+
+      expect(user.plan_credits_balance).to eq(5)
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
   end
 

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -2,14 +2,9 @@ require "rails_helper"
 
 RSpec.describe "API::Profiles", type: :request do
   describe "POST /api/profiles (MySpeak ID limit)" do
-    # New users within TRAIL_PERIOD (14 days) get auto-bumped to basic_trial,
-    # which `paid_plan?` treats as paid. To test the true Free state, bypass
-    # callbacks with update_columns so plan_type stays "free".
-    let(:free_user) do
-      user = FactoryBot.create(:user)
-      user.update_columns(plan_type: "free", created_at: 30.days.ago)
-      user
-    end
+    # New signups land on Free (the no-CC basic_trial soft trial was removed,
+    # drafts/drop-basic-trial-option-a.md), so the base factory is already Free.
+    let(:free_user) { FactoryBot.create(:user) }
     let(:pro_user) { FactoryBot.create(:user, plan_type: "pro") }
 
     let(:create_params) do

--- a/spec/requests/lifecycle_integration_spec.rb
+++ b/spec/requests/lifecycle_integration_spec.rb
@@ -45,10 +45,13 @@ RSpec.describe "Subscription lifecycle (end-to-end)", type: :request do
     )
   end
 
-  it "walks signup → trial → upgrade → cancel → soft-trial sweep" do
-    # ----- Step 1: signup -----
-    # New users land in basic_trial with 400 plan credits (User#after_create
-    # → CreditService.ensure_initial_grant!) and no Stripe customer yet.
+  it "walks legacy basic_trial → trial → upgrade → cancel → soft-trial sweep" do
+    # ----- Step 1: legacy basic_trial account -----
+    # New signups now land on free (the no-CC soft trial was removed,
+    # drafts/drop-basic-trial-option-a.md), but basic_trial remains a valid
+    # fallback state we must keep handling. Construct one explicitly: it gets
+    # the 400-credit grant (User#after_create → CreditService.ensure_initial_grant!)
+    # and no Stripe customer yet.
     user = FactoryBot.create(:user, stripe_customer_id: "cus_lifecycle", plan_type: "basic_trial")
     expect(user.plan_type).to eq("basic_trial")
     expect(user.plan_credits_balance).to eq(400)

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CreditService, type: :service do
   let(:user) { FactoryBot.create(:user) }
 
-  # New users land in `basic_trial` and get an after_create plan_grant (400).
+  # New users land on `free` and get an after_create plan_grant (5).
   # These specs test CreditService in isolation, so wipe the auto-grant first.
   before { reset_user_credits!(user) }
 

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a basic_trial user whose reset_at has passed" do
-      user = FactoryBot.create(:user) # defaults to basic_trial
+      user = FactoryBot.create(:user, plan_type: "basic_trial") # legacy fallback tier
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago, stripe_subscription_id: nil)
 
       described_class.new.perform

--- a/spec/support/credits_helper.rb
+++ b/spec/support/credits_helper.rb
@@ -1,6 +1,6 @@
 # Test helper for the AI credit ledger.
 #
-# New users land in `basic_trial` and get an automatic plan-credit grant
+# New users land on `free` and get an automatic plan-credit grant
 # from User#after_create. Specs that test credit-related behavior in
 # isolation usually want to start from a clean ledger, so they can set
 # up the exact balance they want to exercise. This helper does that.


### PR DESCRIPTION
## Summary

Implements **Option A** from `drafts/drop-basic-trial-option-a.md`: removes the no-credit-card `basic_trial` soft trial so every new signup starts on **Free**. The CC-required Stripe trial is untouched.

This closes the stacked-trial loophole where a patient signup could get ~28 days of premium-level access (14 days no-CC `basic_trial` + 14-day CC Stripe trial) before the first charge.

### Changes
1. **`app/models/user.rb`** — removed `before_create :set_soft_trial_plan, if: :free_trial?`. Replaced with `before_create :setup_new_user_free_plan`, which puts new signups on `free` (the column default) and applies `FREE_PLAN_LIMITS` in-memory on create. It only applies Free limits when the account is actually Free, so an explicit paid/`basic_trial` create still gets its own limits from `before_save :setup_limits`. The 5-credit grant continues to flow through `after_create :grant_initial_plan_credits` (reads `free`). `set_soft_trial_plan` is left defined-but-unused as harmless fallback.
2. **`app/controllers/api/v1/auths_controller.rb`** — deleted the login-time block that re-bumped within-14-day Free users back into `basic_trial`.
3. **`lib/tasks/plans.rake`** — added `plans:migrate_basic_trial_to_free`, modeled on `migrate_myspeak_to_free` and mirroring `DowngradeSoftTrialJob` (setup_free_limits → `free` → re-grant free allowance → `pin_default_editable_board!`). **Runs manually on production after deploy — not in this PR.**
4. **Left as harmless fallback** (not ripped out): `CreditService::PLAN_MONTHLY_CREDITS` / `INITIAL_PERIOD_DAYS`, the `setup_limits` `basic_trial` branch, `RefreshFreeTierCreditsJob::REFRESHABLE_PLAN_TYPES`, and `DowngradeSoftTrialJob` (keeps running as a backstop).

A `CHANGELOG.md` entry was added under `[Unreleased]`.

## Test plan
- Updated specs that assumed new users are `basic_trial`: `user_spec.rb`, `user_lifecycle_spec.rb`, `lifecycle_integration_spec.rb`, `profiles_spec.rb`, `factories.rb`, `credits_helper.rb`, `refresh_free_tier_credits_job_spec.rb`, `credit_service_spec.rb`.
- Added a fresh-signup spec asserting a new user lands on `free` with Free limits, a communicator slot, and a 5-credit grant.
- `downgrade_soft_trial_job_spec.rb` still passes (job + tier retained).
- **Affected specs: 81 examples, 0 failures.**
- **Full suite: 1051 examples, 4 failures, 12 pending.** The 4 failures are pre-existing and environment-related (missing `Stripe.api_key` / OpenAI vision keys in the local test env — `user_mailer_dispatch_spec` and 3 `menus_spec` cases); none reference `plan_type`/`basic_trial` or the signup path. The local env also required `DEVISE_JWT_SECRET_KEY` to be set to boot at all.

## Rollout
1. Merge + deploy.
2. Run `bin/rails plans:migrate_basic_trial_to_free` on production.
3. Spot-check: a new signup shows Free (1 board, 1 communicator, 1 MySpeak demo, 5 credits); a previously-`basic_trial` user shows Free with a non-zero balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)