### PR TITLE
feat(board-builder): robust vocabulary sets (Core 60/84) via OBZ seed + deep clone

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -153,14 +153,74 @@ Label-only picker catalog. No `Image` resolution.
   symbol generation for new interest words; per-tile voice/label overrides
   (today `add_image` derives the label from the `Image`).
 
+## Robust seeded sets (Core 60 / Core 84)
+
+A second template kind: pre-authored, evidence-based **core vocabulary sets**
+(a real core grid + fringe category pages), offered alongside the hardcoded
+starter trees. Instead of building from label-only trees, a robust set is
+**authored as OBF/OBZ**, **seeded** once as admin-owned predefined boards, then
+**deep-cloned per user** on build — preserving the authored grid layout,
+core-tile borders, and `part_of_speech` colors that a rebuild-from-labels would
+lose.
+
+**Authoring + seeding (reuses `ObzImporter`):**
+- Source lives in `db/seeds/board_builder_sets/<slug>/` as editable OBF JSON
+  (`manifest.json` + `boards/*.obf`). Format spec: that dir's `README.md`
+  (share it with whoever authors the word content). Slugs: `core-60`, `core-84`.
+- `bin/rails vocab_sets:seed` (logic in the `VocabSets` service) zips the JSON
+  in memory and imports via `ObzImporter` as `User::DEFAULT_ADMIN_ID` with
+  **`board_group: nil`** — this feature is **root-board only, no `BoardGroup`**.
+  `ObzImporter` lays out the grid, colors tiles by `part_of_speech`, and wires
+  `load_board` → `predictive_board_id`.
+- The set is identified ENTIRELY by a marker on its **root board**:
+  `settings["board_builder_robust"] = true` + `["board_builder_robust_slug"]`.
+  `Boards::RobustSets` (`find_root` / `all_roots` / `slug_for` / `mark_root!`)
+  is the single place that query lives. Idempotent: `Board.from_obf` upserts by
+  `(user_id, obf_id)`.
+
+**Per-user build (reuses `clone_with_images`):**
+- `Boards::StarterBlueprints.catalog` merges the static trees (`kind:
+  "starter"`) with seeded robust sets (`kind: "robust"`, found by root marker).
+- `API::V1::BoardBuilderController#create` branches: if `template` resolves to a
+  robust set via `RobustSets.find_root`, it runs **`Boards::SeededSetCloner`**
+  instead of `BlueprintAssembler` + `BoardTreeBuilder`. Same guards, same
+  response (synchronous **201** with the cloned root) — and the same
+  `at_board_limit?` (422) and `board_builder_root` (409, unless `confirm=true`)
+  gates, which work unchanged because the clone is marked `builder_root`.
+- `SeededSetCloner` walks the source set (root + fringe via
+  `predictive_board_id`, BFS bounded to `MAX_DEPTH = 2`, cycle-safe), clones
+  each board with `clone_with_images` (no `communicator_account` arg → no fringe
+  ChildBoards), **rewires** each cloned folder tile's `predictive_board_id` from
+  the source sub-board to its clone (out-of-set pointers nulled), marks the root
+  `builder_root` + the rest `builder_child` (so the whole set counts as **ONE**
+  board), favorites the root as a ChildBoard, and routes interests into the
+  cloned fringe pages by category name — unmatched → an auto-created, linked
+  `builder_child` "My Favorites" page. Interest normalization/dedup/cap mirror
+  `BlueprintAssembler`. clone_with_images returns clones with a stale
+  counter/association cache, so routing reloads boards before adding tiles.
+
+**Synchronous (v1) — execution note.** The build runs in-request (the existing
+contract). image_ids are pre-resolved so the work is DB-bound; previews, audio,
+and AI art for brand-new interest words are already async jobs. A spike on a
+worst-case ~600-tile set measured ~3s (test env); realistic Core 60/84 sets
+(~120–200 tiles) are ~1s. **If a real set lands materially larger (>~300
+tiles)** and request latency bites, move `SeededSetCloner` into a background job
+with a `status: "building"` root + 202/polling — coordinated with the frontend.
+
 ## Tests
 
 - `spec/services/boards/blueprint_assembler_spec.rb` — routing, catch-all,
   dedup, normalization, image create/reuse, unknown template.
 - `spec/services/boards/interest_categories_spec.rb` — lexicon contract.
 - `spec/services/boards/board_tree_builder_spec.rb` — the persistence half (#259).
+- `spec/services/boards/seeded_set_cloner_spec.rb` — deep clone: rewire,
+  builder markers, favorite ChildBoard, cycle-safety, interest routing +
+  My Favorites, counts-as-one, source untouched.
+- `spec/services/vocab_sets_spec.rb` — seeder: OBZ import, root marker,
+  predefined/published, no BoardGroup, idempotent.
 - `spec/requests/api/v1/board_builder_spec.rb` — endpoint happy path
   (routing + favorites), auth, ownership, unknown template, build failure,
-  and the board-limit gate (tree counts as one; set stays editable).
+  the board-limit gate (tree counts as one; set stays editable), and the
+  robust clone path (catalog, build, limit, re-run).
 
-Run: `RAILS_ENV=test bundle exec rspec spec/services/boards spec/requests/api/v1/board_builder_spec.rb`
+Run: `RAILS_ENV=test bundle exec rspec spec/services/boards spec/services/vocab_sets_spec.rb spec/requests/api/v1/board_builder_spec.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Robust vocabulary sets for the Board Builder (Core 60/84)
+- The Board Builder picker now offers pre-authored **core vocabulary sets** (a
+  real core grid + fringe category pages) alongside the small starter templates.
+  Picking one **deep-clones** the seeded set for the communicator and routes the
+  child's interest words into the cloned fringe pages — same one-round-trip
+  flow, same `POST /api/v1/board_builder` → **201** contract.
+- **Authored as our own OBF/OBZ**, reusing existing infrastructure end to end:
+  sets are seeded with `ObzImporter` (grid layout + `part_of_speech` colors +
+  `load_board`→`predictive_board_id` links), then cloned per user with
+  `Board#clone_with_images` — so authored layout/colors are preserved (a
+  rebuild-from-labels would drop them). Uses **SpeakAnyWay content only**.
+- **Seeder:** `bin/rails vocab_sets:seed` imports the editable OBF-JSON source
+  under `db/seeds/board_builder_sets/<slug>/` as admin, **with no `BoardGroup`** —
+  a set is identified by a marker on its **root board**
+  (`settings["board_builder_robust_slug"]`, via `Boards::RobustSets`).
+  Idempotent. `bin/rails 'vocab_sets:build[core-60]'` emits a distributable
+  `.obz`. Format spec: `db/seeds/board_builder_sets/README.md`. Slugs:
+  `core-60` (ships with a **placeholder** set), `core-84` (content TBD).
+- **A cloned set counts as ONE board** (root marked `builder_root`, the rest
+  `builder_child`) and respects the plan board limit (**422**) and the re-run
+  guard (**409** `board_builder_set_exists` unless `confirm=true`) — the same
+  gates as the starter-template path. New `GET /api/v1/board_builder/templates`
+  entries carry `kind: "starter" | "robust"`.
+- Build runs **synchronously** for v1 (the work is DB-bound; previews/audio/AI
+  art are already backgrounded). If a finalized set lands materially larger than
+  the placeholder, the clone can move to a background job + "building" state
+  (see `.claude-notes/board-builder.md`).
+- New: `Boards::SeededSetCloner`, `Boards::RobustSets`, `VocabSets` service +
+  `lib/tasks/vocab_sets.rake`. No schema changes.
+
 ### Fixed — Board Builder no longer silently duplicates a board set on re-run
 - Re-running the wizard for the same communicator used to silently create a
   **second board set** with another `favorite: true` root (issue #269). The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -500,6 +500,34 @@ Endpoints (`API::V1::BoardBuilderController`, both auth-gated):
     runs *after* the board-limit gate, so a Free user at their limit gets the
     422 first.
 
+### Robust vocabulary sets (Core 60 / Core 84)
+
+A second template **kind** beside the label-only starter trees: pre-authored
+core vocabulary sets, **authored as OBF/OBZ** and seeded as admin-owned
+predefined boards, then **deep-cloned per user** on build (so authored grid
+layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
+`Board#clone_with_images` (build). SpeakAnyWay content only.
+
+- **Seed:** `bin/rails vocab_sets:seed` (logic in the `VocabSets` service)
+  zips the editable OBF-JSON under `db/seeds/board_builder_sets/<slug>/` and
+  imports it via `ObzImporter` as `User::DEFAULT_ADMIN_ID` with
+  **`board_group: nil`**. **No `BoardGroup`** — a set is identified by a marker
+  on its **root board** (`settings["board_builder_robust_slug"]`), queried via
+  `Boards::RobustSets`. Idempotent (`Board.from_obf` upserts by
+  `(user_id, obf_id)`). Format spec: `db/seeds/board_builder_sets/README.md`.
+  Slugs `core-60` (ships a placeholder), `core-84` (TBD).
+- **Build:** `#create` branches on `Boards::RobustSets.find_root(template)`.
+  A match runs `Boards::SeededSetCloner` (walks the linked set to depth 2,
+  clones each board, **rewires** `predictive_board_id` to the clones, marks
+  root `builder_root` / rest `builder_child`, favorites the root ChildBoard,
+  routes interests into the cloned fringe pages / "My Favorites"). Same
+  synchronous **201** response and the **same** limit (422) and re-run (409)
+  guards as the starter path — counts as ONE board.
+- `GET /board_builder/templates` entries now carry `kind: "starter" | "robust"`.
+- v1 is **synchronous** (DB-bound work; previews/audio/AI art already async).
+  If a finalized set is materially larger than the placeholder, move the clone
+  to a background job + "building" state — see `.claude-notes/board-builder.md`.
+
 ## Do not
 
 - Do not install new gems without asking first

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -51,19 +51,36 @@ module API
           return
         end
 
-        assembler = Boards::BlueprintAssembler.new(
-          template:  params[:template],
-          interests: params[:interests],
-          user:      current_user,
-        )
-        blueprint = assembler.call
+        # Two build paths share the same guards/response shape:
+        #  - a seeded "robust vocabulary set" (Core 60/84) -> deep-clone the
+        #    seeded set and route interests into the cloned fringe pages;
+        #  - a hardcoded starter template (home/daily_routine) -> assemble a
+        #    label blueprint and build a fresh linked tree.
+        robust_root = Boards::RobustSets.find_root(params[:template])
 
-        root = Boards::BoardTreeBuilder.new(
-          blueprint, communicator: communicator, favorite_root: true,
-        ).call
+        if robust_root
+          cloner = Boards::SeededSetCloner.new(
+            robust_root, communicator: communicator,
+            interests: params[:interests], favorite_root: true,
+          )
+          root = cloner.call
+          interests = cloner.interests
+        else
+          assembler = Boards::BlueprintAssembler.new(
+            template:  params[:template],
+            interests: params[:interests],
+            user:      current_user,
+          )
+          blueprint = assembler.call
+
+          root = Boards::BoardTreeBuilder.new(
+            blueprint, communicator: communicator, favorite_root: true,
+          ).call
+          interests = assembler.interests
+        end
 
         # Persist the normalized interests for re-runs (jsonb merge, non-destructive).
-        communicator.update!(details: (communicator.details || {}).merge("interests" => assembler.interests))
+        communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
 
         render json: root.api_view(current_user), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e
@@ -71,7 +88,7 @@ module API
         render json: { error: "unknown_template",
                        message: "That template isn't available. Pick one from the list and try again." },
                status: :unprocessable_entity
-      rescue Boards::BoardTreeBuilder::BuildError => e
+      rescue Boards::BoardTreeBuilder::BuildError, Boards::SeededSetCloner::CloneError => e
         Rails.logger.warn "[BoardBuilder] build failed: #{e.message}"
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },

--- a/app/services/boards/robust_sets.rb
+++ b/app/services/boards/robust_sets.rb
@@ -1,0 +1,50 @@
+# app/services/boards/robust_sets.rb
+#
+# Lookup helpers for the Board Builder's "robust vocabulary set" templates
+# (Core 60, Core 84). These sets are seeded (see lib/tasks/vocab_sets.rake) as
+# admin-owned, predefined linked board trees and identified ENTIRELY by a marker
+# on their ROOT board's settings JSONB — there is no BoardGroup. This module is
+# the single place that query lives, shared by the wizard catalog, the create
+# endpoint, and the seeder.
+#
+#   settings["board_builder_robust"]      => true   (root marker)
+#   settings["board_builder_robust_slug"] => "core-60"
+module Boards
+  module RobustSets
+    ROOT_MARKER = "board_builder_robust"
+    SLUG_MARKER = "board_builder_robust_slug"
+
+    module_function
+
+    # All seeded robust-set ROOT boards (one per set), stable order for the
+    # catalog. Empty when nothing is seeded in this environment — callers degrade
+    # gracefully (the set just doesn't appear in the picker).
+    def all_roots
+      Board
+        .where("COALESCE((boards.settings->>'#{ROOT_MARKER}')::boolean, false)")
+        .order(:name)
+    end
+
+    # The seeded root board for a slug, or nil if that set isn't seeded here.
+    def find_root(slug)
+      return nil if slug.blank?
+
+      all_roots.where("boards.settings->>'#{SLUG_MARKER}' = ?", slug.to_s).first
+    end
+
+    # The slug stamped on a root board (nil if it isn't a robust-set root).
+    def slug_for(board)
+      board&.settings&.dig(SLUG_MARKER)
+    end
+
+    # Stamp a freshly-seeded root board so the catalog/endpoint can find it.
+    def mark_root!(board, slug)
+      board.settings = (board.settings || {}).merge(
+        ROOT_MARKER => true,
+        SLUG_MARKER => slug.to_s,
+      )
+      board.save!
+      board
+    end
+  end
+end

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -1,0 +1,223 @@
+# app/services/boards/seeded_set_cloner.rb
+#
+# Builds a per-user "robust vocabulary set" for the Board Builder by DEEP-CLONING
+# a pre-seeded, admin-owned linked board set (a root core board + fringe category
+# pages, linked via BoardImage#predictive_board_id) and routing a child's
+# interest words into the cloned fringe pages.
+#
+# Why clone (not rebuild from labels): cloning preserves the authored grid
+# layout, core-tile borders, and part_of_speech colors of the seeded set, which a
+# rebuild-from-image_ids (Boards::BoardTreeBuilder) would drop.
+#
+# The whole set counts as ONE board against the user's limit: the cloned root is
+# marked settings["builder_root"], every other cloned/created board
+# settings["builder_child"] (excluded from User#countable_board_count), exactly
+# like Boards::BoardTreeBuilder.
+#
+#   root = Boards::SeededSetCloner.new(
+#     source_root_board, communicator: child, interests: ["apple", "grandma"]
+#   ).call
+#
+# Mirrors the normalization/dedup/cap and interest-routing conventions of
+# Boards::BlueprintAssembler, but operates on persisted Board records.
+module Boards
+  class SeededSetCloner
+    MAX_DEPTH      = 2 # mirror Boards::BoardTreeBuilder — root + 2 levels
+    MAX_INTERESTS  = 12 # mirror Boards::BlueprintAssembler
+    FAVORITES_NAME = "My Favorites"
+
+    class CloneError < StandardError; end
+
+    # Normalized interests, exposed so the caller can persist them on the
+    # communicator (same contract as BlueprintAssembler#interests).
+    attr_reader :interests
+
+    def initialize(source_root, communicator:, interests: [], favorite_root: true)
+      @source_root   = source_root
+      @communicator  = communicator
+      @owner         = communicator.owner || communicator.user
+      @interests     = normalize_interests(interests)
+      @favorite_root = favorite_root
+    end
+
+    # Clones the whole linked set + routes interests in a single transaction so a
+    # mid-build failure leaves no orphan boards or dangling ChildBoard. Returns
+    # the cloned root Board.
+    def call
+      raise CloneError, "communicator has no owning user" unless @owner
+      raise CloneError, "no source root board" if @source_root.nil?
+
+      ActiveRecord::Base.transaction do
+        @map = clone_all(collect_source_boards(@source_root))
+        rewire_predictive_links!
+        mark_builder_settings!
+
+        root = @map.fetch(@source_root.id)
+        attach_root_to_communicator(root)
+        route_interests!(root)
+        # clone_with_images leaves the in-memory clones with a stale
+        # board_images_count / association cache; hand back a fresh root.
+        root.reload
+      end
+    end
+
+    private
+
+    # BFS over predictive_board_id links from the root, bounded to MAX_DEPTH and
+    # cycle-safe (visited set). A board reachable twice is collected once. Root
+    # is first in the returned list.
+    def collect_source_boards(root)
+      visited = {}
+      ordered = []
+      queue   = [[root, 0]]
+
+      until queue.empty?
+        board, depth = queue.shift
+        next if board.nil? || visited[board.id]
+
+        visited[board.id] = true
+        ordered << board
+        next if depth >= MAX_DEPTH
+
+        board.board_images.where.not(predictive_board_id: nil).each do |bi|
+          sub = Board.find_by(id: bi.predictive_board_id)
+          queue << [sub, depth + 1] if sub
+        end
+      end
+
+      ordered
+    end
+
+    # Clone each source board for the owner. NO communicator_account arg, so
+    # fringe boards don't each get a ChildBoard (only the root is attached, in
+    # attach_root_to_communicator). Returns { source_board_id => cloned Board }.
+    def clone_all(source_boards)
+      source_boards.each_with_object({}) do |src, map|
+        cloned = src.clone_with_images(@owner.id)
+        raise CloneError, "failed to clone source board #{src.id}" if cloned.nil?
+
+        map[src.id] = cloned
+      end
+    end
+
+    # clone_with_images copies predictive_board_id verbatim, so a cloned folder
+    # tile points at the SOURCE sub-board. Translate every pointer to the cloned
+    # counterpart via the map. A pointer that leaves the set (out of depth, or a
+    # cycle target we didn't collect) is nulled — never leave a user tile opening
+    # an admin-owned board.
+    def rewire_predictive_links!
+      @map.each_value do |cloned|
+        cloned.board_images.where.not(predictive_board_id: nil).find_each do |bi|
+          target = @map[bi.predictive_board_id]
+          bi.update!(predictive_board_id: target&.id)
+        end
+      end
+    end
+
+    # Root counts as one board; every other board in the set is excluded from
+    # User#countable_board_count. Same markers Boards::BoardTreeBuilder sets.
+    def mark_builder_settings!
+      @map.each do |src_id, cloned|
+        key = (src_id == @source_root.id) ? "builder_root" : "builder_child"
+        cloned.settings = (cloned.settings || {}).merge(key => true)
+        cloned.save!
+      end
+    end
+
+    # Mirror Boards::BoardTreeBuilder#attach_root_to_communicator — favorite the
+    # root so the wizard lands on it. No ChildBoard for fringe boards.
+    def attach_root_to_communicator(root)
+      child_board = @communicator.child_boards.create!(board: root, created_by_id: @owner&.id)
+      child_board.update!(favorite: true) if @favorite_root
+      child_board
+    end
+
+    # Route each interest into the cloned fringe board its category maps to;
+    # anything with no matching fringe lands in a "My Favorites" fringe (existing
+    # one if the set has it, else created and linked from the root). Nothing the
+    # user typed is ever dropped.
+    def route_interests!(root)
+      return if @interests.empty?
+
+      root = Board.find(root.id) # fresh — for correct tile positions
+      fringe_by_name = cloned_fringe_by_name
+      unrouted = []
+
+      @interests.each do |word|
+        category = Boards::InterestCategories.category_for(word)
+        fringe   = category && fringe_by_name[category.to_s.downcase]
+        fringe ? add_interest_to_board(fringe, word) : unrouted << word
+      end
+
+      return if unrouted.empty?
+
+      favorites = fringe_by_name[FAVORITES_NAME.downcase] || create_favorites_board!(root)
+      unrouted.each { |word| add_interest_to_board(favorites, word) }
+    end
+
+    # Cloned non-root boards keyed by normalized name, freshly reloaded so their
+    # board_images_count/association reflect the clone. Fringe board names are
+    # authored to match Boards::InterestCategories labels (see the seed-format
+    # README), so "Food" routing lands in the cloned "Food" board.
+    def cloned_fringe_by_name
+      @map.each_with_object({}) do |(src_id, cloned), index|
+        next if src_id == @source_root.id
+
+        fresh = Board.find(cloned.id)
+        index[fresh.name.to_s.strip.downcase] = fresh
+      end
+    end
+
+    # Dedupe (case-insensitively) against what's already on the board, then add.
+    # reload keeps the counter cache / labels fresh across repeated adds.
+    def add_interest_to_board(board, word)
+      board.reload
+      existing = board.board_images.map { |bi| bi.label.to_s.downcase }
+      return if existing.include?(word.to_s.downcase)
+
+      image = resolve_or_create_image(word)
+      board.add_image(image.id)
+    end
+
+    # Create a "My Favorites" fringe owned by the user, marked builder_child so
+    # it doesn't count against the limit, and link it from the root via a folder
+    # tile + predictive_board_id (mirrors the assembler/tree-builder pattern).
+    def create_favorites_board!(root)
+      favorites = Board.new(name: FAVORITES_NAME, user: @owner)
+      favorites.board_type = "static"
+      favorites.assign_parent
+      favorites.voice = VoiceService.normalize_voice(@communicator.voice)
+      favorites.generate_unique_slug
+      favorites.settings = (favorites.settings || {}).merge("builder_child" => true)
+      favorites.save!
+
+      folder_tile = root.add_image(resolve_or_create_image(FAVORITES_NAME).id)
+      folder_tile&.update!(predictive_board_id: favorites.id)
+      favorites
+    end
+
+    # Mirror Board#find_or_create_images_from_word_list / BlueprintAssembler:
+    # the owner's own image, then a public/admin image, else create. A fresh
+    # image starts with no art — acceptable for v1 (blank tile, AI art later).
+    def resolve_or_create_image(label)
+      word  = normalize_word(label)
+      image = @owner.images.find_by(label: word)
+      image ||= Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil])
+      image ||= Image.create!(label: word, user_id: @owner.id)
+      image
+    end
+
+    def normalize_interests(list)
+      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(MAX_INTERESTS)
+    end
+
+    # multi-char words kept as typed, lone "i" -> "I", other single chars lowercased.
+    def normalize_word(string)
+      word = string.to_s.strip
+      return "" if word.blank?
+      return "I" if word.casecmp("i").zero?
+
+      word.length > 1 ? word : word.downcase
+    end
+  end
+end

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -67,15 +67,37 @@ module Boards
       tree && resolve(tree, user)
     end
 
