### PR TITLE
feat(board-images): bulk display-label case transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Bulk display-label case transform
+- `PUT /api/board_images/update` now accepts `payload[:label_case]`
+  (`"upper"`, `"lower"`, or `"sentence"`). When present, each selected board
+  image's `display_label` is rewritten in that case (sentence = first letter
+  up, rest down). Falls back to the image's `label` when `display_label` is
+  blank. Powers the "Aa" case buttons in the frontend bulk-edit drawer.
+
 ### Added — Robust vocabulary sets for the Board Builder (Core 60/84)
 - The Board Builder picker now offers pre-authored **core vocabulary sets** (a
   real core grid + fringe category pages) alongside the small starter templates.

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -82,6 +82,8 @@ class API::BoardImagesController < API::ApplicationController
     create_new_board = payload[:create_new_board] || !new_board_name.blank?
     layout_updates = payload[:layout_updates] if payload[:layout_updates]
     update_to_default_doc = payload[:update_to_default_doc] if payload[:update_to_default_doc]
+    # Bulk display-label case transform: "upper", "lower", or "sentence".
+    label_case = payload[:label_case].to_s if payload[:label_case].present?
 
     if create_new_board
       new_board_name ||= "New Board"
@@ -133,6 +135,11 @@ class API::BoardImagesController < API::ApplicationController
       end
       if make_static
         board_image.predictive_board_id = nil
+      end
+      if label_case
+        source = board_image.display_label.presence || board_image.label
+        transformed = transform_label_case(source, label_case)
+        board_image.display_label = transformed if transformed.present?
       end
 
       layout_to_update = layout_updates.find { |update| update["board_image_id"].to_i == board_image.id } if layout_updates
@@ -321,6 +328,21 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   private
+
+  # Apply a bulk case transform to a display label.
+  #   "upper"    -> "I WANT MORE"
+  #   "lower"    -> "i want more"
+  #   "sentence" -> "I want more" (first letter up, rest down)
+  # Unknown modes return the text unchanged.
+  def transform_label_case(text, mode)
+    return text if text.blank?
+    case mode.to_s
+    when "upper"    then text.upcase
+    when "lower"    then text.downcase
+    when "sentence" then text.capitalize
+    else text
+    end
+  end
 
   # Block edits to a board image when its board is read-only for this user
   # (a downgraded user over their board limit). Playing audio and viewing are

--- a/spec/requests/api/board_images_label_case_spec.rb
+++ b/spec/requests/api/board_images_label_case_spec.rb
@@ -1,0 +1,75 @@
+# spec/requests/api/board_images_label_case_spec.rb
+#
+# Covers the bulk display-label case transform on
+# PUT /api/board_images/update (BoardImagesController#update_multiple).
+# The frontend bulk-edit drawer sends payload[:label_case] = upper|lower|sentence
+# and the backend rewrites each selected board_image's display_label.
+
+require "rails_helper"
+
+RSpec.describe "BoardImages bulk label_case", type: :request do
+  def j
+    JSON.parse(response.body) rescue {}
+  end
+
+  before do
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:authenticate_token!).and_return(true)
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:current_user).and_return(user)
+  end
+
+  let!(:user)  { create(:user) }
+  let!(:board) { create(:board, user: user) }
+  let!(:image) { create(:image, user: user, label: "i WANT more") }
+  let!(:board_image) do
+    create(:board_image, board: board, image: image).tap do |bi|
+      bi.update!(display_label: "i WANT more")
+    end
+  end
+
+  def put_label_case(label_case)
+    put "/api/board_images/update",
+        params: {
+          board_id: board.id,
+          board_image_ids: [board_image.id],
+          payload: { label_case: label_case },
+        }
+  end
+
+  it "upcases the display label" do
+    put_label_case("upper")
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_label).to eq("I WANT MORE")
+  end
+
+  it "downcases the display label" do
+    put_label_case("lower")
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_label).to eq("i want more")
+  end
+
+  it "sentence-cases the display label (first letter up, rest down)" do
+    put_label_case("sentence")
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_label).to eq("I want more")
+  end
+
+  it "leaves the display label untouched when no label_case is sent" do
+    put "/api/board_images/update",
+        params: {
+          board_id: board.id,
+          board_image_ids: [board_image.id],
+          payload: { hide_labels: false },
+        }
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_label).to eq("i WANT more")
+  end
+
+  it "falls back to the image label when display_label is blank" do
+    board_image.update_column(:display_label, nil)
+    put_label_case("upper")
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_label).to eq("I WANT MORE")
+  end
+end


### PR DESCRIPTION
## Summary
Adds a bulk **display-label case transform** to `PUT /api/board_images/update` (`BoardImagesController#update_multiple`).

When the payload includes `label_case` (`"upper"`, `"lower"`, or `"sentence"`), each selected board image's `display_label` is rewritten in that case:
- `upper` → `I WANT MORE`
- `lower` → `i want more`
- `sentence` → `I want more` (first letter up, rest down)

Falls back to the image's `label` when `display_label` is blank. Unknown modes are a no-op. This is the backend half of the frontend bulk-edit "Label case" buttons.

## Ordering
This is the backend directive; **merge/deploy this before** the matching frontend PR (the frontend control sends `label_case` and is a no-op until this ships).

## Test plan
- New request spec `spec/requests/api/board_images_label_case_spec.rb` — covers all three cases, the no-`label_case` passthrough, and the blank-`display_label` → image-label fallback.
- `bundle exec rspec spec/requests/api/board_images_label_case_spec.rb spec/requests/api/board_images_rate_limit_spec.rb spec/models/board_image_spec.rb` → **18 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)