### PR TITLE
feat(analytics): server-side PostHog subscription lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Server-side PostHog subscription lifecycle events
+- The Stripe webhook now fires three **server-side** PostHog events so the
+  money-path funnel (pricing page → `checkout_started` → `subscription_started`)
+  is buildable, and so conversions aren't missed when a user closes the
+  success tab (itty-bitty-frontend#307, backend half):
+  - **`trial_started`** `{ plan }` — on `customer.subscription.created` when the
+    subscription is `trialing`.
+  - **`subscription_started`** `{ plan, billing_interval }` — on the
+    non-active→active transition (trial→paid / first activation).
+  - **`subscription_cancelled`** `{ plan, reason? }` — on
+    `customer.subscription.deleted` (reason from Stripe's cancellation_details
+    when present).
+- Each event also updates the person's `plan` property (`$set`), and uses
+  `distinct_id = user.id.to_s` to match the frontend's `posthog.identify`
+  contract so events land on the same person.
+- Capture is **production-only** by default (staging/dev opt in via
+  `POSTHOG_CAPTURE_ENABLED=true`) and wrapped so a PostHog failure can never
+  break a Stripe webhook. New env vars: `POSTHOG_API_KEY`, `POSTHOG_HOST`
+  (default `https://us.i.posthog.com`), `POSTHOG_CAPTURE_ENABLED`.
+
 ### Added — Robust vocabulary sets for the Board Builder (Core 60/84)
 - The Board Builder picker now offers pre-authored **core vocabulary sets** (a
   real core grid + fringe category pages) alongside the small starter templates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,45 @@ ActionMailer/Gmail SMTP, **not** Mailchimp. True 1:1 transactional via Mailchimp
 would require the separate Transactional/Mandrill product (different gem + key +
 paid add-on) — not integrated.
 
+## PostHog server-side analytics
+
+`PosthogService` (`app/models/posthog_service.rb`) captures the
+**subscription lifecycle events that are only knowable server-side** (Stripe
+webhooks), via the `posthog-ruby` gem. These complement the frontend's own
+PostHog events (which fire intent + `checkout_started`); the backend completes
+the money-path funnel (itty-bitty-frontend#307). Fired from
+`API::WebhooksController`:
+
+- **`trial_started`** `{ plan }` — `handle_trial_started_analytics`, on
+  `customer.subscription.created` when `status == "trialing"`. PostHog-only —
+  the internal `trial_started` AnalyticsEvent already fires at checkout, so we
+  don't double-count.
+- **`subscription_started`** `{ plan, billing_interval }` — in
+  `handle_subscription_upsert`, on the non-active→active transition (alongside
+  the existing `subscription_started` AnalyticsEvent). `billing_interval` is
+  derived from the Stripe Price's `recurring.interval` (`month`→`monthly`,
+  `year`→`yearly`) to match the frontend's `checkout_started` values.
+- **`subscription_cancelled`** `{ plan, reason? }` — in
+  `handle_subscription_deleted`, capturing the plan being left *before*
+  `apply_free_plan` resets it; `reason` from Stripe's `cancellation_details`.
+  Also records an internal `subscription_canceled` AnalyticsEvent for parity.
+
+Key contracts:
+
+- **`distinct_id = user.id.to_s`.** The frontend identifies people as
+  `String(user.id)` (`posthog.identify`), so the backend must use the same id
+  for events to land on the same person. `capture_for_user` enforces this.
+- **Person `plan` stays in sync.** Every capture `$set`s the `plan` property
+  (defaults to `user.plan_type`; cancellation explicitly `$set`s `plan: free`).
+- **Env-gated, prod-only.** `PosthogClient.enabled?` (`config/initializers/
+  posthog.rb`) returns true in production only (staging excluded via
+  `AppEnv.staging?`); dev/staging fire only when `POSTHOG_CAPTURE_ENABLED=true`.
+  Requires `POSTHOG_API_KEY`; `POSTHOG_HOST` defaults to
+  `https://us.i.posthog.com`. Mirrors the Mailchimp-journeys gate.
+- **Never breaks the webhook.** `capture_for_user` rescues and logs — a PostHog
+  outage can't 500 a Stripe webhook. Captures are async (the SDK enqueues to its
+  own background flush thread), so no Sidekiq job is needed.
+
 ## Subscription model
 
 - Most features are free