-    # Label-only catalog for the picker UI: no Image resolution, so it's cheap
-    # and safe to serve even before symbols are seeded. Each entry exposes the
-    # core tile labels so the frontend can render a preview grid.
+    # Picker catalog: the hardcoded label-only starter trees PLUS any seeded
+    # "robust vocabulary set" templates (Core 60/84), found by their root-board
+    # marker (Boards::RobustSets). Each entry exposes core tile labels so the
+    # frontend can render a preview grid, and a `kind` so it can group/badge
+    # them. Robust sets that aren't seeded in this environment simply don't
+    # appear.
     def catalog
+      starter_catalog + robust_catalog
+    end
+
+    # The hardcoded label-only starter trees. Cheap and safe to serve even
+    # before symbols are seeded (no Image resolution).
+    def starter_catalog
       TEMPLATES.map do |key, tree|
         {
           key: key,
           name: tree[:name],
+          kind: "starter",
           tiles: Array(tree[:tiles]).map { |t| t[:label] },
+        }
+      end
+    end
+
+    # Seeded robust sets, sourced from their predefined root boards.
+    def robust_catalog
+      Boards::RobustSets.all_roots.map do |root|
+        {
+          key: Boards::RobustSets.slug_for(root),
+          name: root.name,
+          kind: "robust",
+          tiles: root.board_images.order(:position).map(&:label),
         }
       end
     end

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -1,0 +1,80 @@
+# app/services/vocab_sets.rb
+#
+# Seeds the Board Builder's "robust vocabulary set" templates (Core 60, Core 84)
+# from the authored OBF/OBZ source in db/seeds/board_builder_sets/<slug>/.
+#
+# Each set is imported via ObzImporter as admin (User::DEFAULT_ADMIN_ID) into a
+# linked tree of predefined/published boards. NO BoardGroup is created — the set
+# is identified by a marker on its ROOT board (Boards::RobustSets). The Board
+# Builder then clones the chosen set per user and routes the child's interests
+# into the cloned fringe pages.
+#
+# Driven by lib/tasks/vocab_sets.rake (vocab_sets:seed / vocab_sets:build).
+require "zip"
+
+module VocabSets
+  SETS_DIR = Rails.root.join("db", "seeds", "board_builder_sets")
+
+  module_function
+
+  # Slugs that have authored source (a manifest.json), optionally filtered by a
+  # comma-separated list.
+  def available_slugs(filter = nil)
+    present = Dir.children(SETS_DIR).select do |name|
+      File.file?(SETS_DIR.join(name, "manifest.json"))
+    end.sort
+    return present if filter.blank?
+
+    wanted = filter.split(",").map(&:strip)
+    present & wanted
+  end
+
+  # Zip the authored source dir into in-memory .obz bytes (manifest.json +
+  # boards/*.obf), preserving relative paths.
+  def obz_bytes(slug)
+    dir = SETS_DIR.join(slug)
+    raise "No source dir for slug #{slug.inspect} at #{dir}" unless File.directory?(dir)
+
+    buffer = Zip::OutputStream.write_buffer do |zos|
+      Dir.glob(dir.join("**", "*")).sort.each do |path|
+        next unless File.file?(path)
+
+        rel = Pathname.new(path).relative_path_from(Pathname.new(dir)).to_s
+        zos.put_next_entry(rel)
+        zos.write(File.binread(path))
+      end
+    end
+    buffer.rewind
+    buffer.read
+  end
+
+  def admin
+    User.find_by(id: User::DEFAULT_ADMIN_ID) ||
+      raise("Admin user (User::DEFAULT_ADMIN_ID=#{User::DEFAULT_ADMIN_ID}) not found — seed it first")
+  end
+
+  # Import one slug and stamp the result. Idempotent: Board.from_obf upserts by
+  # (user_id, obf_id), so re-running updates the same boards. Returns the root.
+  def seed_slug!(slug)
+    result = ObzImporter.new(
+      obz_bytes(slug),
+      admin,
+      board_group: nil, # root-board-only — no BoardGroup
+      import_options: {
+        include_images: true, # our own art; copyright gate is for third-party .obz
+        license_acknowledged: true,
+        acknowledged_by_user_id: admin.id,
+      },
+    ).import!
+
+    root = result[:root_board]
+    raise "Import produced no root board for #{slug.inspect}" unless root
+
+    result[:boards].values.each do |board|
+      board.update!(predefined: true, published: true)
+    end
+    Boards::RobustSets.mark_root!(root, slug)
+
+    root
+  end
+end

