### PR TITLE
fix(communicators): Free self-creates are always no-login sandbox accounts

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -300,6 +300,12 @@ class API::ChildAccountsController < API::ApplicationController
     is_demo = params[:is_demo] ? ActiveModel::Type::Boolean.new.cast(params[:is_demo]) : false
     # Prefer the explicit lifecycle status param; fall back to legacy is_demo.
     requested_status = params[:status].presence || (is_demo ? ChildAccount::SANDBOX : ChildAccount::ACTIVE)
+    # A Free user never self-creates a full communicator — every self-create is a
+    # no-login sandbox "MySpeak Free account" (full login is claim/hand-off only).
+    requested_status = Permissions::CommunicatorLimits.self_create_status(
+      user: current_user,
+      requested: requested_status,
+    )
 
     allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
       user: current_user,
@@ -395,15 +401,26 @@ class API::ChildAccountsController < API::ApplicationController
     requested_status = params[:status].presence || (is_demo ? ChildAccount::SANDBOX : ChildAccount::ACTIVE)
     @child_account.status = requested_status
     if was_sandbox && requested_status != ChildAccount::SANDBOX
-      # Promoting sandbox → loaner/active — re-check slot limits.
-      allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
+      # A Free user can't self-promote a sandbox into a full communicator
+      # (claim/hand-off only) — keep it a sandbox. Paid plans may promote, so
+      # re-check slot limits. Only the sandbox→active path is touched here, so
+      # an existing claimed/active communicator is never demoted.
+      requested_status = Permissions::CommunicatorLimits.self_create_status(
         user: current_user,
-        status: requested_status,
+        requested: requested_status,
       )
+      @child_account.status = requested_status
 
-      unless allowed
-        render json: { error: error }, status: http_status
-        return
+      if requested_status != ChildAccount::SANDBOX
+        allowed, http_status, error = Permissions::CommunicatorLimits.can_create?(
+          user: current_user,
+          status: requested_status,
+        )
+
+        unless allowed
+          render json: { error: error }, status: http_status
+          return
+        end
       end
     end
 

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -16,13 +16,18 @@ module API
             return
           end
 
-          # Slot check — the wizard creates a real owned (active) communicator,
-          # not a Pro-only sandbox scratch space. Free has 1 slot by default
-          # (FREE_PAID_COMMUNICATOR_LIMIT); over-cap is 422.
+          # A self-create's status is plan-driven: a Free user's MySpeak account
+          # is a no-login sandbox ("MySpeak Free account"); paid plans get a real
+          # owned (active) communicator. Free's one full slot is claim/hand-off
+          # only (see Permissions::CommunicatorLimits). Over-cap is 422.
+          status = Permissions::CommunicatorLimits.self_create_status(
+            user: current_user,
+            requested: ChildAccount::ACTIVE,
+          )
           allowed, http_status, slot_error =
             Permissions::CommunicatorLimits.can_create?(
               user: current_user,
-              status: ChildAccount::ACTIVE,
+              status: status,
             )
           unless allowed
             render json: { error: "communicator_slot_unavailable", message: slot_error },
@@ -54,14 +59,15 @@ module API
             # explicitly so downstream `api_view`s (which read
             # `child.user.pro?` etc.) don't see a nil user.
             #
