### PR TITLE
feat: fallback mode for over-limit communicators on downgrade (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Communicator fallback mode on downgrade (#255)
+- A paid account dropping to Free now **retains** its over-limit communicators
+  instead of stranding them: boards, MySpeak/profile, and the public page all
+  stay intact. The communicators beyond the Free slot limit enter "fallback
+  mode" — private passcode sign-in is blocked, but the public MySpeak page
+  stays open and read-only, so a nonspeaking child is never cut off mid-use.
+- Sign-in attempts on a fallback communicator return HTTP 403
+  `communicator_in_fallback` with a `redirect_url` to the public page (the
+  frontend redirect lands in itty-bitty-frontend#275). `fallback_mode` is
+  exposed on the communicator API so the client can tell "in fallback" from
+  "doesn't exist."
+- Re-upgrading to Basic/Pro **automatically restores** sign-in, most-recently-
+  active communicators first; any still over the new plan's limit stay in
+  fallback. No manual re-claim. New Free signups remain capped at 1 communicator
+  and are never flagged — fallback only ever results from a downgrade.
+
 ### Changed — Reprice AI feature credit costs
 - Adjusted per-feature credit costs in `CreditService::FEATURE_COSTS`:
   `image_edit` 3 → 5, `image_generation` 5 → 3, `screenshot_import` 5 → 3,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,43 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   frees one board. If the ENV is ever raised above 1, revisit this to a
   per-board flag or join table.
 
+### Communicator sign-in on downgrade (fallback mode)
+
+Mirror of the board read-only rule, for communicators (issue #255). When a
+paid account drops to Free, communicators **beyond the Free slot limit are
+retained, never deleted/archived** — boards, MySpeak/profile, and `public_url`
+all stay intact. The over-limit ones enter **fallback mode**: private passcode
+sign-in is blocked, but the public MySpeak page stays open and read-only, so a
+nonspeaking child is never stranded mid-use.
+
+- **Marker is stored, not derived.** `ChildAccount#fallback_mode?` reads
+  `settings["fallback_mode"]` (with `fallback_since` / `fallback_reason`). Set
+  and cleared **only** by `User#reconcile_communicator_fallback!`, so a fresh
+  Free signup (capped at 1) is never flagged — fallback is *only ever a
+  consequence of downgrade*. Use `enter_fallback!` / `exit_fallback!`.
+- **One reconciler, both directions.** `User#reconcile_communicator_fallback!`
+  orders slotted (loaner+active) communicators **most-recently-active first**
+  (`last_sign_in_at` desc, nulls last), keeps the top `slot_limit` signable,
+  and flags the overflow. A downgrade flags the overflow; a re-upgrade restores
+  them as slots free up (no manual re-claim); any still over the new limit stay
+  in fallback. Idempotent; admins are never limited.
+- **Trigger:** `after_save :reconcile_communicator_fallback!, if:
+  :saved_change_to_plan_type?` on `User`. Every plan transition (Stripe
+  cancel/pause via `apply_free_plan`, `DowngradeSoftTrialJob`, and upgrades via
+  the subscription-upsert webhook) routes plan changes through `plan_type=` +
+  `save`, so this one callback covers all of them.
+- **Gate:** `ChildAccount#can_sign_in?` returns `false` for fallback
+  communicators (a system-admin `user_context` still bypasses for support).
+  `API::V1::ChildAuthsController#create` enforces it specifically for fallback:
+  returns **HTTP 403** `{ error: "communicator_in_fallback", message,
+  redirect_url, public_url }` so the frontend redirects to the public page
+  (companion frontend issue itty-bitty-frontend#275). The older broad
+  `can_sign_in?` controller check stays disabled — only fallback is enforced,
+  so non-fallback Free communicators keep working (AAC "usage must never break").
+- **API exposure:** `fallback_mode` + `fallback_since` on ChildAccount
+  `api_view` / `index_api_view` / `vendor_api_view`, letting the frontend tell
+  "exists but in fallback" from "doesn't exist."
+
 ## Team permissions — owner protection
 
 Communicators (`child_account`) have an `owner_id` (the family/parent

--- a/app/controllers/api/v1/child_auths_controller.rb
+++ b/app/controllers/api/v1/child_auths_controller.rb
@@ -11,6 +11,19 @@ class API::V1::ChildAuthsController < API::ApplicationController
       auth_token = child.authentication_token
       user_context = child.user
 
+      # Fallback-mode communicators (over the Free slot limit after a downgrade)
+      # can't sign in privately — redirect the client to the public MySpeak page,
+      # which stays open and read-only. A system admin still bypasses for support
+      # access. Issue #255 (frontend redirect: itty-bitty-frontend#275).
+      if child.fallback_mode? && !user_context&.admin?
+        return render json: {
+                        error: "communicator_in_fallback",
+                        message: "Private sign-in is unavailable on the Free plan for this communicator. Open its public MySpeak page instead, or upgrade to restore sign-in.",
+                        redirect_url: child.public_url,
+                        public_url: child.public_url,
+                      }, status: :forbidden
+      end
+
       unless child.can_sign_in?(user_context)
         if user_context&.admin?
           child.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip, sign_in_count: child.sign_in_count + 1)

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -136,6 +136,43 @@ class ChildAccount < ApplicationRecord
   def loaner?  = status == LOANER
   def active?  = status == ACTIVE
 
+  # --- Fallback mode (issue #255) --------------------------------------------
+  # A communicator that still exists but exceeds the owner's slot limit *because
+  # the account downgraded to Free*. It keeps its boards, MySpeak/profile, and
+  # public_url, but private passcode sign-in is blocked (`can_sign_in?` returns
+  # false; the controller redirects to the public page). Read-only on the public
+  # fallback — no board editing.
+  #
+  # The marker is only ever set/cleared by User#reconcile_communicator_fallback!,
+  # so a fresh Free signup (capped at 1 communicator) is never flagged — this
+  # state is only ever a consequence of a downgrade. It clears automatically on
+  # re-upgrade when a slot frees up.
+  FALLBACK_MODE_KEY = "fallback_mode".freeze
+
+  def fallback_mode?
+    settings.present? && settings[FALLBACK_MODE_KEY] == true
+  end
+
+  def enter_fallback!(reason: "downgrade")
+    return self if fallback_mode?
+    self.settings ||= {}
+    self.settings[FALLBACK_MODE_KEY] = true
+    self.settings["fallback_since"] = Time.current
+    self.settings["fallback_reason"] = reason
+    save!
+    self
+  end
+
+  def exit_fallback!
+    return self unless fallback_mode?
+    self.settings ||= {}
+    self.settings.delete(FALLBACK_MODE_KEY)
+    self.settings.delete("fallback_since")
+    self.settings.delete("fallback_reason")
+    save!
+    self
+  end
+
   # Can `user` edit the communicator object itself (name, username, voice,
   # layout, safety info)? Distinct from `can_edit` in api_view, which
   # answers "can this user curate boards on this communicator." Spec:
@@ -539,6 +576,8 @@ class ChildAccount < ApplicationRecord
         }
       end,
       can_sign_in: can_sign_in?,
+      fallback_mode: fallback_mode?,
+      fallback_since: settings&.dig("fallback_since"),
       available_boards: available_boards_for_user(viewing_user).map do |b|
         {
           id: b.id,
@@ -611,9 +650,14 @@ class ChildAccount < ApplicationRecord
       return true
     end
 
-    if self.user.admin?
+    if self.user&.admin?
       return true
     end
+
+    # Fallback-mode communicators (over the Free slot limit after a downgrade)
+    # can't use private passcode sign-in. A system admin (handled above) still
+    # bypasses for support access; the public MySpeak page stays open. #255.
+    return false if fallback_mode?
 
     if user
       if user.paid_plan? || user.vendor?
@@ -622,9 +666,6 @@ class ChildAccount < ApplicationRecord
         user.free_trial? || false
       end
     else
-      if self.user.admin?
-        return true
-      end
       Rails.logger.error "No user provided for can_sign_in check"
       false
     end
@@ -884,6 +925,8 @@ class ChildAccount < ApplicationRecord
         }
       end,
       can_sign_in: can_sign_in?,
+      fallback_mode: fallback_mode?,
+      fallback_since: settings&.dig("fallback_since"),
       available_boards: available_boards_for_user(viewing_user).map do |b|
         {
           id: b.id,
@@ -934,6 +977,8 @@ class ChildAccount < ApplicationRecord
       free_trial: user.free_trial?,
       admin: user.admin?,
       can_sign_in: can_sign_in?,
+      fallback_mode: fallback_mode?,
+      fallback_since: settings&.dig("fallback_since"),
       # profile: profile&.api_view,
       week_chart: week_chart,
       avatar_url: profile&.avatar_url,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,6 +177,12 @@ class User < ApplicationRecord
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
 
+  # Reconcile communicator fallback mode whenever the plan changes (issue #255).
+  # Runs after save (so the new slot limits in `settings` are persisted) and in
+  # both directions: a downgrade flags over-limit communicators, a re-upgrade
+  # restores them as slots free up. See reconcile_communicator_fallback!.
+  after_save :reconcile_communicator_fallback!, if: :saved_change_to_plan_type?
+
   # Grant the user's tier's monthly AI credit allowance on signup so the
   # very first AI call doesn't 402. Idempotent in CreditService — safe to
   # call again if a callback runs twice.
@@ -1313,6 +1319,37 @@ class User < ApplicationRecord
     default_id = effective_editable_board_id
     return if default_id.blank?
     update_column(:editable_board_id, default_id)
+  end
+
+  # Reconcile which of this user's communicators are in "fallback mode" after a
+  # plan change (issue #255). Keeps the most-recently-active slotted
+  # communicators (up to the plan's slot limit) signable and flags the overflow
+  # as fallback. Runs in both directions from one place:
+  #
+  #   - Downgrade (paid -> free): slot_limit drops, the overflow gets flagged so
+  #     their boards/MySpeak/public_url survive but private sign-in is blocked.
+  #   - Re-upgrade (free -> paid): slot_limit rises, the now-in-limit
+  #     communicators are restored most-recently-active first; any still over the
+  #     new limit stay in fallback.
+  #
+  # Idempotent. Only ever touches slotted (loaner/active) communicators, so a
+  # fresh Free signup (capped at 1) is never flagged. Admins are never limited.
+  def reconcile_communicator_fallback!
+    limit = Permissions::CommunicatorLimits.slot_limit_for(settings || {})
+    limit = nil if admin?
+
+    accounts = slotted_communicator_accounts
+                 .order(Arel.sql("last_sign_in_at DESC NULLS LAST, updated_at DESC, id DESC"))
+                 .to_a
+
+    accounts.each_with_index do |account, index|
+      keep = limit.nil? || index < limit
+      if keep
+        account.exit_fallback! if account.fallback_mode?
+      else
+        account.enter_fallback! unless account.fallback_mode?
+      end
+    end
   end
 
   # How long a user must wait between editable-board switches. Closes the

--- a/spec/models/communicator_fallback_spec.rb
+++ b/spec/models/communicator_fallback_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+# Downgrade fallback mode for over-limit communicators (issue #255).
+# When a paid account drops to Free, communicators beyond the Free slot limit
+# are retained (boards + MySpeak + public_url intact) but flagged "fallback":
+# private passcode sign-in is blocked while the public page stays open. On
+# re-upgrade the flag clears, most-recently-active first.
+RSpec.describe "Communicator fallback mode (#255)", type: :model do
+  # Build a paid (Pro) owner with `count` active communicators, each stamped
+  # with a distinct last_sign_in_at so the keep/flag ordering is deterministic.
+  def pro_owner_with_active(count)
+    owner = FactoryBot.create(:user)
+    owner.update!(plan_type: "pro") # Pro slot limit = 5
+    accounts = Array.new(count) do |i|
+      acct = FactoryBot.create(:child_account, user: owner, status: ChildAccount::ACTIVE,
+                                                username: "comm_#{owner.id}_#{i}")
+      # Earlier index => more recent sign-in, so index 0 is "most recently active".
+      acct.update_column(:last_sign_in_at, (i + 1).hours.ago)
+      acct
+    end
+    [owner, accounts]
+  end
+
+  describe "ChildAccount fallback marker" do
+    let(:account) { FactoryBot.create(:child_account, status: ChildAccount::ACTIVE) }
+
+    it "is not in fallback mode by default" do
+      expect(account.fallback_mode?).to be(false)
+    end
+
+    it "enter_fallback! sets the marker, reason, and timestamp" do
+      account.enter_fallback!
+      expect(account.fallback_mode?).to be(true)
+      expect(account.settings["fallback_reason"]).to eq("downgrade")
+      expect(account.settings["fallback_since"]).to be_present
+    end
+
+    it "exit_fallback! clears the marker and its metadata" do
+      account.enter_fallback!
+      account.exit_fallback!
+      expect(account.fallback_mode?).to be(false)
+      expect(account.settings).not_to have_key("fallback_since")
+      expect(account.settings).not_to have_key("fallback_reason")
+    end
+
+    it "enter_fallback! is idempotent" do
+      account.enter_fallback!
+      since = account.settings["fallback_since"]
+      account.enter_fallback!
+      expect(account.settings["fallback_since"]).to eq(since)
+    end
+  end
+
+  describe "ChildAccount#can_sign_in?" do
+    it "returns false for a fallback communicator owned by a normal user" do
+      owner = FactoryBot.create(:user)
+      owner.update!(plan_type: "pro")
+      account = FactoryBot.create(:child_account, user: owner, status: ChildAccount::ACTIVE)
+      account.enter_fallback!
+      expect(account.can_sign_in?).to be(false)
+    end
+
+    it "still lets a system admin sign in to a fallback communicator (support access)" do
+      admin = FactoryBot.create(:admin_user)
+      account = FactoryBot.create(:child_account, user: admin, status: ChildAccount::ACTIVE)
+      account.enter_fallback!
+      expect(account.can_sign_in?(admin)).to be(true)
+    end
+  end
+
+  describe "User#reconcile_communicator_fallback!" do
+    it "keeps everything signable while within the slot limit" do
+      _owner, accounts = pro_owner_with_active(3)
+      expect(accounts.map(&:reload).map(&:fallback_mode?)).to all(be(false))
+    end
+
+    it "on downgrade to Free, keeps the most-recently-active and flags the overflow" do
+      owner, accounts = pro_owner_with_active(3)
+
+      owner.update!(plan_type: "free") # Free slot limit = 1, fires reconcile
+
+      kept, *overflow = accounts.map(&:reload)
+      expect(kept.fallback_mode?).to be(false)            # most recently active
+      expect(overflow.map(&:fallback_mode?)).to all(be(true))
+    end
+
+    it "retains the over-limit communicators on downgrade (never deletes them)" do
+      owner, accounts = pro_owner_with_active(3)
+      owner.update!(plan_type: "free")
+      expect(ChildAccount.where(id: accounts.map(&:id)).count).to eq(3)
+    end
+
+    it "on re-upgrade restores fallback communicators most-recently-active first" do
+      owner, accounts = pro_owner_with_active(3)
+      owner.update!(plan_type: "free")  # limit 1: keep #0, flag #1 and #2
+
+      owner.update!(plan_type: "basic") # limit 2: restore one more (the next most recent)
+
+      a0, a1, a2 = accounts.map(&:reload)
+      expect(a0.fallback_mode?).to be(false)
+      expect(a1.fallback_mode?).to be(false) # restored (more recently active than a2)
+      expect(a2.fallback_mode?).to be(true)  # still over the Basic limit of 2
+    end
+
+    it "fully restores everyone when the plan can cover all communicators again" do
+      owner, accounts = pro_owner_with_active(3)
+      owner.update!(plan_type: "free")
+      owner.update!(plan_type: "pro") # limit 5 covers all 3
+      expect(accounts.map(&:reload).map(&:fallback_mode?)).to all(be(false))
+    end
+  end
+
+  describe "new Free signup" do
+    it "is capped at 1 communicator and is never flagged into fallback" do
+      free_user = FactoryBot.create(:free_user)
+      account = FactoryBot.create(:child_account, user: free_user, status: ChildAccount::ACTIVE)
+      free_user.reconcile_communicator_fallback!
+      expect(account.reload.fallback_mode?).to be(false)
+    end
+  end
+
+  describe "api_view exposure" do
+    it "surfaces fallback_mode so the frontend can redirect vs error" do
+      owner = FactoryBot.create(:user)
+      owner.update!(plan_type: "pro")
+      account = FactoryBot.create(:child_account, user: owner, status: ChildAccount::ACTIVE)
+      account.enter_fallback!
+      view = account.api_view(owner)
+      expect(view[:fallback_mode]).to be(true)
+      expect(view[:fallback_since]).to be_present
+    end
+  end
+end

--- a/spec/requests/api/v1/child_auths_spec.rb
+++ b/spec/requests/api/v1/child_auths_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+# Private passcode sign-in for communicators, with the fallback-mode gate
+# from issue #255. A fallback communicator (over the Free slot limit after a
+# downgrade) cannot sign in privately and is redirected to its public page.
+RSpec.describe "API::V1::ChildAuths", type: :request do
+  let(:login_path) { "/api/v1/child_accounts/login" }
+
+  def login(account)
+    post login_path, params: { username: account.username, password: account.passcode }
+    JSON.parse(response.body)
+  end
+
+  describe "POST /child_accounts/login" do
+    it "signs in a normal communicator with valid credentials" do
+      owner = FactoryBot.create(:user)
+      owner.update!(plan_type: "pro")
+      account = FactoryBot.create(:child_account, user: owner, status: ChildAccount::ACTIVE,
+                                                  passcode: "secret123")
+
+      body = login(account)
+
+      expect(response).to have_http_status(:ok)
+      expect(body["token"]).to be_present
+    end
+
+    it "blocks a fallback communicator and redirects to the public page" do
+      owner = FactoryBot.create(:user)
+      owner.update!(plan_type: "pro")
+      account = FactoryBot.create(:child_account, user: owner, status: ChildAccount::ACTIVE,
+                                                  passcode: "secret123")
+      account.create_profile!
+      account.enter_fallback!
+      account.reload # pick up the profile association created above
+
+      body = login(account)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(body["error"]).to eq("communicator_in_fallback")
+      expect(account.public_url).to be_present
+      expect(body["redirect_url"]).to eq(account.public_url)
+      expect(body["token"]).to be_nil
+    end
+
+    it "lets a system admin owner bypass the fallback gate (support access)" do
+      admin = FactoryBot.create(:admin_user)
+      account = FactoryBot.create(:child_account, user: admin, status: ChildAccount::ACTIVE,
+                                                  passcode: "secret123")
+      account.enter_fallback!
+
+      body = login(account)
+
+      expect(response).to have_http_status(:ok)
+      expect(body["token"]).to be_present
+    end
+
+    it "returns unauthorized for invalid credentials" do
+      post login_path, params: { username: "nope", password: "wrong" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
Implements the backend checklist on #255 (comment: backend implementation checklist).

## Why
A Basic/Pro account dropping to Free used to strand communicators beyond the Free slot limit. Per the locked decision on #255, a downgrade must never cut a nonspeaking child off mid-use. This retains those communicators and degrades them gracefully to a public, read-only surface instead.

## What changed
- **Retain on downgrade.** Confirmed nothing reaps over-limit communicators on downgrade (both `apply_free_plan` and `DowngradeSoftTrialJob` only flip plan/limits). Locked in with a test.
- **Fallback marker.** `ChildAccount#fallback_mode?` (stored in `settings["fallback_mode"]`, with `fallback_since`/`fallback_reason`) + `enter_fallback!`/`exit_fallback!`. Set **only** by the reconciler, so a fresh Free signup (capped at 1) is never flagged — fallback is only ever a consequence of a downgrade.
- **One reconciler, both directions.** `User#reconcile_communicator_fallback!` orders slotted (loaner+active) communicators most-recently-active first, keeps the top `slot_limit` signable, flags the overflow. Re-upgrade auto-restores most-recently-active first; remainder stays in fallback. Wired via `after_save :reconcile_communicator_fallback!, if: :saved_change_to_plan_type?` — covers Stripe cancel/pause, the soft-trial job, and upgrades (all route through `plan_type=` + `save`).
- **Sign-in gate.** `ChildAccount#can_sign_in?` returns false in fallback (system admin bypasses). `API::V1::ChildAuthsController#create` enforces it *only* for fallback: HTTP **403** `communicator_in_fallback` with `redirect_url`/`public_url`. The older broad disabled check stays disabled, so non-fallback Free communicators keep working (AAC "usage must never break"). Also fixed a latent nil-`user` NPE in the old `can_sign_in?`.
- **API exposure.** `fallback_mode` + `fallback_since` on `api_view` / `index_api_view` / `vendor_api_view` — lets the frontend tell "exists but in fallback" from "doesn't exist" (unblocks itty-bitty-frontend#275).
- **Docs.** CLAUDE.md ("Communicator sign-in on downgrade") + CHANGELOG.

No migration — reuses the existing `child_accounts.settings` jsonb.

## Checklist (#255)
- [x] Retain over-limit communicators on downgrade
- [x] Add a "fallback mode" marker
- [x] Gate private sign-in via `ChildAccount#can_sign_in?`
- [x] Auto-restore on re-upgrade
- [x] Expose fallback state to the API
- [x] Tests

## Test plan
- New: `spec/models/communicator_fallback_spec.rb` (marker, sign-in gate, reconciler ordering, retention, re-upgrade order, new-Free-capped, api_view) and `spec/requests/api/v1/child_auths_spec.rb` (controller 403 + redirect, admin bypass, valid/invalid sign-in).
- Full suite: **1067 examples, 0 failures, 12 pending** (pre-existing placeholders).

Closes #255. Frontend redirect work tracked in itty-bitty-frontend#275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)