### PR TITLE
feat(board-view): expose per-board thumbnails on parent_boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Per-board thumbnails in the "Active · N" linked-boards list
+- `api_view_with_predictive_images` now exposes `display_image_url` and
+  `preview_image_url` on each `parent_boards` entry, so the frontend's branded
+  LinkedBoardsModal (itty-bitty-frontend#320) can show a real thumbnail per
+  linked board instead of only the colored initial chip. `display_image_url`
+  resolves the board's stored cover with a live-preview fallback (mirrors how a
+  board's own thumbnail is computed). The `parent_boards` query preloads the
+  preview-image attachment to avoid an N+1 across linked boards.
+
 ### Fixed — Board Builder seeded sets: tile colors + one-page display (#279)
 - **Tile colors now follow the authored Fitzgerald key.** `Board.from_obf`
   gained an opt-in `import_options[:apply_button_attributes]` (used by the

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -380,7 +380,13 @@ class Board < ApplicationRecord
     unless viewing_user_id
       []
     end
-    Board.joins(:board_images).where(board_images: { predictive_board_id: id }, user_id: viewing_user_id, is_template: false).where.not(id: id).distinct
+    Board.joins(:board_images)
+      .where(board_images: { predictive_board_id: id }, user_id: viewing_user_id, is_template: false)
+      .where.not(id: id)
+      # Preload the preview-image attachment so the serializer can build a
+      # per-board thumbnail URL without an N+1 across parent boards.
+      .with_attached_preview_image
+      .distinct
   end
 
   def update_board_images_to_default_docs!
@@ -1765,7 +1771,7 @@ class Board < ApplicationRecord
       child_boards: @original_child_boards&.map { |cb| { board_id: cb.board_id, name: cb.name, child_account_id: cb.child_account_id, username: cb.child_account&.username } },
       in_use: in_use,
       is_template: is_template,
-      parent_boards: @parent_boards&.map { |pb| { id: pb.id, name: pb.name, slug: pb.slug, board_type: pb.board_type } },
+      parent_boards: @parent_boards&.map { |pb| { id: pb.id, name: pb.name, slug: pb.slug, board_type: pb.board_type, display_image_url: pb.display_image_url || pb.preview_image_url, preview_image_url: pb.preview_image_url } },
       public_url: public_url,
       # board_groups: board_groups,
       slug: slug,

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -420,6 +420,48 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "#api_view_with_predictive_images parent_boards thumbnails" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:child) { FactoryBot.create(:board, user: user) }
+    let(:parent) { FactoryBot.create(:board, user: user) }
+
+    before do
+      # A "parent board" is one whose board_image points back at `child`
+      # via predictive_board_id.
+      FactoryBot.create(:board_image, board: parent, predictive_board_id: child.id)
+    end
+
+    it "exposes display_image_url and preview_image_url for each parent board" do
+      entry = child.api_view_with_predictive_images(user)[:parent_boards].find { |pb| pb[:id] == parent.id }
+
+      expect(entry).to include(:id, :name, :slug, :board_type, :display_image_url, :preview_image_url)
+    end
+
+    it "falls back to the stored display_image_url when no preview is attached" do
+      parent.update_column(:display_image_url, "https://example.com/parent-cover.png")
+
+      entry = child.api_view_with_predictive_images(user)[:parent_boards].find { |pb| pb[:id] == parent.id }
+
+      expect(entry[:display_image_url]).to eq("https://example.com/parent-cover.png")
+      expect(entry[:preview_image_url]).to be_nil
+    end
+
+    it "uses the live preview URL when a preview image is attached" do
+      parent.preview_image.attach(
+        io: StringIO.new("png-bytes"),
+        filename: "preview.png",
+        content_type: "image/png",
+      )
+
+      freeze_time do
+        entry = child.api_view_with_predictive_images(user)[:parent_boards].find { |pb| pb[:id] == parent.id }
+
+        expect(entry[:preview_image_url]).to eq(parent.preview_image_url)
+        expect(entry[:display_image_url]).to eq(parent.preview_image_url)
+      end
+    end
+  end
+
   describe ".from_obf" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

Backend follow-up for [itty-bitty-frontend#320](https://github.com/brittanyjohns/itty-bitty-frontend/pull/320), which ships the branded `LinkedBoardsModal` for the board view's **Active · N** list. That PR flagged the missing backend piece in its data-contract note:

> `board.parent_boards` items only carry `{ id, name, slug, board_type }` — so **no thumbnails**… Per-board `preview_image_url` thumbnails are intentionally **future work** (a one-line backend serializer change).

This adds those thumbnail fields so each linked-board row can render a real image instead of only the colored initial chip.

## What changed

- **`app/models/board.rb`** — each `parent_boards` entry in `api_view_with_predictive_images` now includes `display_image_url` and `preview_image_url`. `display_image_url` resolves the board's stored cover with a live-preview fallback (`pb.display_image_url || pb.preview_image_url`), mirroring how a board's own thumbnail is computed elsewhere in the same view. Both keys are surfaced: `preview_image_url` to match the contract the frontend named, plus the canonical resolved `display_image_url`.
- **`app/models/board.rb`** — the `parent_boards` query preloads the preview-image attachment (`.with_attached_preview_image`) to avoid an N+1 across linked boards.
- **`spec/models/board_spec.rb`** — 3 focused specs: keys present on each entry, stored-cover fallback when no preview is attached, and live preview URL when one is attached.
- **`CHANGELOG.md`** — Unreleased entry.

## Note for the frontend

The modal currently keys off `preview_image_url` per the original brief, but `display_image_url` is the more reliable thumbnail (many boards have a cover set but no generated preview). Worth pointing the row image at `display_image_url` with `preview_image_url`/chip as fallback.

## Test plan

Run with the CI dummy env vars (`RAILS_ENV=test SECRET_KEY_BASE=dummy DEVISE_JWT_SECRET_KEY=dummy-key`):

- New specs — 3/3 pass.
- `spec/models/board_spec.rb` + `spec/requests/api/board_read_only_spec.rb` (asserts on this same view) — 65/65 pass, no regressions from the query change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)