### PR TITLE
Reprice AI feature credit costs

### DIFF
--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -21,12 +21,12 @@ class CreditService
   FEATURE_COSTS = {
     "word_suggestion" => 1,
     "board_format" => 2,
-    "image_edit" => 3,
+    "image_edit" => 5,
     "image_variation" => 3,
-    "image_generation" => 5,
-    "screenshot_import" => 5,
-    "scenario_create" => 10,
-    "menu_create" => 10,
+    "image_generation" => 3,
+    "screenshot_import" => 3,
+    "scenario_create" => 5,
+    "menu_create" => 5,
     # Legacy single-bucket key (during shadow mode / migration)
     "ai_action" => 1,
   }.freeze


### PR DESCRIPTION
Align credit costs with real per-use API cost:
- image_edit 3 -> 5 (full gpt-image-1, priciest call)
- image_generation 5 -> 3 (cheaper gpt-image-1-mini)
- screenshot_import 5 -> 3 (single vision call, no image gen)
- scenario_create 10 -> 5 (images reuse public seeds; not charged per image)
- menu_create 10 -> 5 (same)