-            # Status MUST be ACTIVE — sandbox is the no-login Pro scratch
-            # space and is filtered out of the family dashboard. The
-            # MySpeak wizard is the family's first real communicator.
+            # `status` is plan-driven (see above): a Free user's MySpeak account
+            # is a no-login sandbox; paid plans get a full (active) communicator.
+            # Sandbox communicators still appear on the family dashboard — the
+            # index lists every owned account regardless of status.
             child = current_user.communicator_accounts.create!(
               name: name,
               username: unique,
               user: current_user,
-              status: ChildAccount::ACTIVE,
+              status: status,
             )
 
             profile = Profile.new(

--- a/app/helpers/permissions/communicator_limits.rb
+++ b/app/helpers/permissions/communicator_limits.rb
@@ -4,8 +4,10 @@ module Permissions
 
     # Slot math:
     #
-    #   Free  — 1 communicator (self-created or claimed). Plus the no-login
-    #           sandbox.
+    #   Free  — 1 full (login) communicator, CLAIM/HAND-OFF ONLY. A Free user
+    #           never self-creates a full communicator: every self-create is a
+    #           no-login sandbox "MySpeak Free account" (see self_create_status).
+    #           The 1 paid slot only ever fills via a claim (see can_claim?).
     #   Basic — 2 communicators (loaner + active total).
     #   Pro   — 5 communicators, loaner-capable, recycling.
     #
@@ -43,6 +45,19 @@ module Permissions
       return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if owned_count >= slot_limit
 
       [true, :ok, nil]
+    end
+
+    # The status a *self-created* communicator must take for this user. A Free
+    # user never self-creates a full (login) communicator — their one paid slot
+    # is reserved for a claim/hand-off (see can_claim?) — so every self-create
+    # (the generic create form AND the MySpeak onboarding wizard) is forced to a
+    # no-login sandbox "MySpeak Free account", regardless of what was requested.
+    # Paid plans self-create whatever they asked for. The frontend mirrors this
+    # in communicator_status.defaultSelfCreateIsSandbox.
+    def self_create_status(user:, requested:)
+      return ChildAccount::SANDBOX if user&.free?
+
+      requested
     end
 
     # The total non-sandbox slots a user occupies right now. Used by the

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -272,7 +272,10 @@ class User < ApplicationRecord
   # Communicator slot math:
   #
   #   paid_communicator_limit — total owned `loaner` + `active` slots.
-  #                             Free has 1 (self-created or claimed).
+  #                             Free has 1, CLAIM/HAND-OFF ONLY — a Free user
+  #                             never self-creates into it (self-creates are
+  #                             always no-login sandboxes; see
+  #                             Permissions::CommunicatorLimits.self_create_status).
   #   demo_communicator_limit — sandbox (no-login, board-capped) slots.
   #
   # `Permissions::CommunicatorLimits.self_create_allowed?` returns true

--- a/lib/tasks/communicators.rake
+++ b/lib/tasks/communicators.rake
@@ -1,0 +1,44 @@
+namespace :communicators do
+  # Backfill for the create-path fix: before this, a Free user's self-created
+  # communicator (generic form OR MySpeak onboarding wizard) was created as a
+  # full `active` login account instead of a no-login sandbox. This converts
+  # those stray self-creates to sandbox so they render as "MySpeak Free
+  # accounts" and stop offering sign-in.
+  #
+  # SAFE BY DESIGN: only touches comms owned by a Free user that were never
+  # claimed (claimed_at IS NULL). A claimed/hand-off communicator keeps its
+  # login — those are exactly the ones a Free family is meant to sign into — so
+  # claimed_at-present comms are skipped.
+  #
+  # Dry-run by default. Apply with DRY_RUN=false:
+  #   rake communicators:convert_free_self_created_to_sandbox            # preview
+  #   DRY_RUN=false rake communicators:convert_free_self_created_to_sandbox
+  desc "Convert Free users' never-claimed active/loaner self-creates to no-login sandbox (DRY_RUN=false to apply)"
+  task convert_free_self_created_to_sandbox: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    free_user_ids = User.where(plan_type: "free").select(:id)
+    scope = ChildAccount
+      .where(status: [ChildAccount::ACTIVE, ChildAccount::LOANER])
+      .where(claimed_at: nil)
+      .where(owner_id: free_user_ids)
+
+    total = scope.count
+    puts "#{dry_run ? '[DRY RUN] ' : ''}#{total} communicator(s) to convert to sandbox"
+
+    converted = 0
+    scope.find_each do |ca|
+      puts "  ##{ca.id} #{ca.name.inspect} (owner #{ca.owner_id}) #{ca.status} -> sandbox"
+      unless dry_run
+        ca.update!(status: ChildAccount::SANDBOX, passcode: nil)
+        converted += 1
+      end
+    end
+
+    if dry_run
+      puts "Dry run only — re-run with DRY_RUN=false to apply."
+    else
+      puts "Converted #{converted} communicator(s) to sandbox."
+    end
+  end
+end

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 
 RSpec.describe Permissions::CommunicatorLimits do
   # Slot math:
-  #   Free  — 1 communicator (self-created or claimed); +1 sandbox.
+  #   Free  — 1 full communicator, CLAIM/HAND-OFF ONLY; +1 sandbox self-create.
+  #           (`can_create?` reports the active slot as available capacity, but a
+  #           self-create is coerced to sandbox by `.self_create_status`.)
   #   Basic — 2 self-created.
   #   Pro   — 3 self-created, loaner-capable.
 
@@ -33,7 +35,10 @@ RSpec.describe Permissions::CommunicatorLimits do
         expect(error).to match(/limit reached/i)
       end
 
-      it "allows self-creating one active communicator (Free gets 1 slot)" do
+      it "reports the active slot as available capacity (the slot a claim fills)" do
+        # `can_create?` is a pure capacity check — the Free user has 1 active
+        # slot. Whether a *self-create* may take it is the separate policy in
+        # `.self_create_status` (it can't: self-creates are coerced to sandbox).
         allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
 
         expect(allowed).to be(true)
@@ -99,6 +104,36 @@ RSpec.describe Permissions::CommunicatorLimits do
         expect(allowed).to be(false)
         expect(http_status).to eq(:unprocessable_entity)
       end
+    end
+  end
+
+  describe ".self_create_status" do
+    it "forces a Free user's self-create to sandbox, whatever was requested" do
+      user = create(:user, created_at: 2.months.ago)
+      user.setup_free_limits
+      user.save!
+
+      expect(
+        described_class.self_create_status(user: user, requested: ChildAccount::ACTIVE),
+      ).to eq(ChildAccount::SANDBOX)
+      expect(
+        described_class.self_create_status(user: user, requested: ChildAccount::LOANER),
+      ).to eq(ChildAccount::SANDBOX)
+      expect(
+        described_class.self_create_status(user: user, requested: ChildAccount::SANDBOX),
+      ).to eq(ChildAccount::SANDBOX)
+    end
+
+    it "leaves a paid user's requested status untouched" do
+      basic = create(:user, plan_type: "basic", created_at: 2.months.ago)
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+
+      expect(
+        described_class.self_create_status(user: basic, requested: ChildAccount::ACTIVE),
+      ).to eq(ChildAccount::ACTIVE)
+      expect(
+        described_class.self_create_status(user: pro, requested: ChildAccount::ACTIVE),
+      ).to eq(ChildAccount::ACTIVE)
     end
   end
 

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -32,16 +32,19 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it "allows self-creating one non-sandbox communicator on Free" do
+      it "coerces a Free user's active self-create into a no-login sandbox" do
         post "/api/child_accounts",
           params: { name: "Real", username: "real-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
         expect(response).to have_http_status(:created)
+        # Free self-creates are always sandbox — full login is claim/hand-off only.
+        account = ChildAccount.where(owner_id: user.id).order(:created_at).last
+        expect(account.status).to eq(ChildAccount::SANDBOX)
       end
 
-      it "blocks a second non-sandbox communicator once the Free slot is used" do
-        create(:child_account, user: user, owner: user, status: ChildAccount::ACTIVE)
+      it "blocks a Free user's active self-create once the sandbox slot is used (it's coerced to sandbox)" do
+        create(:child_account, user: user, owner: user, status: ChildAccount::SANDBOX)
 
         post "/api/child_accounts",
           params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
     end
 
     context "happy path" do
-      it "creates an active child account + safety profile, attaches avatar, writes settings, sets up a team" do
+      it "creates a no-login sandbox (MySpeak Free) child account + safety profile, attaches avatar, writes settings, sets up a team" do
         expect {
           post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
         }.to change { user.communicator_accounts.count }.by(1)
@@ -63,7 +63,9 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         child = user.communicator_accounts.order(:created_at).last
         expect(child.name).to eq("River Stone")
         expect(child.username).to eq("river-stone")
-        expect(child.status).to eq(ChildAccount::ACTIVE)
+        # A Free user's self-created MySpeak account is a no-login sandbox —
+        # full login only ever arrives via claim/hand-off.
+        expect(child.status).to eq(ChildAccount::SANDBOX)
 
         team = child.teams.first
         expect(team).to be_present
@@ -88,6 +90,22 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(body["profile_kind"]).to eq("safety")
         expect(body["settings"]["pronouns"]).to eq("they/them")
         expect(body["settings"]["ice_contact_1"]["phone"]).to eq("555-0101")
+      end
+    end
+
+    context "paid user" do
+      let(:user) do
+        u = FactoryBot.create(:user)
+        u.update_columns(plan_type: "pro", created_at: 60.days.ago)
+        u
+      end
+
+      it "creates a full (active) communicator — only Free self-creates are sandboxed" do
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        child = user.communicator_accounts.order(:created_at).last
+        expect(child.status).to eq(ChildAccount::ACTIVE)
       end
     end
 
@@ -272,12 +290,13 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
 
     context "free user has no available communicator slot" do
       it "returns 422 communicator_slot_unavailable" do
-        # Free's default paid_communicator_limit is 1. Take it.
+        # A Free MySpeak account is a no-login sandbox, so the binding limit is
+        # the sandbox slot (demo_communicator_limit = 1). Take it.
         FactoryBot.create(
           :child_account,
           user: user,
           owner: user,
-          status: ChildAccount::ACTIVE,
+          status: ChildAccount::SANDBOX,
         )
 
         post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers


### PR DESCRIPTION
## What

A new Free user's self-created communicator was created as a full, signing-in `active` account instead of a no-login sandbox **MySpeak Free account**. On the family dashboard / view page this surfaced as "Full communicator" + Sign-in/Set-passcode (e.g. communicator #193).

Two self-create paths caused it:
- The **MySpeak onboarding wizard** (`API::V1::Onboarding::Myspeak#create`) hard-coded `status: ChildAccount::ACTIVE`, with a comment asserting the family's first communicator must be a real login account.
- The generic `child_accounts#create` defaulted to `active` when no explicit status was sent.

The frontend then correctly rendered the `active` comm as a full communicator — so the bug was in creation, not display.

## Policy

**Free self-creates are always no-login sandbox accounts; a full-login communicator only ever arrives via claim/hand-off.** The single Free paid slot is claim-only.

## Changes

- **`Permissions::CommunicatorLimits.self_create_status(user:, requested:)`** — the canonical policy: returns `SANDBOX` for a Free user, else the requested status.
- Applied in:
  - `child_accounts#create` (every self-create)
  - `child_accounts#update` — **only** the sandbox→active promotion branch, so an existing claimed/active communicator is never demoted
  - the **MySpeak onboarding wizard** (now plan-driven: Free → sandbox, paid → active)
- `can_create?` left unchanged as a pure **capacity** check (still used by provisioning/recycle paths).
- **De-drift:** updated the now-stale comments/spec text that said Free gets a self-created full communicator — `communicator_limits.rb`, `myspeak_controller.rb`, `user.rb`, and `communicator_limits_spec.rb`.
- **Cleanup:** `rake communicators:convert_free_self_created_to_sandbox` — dry-run by default; only touches **Free-owned, never-claimed** (`claimed_at IS NULL`) communicators, so claimed/hand-off comms keep their login. Apply with `DRY_RUN=false`.

## Migration note

After deploy, run the cleanup task to fix existing stray comms (incl. #193):

```
DRY_RUN=false rake communicators:convert_free_self_created_to_sandbox
```

(Run without `DRY_RUN` first to preview.)

## Reviewer notes

- Frontend companion PR: brittanyjohns/itty-bitty-frontend#285 (mirrors the rule in `defaultSelfCreateIsSandbox`). The server-side enforcement here is what makes the policy hold regardless of client.

## Test plan

- `bundle exec rspec` on the affected + adjacent suites — green:
  - `spec/helpers/permissions/communicator_limits_spec.rb` (new `self_create_status` cases)
  - `spec/requests/api/v1/onboarding/myspeak_spec.rb` (Free → sandbox, paid → active, slot-unavailable)
  - `spec/requests/api/child_accounts_demo_limit_spec.rb` (create coercion)
  - claim / promote / archive / owner-protection / lifecycle / status specs — 82 passing, 0 failures
- Rake task syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)