### PR TITLE
fix(board-builder): self-heal missing core template symbols (no more 500)

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -47,10 +47,13 @@ hash and it is instantly selectable in the picker (`#catalog`) and buildable
 (`#for`) — no other wiring.
 
 Templates are defined by **label** (DB-portable). `StarterBlueprints.for(key,
-user)` resolves each label to an `Image#id` for that user at call time and
-**raises** if a core label has no `Image` — so the curated templates assume
-their symbols are seeded. `#catalog` is label-only (no `Image` resolution),
-so the picker grid is cheap and safe to serve even before symbols exist.
+user)` resolves each label to an `Image#id` for that user at call time,
+**creating a blank-art image if a core label has none** (same create-if-missing
+path the interest words use) so a template builds even when its curated symbols
+aren't seeded in this environment — including the capitalized folder labels
+(`Food`, `Feelings`, `Play`, `Bathroom`), which are folder names rather than
+seeded vocabulary. `#catalog` is label-only (no `Image` resolution), so the
+picker grid is cheap and safe to serve even before symbols exist.
 
 `HOME` carries category folders `Food`, `Feelings`, `Play`; `DAILY_ROUTINE`
 carries `Bathroom`. Those folder labels are what interest routing targets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,8 +423,10 @@ Three seams (input contract tightens left→right):
 
 - `Boards::StarterBlueprints` — `TEMPLATES` registry of label-only starter
   trees (`"home"`, `"daily_routine"`). Add a tree to the hash → instantly in
-  the picker (`#catalog`) and buildable (`#for`). Resolution raises on a
-  missing core symbol.
+  the picker (`#catalog`) and buildable (`#for`). Core labels resolve
+  **create-if-missing** (blank art, same path as interest words), so a template
+  builds even when its curated symbols — including the capitalized folder labels
+  (`Food`, `Feelings`, `Play`, `Bathroom`) — aren't seeded in this environment.
 - `Boards::BlueprintAssembler` — the resolution + routing seam. Resolves every
   label to an `image_id` (create-if-missing for new interest words, blank art
   for v1), then **routes interests into category folders** via

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -49,6 +49,13 @@ module API
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },
                status: :unprocessable_entity
+      rescue StandardError => e
+        # Last-resort guard: never leak an internal error (or a 500) to the
+        # client. Core symbols now self-heal, so this should be rare.
+        Rails.logger.error "[BoardBuilder] unexpected error: #{e.class}: #{e.message}"
+        render json: { error: "build_failed",
+                       message: "Something went wrong building the board set — your info is safe, give it another try." },
+               status: :unprocessable_entity
       end
     end
   end

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -7,8 +7,9 @@
 #
 # NOTE: the label -> image_id step is intentionally OUTSIDE the builder. The
 # builder's input contract is a blueprint of already-resolved image_ids;
-# real label->image_id resolution (against interests, AI, etc.) is a separate
-# seam not built here.
+# resolution lives here. Core labels resolve create-if-missing (blank art),
+# mirroring the interest path in Boards::BlueprintAssembler, so a template can
+# build even when its curated symbols aren't seeded in this environment.
 #
 # Console exercise:
 #   Boards::BoardTreeBuilder.new(
@@ -88,12 +89,23 @@ module Boards
     end
 
     def resolve_tile(tile, user)
-      image = Image.where(label: tile[:label]).where(user_id: [nil, user.id, User::DEFAULT_ADMIN_ID], is_private: [nil, false]).first
-      raise "Boards::StarterBlueprints: no Image for label #{tile[:label].inspect}" unless image
-
-      resolved = { label: tile[:label], image_id: image.id }
+      resolved = { label: tile[:label], image_id: resolve_or_create_image(tile[:label], user).id }
       resolved[:children] = resolve(tile[:children], user) if tile[:children]
       resolved
+    end
+
+    # Resolve a core label -> Image, creating a blank-art image if none exists.
+    # Mirrors Boards::BlueprintAssembler#resolve_or_create_image (the interest
+    # path) so the templates self-heal: a missing core symbol — including the
+    # capitalized folder labels ("Food", "Feelings", "Play"), which are folder
+    # names, not seeded vocabulary — yields a blank tile instead of a 500. Art
+    # can be added later. Resolution order: the user's own image, then a
+    # public/admin image, else create.
+    def resolve_or_create_image(label, user)
+      image = user.images.find_by(label: label)
+      image ||= Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil])
+      image ||= Image.create!(label: label, user_id: user.id)
+      image
     end
 
     def home(user)

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
   let(:communicator) { create(:child_account, user: user) }
   let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
 
-  # The "home" template resolves every core label -> Image; seed them so a build
-  # doesn't blow up on a missing symbol.
+  # The "home" template resolves every core label -> Image. Core labels now
+  # create-if-missing, so seeding isn't required for a build to succeed; these
+  # specs seed to exercise the reuse path and keep label assertions stable.
   def seed_template_images!
     collect_labels(Boards::StarterBlueprints::HOME).each do |label|
       create(:image, label: label, user_id: user.id)
@@ -87,6 +88,24 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(response).to have_http_status(:created)
         root = Board.find(JSON.parse(response.body)["id"])
         expect(root.board_images.map(&:label)).not_to include("My Favorites")
+      end
+    end
+
+    context "with no core symbols seeded (the staging 500 regression)" do
+      # Reproduces the outage: a build used to 500 with
+      # RuntimeError("no Image for label \"Food\"") when the curated symbols
+      # weren't seeded. Core labels now self-heal, so the build succeeds.
+      it "builds successfully, creating images for the core labels" do
+        no_seed_user = create(:user)
+        no_seed_comm = create(:child_account, user: no_seed_user)
+        no_seed_headers = auth_headers(no_seed_user).merge("Content-Type" => "application/json")
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: no_seed_comm.id, template: "home" }.to_json,
+             headers: no_seed_headers
+
+        expect(response).to have_http_status(:created)
+        expect(Image.find_by(label: "Food", user_id: no_seed_user.id)).to be_present
       end
     end
 

