### PR TITLE
feat: deterministic Board Builder for linked board sets

### DIFF
--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -1,0 +1,95 @@
+# app/services/boards/board_tree_builder.rb
+#
+# Deterministic backend for the Board Builder. Takes a nested "blueprint"
+# (a root board + linked sub-boards) and persists it as real, linked Board
+# records, then attaches the root to a communicator (child_account) via a
+# ChildBoard join.
+#
+# A tile is a BoardImage. A tile becomes a *folder* when its
+# predictive_board_id points at another board, so "build a set" = create
+# boards, add their tiles, and set predictive_board_id on folder tiles. No
+# new schema. This is unrelated to BoardGroup / board_group_boards.
+#
+# Closest reference in the codebase: Board.from_obf + ObzImporter's
+# create-then-link two-pass.
+#
+# Blueprint shape (input contract — image_ids are already resolved):
+#
+#   { name: "Leo's Home",
+#     tiles: [
+#       { label: "I",    image_id: 101 },
+#       { label: "Food", image_id: 140, children: { name: "Food", tiles: [...] } },
+#     ] }
+#
+# A tile with a `children:` key is a folder; everything else is a leaf.
+module Boards
+  class BoardTreeBuilder
+    # Depth cap lives in exactly ONE place: root + 2 => 3 board levels total.
+    # depth 0 = root; build children only when depth < MAX_DEPTH. A folder tile
+    # at depth 2 stays a leaf (no child board, no link).
+    MAX_DEPTH = 2
+
+    class BuildError < StandardError; end
+
+    def initialize(blueprint, communicator:, favorite_root: false)
+      @blueprint     = blueprint.deep_symbolize_keys
+      @communicator  = communicator
+      @owner         = communicator.owner || communicator.user
+      @favorite_root = favorite_root
+    end
+
+    # Builds the whole tree in a single transaction so a mid-build failure
+    # leaves no orphan boards or dangling ChildBoard. Returns the root Board.
+    def call
+      raise BuildError, "communicator has no owning user" unless @owner
+
+      ActiveRecord::Base.transaction do
+        root = build_board(@blueprint, depth: 0)
+        attach_root_to_communicator(root)
+        root
+      end
+    end
+
+    private
+
+    # Depth-first: build the child board first, then point the parent tile's
+    # predictive_board_id at it (can't link to a board that doesn't exist yet).
+    def build_board(node, depth:)
+      board = Board.new(name: node[:name], user: @owner)
+      board.board_type = board_type_for(node, depth) # "dynamic" or "static"
+      board.assign_parent                            # => parent is the owning User
+      board.voice = VoiceService.normalize_voice(@communicator.voice)
+      board.generate_unique_slug
+      board.save!
+
+      Array(node[:tiles]).each do |tile|
+        # add_image resolves the Image and sets label/voice/part-of-speech/
+        # colors/layout. It also enqueues a SaveAudioJob via BoardImage's
+        # after_create — expected fan-out, runs post-commit.
+        board_image = board.add_image(tile[:image_id])
+        raise BuildError, "image #{tile[:image_id].inspect} not found" if board_image.nil?
+
+        if tile[:children] && depth < MAX_DEPTH
+          child = build_board(tile[:children], depth: depth + 1)
+          board_image.update!(predictive_board_id: child.id) # link folder -> child
+        end
+      end
+
+      board
+    end
+
+    def attach_root_to_communicator(root)
+      child_board = @communicator.child_boards.create!(board: root, created_by_id: @owner&.id)
+      child_board.update!(favorite: true) if @favorite_root
+      child_board
+    end
+
+    # User-owned boards: use "dynamic" when this board links children, else
+    # "static". Both route Board#assign_parent to the owning User (not an Image,
+    # which "category"/"predictive" board_types would create).
+    def board_type_for(node, depth)
+      links_children = depth < MAX_DEPTH && Array(node[:tiles]).any? { |t| t[:children] }
+      links_children ? "dynamic" : "static"
+    end
+  end
+end

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -48,7 +48,7 @@ module Boards
     end
 
     def resolve_tile(tile, user)
-      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id]).first
+      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id, User::DEFAULT_ADMIN_ID], private: [nil, false]).first
       raise "Boards::StarterBlueprints: no Image for label #{tile[:label].inspect}" unless image
 
       resolved = { label: tile[:label], image_id: image.id }

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -48,7 +48,7 @@ module Boards
     end
 
     def resolve_tile(tile, user)
