### PR TITLE
feat(board-builder): move set build onto async rails via BuildBoardSetJob

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -5,10 +5,14 @@ module API
     #   GET  /api/v1/board_builder/templates  -> picker catalog (no auth-sensitive data)
     #   POST /api/v1/board_builder            -> build a linked board set for a communicator
     #
-    # Flow: BlueprintAssembler turns {template, interests} into a builder-ready
-    # blueprint, BoardTreeBuilder persists the linked tree and attaches the root
-    # to the communicator, and we stash the normalized interests on the
-    # communicator so the wizard can be re-run / pre-filled.
+    # Flow (async, same rails as GenerateBoardJob): every synchronous pre-check
+    # stays in-request, then we create JUST the root board (status
+    # "building_board"), attach it to the communicator (ChildBoard + favorite,
+    # so the set appears immediately in "building" state), stash the normalized
+    # interests for re-runs, enqueue BuildBoardSetJob to build everything else
+    # (fringe boards, tiles, links, interest routing, AI art), and return 201
+    # with the root payload right away. The frontend polls GET /api/boards/:id
+    # until status flips to "complete" (or "failed").
     #
     # Re-run guard (issue #269): if the communicator already has a builder set,
     # create returns HTTP 409 `board_builder_set_exists` instead of silently
@@ -40,6 +44,14 @@ module API
         # Re-run guard (issue #269): if this communicator already has a builder
         # set, don't silently stack a second favorited root. Warn so the frontend
         # can confirm; `confirm=true` is the explicit "build another" opt-in.
+        #
+        # Async note (#271): a root that's still building (status
+        # "building_board") — or one whose job failed (status "failed") — DOES
+        # count as "an existing set" here, deliberately. While a build is in
+        # flight it stops a concurrent double-build; after a failure the root is
+        # the user-visible failure artifact and `confirm=true` is the explicit
+        # "build another" path. The guard can't trip on its OWN root because the
+        # root is created below, after this check.
         existing = communicator.board_builder_root
         if existing && params[:confirm].to_s != "true"
           render json: { error: "board_builder_set_exists",
@@ -52,35 +64,57 @@ module API
         end
 
         # Two build paths share the same guards/response shape:
-        #  - a seeded "robust vocabulary set" (Core 60/84) -> deep-clone the
-        #    seeded set and route interests into the cloned fringe pages;
-        #  - a hardcoded starter template (home/daily_routine) -> assemble a
-        #    label blueprint and build a fresh linked tree.
-        robust_root = Boards::RobustSets.find_root(params[:template])
-
-        if robust_root
-          cloner = Boards::SeededSetCloner.new(
-            robust_root, communicator: communicator,
-            interests: params[:interests], favorite_root: true,
-          )
-          root = cloner.call
-          interests = cloner.interests
-        else
-          assembler = Boards::BlueprintAssembler.new(
-            template:  params[:template],
-            interests: params[:interests],
-            user:      current_user,
-          )
-          blueprint = assembler.call
-
-          root = Boards::BoardTreeBuilder.new(
-            blueprint, communicator: communicator, favorite_root: true,
-          ).call
-          interests = assembler.interests
+        #  - a seeded "robust vocabulary set" (Core 60/84) -> BuildBoardSetJob
+        #    deep-clones the seeded set into the pre-created root;
+        #  - a hardcoded starter template (home/daily_routine) -> the job
+        #    assembles a label blueprint and builds the linked tree under it.
+        # Resolve the template synchronously so an unknown key still 422s
+        # in-request — only the heavy build moves to the job.
+        robust_root  = Boards::RobustSets.find_root(params[:template])
+        starter_tree = robust_root ? nil : Boards::StarterBlueprints.tree_for(params[:template])
+        if robust_root.nil? && starter_tree.nil?
+          raise Boards::BlueprintAssembler::UnknownTemplate,
+                "unknown template #{params[:template].inspect}"
         end
 
-        # Persist the normalized interests for re-runs (jsonb merge, non-destructive).
-        communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
+        owner = communicator.owner || communicator.user
+        raise Boards::BoardTreeBuilder::BuildError, "communicator has no owning user" unless owner
+
+        interests = Boards::InterestWords.normalize_list(params[:interests])
+        root_name = robust_root ? robust_root.name : starter_tree[:name]
+
+        # Create the root in-request so the 201 payload (and the duplicate
+        # guard, and the board-limit count) see it immediately; the job adopts
+        # it and fills in the rest. ChildBoard attach + favorite stay in-request
+        # too, so the set appears on the communicator right away — in
+        # "building" state.
+        root = nil
+        ActiveRecord::Base.transaction do
+          root = Board.new(name: root_name, user: owner)
+          root.board_type = "dynamic" # builder roots link child folders
+          root.assign_parent          # => parent is the owning User
+          root.voice = VoiceService.normalize_voice(communicator.voice)
+          root.generate_unique_slug
+          # Same markers the builders set: root is countable + re-run
+          # detectable; status drives the frontend polling page.
+          root.settings = (root.settings || {}).merge("builder_root" => true)
+          root.status = "building_board"
+          root.save!
+
+          child_board = communicator.child_boards.create!(board: root, created_by_id: owner.id)
+          child_board.update!(favorite: true)
+
+          # Persist the normalized interests for re-runs (jsonb merge, non-destructive).
+          communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
+        end
+
+        # Credits: the Board Builder charges NO AI credits in-request (there is
+        # no check_credits! gate on this endpoint — compare scenarios/menus).
+        # The only credit-adjacent work is AI art for novel interest words,
+        # which was ALREADY queued asynchronously (GenerateImagesJob) and is
+        # paid where it always was. So there is nothing to refund if
+        # BuildBoardSetJob fails — no refund path needed, by decision.
+        BuildBoardSetJob.perform_async(root.id, communicator.id, params[:template].to_s, interests)
 
         render json: root.api_view(current_user), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e
@@ -96,7 +130,11 @@ module API
       rescue StandardError => e
         # Last-resort guard: never leak an internal error (or a 500) to the
         # client. Core symbols now self-heal, so this should be rare.
+        # If the root already committed (e.g. the enqueue itself raised), don't
+        # strand it in "building_board" — mark it failed so the duplicate guard
+        # offers the normal confirm-to-rebuild path instead of a stuck spinner.
         Rails.logger.error "[BoardBuilder] unexpected error: #{e.class}: #{e.message}"
+        root.update_column(:status, "failed") if defined?(root) && root&.persisted?
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },
                status: :unprocessable_entity

