### PR TITLE
test: align credit specs with repriced AI feature costs (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Reprice AI feature credit costs
+- Adjusted per-feature credit costs in `CreditService::FEATURE_COSTS`:
+  `image_edit` 3 → 5, `image_generation` 5 → 3, `screenshot_import` 5 → 3,
+  `scenario_create` 10 → 5, and `menu_create` 10 → 5. (`word_suggestion`,
+  `board_format`, and `image_variation` are unchanged.)
+- Aligned the credit specs (`credit_service_spec`, `credit_enforcement_spec`,
+  `board_images_rate_limit_spec`) with the new costs — the repricing landed
+  without updating them, which had turned `main` red.
+
 ### Changed — Drop the no-CC `basic_trial` soft trial (Option A)
 - Every new signup now starts on **Free** (5 credits, Free-tier limits)
   instead of the 14-day no-credit-card `basic_trial`. The credit-card

--- a/spec/requests/api/board_images_rate_limit_spec.rb
+++ b/spec/requests/api/board_images_rate_limit_spec.rb
@@ -32,16 +32,17 @@ RSpec.describe "BoardImages AI gating (credits)", type: :request do
   let!(:board_image) { create(:board_image, board: board, image: image) }
 
   describe "POST /api/board_images/:id/create_edit" do
-    it "returns 402 insufficient_credits when balance is below image_edit cost (3)" do
+    it "returns 402 insufficient_credits when balance is below image_edit cost (5)" do
       post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }
       expect(response.status).to eq(402)
       expect(j["error"]).to eq("insufficient_credits")
       expect(j["feature"]).to eq("image_edit")
-      expect(j["needed"]).to eq(3)
+      expect(j["needed"]).to eq(5)
     end
 
     it "succeeds while credits are available, then blocks once exhausted" do
-      CreditService.grant_plan!(user, amount: 9, period_end: 30.days.from_now)
+      # image_edit costs 5; grant exactly 3 calls' worth so the 4th is blocked.
+      CreditService.grant_plan!(user, amount: 15, period_end: 30.days.from_now)
 
       3.times do
         post "/api/board_images/#{board_image.id}/create_edit", params: { prompt: "x" }

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
       expect(body).to include(
         "error" => "insufficient_credits",
         "feature" => "scenario_create",
-        "needed" => 10,
+        "needed" => 5,
         "balance" => 0,
         "plan_credits" => 0,
         "topup_credits" => 0,
@@ -36,10 +36,10 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
   describe "spending the configured weight per feature" do
     before { CreditService.grant_plan!(user, amount: 1000, period_end: 30.days.from_now) }
 
-    it "image_generation costs 5" do
+    it "image_generation costs 3" do
       expect {
         post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
-      }.to change { user.reload.plan_credits_balance }.by(-5)
+      }.to change { user.reload.plan_credits_balance }.by(-3)
     end
 
     it "word_suggestion costs 1" do
@@ -50,10 +50,10 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
       }.to change { user.reload.plan_credits_balance }.by(-1)
     end
 
-    it "scenario_create costs 10" do
+    it "scenario_create costs 5" do
       expect {
         post "/api/scenarios", params: { scenario: { name: "morning routine" } }, headers: auth
-      }.to change { user.reload.plan_credits_balance }.by(-10)
+      }.to change { user.reload.plan_credits_balance }.by(-5)
     end
   end
 
@@ -72,16 +72,16 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
 
   describe "drains plan credits before top-up" do
     before do
-      CreditService.grant_plan!(user, amount: 3, period_end: 30.days.from_now)
+      CreditService.grant_plan!(user, amount: 2, period_end: 30.days.from_now)
       CreditService.grant_topup!(user, amount: 100, stripe_event_id: "evt_seed")
     end
 
     it "uses plan balance first for an image_generation call" do
       post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
       user.reload
-      # cost 5 — plan had 3, topup absorbs 2
+      # cost 3 — plan had 2, topup absorbs 1
       expect(user.plan_credits_balance).to eq(0)
