### PR TITLE
feat(board-sets): open BoardGroup CRUD to all users + fix auth holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Board Sets (BoardGroup) CRUD opened to all users
+- Creating, editing, and organizing **Board Sets** is no longer admin-only.
+  Any signed-in user can now create their own sets and manage the boards in
+  them. Viewing stays public-by-link (`show` / `show_by_slug` / `preset`).
+- **Security fix:** `rearrange_boards`, `save_layout`, and `remove_board` had
+  **no authorization** — any signed-in user could modify (or empty out)
+  anyone's set, including admin-curated predefined ones. All mutating actions
+  (`update`, `destroy`, `rearrange_boards`, `save_layout`, `remove_board`, and
+  the new `add_board`) now require the caller to be the set's owner or an admin,
+  returning **HTTP 403** otherwise. Predefined sets remain admin-only.
+- Regular users can no longer create or flip a set to `predefined`/`featured`
+  — those params are stripped for non-admins.
+- **Per-plan creation limits** (mirrors the board limit): Free 1, Basic 25,
+  Pro 50. At the cap, `create` returns **HTTP 422** with `{ error, limit,
+  count }`. Admins are unlimited. New optional env vars (defaults are sane):
+  `FREE_BOARD_GROUP_LIMIT`, `BASIC_BOARD_GROUP_LIMIT`, `PRO_BOARD_GROUP_LIMIT`.
+- New route `POST /api/board_groups/:id/add_board/:board_id` adds a board the
+  caller owns (or a predefined/public board) to one of their sets.
+
 ### Added — Server-side PostHog subscription lifecycle events
 - The Stripe webhook now fires three **server-side** PostHog events so the
   money-path funnel (pricing page → `checkout_started` → `subscription_started`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,36 @@ image pool:
   (4th positional arg). All default to `{}` for backward compat with
   callers that don't care.
 
+## Board Sets (BoardGroup) — user CRUD + limits
+
+Board Sets (`BoardGroup`, user-facing name "Board Sets") are user-owned
+collections of boards. CRUD is open to any signed-in user;
+`predefined: true` sets stay admin-curated. Viewing is **public by link** —
+`index`, `show`, `show_by_slug`, and `preset` keep
+`skip_before_action :authenticate_token!`.
+
+- **Owner-or-admin authorization.** Every mutating action in
+  `API::BoardGroupsController` (`update`, `destroy`, `rearrange_boards`,
+  `save_layout`, `remove_board`, `add_board`) routes through the private
+  `authorize_board_group!` helper: admins always pass; everyone else is
+  blocked (**HTTP 403** `"You don't have permission to modify this board
+  set."`) unless they own the set *and* it isn't `predefined`. Before this
+  work, `rearrange_boards`/`save_layout`/`remove_board` had **no** auth at all
+  — any user could mutate anyone's set. `create` is open to all authed users.
+- **Protected flags.** `board_group_params` strips `predefined` and `featured`
+  for non-admins, so a regular user can't self-promote their set into the
+  curated/featured pools.
+- **Per-plan creation limits.** Mirrors the board-limit pattern.
+  `User#board_group_limit` resolves from the plan hash by `plan_type` (Free 1,
+  Basic 25, Pro 50; ENV-overridable via `FREE_/BASIC_/PRO_BOARD_GROUP_LIMIT`),
+  with a `settings["board_group_limit"]` override. `User#countable_board_group_count`
+  counts own non-predefined sets; `User#at_board_group_limit?` is the gate
+  (admins exempt). `create` returns **HTTP 422** `{ error, limit, count }` at
+  the cap. **Not 402** — 402 is reserved for credit exhaustion.
+- **`add_board` route.** `POST /api/board_groups/:id/add_board/:board_id`
+  (`BoardGroup#add_board` does the join + layout init). Beyond the owner-or-admin
+  set check, the *board* must belong to the caller or be predefined/public.
+
 ## Board Builder wizard
 
 Turns wizard input — a starter **template** + a few **interest words** — into

--- a/app/controllers/api/board_groups_controller.rb
+++ b/app/controllers/api/board_groups_controller.rb
@@ -43,6 +43,15 @@ class API::BoardGroupsController < API::ApplicationController
   end
 
   def create
+    if current_user.at_board_group_limit?
+      render json: {
+        error: "You've reached your plan's board set limit. Upgrade to create more.",
+        limit: current_user.board_group_limit,
+        count: current_user.countable_board_group_count,
+      }, status: :unprocessable_entity
+      return
+    end
+
     board_group = BoardGroup.new
     board_group.user = current_user
     Rails.logger.debug "Creating Board Group with parameters: #{board_group_params.inspect}"
@@ -66,7 +75,7 @@ class API::BoardGroupsController < API::ApplicationController
     if board_group.save
       mark_default(board_group)
       # board_group.calculate_grid_layout_for_screen_size(screen_size)
-      render json: board_group.api_view_with_boards(current_user)
+      render json: board_group.api_view_with_boards(current_user), status: :created
     else
       render json: { errors: board_group.errors.full_messages }, status: :unprocessable_entity
     end
@@ -82,6 +91,8 @@ class API::BoardGroupsController < API::ApplicationController
 
   def rearrange_boards
     board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(board_group)
+
     screen_size = params[:screen_size] || "lg"
     board_group.calculate_grid_layout_for_screen_size(screen_size)
     board_group.save
@@ -90,6 +101,8 @@ class API::BoardGroupsController < API::ApplicationController
 
   def save_layout
     @board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(@board_group)
+
     save_layout!
 
     @board_group.reload
@@ -98,6 +111,8 @@ class API::BoardGroupsController < API::ApplicationController
 
   def remove_board
     board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(board_group)
+
     board = Board.find(params[:board_id])
     board_group_boards = board_group.board_group_boards.find_by(board: board)
     if board_group_boards.nil?
@@ -115,11 +130,9 @@ class API::BoardGroupsController < API::ApplicationController
   end
 
   def update
-    unless current_user&.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
-      return
-    end
     board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(board_group)
+
     Rails.logger.debug "Updating parameters: #{params.inspect}"
     board_group.predefined = board_group_params[:predefined]
     board_group.number_of_columns = board_group_params[:number_of_columns]
@@ -185,20 +198,56 @@ class API::BoardGroupsController < API::ApplicationController
   end
 
   def destroy
-    unless current_user&.admin?
-      render json: { error: "Unauthorized" }, status: :unauthorized
-      return
-    end
     board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(board_group)
+
     board_group.destroy
 
     render json: { message: "Board Group deleted" }
   end
 
+  def add_board
+    board_group = BoardGroup.find(params[:id])
+    return unless authorize_board_group!(board_group)
+
+    board = Board.find(params[:board_id])
+    unless current_user&.admin? || board.user_id == current_user&.id || board.predefined? || board.public_board?
+      render json: { error: "You don't have permission to add this board." }, status: :forbidden
+      return
+    end
+
+    board_group.add_board(board)
+    board_group.reload
+    render json: board_group.api_view_with_boards(current_user)
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Board or Board Group not found" }, status: :not_found
+  end
+
   private
 
+  # Owner-or-admin gate for mutating a Board Set. Non-admins may only touch
+  # their own, non-predefined sets (predefined sets stay admin-curated even
+  # if somehow owned). Renders 403 and returns false when the caller isn't
+  # allowed; returns true otherwise so callers can `return unless ...`.
+  def authorize_board_group!(board_group)
+    return true if current_user&.admin?
+
+    if board_group.predefined? || board_group.user_id != current_user&.id
+      render json: { error: "You don't have permission to modify this board set." }, status: :forbidden
+      return false
+    end
+    true
+  end
+
   def board_group_params
-    params.require(:board_group).permit(:name, :featured, :description, :display_image_url, :predefined, :number_of_columns, :small_screen_columns, :medium_screen_columns, :large_screen_columns, board_ids: [], settings: {}, margin_settings: {}, make_default: [true, false], screen_size: [:lg, :md, :sm], layout: [])
+    permitted = params.require(:board_group).permit(:name, :featured, :description, :display_image_url, :predefined, :number_of_columns, :small_screen_columns, :medium_screen_columns, :large_screen_columns, board_ids: [], settings: {}, margin_settings: {}, make_default: [true, false], screen_size: [:lg, :md, :sm], layout: [])
+    # Only admins may curate `predefined`/`featured` sets. Strip them for
+    # everyone else so a regular user can't self-promote their own set.
+    unless current_user&.admin?
+      permitted.delete(:predefined)
+      permitted.delete(:featured)
+    end
+    permitted
   end
 
   def mark_default(board_group)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -284,6 +284,7 @@ class User < ApplicationRecord
   FREE_PLAN_LIMITS = {
     "plan_type" => "free",
     "board_limit" => ENV.fetch("FREE_BOARD_LIMIT", 1).to_i,
+    "board_group_limit" => ENV.fetch("FREE_BOARD_GROUP_LIMIT", 1).to_i,
     "paid_communicator_limit" => ENV.fetch("FREE_PAID_COMMUNICATOR_LIMIT", 1).to_i,
     "demo_communicator_limit" => ENV.fetch("FREE_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
     "ai_monthly_limit" => ENV.fetch("FREE_AI_MONTHLY_LIMIT", 5).to_i,
@@ -291,6 +292,7 @@ class User < ApplicationRecord
   BASIC_PLAN_LIMITS = {
     "plan_type" => "basic",
     "board_limit" => ENV.fetch("BASIC_BOARD_LIMIT", 100).to_i,
+    "board_group_limit" => ENV.fetch("BASIC_BOARD_GROUP_LIMIT", 25).to_i,
     "paid_communicator_limit" => ENV.fetch("BASIC_PAID_COMMUNICATOR_LIMIT", 2).to_i,
     "demo_communicator_limit" => ENV.fetch("BASIC_DEMO_COMMUNICATOR_LIMIT", 0).to_i,
     "ai_monthly_limit" => ENV.fetch("BASIC_AI_MONTHLY_LIMIT", 100).to_i,
@@ -298,6 +300,7 @@ class User < ApplicationRecord
   PRO_PLAN_LIMITS = {
     "plan_type" => "pro",
     "board_limit" => ENV.fetch("PRO_BOARD_LIMIT", 300).to_i,
+    "board_group_limit" => ENV.fetch("PRO_BOARD_GROUP_LIMIT", 50).to_i,
     "paid_communicator_limit" => ENV.fetch("PRO_PAID_COMMUNICATOR_LIMIT", 5).to_i,
     "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
     "ai_monthly_limit" => ENV.fetch("PRO_AI_MONTHLY_LIMIT", 300).to_i,
@@ -430,6 +433,23 @@ class User < ApplicationRecord
 
   def board_limit
     settings["board_limit"] || FREE_PLAN_LIMITS["board_limit"]
+  end
+
+  # Per-plan Board Set (BoardGroup) creation cap. Mirrors `board_limit`, but
+  # resolves from the plan hash by `plan_type` so existing paid users get the
+  # right cap without a settings backfill. An explicit `settings` override
+  # still wins. Defaults: free 1, basic 25, pro 50 (all ENV-overridable).
+  def board_group_limit
+    return settings["board_group_limit"].to_i if settings["board_group_limit"].present?
+
+    case plan_type
+    when "basic", "basic_yearly", "basic_trial"
+      BASIC_PLAN_LIMITS["board_group_limit"]
+    when "pro", "pro_yearly", "partner_pro"
+      PRO_PLAN_LIMITS["board_group_limit"]
+    else
+      FREE_PLAN_LIMITS["board_group_limit"]
+    end
   end
 
   def comm_account_limit
@@ -1291,6 +1311,19 @@ class User < ApplicationRecord
 
   def can_create_boards
     !at_board_limit?
+  end
+
+  # Board Sets the user owns that count against their plan cap. Predefined
+  # (admin-curated) sets are excluded — only the user's own sets count.
+  def countable_board_group_count
+    board_groups.where(predefined: [false, nil]).count
+  end
+
+  # The gate every Board Set creation path checks. Admins are never limited.
+  def at_board_group_limit?
+    return false if admin?
+
+    countable_board_group_count >= board_group_limit
   end
 
   # The single board a limited-plan user keeps full edit access to. Returns

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
       member do
         post "rearrange_boards"
         post "save_layout"
+        post "add_board/:board_id", to: "board_groups#add_board"
         post "remove_board/:board_id", to: "board_groups#remove_board"
       end
     end

--- a/spec/requests/api/board_groups_spec.rb
+++ b/spec/requests/api/board_groups_spec.rb
@@ -1,7 +1,239 @@
-require 'rails_helper'
+require "rails_helper"
 
+# Covers the user-facing CRUD opened up in the board-sets-user-crud work:
+# owner-or-admin authorization on every mutating action, per-plan creation
+# limits, the predefined/featured flag guard, and the new add_board route.
 RSpec.describe "API::BoardGroups", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user)  { FactoryBot.create(:user) }        # free, owns nothing yet
+  let(:other) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin_user) }
+
+  # layout: {} — the shared factory defaults layout to the JSON string "{}",
+  # which trips print_grid_layout when a set has no boards; a real jsonb hash
+  # is what production rows hold.
+  let(:own_group)        { FactoryBot.create(:board_group, user: user, layout: {}) }
+  let(:other_group)      { FactoryBot.create(:board_group, user: other, layout: {}) }
+  let(:predefined_group) { FactoryBot.create(:board_group, user: admin, predefined: true, layout: {}) }
+
+  describe "POST /api/board_groups (create)" do
+    it "rejects anonymous callers with 401" do
+      post "/api/board_groups", params: { board_group: { name: "Mine" } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "creates a set for a user under their plan limit (201)" do
+      expect {
+        post "/api/board_groups", params: { board_group: { name: "Mine" } }, headers: auth_headers(user)
+      }.to change { user.board_groups.count }.by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "returns 422 with limit/count when a free user is at their limit" do
+      FactoryBot.create(:board_group, user: user) # free limit is 1
+
+      post "/api/board_groups", params: { board_group: { name: "Second" } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to match(/board set limit/i)
+      expect(body["limit"]).to eq(1)
+      expect(body["count"]).to eq(1)
+    end
+
+    it "lets an admin create without a limit" do
+      3.times { FactoryBot.create(:board_group, user: admin) }
+
+      post "/api/board_groups", params: { board_group: { name: "Admin set" } }, headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "ignores predefined/featured from a non-admin" do
+      post "/api/board_groups",
+        params: { board_group: { name: "Sneaky", predefined: true, featured: true } },
+        headers: auth_headers(user)
+
+      expect(response).to have_http_status(:created)
+      created = user.board_groups.order(:created_at).last
+      expect(created.predefined).to be_falsey
+      expect(created.featured).to be_falsey
+    end
+
+    it "honors predefined/featured from an admin" do
+      post "/api/board_groups",
+        params: { board_group: { name: "Curated", predefined: true, featured: true } },
+        headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:created)
+      created = admin.board_groups.order(:created_at).last
+      expect(created.predefined).to be true
+      expect(created.featured).to be true
+    end
+  end
+
+  describe "PATCH /api/board_groups/:id (update)" do
+    it "rejects anonymous callers with 401" do
+      patch "/api/board_groups/#{own_group.id}", params: { board_group: { name: "X" } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "lets the owner update their own set (200)" do
+      patch "/api/board_groups/#{own_group.id}",
+        params: { board_group: { name: "Renamed", display_image_url: "http://example.com/a.png" } },
+        headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(own_group.reload.name).to eq("Renamed")
+    end
+
+    it "forbids updating another user's set (403)" do
+      patch "/api/board_groups/#{other_group.id}",
+        params: { board_group: { name: "Hijack" } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(other_group.reload.name).not_to eq("Hijack")
+    end
+
+    it "forbids a non-admin from updating a predefined set (403)" do
+      patch "/api/board_groups/#{predefined_group.id}",
+        params: { board_group: { name: "Hijack" } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "lets an admin update another user's set (200)" do
+      patch "/api/board_groups/#{other_group.id}",
+        params: { board_group: { name: "Admin edit", display_image_url: "http://example.com/a.png" } },
+        headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(other_group.reload.name).to eq("Admin edit")
+    end
+
+    it "lets an admin update a predefined set (200)" do
+      patch "/api/board_groups/#{predefined_group.id}",
+        params: { board_group: { name: "Admin curated", predefined: true, display_image_url: "http://example.com/a.png" } },
+        headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(predefined_group.reload.name).to eq("Admin curated")
+    end
+  end
+
+  describe "DELETE /api/board_groups/:id (destroy)" do
+    it "rejects anonymous callers with 401" do
+      delete "/api/board_groups/#{own_group.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "lets the owner destroy their own set (200)" do
+      own_group # create it
+      expect {
+        delete "/api/board_groups/#{own_group.id}", headers: auth_headers(user)
+      }.to change { BoardGroup.where(id: own_group.id).count }.from(1).to(0)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "forbids destroying another user's set (403)" do
+      other_group
+      expect {
+        delete "/api/board_groups/#{other_group.id}", headers: auth_headers(user)
+      }.not_to change { BoardGroup.where(id: other_group.id).count }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "lets an admin destroy any set (200)" do
+      other_group
+      delete "/api/board_groups/#{other_group.id}", headers: auth_headers(admin)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "layout / membership mutations" do
+    describe "POST /api/board_groups/:id/save_layout" do
+      it "rejects anonymous callers with 401" do
+        post "/api/board_groups/#{own_group.id}/save_layout"
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "lets the owner save layout (200)" do
+        post "/api/board_groups/#{own_group.id}/save_layout", headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "forbids saving layout on another user's set (403)" do
+        post "/api/board_groups/#{other_group.id}/save_layout", headers: auth_headers(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "POST /api/board_groups/:id/rearrange_boards" do
+      it "lets the owner rearrange (200)" do
+        post "/api/board_groups/#{own_group.id}/rearrange_boards", headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "forbids rearranging another user's set (403)" do
+        post "/api/board_groups/#{other_group.id}/rearrange_boards", headers: auth_headers(user)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "POST /api/board_groups/:id/remove_board/:board_id" do
+      it "lets the owner remove a board from their own set (200)" do
+        board = FactoryBot.create(:board, user: user)
+        own_group.add_board(board)
+
+        post "/api/board_groups/#{own_group.id}/remove_board/#{board.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(own_group.reload.boards).not_to include(board)
+      end
+
+      it "forbids removing a board from another user's set (403)" do
+        board = FactoryBot.create(:board, user: other)
+        other_group.add_board(board)
+
+        post "/api/board_groups/#{other_group.id}/remove_board/#{board.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(other_group.reload.boards).to include(board)
+      end
+    end
+
+    describe "POST /api/board_groups/:id/add_board/:board_id" do
+      it "rejects anonymous callers with 401" do
+        board = FactoryBot.create(:board, user: user)
+        post "/api/board_groups/#{own_group.id}/add_board/#{board.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "lets the owner add their own board to their own set (200)" do
+        board = FactoryBot.create(:board, user: user)
+
+        post "/api/board_groups/#{own_group.id}/add_board/#{board.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(own_group.reload.boards).to include(board)
+      end
+
+      it "forbids adding a board to another user's set (403)" do
+        board = FactoryBot.create(:board, user: user)
+
+        post "/api/board_groups/#{other_group.id}/add_board/#{board.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(other_group.reload.boards).not_to include(board)
+      end
+
+      it "forbids adding a board the user doesn't own (403)" do
+        board = FactoryBot.create(:board, user: other)
+
+        post "/api/board_groups/#{own_group.id}/add_board/#{board.id}", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(own_group.reload.boards).not_to include(board)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implements `.claude-notes/board-sets-user-crud-handoff.md`: opens **Board Sets** (`BoardGroup`) CRUD to all signed-in users, with the security holes closed and per-plan limits added. Predefined sets stay admin-curated. Viewing remains public-by-link.

### 1. Owner-or-admin authorization (the live security hole)
`rearrange_boards`, `save_layout`, and `remove_board` had **no authorization** — any signed-in user could modify or empty out anyone's set, including admin-curated predefined ones. The two admin-only checks on `update`/`destroy` were also `401`s.

All mutating actions (`update`, `destroy`, `rearrange_boards`, `save_layout`, `remove_board`, `add_board`) now route through a private `authorize_board_group!` helper: admins always pass; everyone else is blocked with **HTTP 403** unless they own the set *and* it isn't `predefined`.

### 2. Protected flags
`predefined` and `featured` are stripped from params for non-admins, so a regular user can't self-promote their set into the curated/featured pools.

### 3. Per-plan creation limits
Mirrors the existing `board_limit` pattern. `User#board_group_limit` (Free 1, Basic 25, Pro 50; ENV-overridable), `User#countable_board_group_count`, `User#at_board_group_limit?` (admins exempt). `create` returns **HTTP 422** `{ error, limit, count }` at the cap. (Not 402 — that's reserved for credit exhaustion.)

### 4. `add_board` route + action
New `POST /api/board_groups/:id/add_board/:board_id` (the frontend already calls this; it 404'd before). Beyond the owner-or-admin set check, the *board* must belong to the caller or be predefined/public. `create` now returns `201` on success.

## Deploy notes
New optional env vars (defaults sane): `FREE_BOARD_GROUP_LIMIT`, `BASIC_BOARD_GROUP_LIMIT`, `PRO_BOARD_GROUP_LIMIT`. Safe to ship independently of the frontend — the security fix stands alone.

## Test plan
- New request spec `spec/requests/api/board_groups_spec.rb` covers the full actor × action matrix (anonymous 401, owner 200, other-user 403, predefined 403, admin 200, free-at-limit 422, under-limit 201, flag guard, `add_board` happy path + board-ownership 403).
- **Full suite green: 1222 examples, 0 failures, 11 pending** (pre-existing placeholders) via `bundle exec rspec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)