--- a/app/services/boards/blueprint_assembler.rb
+++ b/app/services/boards/blueprint_assembler.rb
@@ -109,18 +109,16 @@ module Boards
       image
     end
 
+    # Normalization lives in Boards::InterestWords (shared with the cloner
+    # and the controller, which persists the list and feeds BuildBoardSetJob).
+    # Casing matches find_or_create_images_from_word_list: multi-char words
+    # kept as typed, lone "i" -> "I", other single chars lowercased.
     def normalize_interests(list)
-      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(MAX_INTERESTS)
+      Boards::InterestWords.normalize_list(list, max: MAX_INTERESTS)
     end
 
-    # Match the casing convention used elsewhere (find_or_create_images_from_word_list):
-    # multi-char words kept as typed, lone "i" -> "I", other single chars lowercased.
     def normalize_word(string)
-      word = string.to_s.strip
-      return "" if word.blank?
-      return "I" if word.casecmp("i").zero?
-
-      word.length > 1 ? word : word.downcase
+      Boards::InterestWords.normalize_word(string)
     end
   end
 end

--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -31,43 +31,44 @@ module Boards
 
     class BuildError < StandardError; end
 
-    def initialize(blueprint, communicator:, favorite_root: false)
+    # `root:` (optional) is an ADOPTED root: a board the caller already created
+    # (named, parented, slugged, marked builder_root, attached to the
+    # communicator) — the async path, where BuildBoardSetJob fills in the tree
+    # under the root the controller returned with status "building_board".
+    # When a root is adopted, the caller owns the ChildBoard attach/favorite;
+    # this builder only adds tiles and sub-boards under it.
+    def initialize(blueprint, communicator:, favorite_root: false, root: nil)
       @blueprint     = blueprint.deep_symbolize_keys
       @communicator  = communicator
       @owner         = communicator.owner || communicator.user
       @favorite_root = favorite_root
+      @root          = root
     end
 
     # Builds the whole tree in a single transaction so a mid-build failure
-    # leaves no orphan boards or dangling ChildBoard. Returns the root Board.
+    # leaves no orphan boards or dangling ChildBoard (with an adopted root,
+    # the rollback strips every child/tile and leaves the bare root for the
+    # caller to mark "failed"). Returns the root Board.
     def call
       raise BuildError, "communicator has no owning user" unless @owner
 
       ActiveRecord::Base.transaction do
         root = build_board(@blueprint, depth: 0)
-        attach_root_to_communicator(root)
+        attach_root_to_communicator(root) unless adopted_root?
         root
       end
     end
 
     private
 
+    def adopted_root?
+      @root.present?
+    end
+
     # Depth-first: build the child board first, then point the parent tile's
     # predictive_board_id at it (can't link to a board that doesn't exist yet).
     def build_board(node, depth:)
-      board = Board.new(name: node[:name], user: @owner)
-      board.board_type = board_type_for(node, depth) # "dynamic" or "static"
-      board.assign_parent                            # => parent is the owning User
-      board.voice = VoiceService.normalize_voice(@communicator.voice)
-      board.generate_unique_slug
-      # Sub-boards (folders) don't count against the user's board limit — the
-      # whole tree counts as one via its root. See User#countable_board_count.
-      board.settings = (board.settings || {}).merge("builder_child" => true) if depth.positive?
-      # Mark the root so a re-run can detect an existing builder set and warn
-      # instead of silently duplicating it (issue #269). Root stays countable —
-      # countable_board_count only excludes builder_child, not builder_root.
-      board.settings = (board.settings || {}).merge("builder_root" => true) if depth.zero?
-      board.save!
+      board = board_for(node, depth)
 
       Array(node[:tiles]).each do |tile|
         # add_image resolves the Image and sets label/voice/part-of-speech/
@@ -82,6 +83,35 @@ module Boards
         end
       end
 
+      board
+    end
+
+    # The Board a node persists into: a fresh Board for every node in the sync
+    # path, but at depth 0 with an adopted root, the pre-created board itself.
+    # The adopted root keeps the identity the controller's 201 payload already
+    # exposed (name, slug, parent, voice, status "building_board"); we only
+    # true-up board_type for whether this blueprint links children.
+    def board_for(node, depth)
+      if depth.zero? && adopted_root?
+        @root.board_type = board_type_for(node, depth)
+        @root.settings = (@root.settings || {}).merge("builder_root" => true)
+        @root.save!
+        return @root
+      end
+
+      board = Board.new(name: node[:name], user: @owner)
+      board.board_type = board_type_for(node, depth) # "dynamic" or "static"
+      board.assign_parent                            # => parent is the owning User
+      board.voice = VoiceService.normalize_voice(@communicator.voice)
+      board.generate_unique_slug
+      # Sub-boards (folders) don't count against the user's board limit — the
+      # whole tree counts as one via its root. See User#countable_board_count.
+      board.settings = (board.settings || {}).merge("builder_child" => true) if depth.positive?
+      # Mark the root so a re-run can detect an existing builder set and warn
+      # instead of silently duplicating it (issue #269). Root stays countable —
+      # countable_board_count only excludes builder_child, not builder_root.
+      board.settings = (board.settings || {}).merge("builder_root" => true) if depth.zero?
+      board.save!
       board
     end
 

--- a/app/services/boards/interest_words.rb
+++ b/app/services/boards/interest_words.rb
@@ -1,0 +1,27 @@
+# app/services/boards/interest_words.rb
+#
+# Single home for the Board Builder's interest-word normalization, shared by
+# Boards::BlueprintAssembler, Boards::SeededSetCloner, and the controller
+# (which persists the normalized list on the communicator and hands it to
+# BuildBoardSetJob). Behavior is exactly what both services did privately:
+# trim, drop blanks, dedupe (post-normalization), cap, lone "i" -> "I",
+# other single chars lowercased, multi-char words kept as typed.
+module Boards
+  module InterestWords
+    MAX_INTERESTS = 12
+
+    module_function
+
+    def normalize_list(list, max: MAX_INTERESTS)
+      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(max)
+    end
+
+    def normalize_word(string)
+      word = string.to_s.strip
+      return "" if word.blank?
+      return "I" if word.casecmp("i").zero?
+
+      word.length > 1 ? word : word.downcase
+    end
+  end
+end

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -32,17 +32,26 @@ module Boards
     # communicator (same contract as BlueprintAssembler#interests).
     attr_reader :interests
 
