### PR TITLE
fix: count scalar board_ids correctly in sandbox assign_boards cap

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -448,6 +448,16 @@ class API::ChildAccountsController < API::ApplicationController
 
   def assign_boards
     board_ids = params[:board_ids]
+    if board_ids.blank?
+      render json: { error: "No board_ids provided" }, status: :unprocessable_entity
+      return
+    end
+
+    # Normalize a single id (String/Integer) to an array *before* counting,
+    # so the sandbox limit check below counts boards — not the characters of
+    # a bare string id (e.g. "123".size == 3 would corrupt the cap check).
+    board_ids = Array(board_ids).map(&:to_i)
+
     total_boards = @child_account.child_boards.count + board_ids.size
     if @child_account.sandbox?
       demo_limit = (@child_account.settings["demo_board_limit"] || ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT).to_i
@@ -456,19 +466,13 @@ class API::ChildAccountsController < API::ApplicationController
         return
       end
     end
-    if board_ids
-      if board_ids.is_a?(String) || board_ids.is_a?(Integer)
-        board_ids = [board_ids.to_i]
-      end
-      board_ids.each do |board_id|
-        board = Board.find(board_id)
-        voice = @child_account.voice || "polly:kevin"
-        child_board_copy = board.clone_with_images(current_user&.id, board.name, voice, @child_account)
-      end
-      render json: @child_account.api_view(current_user), status: :ok
-    else
-      render json: { error: "No board_ids provided" }, status: :unprocessable_entity
+
+    board_ids.each do |board_id|
+      board = Board.find(board_id)
+      voice = @child_account.voice || "polly:kevin"
+      board.clone_with_images(current_user&.id, board.name, voice, @child_account)
     end
+    render json: @child_account.api_view(current_user), status: :ok
   end
 
   # DELETE /child_accounts/1

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -96,6 +96,55 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
     end
   end
 
+  # Sandbox accounts are capped server-side (settings["demo_board_limit"],
+  # default ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT). The cap must count
+  # *boards*, not the characters of a scalar id — board_ids can arrive as a
+  # single value rather than an array, and an earlier version measured its
+  # `.size` before normalizing, so "42" counted as 2 boards.
+  describe "POST /api/child_accounts/:id/assign_boards (sandbox limit)" do
+    let!(:sandbox) do
+      create(:child_account,
+             user: parent,
+             owner: parent,
+             status: ChildAccount::SANDBOX,
+             settings: { "demo_board_limit" => 1 })
+    end
+    # Multi-digit id so a `.size`-on-string regression (2) differs from the
+    # real count (1) and would trip the cap incorrectly.
+    let!(:public_board) { Board.create!(id: 90_001, user: slp, name: "Public Board", number_of_columns: 3, predefined: true) }
+
+    it "counts a single (scalar) board id as one board against the cap" do
+      expect {
+        post "/api/child_accounts/#{sandbox.id}/assign_boards",
+             params: { board_ids: public_board.id },
+             headers: auth_headers(parent)
+      }.to change { sandbox.reload.child_boards.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects with 422 once the sandbox is over its board limit" do
+      sandbox.update!(settings: { "demo_board_limit" => 0 })
+
+      expect {
+        post "/api/child_accounts/#{sandbox.id}/assign_boards",
+             params: { board_ids: [public_board.id] },
+             headers: auth_headers(parent)
+      }.not_to change { sandbox.reload.child_boards.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/Demo board limit exceeded/)
+    end
+
+    it "returns 422 when no board_ids are provided" do
+      post "/api/child_accounts/#{sandbox.id}/assign_boards",
+           headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("No board_ids provided")
+    end
+  end
+
   describe "POST /api/child_accounts/:id/send_setup_email" do
     before do
       mailer = double("CommunicationAccountMailer", deliver_later: true)


### PR DESCRIPTION
## What

`POST /api/child_accounts/:id/assign_boards` measured `params[:board_ids].size` **before** normalizing a scalar id to an array. When `board_ids` arrived as a single bare value instead of an array (e.g. `"42"`), `.size` returned the string length (2), so one board counted as two against the sandbox `demo_board_limit` — falsely tripping the cap. A `nil` `board_ids` also crashed on `.size` before reaching the "No board_ids provided" branch.

The fix normalizes `board_ids` to an array of ints up front (`Array(board_ids).map(&:to_i)`) and guards the blank case, so the limit check counts boards regardless of how the client serializes the param.

## Why

Surfaced while confirming the backend dependency called out in frontend [PR #284](https://github.com/brittanyjohns/itty-bitty-frontend/pull/284), which assigns public-library boards to communicators (including sandbox/MySpeak Free accounts). The sandbox cap is enforced here, so the miscount could reject a legitimate single-board assign. The public-board assign itself already works — `Board.find` is unscoped and the board is cloned for the communicator, so ownership of the source board is irrelevant.

## Notes for reviewer

- Behavior is unchanged when the frontend sends `board_ids` as an array (which it does today) — this is correctness + defense-in-depth for the scalar path.
- No new assignment plumbing; only the count/guard logic changed.

## Test plan

Added a `sandbox limit` block to `spec/requests/api/child_accounts_owner_protection_spec.rb`:
- scalar (non-array) board id counts as **one** board against the cap (regression — uses a forced multi-digit board id so it deterministically failed under the old code),
- over-limit sandbox returns 422 `Demo board limit exceeded`,
- missing `board_ids` returns 422 `No board_ids provided`.

`bundle exec rspec spec/requests/api/child_accounts_owner_protection_spec.rb` → **12 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)