--- a/db/seeds/board_builder_sets/README.md
+++ b/db/seeds/board_builder_sets/README.md
@@ -1,0 +1,136 @@
+# Board Builder — robust vocabulary set seed format
+
+This directory holds the **authored source** for the Board Builder's "robust
+vocabulary set" templates (Core 60, Core 84). Each set is a small linked board
+tree authored as **OpenBoard (OBF/OBZ)** JSON, seeded into the database as
+admin-owned, predefined boards by `bin/rails vocab_sets:seed`, then **cloned
+per user** by the wizard.
+
+> **Share this file with the vocabulary session.** It defines the exact format,
+> the slugs, and the conventions the word content must follow. The finalized
+> word lists live in the workspace `drafts/` folder; drop them in here by
+> overwriting the placeholder `.obf` JSON.
+
+## Slugs (stable identifiers)
+
+| slug      | name    | status                          |
+|-----------|---------|---------------------------------|
+| `core-60` | Core 60 | **placeholder** (this dir)      |
+| `core-84` | Core 84 | not yet authored                |
+
+The slug is the key the wizard sends as `template` and the identifier stamped on
+the seeded **root board** (`settings["board_builder_robust_slug"]`). It must be
+URL-safe and stable — don't rename it once shipped.
+
+## Directory layout
+
+```
+db/seeds/board_builder_sets/
+  README.md                      <- this file
+  core-60/
+    manifest.json                <- OBZ manifest (root + path map)
+    boards/
+      core-60.obf                <- root core board
+      food.obf                   <- fringe category page
+      feelings.obf
+      play.obf
+  core-84/                       <- same shape, when authored
+```
+
+The seeder reads this directory, zips it **in memory** into an `.obz`, and feeds
+it to `ObzImporter`. You never commit a binary `.obz` — the JSON is the source
+of truth, so diffs stay reviewable. `bin/rails vocab_sets:build[core-60]` can
+emit a distributable `.obz` if you need the binary for an external tool.
+
+## OBF file format (OpenBoard 0.1)
+
+One `.obf` per board. Minimal shape:
+
+```jsonc
+{
+  "format": "open-board-0.1",
+  "id": "food",                  // unique within the set; matches manifest paths key
+  "locale": "en",
+  "name": "Food",                // see "Fringe board names" below — load-bearing
+  "grid": { "rows": 2, "columns": 3, "order": [[1,2,3],[4,5,6]] },
+  "buttons": [
+    { "id": 1, "label": "apple", "part_of_speech": "noun" },
+    { "id": 2, "label": "Play",  "part_of_speech": "noun",
+      "load_board": { "path": "boards/play.obf" } }   // folder tile -> fringe page
+  ],
+  "images": [],
+  "sounds": []
+}
+```
+
+- **`grid.order`** is a `rows × columns` matrix of button `id`s (`null` = empty
+  cell). `ObzImporter` lays the tiles out from this — no manual layout needed.
+- **`buttons[].label`** — the word/phrase. Symbols resolve like normal board
+  creation: lowercased lookup against existing public/admin images (proper nouns
+  and `"I"` keep their casing); a miss creates a blank-art image and AI art is
+  generated later. **Use our own labels only — never copy a commercial pageset
+  (CommuniKate, SymbolStix word lists, etc.).**
+- **`buttons[].part_of_speech`** — drives tile color via the modified Fitzgerald
+  key (`ImageHelper`/`BoardImage#set_colors`). Supported values:
+  `pronoun` (yellow), `verb` (green), `adjective` (blue), `noun` (orange),
+  `preposition`/`social` (pink), `question` (purple), `adverb` (brown),
+  `conjunction` (white), `determiner` (gray), `important_function` (red).
+  Omit for default (gray).
+- **`buttons[].load_board.path`** — makes a button a **folder tile** that opens
+  another board in the set (relative path into `boards/`). The importer wires
+  this to `BoardImage#predictive_board_id`. This is how the root core board
+  links to its fringe pages.
+- **`ext_saw_image_id`** (optional) — pin a button to a specific SpeakAnyWay
+  `Image#id` instead of resolving by label. Use sparingly.
+- **Do NOT include a top-level `board_group` key.** This feature is deliberately
+  **root-board only** (no `BoardGroup`); a `board_group` block would make the
+  importer create one.
+
+## manifest.json
+
+```jsonc
+{
+  "format": "open-board-0.1",
+  "root": "boards/core-60.obf",   // the core board the user lands on
+  "paths": {
+    "boards": {
+      "core-60": "boards/core-60.obf",
+      "food":    "boards/food.obf"
+      // one entry per board id -> path
+    }
+  }
+}
+```
+
+## Fringe board names are load-bearing
+
+A child's interest words are routed into fringe pages by **board name**. The
+wizard maps each interest to a category via `Boards::InterestCategories`
+(`Food`, `Feelings`, `Play`, `Bathroom`, …) and drops it into the cloned fringe
+board whose name matches that category. So:
+
+- Name a fringe page exactly after its category (`"Food"`, `"Feelings"`,
+  `"Play"`) for interest routing to land there.
+- Anything with no matching fringe page falls through to an auto-created
+  **"My Favorites"** page — nothing the child typed is ever dropped.
+- To add routing for a new category, add its words to
+  `Boards::InterestCategories::KEYWORDS` and give the set a fringe page with
+  that category's name.
+
+## Depth limit
+
+The clone walks the linked tree to **depth 2** (root + fringe + one more level),
+matching `Boards::BoardTreeBuilder::MAX_DEPTH`. Keep sets to a core board + one
+layer of fringe pages.
+
+## Seeding & rebuilding
+
+```bash
+bin/rails vocab_sets:seed                 # seed all known slugs
+bin/rails vocab_sets:seed SLUGS=core-60   # seed one
+DRY_RUN=1 bin/rails vocab_sets:seed       # report only, no writes
+bin/rails 'vocab_sets:build[core-60]'     # emit a distributable .obz
+```
+
+Seeding is **idempotent**: re-running finds the existing set by its root
+`board_builder_robust_slug` and updates in place (no duplicates).