--- a/Gemfile
+++ b/Gemfile
@@ -119,6 +119,10 @@ gem "stripe", "~> 12.0"
 # MAilCHIMP
 gem 'MailchimpMarketing', :git => 'https://github.com/mailchimp/mailchimp-marketing-ruby.git'
 
+# PostHog server-side analytics (subscription lifecycle events fired from
+# the Stripe webhook). See PosthogService / config/initializers/posthog.rb.
+gem "posthog-ruby", "~> 2.0"
+
 # To use Braintree + PayPal, also include:
 gem "braintree", "~> 4.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,8 @@ GEM
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
+    posthog-ruby (2.11.0)
+      concurrent-ruby (~> 1)
     pp (0.6.3)
       prettyprint
     prawn (2.5.0)
@@ -601,6 +603,7 @@ DEPENDENCIES
   pay (~> 7.0)
   pg (~> 1.1)
   pg_search
+  posthog-ruby (~> 2.0)
   puma (>= 5.0)
   pundit (~> 2.3)
   rack-cors

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
   - `GOOGLE_CUSTOM_SEARCH_CX` - Google Custom Search CX
   - `PREDICTIVE_DEFAULT_ID` - Predictive Default ID (going to be removed)
   - `INTERNAL_API_KEY` - Shared key used to authenticate the internal API (see "Internal API" section below)
+  - `POSTHOG_API_KEY` - PostHog project API key for server-side capture of subscription lifecycle events (use the same project the frontend reports to). When blank, server-side capture no-ops.
+  - `POSTHOG_HOST` - PostHog ingestion host (optional; defaults to `https://us.i.posthog.com`)
+  - `POSTHOG_CAPTURE_ENABLED` - Set to `true` to fire server-side PostHog events outside production (dev/staging opt-in). Production fires automatically; staging stays off unless this is set.
 
 - Database creation:
 

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -45,6 +45,7 @@ class API::WebhooksController < API::ApplicationController
       # via invoice.payment_succeeded below, but trials have no invoice yet.
       if event.type == "customer.subscription.created"
         handle_trial_credit_grant(event.data.object, event.id)
+        handle_trial_started_analytics(event.data.object)
       end
     when "customer.subscription.trial_will_end"
       handle_trial_will_end(event.data.object)
@@ -279,6 +280,16 @@ class API::WebhooksController < API::ApplicationController
           subscription_id: subscription.id,
         },
       )
+      # Server-side PostHog mirror (itty-bitty-frontend#307) so the money-path
+      # funnel completes for users who never return to the success screen.
+      PosthogService.capture_for_user(
+        user,
+        "subscription_started",
+        properties: {
+          plan: user.plan_type,
+          billing_interval: billing_interval_from_price(price),
+        },
+      )
     end
 
     # Optional: team seats logic if this is a team plan
@@ -380,6 +391,33 @@ class API::WebhooksController < API::ApplicationController
     Rails.logger.error "[StripeWebhook] handle_trial_credit_grant error: #{e.class} - #{e.message}"
   end
 
+  # A trial only truly begins when Stripe creates the subscription with a trial
+  # period (status "trialing") — so we fire the server-side PostHog
+  # `trial_started` here rather than from the frontend (itty-bitty-frontend#307).
+  # PostHog-only: the internal `trial_started` AnalyticsEvent is already recorded
+  # at checkout (CheckoutSessionsController), so we don't double-count there.
+  # Called only from `customer.subscription.created`, so it can't re-fire on
+  # trialing→trialing updates.
+  def handle_trial_started_analytics(subscription)
+    return unless subscription.status == "trialing"
+
+    user = find_user_for_subscription(subscription)
+    return unless user
+    return if user.admin?
+
+    price = first_price_from_subscription(subscription)
+    plan = (price&.metadata || {})["plan_type"].presence || user.plan_type
+
+    PosthogService.capture_for_user(
+      user,
+      "trial_started",
+      properties: { plan: plan },
+      set: { plan: plan },
+    )
+  rescue => e
+    Rails.logger.error "[StripeWebhook] handle_trial_started_analytics error: #{e.class} - #{e.message}"
+  end
+
   # Mark the user's subscription as past_due. Stripe will keep retrying
   # the charge per its dunning rules; we just need state visibility so
   # downstream code (and the user) can see something went wrong. We do NOT