-      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id, User::DEFAULT_ADMIN_ID], private: [nil, false]).first
+      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id, User::DEFAULT_ADMIN_ID], is_private: [nil, false]).first
       raise "Boards::StarterBlueprints: no Image for label #{tile[:label].inspect}" unless image
 
       resolved = { label: tile[:label], image_id: image.id }

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -1,0 +1,67 @@
+# app/services/boards/starter_blueprints.rb
+#
+# Hardcoded starter blueprints for exercising Boards::BoardTreeBuilder end to
+# end. Trees are defined by *label* (DB-portable) and a dev helper resolves each
+# label -> Image#id for a given user at call time, returning a builder-ready
+# blueprint of resolved image_ids.
+#
+# NOTE: the label -> image_id step is intentionally OUTSIDE the builder. The
+# builder's input contract is a blueprint of already-resolved image_ids;
+# real label->image_id resolution (against interests, AI, etc.) is a separate
+# seam not built here.
+#
+# Console exercise:
+#   Boards::BoardTreeBuilder.new(
+#     Boards::StarterBlueprints.home(user), communicator: child
+#   ).call
+module Boards
+  module StarterBlueprints
+    HOME = {
+      name: "Home",
+      tiles: [
+        { label: "I" }, { label: "want" }, { label: "more" }, { label: "help" },
+        { label: "yes" }, { label: "no" },
+        { label: "Food", children: { name: "Food",
+                                      tiles: [{ label: "apple" }, { label: "water" }, { label: "snack" }] } },
+        { label: "Feelings", children: { name: "Feelings",
+                                         tiles: [{ label: "happy" }, { label: "sad" }, { label: "tired" }] } },
+      ],
+    }.freeze
+
+    DAILY_ROUTINE = {
+      name: "My Day",
+      tiles: [
+        { label: "morning" }, { label: "school" }, { label: "play" }, { label: "bed" },
+        { label: "Bathroom", children: { name: "Bathroom",
+                                         tiles: [{ label: "toilet" }, { label: "wash" }, { label: "all done" }] } },
+      ],
+    }.freeze
+
+    module_function
+
+    # Resolve a label-based tree into a builder-ready blueprint for `user`.
+    def resolve(tree, user)
+      {
+        name: tree[:name],
+        tiles: Array(tree[:tiles]).map { |tile| resolve_tile(tile, user) },
+      }
+    end
+
+    def resolve_tile(tile, user)
+      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id]).first
+      raise "Boards::StarterBlueprints: no Image for label #{tile[:label].inspect}" unless image
+
+      resolved = { label: tile[:label], image_id: image.id }
+      resolved[:children] = resolve(tile[:children], user) if tile[:children]
+      resolved
+    end
+
+    def home(user)
+      resolve(HOME, user)
+    end
+
+    def daily_routine(user)
+      resolve(DAILY_ROUTINE, user)
+    end
+  end
+end