--- a/db/seeds/board_builder_sets/core-60/boards/core-60.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/core-60.obf
@@ -1,0 +1,32 @@
+{
+  "format": "open-board-0.1",
+  "id": "core-60",
+  "locale": "en",
+  "name": "Core 60",
+  "description_html": "PLACEHOLDER Core 60 starter board. Replace the buttons/grid with the finalized Core 60 vocabulary. Folder tiles (Food, Feelings, Play) link to fringe category pages so the Board Builder can route a child's interests into them.",
+  "grid": {
+    "rows": 3,
+    "columns": 4,
+    "order": [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12]
+    ]
+  },
+  "buttons": [
+    { "id": 1, "label": "I", "part_of_speech": "pronoun" },
+    { "id": 2, "label": "you", "part_of_speech": "pronoun" },
+    { "id": 3, "label": "want", "part_of_speech": "verb" },
+    { "id": 4, "label": "more", "part_of_speech": "adjective" },
+    { "id": 5, "label": "help", "part_of_speech": "verb" },
+    { "id": 6, "label": "like", "part_of_speech": "verb" },
+    { "id": 7, "label": "go", "part_of_speech": "verb" },
+    { "id": 8, "label": "stop", "part_of_speech": "verb" },
+    { "id": 9, "label": "Food", "part_of_speech": "noun", "load_board": { "path": "boards/food.obf" } },
+    { "id": 10, "label": "Feelings", "part_of_speech": "noun", "load_board": { "path": "boards/feelings.obf" } },
+    { "id": 11, "label": "Play", "part_of_speech": "noun", "load_board": { "path": "boards/play.obf" } },
+    { "id": 12, "label": "all done", "part_of_speech": "verb" }
+  ],
+  "images": [],
+  "sounds": []
+}

