### PR TITLE
fix(board-builder): apply authored part_of_speech colors on seed + one-page seeded boards (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board Builder seeded sets: tile colors + one-page display (#279)
+- **Tile colors now follow the authored Fitzgerald key.** `Board.from_obf`
+  gained an opt-in `import_options[:apply_button_attributes]` (used by the
+  `vocab_sets:seed` seeder only): each OBF button's authored `part_of_speech`
+  is applied to the BoardImage and its background color derived via
+  `ColorHelper::PRESET_DATA` (e.g. pronouns yellow `#FFEA75`, verbs green
+  `#A1F571`, questions purple `#A07AFF`). OBF-standard explicit
+  `background_color`/`border_color` win when authored. The shared Image's
+  `part_of_speech` is backfilled only when blank — never overwritten. Re-seed
+  heals mangled colors; user OBZ imports are unchanged.
+- **Clones keep the authored colors.** `BoardImage#set_defaults` now respects a
+  part_of_speech already present on the record (e.g. set by
+  `Board#clone_with_images`' dup) instead of always re-reading the shared Image.
+- **Seeded boards display on one page.** The seeder stamps
+  `settings["disable_scroll"] = true` on every set board; the native board page
+  reads this and fits the whole authored grid (Core 60: 10×6, Core 84: 12×7)
+  on screen without scrolling. Cloned user sets inherit it.
+- Run `bin/rails vocab_sets:seed` once after deploy to apply colors and
+  one-page settings to existing seeded sets (already-cloned user sets keep
+  their old colors).
+
 ### Added — Server-side PostHog subscription lifecycle events
 - The Stripe webhook now fires three **server-side** PostHog events so the
   money-path funnel (pricing page → `checkout_started` → `subscription_started`)

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2442,6 +2442,14 @@ class Board < ApplicationRecord
   #                             BoardGroup.settings. Must be true to set
   #                             include_images: true (enforced by controller).
   #   acknowledged_by_user_id:  Integer. Audit-only.
+  #   apply_button_attributes:  Boolean. When true, each button's authored
+  #                             part_of_speech (and OBF-standard
+  #                             background_color / border_color when present) is
+  #                             applied to the BoardImage, so tile colors follow
+  #                             the authored Fitzgerald key instead of whatever
+  #                             the shared Image record happens to carry (#279).
+  #                             Used by the VocabSets seeder; user OBZ imports
+  #                             keep the historical default (off).
   def self.from_obf(data, current_user, board_group = nil, board_id = nil, import_options: {})
     obj = parse_obf_input(data)
     raise ArgumentError, "OBF data must be a Hash" unless obj.is_a?(Hash)
@@ -2474,6 +2482,7 @@ class Board < ApplicationRecord
     dynamic_data = {}
     temp_display_image = nil
     reset_layouts_after_import = obj["reset_layouts_after_import"] || false
+    apply_button_attributes = import_options[:apply_button_attributes] ? true : false
 
     buttons.each do |item|
       image = find_or_create_image_for_button(item, current_user)
@@ -2485,7 +2494,8 @@ class Board < ApplicationRecord
       coords = coords_by_button_id[item["id"].to_s]
       reset_layouts_after_import ||= coords.nil?
 
-      board_image = upsert_board_image(board, image, item, coords, temp_display_image)
+      board_image = upsert_board_image(board, image, item, coords, temp_display_image,
+                                       apply_button_attributes: apply_button_attributes)
       dynamic_data[image.id] = {
         "board_id" => board.id,
         "board" => board,
@@ -2613,7 +2623,7 @@ class Board < ApplicationRecord
   end
   private_class_method :attach_image_doc
 
-  def self.upsert_board_image(board, image, item, coords, display_url)
+  def self.upsert_board_image(board, image, item, coords, display_url, apply_button_attributes: false)
     board_image = board.board_images.find_by(image_id: image.id)
     unless board_image
       board_image = board.board_images.new(image_id: image.id, voice: board.voice,
@@ -2628,6 +2638,8 @@ class Board < ApplicationRecord
       board_image.save!
     end
 
+    apply_obf_part_of_speech(board_image, image, item) if apply_button_attributes
+
     if coords
       layout = { "x" => coords[0], "y" => coords[1], "w" => 1, "h" => 1, "i" => board_image.id.to_s }
       board_image.layout["lg"] = layout
@@ -2640,11 +2652,51 @@ class Board < ApplicationRecord
       # we want re-enqueue on every layout tweak.
       board_image.skip_create_voice_audio = true
       board_image.save!
+    elsif board_image.changed?
+      board_image.skip_create_voice_audio = true
+      board_image.save!
     end
+
+    apply_obf_explicit_colors(board_image, item) if apply_button_attributes
 
     board_image
   end
   private_class_method :upsert_board_image
+
+  # #279: honor the OBF button's authored part_of_speech so the tile gets its
+  # Fitzgerald-key color (ColorHelper::PRESET_DATA) instead of inheriting
+  # whatever the shared Image record carries. Assigns only — the caller's save
+  # persists it (and BoardImage's before_update :set_colors recomputes when the
+  # value changed). set_colors is also run here directly so a re-seed heals a
+  # stale bg_color even when part_of_speech itself didn't change.
+  # The shared Image is backfilled ONLY when its part_of_speech is blank —
+  # never overwrite a value an admin (or the categorizer) already set.
+  def self.apply_obf_part_of_speech(board_image, image, item)
+    pos = item["part_of_speech"].presence
+    return unless pos
+
+    board_image.part_of_speech = pos
+    board_image.set_colors
+    # update_column: skip Image's ensure_defaults/save callbacks, which would
+    # re-categorize and could fight the authored value.
+    image.update_column(:part_of_speech, pos) if image.part_of_speech.blank?
+  end
+  private_class_method :apply_obf_part_of_speech
+
+  # OBF-standard explicit button colors (background_color / border_color) win
+  # over the part-of-speech preset. Applied via update_columns AFTER the main
+  # save so BoardImage's set_colors callback can't recompute over them.
+  def self.apply_obf_explicit_colors(board_image, item)
+    updates = {}
+    if item["background_color"].present?
+      bg = ColorHelper.to_hex(item["background_color"], default: "#FFFFFF")
+      updates[:bg_color] = bg
+      updates[:text_color] = ColorHelper.text_hex_for(bg)
+    end
+    updates[:border_color] = item["border_color"] if item["border_color"].present?
+    board_image.update_columns(updates) if updates.any?
+  end
+  private_class_method :apply_obf_explicit_colors
 
   def source_type
     data = self.data || {}

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -587,7 +587,7 @@ class BoardImage < ApplicationRecord
       end
       Rails.logger.debug "Created image edit with ID #{image_url.class}"
       # strip quotes if present
-      url = image_url.gsub(/^\"|\"$/, "")
+      url = image_url.gsub(/^"|"$/, "")
       Rails.logger.debug "Generated image edit URL: #{url}"
       self.display_image_url = url
       self.save!

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -513,7 +513,13 @@ class BoardImage < ApplicationRecord
     # self.display_image_url = image.display_tile_url(user)
     self.display_image_url = image.src_url
     self.next_words = image.next_words || []
-    self.part_of_speech = image.part_of_speech || "default"
+    # Respect a part_of_speech that was explicitly set before create (e.g. a
+    # clone via Board#clone_with_images dup'ing a seeded tile, #279) — only
+    # fall back to the shared Image's value when this record carries none.
+    # New records get the column default ("default"), which counts as "none".
+    if part_of_speech.blank? || part_of_speech == "default"
+      self.part_of_speech = image.part_of_speech || "default"
+    end
   end
 
   def create_voice_audio_after_create
@@ -581,7 +587,7 @@ class BoardImage < ApplicationRecord
       end
       Rails.logger.debug "Created image edit with ID #{image_url.class}"
       # strip quotes if present
-      url = image_url.gsub(/^"|"$/, "")
+      url = image_url.gsub(/^\"|\"$/, "")
       Rails.logger.debug "Generated image edit URL: #{url}"
       self.display_image_url = url
       self.save!

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -79,6 +79,10 @@ module VocabSets
         include_images: true, # our own art; copyright gate is for third-party .obz
         license_acknowledged: true,
         acknowledged_by_user_id: admin.id,
+        # #279: apply each button's authored part_of_speech (Fitzgerald-key
+        # color) to the BoardImage. Seeder-only — user OBZ imports keep the
+        # historical Board.from_obf behavior.
+        apply_button_attributes: true,
       },
     ).import!
 
@@ -87,6 +91,12 @@ module VocabSets
 
     boards_by_obf_id = result[:boards]
     boards_by_obf_id.values.each do |board|
+      # disable_scroll: the native board page (BoardNativeGridPage) reads
+      # settings["disable_scroll"] and, when true, locks IonContent scrolling
+      # and sizes rows so the whole authored grid (Core 60: 10×6,
+      # Core 84: 12×7) renders on one page. clone_with_images dups settings,
+      # so user clones inherit it.
+      board.settings = (board.settings || {}).merge("disable_scroll" => true)
       board.update!(predefined: true, published: true)
     end
     Boards::RobustSets.mark_root!(root, slug)

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -194,5 +194,38 @@ RSpec.describe Boards::SeededSetCloner do
         end
       end
     end
+
+    # #279: the seeded set's Fitzgerald-key colors (from each OBF button's
+    # authored part_of_speech) must survive the deep clone. Pre-fix, the import
+    # dropped part_of_speech, so the cloner faithfully copied wrong colors.
+    it "carries the authored part_of_speech colors onto the cloned set" do
+      source_root = Boards::RobustSets.find_root("core-60")
+      cloned_root = described_class.new(source_root, communicator: communicator).call
+
+      { "I" => ["pronoun", "#FFEA75"],
+        "want" => ["verb", "#A1F571"],
+        "what" => ["question", "#A07AFF"] }.each do |label, (pos, hex)|
+        tile = cloned_root.board_images.find_by(label: label)
+        expect(tile).to be_present, "expected a cloned '#{label}' tile"
+        expect(tile.part_of_speech).to eq(pos)
+        expect(tile.bg_color).to eq(hex)
+      end
+    end
+
+    # One-page display: the seeder stamps settings["disable_scroll"] on every
+    # set board (read by the frontend's BoardNativeGridPage); clone_with_images
+    # dups settings, so user clones must inherit it on root AND fringe.
+    it "carries disable_scroll (one-page display) onto every cloned board" do
+      source_root = Boards::RobustSets.find_root("core-60")
+      cloned_root = described_class.new(source_root, communicator: communicator).call
+
+      expect(cloned_root.settings["disable_scroll"]).to be(true)
+      fringe = owner.boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+      expect(fringe.count).to be > 0
+      fringe.each do |board|
+        expect(board.settings["disable_scroll"]).to be(true),
+          "expected cloned fringe '#{board.name}' to keep disable_scroll"
+      end
+    end
   end
 end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -162,6 +162,100 @@ RSpec.describe VocabSets do
     end
   end
 
+  describe "tile colors from authored part_of_speech (#279)" do
+    # Modified Fitzgerald key, via ColorHelper::PRESET_DATA:
+    #   pronoun -> yellow, verb -> green, question -> purple.
+    EXPECTED_TILES = {
+      "I" => { pos: "pronoun", hex: "#FFEA75" },
+      "want" => { pos: "verb", hex: "#A1F571" },
+      "what" => { pos: "question", hex: "#A07AFF" },
+    }.freeze
+
+    def expect_authored_colors(board)
+      EXPECTED_TILES.each do |label, expected|
+        tile = board.board_images.find_by(label: label)
+        expect(tile).to be_present, "expected a '#{label}' tile on #{board.name}"
+        expect(tile.part_of_speech).to eq(expected[:pos]),
+          "expected '#{label}' part_of_speech #{expected[:pos]}, got #{tile.part_of_speech}"
+        expect(tile.bg_color).to eq(expected[:hex]),
+          "expected '#{label}' bg_color #{expected[:hex]}, got #{tile.bg_color}"
+      end
+    end
+
+    it "colors seeded home tiles per the authored OBF part_of_speech" do
+      root = VocabSets.seed_slug!("core-60")
+      expect_authored_colors(root)
+    end
+
+    it "restores authored colors on re-seed after a tile was mangled" do
+      root = VocabSets.seed_slug!("core-60")
+      tile = root.board_images.find_by(label: "I")
+      tile.update_columns(part_of_speech: "noun", bg_color: "#FFFFFF")
+
+      VocabSets.seed_slug!("core-60")
+      expect_authored_colors(root.reload)
+    end
+
+    it "heals a stale bg_color on re-seed even when part_of_speech is already right" do
+      root = VocabSets.seed_slug!("core-60")
+      tile = root.board_images.find_by(label: "I")
+      tile.update_columns(bg_color: "#FFFFFF") # pos stays "pronoun"
+
+      VocabSets.seed_slug!("core-60")
+      expect(root.reload.board_images.find_by(label: "I").bg_color).to eq("#FFEA75")
+    end
+
+    it "never overwrites a non-blank part_of_speech on the shared Image record" do
+      root = VocabSets.seed_slug!("core-60")
+      image = root.board_images.find_by(label: "I").image
+      image.update_column(:part_of_speech, "noun") # an admin's deliberate choice
+
+      VocabSets.seed_slug!("core-60")
+      expect(image.reload.part_of_speech).to eq("noun")
+      # ...while the seeded tile still follows the authored OBF value.
+      expect(root.reload.board_images.find_by(label: "I").part_of_speech).to eq("pronoun")
+    end
+
+    it "backfills a blank Image part_of_speech from the authored OBF" do
+      root = VocabSets.seed_slug!("core-60")
+      image = root.board_images.find_by(label: "I").image
+      image.update_column(:part_of_speech, nil)
+
+      VocabSets.seed_slug!("core-60")
+      expect(image.reload.part_of_speech).to eq("pronoun")
+    end
+  end
+
+  describe "one-page display (no scrolling)" do
+    it "marks every seeded board disable_scroll so the native page fits it on one screen" do
+      VocabSets.seed_slug!("core-60")
+
+      boards = Board.where(user_id: admin.id)
+      expect(boards).not_to be_empty
+      boards.each do |board|
+        expect(board.settings["disable_scroll"]).to be(true),
+          "expected #{board.name} to have settings['disable_scroll'] = true"
+      end
+    end
+
+    it "keeps disable_scroll set across a re-seed" do
+      VocabSets.seed_slug!("core-60")
+      VocabSets.seed_slug!("core-60")
+
+      expect(Board.where(user_id: admin.id).all? { |b| b.settings["disable_scroll"] == true }).to be(true)
+    end
+
+    it "preserves each home board's authored grid (Core 60: 10×6, Core 84: 12×7)" do
+      c60 = VocabSets.seed_slug!("core-60")
+      c84 = VocabSets.seed_slug!("core-84")
+
+      expect(c60.large_screen_columns).to eq(10)
+      expect(c60.large_screen_rows).to eq(6)
+      expect(c84.large_screen_columns).to eq(12)
+      expect(c84.large_screen_rows).to eq(7)
+    end
+  end
+
   # All admin-owned board ids reachable from a seeded set's root (root + fringe).
   def collect_set_board_ids(root)
     ids = [root.id]


### PR DESCRIPTION
Closes #279.

## Problem

The seed OBFs author a `part_of_speech` per button (drives Fitzgerald-key color via `ColorHelper::PRESET_DATA`), but `Board.from_obf`'s button loop never read it: `find_or_create_image_for_button` creates label-only Images and `upsert_board_image` sets only position/layout/voice. `BoardImage#set_defaults` then took color from whatever the shared admin Image happened to carry — so seeded tile colors were arbitrary, and `Boards::SeededSetCloner` copied the wrong colors to every user set.

## Changes

- **Opt-in `import_options[:apply_button_attributes]` on `Board.from_obf`** (the seeder passes it; user OBZ import behavior is unchanged): applies each button's authored `part_of_speech` to the board_image and lets `set_colors` run; applies OBF-standard explicit `background_color`/`border_color` post-save so callbacks can't clobber them; backfills `image.part_of_speech` **only when blank** — never overwrites a non-blank value on the shared Image.
- **`BoardImage#set_defaults` now respects a `part_of_speech` already on the record** (fixes the `clone_with_images` dup path); new records fall back exactly as before.
- **One-page display:** the seeder stamps `settings["disable_scroll"] = true` on every seeded board. The frontend's `BoardNativeGridPage` reads `board.settings.disable_scroll` to fit the whole board on one page (scroll off, row height derived from viewport). Clones inherit settings + colors via the existing deep copy — no cloner change needed.

## Tests

- Concrete hex per part of speech ("I" → `#FFEA75` pronoun, "want" → `#A1F571` verb, "what" → `#A07AFF` question) on seed, on re-seed (heals mangled tiles), and on a cloned set.
- `disable_scroll` present on all seeded boards and carried onto cloned root + every fringe page.
- Authored grids preserved (Core 60 home 10×6, Core 84 home 12×7).
- Image backfill only-when-blank; non-blank shared-Image `part_of_speech` never overwritten.

⚠️ **Specs were written but not executed in the sandbox** (no Ruby 3.3/Postgres). Before merge:

```
DEVISE_JWT_SECRET_KEY=anything RAILS_ENV=test bundle exec rspec spec/services/vocab_sets_spec.rb spec/services/boards spec/models/board_spec.rb
```

## After merge

One `bin/rails vocab_sets:seed` on prod/staging applies colors + one-page to the seeded sets (self-healing). User sets cloned **before** this fix keep their old colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)