-    def initialize(source_root, communicator:, interests: [], favorite_root: true)
+    # `root:` (optional) is an ADOPTED root: a board the caller already created
+    # (named, parented, slugged, marked builder_root, attached to the
+    # communicator) — the async path, where BuildBoardSetJob fills in the set
+    # under the root the controller returned with status "building_board".
+    # When a root is adopted, the source root's CONTENT (tiles, layout columns)
+    # is cloned INTO it instead of dup-ing a fresh board, and the caller owns
+    # the ChildBoard attach/favorite.
+    def initialize(source_root, communicator:, interests: [], favorite_root: true, root: nil)
       @source_root   = source_root
       @communicator  = communicator
       @owner         = communicator.owner || communicator.user
       @interests     = normalize_interests(interests)
       @favorite_root = favorite_root
+      @root          = root
     end
 
     # Clones the whole linked set + routes interests in a single transaction so a
-    # mid-build failure leaves no orphan boards or dangling ChildBoard. Returns
-    # the cloned root Board.
+    # mid-build failure leaves no orphan boards or dangling ChildBoard (with an
+    # adopted root, the rollback strips every fringe board/tile and leaves the
+    # bare root for the caller to mark "failed"). Returns the cloned root Board.
     def call
       raise CloneError, "communicator has no owning user" unless @owner
       raise CloneError, "no source root board" if @source_root.nil?
@@ -53,7 +62,7 @@ module Boards
         mark_builder_settings!
 
         root = @map.fetch(@source_root.id)
-        attach_root_to_communicator(root)
+        attach_root_to_communicator(root) unless adopted_root?
         route_interests!(root)
         # clone_with_images leaves the in-memory clones with a stale
         # board_images_count / association cache; hand back a fresh root.
@@ -62,6 +71,10 @@ module Boards
     end
 
     private
+
+    def adopted_root?
+      @root.present?
+    end
 
     # BFS over predictive_board_id links from the root, bounded to MAX_DEPTH and
     # cycle-safe (visited set). A board reachable twice is collected once. Root
@@ -90,13 +103,81 @@ module Boards
 
     # Clone each source board for the owner. NO communicator_account arg, so
     # fringe boards don't each get a ChildBoard (only the root is attached, in
-    # attach_root_to_communicator). Returns { source_board_id => cloned Board }.
+    # attach_root_to_communicator). With an adopted root, the source ROOT's
+    # content is cloned into the pre-created board instead of dup-ing a new
+    # one. Returns { source_board_id => cloned Board }.
     def clone_all(source_boards)
       source_boards.each_with_object({}) do |src, map|
-        cloned = src.clone_with_images(@owner.id)
+        cloned =
+          if adopted_root? && src.id == @source_root.id
+            clone_into_adopted_root(src)
+          else
+            src.clone_with_images(@owner.id)
+          end
         raise CloneError, "failed to clone source board #{src.id}" if cloned.nil?
 
         map[src.id] = cloned
+      end
+    end
+
+    # The adopted-root version of Board#clone_with_images: copy the source
+    # root's presentation attributes and tiles into the board the controller
+    # pre-created, leaving the identity its 201 payload already exposed (name,
+    # slug, user, parent, voice, status "building_board") untouched.
+    def clone_into_adopted_root(src)
+      root = @root
+      root.board_type            = src.board_type
+      root.number_of_columns     = src.number_of_columns
+      root.small_screen_columns  = src.small_screen_columns
+      root.medium_screen_columns = src.medium_screen_columns
+      root.large_screen_columns  = src.large_screen_columns
+      root.margin_settings       = src.margin_settings
+      root.layout                = src.layout
+      root.bg_color              = src.bg_color
+      root.language              = src.language
+      root.description           = src.description
+      # Source settings minus the robust-set catalog markers — a user's copy
+      # must never surface as a pickable template (the dup-based clone path
+      # predates this concern). The controller's own settings (builder_root)
+      # win on conflict; display_follows_preview mirrors clone_with_images.
+      root.settings = (src.settings || {})
+        .except(Boards::RobustSets::ROOT_MARKER, Boards::RobustSets::SLUG_MARKER)
+        .merge(root.settings || {})
+        .merge("display_follows_preview" => true)
+      root.save!
+
+      copy_tiles!(src, root)
+      root.run_generate_preview_job if root.board_images.reload.any?
+      # clone_with_images repoints the owner's pre-existing tiles that target
+      # the SOURCE board at the clone; keep that parity for the adopted root.
+      UpdateUserBoardsJob.perform_async(root.id, src.id) if src.user_id != root.user_id
+      root
+    end
+
+    # Mirrors the per-tile copy inside Board#clone_with_images: dup each
+    # BoardImage so the authored layout/colors/part_of_speech survive, re-point
+    # it at an image the owner can use, and keep predictive_board_id verbatim —
+    # rewire_predictive_links! translates the pointers afterwards.
+    def copy_tiles!(src, target)
+      src.board_images.each do |board_image|
+        original_image = board_image.image
+        image = original_image
+        if image.user_id
+          image = Image.find_by(label: image.label, user_id: target.user_id) if image.user_id == target.user_id
+        else
+          image = Image.find_by(label: image.label, user_id: [nil, target.user_id, User::DEFAULT_ADMIN_ID])
+        end
+        image ||= Image.create(label: original_image.label, user_id: target.user_id)
+
+        new_board_image = board_image.dup
+        new_board_image.board_id = target.id
+        new_board_image.image_id = image.id
+        new_board_image.set_labels
+        new_board_image.display_label = board_image.display_label
+        new_board_image.voice = board_image.voice
+        new_board_image.predictive_board_id = board_image.predictive_board_id
+        new_board_image.audio_url = board_image.audio_url
+        new_board_image.save!
       end
     end
 
@@ -219,17 +300,14 @@ module Boards
       image
     end
 
+    # Normalization lives in Boards::InterestWords (shared with the assembler
+    # and the controller, which persists the list and feeds BuildBoardSetJob).
     def normalize_interests(list)
-      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(MAX_INTERESTS)
+      Boards::InterestWords.normalize_list(list, max: MAX_INTERESTS)
     end
 
-    # multi-char words kept as typed, lone "i" -> "I", other single chars lowercased.
     def normalize_word(string)
