### PR TITLE
test: fix menus spec broken by soft-trial drop (#250)

### DIFF
--- a/spec/requests/api/menus_spec.rb
+++ b/spec/requests/api/menus_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe "API::Menus", type: :request do
       )
     end
 
+    # Menu creation is credit-gated (menu_create = 10 credits). Free signups
+    # only grant 5, so give the user enough to clear check_credits! — these
+    # specs exercise menu creation, not the credit gate itself.
+    before do
+      CreditService.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+    end
+
     it "requires authentication" do
       post "/api/menus", params: { menu: { name: "Lunch" } }
       expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
## Summary

CI on `main` ([run 26901312769](https://github.com/brittanyjohns/itty_bitty_boards/actions/runs/26901312769/job/79354162920)) was red: 3 failures in `spec/requests/api/menus_spec.rb` (`Menu.count` unchanged on create).

**Root cause:** `POST /api/menus` is credit-gated — `check_credits!(feature_key: "menu_create")` costs **10** credits. Commit [21c0051d](https://github.com/brittanyjohns/itty_bitty_boards/commit/21c0051d) dropped the no-CC `basic_trial` soft trial, so `create(:user)` now starts on **Free** with only **5** credits. `check_credits!` short-circuits with HTTP 402 before the `Menu` is ever created, so the creation specs fail.

These specs exercise menu creation, not the credit gate, so the fix grants the test user enough credits up front via `CreditService.grant_plan!` — the same pattern already used in `credit_enforcement_spec.rb`.

## Test plan

- `bundle exec rspec spec/requests/api/menus_spec.rb` → 4 examples, 0 failures (was 3 failures)
- Full suite: **1052 examples, 0 failures, 12 pending** (the 12 pending are pre-existing "Not yet implemented" placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)