--- a/spec/services/boards/blueprint_assembler_spec.rb
+++ b/spec/services/boards/blueprint_assembler_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.describe Boards::BlueprintAssembler, type: :service do
   let(:user) { create(:user) }
 
-  # The "home" template resolves every core label -> Image, raising if any is
-  # missing, so seed images for the whole HOME tree before exercising it.
+  # The "home" template resolves every core label -> Image (create-if-missing).
+  # Seeding the HOME tree up front exercises the reuse path and keeps these
+  # specs focused on routing rather than image creation.
   def seed_template_images!
     labels = collect_labels(Boards::StarterBlueprints::HOME)
     labels.each { |label| create(:image, label: label, user_id: user.id) }

--- a/spec/services/boards/starter_blueprints_spec.rb
+++ b/spec/services/boards/starter_blueprints_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Boards::StarterBlueprints, type: :service do
+  let(:user) { create(:user) }
+
+  def all_tiles(node)
+    Array(node[:tiles]).flat_map do |tile|
+      [tile] + (tile[:children] ? all_tiles(tile[:children]) : [])
+    end
+  end
+
+  describe ".for" do
+    it "returns nil for an unknown template key" do
+      expect(described_class.for("not_a_template", user)).to be_nil
+    end
+
+    context "with no images seeded (the staging outage scenario)" do
+      it "self-heals: builds the blueprint, creating a blank-art image per label" do
+        # Regression for the 500 RuntimeError("no Image for label \"Food\"").
+        blueprint = nil
+        expect {
+          blueprint = described_class.for("home", user)
+        }.not_to raise_error
+
+        all_tiles(blueprint).each { |t| expect(t[:image_id]).to be_a(Integer) }
+
+        # The capitalized folder labels — folder names, never seeded vocabulary —
+        # are exactly what used to blow up. They now resolve to created images.
+        %w[Food Feelings Play].each do |folder_label|
+          expect(Image.find_by(label: folder_label, user_id: user.id)).to be_present
+        end
+      end
+    end
+
+    context "with a label already owned by the user" do
+      it "reuses the existing image instead of creating a duplicate" do
+        existing = create(:image, label: "Food", user_id: user.id)
+
+        expect {
+          described_class.for("home", user)
+        }.not_to change { Image.where(label: "Food").count }
+
+        food = described_class.for("home", user)[:tiles].find { |t| t[:label] == "Food" }
+        expect(food[:image_id]).to eq(existing.id)
+      end
+    end
+
+    context "with a label available as a public image" do
+      it "reuses the public image rather than creating a private duplicate" do
+        public_img = create(:image, label: "water", user_id: nil, is_private: false)
+
+        expect {
+          described_class.for("home", user)
+        }.not_to change { Image.where(label: "water").count }
+
+        water = all_tiles(described_class.for("home", user)).find { |t| t[:label] == "water" }
+        expect(water[:image_id]).to eq(public_img.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`POST /api/v1/board_builder` was returning **HTTP 500** on staging:

```
RuntimeError Boards::StarterBlueprints: no Image for label "Food"
```

**Root cause:** `StarterBlueprints#resolve_tile` required a pre-existing `Image` for every core template label and raised a bare `RuntimeError` if none was found. The capitalized folder labels — `Food`, `Feelings`, `Play`, `Bathroom` — are *folder names*, not seeded vocabulary symbols (real vocab is lowercase), and nothing in `db/` or `lib/tasks/` ever creates them. The only place they exist is the specs, which self-seed every label before each test (`seed_template_images!`) — so the suite was green while real environments 500'd on the very first folder tile. This was almost certainly broken in **production** too, not just staging. The `RuntimeError` also escaped the controller's rescue list (`UnknownTemplate` / `BuildError` only), leaking an internal message as a 500 — against the "don't expose internal errors" rule.

## Fix

- **Self-healing core resolution.** `resolve_tile` now resolves create-if-missing (blank art), exactly mirroring the interest-word path already in `BlueprintAssembler#resolve_or_create_image`: the user's own image → a public/admin image → create. A template now builds in any environment regardless of seeding. Art can be added later (consistent with the v1 blank-art decision for interest words).
- **Last-resort controller guard.** Added a `rescue StandardError` in `BoardBuilderController#create` that logs and returns the generic `build_failed` 422, so no unexpected error ever leaks a 500 to the client.

## Tests

- **New** `spec/services/boards/starter_blueprints_spec.rb` — self-heal with no images seeded (the outage scenario, asserts `Food`/`Feelings`/`Play` images get created), reuse of a user-owned image, reuse of a public image.
- `spec/requests/api/v1/board_builder_spec.rb` — added a regression test that a build with **no** core symbols seeded returns **201** and creates the `Food` image.
- Updated now-stale "raises if missing" comments in the assembler/request specs.

**Docs:** updated `CLAUDE.md` and `.claude-notes/board-builder.md` to describe the create-if-missing behavior (previously documented as "raises on a missing core symbol").

⚠️ **Test plan note:** I could not run the suite locally — this worktree is missing the gitignored `config/application.yml` (Figaro), so `config/environment.rb` fails to boot (`KeyError: DEVISE_JWT_SECRET_KEY`). Please run before merging:

```
RAILS_ENV=test bundle exec rspec spec/services/boards/starter_blueprints_spec.rb spec/services/boards/blueprint_assembler_spec.rb spec/requests/api/v1/board_builder_spec.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)