@@ -434,8 +472,31 @@ class API::WebhooksController < API::ApplicationController
       return
     end
 
+    # Capture the plan we're leaving BEFORE apply_free_plan resets it to "free".
+    cancelled_plan = user.plan_type
+    reason = cancellation_reason_from_subscription(subscription)
+
     apply_free_plan(user)
     Rails.logger.info "[StripeWebhook] subscription deleted: downgraded user=#{user.id} to free"
+
+    # Internal + PostHog analytics for the cancellation (itty-bitty-frontend#307).
+    # Cancellation happens entirely inside Stripe's billing portal, so the
+    # frontend never sees it — capture it server-side. $set plan -> "free"
+    # (user.plan_type is now free after apply_free_plan) keeps cohorts correct.
+    AnalyticsEvent.track(
+      "subscription_canceled",
+      user_id: user.id,
+      metadata: {
+        plan_type: cancelled_plan,
+        reason: reason,
+        subscription_id: subscription.id,
+      },
+    )
+    PosthogService.capture_for_user(
+      user,
+      "subscription_cancelled",
+      properties: { plan: cancelled_plan, reason: reason },
+    )
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_subscription_deleted error: #{e.class} - #{e.message}"
   end
@@ -481,6 +542,40 @@ class API::WebhooksController < API::ApplicationController
     item = subscription.items&.data&.first
     return nil unless item
     item.price
+  end
+
+  # Map a Stripe Price's recurring interval to the frontend's billing_interval
+  # values ("monthly" / "yearly") so the money-path funnel lines up across
+  # client- and server-fired events. Returns nil when no recurring interval is
+  # present (defensive — one-time prices, or a Price without `recurring`).
+  def billing_interval_from_price(price)
+    recurring = price.respond_to?(:recurring) ? price.recurring : nil
+    return nil if recurring.nil?
+
+    interval = recurring.respond_to?(:interval) ? recurring.interval : recurring["interval"]
+    case interval
+    when "month" then "monthly"
+    when "year" then "yearly"
+    else interval
+    end
+  rescue => e
+    Rails.logger.error "[StripeWebhook] billing_interval_from_price error: #{e.class} - #{e.message}"
+    nil
+  end
+
+  # Best-effort cancellation reason from Stripe's cancellation_details
+  # (feedback is the user-selected reason in the billing portal; reason is the
+  # system reason). nil when Stripe didn't collect one.
+  def cancellation_reason_from_subscription(subscription)
+    details = subscription.respond_to?(:cancellation_details) ? subscription.cancellation_details : nil
+    return nil if details.nil?
+
+    feedback = details.respond_to?(:feedback) ? details.feedback : details["feedback"]
+    reason = details.respond_to?(:reason) ? details.reason : details["reason"]
+    feedback.presence || reason.presence
+  rescue => e
+    Rails.logger.error "[StripeWebhook] cancellation_reason_from_subscription error: #{e.class} - #{e.message}"
+    nil
   end
 
   def apply_team_limits_for(user, subscription, meta)

