### PR TITLE
feat: no-card reverse trial for Basic/Pro (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — No-card reverse trial for Basic/Pro (issue #264)
+- Starting a Basic/Pro trial **no longer requires a credit card** by default.
+  Checkout uses `payment_method_collection: "if_required"` (no-card reverse
+  trial): 14 days of full access, and when the trial ends without an upgrade
+  the account drops to **Free in fallback mode** (#255) — never an unexpected
+  charge, never stuck `past_due`.
+- The trial subscription is created with
+  `trial_settings.end_behavior.missing_payment_method = "cancel"`, so a
+  no-card trial lapses by cleanly canceling → `customer.subscription.deleted`
+  → existing Free downgrade. As a safety net, the webhook also downgrades to
+  Free when a subscription update arrives as `unpaid` / `incomplete_expired`.
+  `past_due` is left in Stripe dunning (real payers' failed renewals).
+- The card-required arm is kept for the A/B experiment: force it per-request
+  with `require_card=true` (PostHog-driven) or globally via
+  `STRIPE_PAYMENT_METHOD_COLLECTION=always`. The `NOCC` /
+  `bypass_payment_required` no-card path still wins over both.
+- New analytics events so trial→paid is measurable: `trial_started` (on
+  checkout), `trial_will_end` (Stripe pre-end webhook), and
+  `subscription_started` (on the trial→paid conversion).
+
 ### Added — Mailchimp Customer Journey triggers
 - The backend can now enrol a contact into a **Mailchimp Customer Journey**
   via its API-trigger step, so events in the app send real, on-brand emails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,31 @@ paid add-on) — not integrated.
 - Premium features (Menu Board Creator, AI image generation) require active subscription
 - Subscription managed via Stripe/RevenueCat — check status before allowing access to premium endpoints
 
+### No-card reverse trial (Basic/Pro)
+
+Basic/Pro trials default to **no credit card** (issue #264). In
+`API::Stripe::CheckoutSessionsController#create`, `payment_method_collection`
+is `"if_required"` by default; the card-required A/B arm is forced via
+`params[:require_card] == "true"` (PostHog-driven from the frontend) or the
+`STRIPE_PAYMENT_METHOD_COLLECTION=always` env override. The legacy `NOCC` /
+`bypass_payment_required` no-card path still wins over both.
+
+The trial subscription is created with
+`subscription_data.trial_settings.end_behavior.missing_payment_method =
+"cancel"`, so a no-card trial that lapses **cancels cleanly** →
+`customer.subscription.deleted` → `apply_free_plan` (Free + fallback mode,
+#255). As a safety net, `API::WebhooksController#handle_subscription_upsert`
+also routes terminal statuses (`unpaid`, `incomplete_expired` —
+`TRIAL_LAPSED_STATUSES`) to `apply_free_plan`. **`past_due` is excluded** —
+that's a real payer's failed renewal, left in Stripe dunning
+(`handle_invoice_payment_failed`).
+
+Trial→paid is measured via `AnalyticsEvent`: `trial_started` (checkout),
+`trial_will_end` (Stripe pre-end webhook), `subscription_started` (fired on
+the non-active→active transition in the upsert; guarded so renewals don't
+double-count). Primary A/B metric is **net paid users per 100 signups**, not
+trial→paid rate.
+
 ### `paid_plan?` semantics
 
 `User#paid_plan?` is the single gate for paid-tier checks. It considers

--- a/README.md
+++ b/README.md
@@ -208,7 +208,17 @@ webhooks:
   trial period.
 - `customer.subscription.deleted` / `.paused` → expire plan credits
   (top-up credits preserved).
+- `customer.subscription.updated` with status `unpaid` /
+  `incomplete_expired` (a lapsed no-card trial) → downgrade to Free in
+  fallback mode (issue #264). `past_due` is left in Stripe dunning.
 - Hourly `ExpirePlanCreditsJob` as a backstop.
+
+**No-card reverse trial (issue #264):** Basic/Pro trials default to no
+card on file (`payment_method_collection: "if_required"`). When a no-card
+trial ends, Stripe cancels it (`trial_settings.end_behavior.missing_payment_method
+= "cancel"`) and the user lands on Free — never charged, never stuck
+`past_due`. The card-required A/B arm is forced per-request with
+`require_card=true` or globally via `STRIPE_PAYMENT_METHOD_COLLECTION=always`.
 
 Admins bypass the credit check. `MonthlyFeatureLimiter` is no longer in
 the AI hot path.

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -54,7 +54,18 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     end
     is_partner = plan_key == "partner_pro"
 
-    payment_method_collection = ENV["STRIPE_PAYMENT_METHOD_COLLECTION"] == "always" ? "always" : "if_required"
+    # No-card reverse trial is the default (issue #264): a Basic/Pro trial
+    # starts with no card on file and, if it ends without an upgrade, the
+    # account drops to Free (handled in API::WebhooksController) rather than
+    # being charged or stranded `past_due`.
+    #
+    # The card-required arm ("always") is the A/B experiment's control. It can
+    # be forced per-request via params[:require_card] (so the PostHog
+    # experiment can drive the split from the frontend) or globally via the
+    # STRIPE_PAYMENT_METHOD_COLLECTION=always env override.
+    require_card = params[:require_card].to_s == "true" ||
+                   ENV["STRIPE_PAYMENT_METHOD_COLLECTION"] == "always"
+    payment_method_collection = require_card ? "always" : "if_required"
     ensure_customer!
 
     trial_days = 14
@@ -63,10 +74,13 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
       cancel_url = "#{frontend_base_url}/onboarding/partner"
     end
 
+    # Explicit no-card bypass (legacy NOCC promo / param). Always wins over the
+    # card-required arm — used for partner pilots and support comps.
     bypass_payment_required = params[:bypass_payment_required] == "true" || promo_code&.upcase == NO_CC_KEY
 
     if bypass_payment_required
       payment_method_collection = "if_required"
+      require_card = false
     end
 
     promo_code_str = nil
@@ -102,10 +116,30 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     end
     session_params[:subscription_data] = {
       trial_period_days: trial_days,
+      # When a no-card trial ends with no payment method on file, cancel the
+      # subscription instead of generating an unpayable invoice. The resulting
+      # `customer.subscription.deleted` webhook downgrades the user to Free in
+      # fallback mode (issue #264 + #255) — never an unexpected charge, never
+      # stuck `past_due`. Harmless on the card-required arm: a payment method
+      # is present, so this end_behavior never triggers and the card is charged.
+      trial_settings: {
+        end_behavior: { missing_payment_method: "cancel" },
+      },
     }
 
     session = Stripe::Checkout::Session.create(session_params)
     current_user.update!(paid_plan_type: plan_key)
+    # Measure trial starts so trial→paid conversion is computable against the
+    # later `subscription_started` event (issue #264 A/B instrumentation).
+    AnalyticsEvent.track(
+      "trial_started",
+      user_id: current_user.id,
+      metadata: {
+        plan_key: plan_key,
+        require_card: require_card,
+        payment_method_collection: payment_method_collection,
+      },
+    )
     Rails.logger.info "session: #{session.inspect}"
     render json: { url: session.url }
   rescue StandardError => e

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -46,6 +46,8 @@ class API::WebhooksController < API::ApplicationController
       if event.type == "customer.subscription.created"
         handle_trial_credit_grant(event.data.object, event.id)
       end
+    when "customer.subscription.trial_will_end"
+      handle_trial_will_end(event.data.object)
     when "customer.subscription.deleted"
       handle_subscription_deleted(event.data.object)
     when "customer.subscription.paused"
@@ -66,7 +68,40 @@ class API::WebhooksController < API::ApplicationController
 
   private
 
+  # Terminal Stripe subscription statuses that mean "the trial/subscription
+  # ended without a successful payment." A no-card reverse trial (issue #264)
+  # lands here when it lapses. `past_due` is deliberately NOT in this list — a
+  # real payer's failed renewal stays in dunning (see handle_invoice_payment_failed).
+  TRIAL_LAPSED_STATUSES = %w[unpaid incomplete_expired].freeze
+
   # ========== Event handlers ==========
+
+  # Stripe fires this ~3 days before a trial ends. No state change here — the
+  # actual downgrade happens when the trial truly ends (subscription canceled
+  # via the `missing_payment_method: cancel` end_behavior, or upsert sees a
+  # terminal status). We record an analytics event so the trial-ending upgrade
+  # nudge (frontend #293) is measurable.
+  def handle_trial_will_end(subscription)
+    user = find_user_for_subscription(subscription)
+    unless user
+      Rails.logger.error "[StripeWebhook] trial_will_end: no user for customer #{subscription.customer}"
+      return
+    end
+
+    trial_end = subscription.respond_to?(:trial_end) ? subscription.trial_end : nil
+    AnalyticsEvent.track(
+      "trial_will_end",
+      user_id: user.id,
+      metadata: {
+        plan_type: user.plan_type,
+        subscription_id: subscription.id,
+        trial_end: trial_end,
+      },
+    )
+    Rails.logger.info "[StripeWebhook] trial_will_end: user=#{user.id} sub=#{subscription.id}"
+  rescue => e
+    Rails.logger.error "[StripeWebhook] handle_trial_will_end error: #{e.class} - #{e.message}"
+  end
 
   def handle_customer_created(customer)
     stripe_customer_id = customer.id
@@ -192,6 +227,20 @@ class API::WebhooksController < API::ApplicationController
       return
     end
 
+    # A no-card reverse trial that ends without an upgrade lands here as
+    # `unpaid` / `incomplete_expired` (terminal, no payment ever taken). Drop
+    # the user to Free in fallback mode (#255) instead of leaving them stranded
+    # in a non-active paid state. `past_due` is intentionally excluded — that's
+    # a real payer's failed renewal where Stripe dunning should keep retrying
+    # (handled by invoice.payment_failed). See issue #264.
+    if TRIAL_LAPSED_STATUSES.include?(subscription.status)
+      apply_free_plan(user, subscription.status)
+      Rails.logger.info "[StripeWebhook] subscription upsert: user=#{user.id} status=#{subscription.status} -> downgraded to free (trial lapsed / unpaid)"
+      return
+    end
+
+    previous_status = user.plan_status
+
     price = first_price_from_subscription(subscription)
     unless price
       Rails.logger.error "[StripeWebhook] subscription upsert: no price for subscription #{subscription.id}"
@@ -216,6 +265,21 @@ class API::WebhooksController < API::ApplicationController
     user.setup_limits
 
     user.save!
+
+    # Fire `subscription_started` on the trial→paid (or any non-active→active)
+    # conversion so trial→paid is measurable against `trial_started`. Guarded on
+    # the status transition so renewals (active→active) don't double-count.
+    if subscription.status == "active" && previous_status != "active"
+      AnalyticsEvent.track(
+        "subscription_started",
+        user_id: user.id,
+        metadata: {
+          plan_type: user.plan_type,
+          previous_status: previous_status,
+          subscription_id: subscription.id,
+        },
+      )
+    end
 
     # Optional: team seats logic if this is a team plan
     if meta["team_seats"].present?

--- a/app/models/analytics_event.rb
+++ b/app/models/analytics_event.rb
@@ -8,6 +8,8 @@ class AnalyticsEvent < ApplicationRecord
 
   VALID_EVENT_TYPES = %w[
     user_signed_up
+    trial_started
+    trial_will_end
     subscription_started
     subscription_canceled
     board_generated

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -50,7 +50,11 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       expect(captured[:mode]).to eq("subscription")
       expect(captured[:customer]).to eq("cus_existing")
       expect(captured[:line_items]).to eq([{ price: "price_basic_monthly", quantity: 1 }])
-      expect(captured[:subscription_data]).to eq(trial_period_days: 14)
+      expect(captured[:subscription_data][:trial_period_days]).to eq(14)
+      # No-card reverse trial: lapses cancel cleanly instead of charging.
+      expect(captured[:subscription_data][:trial_settings]).to eq(
+        end_behavior: { missing_payment_method: "cancel" },
+      )
       expect(captured[:metadata][:user_id]).to eq(user.id)
       expect(captured[:metadata][:plan_key]).to eq("basic")
       # When no promo, allow_promotion_codes is enabled
@@ -122,6 +126,57 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
 
       expect(response).to have_http_status(:bad_request)
       expect(JSON.parse(response.body)["error"]).to eq("Failed to create checkout session")
+    end
+  end
+
+  describe "payment_method_collection (no-card reverse trial / A-B arm)" do
+    let(:captured) { {} }
+
+    before do
+      user.update!(stripe_customer_id: "cus_existing")
+      ENV.delete("STRIPE_PAYMENT_METHOD_COLLECTION")
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured.replace(params)
+        OpenStruct.new(url: "https://stripe.test/x")
+      end
+    end
+
+    it "defaults to no-card (if_required) for a Basic/Pro trial" do
+      do_post.call({ plan_key: "basic" })
+      expect(captured[:payment_method_collection]).to eq("if_required")
+    end
+
+    it "forces the card-required arm when params[:require_card] is true" do
+      do_post.call({ plan_key: "basic", require_card: "true" })
+      expect(captured[:payment_method_collection]).to eq("always")
+    end
+
+    it "forces the card-required arm via STRIPE_PAYMENT_METHOD_COLLECTION=always" do
+      ENV["STRIPE_PAYMENT_METHOD_COLLECTION"] = "always"
+      do_post.call({ plan_key: "basic" })
+      expect(captured[:payment_method_collection]).to eq("always")
+    ensure
+      ENV.delete("STRIPE_PAYMENT_METHOD_COLLECTION")
+    end
+
+    it "lets the NOCC bypass win over the card-required arm" do
+      ENV["STRIPE_PAYMENT_METHOD_COLLECTION"] = "always"
+      do_post.call({ plan_key: "basic", promo_code: "NOCC" })
+      expect(captured[:payment_method_collection]).to eq("if_required")
+    ensure
+      ENV.delete("STRIPE_PAYMENT_METHOD_COLLECTION")
+    end
+
+    it "records a trial_started analytics event with the arm metadata" do
+      expect {
+        do_post.call({ plan_key: "basic" })
+      }.to change { AnalyticsEvent.for_event("trial_started").count }.by(1)
+
+      event = AnalyticsEvent.for_event("trial_started").last
+      expect(event.user_id).to eq(user.id)
+      expect(event.metadata["plan_key"]).to eq("basic")
+      expect(event.metadata["require_card"]).to eq(false)
+      expect(event.metadata["payment_method_collection"]).to eq("if_required")
     end
   end
 

--- a/spec/requests/api/webhooks_plan_type_spec.rb
+++ b/spec/requests/api/webhooks_plan_type_spec.rb
@@ -122,6 +122,94 @@ RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
     end
   end
 
+  describe "customer.subscription.updated (no-card trial lapsed → Free)" do
+    # Issue #264: a no-card reverse trial that ends without an upgrade arrives
+    # as a terminal status (unpaid / incomplete_expired). The user must drop to
+    # Free in fallback mode, not stay stranded in a non-active paid state.
+    %w[unpaid incomplete_expired].each do |terminal_status|
+      it "downgrades to Free and preserves paid_plan_type for status=#{terminal_status}" do
+        user.update!(plan_type: "basic", plan_status: "trialing", paid_plan_type: nil)
+        sub = build_subscription(status: terminal_status)
+        stub_event(sub, type: "customer.subscription.updated")
+
+        post_webhook("{}", header_with_signature)
+
+        user.reload
+        expect(user.plan_type).to eq("free")
+        expect(user.paid_plan_type).to eq("basic")
+        expect(user.plan_status).to eq(terminal_status)
+        expect(user.stripe_subscription_id).to be_nil
+      end
+    end
+
+    it "triggers fallback-mode reconciliation on the trial-lapse downgrade" do
+      user.update!(plan_type: "basic", plan_status: "trialing")
+      sub = build_subscription(status: "unpaid")
+      stub_event(sub, type: "customer.subscription.updated")
+
+      # plan_type changes basic→free, so the User after_save callback runs.
+      expect_any_instance_of(User).to receive(:reconcile_communicator_fallback!).and_call_original
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "does NOT downgrade a real payer whose renewal is past_due" do
+      # past_due is dunning, not a lapsed no-card trial — keep the paid plan,
+      # don't force Free.
+      user.update!(plan_type: "basic", plan_status: "active")
+      sub = build_subscription(status: "past_due", price: build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic"))
+      stub_event(sub, type: "customer.subscription.updated")
+
+      post_webhook("{}", header_with_signature)
+
+      user.reload
+      expect(user.plan_type).to eq("basic")
+      expect(user.plan_status).to eq("past_due")
+    end
+  end
+
+  describe "customer.subscription.updated (trial → paid conversion)" do
+    it "fires a subscription_started event on the non-active → active transition" do
+      user.update!(plan_type: "basic", plan_status: "trialing")
+      sub = build_subscription(status: "active", price: build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic"))
+      stub_event(sub, type: "customer.subscription.updated")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { AnalyticsEvent.for_event("subscription_started").count }.by(1)
+
+      event = AnalyticsEvent.for_event("subscription_started").last
+      expect(event.user_id).to eq(user.id)
+      expect(event.metadata["previous_status"]).to eq("trialing")
+    end
+
+    it "does not double-count subscription_started on an active → active renewal" do
+      user.update!(plan_type: "basic", plan_status: "active")
+      sub = build_subscription(status: "active", price: build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic"))
+      stub_event(sub, type: "customer.subscription.updated")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change { AnalyticsEvent.for_event("subscription_started").count }
+    end
+  end
+
+  describe "customer.subscription.trial_will_end" do
+    it "records a trial_will_end analytics event without changing plan state" do
+      user.update!(plan_type: "basic", plan_status: "trialing")
+      sub = build_subscription(status: "trialing", trial_end: 3.days.from_now)
+      stub_event(sub, type: "customer.subscription.trial_will_end")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { AnalyticsEvent.for_event("trial_will_end").count }.by(1)
+
+      user.reload
+      expect(user.plan_type).to eq("basic")
+      expect(user.plan_status).to eq("trialing")
+    end
+  end
+
   describe "customer.subscription.deleted" do
     it "preserves paid_plan_type and sets plan_status='canceled'" do
       user.update!(plan_type: "pro", paid_plan_type: nil)


### PR DESCRIPTION
Closes #264.

Backend half of the credit-card-trial change. Makes **no-card** the default for Basic/Pro trial checkout (a reverse trial) and lands lapsed trials on **Free in fallback mode** (#255) instead of an unexpected charge or a stuck `past_due`. Frontend companion: brittanyjohns/itty-bitty-frontend#293.

## What changed

**Checkout — `API::Stripe::CheckoutSessionsController#create`**
- `payment_method_collection` defaults to `"if_required"` (no card on file). The card-required A/B arm is forced per-request via `params[:require_card]=="true"` (PostHog-driven from the frontend) or globally via `STRIPE_PAYMENT_METHOD_COLLECTION=always`. The legacy `NOCC` / `bypass_payment_required` no-card path still wins over both.
- Trial subscription is created with `trial_settings.end_behavior.missing_payment_method = "cancel"`, so a no-card trial that lapses **cancels cleanly** → `customer.subscription.deleted` → existing `apply_free_plan` (Free + fallback).
- Fires a `trial_started` analytics event with the arm metadata.

**Webhook — `API::WebhooksController`**
- Safety net in `handle_subscription_upsert`: terminal statuses (`unpaid`, `incomplete_expired` — `TRIAL_LAPSED_STATUSES`) route to `apply_free_plan`. **`past_due` is excluded** — that's a real payer's failed renewal, left in Stripe dunning (`handle_invoice_payment_failed`).
- New `customer.subscription.trial_will_end` handler → `trial_will_end` event (no state change; for the trial-ending upgrade nudge).
- Fires `subscription_started` on the non-active→active conversion, guarded so renewals don't double-count.

**Analytics** — `trial_started` / `trial_will_end` added to `AnalyticsEvent::VALID_EVENT_TYPES`.

**Docs** — CHANGELOG entry, README webhook list, project CLAUDE.md subscription section.

## Why
- A user can start a Basic/Pro trial with no card on file.
- When the trial ends without payment, the webhook moves the account to Free in fallback mode — never an unexpected charge, never stuck `past_due`.
- `trial_started` / `subscription_started` make trial→paid measurable (primary A/B metric is net paid users per 100 signups).
- Behavior is togglable for the A/B experiment via `require_card` / the env override.

## Test plan
Ran the affected specs locally (with CI dummy secrets, matching `.github/workflows/ci.yml`):

```
spec/requests/api/stripe/checkout_sessions_spec.rb
spec/requests/api/stripe/checkout_sessions_topup_spec.rb
spec/requests/api/webhooks_plan_type_spec.rb
spec/requests/api/webhooks_plan_credits_spec.rb
spec/requests/api/webhooks_topup_spec.rb
spec/models/communicator_fallback_spec.rb
spec/requests/lifecycle_integration_spec.rb
→ 79 examples, 0 failures
```

New coverage: no-card default, both card-required arms, NOCC bypass, `trial_settings`, `trial_started`; webhook `unpaid`/`incomplete_expired`→Free+fallback, `past_due`-not-downgraded, `subscription_started` (fires once / renewal no-op), `trial_will_end`.

## Reviewer notes
- The A/B experiment still needs the PostHog flag wired on the frontend; `require_card` is the server-side hook for it.
- The repo has no committed test-env secrets, so specs were run with the CI dummy values (`DEVISE_JWT_SECRET_KEY`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)