--- a/db/seeds/board_builder_sets/core-60/boards/feelings.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/feelings.obf
@@ -1,0 +1,25 @@
+{
+  "format": "open-board-0.1",
+  "id": "feelings",
+  "locale": "en",
+  "name": "Feelings",
+  "description_html": "PLACEHOLDER fringe page. The board NAME must stay a recognized interest category (Feelings) so the Board Builder routes feeling interests here.",
+  "grid": {
+    "rows": 2,
+    "columns": 3,
+    "order": [
+      [1, 2, 3],
+      [4, 5, 6]
+    ]
+  },
+  "buttons": [
+    { "id": 1, "label": "happy", "part_of_speech": "adjective" },
+    { "id": 2, "label": "sad", "part_of_speech": "adjective" },
+    { "id": 3, "label": "tired", "part_of_speech": "adjective" },
+    { "id": 4, "label": "mad", "part_of_speech": "adjective" },
+    { "id": 5, "label": "scared", "part_of_speech": "adjective" },
+    { "id": 6, "label": "calm", "part_of_speech": "adjective" }
+  ],
+  "images": [],
+  "sounds": []
+}

--- a/db/seeds/board_builder_sets/core-60/boards/food.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/food.obf
@@ -1,0 +1,25 @@
+{
+  "format": "open-board-0.1",
+  "id": "food",
+  "locale": "en",
+  "name": "Food",
+  "description_html": "PLACEHOLDER fringe page. The board NAME must stay a recognized interest category (Food) so the Board Builder routes food interests here.",
+  "grid": {
+    "rows": 2,
+    "columns": 3,
+    "order": [
+      [1, 2, 3],
+      [4, 5, 6]
+    ]
+  },
+  "buttons": [
+    { "id": 1, "label": "apple", "part_of_speech": "noun" },
+    { "id": 2, "label": "banana", "part_of_speech": "noun" },
+    { "id": 3, "label": "water", "part_of_speech": "noun" },
+    { "id": 4, "label": "snack", "part_of_speech": "noun" },
+    { "id": 5, "label": "drink", "part_of_speech": "noun" },
+    { "id": 6, "label": "cookie", "part_of_speech": "noun" }
+  ],
+  "images": [],
+  "sounds": []
+}

