### PR TITLE
fix(board-builder): queue AI art for novel interest words in robust clone

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -196,8 +196,12 @@ lose.
   board), favorites the root as a ChildBoard, and routes interests into the
   cloned fringe pages by category name — unmatched → an auto-created, linked
   `builder_child` "My Favorites" page. Interest normalization/dedup/cap mirror
-  `BlueprintAssembler`. clone_with_images returns clones with a stale
-  counter/association cache, so routing reloads boards before adding tiles.
+  `BlueprintAssembler`. A novel interest word with no existing public/admin
+  symbol is created and **queued for AI art** (`GenerateImagesJob`), mirroring
+  `Board#find_or_create_images_from_word_list` — words that resolve to existing
+  art are skipped, so we never pay to regenerate. clone_with_images returns
+  clones with a stale counter/association cache, so routing reloads boards
+  before adding tiles.
 
 **Synchronous (v1) — execution note.** The build runs in-request (the existing
 contract). image_ids are pre-resolved so the work is DB-bound; previews, audio,

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -177,6 +177,18 @@ module Boards
 
       image = resolve_or_create_image(word)
       board.add_image(image.id)
+      generate_art_if_blank(image, board)
+    end
+
+    # A novel interest word (no existing public/admin art) clones in blank; queue
+    # AI art so it fills in "later", matching Board#find_or_create_images_from_word_list
+    # (board.rb:900/905). Words that resolved to existing art are skipped, so we
+    # never pay to regenerate something we already have.
+    def generate_art_if_blank(image, board)
+      return if image.display_tile_url(@owner).present?
+      return if image.docs.any? { |doc| [User::DEFAULT_ADMIN_ID, @owner.id].include?(doc.user_id) }
+
+      GenerateImagesJob.perform_async([image.id], board.id)
     end
 
     # Create a "My Favorites" fringe owned by the user, marked builder_child so

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -131,6 +131,19 @@ RSpec.describe Boards::SeededSetCloner do
       expect(User.find(owner.id).countable_board_count).to eq(1)
     end
 
+    it "queues AI art for a novel interest word with no existing symbol" do
+      expect(GenerateImagesJob).to receive(:perform_async).with(kind_of(Array), kind_of(Integer)).at_least(:once)
+
+      described_class.new(source[:root], communicator: communicator, interests: ["dinosaurs"]).call
+    end
+
+    it "does not queue art when the interest already exists on the fringe" do
+      # "apple" is already on the cloned Food page -> deduped, nothing created.
+      expect(GenerateImagesJob).not_to receive(:perform_async)
+
+      described_class.new(source[:root], communicator: communicator, interests: ["apple"]).call
+    end
+
     it "does not mutate the source seed set" do
       described_class.new(source[:root], communicator: communicator, interests: ["pizza"]).call
 

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe VocabSets do
       expect(Boards::RobustSets.slug_for(root)).to eq("core-60")
     end
 
+    it "names every fringe page after a recognized interest category so routing lands" do
+      # Guards against content drift: if a fringe page is renamed to something
+      # InterestCategories doesn't know, interests for it silently fall to
+      # "My Favorites". The placeholder's pages are Food/Feelings/Play.
+      VocabSets.seed_slug!("core-60")
+
+      fringe_names = Board.where(user_id: admin.id).where.not(name: "Core 60").pluck(:name)
+      expect(fringe_names).not_to be_empty
+      fringe_names.each do |name|
+        expect(Boards::InterestCategories.categories).to include(name),
+                                                          "fringe page #{name.inspect} is not a routable interest category"
+      end
+    end
+
     it "is idempotent — re-seeding doesn't duplicate boards or roots" do
       VocabSets.seed_slug!("core-60")
       expect { VocabSets.seed_slug!("core-60") }.not_to change { Board.where(user_id: admin.id).count }


### PR DESCRIPTION
Follow-up to the review on #273 (now merged).

## Required change addressed
**Novel interest words got a permanently blank tile.** `Boards::SeededSetCloner#resolve_or_create_image` created an `Image` on a miss but never scheduled art, so a child's novel interest (e.g. "dinosaurs" with no admin symbol) cloned in blank and stayed blank — contradicting the locked "AI-generate on miss" decision.

Fix: after adding an interest tile, enqueue `GenerateImagesJob([image.id], board.id)` when the image has no existing public/admin art — mirroring `Board#find_or_create_images_from_word_list` (board.rb:900/905). Words that resolve to existing art are skipped, so we never pay to regenerate something we already have. Folder-label images (e.g. "My Favorites") are unaffected — only interest words trigger generation.

## Also (non-blocking note from the review)
Added a seeder spec asserting **every placeholder fringe page name is a recognized `InterestCategories` category**, so content drift that would silently route interests to "My Favorites" is caught when the real Core 60/84 content replaces the stub.

## Test plan
`RAILS_ENV=test`, green:
- `spec/services/boards/seeded_set_cloner_spec` — new: queues art for a novel interest; does **not** queue when the interest already exists on the fringe (dedup).
- `spec/services/vocab_sets_spec` — new: fringe page names are routable categories.
- Full robust suite (`spec/services/boards`, `vocab_sets_spec`, `board_builder_spec`) still green.

Docs: `.claude-notes/board-builder.md` updated to note novel interests queue art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)