-      word = string.to_s.strip
-      return "" if word.blank?
-      return "I" if word.casecmp("i").zero?
-
-      word.length > 1 ? word : word.downcase
+      Boards::InterestWords.normalize_word(string)
     end
   end
 end

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -1,0 +1,82 @@
+# app/sidekiq/build_board_set_job.rb
+#
+# Async half of the Board Builder (POST /api/v1/board_builder). The controller
+# does every synchronous pre-check (404 / 422 board-limit / 409 duplicate-set),
+# creates the ROOT board with status "building_board", attaches it to the
+# communicator (ChildBoard + favorite), and enqueues this job. This job builds
+# everything else under that pre-created root:
+#
+#   - fringe/sub boards + their tiles
+#   - predictive_board_id folder links
+#   - interest -> category routing (+ a "My Favorites" fringe for leftovers)
+#   - AI-art queuing for novel interest words (GenerateImagesJob)
+#
+# Status lifecycle mirrors GenerateBoardJob: the ROOT (and only the root)
+# carries the generation status — "building_board" -> "complete", or "failed"
+# on any raise (then re-raise so Sidekiq retries once). Child boards keep
+# their normal defaults; the frontend polls only the root.
+#
+# Mid-build failure safety: both build services (Boards::SeededSetCloner and
+# Boards::BoardTreeBuilder) wrap their persistence in a single transaction, so
+# a failure rolls back every child board/tile and leaves just the root, marked
+# "failed" — the user-visible failure artifact, same as single-board
+# generation. (Blueprint-path Image rows created during label resolution may
+# survive a rollback; that matches today's in-request behavior and images are
+# user-scoped, reusable records — not orphans.)
+class BuildBoardSetJob
+  include Sidekiq::Job
+  sidekiq_options retry: 1, queue: :default
+
+  def perform(root_board_id, communicator_id, template, interests = [])
+    root = Board.find_by(id: root_board_id)
+    unless root
+      Rails.logger.error "BuildBoardSetJob: Board with ID #{root_board_id} not found."
+      return
+    end
+
+    # Retry guard — don't double-build. The build is transactional, so a
+    # retried failure finds a bare root and rebuilds cleanly; but if a previous
+    # attempt's transaction committed (e.g. the process died between commit and
+    # the status update), the root already has tiles. Treat that as built.
+    if root.status == "complete" || root.board_images.exists?
+      root.update_column(:status, "complete")
+      return
+    end
+
+    communicator = ChildAccount.find_by(id: communicator_id)
+    unless communicator
+      Rails.logger.error "BuildBoardSetJob: ChildAccount with ID #{communicator_id} not found for Board ID #{root_board_id}."
+      root.update_column(:status, "failed")
+      return
+    end
+
+    begin
+      robust_root = Boards::RobustSets.find_root(template)
+
+      if robust_root
+        Boards::SeededSetCloner.new(
+          robust_root, communicator: communicator,
+          interests: interests, root: root,
+        ).call
+      else
+        owner = communicator.owner || communicator.user
+        assembler = Boards::BlueprintAssembler.new(
+          template:  template,
+          interests: interests,
+          user:      owner,
+        )
+        blueprint = assembler.call
+
+        Boards::BoardTreeBuilder.new(
+          blueprint, communicator: communicator, root: root,
+        ).call
+      end
+
+      root.update_column(:status, "complete")
+    rescue => e
+      Rails.logger.error "\n**** SIDEKIQ - BuildBoardSetJob #{root.id} #{template.inspect} \n\nERROR **** \n#{e.message}\n#{e.backtrace&.join("\n")}\n"
+      root.update_column(:status, "failed")
+      raise
+    end
+  end
+end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
   end
 
   describe "POST /api/v1/board_builder" do
-    before { seed_template_images! }
+    before do
+      seed_template_images!
+      BuildBoardSetJob.clear # Sidekiq fake-mode queues accumulate across examples
+    end
 
     context "without auth" do
       it "returns 401" do
@@ -74,25 +77,52 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
-    context "happy path" do
-      it "builds a linked set, routes interests into category vs favorites folders, and persists interests" do
-        # dinosaurs -> the template's Play folder; grandma -> "My Favorites".
+    context "happy path (async)" do
+      it "returns 201 immediately with the root in building_board and enqueues BuildBoardSetJob with the right args" do
         expect {
           post "/api/v1/board_builder",
                params: { communicator_id: communicator.id, template: "home",
                          interests: ["dinosaurs", "grandma"] }.to_json,
                headers: headers
         }.to change { communicator.child_boards.count }.by(1)
+          .and change { BuildBoardSetJob.jobs.size }.by(1)
 
         expect(response).to have_http_status(:created)
         body = JSON.parse(response.body)
+        expect(body["status"]).to eq("building_board")
 
         root = Board.find(body["id"])
         expect(root.name).to eq("Home")
         expect(root.user_id).to eq(user.id)
+        expect(root.settings["builder_root"]).to be(true)
+        expect(root.status).to eq("building_board")
+        # The root is created bare — the job builds the tiles/sub-boards.
+        expect(root.board_images.count).to eq(0)
 
+        # Attach + favorite happen in-request, so the set shows on the
+        # communicator immediately (in "building" state).
         child_board = communicator.child_boards.find_by(board_id: root.id)
         expect(child_board.favorite).to eq(true)
+
+        # Interests are normalized + persisted in-request for re-run prefill.
+        expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "grandma"])
+
+        expect(BuildBoardSetJob.jobs.last["args"])
+          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"]])
+      end
+
+      it "builds a linked set, routes interests into category vs favorites folders, and completes (job drained)" do
+        # dinosaurs -> the template's Play folder; grandma -> "My Favorites".
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home",
+                       interests: ["dinosaurs", "grandma"] }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        BuildBoardSetJob.drain
+
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.status).to eq("complete")
 
         # "dinosaurs" was routed into the existing Play folder (alongside seeds).
         play_tile = root.board_images.find { |bi| bi.label == "Play" }
@@ -106,7 +136,11 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         favorites_board = Board.find(favorites_tile.predictive_board_id)
         expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
 
-        expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "grandma"])
+        # Only the ROOT carries a generation status; children stay default.
+        sub_boards = User.find(user.id).boards
+                         .where("COALESCE((settings->>'builder_child')::boolean, false)")
+        expect(sub_boards).to be_present
+        expect(sub_boards.pluck(:status)).not_to include("building_board", "complete", "failed")
       end
 
       it "builds the core template with no favorites folder when interests are empty" do
@@ -115,6 +149,8 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
              headers: headers
 
         expect(response).to have_http_status(:created)