--- a/db/seeds/board_builder_sets/core-60/boards/play.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/play.obf
@@ -1,0 +1,25 @@
+{
+  "format": "open-board-0.1",
+  "id": "play",
+  "locale": "en",
+  "name": "Play",
+  "description_html": "PLACEHOLDER fringe page. The board NAME must stay a recognized interest category (Play) so the Board Builder routes play interests here.",
+  "grid": {
+    "rows": 2,
+    "columns": 3,
+    "order": [
+      [1, 2, 3],
+      [4, 5, 6]
+    ]
+  },
+  "buttons": [
+    { "id": 1, "label": "ball", "part_of_speech": "noun" },
+    { "id": 2, "label": "music", "part_of_speech": "noun" },
+    { "id": 3, "label": "books", "part_of_speech": "noun" },
+    { "id": 4, "label": "bubbles", "part_of_speech": "noun" },
+    { "id": 5, "label": "blocks", "part_of_speech": "noun" },
+    { "id": 6, "label": "cars", "part_of_speech": "noun" }
+  ],
+  "images": [],
+  "sounds": []
+}

--- a/db/seeds/board_builder_sets/core-60/manifest.json
+++ b/db/seeds/board_builder_sets/core-60/manifest.json
@@ -1,0 +1,12 @@
+{
+  "format": "open-board-0.1",
+  "root": "boards/core-60.obf",
+  "paths": {
+    "boards": {
+      "core-60": "boards/core-60.obf",
+      "food": "boards/food.obf",
+      "feelings": "boards/feelings.obf",
+      "play": "boards/play.obf"
+    }
+  }
+}

--- a/lib/tasks/vocab_sets.rake
+++ b/lib/tasks/vocab_sets.rake
@@ -1,0 +1,51 @@
+# lib/tasks/vocab_sets.rake
+#
+# Seeds the Board Builder's "robust vocabulary set" templates (Core 60, Core 84)
+# from the authored OBF/OBZ source in db/seeds/board_builder_sets/<slug>/.
+# Logic lives in the autoloaded VocabSets service; these are thin wrappers.
+#
+#   bin/rails vocab_sets:seed                 # seed every authored slug
+#   bin/rails vocab_sets:seed SLUGS=core-60   # seed only the named slug(s)
+#   DRY_RUN=1 bin/rails vocab_sets:seed       # report only, no DB writes
+#   bin/rails 'vocab_sets:build[core-60]'     # emit a distributable .obz to tmp/
+#
+# Idempotent: re-running upserts the same boards (Board.from_obf matches by
+# (user_id, obf_id)) and re-applies the markers — no duplicate sets.
+namespace :vocab_sets do
+  desc "Seed robust vocabulary sets (Core 60/84) as predefined Board Builder templates"
+  task seed: :environment do
+    dry_run = ENV["DRY_RUN"].present?
+    slugs = VocabSets.available_slugs(ENV["SLUGS"])
+
+    if slugs.empty?
+      puts "[vocab_sets:seed] No authored sets found under #{VocabSets::SETS_DIR} (SLUGS=#{ENV["SLUGS"].inspect})"
+      next
+    end
+
+    puts "[vocab_sets:seed] #{dry_run ? "DRY RUN — " : ""}seeding: #{slugs.join(", ")}"
+
+    slugs.each do |slug|
+      if dry_run
+        existing = Boards::RobustSets.find_root(slug)
+        puts "  - #{slug}: would #{existing ? "update existing root ##{existing.id}" : "create new set"}"
+        next
+      end
+
+      root = VocabSets.seed_slug!(slug)
+      puts "  - #{slug}: root ##{root.id} \"#{root.name}\" (#{root.board_images.count} core tiles)"
+    rescue StandardError => e
+      warn "  - #{slug}: FAILED — #{e.class}: #{e.message}"
+    end
+
+    puts "[vocab_sets:seed] done"
+  end
+
+  desc "Emit a distributable .obz for a slug to tmp/<slug>.obz"
+  task :build, [:slug] => :environment do |_t, args|
+    slug = args[:slug] or abort "usage: bin/rails 'vocab_sets:build[core-60]'"
+    out = Rails.root.join("tmp", "#{slug}.obz")
+    FileUtils.mkdir_p(out.dirname)
+    File.binwrite(out, VocabSets.obz_bytes(slug))
+    puts "[vocab_sets:build] wrote #{out} (#{File.size(out)} bytes)"
+  end
+end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
     end
   end
 
+  # Seeds a tiny admin-owned robust set (a "Core 60" root linked to a "Food"
+  # fringe page) and stamps the root marker so Boards::RobustSets finds it.
+  # Mirrors what `bin/rails vocab_sets:seed` produces, without the OBZ import.
+  def seed_robust_set!(slug: "core-60")
+    admin = create(:admin_user)
+    root  = create(:board, user: admin, name: "Core 60", predefined: true, published: true)
+    food  = create(:board, user: admin, name: "Food", predefined: true, published: true)
+    create(:board_image, board: root, label: "I", image: create(:image, label: "I", user_id: admin.id))
+    food_tile = create(:board_image, board: root, label: "Food",
+                                     image: create(:image, label: "Food", user_id: admin.id))
+    food_tile.update!(predictive_board_id: food.id)
+    create(:board_image, board: food, label: "apple", image: create(:image, label: "apple", user_id: admin.id))
+    Boards::RobustSets.mark_root!(root, slug)
+    root
+  end
+
   describe "GET /api/v1/board_builder/templates" do
     it "returns the label-only catalog" do
       get "/api/v1/board_builder/templates", headers: headers
@@ -30,6 +46,19 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       expect(keys).to include("home", "daily_routine")
       home = body["templates"].find { |t| t["key"] == "home" }
       expect(home["tiles"]).to include("I", "Food")
+      expect(home["kind"]).to eq("starter")
+    end
+
+    it "includes seeded robust sets, tagged kind=robust" do
+      seed_robust_set!
+      get "/api/v1/board_builder/templates", headers: headers
+
+      body = JSON.parse(response.body)
+      robust = body["templates"].find { |t| t["key"] == "core-60" }
+      expect(robust).to be_present
+      expect(robust["kind"]).to eq("robust")
+      expect(robust["name"]).to eq("Core 60")
+      expect(robust["tiles"]).to include("I", "Food")
     end
   end
 