--- a/app/models/posthog_service.rb
+++ b/app/models/posthog_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Server-side PostHog capture for subscription lifecycle events.
+#
+# These events are only knowable server-side (Stripe webhooks), so the frontend
+# deliberately does NOT fire them (see itty-bitty-frontend#307). Capturing them
+# here with the same distinct_id the frontend uses keeps the money-path funnel
+# (pricing page -> checkout_started -> subscription_started) buildable in PostHog.
+#
+# distinct_id contract: the frontend identifies people as `String(user.id)`
+# (src/data/analytics.ts -> posthog.identify(String(user.id))), so the backend
+# MUST use the same `user.id.to_s` for events to land on the same person.
+#
+# Capture is env-gated (production only unless POSTHOG_CAPTURE_ENABLED=true) and
+# wrapped so a PostHog failure can never break a Stripe webhook.
+class PosthogService
+  class << self
+    # Capture an event for a user, keeping the person's `plan` property in sync.
+    #
+    # @param user [User]
+    # @param event [String] PostHog event name (e.g. "subscription_started")
+    # @param properties [Hash] event properties (e.g. { plan:, billing_interval: })
+    # @param set [Hash] person properties to $set; defaults to { plan: user.plan_type }
+    def capture_for_user(user, event, properties: {}, set: nil)
+      return unless user
+      return unless PosthogClient.enabled?
+
+      client = PosthogClient.client
+      return if client.nil?
+
+      person_props = set.nil? ? { plan: user.plan_type } : set
+      merged = properties.merge("$set" => compact(person_props))
+
+      client.capture(
+        distinct_id: user.id.to_s,
+        event: event.to_s,
+        properties: compact(merged),
+      )
+      Rails.logger.info("[PostHog] captured event=#{event} user=#{user.id}")
+    rescue => e
+      # Analytics must never break the webhook path.
+      Rails.logger.error("[PostHog] capture_for_user failed event=#{event} user=#{user&.id}: #{e.class} - #{e.message}")
+      nil
+    end
+
+    private
+
+    # Drop nil values so they don't surface as empty PostHog properties
+    # (mirrors the frontend's `clean()` helper).
+    def compact(hash)
+      hash.reject { |_, v| v.nil? }
+    end
+  end
+end

--- a/config/initializers/posthog.rb
+++ b/config/initializers/posthog.rb
@@ -1,0 +1,43 @@
+# config/initializers/posthog.rb
+require "posthog"
+
+# Thin wrapper around the posthog-ruby client used for SERVER-SIDE event
+# capture (subscription lifecycle events fired from the Stripe webhook —
+# see PosthogService). The frontend captures its own events directly via the
+# JS SDK; this is only for transitions that are only knowable server-side
+# (Stripe webhooks): trial_started, subscription_started, subscription_cancelled.
+module PosthogClient
+  DEFAULT_HOST = "https://us.i.posthog.com"
+
+  # Memoized client. Built lazily and only when capture is enabled, so test/dev
+  # don't spin up the SDK's background flush thread or require a key. Returns nil
+  # when no API key is configured (callers no-op).
+  def self.client
+    return @client if defined?(@client) && !@client.nil?
+
+    api_key = ENV["POSTHOG_API_KEY"].presence
+    return nil if api_key.blank?
+
+    @client = PostHog::Client.new(
+      api_key: api_key,
+      host: ENV["POSTHOG_HOST"].presence || DEFAULT_HOST,
+      on_error: proc { |status, msg| Rails.logger.error("[PostHog] capture error status=#{status} #{msg}") },
+    )
+  end
+
+  # Reset the memoized client (used by tests that toggle ENV).
+  def self.reset!
+    @client = nil
+  end
+
+  # Server-side capture only fires where intended. Production fires
+  # automatically; staging (shares the prod box) and dev/test stay off unless
+  # POSTHOG_CAPTURE_ENABLED is explicitly set (used for end-to-end verification).
+  # Also requires an API key to be present.
+  def self.enabled?
+    return false if ENV["POSTHOG_API_KEY"].blank?
+    return true if ENV["POSTHOG_CAPTURE_ENABLED"] == "true"
+
+    Rails.env.production? && !AppEnv.staging?
+  end
+end

