### PR TITLE
fix(board-builder): guard against duplicate board sets on re-run (#269)

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -114,6 +114,18 @@ Label-only picker catalog. No `Image` resolution.
   persists the normalized interests to `child_account.details["interests"]`
   (jsonb merge, non-destructive — so the wizard can be re-run / pre-filled),
   and returns the root board's `api_view` with **HTTP 201**.
+- **409 `board_builder_set_exists`** — re-run guard (issue #269). When the
+  communicator already has a builder set, `create` returns
+  `{ error, message, existing_root_id, existing_root_name, built_at }` and
+  builds nothing, so the wizard never silently stacks a second favorited root.
+  The client confirms and re-sends with **`confirm=true`** to build another set.
+  Detection is `ChildAccount#board_builder_root`: each root is marked
+  `settings["builder_root"] = true` by `BoardTreeBuilder`, and the helper finds
+  one still attached to the communicator (deletion-safe — delete the set and a
+  re-run is a fresh build). `builder_root` is the counterpart to `builder_child`
+  and does **not** affect the board-limit count (only `builder_child` is
+  excluded from `countable_board_count`). The gate runs after the board-limit
+  check, so Free users at their limit still get the 422 below first.
 - **422 `unknown_template`** — template key not in the registry (builds nothing).
 - **422 `build_failed`** — `BoardTreeBuilder::BuildError` mid-build; the whole
   build rolls back in its transaction, so no orphan boards.
@@ -129,6 +141,13 @@ Label-only picker catalog. No `Image` resolution.
 
 - **Interests persisted** to `child_account.details` (not a new column) so the
   wizard is idempotent/re-runnable.
+- **Re-running the wizard (open decision #3) — RESOLVED: detect + warn.** A
+  re-run is non-destructive and never silently dupes: the backend returns
+  **409 `board_builder_set_exists`** unless `confirm=true` is sent. We keep
+  the prior set intact rather than replacing it (option 1 in issue #269), and
+  the marker is `settings["builder_root"]` on the root board (not a `details`
+  marker, which would go stale if the board were deleted). Frontend confirm UX
+  is a small follow-up (frontend repo).
 - **Blank-art interest images** are acceptable for v1.
 - **Future:** richer lexicon + more category folders across templates; AI
   symbol generation for new interest words; per-tile voice/label overrides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board Builder no longer silently duplicates a board set on re-run
+- Re-running the wizard for the same communicator used to silently create a
+  **second board set** with another `favorite: true` root (issue #269). The
+  board-limit gate (#270) already blocked Free users on a re-run, but paid
+  users (Basic/Pro) could stack duplicates.
+- `POST /api/v1/board_builder` now **detects an existing builder set and warns**:
+  it returns **HTTP 409** `{ error: "board_builder_set_exists", message,
+  existing_root_id, existing_root_name, built_at }` instead of building. The
+  client confirms and re-sends with **`confirm=true`** to intentionally build
+  another set.
+- Detection is durable and deletion-safe: each builder **root** board is now
+  marked `settings["builder_root"] = true` (the counterpart to the sub-board
+  `builder_child` marker), and `ChildAccount#board_builder_root` looks for one
+  still attached to the communicator. Delete the set and a re-run is treated as
+  a fresh build. The root stays countable — `builder_root` does not affect the
+  board-limit count.
+
 ### Fixed — Board limit now enforced on all creation paths
 - Three board-creation paths previously bypassed the plan board limit entirely:
   the **Board Builder** (`POST /api/v1/board_builder`), **OBF/OBZ import**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,17 @@ Endpoints (`API::V1::BoardBuilderController`, both auth-gated):
     `settings["builder_child"] = true`, and `User#countable_board_count` excludes
     them — so the tree counts as its single root, not ~5. This also keeps the
     whole built set editable (the read-only lock keys off the same count).
+  - **Re-run guard (issue #269): detect + warn, never silently dupe.** If the
+    communicator already has a builder set, `create` returns **409
+    `board_builder_set_exists`** (`{ existing_root_id, existing_root_name,
+    built_at }`) instead of stacking a second favorited root; the client
+    re-sends with **`confirm=true`** to build another. Detection is
+    `ChildAccount#board_builder_root` — each root is marked
+    `settings["builder_root"] = true` by `BoardTreeBuilder` (counterpart to
+    `builder_child`; does **not** affect the board-limit count). It's
+    deletion-safe: delete the set and a re-run is a fresh build. The 409 check
+    runs *after* the board-limit gate, so a Free user at their limit gets the
+    422 first.
 
 ## Do not
 

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -9,6 +9,10 @@ module API
     # blueprint, BoardTreeBuilder persists the linked tree and attaches the root
     # to the communicator, and we stash the normalized interests on the
     # communicator so the wizard can be re-run / pre-filled.
+    #
+    # Re-run guard (issue #269): if the communicator already has a builder set,
+    # create returns HTTP 409 `board_builder_set_exists` instead of silently
+    # duplicating it; the client re-sends with `confirm=true` to build another.
     class BoardBuilderController < API::ApplicationController
       # Label-only template catalog for the picker grid.
       def templates
@@ -30,6 +34,20 @@ module API
         if current_user.at_board_limit?
           render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." },
                  status: :unprocessable_entity
+          return
+        end
+
+        # Re-run guard (issue #269): if this communicator already has a builder
+        # set, don't silently stack a second favorited root. Warn so the frontend
+        # can confirm; `confirm=true` is the explicit "build another" opt-in.
+        existing = communicator.board_builder_root
+        if existing && params[:confirm].to_s != "true"
+          render json: { error: "board_builder_set_exists",
+                         message: "You already built a board set for this communicator. Build another?",
+                         existing_root_id: existing.id,
+                         existing_root_name: existing.name,
+                         built_at: existing.created_at },
+                 status: :conflict
           return
         end
 

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -181,6 +181,17 @@ class ChildAccount < ApplicationRecord
     user.present? && (user.id == owner_id || user.admin?)
   end
 
+  # Most-recent Board Builder root still attached to this communicator, if any.
+  # Detector for the re-run duplicate guard (issue #269): the wizard marks each
+  # root board settings["builder_root"] = true. Deletion-safe — if the user
+  # deletes the set, the join row goes with it, so this returns nil and a
+  # re-run is treated as a fresh build.
+  def board_builder_root
+    boards.where("COALESCE((boards.settings->>'builder_root')::boolean, false)")
+          .order("boards.created_at DESC")
+          .first
+  end
+
   # `is_demo` is derived from status now. The DB column is retained until the
   # frontend cutover (F1) is complete, then dropped. Writes to `is_demo` flow
   # into `status` for backwards compatibility.

--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -63,6 +63,10 @@ module Boards
       # Sub-boards (folders) don't count against the user's board limit — the
       # whole tree counts as one via its root. See User#countable_board_count.
       board.settings = (board.settings || {}).merge("builder_child" => true) if depth.positive?
+      # Mark the root so a re-run can detect an existing builder set and warn
+      # instead of silently duplicating it (issue #269). Root stays countable —
+      # countable_board_count only excludes builder_child, not builder_root.
+      board.settings = (board.settings || {}).merge("builder_root" => true) if depth.zero?
       board.save!
 
       Array(node[:tiles]).each do |tile|

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -177,6 +177,51 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    context "re-run guard (issue #269)" do
+      # Raise the board limit so the #270 limit gate doesn't pre-empt the re-run
+      # guard — that gate only blocks Free users; the dup problem is paid users.
+      before { user.update!(settings: user.settings.to_h.merge("board_limit" => 10)) }
+
+      it "warns with 409 board_builder_set_exists on a re-run and builds nothing" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+        first_root_id = JSON.parse(response.body)["id"]
+
+        boards_before = Board.count
+        child_boards_before = communicator.child_boards.count
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:conflict)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("board_builder_set_exists")
+        expect(body["existing_root_id"]).to eq(first_root_id)
+
+        # Guarded — nothing new was persisted.
+        expect(Board.count).to eq(boards_before)
+        expect(communicator.child_boards.count).to eq(child_boards_before)
+      end
+
+      it "builds another set when confirm=true" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "home", confirm: true }.to_json,
+               headers: headers
+        }.to change { communicator.child_boards.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
     context "when the tree builder fails mid-build" do
       it "returns 422 build_failed with a warm message" do
         allow_any_instance_of(Boards::BoardTreeBuilder)

--- a/spec/services/boards/board_tree_builder_spec.rb
+++ b/spec/services/boards/board_tree_builder_spec.rb
@@ -164,6 +164,30 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect { builder.call }.to raise_error(StandardError)
     end
 
+    it "marks the root builder_root and sub-boards builder_child (issue #269 / #270)" do
+      blueprint = {
+        name: "Home",
+        tiles: [
+          { label: "I", image_id: image_id_for("I") },
+          { label: "Food", image_id: image_id_for("Food"), children: {
+            name: "Food",
+            tiles: [{ label: "apple", image_id: image_id_for("apple") }],
+          } },
+        ],
+      }
+
+      root = described_class.new(blueprint, communicator: communicator).call
+
+      # Root is the re-run detector marker, and stays countable (not builder_child).
+      expect(root.settings["builder_root"]).to be(true)
+      expect(root.settings["builder_child"]).to be_falsey
+
+      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      sub_board = Board.find(food_tile.predictive_board_id)
+      expect(sub_board.settings["builder_child"]).to be(true)
+      expect(sub_board.settings["builder_root"]).to be_falsey
+    end
+
     it "raises when the communicator has no owning user" do
       ownerless = create(:child_account, user: nil)
       blueprint = { name: "Home", tiles: [] }


### PR DESCRIPTION
## Summary

Re-running the Board Builder wizard for the same communicator silently created a **second board set** with another `favorite: true` root. The board-limit gate (#270) already blocked Free users on a re-run, but **paid (Basic/Pro) users could stack duplicates**.

This adds a **detect + warn** guard (issue #269's recommended option 1) — non-destructive, never silently dupes:

- `Boards::BoardTreeBuilder` marks each **root** board `settings["builder_root"] = true` — the counterpart to the existing sub-board `builder_child` marker. It does **not** affect the board-limit count (only `builder_child` is excluded from `countable_board_count`).
- `ChildAccount#board_builder_root` finds a builder root still attached to the communicator. **Deletion-safe**: delete the set and a re-run is treated as a fresh build (preferred over a `child_account.details` marker, which would go stale).
- `POST /api/v1/board_builder` returns **HTTP 409** `{ error: "board_builder_set_exists", message, existing_root_id, existing_root_name, built_at }` instead of building. The client confirms and re-sends with **`confirm=true`** to build another set.
- **Gate ordering:** ownership (404) → board-limit (422) → re-run guard (409 unless `confirm`) → build. A Free user already at their limit still gets the 422 first.

Closes #269.

## API contract

| Condition | Status | Body |
|---|---|---|
| Existing builder set, no `confirm` | **409** | `{ error: "board_builder_set_exists", message, existing_root_id, existing_root_name, built_at }` |
| `confirm=true` | 201 | builds another set, root `api_view` |

## Test plan

- `bundle exec rspec spec/requests/api/v1/board_builder_spec.rb spec/services/boards/board_tree_builder_spec.rb` — **20 examples, 0 failures**.
  - New: 409 on re-run + asserts nothing persisted; `confirm=true` builds another set; tree-builder marks root `builder_root` / sub-boards `builder_child`.
- Regression sweep `spec/models/child_account_spec.rb spec/models/board_spec.rb spec/requests/api/v1/board_builder_spec.rb spec/services/boards/` — **107 examples, 0 failures** (existing #270 board-limit specs stay green).

## Docs

- `CHANGELOG.md` `[Unreleased]`, `.claude-notes/board-builder.md` (open decision #3 marked resolved), and project `CLAUDE.md` all updated.

## Notes for reviewer

- Frontend confirm UX is a small follow-up in `itty-bitty-frontend` (sibling issues #296/#297) — the backend contract here is `409` + `confirm=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)