### PR TITLE
ci: ignore non-applicable puma PROXY-protocol CVEs (#266)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,8 +37,18 @@ jobs:
       #   CVE-2026-33195  activestorage path traversal (DiskService)
       #   CVE-2026-33202  activestorage glob injection (DiskService)
       #   CVE-2026-33658  activestorage DoS (proxy mode multi-range)
+      #
+      # The two puma CVEs below are PROXY protocol v1 parser bugs, only
+      # reachable when a `bind` enables `proxy_protocol`. config/puma.rb binds
+      # by plain port (nginx proxies over normal HTTP), so they are not
+      # exploitable here. The fix is a major puma bump (6.5.0 -> 7.2.1+/8.0.2+);
+      # tracked in https://github.com/brittanyjohns/itty_bitty_boards/issues/266
+      # — remove these two ignores once that upgrade merges.
+      #   CVE-2026-47736  puma PROXY protocol v1 parser memory exhaustion
+      #   CVE-2026-47737  puma PROXY protocol v1 repeated headers (keep-alive)
       - run: |
           bundle exec bundler-audit check --update \
             --ignore CVE-2026-33168 CVE-2026-33169 CVE-2026-33170 \
                      CVE-2026-33173 CVE-2026-33174 CVE-2026-33176 \
-                     CVE-2026-33195 CVE-2026-33202 CVE-2026-33658
+                     CVE-2026-33195 CVE-2026-33202 CVE-2026-33658 \
+                     CVE-2026-47736 CVE-2026-47737


### PR DESCRIPTION
Unblocks the **Bundler audit (known CVEs)** job, which started failing repo-wide (every open PR + `main`) after ruby-advisory-db published two new **High** puma advisories today against the pinned `puma 6.5.0`. The failure surfaced on #265 but is unrelated to that PR's Stripe changes.

## What changed

`.github/workflows/security.yml` — add two CVEs to the bundler-audit `--ignore` list, with a justification comment, mirroring the existing Rails-CVE pattern (tracked in #56):

- **CVE-2026-47736** — Puma PROXY protocol v1 parser memory exhaustion
- **CVE-2026-47737** — Puma PROXY protocol v1 repeated headers on keep-alive

## Why ignore rather than upgrade

Both CVEs are reachable **only** when a `bind` enables `proxy_protocol`. `config/puma.rb` binds by plain `port`; nginx proxies to puma over normal HTTP, so the vulnerable parser is never invoked — **not exploitable in this deployment**.

The advisory fix is `puma ~> 7.2.1` / `>= 8.0.2` — a **major** version bump on the production web server (the component behind the 2026-05-30 wedged-puma outage). That deserves its own carefully smoke-tested change, deferred to **#266**. The ignores get removed when that upgrade lands.

## Test plan

CI-config-only change, no application code touched — **test-irrelevant** (no specs to add), and **not user-facing** (no CHANGELOG entry).

Verified locally with the exact updated ignore list:

```
bundle exec bundler-audit check --update --ignore <existing 9> CVE-2026-47736 CVE-2026-47737
→ No vulnerabilities found  (exit 0)
```

Closes nothing; tracking issue is #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)