--- a/spec/models/posthog_service_spec.rb
+++ b/spec/models/posthog_service_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PosthogService do
+  let(:user) { FactoryBot.build_stubbed(:user, id: 4242, plan_type: "pro") }
+  let(:client) { instance_double("PostHog::Client") }
+
+  describe ".capture_for_user" do
+    context "when capture is enabled" do
+      before do
+        allow(PosthogClient).to receive(:enabled?).and_return(true)
+        allow(PosthogClient).to receive(:client).and_return(client)
+      end
+
+      it "captures with distinct_id = user.id.to_s (matches the frontend identify contract)" do
+        expect(client).to receive(:capture).with(
+          hash_including(distinct_id: "4242", event: "subscription_started"),
+        )
+        described_class.capture_for_user(user, "subscription_started", properties: { plan: "pro" })
+      end
+
+      it "passes through event properties and defaults $set to the user's plan" do
+        expect(client).to receive(:capture).with(
+          distinct_id: "4242",
+          event: "subscription_started",
+          properties: {
+            plan: "pro",
+            billing_interval: "monthly",
+            "$set" => { plan: "pro" },
+          },
+        )
+        described_class.capture_for_user(
+          user,
+          "subscription_started",
+          properties: { plan: "pro", billing_interval: "monthly" },
+        )
+      end
+
+      it "uses an explicit :set override for $set" do
+        expect(client).to receive(:capture).with(
+          hash_including(properties: hash_including("$set" => { plan: "free" })),
+        )
+        described_class.capture_for_user(
+          user,
+          "subscription_cancelled",
+          properties: { plan: "pro" },
+          set: { plan: "free" },
+        )
+      end
+
+      it "drops nil properties so they don't surface as empty PostHog props" do
+        expect(client).to receive(:capture).with(
+          hash_including(properties: { plan: "pro", "$set" => { plan: "pro" } }),
+        )
+        described_class.capture_for_user(
+          user,
+          "subscription_cancelled",
+          properties: { plan: "pro", reason: nil },
+        )
+      end
+
+      it "never raises when the client errors (analytics must not break the webhook)" do
+        allow(client).to receive(:capture).and_raise(StandardError, "boom")
+        expect {
+          described_class.capture_for_user(user, "subscription_started", properties: {})
+        }.not_to raise_error
+      end
+
+      it "no-ops without a user" do
+        expect(client).not_to receive(:capture)
+        described_class.capture_for_user(nil, "subscription_started")
+      end
+    end
+
+    context "when capture is disabled" do
+      before { allow(PosthogClient).to receive(:enabled?).and_return(false) }
+
+      it "does not build a client or capture" do
+        expect(PosthogClient).not_to receive(:client)
+        described_class.capture_for_user(user, "subscription_started", properties: {})
+      end
+    end
+  end
+end
+
+RSpec.describe PosthogClient do
+  describe ".enabled?" do
+    it "is false without an API key, even with the override on" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_API_KEY").and_return(nil)
+      allow(ENV).to receive(:[]).with("POSTHOG_CAPTURE_ENABLED").and_return("true")
+      expect(described_class.enabled?).to be(false)
+    end
+
+    it "is true when POSTHOG_CAPTURE_ENABLED=true and a key is present (dev/staging opt-in)" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_API_KEY").and_return("phc_test")
+      allow(ENV).to receive(:[]).with("POSTHOG_CAPTURE_ENABLED").and_return("true")
+      expect(described_class.enabled?).to be(true)
+    end
+
+    it "is false in the test environment by default (no override)" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_API_KEY").and_return("phc_test")
+      allow(ENV).to receive(:[]).with("POSTHOG_CAPTURE_ENABLED").and_return(nil)
+      expect(described_class.enabled?).to be(false)
+    end
+  end
+end