-      expect(user.topup_credits_balance).to eq(98)
+      expect(user.topup_credits_balance).to eq(99)
     end
   end
 end

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe CreditService, type: :service do
 
   describe ".cost_for" do
     it "returns the configured weight for a known feature" do
-      expect(described_class.cost_for("image_generation")).to eq(5)
+      expect(described_class.cost_for("image_generation")).to eq(3)
       expect(described_class.cost_for(:word_suggestion)).to eq(1)
-      expect(described_class.cost_for("menu_create")).to eq(10)
+      expect(described_class.cost_for("menu_create")).to eq(5)
     end
 
     it "defaults to 1 for unknown features" do
@@ -181,22 +181,25 @@ RSpec.describe CreditService, type: :service do
 
     it "drains plan credits first" do
       described_class.grant_topup!(user, amount: 50, stripe_event_id: "t1")
-      described_class.spend!(user, feature_key: "image_generation") # cost 5
+      described_class.spend!(user, feature_key: "image_generation") # cost 3
       user.reload
-      expect(user.plan_credits_balance).to eq(5)
+      expect(user.plan_credits_balance).to eq(7)
       expect(user.topup_credits_balance).to eq(50)
       tx = user.credit_transactions.spends.last
       expect(tx.feature_key).to eq("image_generation")
-      expect(tx.amount).to eq(-5)
+      expect(tx.amount).to eq(-3)
     end
 
     it "spills into topup when plan is insufficient" do
       described_class.grant_topup!(user, amount: 50, stripe_event_id: "t2")
-      described_class.spend!(user, feature_key: "menu_create") # cost 10, plan has 10
-      described_class.spend!(user, feature_key: "menu_create") # cost 10, must come from topup
+      # plan starts at 10; three menu_create spends (cost 5 each) total 15,
+      # so the third must draw from topup.
+      described_class.spend!(user, feature_key: "menu_create") # cost 5, plan 10 -> 5
+      described_class.spend!(user, feature_key: "menu_create") # cost 5, plan 5 -> 0
+      described_class.spend!(user, feature_key: "menu_create") # cost 5, from topup 50 -> 45
       user.reload
       expect(user.plan_credits_balance).to eq(0)
-      expect(user.topup_credits_balance).to eq(40)
+      expect(user.topup_credits_balance).to eq(45)
     end
 
     it "raises InsufficientCredits when total balance < cost" do


### PR DESCRIPTION
## Summary

`main` is currently **red**: PR #252 ("Reprice AI feature credit costs", `d20cf168`) changed `CreditService::FEATURE_COSTS` in a single file and didn't update the specs, leaving 9 failures across three spec files. This PR realigns the specs with the deliberate new costs and greens the suite.

New costs (from #252):

| feature | old | new |
|---|---:|---:|
| `image_edit` | 3 | **5** |
| `image_generation` | 5 | **3** |
| `screenshot_import` | 5 | **3** |
| `scenario_create` | 10 | **5** |
| `menu_create` | 10 | **5** |

(`word_suggestion`, `board_format`, `image_variation` unchanged.)

## Not just number swaps

Two tests had setup logic that depended on the old numbers, so I restructured them to preserve intent:

- **`credit_service_spec` "spills into topup"** — two `menu_create` spends used to total 20 (> 10 plan); at cost 5 that's only 10 and never spills. Now does three spends (15 > 10) so the third draws from topup.
- **`credit_enforcement_spec` "drains plan before top-up"** — plan grant of 3 used to be exceeded by `image_generation`'s old cost of 5; at cost 3 it exactly covers and never spills. Lowered the grant to 2 so 1 credit still spills.
- **`board_images_rate_limit_spec` "succeeds then blocks"** — `image_edit` rose 3→5, so the 3-success grant went 9 → 15.

Also adds the CHANGELOG entry #252 was missing (the repricing is user-facing).

## Test plan

- Greps confirm no other specs reference the old costs.
- CI (full RSpec suite) green on this branch — this is the verification that matters since the failures were CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)