### PR TITLE
feat(board-builder): hybrid wizard endpoint + blueprint assembler

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -1,0 +1,55 @@
+module API
+  module V1
+    # Board Builder wizard endpoint (standalone — NOT part of MySpeak onboarding).
+    #
+    #   GET  /api/v1/board_builder/templates  -> picker catalog (no auth-sensitive data)
+    #   POST /api/v1/board_builder            -> build a linked board set for a communicator
+    #
+    # Flow: BlueprintAssembler turns {template, interests} into a builder-ready
+    # blueprint, BoardTreeBuilder persists the linked tree and attaches the root
+    # to the communicator, and we stash the normalized interests on the
+    # communicator so the wizard can be re-run / pre-filled.
+    class BoardBuilderController < API::ApplicationController
+      # Label-only template catalog for the picker grid.
+      def templates
+        render json: { templates: Boards::StarterBlueprints.catalog }, status: :ok
+      end
+
+      def create
+        communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
+        unless communicator
+          render json: { error: "communicator_not_found",
+                         message: "We couldn't find that communicator on your account." },
+                 status: :not_found
+          return
+        end
+
+        assembler = Boards::BlueprintAssembler.new(
+          template:  params[:template],
+          interests: params[:interests],
+          user:      current_user,
+        )
+        blueprint = assembler.call
+
+        root = Boards::BoardTreeBuilder.new(
+          blueprint, communicator: communicator, favorite_root: true,
+        ).call
+
+        # Persist the normalized interests for re-runs (jsonb merge, non-destructive).
+        communicator.update!(details: (communicator.details || {}).merge("interests" => assembler.interests))
+
+        render json: root.api_view(current_user), status: :created
+      rescue Boards::BlueprintAssembler::UnknownTemplate => e
+        Rails.logger.warn "[BoardBuilder] #{e.message}"
+        render json: { error: "unknown_template",
+                       message: "That template isn't available. Pick one from the list and try again." },
+               status: :unprocessable_entity
+      rescue Boards::BoardTreeBuilder::BuildError => e
+        Rails.logger.warn "[BoardBuilder] build failed: #{e.message}"
+        render json: { error: "build_failed",
+                       message: "Something went wrong building the board set — your info is safe, give it another try." },
+               status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/services/boards/blueprint_assembler.rb
+++ b/app/services/boards/blueprint_assembler.rb
@@ -1,0 +1,92 @@
+# app/services/boards/blueprint_assembler.rb
+#
+# The "front of the pipe" for the hybrid Board Builder wizard. Turns the wizard's
+# input (a chosen starter template + a few interest words) into a *builder-ready*
+# blueprint — a tree whose every tile already has a resolved `image_id` — and
+# hands it to Boards::BoardTreeBuilder.
+#
+# Why a separate seam: BoardTreeBuilder's contract is "resolved image_ids only"
+# (see #259). All label -> Image resolution, and the create-if-missing path for
+# brand-new interest words, lives here so the builder stays dumb and deterministic.
+#
+#   assembler = Boards::BlueprintAssembler.new(
+#     template: "home",
+#     interests: ["dinosaurs", "trains", "grandma"],
+#     user: current_user,
+#   )
+#   blueprint = assembler.call            # => builder-ready blueprint (or raises)
+#   assembler.interests                   # => normalized list, for persisting
+#
+# Interest placement (v1 decision): all interests land in ONE "My Favorites"
+# folder hanging off the root, leaving the curated core untouched.
+# FUTURE: route interests into matching category boards (trains -> Play,
+# apple -> Food) via a word->category map. Deferred on purpose — see
+# drafts/board-builder-wizard-step3-plan.md.
+module Boards
+  class BlueprintAssembler
+    FAVORITES_NAME = "My Favorites"
+    MAX_INTERESTS  = 12
+
+    class UnknownTemplate < StandardError; end
+
+    attr_reader :interests
+
+    def initialize(template:, user:, interests: [])
+      @template_key = template.to_s
+      @user         = user
+      @interests    = normalize_interests(interests)
+    end
+
+    # Returns a builder-ready blueprint: { name:, tiles: [ ...image_ids..., favorites? ] }.
+    # Raises UnknownTemplate if the template key isn't registered.
+    def call
+      blueprint = StarterBlueprints.for(@template_key, @user)
+      raise UnknownTemplate, "unknown template #{@template_key.inspect}" if blueprint.nil?
+
+      blueprint[:tiles] = blueprint[:tiles] + [favorites_folder] if @interests.any?
+      blueprint
+    end
+
+    private
+
+    # A folder tile (has `children`) pointing at a board built from the interest
+    # words. The folder tile itself needs an image (board_images.image_id is NOT
+    # NULL), so we resolve/create one for the folder label too.
+    def favorites_folder
+      {
+        label:    FAVORITES_NAME,
+        image_id: resolve_or_create_image(FAVORITES_NAME).id,
+        children: {
+          name:  FAVORITES_NAME,
+          tiles: @interests.map { |word| { label: word, image_id: resolve_or_create_image(word).id } },
+        },
+      }
+    end
+
+    # Mirrors Board#find_or_create_images_from_word_list resolution order:
+    # the user's own image, then a public/admin image, else create a new one.
+    # A freshly-created image starts with no symbol art — acceptable for v1
+    # (blank tile, art can be generated later). See the plan doc's symbol note.
+    def resolve_or_create_image(label)
+      word = normalize_word(label)
+      image = @user.images.find_by(label: word)
+      image ||= Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil])
+      image ||= Image.create!(label: word, user_id: @user.id)
+      image
+    end
+
+    def normalize_interests(list)
+      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(MAX_INTERESTS)
+    end
+
+    # Match the casing convention used elsewhere (find_or_create_images_from_word_list):
+    # multi-char words kept as typed, lone "i" -> "I", other single chars lowercased.
+    def normalize_word(string)
+      word = string.to_s.strip
+      return "" if word.blank?
+      return "I" if word.casecmp("i").zero?
+
+      word.length > 1 ? word : word.downcase
+    end
+  end
+end

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -37,7 +37,45 @@ module Boards
       ],
     }.freeze
 