+        BuildBoardSetJob.drain
+
         root = Board.find(JSON.parse(response.body)["id"])
         expect(root.board_images.map(&:label)).not_to include("My Favorites")
       end
@@ -134,7 +170,9 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
              headers: no_seed_headers
 
         expect(response).to have_http_status(:created)
+        BuildBoardSetJob.drain
         expect(Image.find_by(label: "Food", user_id: no_seed_user.id)).to be_present
+        expect(Board.find(JSON.parse(response.body)["id"]).status).to eq("complete")
       end
     end
 
@@ -149,25 +187,29 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
     end
 
     context "unknown template" do
-      it "returns 422 and builds nothing" do
+      it "returns 422, builds nothing, and enqueues no job" do
+        jobs_before = BuildBoardSetJob.jobs.size
         expect {
           post "/api/v1/board_builder",
                params: { communicator_id: communicator.id, template: "nope" }.to_json,
                headers: headers
         }.not_to change { Board.count }
+        expect(BuildBoardSetJob.jobs.size).to eq(jobs_before)
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
     context "board-limit gate (a built tree counts as ONE board)" do
-      it "returns 422 and builds nothing when the user is already at their limit" do
+      it "returns 422, builds nothing, and enqueues no job when the user is already at their limit" do
         create(:board, user: user) # user is Free (limit 1) → now at limit
+        jobs_before = BuildBoardSetJob.jobs.size
 
         expect {
           post "/api/v1/board_builder",
                params: { communicator_id: communicator.id, template: "home" }.to_json,
                headers: headers
         }.not_to change { Board.count }
+        expect(BuildBoardSetJob.jobs.size).to eq(jobs_before)
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
@@ -179,6 +221,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                        interests: ["dinosaurs"] }.to_json,
              headers: headers
         expect(response).to have_http_status(:created)
+        BuildBoardSetJob.drain
 
         fresh = User.find(user.id)
         # The tree persisted multiple boards, but it counts as one.
@@ -196,6 +239,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
              params: { communicator_id: communicator.id, template: "home",
                        interests: ["dinosaurs"] }.to_json,
              headers: headers
+        BuildBoardSetJob.drain
         root = Board.find(JSON.parse(response.body)["id"])
 
         fresh = User.find(user.id)
@@ -217,6 +261,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
              headers: headers
         expect(response).to have_http_status(:created)
         first_root_id = JSON.parse(response.body)["id"]
+        BuildBoardSetJob.drain
 
         boards_before = Board.count
         child_boards_before = communicator.child_boards.count
@@ -235,6 +280,23 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(communicator.child_boards.count).to eq(child_boards_before)
       end
 
+      it "trips the guard even while the first build is still running (#271 async window)" do
+        # Root exists with status building_board the moment the 201 returns —
+        # a concurrent second request must 409, not double-build.
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+        root_id = JSON.parse(response.body)["id"]
+        expect(Board.find(root_id).status).to eq("building_board") # job not drained
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:conflict)
+        expect(JSON.parse(response.body)["error"]).to eq("board_builder_set_exists")
+      end
+
       it "builds another set when confirm=true" do
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "home" }.to_json,
@@ -251,10 +313,9 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
-    context "when the tree builder fails mid-build" do
-      it "returns 422 build_failed with a warm message" do
-        allow_any_instance_of(Boards::BoardTreeBuilder)
-          .to receive(:call).and_raise(Boards::BoardTreeBuilder::BuildError, "boom")
+    context "when something fails in-request after the root was created" do
+      it "returns 422 build_failed and marks the root failed (no stuck building_board)" do
+        allow(BuildBoardSetJob).to receive(:perform_async).and_raise(StandardError, "redis down")
 
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "home" }.to_json,
@@ -262,11 +323,43 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(JSON.parse(response.body)["error"]).to eq("build_failed")
+
+        root = communicator.reload.board_builder_root
+        expect(root).to be_present
+        expect(root.status).to eq("failed")
+      end
+    end
+
+    context "when the build job fails mid-build" do
+      # The full failure matrix (transaction rollback, no orphan children,
+      # retry idempotency) lives in spec/sidekiq/build_board_set_job_spec.rb;
+      # this covers the user-visible request-level artifact.
+      it "leaves the root as the failed artifact and the next run 409s until confirmed" do
+        # Lift the Free board limit so the second POST reaches the 409 guard
+        # (the limit gate runs first and the failed root still counts as one).
+        user.update!(settings: user.settings.to_h.merge("board_limit" => 10))
+        allow_any_instance_of(Boards::BoardTreeBuilder)
+          .to receive(:call).and_raise(Boards::BoardTreeBuilder::BuildError, "boom")
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+        root_id = JSON.parse(response.body)["id"]
+
+        expect { BuildBoardSetJob.drain }.to raise_error(Boards::BoardTreeBuilder::BuildError)
+        expect(Board.find(root_id).status).to eq("failed")
+
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:conflict)
+        expect(JSON.parse(response.body)["error"]).to eq("board_builder_set_exists")
       end
     end
 
     context "robust seeded set (clone path)" do
-      it "clones the seeded set, favorites the root, and routes interests into the cloned fringe" do
+      it "returns 201 with a building_board root named for the set, then the job clones and routes interests" do
         seed_robust_set!
 
         expect {
@@ -275,24 +368,40 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                          interests: ["pizza"] }.to_json,
                headers: headers
         }.to change { communicator.child_boards.count }.by(1)
+          .and change { BuildBoardSetJob.jobs.size }.by(1)
 
         expect(response).to have_http_status(:created)
         root = Board.find(JSON.parse(response.body)["id"])
         expect(root.name).to eq("Core 60")
         expect(root.user_id).to eq(user.id)
         expect(root.settings["builder_root"]).to be(true)
+        expect(root.status).to eq("building_board")
 
         child_board = communicator.child_boards.find_by(board_id: root.id)
         expect(child_board.favorite).to eq(true)
 
+        expect(communicator.reload.details["interests"]).to eq(["pizza"])
+        expect(BuildBoardSetJob.jobs.last["args"])
+          .to eq([root.id, communicator.id, "core-60", ["pizza"]])
+
+        BuildBoardSetJob.drain
+        root.reload
+        expect(root.status).to eq("complete")
+
         # The whole cloned set counts as ONE board.
         expect(User.find(user.id).countable_board_count).to eq(1)
 