@@ -233,6 +262,74 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(JSON.parse(response.body)["error"]).to eq("build_failed")
+      end
+    end
+
+    context "robust seeded set (clone path)" do
+      it "clones the seeded set, favorites the root, and routes interests into the cloned fringe" do
+        seed_robust_set!
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "core-60",
+                         interests: ["pizza"] }.to_json,
+               headers: headers
+        }.to change { communicator.child_boards.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.name).to eq("Core 60")
+        expect(root.user_id).to eq(user.id)
+        expect(root.settings["builder_root"]).to be(true)
+
+        child_board = communicator.child_boards.find_by(board_id: root.id)
+        expect(child_board.favorite).to eq(true)
+
+        # The whole cloned set counts as ONE board.
+        expect(User.find(user.id).countable_board_count).to eq(1)
+
+        # "pizza" routed into the cloned Food fringe page.
+        cloned_food = user.boards.find_by(name: "Food")
+        expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
+
+        expect(communicator.reload.details["interests"]).to eq(["pizza"])
+      end
+
+      it "is blocked by the board limit (422) — a cloned set still counts as one" do
+        seed_robust_set!
+        create(:board, user: user) # Free (limit 1) → at limit
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "core-60" }.to_json,
+               headers: headers
+        }.not_to change { communicator.child_boards.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+      end
+
+      it "warns with 409 on a re-run unless confirm=true" do
+        seed_robust_set!
+        user.update!(settings: user.settings.to_h.merge("board_limit" => 10))
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "core-60" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "core-60" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:conflict)
+        expect(JSON.parse(response.body)["error"]).to eq("board_builder_set_exists")
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "core-60", confirm: true }.to_json,
+               headers: headers
+        }.to change { communicator.child_boards.count }.by(1)
+        expect(response).to have_http_status(:created)
       end
     end
   end

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -1,0 +1,154 @@
+require "rails_helper"
+
+RSpec.describe Boards::SeededSetCloner do
+  let(:admin) { create(:admin_user) }
+  let(:owner) { create(:user) }
+  let(:communicator) { create(:child_account, user: owner) }
+
+  # Builds an admin-owned seeded set: a root core board linked to two fringe
+  # category pages (Food, Feelings) via predictive_board_id, plus a deliberate
+  # CYCLE (a Feelings tile links back to the root) to exercise cycle-safety.
+  def build_source_set!
+    root     = create(:board, user: admin, name: "Core 60", predefined: true, published: true)
+    food     = create(:board, user: admin, name: "Food", predefined: true, published: true)
+    feelings = create(:board, user: admin, name: "Feelings", predefined: true, published: true)
+
+    %w[I want help].each do |label|
+      create(:board_image, board: root, label: label, image: create(:image, label: label, user_id: admin.id))
+    end
+    food_tile = create(:board_image, board: root, label: "Food",
+                                     image: create(:image, label: "Food", user_id: admin.id))
+    food_tile.update!(predictive_board_id: food.id)
+    feelings_tile = create(:board_image, board: root, label: "Feelings",
+                                         image: create(:image, label: "Feelings", user_id: admin.id))
+    feelings_tile.update!(predictive_board_id: feelings.id)
+
+    %w[apple banana].each do |label|
+      create(:board_image, board: food, label: label, image: create(:image, label: label, user_id: admin.id))
+    end
+    %w[happy sad].each do |label|
+      create(:board_image, board: feelings, label: label, image: create(:image, label: label, user_id: admin.id))
+    end
+
+    # CYCLE: a Feelings tile points back at the root.
+    back = create(:board_image, board: feelings, label: "home",
+                                image: create(:image, label: "home", user_id: admin.id))
+    back.update!(predictive_board_id: root.id)
+
+    { root: root, food: food, feelings: feelings, food_tile: food_tile, feelings_tile: feelings_tile }
+  end
+
+  let(:source) { build_source_set! }
+
+  describe "#call" do
+    it "clones the linked set for the owner and counts the whole set as ONE board" do
+      # Fresh User each evaluation — countable_board_count is memoized and
+      # survives reload, so owner.reload would report a stale 0.
+      expect {
+        @root = described_class.new(source[:root], communicator: communicator).call
+      }.to change { User.find(owner.id).countable_board_count }.from(0).to(1)
+
+      expect(@root.user_id).to eq(owner.id)
+      expect(@root.predefined).to be(false)
+      expect(@root.settings["builder_root"]).to be(true)
+
+      # 3 source boards (root + Food + Feelings) -> 3 owner-owned clones; the
+      # cycle does not clone the root twice.
+      owner_boards = owner.boards
+      expect(owner_boards.count).to eq(3)
+      fringe = owner_boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+      expect(fringe.count).to eq(2)
+      expect(fringe.pluck(:name)).to contain_exactly("Food", "Feelings")
+    end
+
+    it "rewires folder tiles to the cloned fringe boards and nulls out-of-set pointers" do
+      root = described_class.new(source[:root], communicator: communicator).call
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      cloned_feelings = owner.boards.find_by(name: "Feelings")
+
+      food_tile = root.board_images.find_by(label: "Food")
+      expect(food_tile.predictive_board_id).to eq(cloned_food.id)
+
+      # The cloned Feelings board's cyclic "home" tile pointed back at the root —
+      # that target is in the set, so it rewires to the cloned root (not nulled).
+      home_tile = cloned_feelings.board_images.find_by(label: "home")
+      expect(home_tile.predictive_board_id).to eq(root.id)
+
+      # No cloned tile may still point at a SOURCE board.
+      source_ids = [source[:root].id, source[:food].id, source[:feelings].id]
+      cloned_predictive = owner.boards.flat_map { |b| b.board_images.pluck(:predictive_board_id) }.compact
+      expect(cloned_predictive & source_ids).to be_empty
+    end
+
+    it "attaches exactly one favorite ChildBoard (the root), none for fringe" do
+      root = described_class.new(source[:root], communicator: communicator).call
+
+      child_boards = communicator.child_boards.reload
+      expect(child_boards.count).to eq(1)
+      expect(child_boards.first.board_id).to eq(root.id)
+      expect(child_boards.first.favorite).to be(true)
+    end
+
+    it "routes interests into matching cloned fringe pages" do
+      root = described_class.new(
+        source[:root], communicator: communicator, interests: ["apple", "happy"]
+      ).call
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      cloned_feelings = owner.boards.find_by(name: "Feelings")
+
+      # "apple" already exists on Food -> deduped (no second tile).
+      expect(cloned_food.board_images.where(label: "apple").count).to eq(1)
+      # "happy" already exists on Feelings -> deduped too.
+      expect(cloned_feelings.board_images.where(label: "happy").count).to eq(1)
+    end
+
+    it "adds a brand-new food interest to the cloned Food page" do
+      root = described_class.new(
+        source[:root], communicator: communicator, interests: ["pizza"]
+      ).call
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      expect(cloned_food.board_images.map(&:label)).to include("pizza")
+    end
+
+    it "routes unmatched interests into a created, linked, builder_child 'My Favorites'" do
+      root = described_class.new(
+        source[:root], communicator: communicator, interests: ["grandma"]
+      ).call
+
+      favorites = owner.boards.find_by(name: "My Favorites")
+      expect(favorites).to be_present
+      expect(favorites.settings["builder_child"]).to be(true)
+      expect(favorites.board_images.map(&:label)).to include("grandma")
+
+      # Linked from the root via a folder tile.
+      fav_tile = root.board_images.find_by(label: "My Favorites")
+      expect(fav_tile.predictive_board_id).to eq(favorites.id)
+
+      # Still counts as ONE board (favorites is builder_child).
+      expect(User.find(owner.id).countable_board_count).to eq(1)
+    end
+
+    it "does not mutate the source seed set" do
+      described_class.new(source[:root], communicator: communicator, interests: ["pizza"]).call
+
+      expect(source[:root].reload.predefined).to be(true)
+      expect(source[:food_tile].reload.predictive_board_id).to eq(source[:food].id)
+      # Source boards still belong to admin; clones belong to the owner.
+      expect(Board.where(user_id: admin.id).count).to eq(3)
+      expect(source[:food].reload.board_images.map { |bi| bi.image.label }).to contain_exactly("apple", "banana")
+    end
+
+    it "raises CloneError when the communicator has no owning user" do
+      orphan = build(:child_account)
+      allow(orphan).to receive(:owner).and_return(nil)
+      allow(orphan).to receive(:user).and_return(nil)
+
+      expect {
+        described_class.new(source[:root], communicator: orphan).call
+      }.to raise_error(Boards::SeededSetCloner::CloneError)
+    end
+  end
+end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe VocabSets do
+  # The seeder imports as User::DEFAULT_ADMIN_ID, so an admin with that id must
+  # exist. The placeholder Core 60 source ships in db/seeds/board_builder_sets/.
+  let!(:admin) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  describe ".available_slugs" do
+    it "lists slugs that have a manifest.json" do
+      expect(VocabSets.available_slugs).to include("core-60")
+    end
+
+    it "filters by the provided list" do
+      expect(VocabSets.available_slugs("core-60")).to eq(["core-60"])
+      expect(VocabSets.available_slugs("does-not-exist")).to be_empty
+    end
+  end
+
+  describe ".seed_slug!" do
+    it "imports the placeholder set as a marked, predefined, linked tree (no BoardGroup)" do
+      expect { @root = VocabSets.seed_slug!("core-60") }.not_to change { BoardGroup.count }
+
+      expect(@root.name).to eq("Core 60")
+      expect(@root.settings["board_builder_robust"]).to be(true)
+      expect(@root.settings["board_builder_robust_slug"]).to eq("core-60")
+
+      # Root + 3 fringe pages, all admin-owned and predefined/published.
+      admin_boards = Board.where(user_id: admin.id)
+      expect(admin_boards.count).to eq(4)
+      expect(admin_boards.pluck(:name)).to contain_exactly("Core 60", "Food", "Feelings", "Play")
+      expect(admin_boards.all? { |b| b.predefined && b.published }).to be(true)
+
+      # The root's "Food" folder tile links to the imported Food fringe board.
+      food_tile = @root.board_images.find_by(label: "Food")
+      expect(food_tile.predictive_board_id).to be_present
+      expect(Board.find(food_tile.predictive_board_id).name).to eq("Food")
+    end
+
+    it "is findable via Boards::RobustSets after seeding" do
+      VocabSets.seed_slug!("core-60")
+      root = Boards::RobustSets.find_root("core-60")
+      expect(root).to be_present
+      expect(Boards::RobustSets.slug_for(root)).to eq("core-60")
+    end
+
+    it "is idempotent — re-seeding doesn't duplicate boards or roots" do
+      VocabSets.seed_slug!("core-60")
+      expect { VocabSets.seed_slug!("core-60") }.not_to change { Board.where(user_id: admin.id).count }
+      expect(Boards::RobustSets.all_roots.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a **robust vocabulary set** path to the Board Builder wizard that reuses existing infrastructure end to end. Pre-authored core vocabulary sets (Core 60, Core 84) are **authored as our own OBF/OBZ**, **seeded** via `ObzImporter` (grid layout + `part_of_speech` colors + `load_board`→`predictive_board_id` links), and on build **deep-cloned per user** via `Board#clone_with_images` — with the child's interests routed into the cloned fringe pages. SpeakAnyWay content only.

This is the standalone Board Builder feature (not MySpeak onboarding). The React picker ships separately in `itty-bitty-frontend`.

### What's here
- **Seed format + placeholder** — editable OBF-JSON under `db/seeds/board_builder_sets/<slug>/` (`manifest.json` + `boards/*.obf`), format spec in `db/seeds/board_builder_sets/README.md` (the artifact to share with the vocabulary session). Ships a tiny **placeholder `core-60`** set; `core-84` content TBD.
- **Seeder** — `VocabSets` service + `bin/rails vocab_sets:seed` zips the JSON in-memory and imports as `User::DEFAULT_ADMIN_ID` with **`board_group: nil`**. **No `BoardGroup`** — a set is identified by a marker on its **root board** (`settings["board_builder_robust_slug"]`, via `Boards::RobustSets`). Idempotent (`Board.from_obf` upserts by `(user_id, obf_id)`). `vocab_sets:build` emits a distributable `.obz`.
- **Deep-clone** — `Boards::SeededSetCloner`: bounded (depth 2), cycle-safe walk of the linked set; clones each board; **rewires** `predictive_board_id` to the clones (out-of-set pointers nulled); marks root `builder_root` / rest `builder_child` so the whole set counts as **ONE** board; favorites the root `ChildBoard`; routes interests into the cloned fringe pages by category, with an auto-created, linked **"My Favorites"** for leftovers.
- **Catalog + endpoint** — `StarterBlueprints.catalog` merges robust sets (`kind: "starter" | "robust"`); `API::V1::BoardBuilderController#create` branches to the cloner for robust slugs, **synchronous 201**, keeping the existing **board-limit (422)** and **re-run (409 `board_builder_set_exists`, unless `confirm=true`)** guards.

### Decisions (from review)
- **No `BoardGroup`** — root-board-only, consistent with the rest of the Board Builder.
- **Synchronous first.** Work is DB-bound; previews/audio/AI art are already backgrounded. **Spike:** a worst-case ~600-tile clone measured ~3s (test env); realistic Core 60/84 sets (~120–200 tiles) ~1s. If a finalized set lands materially larger (>~300 tiles), moving the clone to a background job + "building" state is a documented follow-up (`.claude-notes/board-builder.md`).

No schema changes. Content for the real Core 60/84 word lists will be dropped in later by overwriting the placeholder JSON.

## Test plan
Run locally (`RAILS_ENV=test`), all green:
- `spec/services/boards` (incl. new `seeded_set_cloner_spec` — rewire, builder markers, favorite ChildBoard, cycle-safety, interest routing + My Favorites, counts-as-one, source untouched) — and `starter_blueprints` / `blueprint_assembler` / `interest_categories` / `board_tree_builder` unaffected.
- `spec/services/vocab_sets_spec` — OBZ import, root marker, predefined/published, **no BoardGroup**, idempotent.
- `spec/requests/api/v1/board_builder_spec` — robust catalog entry, clone build (201 + interest routing), board-limit 422, re-run 409/confirm.
- `spec/models/board_spec` — clone path unaffected (51 ex).
- Manual: `vocab_sets:build[core-60]` round-trips to a valid `.obz`; `DRY_RUN=1 vocab_sets:seed` reports correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)