--- a/spec/requests/api/webhooks_analytics_spec.rb
+++ b/spec/requests/api/webhooks_analytics_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+# Server-side PostHog subscription lifecycle events (itty-bitty-frontend#307).
+# Verifies the Stripe webhook fires PosthogService.capture_for_user with the
+# right event + properties on each money-path transition. Gating itself is
+# covered in spec/models/posthog_service_spec.rb; here we spy on the service so
+# the assertions don't depend on env.
+RSpec.describe "POST /api/webhooks (PostHog analytics)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_analytics_user",
+      plan_type: "basic",
+      plan_status: "active")
+  end
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def build_metadata(hash)
+    Class.new do
+      def initialize(h) = (@h = h.transform_keys(&:to_s))
+      def [](k) = @h[k.to_s]
+      def presence; @h.presence; end
+      def to_h; @h; end
+    end.new(hash)
+  end
+
+  def build_price(plan_type: "basic", interval: "month", id: "price_basic")
+    OpenStruct.new(
+      id: id,
+      metadata: build_metadata({ "plan_type" => plan_type, "monthly_credits" => "400" }),
+      recurring: OpenStruct.new(interval: interval),
+    )
+  end
+
+  def build_subscription(status: "active", price: build_price, trial_end: nil,
+                         cancellation_details: nil, customer: user.stripe_customer_id)
+    OpenStruct.new(
+      id: "sub_#{SecureRandom.hex(3)}",
+      customer: customer,
+      status: status,
+      current_period_end: 30.days.from_now.to_i,
+      trial_end: trial_end&.to_i,
+      cancellation_details: cancellation_details,
+      items: OpenStruct.new(data: [OpenStruct.new(price: price, quantity: 1)]),
+    )
+  end
+
+  describe "subscription_started (non-active → active)" do
+    it "captures subscription_started with plan + billing_interval" do
+      user.update!(plan_status: "trialing")
+      sub = build_subscription(status: "active", price: build_price(interval: "month"))
+      stub_event(sub, type: "customer.subscription.updated")
+
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "subscription_started",
+        properties: { plan: "basic", billing_interval: "monthly" },
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "maps a yearly Stripe interval to billing_interval=yearly" do
+      user.update!(plan_status: "trialing")
+      sub = build_subscription(status: "active", price: build_price(interval: "year"))
+      stub_event(sub, type: "customer.subscription.updated")
+
+      expect(PosthogService).to receive(:capture_for_user).with(
+        anything, "subscription_started",
+        properties: hash_including(billing_interval: "yearly"),
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "does not capture on an active → active renewal" do
+      user.update!(plan_status: "active")
+      sub = build_subscription(status: "active")
+      stub_event(sub, type: "customer.subscription.updated")
+
+      expect(PosthogService).not_to receive(:capture_for_user)
+
+      post_webhook("{}", header_with_signature)
+    end
+  end
+
+  describe "trial_started (subscription.created, trialing)" do
+    it "captures trial_started with the plan and $set plan" do
+      sub = build_subscription(status: "trialing", trial_end: 14.days.from_now)
+      stub_event(sub, type: "customer.subscription.created")
+
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "trial_started",
+        properties: { plan: "basic" },
+        set: { plan: "basic" },
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "does not capture trial_started on a non-trialing create" do
+      sub = build_subscription(status: "active")
+      stub_event(sub, type: "customer.subscription.created")
+
+      expect(PosthogService).not_to receive(:capture_for_user).with(
+        anything, "trial_started", anything,
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "skips admin users" do
+      user.update!(role: "admin")
+      sub = build_subscription(status: "trialing", trial_end: 14.days.from_now)
+      stub_event(sub, type: "customer.subscription.created")
+
+      expect(PosthogService).not_to receive(:capture_for_user)
+
+      post_webhook("{}", header_with_signature)
+    end
+  end
+
+  describe "subscription_cancelled (subscription.deleted)" do
+    it "captures subscription_cancelled with the cancelled plan + reason before downgrade" do
+      user.update!(plan_type: "pro", plan_status: "active")
+      details = OpenStruct.new(feedback: "too_expensive", reason: "cancellation_requested")
+      sub = build_subscription(status: "canceled", cancellation_details: details)
+      stub_event(sub, type: "customer.subscription.deleted")
+
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "subscription_cancelled",
+        properties: { plan: "pro", reason: "too_expensive" },
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+
+    it "also records an internal subscription_canceled AnalyticsEvent" do
+      user.update!(plan_type: "pro", plan_status: "active")
+      allow(PosthogService).to receive(:capture_for_user)
+      sub = build_subscription(status: "canceled")
+      stub_event(sub, type: "customer.subscription.deleted")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change { AnalyticsEvent.for_event("subscription_canceled").count }.by(1)
+
+      event = AnalyticsEvent.for_event("subscription_canceled").last
+      expect(event.user_id).to eq(user.id)
+      expect(event.metadata["plan_type"]).to eq("pro")
+    end
+
+    it "captures a nil reason when Stripe collected none" do
+      user.update!(plan_type: "basic", plan_status: "active")
+      sub = build_subscription(status: "canceled", cancellation_details: nil)
+      stub_event(sub, type: "customer.subscription.deleted")
+
+      expect(PosthogService).to receive(:capture_for_user).with(
+        anything, "subscription_cancelled",
+        properties: { plan: "basic", reason: nil },
+      )
+
+      post_webhook("{}", header_with_signature)
+    end
+  end
+end


### PR DESCRIPTION
Backend half of [itty-bitty-frontend#307](https://github.com/brittanyjohns/itty-bitty-frontend/issues/307). Fires the subscription lifecycle events that are **only knowable server-side** (Stripe webhooks), completing the money-path funnel `pricing page → checkout_started → subscription_started`.

## Events

| Event | Where | Props |
|---|---|---|
| `trial_started` | `customer.subscription.created` when `status == "trialing"` | `{ plan }` |
| `subscription_started` | non-active→active transition in `handle_subscription_upsert` | `{ plan, billing_interval }` |
| `subscription_cancelled` | `customer.subscription.deleted` | `{ plan, reason? }` |

- **distinct_id = `user.id.to_s`** — matches the frontend's `posthog.identify(String(user.id))` so events land on the same person.
- **Person `plan` synced** — every capture `$set`s `plan` (cancellation `$set`s `plan: free`).
- **`billing_interval`** derived from the Stripe Price's `recurring.interval` (`month`→`monthly`, `year`→`yearly`) to match the frontend's `checkout_started` values.
- Internal `subscription_canceled` `AnalyticsEvent` also recorded for parity.

## Design notes

- `PosthogService` (`app/models/posthog_service.rb`) wraps the `posthog-ruby` gem. Captures are **async** (SDK enqueues to its own flush thread), so no Sidekiq job — and **rescued + logged**, so a PostHog outage can never 500 a Stripe webhook.
- **Env-gated, prod-only.** `PosthogClient.enabled?` returns true in production only (staging excluded via `AppEnv.staging?`); dev/staging fire only when `POSTHOG_CAPTURE_ENABLED=true`. Requires `POSTHOG_API_KEY`; `POSTHOG_HOST` defaults to `https://us.i.posthog.com`. Mirrors the Mailchimp-journeys gate.
- `trial_started` is PostHog-only here (the internal `trial_started` AnalyticsEvent already fires at checkout — no double-count).

## Deploy

Set `POSTHOG_API_KEY` on the prod box to the **prod** PostHog project key (the one the frontend `.env.production` reports to) so client + server events share a project. Until set, capture cleanly no-ops.

## Test plan

- `bundle exec rspec` — **1187 examples, 0 failures** (12 pre-existing pending placeholders).
- 19 new specs: `spec/models/posthog_service_spec.rb` (gating matrix, distinct_id, `$set`, nil-prop stripping, never-raises) + `spec/requests/api/webhooks_analytics_spec.rb` (all three transitions, `month`/`year` interval mapping, admin/renewal/non-trialing guards, nil reason).
- Existing webhook specs (`webhooks_plan_type`, `webhooks_plan_credits`, `webhooks_topup`) still green — no regressions.

## Acceptance criteria (issue)

- [x] Funnel pricing page → `checkout_started` → `subscription_started` is buildable in PostHog
- [x] `source` distinguishes CTA — handled frontend-side on `checkout_started`; backend events carry `plan` / `billing_interval`
- [x] Person `plan` property stays in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)