+    # Registry keyed by the stable string the wizard/API sends. Add a tree here
+    # and it's instantly selectable in the picker (via #catalog) and buildable
+    # (via #for) — no other wiring.
+    TEMPLATES = {
+      "home" => HOME,
+      "daily_routine" => DAILY_ROUTINE,
+    }.freeze
+
     module_function
+
+    # Stable keys the API/wizard can request.
+    def template_keys
+      TEMPLATES.keys
+    end
+
+    # Raw (unresolved, label-only) tree for a key, or nil if unknown.
+    def tree_for(key)
+      TEMPLATES[key.to_s]
+    end
+
+    # Resolve a template key -> builder-ready blueprint for `user`.
+    # Returns nil for an unknown key (caller decides how to surface that).
+    def for(key, user)
+      tree = tree_for(key)
+      tree && resolve(tree, user)
+    end
+
+    # Label-only catalog for the picker UI: no Image resolution, so it's cheap
+    # and safe to serve even before symbols are seeded. Each entry exposes the
+    # core tile labels so the frontend can render a preview grid.
+    def catalog
+      TEMPLATES.map do |key, tree|
+        {
+          key: key,
+          name: tree[:name],
+          tiles: Array(tree[:tiles]).map { |t| t[:label] },
+        }
+      end
+    end
 
     # Resolve a label-based tree into a builder-ready blueprint for `user`.
     def resolve(tree, user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -389,6 +389,10 @@ Rails.application.routes.draw do
         post :myspeak, to: "myspeak#create"
       end
 
+      # Board Builder wizard (hybrid: pick a starter template + add interests).
+      get  "board_builder/templates", to: "board_builder#templates"
+      post "board_builder",           to: "board_builder#create"
+
       resource :auth, only: [:create, :destroy]
       delete "/child_accounts/logout", to: "child_auths#destroy"
       post "/child_accounts/login", to: "child_auths#create"

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe "API::V1::BoardBuilder", type: :request do
+  let(:user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user) }
+  let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
+
+  # The "home" template resolves every core label -> Image; seed them so a build
+  # doesn't blow up on a missing symbol.
+  def seed_template_images!
+    collect_labels(Boards::StarterBlueprints::HOME).each do |label|
+      create(:image, label: label, user_id: user.id)
+    end
+  end
+
+  def collect_labels(tree)
+    Array(tree[:tiles]).flat_map do |tile|
+      [tile[:label]] + (tile[:children] ? collect_labels(tile[:children]) : [])
+    end
+  end
+
+  describe "GET /api/v1/board_builder/templates" do
+    it "returns the label-only catalog" do
+      get "/api/v1/board_builder/templates", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      keys = body["templates"].map { |t| t["key"] }
+      expect(keys).to include("home", "daily_routine")
+      home = body["templates"].find { |t| t["key"] == "home" }
+      expect(home["tiles"]).to include("I", "Food")
+    end
+  end
+
+  describe "POST /api/v1/board_builder" do
+    before { seed_template_images! }
+
+    context "without auth" do
+      it "returns 401" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: { "Content-Type" => "application/json" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "happy path" do
+      it "builds a linked board set owned by the user, attaches a favorited root, and persists interests" do
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "home",
+                         interests: ["dinosaurs", "trains"] }.to_json,
+               headers: headers
+        }.to change { communicator.child_boards.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        body = JSON.parse(response.body)
+
+        root = Board.find(body["id"])
+        expect(root.name).to eq("Home")
+        expect(root.user_id).to eq(user.id)
+
+        child_board = communicator.child_boards.find_by(board_id: root.id)
+        expect(child_board.favorite).to eq(true)
+
+        # A "My Favorites" folder tile links to a board built from the interests.
+        favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+        expect(favorites_tile.predictive_board_id).to be_present
+        favorites_board = Board.find(favorites_tile.predictive_board_id)
+        expect(favorites_board.board_images.map(&:label)).to contain_exactly("dinosaurs", "trains")
+
+        expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "trains"])
+      end
+
+      it "builds the core template with no favorites folder when interests are empty" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home", interests: [] }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:created)
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.board_images.map(&:label)).not_to include("My Favorites")
+      end
+    end
+
+    context "communicator the user doesn't own" do
+      it "returns 404" do
+        other = create(:child_account, user: create(:user))
+        post "/api/v1/board_builder",
+             params: { communicator_id: other.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "unknown template" do
+      it "returns 422 and builds nothing" do
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "nope" }.to_json,
+               headers: headers
+        }.not_to change { Board.count }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/services/boards/blueprint_assembler_spec.rb
+++ b/spec/services/boards/blueprint_assembler_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe Boards::BlueprintAssembler, type: :service do
+  let(:user) { create(:user) }
+
+  # The "home" template resolves every core label -> Image, raising if any is
+  # missing, so seed images for the whole HOME tree before exercising it.
+  def seed_template_images!
+    labels = collect_labels(Boards::StarterBlueprints::HOME)
+    labels.each { |label| create(:image, label: label, user_id: user.id) }
+  end
+
+  def collect_labels(tree)
+    Array(tree[:tiles]).flat_map do |tile|
+      [tile[:label]] + (tile[:children] ? collect_labels(tile[:children]) : [])
+    end
+  end
+
+  describe "#call" do
+    context "with a known template and interests" do
+      before { seed_template_images! }
+
+      it "returns the resolved template with a 'My Favorites' folder of interests appended" do
+        blueprint = described_class.new(
+          template: "home", interests: ["dinosaurs", "trains"], user: user,
+        ).call
+
+        expect(blueprint[:name]).to eq("Home")
+
+        # Every tile (core + favorites) has a resolved integer image_id.
+        all_tiles(blueprint).each { |t| expect(t[:image_id]).to be_a(Integer) }
+
+        favorites = blueprint[:tiles].last
+        expect(favorites[:label]).to eq("My Favorites")
+        expect(favorites[:children][:name]).to eq("My Favorites")
+        expect(favorites[:children][:tiles].map { |t| t[:label] }).to eq(["dinosaurs", "trains"])
+      end
+
+      it "leaves the curated core untouched (interests only live in the folder)" do
+        blueprint = described_class.new(
+          template: "home", interests: ["dinosaurs"], user: user,
+        ).call
+
+        core_labels = blueprint[:tiles][0..-2].map { |t| t[:label] }
+        expect(core_labels).to include("I", "want", "Food", "Feelings")
+        expect(core_labels).not_to include("dinosaurs")
+      end
+    end
+
+    context "interest image resolution" do
+      before { seed_template_images! }
+
+      it "creates a new Image for an interest word that doesn't exist yet" do
+        expect {
+          described_class.new(template: "home", interests: ["dinosaurs"], user: user).call
+        }.to change { Image.where(label: "dinosaurs").count }.from(0).to(1)
+      end
+
+      it "reuses an existing image instead of creating a duplicate" do
+        create(:image, label: "trains", user_id: user.id)
+
+        expect {
+          described_class.new(template: "home", interests: ["trains"], user: user).call
+        }.not_to change { Image.where(label: "trains").count }
+      end
+    end
+
+    context "interest normalization" do
+      before { seed_template_images! }
+
+      it "trims, drops blanks, dedupes, lone-i -> I, and caps at MAX_INTERESTS" do
+        raw = ["  trains ", "", "trains", "i"] + (1..20).map { |n| "word#{n}" }
+        assembler = described_class.new(template: "home", interests: raw, user: user)
+
+        expect(assembler.interests).to start_with("trains", "I")
+        expect(assembler.interests.size).to eq(described_class::MAX_INTERESTS)
+        expect(assembler.interests.count("trains")).to eq(1)
+      end
+    end
+
+    context "with no interests" do
+      before { seed_template_images! }
+
+      it "builds the core template with no favorites folder" do
+        blueprint = described_class.new(template: "home", interests: [], user: user).call
+        expect(blueprint[:tiles].map { |t| t[:label] }).not_to include("My Favorites")
+      end
+    end
+
+    context "with an unknown template" do
+      it "raises UnknownTemplate" do
+        expect {
+          described_class.new(template: "not_a_template", user: user).call
+        }.to raise_error(Boards::BlueprintAssembler::UnknownTemplate)
+      end
+    end
+  end
+
+  # Flatten every tile in a blueprint (depth-first) for assertions.
+  def all_tiles(node)
+    Array(node[:tiles]).flat_map do |tile|
+      [tile] + (tile[:children] ? all_tiles(tile[:children]) : [])
+    end
+  end
+end