-        # "pizza" routed into the cloned Food fringe page.
+        # Cloned core tiles landed on the SAME root the 201 returned.
+        expect(root.board_images.map(&:label)).to include("I", "Food")
+
+        # "pizza" routed into the cloned Food fringe page, linked from the root.
         cloned_food = user.boards.find_by(name: "Food")
         expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
+        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
-        expect(communicator.reload.details["interests"]).to eq(["pizza"])
+        # The user's copy must never surface as a pickable robust template.
+        expect(Boards::RobustSets.all_roots.pluck(:id)).not_to include(root.id)
       end
 
       it "is blocked by the board limit (422) — a cloned set still counts as one" do

--- a/spec/services/boards/board_tree_builder_spec.rb
+++ b/spec/services/boards/board_tree_builder_spec.rb
@@ -195,5 +195,77 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect { described_class.new(blueprint, communicator: ownerless).call }
         .to raise_error(Boards::BoardTreeBuilder::BuildError, /owning user/)
     end
+
+    context "with an adopted root (async path via BuildBoardSetJob)" do
+      # Mirrors the controller's in-request root creation.
+      def precreated_root
+        root = Board.new(name: "Home", user: owner)
+        root.board_type = "dynamic"
+        root.assign_parent
+        root.generate_unique_slug
+        root.settings = (root.settings || {}).merge("builder_root" => true)
+        root.status = "building_board"
+        root.save!
+        communicator.child_boards.create!(board: root, created_by_id: owner.id).update!(favorite: true)
+        root
+      end
+
+      let(:blueprint) do
+        {
+          name: "Home",
+          tiles: [
+            { label: "I", image_id: image_id_for("I") },
+            { label: "Food", image_id: image_id_for("Food"), children: {
+              name: "Food",
+              tiles: [{ label: "apple", image_id: image_id_for("apple") }],
+            } },
+          ],
+        }
+      end
+
+      it "builds the tree into the adopted root instead of creating a new one" do
+        root = precreated_root
+
+        returned = nil
+        expect {
+          returned = described_class.new(blueprint, communicator: communicator, root: root).call
+        }.to change { Board.where(user_id: owner.id).count }.by(1) # only the Food sub-board
+
+        expect(returned.id).to eq(root.id)
+        expect(root.reload.board_images.map(&:label)).to contain_exactly("I", "Food")
+        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        expect(Board.find(food_tile.predictive_board_id).settings["builder_child"]).to be(true)
+      end
+
+      it "preserves the adopted root's identity (name, slug, status) and does not re-attach" do
+        root = precreated_root
+        original_slug = root.slug
+
+        expect {
+          described_class.new(blueprint, communicator: communicator, root: root).call
+        }.not_to change { communicator.child_boards.count }
+
+        root.reload
+        expect(root.name).to eq("Home")
+        expect(root.slug).to eq(original_slug)
+        # Status is the JOB's to flip; the builder must not touch it.
+        expect(root.status).to eq("building_board")
+        expect(communicator.child_boards.where(board_id: root.id).count).to eq(1)
+      end
+
+      it "rolls back children/tiles on failure but leaves the adopted root" do
+        root = precreated_root
+        bad = blueprint.deep_dup
+        bad[:tiles] << { label: "broken", image_id: 999_999_999 }
+
+        expect {
+          described_class.new(bad, communicator: communicator, root: root).call
+        }.to raise_error(StandardError)
+
+        expect(root.reload).to be_persisted
+        expect(root.board_images.count).to eq(0)
+        expect(Board.where(user_id: owner.id).where.not(id: root.id).count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -163,6 +163,93 @@ RSpec.describe Boards::SeededSetCloner do
         described_class.new(source[:root], communicator: orphan).call
       }.to raise_error(Boards::SeededSetCloner::CloneError)
     end