--- a/spec/services/boards/board_tree_builder_spec.rb
+++ b/spec/services/boards/board_tree_builder_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe Boards::BoardTreeBuilder, type: :service do
+  let(:owner) { create(:user) }
+  let(:communicator) { create(:child_account, user: owner) }
+
+  # Each tile needs a real persisted Image (board_images.image_id is NOT NULL).
+  # Helper resolves a label to a freshly-created image id for this owner.
+  def image_id_for(label)
+    create(:image, label: label, user_id: owner.id).id
+  end
+
+  describe "#call" do
+    it "builds a real 3-level linked set with correct predictive_board_id links" do
+      blueprint = {
+        name: "Home",
+        tiles: [
+          { label: "I", image_id: image_id_for("I") },
+          { label: "Food", image_id: image_id_for("Food"), children: {
+            name: "Food",
+            tiles: [
+              { label: "apple", image_id: image_id_for("apple") },
+              { label: "Drinks", image_id: image_id_for("Drinks"), children: {
+                name: "Drinks",
+                tiles: [
+                  { label: "water", image_id: image_id_for("water") },
+                  { label: "juice", image_id: image_id_for("juice") },
+                ],
+              } },
+            ],
+          } },
+        ],
+      }
+
+      root = described_class.new(blueprint, communicator: communicator).call
+
+      expect(root).to be_a(Board)
+      expect(root.name).to eq("Home")
+
+      # Root's folder tile links to the Food board.
+      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      expect(food_tile.predictive_board_id).to be_present
+      expect(food_tile.is_dynamic?).to be(true)
+
+      food_board = Board.find(food_tile.predictive_board_id)
+      expect(food_board.name).to eq("Food")
+
+      # Food board's folder tile links to the Drinks board (level 3).
+      drinks_tile = food_board.board_images.find { |bi| bi.label == "Drinks" }
+      expect(drinks_tile.predictive_board_id).to be_present
+      expect(drinks_tile.is_dynamic?).to be(true)
+
+      drinks_board = Board.find(drinks_tile.predictive_board_id)
+      expect(drinks_board.name).to eq("Drinks")
+      expect(drinks_board.board_images.map(&:label)).to contain_exactly("water", "juice")
+
+      # Leaf tiles never get a predictive board.
+      i_tile = root.board_images.find { |bi| bi.label == "I" }
+      expect(i_tile.predictive_board_id).to be_nil
+    end
+
+    it "attaches only the root to the communicator via ChildBoard" do
+      blueprint = {
+        name: "Home",
+        tiles: [
+          { label: "Food", image_id: image_id_for("Food"), children: {
+            name: "Food",
+            tiles: [{ label: "apple", image_id: image_id_for("apple") }],
+          } },
+        ],
+      }
+
+      root = nil
+      expect { root = described_class.new(blueprint, communicator: communicator).call }
+        .to change { communicator.child_boards.count }.by(1)
+
+      communicator.reload
+      expect(communicator.boards).to include(root)
+
+      # Sub-boards are reachable only via predictive_board_id, not joined.
+      sub_board_ids = Board.where(user_id: owner.id).where.not(id: root.id).pluck(:id)
+      expect(communicator.boards.pluck(:id)).not_to include(*sub_board_ids)
+      expect(communicator.child_boards.first.favorite).to be(false)
+    end
+
+    it "honors the depth cap: a folder tile at depth 2 stays a leaf" do
+      blueprint = {
+        name: "Level0",
+        tiles: [
+          { label: "A", image_id: image_id_for("A"), children: {
+            name: "Level1",
+            tiles: [
+              { label: "B", image_id: image_id_for("B"), children: {
+                name: "Level2",
+                tiles: [
+                  # This folder tile sits at depth 2 -> must stay a leaf.
+                  { label: "C", image_id: image_id_for("C"), children: {
+                    name: "Level3",
+                    tiles: [{ label: "D", image_id: image_id_for("D") }],
+                  } },
+                ],
+              } },
+            ],
+          } },
+        ],
+      }
+
+      described_class.new(blueprint, communicator: communicator).call
+
+      built = Board.where(user_id: owner.id)
+      # Only root + level1 + level2 — Level3 is never built.
+      expect(built.count).to eq(3)
+      expect(built.pluck(:name)).to contain_exactly("Level0", "Level1", "Level2")
+
+      level2 = built.find_by(name: "Level2")
+      c_tile = level2.board_images.find { |bi| bi.label == "C" }
+      expect(c_tile.predictive_board_id).to be_nil
+    end
+
+    it "gives every board a unique, non-blank slug" do
+      blueprint = {
+        name: "Home",
+        tiles: [
+          { label: "Food", image_id: image_id_for("Food"), children: {
+            name: "Food",
+            tiles: [
+              { label: "Drinks", image_id: image_id_for("Drinks"), children: {
+                name: "Drinks",
+                tiles: [{ label: "water", image_id: image_id_for("water") }],
+              } },
+            ],
+          } },
+        ],
+      }
+
+      described_class.new(blueprint, communicator: communicator).call
+
+      slugs = Board.where(user_id: owner.id).pluck(:slug)
+      expect(slugs.size).to eq(3)
+      expect(slugs).to all(be_present)
+      expect(slugs.uniq.size).to eq(slugs.size)
+    end
+
+    it "rolls the whole build back when a tile fails mid-build" do
+      blueprint = {
+        name: "Home",
+        tiles: [
+          { label: "I", image_id: image_id_for("I") },
+          { label: "Food", image_id: image_id_for("Food"), children: {
+            name: "Food",
+            tiles: [
+              { label: "apple", image_id: image_id_for("apple") },
+              # Bogus image_id -> add_image fails after several boards exist.
+              { label: "broken", image_id: 999_999_999 },
+            ],
+          } },
+        ],
+      }
+
+      builder = described_class.new(blueprint, communicator: communicator)
+
+      expect { builder.call rescue nil }.not_to change { Board.where(user_id: owner.id).count }
+      expect { builder.call rescue nil }.not_to change { ChildBoard.count }
+      expect { builder.call }.to raise_error(StandardError)
+    end
+
+    it "raises when the communicator has no owning user" do
+      ownerless = create(:child_account, user: nil)
+      blueprint = { name: "Home", tiles: [] }
+
+      expect { described_class.new(blueprint, communicator: ownerless).call }
+        .to raise_error(Boards::BoardTreeBuilder::BuildError, /owning user/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the **deterministic backend half** of the Board Builder: a service that takes a nested *blueprint* (a root board + linked sub-boards) and persists it as real, linked `Board` records, then attaches the root to a communicator (`child_account`) via a `ChildBoard` join.

This is the deterministic half only — **no wizard UI, no AI/smart generation, no label→image_id resolution**. The blueprint carries already-resolved `image_id`s.

The one model fact: a tile is a `BoardImage`; a tile becomes a *folder* when its `predictive_board_id` points at another board. So "build a set" = create boards, add tiles, set `predictive_board_id` on folder tiles. **No new schema.** This is unrelated to `BoardGroup` / `board_group_boards` (a separate feature, deliberately untouched).

## What changed

- **`app/services/boards/board_tree_builder.rb`** — `Boards::BoardTreeBuilder.new(blueprint, communicator:).call` returns the root `Board`.
  - Recursive depth-first: build the child board first, then point the parent folder tile's `predictive_board_id` at it.
  - Single `MAX_DEPTH = 2` constant → root + 2 (3 board levels); a folder tile at depth 2 stays a leaf.
  - Boards owned by `communicator.owner || communicator.user` (`parent_type: "User"` via `assign_parent` using `static`/`dynamic` board_type, never an Image parent). Mirrors the controller sequence `Board.new → assign_parent → generate_unique_slug → save!`, then `add_image` per tile.
  - Whole build wrapped in one `ActiveRecord::Base.transaction`; raises on a missing image so a mid-build failure rolls back with no orphan boards or dangling `ChildBoard`.
  - Only the root is joined via `ChildBoard` (sub-boards are reached via `predictive_board_id`); `favorite_root:` defaults to `false`.
- **`app/services/boards/starter_blueprints.rb`** — label-based starter trees (`HOME`, `DAILY_ROUTINE`) plus a dev helper resolving labels → `image_id` at call time. Label resolution stays *outside* the builder, preserving its resolved-`image_id` input contract.
- **`spec/services/boards/board_tree_builder_spec.rb`** — tests (see plan below).

## Why

Closest existing reference is `Board.from_obf` + `ObzImporter#link_dynamic_boards!` (same create-then-link two-pass). This service generalizes that pattern for building a fresh linked set for a communicator from a blueprint.

## Reviewer notes

- Audio fan-out is expected: `add_image` enqueues a `SaveAudioJob` per tile via `BoardImage`'s `after_create` (runs post-commit). A large set fans out many jobs.
- Purely additive — no existing files touched, so no regression surface. Not yet wired to any route/controller (backend half only); `CLAUDE.md` will get a subsystem note when an endpoint lands.

## Test plan

`bundle exec rspec spec/services/boards/board_tree_builder_spec.rb` → **6 examples, 0 failures.** Proves:
- a real 3-level linked set lands with correct `predictive_board_id` links (`is_dynamic?` true),
- only the root is attached via `ChildBoard` (sub-boards reached via predictive links),
- the depth cap holds (depth-2 folder tile stays a leaf),
- every board gets a unique, non-blank slug,
- a mid-build failure rolls the whole thing back (no orphan boards, no dangling `ChildBoard`),
- ownerless communicator raises a clear `BuildError`.

(Run with CI dummy secrets: `SECRET_KEY_BASE`, `DEVISE_JWT_SECRET_KEY`, `RAILS_MASTER_KEY=""`.)

## Out of scope (left as seams)

Wizard UI; AI/interest-driven blueprint generation; label→image_id resolution inside the builder; shared sub-boards (DAG — v1 is a strict tree); per-tile label/voice overrides (`add_image` derives the label from the `Image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)