### PR DESCRIPTION
Wires the merged Board Builder (#259) up to a usable endpoint for the hybrid wizard (starter template + interests).

## What
- **`Boards::BlueprintAssembler`** — the resolution seam. Turns `{template, interests}` into a builder-ready blueprint: resolves the template via `StarterBlueprints`, resolves each interest word to an `Image` (creates one if the symbol doesn't exist yet), and appends a single **"My Favorites"** folder. Normalizes/dedupes/caps interests at 12 and exposes the cleaned list.
- **`Boards::StarterBlueprints`** — added a `TEMPLATES` registry plus `for`, `template_keys`, and a label-only `catalog` for the picker.
- **`API::V1::BoardBuilderController`** — `GET /api/v1/board_builder/templates` (catalog) and `POST /api/v1/board_builder` (ownership check → assemble → `BoardTreeBuilder` → persist normalized interests to `child_account.details` → return the root board's `api_view`). Warm error copy for unknown template / build failure.
- Service + request specs.

## Decisions (see `drafts/board-builder-wizard-step3-plan.md`)
- Interests land in **one "My Favorites" folder** for v1; the curated core stays untouched. **Future:** route interests into matching category boards (trains→Play, apple→Food) — deferred on purpose.
- **Standalone** feature, not part of MySpeak onboarding. The frontend `BoardBuilderPage` ships in a separate PR.
- Interests are **persisted** to `child_account.details` so the wizard can be re-run / pre-filled.
- Interest words with no symbol get a created `Image` (blank art for now) — acceptable for v1.

## Notes
- No schema changes. Root-board model via `predictive_board_id`; unrelated to `BoardGroup`.
- Built on the proven `Board.from_obf` / `BoardTreeBuilder` pattern.