+
+    context "with an adopted root (async path via BuildBoardSetJob)" do
+      # Mirrors the controller's in-request root creation.
+      def precreated_root(name: "Core 60")
+        root = Board.new(name: name, user: owner)
+        root.board_type = "dynamic"
+        root.assign_parent
+        root.generate_unique_slug
+        root.settings = (root.settings || {}).merge("builder_root" => true)
+        root.status = "building_board"
+        root.save!
+        communicator.child_boards.create!(board: root, created_by_id: owner.id).update!(favorite: true)
+        root
+      end
+
+      it "clones the source root's tiles INTO the adopted root and rewires links to the clones" do
+        root = precreated_root
+
+        returned = described_class.new(source[:root], communicator: communicator, root: root).call
+
+        expect(returned.id).to eq(root.id)
+        root.reload
+        expect(root.board_images.map(&:label)).to include("I", "want", "help", "Food", "Feelings")
+
+        cloned_food = owner.boards.find_by(name: "Food")
+        food_tile = root.board_images.find_by(label: "Food")
+        expect(food_tile.predictive_board_id).to eq(cloned_food.id)
+
+        # The cycle tile on the cloned Feelings board points back at the ADOPTED root.
+        cloned_feelings = owner.boards.find_by(name: "Feelings")
+        expect(cloned_feelings.board_images.find_by(label: "home").predictive_board_id).to eq(root.id)
+
+        # 1 adopted root + 2 fringe clones, still counted as ONE board.
+        expect(owner.boards.count).to eq(3)
+        expect(User.find(owner.id).countable_board_count).to eq(1)
+      end
+
+      it "preserves the adopted root's identity, does not re-attach, and never inherits the robust catalog markers" do
+        Boards::RobustSets.mark_root!(source[:root], "core-60")
+        root = precreated_root
+        original_slug = root.slug
+
+        expect {
+          described_class.new(source[:root], communicator: communicator, root: root).call
+        }.not_to change { communicator.child_boards.count }
+
+        root.reload
+        expect(root.name).to eq("Core 60")
+        expect(root.slug).to eq(original_slug)
+        expect(root.user_id).to eq(owner.id)
+        # Status is the JOB's to flip; the cloner must not touch it.
+        expect(root.status).to eq("building_board")
+        expect(root.settings["builder_root"]).to be(true)
+        # The user's copy must never surface as a pickable robust template.
+        expect(Boards::RobustSets.all_roots.pluck(:id)).to contain_exactly(source[:root].id)
+      end
+
+      it "routes interests into the cloned fringe pages under the adopted root" do
+        root = precreated_root
+
+        described_class.new(
+          source[:root], communicator: communicator, interests: ["pizza", "grandma"], root: root
+        ).call
+
+        cloned_food = owner.boards.find_by(name: "Food")
+        expect(cloned_food.board_images.map(&:label)).to include("pizza")
+
+        favorites = owner.boards.find_by(name: "My Favorites")
+        expect(favorites.board_images.map(&:label)).to include("grandma")
+        fav_tile = root.reload.board_images.find_by(label: "My Favorites")
+        expect(fav_tile.predictive_board_id).to eq(favorites.id)
+      end
+
+      it "rolls back fringe clones/tiles on failure but leaves the adopted root" do
+        root = precreated_root
+        allow_any_instance_of(described_class)
+          .to receive(:route_interests!).and_raise(Boards::SeededSetCloner::CloneError, "boom")
+
+        expect {
+          described_class.new(source[:root], communicator: communicator, root: root).call
+        }.to raise_error(Boards::SeededSetCloner::CloneError)
+
+        expect(root.reload).to be_persisted
+        expect(root.board_images.count).to eq(0)
+        expect(owner.boards.where.not(id: root.id).count).to eq(0)
+      end
+    end
   end
 
   # Regression for #278: seed BOTH real sets (whose fringe ids are now

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -1,0 +1,222 @@
+require "rails_helper"
+
+RSpec.describe BuildBoardSetJob do
+  let(:user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user) }
+
+  # Mirrors what Api::V1::BoardBuilderController#create persists in-request
+  # before enqueueing this job: a bare root in "building_board", attached to
+  # the communicator as a favorite.
+  def precreate_root!(name:, for_communicator: communicator, owner: user)
+    root = Board.new(name: name, user: owner)
+    root.board_type = "dynamic"
+    root.assign_parent
+    root.voice = VoiceService.normalize_voice(for_communicator.voice)
+    root.generate_unique_slug
+    root.settings = (root.settings || {}).merge("builder_root" => true)
+    root.status = "building_board"
+    root.save!
+    child_board = for_communicator.child_boards.create!(board: root, created_by_id: owner.id)
+    child_board.update!(favorite: true)
+    root
+  end
+
+  # Seeds a tiny admin-owned robust set (root + Food fringe), same shape the
+  # request spec uses, marked so Boards::RobustSets finds it.
+  def seed_robust_set!(slug: "core-60")
+    admin = create(:admin_user)
+    source_root = create(:board, user: admin, name: "Core 60", predefined: true, published: true)
+    food = create(:board, user: admin, name: "Food", predefined: true, published: true)
+    create(:board_image, board: source_root, label: "I",
+                         image: create(:image, label: "I", user_id: admin.id))
+    food_tile = create(:board_image, board: source_root, label: "Food",
+                                     image: create(:image, label: "Food", user_id: admin.id))
+    food_tile.update!(predictive_board_id: food.id)
+    create(:board_image, board: food, label: "apple",
+                         image: create(:image, label: "apple", user_id: admin.id))
+    Boards::RobustSets.mark_root!(source_root, slug)
+    source_root
+  end
+
+  describe "#perform with a starter template" do
+    it "builds the full tree under the pre-created root and marks it complete" do
+      root = precreate_root!(name: "Home")
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"])
+
+      root.reload
+      expect(root.status).to eq("complete")
+      expect(root.settings["builder_root"]).to be(true)
+
+      # Core tiles landed on the SAME root the controller returned.
+      labels = root.board_images.map(&:label)
+      expect(labels).to include("I", "want", "Food", "Feelings", "Play")
+
+      # Folder tiles link to builder_child sub-boards.
+      play_tile = root.board_images.find { |bi| bi.label == "Play" }
+      expect(play_tile.predictive_board_id).to be_present
+      play_board = Board.find(play_tile.predictive_board_id)
+      expect(play_board.settings["builder_child"]).to be(true)
+      expect(play_board.board_images.map(&:label)).to include("dinosaurs", "ball")
+
+      # Unmatched interest fell through to "My Favorites".
+      favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+      favorites_board = Board.find(favorites_tile.predictive_board_id)
+      expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
+
+      # Only the root carries a generation status.
+      children = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+      expect(children).to be_present
+      expect(children.pluck(:status)).not_to include("building_board", "complete", "failed")
+
+      # No second ChildBoard — the controller's in-request attach is the only one.
+      expect(communicator.child_boards.where(board_id: root.id).count).to eq(1)
+      expect(communicator.child_boards.count).to eq(1)
+
+      # The whole tree counts as ONE board.
+      expect(User.find(user.id).countable_board_count).to eq(1)
+    end
+
+    it "preserves the root identity the 201 payload exposed (name, slug, user)" do
+      root = precreate_root!(name: "Home")
+      original_slug = root.slug
+
+      described_class.new.perform(root.id, communicator.id, "home", [])
+
+      root.reload
+      expect(root.name).to eq("Home")
+      expect(root.slug).to eq(original_slug)
+      expect(root.user_id).to eq(user.id)
+    end
+  end
+
+  describe "#perform with a robust seeded set" do
+    it "clones the set into the pre-created root, rewires links, routes interests, and completes" do
+      source_root = seed_robust_set!
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "core-60", ["pizza"])
+
+      root.reload
+      expect(root.status).to eq("complete")
+      expect(root.board_images.map(&:label)).to include("I", "Food")
+
+      cloned_food = user.boards.find_by(name: "Food")
+      expect(cloned_food).to be_present
+      expect(cloned_food.settings["builder_child"]).to be(true)
+      expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
+
+      # Folder tile points at the CLONED fringe, not the admin source.
+      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      expect(food_tile.predictive_board_id).to eq(cloned_food.id)
+
+      # Source set untouched; user's copy never surfaces as a pickable template.
+      expect(source_root.reload.user_id).not_to eq(user.id)
+      expect(Boards::RobustSets.all_roots.pluck(:id)).to contain_exactly(source_root.id)
+
+      expect(communicator.child_boards.count).to eq(1)
+      expect(User.find(user.id).countable_board_count).to eq(1)
+    end
+
+    it "queues AI art for a novel interest word with no existing symbol" do
+      seed_robust_set!
+      root = precreate_root!(name: "Core 60")
+
+      expect(GenerateImagesJob).to receive(:perform_async)
+        .with(kind_of(Array), kind_of(Integer)).at_least(:once)
+
+      described_class.new.perform(root.id, communicator.id, "core-60", ["dinosaurs"])
+    end
+  end
+
+  describe "failure path" do
+    it "marks the root failed, re-raises, and leaves no orphan children" do
+      root = precreate_root!(name: "Home")
+      allow_any_instance_of(Boards::BoardTreeBuilder)
+        .to receive(:call).and_raise(Boards::BoardTreeBuilder::BuildError, "boom")
+
+      boards_before = Board.count
+      expect {
+        described_class.new.perform(root.id, communicator.id, "home", [])
+      }.to raise_error(Boards::BoardTreeBuilder::BuildError)
+
+      expect(root.reload.status).to eq("failed")
+      # The transactional build rolled back: root remains, nothing else.
+      expect(Board.count).to eq(boards_before)
+      expect(user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").count).to eq(0)
+      expect(communicator.child_boards.count).to eq(1) # still just the root attach
+    end
+
+    it "marks the root failed when a mid-build raise happens inside the tree build (real rollback)" do
+      root = precreate_root!(name: "Home")
+      # Blow up while linking a folder tile — boards/tiles created up to that
+      # point must roll back, leaving only the bare root.
+      allow_any_instance_of(BoardImage).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+
+      expect {
+        described_class.new.perform(root.id, communicator.id, "home", [])
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect(root.reload.status).to eq("failed")
+      expect(root.board_images.count).to eq(0)
+      expect(user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").count).to eq(0)
+    end
+
+    it "marks the root failed when the communicator is gone" do
+      root = precreate_root!(name: "Home")
+      missing_id = communicator.id
+      communicator.child_boards.destroy_all
+      communicator.destroy!
+
+      described_class.new.perform(root.id, missing_id, "home", [])
+
+      expect(root.reload.status).to eq("failed")
+    end
+
+    it "marks the root failed on an unknown template (validated again job-side)" do
+      root = precreate_root!(name: "Home")
+
+      expect {
+        described_class.new.perform(root.id, communicator.id, "nope", [])
+      }.to raise_error(Boards::BlueprintAssembler::UnknownTemplate)
+
+      expect(root.reload.status).to eq("failed")
+    end
+  end
+
+  describe "retry idempotency" do
+    it "does not double-build a root that already completed" do
+      root = precreate_root!(name: "Home")
+      described_class.new.perform(root.id, communicator.id, "home", [])
+      tiles_after_first = root.reload.board_images.count
+      boards_after_first = Board.count
+
+      described_class.new.perform(root.id, communicator.id, "home", [])
+
+      expect(root.reload.board_images.count).to eq(tiles_after_first)
+      expect(Board.count).to eq(boards_after_first)
+      expect(root.status).to eq("complete")
+    end
+
+    it "treats a root that already has tiles as built (commit landed, status update didn't)" do
+      root = precreate_root!(name: "Home")
+      described_class.new.perform(root.id, communicator.id, "home", [])
+      # Simulate dying between the build transaction's commit and the status flip.
+      root.update_column(:status, "building_board")
+      boards_before = Board.count
+
+      described_class.new.perform(root.id, communicator.id, "home", [])
+
+      expect(Board.count).to eq(boards_before)
+      expect(root.reload.status).to eq("complete")
+    end
+  end
+
+  describe "missing root" do
+    it "logs and returns without raising" do
+      expect {
+        described_class.new.perform(-1, communicator.id, "home", [])
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Moves the Board Builder set build out of the request cycle onto the same async pattern as `GenerateBoardJob` (`Board#status` lifecycle + the `/boards/:id/generating` polling page).

> ⚠️ **Merge order:** merge AFTER the seeder-colors PR (#283) — expect one additive conflict in `spec/services/boards/seeded_set_cloner_spec.rb`.

## Changes

- **Controller** keeps all synchronous pre-checks byte-identical: 409 `board_builder_set_exists` + `confirm: true` re-send, 422 board limit. (This endpoint never charged credits in-request — AI art for novel interest words was already async via `GenerateImagesJob` — so there is no refund path; documented in a controller comment.) It now creates the root board in-request (name from template, `assign_parent`, `generate_unique_slug`, builder settings flags, `status: "building_board"`), attaches ChildBoard + favorite in-request so the set appears on the communicator immediately, enqueues `BuildBoardSetJob`, and returns **201 with the same serializer**.
- **New `app/sidekiq/build_board_set_job.rb`** (`retry: 1`): builds fringe boards, tiles, predictive links, interest→category routing, My Favorites, and AI-art queuing under the pre-created root, inside a transaction. Success → `update_column(:status, "complete")`; failure → `"failed"` + re-raise. Failure leaves the root as the user-visible artifact with **zero orphan children**. Only the root carries status.
- **Core refactor:** `Boards::SeededSetCloner` and `Boards::BoardTreeBuilder` accept an optional `root:` kwarg and build content *into* the adopted root instead of creating one. New shared `Boards::InterestWords` normalizer.
- **Duplicate guard (#271):** `building_board`/`failed` roots intentionally count as "an existing set," so concurrent builds can't double-create during the async window; the guard runs before the root exists, so it can't trip on its own root. Bonus: adopted robust clones strip `board_builder_robust`/`_slug` markers so user copies don't surface in the template catalog.

## Behavior deltas worth knowing

- A **failed** async build leaves a `failed` root that trips the 409 guard (the old sync flow rolled back fully) — by design; it's the frontend's failure artifact, same as single-board generation.
- The adopted root's voice is the communicator's voice (controller-set) rather than the admin source board's; per-tile voices still copy from the source.

## Frontend counterpart

itty-bitty-frontend PR "hand off to the generation-status page" points the wizard at `/boards/:id/generating?type=builder`. Safe to merge in either order — the old frontend just sees a root that finishes shortly after; the new frontend resolves instantly against the old backend.

## Tests

Request specs: 201-immediate with root `status: "building_board"` + job args; 409/422 contracts unchanged; full-tree assertions via `BuildBoardSetJob.drain`; mid-build 409 window; enqueue-failure path. New `spec/sidekiq/build_board_set_job_spec.rb`: starter + robust builds under the adopted root, failure → `failed` + rollback with no orphans, retry idempotency (no double-build). Adopted-root contexts added to tree-builder + cloner specs.

⚠️ **Specs were written but not executed in the sandbox** (no Ruby 3.3/Postgres). Before merge:

```
DEVISE_JWT_SECRET_KEY=anything RAILS_ENV=test bundle exec rspec spec/requests/api/v1/board_builder_spec.rb spec/services/boards spec/sidekiq/build_board_set_job_spec.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)