### PR TITLE
fix: enforce board limit on Board Builder, OBF import, and create_from_template

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -117,6 +117,13 @@ Label-only picker catalog. No `Image` resolution.
 - **422 `unknown_template`** — template key not in the registry (builds nothing).
 - **422 `build_failed`** — `BoardTreeBuilder::BuildError` mid-build; the whole
   build rolls back in its transaction, so no orphan boards.
+- **422 "Maximum number of boards reached"** — `current_user.at_board_limit?`
+  when `create` is called. Gated like every other creation path, **but a built
+  tree counts as ONE board**: `BoardTreeBuilder` marks sub-boards (depth > 0)
+  `settings["builder_child"] = true`, and `User#countable_board_count`
+  (the single source of truth for board counting) excludes them. So a Free user
+  (limit 1) can build one tree, and the tree's own sub-boards never trip the
+  read-only lock; a second build is blocked.
 
 ## Decisions & future work
 
@@ -134,6 +141,7 @@ Label-only picker catalog. No `Image` resolution.
 - `spec/services/boards/interest_categories_spec.rb` — lexicon contract.
 - `spec/services/boards/board_tree_builder_spec.rb` — the persistence half (#259).
 - `spec/requests/api/v1/board_builder_spec.rb` — endpoint happy path
-  (routing + favorites), auth, ownership, unknown template, build failure.
+  (routing + favorites), auth, ownership, unknown template, build failure,
+  and the board-limit gate (tree counts as one; set stays editable).
 
 Run: `RAILS_ENV=test bundle exec rspec spec/services/boards spec/requests/api/v1/board_builder_spec.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board limit now enforced on all creation paths
+- Three board-creation paths previously bypassed the plan board limit entirely:
+  the **Board Builder** (`POST /api/v1/board_builder`), **OBF/OBZ import**
+  (`POST /api/boards/import_obf`), and **create from template**
+  (`POST /api/boards/create_from_template`). A Free user (limit 1) could blow
+  past the cap through any of them — worst with the Board Builder, where one
+  wizard run persists a whole linked tree (~5+ boards). All three now return
+  **HTTP 422** when the user is already at their limit.
+- A **Board Builder tree counts as ONE board** against the limit: its folder
+  sub-boards are marked `settings["builder_child"]` and excluded from the count,
+  so the wizard's own output never trips the read-only lock.
+- Board-limit counting is centralized on `User#countable_board_count` /
+  `User#at_board_limit?` (excludes predefined + builder-child boards). All gates
+  — create, clone, menus, generated-board claim, and the three above — and the
+  `can_create_boards` api_view flag now share this one definition, fixing prior
+  count drift (`boards.count` vs filtered count).
+
 ### Changed — No-card reverse trial for Basic/Pro (issue #264)
 - Starting a Basic/Pro trial **no longer requires a credit card** by default.
   Checkout uses `payment_method_collection: "if_required"` (no-card reverse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,14 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   `User#board_editable?` (`app/models/user.rb`) and `Board#can_edit_for`
   (`app/models/board.rb`). The board's `api_view` exposes `can_edit`,
   `locked`, and `lock_reason` for the frontend.
+- "Over their board limit" is computed by `User#countable_board_count` (own,
+  non-predefined, non-`builder_child` boards) vs `User#board_limit`. This is the
+  **single source of truth** for board counting — `User#at_board_limit?` wraps
+  it (admins never limited), and every creation gate (create, clone,
+  `create_from_template`, `import_obf`, menus, generated-board claim,
+  Board Builder) plus the `can_create_boards` api_view flag and this read-only
+  rule all route through it. Board Builder sub-boards are excluded so a built
+  tree counts as one (see the Board Builder section).
 - The user picks which single board keeps full edit access via
   `PATCH /api/boards/:id/make_editable`. The selection is persisted on
   `users.editable_board_id`. If none is set, `effective_editable_board_id`
@@ -473,6 +481,13 @@ Endpoints (`API::V1::BoardBuilderController`, both auth-gated):
   favorited root board's `api_view` (**201**). **422 `unknown_template`** /
   **422 `build_failed`** (the build is transactional — failure rolls back, no
   orphans). The frontend page ships separately in `itty-bitty-frontend`.
+  - **Board-limit gated, but a tree counts as ONE board.** `create` returns
+    **422 "Maximum number of boards reached"** when `current_user.at_board_limit?`
+    (see the board-limit section below). Because one wizard run persists a whole
+    linked tree, `BoardTreeBuilder` marks every sub-board (depth > 0)
+    `settings["builder_child"] = true`, and `User#countable_board_count` excludes
+    them — so the tree counts as its single root, not ~5. This also keeps the
+    whole built set editable (the read-only lock keys off the same count).
 
 ## Do not
 

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -3,7 +3,7 @@ class API::BoardsController < API::ApplicationController
 
   before_action :set_board, only: %i[ associate_image remove_image destroy associate_images print pdf assign_accounts show make_editable ]
   before_action :check_board_view_edit_permissions, only: %i[update destroy]
-  before_action :check_board_create_permissions, only: %i[ create clone ]
+  before_action :check_board_create_permissions, only: %i[ create clone create_from_template import_obf ]
   before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
 
   def index
@@ -1087,17 +1087,16 @@ class API::BoardsController < API::ApplicationController
   private
 
   def check_board_create_permissions
-    return if current_user.admin?
     unless current_user
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
+    return if current_user.admin?
+
+    # Fresh instance so the count isn't stale from earlier in the request.
     refreshed_user = User.find(current_user.id)
-    refreshed_user.boards.reload
-    user_board_count = refreshed_user.boards.where(predefined: false).count
-    if user_board_count >= refreshed_user.board_limit
-      render json: { error: "Maximum number of boards reached (#{user_board_count}/#{refreshed_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
-      return
+    if refreshed_user.at_board_limit?
+      render json: { error: "Maximum number of boards reached (#{refreshed_user.countable_board_count}/#{refreshed_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/generated_boards_controller.rb
+++ b/app/controllers/api/generated_boards_controller.rb
@@ -67,10 +67,8 @@ class API::GeneratedBoardsController < API::ApplicationController
       render json: { error: "You must be logged in to claim a board" }, status: :unauthorized
       return
     end
-    current_user.boards.reload
-    user_board_count = current_user.boards.where(predefined: false).count
-    if user_board_count >= current_user.board_limit
-      render json: { error: "Maximum number of boards reached (#{user_board_count}/#{current_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
+    if current_user.at_board_limit?
+      render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
       return
     end
 

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -189,7 +189,7 @@ class API::MenusController < API::ApplicationController
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
-    unless current_user.admin? || current_user.boards.count < current_user.board_limit
+    if current_user.at_board_limit?
       render json: { error: "Maximum number of boards reached. Please upgrade to add more." }, status: :unprocessable_entity
       return
     end

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -24,6 +24,15 @@ module API
           return
         end
 
+        # A wizard run persists a linked tree but counts as ONE board (the root;
+        # sub-boards are marked builder_child). So gate on current state — block
+        # only when the user is already at/over their limit.
+        if current_user.at_board_limit?
+          render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." },
+                 status: :unprocessable_entity
+          return
+        end
+
         assembler = Boards::BlueprintAssembler.new(
           template:  params[:template],
           interests: params[:interests],

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -125,6 +125,10 @@ class Board < ApplicationRecord
   scope :created_today, -> { where("created_at > ?", 1.day.ago.end_of_day) }
   scope :created_yesterday, -> { where("created_at > ? AND created_at < ?", 1.day.ago.beginning_of_day, Time.zone.now.beginning_of_day) }
   scope :communikate_boards, -> { where("name ILIKE ?", "%CommuniKate%") }
+  # Board Builder persists a linked tree (root + folder sub-boards). The
+  # sub-boards are marked settings["builder_child"]=true so the whole tree
+  # counts as ONE board against the user's limit (see User#countable_board_count).
+  scope :not_builder_child, -> { where("NOT COALESCE((settings->>'builder_child')::boolean, false)") }
 
   scope :including_images, -> { includes(board_images: :image) }
   scope :public_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, predefined: true, published: true).where.not(parent_type: "Menu").where(obf_id: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1273,21 +1273,24 @@ class User < ApplicationRecord
     limiter.reset_limit!
   end
 
-  def can_create_boards
-    board_limit = settings["board_limit"]&.to_i
-    if board_limit.nil? || board_limit <= 0
-      board_limit = FREE_PLAN_LIMITS["board_limit"]
-      settings["board_limit"] = board_limit
-      save
-    end
-    board_count = boards.count
-    board_count < board_limit
+  # Single source of truth for "how many boards count against the limit."
+  # Excludes predefined boards and Board Builder sub-boards — a builder wizard
+  # run persists a whole linked tree, but the user only chose one thing, so the
+  # tree counts as ONE (its root). Memoized because board list serialization
+  # calls board_editable? once per board.
+  def countable_board_count
+    @countable_board_count ||= boards.where(predefined: false).not_builder_child.count
   end
 
-  # Count of the user's own (non-predefined) boards. Memoized because board
-  # list serialization calls board_editable? once per board.
-  def owned_board_count
-    @owned_board_count ||= boards.where(predefined: false).count
+  # The one gate every board-creation path checks. Admins are never limited.
+  def at_board_limit?
+    return false if admin?
+
+    countable_board_count >= board_limit
+  end
+
+  def can_create_boards
+    !at_board_limit?
   end
 
   # The single board a limited-plan user keeps full edit access to. Returns
@@ -1404,7 +1407,7 @@ class User < ApplicationRecord
     return true if admin?
     return true if board.nil? || board.user_id != id
     return true if paid_plan?
-    return true if owned_board_count <= board_limit
+    return true if countable_board_count <= board_limit
 
     board.id == effective_editable_board_id
   end

--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -60,6 +60,9 @@ module Boards
       board.assign_parent                            # => parent is the owning User
       board.voice = VoiceService.normalize_voice(@communicator.voice)
       board.generate_unique_slug
+      # Sub-boards (folders) don't count against the user's board limit — the
+      # whole tree counts as one via its root. See User#countable_board_count.
+      board.settings = (board.settings || {}).merge("builder_child" => true) if depth.positive?
       board.save!
 
       Array(node[:tiles]).each do |tile|

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -41,6 +41,43 @@ RSpec.describe User, "plan limits", type: :model do
     end
   end
 
+  describe "#countable_board_count / #at_board_limit? (board-limit counting)" do
+    let(:user) { create(:free_user) } # board_limit 1
+
+    it "counts the user's own non-predefined boards" do
+      create(:board, user: user)
+      expect(user.countable_board_count).to eq(1)
+      expect(user.at_board_limit?).to be(true)
+    end
+
+    it "excludes predefined boards from the count" do
+      create(:board, user: user, predefined: true)
+      expect(user.countable_board_count).to eq(0)
+      expect(user.at_board_limit?).to be(false)
+    end
+
+    it "counts a Board Builder tree as ONE (excludes builder_child sub-boards)" do
+      create(:board, user: user, name: "root")
+      create(:board, user: user, name: "Food",  settings: { "builder_child" => true })
+      create(:board, user: user, name: "Play",  settings: { "builder_child" => true })
+      expect(user.countable_board_count).to eq(1)
+      expect(user.at_board_limit?).to be(true)
+    end
+
+    it "never limits admins" do
+      admin = create(:admin_user)
+      create(:board, user: admin)
+      expect(admin.at_board_limit?).to be(false)
+    end
+
+    it "exposes can_create_boards as the inverse of at_board_limit?" do
+      expect(user.can_create_boards).to be(true)
+      create(:board, user: user)
+      # Fresh instance — countable_board_count memoizes, matching the controller.
+      expect(User.find(user.id).can_create_boards).to be(false)
+    end
+  end
+
   describe "#has_myspeak_feature?" do
     it "is true when the user has a sandbox communicator slot" do
       user = build(:user, settings: { "demo_communicator_limit" => 1 })

--- a/spec/requests/api/boards/create_from_template_limit_spec.rb
+++ b/spec/requests/api/boards/create_from_template_limit_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+# create_from_template was an ungated board-creation path. It now shares the
+# board-limit gate (check_board_create_permissions) with create/clone.
+RSpec.describe "API::Boards create_from_template board-limit gate", type: :request do
+  describe "POST /api/boards/create_from_template" do
+    it "returns 422 and builds nothing when the user is already at their limit" do
+      user = create(:user) # Free, board_limit 1
+      create(:board, user: user) # at limit
+
+      expect {
+        post "/api/boards/create_from_template",
+             params: { data: "{}" },
+             headers: auth_headers(user)
+      }.not_to change { Board.count }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+    end
+
+    it "passes the gate and builds when under the limit" do
+      user = create(:user) # 0 boards → under limit
+      allow(Board).to receive(:create_from_obf) { create(:board, user: user) }
+
+      post "/api/boards/create_from_template",
+           params: { data: "{}" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(Board).to have_received(:create_from_obf)
+    end
+  end
+end

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       expect(JSON.parse(response.body)["error"]).to match(/unsupported/i)
     end
 
+    context "board-limit gate" do
+      it "returns 422 and imports nothing when the user is already at their limit" do
+        create(:board, user: user) # user is Free (limit 1) → now at limit
+
+        expect {
+          post "/api/boards/import_obf",
+               params: { file: obz_upload },
+               headers: auth_headers(user)
+        }.not_to change { user.boards.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+      end
+    end
+
     context "image opt-in policy" do
       def fresh_upload
         Rack::Test::UploadedFile.new(obz_path, "application/zip")

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -130,6 +130,53 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    context "board-limit gate (a built tree counts as ONE board)" do
+      it "returns 422 and builds nothing when the user is already at their limit" do
+        create(:board, user: user) # user is Free (limit 1) → now at limit
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "home" }.to_json,
+               headers: headers
+        }.not_to change { Board.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+      end
+
+      it "counts the whole built tree as one, so a second build is blocked" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home",
+                       interests: ["dinosaurs"] }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        fresh = User.find(user.id)
+        # The tree persisted multiple boards, but it counts as one.
+        expect(fresh.boards.where(predefined: false).count).to be > 1
+        expect(fresh.countable_board_count).to eq(1)
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "keeps the whole built set editable (no spurious board_locked)" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home",
+                       interests: ["dinosaurs"] }.to_json,
+             headers: headers
+        root = Board.find(JSON.parse(response.body)["id"])
+
+        fresh = User.find(user.id)
+        child = fresh.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").first
+        expect(child).to be_present
+        expect(fresh.board_editable?(root)).to be(true)
+        expect(fresh.board_editable?(child)).to be(true)
+      end
+    end
+
     context "when the tree builder fails mid-build" do
       it "returns 422 build_failed with a warm message" do
         allow_any_instance_of(Boards::BoardTreeBuilder)


### PR DESCRIPTION
## What & why

Audit (this session) found three user-reachable board-creation paths that bypassed the plan board limit **entirely**:

- **Board Builder** — `POST /api/v1/board_builder`
- **OBF/OBZ import** — `POST /api/boards/import_obf`
- **Create from template** — `POST /api/boards/create_from_template`

A Free user (limit 1) could blow past the cap through any of them. The Board Builder was worst: one wizard call persists a whole linked **tree** (root + a board per folder, ~5+ boards), so a single request could create five-plus boards against a limit of one.

## The fix

Gate all three, **but a Board Builder tree counts as ONE board** (per product decision — it's one logical unit the user chose once):

1. **Mark sub-boards** — `BoardTreeBuilder` tags depth>0 boards `settings["builder_child"]=true`; new `Board.not_builder_child` scope excludes them. The root is the 1.
2. **Centralize counting** — new `User#countable_board_count` + `User#at_board_limit?` replace three inconsistent count bases (`boards.count` vs `boards.where(predefined: false).count`). `board_editable?` and the `can_create_boards` api_view flag now route through them, so the Builder set stays fully editable instead of self-locking under the read-only rule.
3. **Gate the paths** — `create_from_template` + `import_obf` join the existing `check_board_create_permissions` before_action; an inline `at_board_limit?` check guards the Builder controller. All return **HTTP 422** at limit.

## Reviewer notes

- **Behavior change:** dropped the self-healing write in `can_create_boards` (it wrote `settings["board_limit"]` during a read/serialization path — a smell). The `board_limit` getter already defaults nil→1, so reads are unchanged; `board_limit==0` doesn't occur in normal flows (Free default and `apply_free_plan` both set 1).
- **Counts as one** is enforced both at the pre-create gate and in the ongoing count, so the wizard's sub-boards don't immediately trip `board_locked`.
- Import/template count their boards normally — only the Builder collapses to one.

## Test plan

`RAILS_ENV=test bundle exec rspec` on the touched areas — **all green**:

- `spec/models/user_plan_limits_spec.rb` — countable count, builder-child exclusion, admin bypass, `can_create_boards` inverse (11 ex)
- `spec/requests/api/v1/board_builder_spec.rb` — limit gate: 422 at limit, tree-counts-as-one, set-stays-editable
- `spec/requests/api/boards/import_export_spec.rb` — import 422 at limit
- `spec/requests/api/boards/create_from_template_limit_spec.rb` — new: 422 at limit + passes gate under limit
- Regression: `boards_spec.rb`, `menus_spec.rb`, `board_read_only_spec.rb` (request + model), `spec/services/boards` — 0 failures

## Docs

CHANGELOG (Unreleased → Fixed), `CLAUDE.md` (Board Builder + read-only sections), `.claude-notes/board-builder.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)