### PR TITLE
fix(board-builder): prune on vocab-set re-seed + namespace OBF ids (#277, #278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,31 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `lib/tasks/vocab_sets.rake`. No schema changes.
 - **Real Core 60 / Core 84 content seeded.** Both sets now ship authored
   SpeakAnyWay vocabulary, replacing the Core 60 placeholder and adding Core 84:
-  Core 60 is a 10×6 core home + 9 fringe category pages (People, Feelings, Food,
-  Drinks, Play, Places, Body, More, Keyboard); Core 84 is the 12×7 superset home
+  Core 60 is a 10×6 core home + 8 fringe category pages (People, Feelings, Food,
+  Drinks, Play, Places, Body, More); Core 84 is the 12×7 superset home
   with the same fringe plus School, Time, and Describe pages. Every tile carries
   a `part_of_speech` color and fringe folders link via `load_board`. Run
   `bin/rails vocab_sets:seed` to seed both as predefined, root-marked sets.
+
+### Fixed — Board Builder vocab-set seeder now syncs removals and isolates the two sets (#277, #278)
+- **Re-seed now propagates content removals (#277).** `bin/rails vocab_sets:seed`
+  previously only upserted, so tiles and boards removed from the OBF source
+  survived a re-seed (e.g. after the Keyboard board and the please/thank-you/and
+  home tiles were cut). The seeder now runs a **destructive sync over admin-owned
+  set boards only**: it destroys tiles whose label is gone from the source OBF and
+  destroys boards whose `obf_id` left the manifest. `Board.from_obf` semantics for
+  user OBZ imports are unchanged; **user clones (deep copies) are never touched.**
+- **Core 60 and Core 84 no longer share fringe boards (#278).** Both sets used the
+  same bare OBF ids (`people`, `food`, …) and seed as the same admin, so both roots
+  linked to one shared fringe board and the last-seeded set won the in-set Home
+  pointer — leaving the other set's cloned pages with **dead Home tiles**. Every
+  board id in the seed source is now namespaced `"<slug>:<name>"` (e.g.
+  `core-60:people`), so each set seeds its own disjoint fringe tree with in-set
+  Home links.
+- **Migration is self-healing.** The same prune step destroys the legacy
+  un-namespaced boards (`people`, `food`, …) and the removed `keyboard` board, so a
+  single `bin/rails vocab_sets:seed` after deploy cleans up the collision-era
+  boards — no manual console cleanup.
 
 ### Fixed — Board Builder no longer silently duplicates a board set on re-run
 - Re-running the wizard for the same communicator used to silently create a

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -15,6 +15,13 @@ require "zip"
 module VocabSets
   SETS_DIR = Rails.root.join("db", "seeds", "board_builder_sets")
 
+  # OBF ids that used to belong to the sets but have been removed from the
+  # manifests entirely (no namespaced successor). Listed here so a re-seed
+  # cleans up the stale admin-owned boards they created. `keyboard` was dropped
+  # in #276 (the Keyboard board/feature was cut). These are bare (un-namespaced)
+  # ids from the pre-namespacing collision era — see #277/#278.
+  LEGACY_REMOVED_OBF_IDS = %w[keyboard].freeze
+
   module_function
 
   # Slugs that have authored source (a manifest.json), optionally filtered by a
@@ -55,6 +62,14 @@ module VocabSets
 
   # Import one slug and stamp the result. Idempotent: Board.from_obf upserts by
   # (user_id, obf_id), so re-running updates the same boards. Returns the root.
+  #
+  # Because Board.from_obf only ever UPSERTS (it never removes tiles/boards that
+  # vanished from the OBF source — correct for user OBZ imports), the seeder adds
+  # a destructive SYNC pass afterwards, scoped strictly to admin-owned set boards:
+  # removed tiles and removed/renamed boards are pruned so a re-seed fully applies
+  # content revisions (#277) and the one-time migration off the colliding
+  # un-namespaced ids (#278) is automatic. User clones are deep copies and are
+  # never touched.
   def seed_slug!(slug)
     result = ObzImporter.new(
       obz_bytes(slug),
@@ -70,11 +85,73 @@ module VocabSets
     root = result[:root_board]
     raise "Import produced no root board for #{slug.inspect}" unless root
 
-    result[:boards].values.each do |board|
+    boards_by_obf_id = result[:boards]
+    boards_by_obf_id.values.each do |board|
       board.update!(predefined: true, published: true)
     end
     Boards::RobustSets.mark_root!(root, slug)
 
+    prune_removed_tiles!(slug, boards_by_obf_id)
+    prune_removed_boards!(slug, boards_by_obf_id)
+
     root
+  end
+
+  # Map of obf_id => [button labels] parsed straight from the authored source
+  # for a slug. Used to decide which tiles on a seeded board are still authored.
+  def source_labels_by_obf_id(slug)
+    dir = SETS_DIR.join(slug)
+    manifest = JSON.parse(File.read(dir.join("manifest.json")))
+    paths = (manifest.dig("paths", "boards") || {}).values.uniq
+
+    paths.each_with_object({}) do |rel, acc|
+      file = dir.join(rel)
+      next unless File.file?(file)
+
+      obf = JSON.parse(File.read(file))
+      acc[obf["id"].to_s] = Array(obf["buttons"]).map { |b| b["label"] }.compact
+    end
+  end
+
+  # Destroy board_images on each seeded board whose label is no longer present in
+  # the source OBF's buttons (e.g. #276 removed please/thank you/and from the
+  # homes, "more" from fringe pages, and the self-link folder tiles). Matching is
+  # by image label, case-insensitively — the same value Board.from_obf resolves a
+  # button to. Admin-owned set boards only; user clones are separate rows.
+  def prune_removed_tiles!(slug, boards_by_obf_id)
+    labels_by_id = source_labels_by_obf_id(slug)
+
+    boards_by_obf_id.each do |obf_id, board|
+      next unless labels_by_id.key?(obf_id) # never blank-prune a board we can't source
+
+      keep = labels_by_id[obf_id].map { |l| l.to_s.strip.downcase }
+      board.board_images.includes(:image).find_each do |bi|
+        label = (bi.image&.label || bi.label).to_s.strip.downcase
+        bi.destroy unless keep.include?(label)
+      end
+    end
+  end
+
+  # Destroy admin-owned boards that belonged to this set but are no longer in the
+  # manifest: namespaced ids dropped from the manifest, plus the bare
+  # (un-namespaced) ids from the pre-namespacing collision era (#278) and any
+  # fully-removed boards (LEGACY_REMOVED_OBF_IDS, e.g. keyboard from #276). This
+  # makes the migration off the shared fringe boards self-healing on one re-seed.
+  # Strictly scoped to User::DEFAULT_ADMIN_ID; destroying these nulls inbound
+  # predictive_board_id pointers (Board has_many predictive_board_images,
+  # dependent: :nullify), so nothing dangles. User clones never point at these.
+  def prune_removed_boards!(slug, boards_by_obf_id)
+    current_ids = boards_by_obf_id.keys
+
+    # Namespaced orphans: in this set's namespace but no longer imported.
+    Board.where(user_id: admin.id)
+      .where("obf_id LIKE ?", "#{slug}:%")
+      .where.not(obf_id: current_ids)
+      .destroy_all
+
+    # Legacy bare ids: the pre-namespacing version of each current board, plus
+    # boards removed from the manifest outright.
+    legacy_ids = (current_ids.map { |id| id.split(":", 2).last } + LEGACY_REMOVED_OBF_IDS).uniq
+    Board.where(user_id: admin.id, obf_id: legacy_ids).destroy_all
   end
 end

--- a/db/seeds/board_builder_sets/README.md
+++ b/db/seeds/board_builder_sets/README.md
@@ -32,13 +32,13 @@ db/seeds/board_builder_sets/
     boards/
       core-60.obf                <- root core board (home 10×6)
       people.obf  feelings.obf  food.obf  drinks.obf   <- fringe category pages
-      play.obf  places.obf  body.obf  more.obf  keyboard.obf
+      play.obf  places.obf  body.obf  more.obf
   core-84/                       <- same shape: home 12×7 superset + the core-60
     manifest.json                   fringe + School / Time / Describe pages
     boards/
       core-84.obf
       people.obf  feelings.obf  food.obf  drinks.obf  play.obf  places.obf
-      body.obf  more.obf  keyboard.obf  school.obf  time.obf  describe.obf
+      body.obf  more.obf  school.obf  time.obf  describe.obf
 ```
 
 The seeder reads this directory, zips it **in memory** into an `.obz`, and feeds
@@ -53,7 +53,7 @@ One `.obf` per board. Minimal shape:
 ```jsonc
 {
   "format": "open-board-0.1",
-  "id": "food",                  // unique within the set; matches manifest paths key
+  "id": "core-60:food",          // MUST be namespaced "<slug>:<name>" — see "OBF id namespacing"
   "locale": "en",
   "name": "Food",                // see "Fringe board names" below — load-bearing
   "grid": { "rows": 2, "columns": 3, "order": [[1,2,3],[4,5,6]] },
@@ -95,16 +95,40 @@ One `.obf` per board. Minimal shape:
 ```jsonc
 {
   "format": "open-board-0.1",
-  "root": "boards/core-60.obf",   // the core board the user lands on
+  "root": "boards/core-60.obf",   // path, NOT an id — never namespaced
   "paths": {
     "boards": {
-      "core-60": "boards/core-60.obf",
-      "food":    "boards/food.obf"
-      // one entry per board id -> path
+      "core-60:core-60": "boards/core-60.obf",
+      "core-60:food":    "boards/food.obf"
+      // one entry per namespaced board id -> path
     }
   }
 }
 ```
+
+## OBF id namespacing (one rule, non-negotiable)
+
+Every board's top-level **`id`** MUST be prefixed with its set slug:
+`"<slug>:<name>"` (e.g. `"core-60:people"`, `"core-84:people"`,
+`"core-60:core-60"`). The `paths.boards` **keys** in `manifest.json` use the
+same namespaced ids.
+
+Why: `Board.from_obf` resolves the target board by `(user_id, obf_id)`, and both
+sets seed as the same admin user. Before namespacing, Core 60 and Core 84 shared
+the bare ids (`people`, `food`, …), so both roots ended up linked to **one**
+shared fringe board and the last set seeded won the in-set Home pointer — leaving
+the other set's cloned pages with dead Home tiles (#278).
+
+What is NOT namespaced:
+
+- **Button `id`s** stay local integers (`1`, `2`, …) — they're scoped to one board.
+- **`load_board.path`** stays a zip path (`"boards/play.obf"`) — links resolve by
+  path, so they're unaffected by the namespace. Don't use `load_board.id`.
+- **`manifest.root`** is a path, not an id.
+
+Adding a board to a set = give its `.obf` a `"<slug>:<name>"` id and add the same
+key to the manifest. The seeder's destructive sync (below) cleans up any board or
+tile you remove.
 
 ## Fringe board names are load-bearing
 
@@ -138,3 +162,16 @@ bin/rails 'vocab_sets:build[core-60]'     # emit a distributable .obz
 
 Seeding is **idempotent**: re-running finds the existing set by its root
 `board_builder_robust_slug` and updates in place (no duplicates).
+
+Seeding is also a **destructive sync** (admin-owned set boards only — user clones
+are deep copies and never touched): after upserting, the seeder
+
+- destroys any tile (`board_image`) on a seeded board whose label is no longer in
+  the source OBF (so removing a tile from the JSON removes it on re-seed), and
+- destroys any admin-owned board whose `obf_id` belonged to this set but is no
+  longer in the manifest — including the legacy **un-namespaced** ids
+  (`people`, `food`, …) and fully-removed boards (`keyboard`).
+
+That last step makes the migration off the pre-namespacing collision era (#278)
+and the #276 content revisions **self-healing**: one `bin/rails vocab_sets:seed`
+after deploy cleans up the old shared boards — no manual console work needed.

--- a/db/seeds/board_builder_sets/core-60/boards/body.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/body.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "body",
+  "id": "core-60:body",
   "locale": "en",
   "name": "Body",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/core-60.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/core-60.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "core-60",
+  "id": "core-60:core-60",
   "locale": "en",
   "name": "Core 60",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/drinks.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/drinks.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "drinks",
+  "id": "core-60:drinks",
   "locale": "en",
   "name": "Drinks",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/feelings.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/feelings.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "feelings",
+  "id": "core-60:feelings",
   "locale": "en",
   "name": "Feelings",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/food.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/food.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "food",
+  "id": "core-60:food",
   "locale": "en",
   "name": "Food",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/more.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/more.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "more",
+  "id": "core-60:more",
   "locale": "en",
   "name": "More",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/people.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/people.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "people",
+  "id": "core-60:people",
   "locale": "en",
   "name": "People",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/places.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/places.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "places",
+  "id": "core-60:places",
   "locale": "en",
   "name": "Places",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/boards/play.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/play.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "play",
+  "id": "core-60:play",
   "locale": "en",
   "name": "Play",
   "grid": {

--- a/db/seeds/board_builder_sets/core-60/manifest.json
+++ b/db/seeds/board_builder_sets/core-60/manifest.json
@@ -3,15 +3,15 @@
   "root": "boards/core-60.obf",
   "paths": {
     "boards": {
-      "core-60": "boards/core-60.obf",
-      "people": "boards/people.obf",
-      "feelings": "boards/feelings.obf",
-      "food": "boards/food.obf",
-      "drinks": "boards/drinks.obf",
-      "play": "boards/play.obf",
-      "places": "boards/places.obf",
-      "body": "boards/body.obf",
-      "more": "boards/more.obf"
+      "core-60:core-60": "boards/core-60.obf",
+      "core-60:people": "boards/people.obf",
+      "core-60:feelings": "boards/feelings.obf",
+      "core-60:food": "boards/food.obf",
+      "core-60:drinks": "boards/drinks.obf",
+      "core-60:play": "boards/play.obf",
+      "core-60:places": "boards/places.obf",
+      "core-60:body": "boards/body.obf",
+      "core-60:more": "boards/more.obf"
     }
   }
 }

--- a/db/seeds/board_builder_sets/core-84/boards/body.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/body.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "body",
+  "id": "core-84:body",
   "locale": "en",
   "name": "Body",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/core-84.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/core-84.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "core-84",
+  "id": "core-84:core-84",
   "locale": "en",
   "name": "Core 84",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/describe.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/describe.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "describe",
+  "id": "core-84:describe",
   "locale": "en",
   "name": "Describe",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/drinks.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/drinks.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "drinks",
+  "id": "core-84:drinks",
   "locale": "en",
   "name": "Drinks",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/feelings.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/feelings.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "feelings",
+  "id": "core-84:feelings",
   "locale": "en",
   "name": "Feelings",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/food.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/food.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "food",
+  "id": "core-84:food",
   "locale": "en",
   "name": "Food",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/more.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/more.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "more",
+  "id": "core-84:more",
   "locale": "en",
   "name": "More",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/people.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/people.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "people",
+  "id": "core-84:people",
   "locale": "en",
   "name": "People",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/places.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/places.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "places",
+  "id": "core-84:places",
   "locale": "en",
   "name": "Places",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/play.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/play.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "play",
+  "id": "core-84:play",
   "locale": "en",
   "name": "Play",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/school.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/school.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "school",
+  "id": "core-84:school",
   "locale": "en",
   "name": "School",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/boards/time.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/time.obf
@@ -1,6 +1,6 @@
 {
   "format": "open-board-0.1",
-  "id": "time",
+  "id": "core-84:time",
   "locale": "en",
   "name": "Time",
   "grid": {

--- a/db/seeds/board_builder_sets/core-84/manifest.json
+++ b/db/seeds/board_builder_sets/core-84/manifest.json
@@ -3,18 +3,18 @@
   "root": "boards/core-84.obf",
   "paths": {
     "boards": {
-      "core-84": "boards/core-84.obf",
-      "people": "boards/people.obf",
-      "feelings": "boards/feelings.obf",
-      "food": "boards/food.obf",
-      "drinks": "boards/drinks.obf",
-      "play": "boards/play.obf",
-      "places": "boards/places.obf",
-      "body": "boards/body.obf",
-      "more": "boards/more.obf",
-      "school": "boards/school.obf",
-      "time": "boards/time.obf",
-      "describe": "boards/describe.obf"
+      "core-84:core-84": "boards/core-84.obf",
+      "core-84:people": "boards/people.obf",
+      "core-84:feelings": "boards/feelings.obf",
+      "core-84:food": "boards/food.obf",
+      "core-84:drinks": "boards/drinks.obf",
+      "core-84:play": "boards/play.obf",
+      "core-84:places": "boards/places.obf",
+      "core-84:body": "boards/body.obf",
+      "core-84:more": "boards/more.obf",
+      "core-84:school": "boards/school.obf",
+      "core-84:time": "boards/time.obf",
+      "core-84:describe": "boards/describe.obf"
     }
   }
 }

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -164,4 +164,35 @@ RSpec.describe Boards::SeededSetCloner do
       }.to raise_error(Boards::SeededSetCloner::CloneError)
     end
   end
+
+  # Regression for #278: seed BOTH real sets (whose fringe ids are now
+  # namespaced), then clone each. Pre-fix, the two sets shared fringe boards and
+  # whichever seeded last won the Home pointer, so the other set's clones shipped
+  # with dead Home tiles on every fringe page.
+  describe "cloning a real seeded robust set" do
+    let!(:seed_admin) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+    before do
+      VocabSets.seed_slug!("core-60")
+      VocabSets.seed_slug!("core-84")
+    end
+
+    %w[core-60 core-84].each do |slug|
+      it "gives #{slug} clones a working Home tile on every fringe page" do
+        source_root = Boards::RobustSets.find_root(slug)
+        cloned_root = described_class.new(source_root, communicator: communicator).call
+
+        fringe = owner.boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+        expect(fringe.count).to be > 0
+
+        # Every fringe page carries a Home tile, and it resolves to the cloned
+        # root (in-set) — never nulled, never the other set's root.
+        fringe.each do |board|
+          home = board.board_images.find_by(label: "Home")
+          expect(home).to be_present, "expected fringe '#{board.name}' to have a Home tile"
+          expect(home.predictive_board_id).to eq(cloned_root.id)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -81,4 +81,93 @@ RSpec.describe VocabSets do
       expect(Boards::RobustSets.all_roots.count).to eq(1)
     end
   end
+
+  describe "cross-set isolation (#278)" do
+    it "seeds disjoint fringe boards per set, each fringe Home resolving to its own root" do
+      c60 = VocabSets.seed_slug!("core-60")
+      c84 = VocabSets.seed_slug!("core-84")
+
+      c60_people = Board.find(c60.board_images.find_by(label: "People").predictive_board_id)
+      c84_people = Board.find(c84.board_images.find_by(label: "People").predictive_board_id)
+
+      # Namespaced ids -> the two sets get distinct fringe boards (the collision
+      # made both roots share one People board).
+      expect(c60_people.id).not_to eq(c84_people.id)
+      expect(c60_people.obf_id).to eq("core-60:people")
+      expect(c84_people.obf_id).to eq("core-84:people")
+
+      # Each fringe page's Home tile points at ITS OWN set's root.
+      expect(c60_people.board_images.find_by(label: "Home").predictive_board_id).to eq(c60.id)
+      expect(c84_people.board_images.find_by(label: "Home").predictive_board_id).to eq(c84.id)
+    end
+
+    it "shares no fringe boards between the two seeded sets" do
+      c60 = VocabSets.seed_slug!("core-60")
+      c84 = VocabSets.seed_slug!("core-84")
+
+      c60_ids = collect_set_board_ids(c60)
+      c84_ids = collect_set_board_ids(c84)
+      expect(c60_ids & c84_ids).to be_empty
+    end
+  end
+
+  describe "destructive re-seed sync (#277)" do
+    it "prunes a tile that is no longer present in the source OBF on re-seed" do
+      root = VocabSets.seed_slug!("core-60")
+
+      # A stale tile from an older OBF revision (e.g. please/thank you/and that
+      # #276 removed from the home) — not in the current source.
+      create(:board_image, board: root, label: "obsolete_word",
+                           image: create(:image, label: "obsolete_word", user_id: admin.id))
+      expect(root.board_images.where(label: "obsolete_word")).to exist
+
+      VocabSets.seed_slug!("core-60")
+      expect(root.reload.board_images.where(label: "obsolete_word")).not_to exist
+    end
+
+    it "keeps authored tiles intact across a re-seed" do
+      root = VocabSets.seed_slug!("core-60")
+      before_tile_count = root.board_images.count
+
+      VocabSets.seed_slug!("core-60")
+      expect(root.reload.board_images.count).to eq(before_tile_count)
+    end
+
+    it "destroys an admin board dropped from the manifest (namespaced orphan) on re-seed" do
+      VocabSets.seed_slug!("core-60")
+      orphan = create(:board, user: admin, obf_id: "core-60:retired", name: "Retired", predefined: true)
+
+      VocabSets.seed_slug!("core-60")
+      expect(Board.exists?(orphan.id)).to be(false)
+    end
+
+    it "cleans up legacy un-namespaced and removed (keyboard) boards in one re-seed" do
+      # Pre-namespacing collision-era fringe board + the Keyboard board removed
+      # in #276 — both admin-owned, both stale.
+      legacy_people   = create(:board, user: admin, obf_id: "people", name: "People (legacy)", predefined: true)
+      legacy_keyboard = create(:board, user: admin, obf_id: "keyboard", name: "Keyboard", predefined: true)
+
+      VocabSets.seed_slug!("core-60")
+
+      expect(Board.exists?(legacy_people.id)).to be(false)
+      expect(Board.exists?(legacy_keyboard.id)).to be(false)
+    end
+
+    it "leaves another admin's lookalike boards untouched (scoped to DEFAULT_ADMIN_ID)" do
+      other = create(:user)
+      theirs = create(:board, user: other, obf_id: "people", name: "People")
+
+      VocabSets.seed_slug!("core-60")
+      expect(Board.exists?(theirs.id)).to be(true)
+    end
+  end
+
+  # All admin-owned board ids reachable from a seeded set's root (root + fringe).
+  def collect_set_board_ids(root)
+    ids = [root.id]
+    root.board_images.where.not(predictive_board_id: nil).each do |bi|
+      ids << bi.predictive_board_id
+    end
+    ids.uniq
+  end
 end


### PR DESCRIPTION
Closes #277, #278.

## Problem
- **#277 — re-seed never deletes.** `vocab_sets:seed` imports via `ObzImporter` → `Board.from_obf`, which upserts boards by `(user_id, obf_id)` and only visits buttons present in the OBF. Tiles and boards removed from the source (the Keyboard board; please/thank you/and from the homes; "more" from fringe pages; self-link folders — all cut in #276) survived a re-seed at their old coordinates.
- **#278 — cross-set OBF id collision.** Core 60 and Core 84 fringe files shared bare ids (`people`, `food`, …) and both seed as `User::DEFAULT_ADMIN_ID`, so both roots linked to the **same** fringe boards. The fringe Home link differs per set, so whichever seeded last won the Home pointer; `Boards::SeededSetCloner` then nulls out-of-set pointers, giving the other set's users **dead Home tiles on every cloned fringe page**.

## Changes
- **Namespace OBF ids** in `db/seeds/board_builder_sets/`: every board top-level `id` is now `"<slug>:<name>"` (e.g. `core-60:people`, `core-84:people`, `core-60:core-60`), with matching `manifest.json` `paths.boards` keys. `load_board.path` (path-based) and integer button ids are untouched.
- **Prune on seed (seeder path only — `Board.from_obf` semantics for user OBZ imports unchanged):** after import, `VocabSets.seed_slug!` runs a destructive sync over `User::DEFAULT_ADMIN_ID` set boards only:
  - destroys `board_images` whose label is no longer in the source OBF's buttons;
  - destroys admin-owned boards whose `obf_id` left the manifest — namespaced orphans **plus** the legacy un-namespaced ids (`people`, `food`, …) and fully-removed boards (`keyboard`), making the collision-era migration automatic.
  - User clones are deep copies and are untouched; inbound `predictive_board_id` pointers are protected by `Board has_many :predictive_board_images, dependent: :nullify` + `BoardImage#check_predictive_board`.

## Tests
- `spec/services/vocab_sets_spec.rb`: seeds **both** slugs — disjoint fringe boards, each fringe Home resolves to its own root; tile removal pruned on re-seed; namespaced-orphan and legacy/`keyboard` board cleanup in one re-seed; admin scoping (other users' lookalike boards untouched); idempotency preserved.
- `spec/services/boards/seeded_set_cloner_spec.rb`: regression — cloned Core 60 **and** Core 84 sets have a working Home tile on every fringe page.

⚠️ **I was unable to run the suite in this environment** — boot requires `DEVISE_JWT_SECRET_KEY` (no dotenv in the repo). Please run:

```
bundle exec rspec spec/services/vocab_sets_spec.rb spec/services/boards spec/requests/api/v1/board_builder_spec.rb
```

## Docs
- `db/seeds/board_builder_sets/README.md`: new "OBF id namespacing" rule + destructive-sync note; dropped stale `keyboard.obf` from the layout.
- `CHANGELOG.md` [Unreleased]: Fixed entry; corrected the robust-sets entry that still listed Keyboard.

## After merge
Prod/staging need **one** `bin/rails vocab_sets:seed` after deploy. The prune + legacy-id cleanup makes it self-healing — no manual console work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)