### PR TITLE
feat(mailchimp): wire #2 first-board nudge and #3 hit-your-limit journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Mailchimp Customer Journey triggers for first-board nudge (#2) and hit-your-limit (#3) emails
+- **First-board nudge.** New `MailchimpFirstBoardNudgeJob` (Sidekiq-cron,
+  daily at 4am UTC) finds non-admin users who signed up 48-72h ago with no
+  boards and enqueues the Mailchimp `first_board_nudge` Customer Journey.
+  Per-user dedupe via `user.settings["first_board_nudge_sent"]` so the
+  same user isn't nudged across runs; the 24h window gives a missed cron
+  run a chance to catch up. (Issue #291, journey #2.)
+- **Hit-your-limit.** `API::BoardsController#check_board_create_permissions`
+  now enqueues the Mailchimp `hit_limit` Customer Journey when a Free user
+  trips the board cap on `create` / `clone` / `create_from_template`. Free
+  users only; deduped per user for 14 days via `Rails.cache` so a user
+  mashing the create button isn't spammed. Guarded so a Mailchimp/Redis
+  blip can't 500 the API request. (Issue #291, journey #3.)
+- Inert until configured: both keys no-op until
+  `MAILCHIMP_JOURNEY_FIRST_BOARD_NUDGE_ID/_STEP` and
+  `MAILCHIMP_JOURNEY_HIT_LIMIT_ID/_STEP` ENV vars are set, and journeys
+  remain prod-only by default (`MAILCHIMP_JOURNEYS_ENABLED=true` to
+  override in staging/dev).
+
 ### Added — RevenueCat / Apple IAP subscription path reaches Stripe parity
 - **Closed a self-upgrade hole.** `POST /api/billing/update_subscription` no
   longer trusts the native client's claimed plan. It now verifies the user's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,18 @@ GitHub build). Two distinct uses:
     `MAILCHIMP_JOURNEY_<KEY>_ID` / `_STEP` ENV vars; unconfigured keys no-op
     with a log line. Adding a new journey = new ENV pair + a
     `MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "<key>" })`
-    enqueue. The first wired journey is `welcome` (enqueued on signup).
+    enqueue. Wired journey keys:
+    - `welcome` — enqueued from `API::V1::AuthsController#sign_up` and
+      `API::Stripe::CheckoutSessionsController` on signup.
+    - `hit_limit` — enqueued from `API::BoardsController#check_board_create_permissions`
+      when a Free user trips the board cap on create/clone/create_from_template.
+      Free-only; deduped per user for 14 days via `Rails.cache` so a user
+      mashing the create button isn't spammed.
+    - `first_board_nudge` — enqueued by `MailchimpFirstBoardNudgeJob` (daily
+      at 4am UTC) for non-admin users who signed up 48-72h ago with no boards.
+      The `user.settings["first_board_nudge_sent"]` flag prevents re-nudging
+      across runs. Window has 24h slop so a single missed cron run doesn't
+      permanently skip users.
   - **Env-gated to avoid emailing real users from non-prod.**
     `MailchimpClient.journeys_enabled?` returns true in production (and only
     production — staging is excluded via `AppEnv.staging?`); dev/staging fire

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1097,7 +1097,26 @@ class API::BoardsController < API::ApplicationController
     refreshed_user = User.find(current_user.id)
     if refreshed_user.at_board_limit?
       render json: { error: "Maximum number of boards reached (#{refreshed_user.countable_board_count}/#{refreshed_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
+      notify_mailchimp_hit_limit(refreshed_user)
     end
+  end
+
+  # Enqueue the Mailchimp "hit_limit" Customer Journey when a Free user
+  # bumps into the board cap. Deduped per user (Rails.cache, 14d TTL) so
+  # a user mashing the create button doesn't get the email re-sent. Fires
+  # for create / clone / create_from_template (the three actions gated by
+  # check_board_create_permissions). Guarded — any Redis/Sidekiq blip
+  # logs a warning rather than 500ing the API request.
+  def notify_mailchimp_hit_limit(user)
+    return unless user.plan_type == "free"
+
+    dedupe_key = "mailchimp:hit_limit:#{user.id}"
+    return if Rails.cache.read(dedupe_key)
+
+    MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "hit_limit" })
+    Rails.cache.write(dedupe_key, true, expires_in: 14.days)
+  rescue StandardError => e
+    Rails.logger.warn("[Mailchimp] hit_limit enqueue failed for user #{user.id}: #{e.message}")
   end
 
   def apply_filter(scope, filter)

--- a/app/sidekiq/mailchimp_first_board_nudge_job.rb
+++ b/app/sidekiq/mailchimp_first_board_nudge_job.rb
@@ -1,0 +1,54 @@
+# Daily Sidekiq-cron job that nudges signed-up users who haven't made
+# their first board yet. Enqueues the Mailchimp "first_board_nudge"
+# Customer Journey for each eligible user, then flags
+# user.settings["first_board_nudge_sent"] so they're only nudged once.
+#
+# Window is 72h..48h ago (24h slop) so a single missed cron run doesn't
+# permanently skip users; the per-user flag prevents re-nudging across
+# runs once a user has been processed.
+#
+# Failure-isolated per user — a bad row logs and continues, doesn't
+# poison the whole batch (matches DowngradeSoftTrialJob's pattern).
+class MailchimpFirstBoardNudgeJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :default, retry: 3
+
+  WINDOW_START = 72.hours
+  WINDOW_END = 48.hours
+  SETTINGS_FLAG = "first_board_nudge_sent".freeze
+
+  def perform
+    count = 0
+
+    eligible_users.find_each do |user|
+      next if already_nudged?(user)
+      next if user.boards.any?
+
+      enqueue_and_flag(user)
+      count += 1
+    rescue => e
+      Rails.logger.error "MailchimpFirstBoardNudgeJob: failed for user #{user.id} - #{e.message}"
+    end
+
+    Rails.logger.info "MailchimpFirstBoardNudgeJob: completed — #{count} user(s) nudged"
+  end
+
+  private
+
+  def eligible_users
+    User
+      .where.not(role: "admin")
+      .where(created_at: WINDOW_START.ago..WINDOW_END.ago)
+  end
+
+  def already_nudged?(user)
+    user.settings.is_a?(Hash) && user.settings[SETTINGS_FLAG] == true
+  end
+
+  def enqueue_and_flag(user)
+    MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "first_board_nudge" })
+    user.settings = (user.settings || {}).merge(SETTINGS_FLAG => true)
+    user.save!
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -42,5 +42,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Daily reclaim sweep for loaner communicators unclaimed past LOANER_RECLAIM_AFTER_DAYS (default 90). Frees the SLP's slot.",
     },
+    "mailchimp_first_board_nudge" => {
+      "cron" => "0 4 * * *",
+      "class" => "MailchimpFirstBoardNudgeJob",
+      "queue" => "default",
+      "description" => "Daily Mailchimp Customer Journey trigger for users who signed up 48-72h ago without making a board. Runs at 4am UTC, after DowngradeSoftTrialJob (2am) and RefreshFreeTierCreditsJob (3am). Flags user.settings[\"first_board_nudge_sent\"] so each user is only nudged once.",
+    },
   })
 end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -562,4 +562,58 @@ RSpec.describe "API::Boards", type: :request do
       expect(board_image.display_image_url).to eq(new_doc.tile_url)
     end
   end
+
+  # Mailchimp "hit_limit" Customer Journey trigger (issue #291, journey #3).
+  # Enqueued from check_board_create_permissions when a Free user trips the
+  # board cap on create / clone / create_from_template. Deduped 14d via
+  # Rails.cache so a user mashing the create button isn't spammed.
+  describe "POST /api/boards triggers the Mailchimp hit_limit journey" do
+    let(:free_user) { create(:free_user) }
+    let!(:existing_board) { create(:board, user: free_user) }
+    let(:memory_cache) { ActiveSupport::Cache::MemoryStore.new }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory_cache)
+      MailchimpEventJob.clear
+    end
+
+    it "enqueues MailchimpEventJob with journey_key=hit_limit on a Free user at the cap" do
+      expect {
+        post "/api/boards",
+             params: { board: { name: "Second" } },
+             headers: auth_headers(free_user)
+      }.to change(MailchimpEventJob.jobs, :size).by(1)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(MailchimpEventJob.jobs.last["args"]).to eq(
+        [free_user.id, "journey", { "journey_key" => "hit_limit" }],
+      )
+    end
+
+    it "sets a Rails.cache dedupe key so the next 422 doesn't re-enqueue" do
+      post "/api/boards",
+           params: { board: { name: "Second" } },
+           headers: auth_headers(free_user)
+
+      expect(memory_cache.read("mailchimp:hit_limit:#{free_user.id}")).to eq(true)
+
+      expect {
+        post "/api/boards",
+             params: { board: { name: "Third" } },
+             headers: auth_headers(free_user)
+      }.not_to change(MailchimpEventJob.jobs, :size)
+    end
+
+    it "logs and swallows errors so a Mailchimp blip can't 500 the create request" do
+      allow(MailchimpEventJob).to receive(:perform_async).and_raise("redis down")
+      expect(Rails.logger).to receive(:warn).with(/hit_limit enqueue failed/)
+
+      post "/api/boards",
+           params: { board: { name: "Second" } },
+           headers: auth_headers(free_user)
+
+      # The 422 response itself is unaffected.
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
 end

--- a/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
+++ b/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe MailchimpFirstBoardNudgeJob, type: :job do
+  subject(:job) { described_class.new }
+
+  before { MailchimpEventJob.clear }
+
+  def create_eligible_user(overrides = {})
+    user = create(:user, **overrides.except(:created_at))
+    timestamp = overrides[:created_at] || 60.hours.ago
+    user.update_column(:created_at, timestamp)
+    user
+  end
+
+  describe "#perform" do
+    context "when a Free user signed up 48-72h ago with no boards" do
+      it "enqueues MailchimpEventJob with journey_key=first_board_nudge" do
+        user = create_eligible_user
+        expect { job.perform }.to change(MailchimpEventJob.jobs, :size).by(1)
+
+        args = MailchimpEventJob.jobs.last["args"]
+        expect(args).to eq([user.id, "journey", { "journey_key" => "first_board_nudge" }])
+      end
+
+      it "flags the user in settings so they aren't nudged again" do
+        user = create_eligible_user
+        job.perform
+        expect(user.reload.settings["first_board_nudge_sent"]).to eq(true)
+      end
+    end
+
+    context "when the user already has a board" do
+      it "does not enqueue" do
+        user = create_eligible_user
+        create(:board, user: user)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+        expect(user.reload.settings["first_board_nudge_sent"]).not_to eq(true)
+      end
+    end
+
+    context "when the user has already been nudged" do
+      it "does not re-enqueue" do
+        user = create_eligible_user
+        user.update!(settings: (user.settings || {}).merge("first_board_nudge_sent" => true))
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user is an admin" do
+      it "is skipped even if otherwise eligible" do
+        admin = create(:admin_user)
+        admin.update_column(:created_at, 60.hours.ago)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user signed up less than 48h ago" do
+      it "is skipped" do
+        create_eligible_user(created_at: 24.hours.ago)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user signed up more than 72h ago" do
+      it "is skipped (already missed the window)" do
+        create_eligible_user(created_at: 5.days.ago)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when one user's save raises" do
+      it "logs and continues processing the rest" do
+        user_a = create_eligible_user
+        user_b = create_eligible_user
+
+        # Make save! blow up only for user_a
+        allow_any_instance_of(User).to receive(:save!).and_wrap_original do |original, *args|
+          if original.receiver.id == user_a.id
+            raise "boom"
+          else
+            original.call(*args)
+          end
+        end
+        expect(Rails.logger).to receive(:error).with(/failed for user #{user_a.id}/)
+        allow(Rails.logger).to receive(:info)
+
+        # user_a's enqueue happens before the failing save!, so it's still in
+        # the queue (Mailchimp's own journey dedupe catches a stray double).
+        # user_b succeeds end-to-end and ends up flagged.
+        expect { job.perform }.to change(MailchimpEventJob.jobs, :size).by(2)
+        expect(user_b.reload.settings["first_board_nudge_sent"]).to eq(true)
+        expect(user_a.reload.settings["first_board_nudge_sent"]).not_to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Wires up two more Mailchimp Customer Journey triggers on top of the existing `welcome` plumbing (PR #257). Implements journeys **#2** (first-board nudge) and **#3** (hit-your-limit) from issue #291.

- **Hit-your-limit (#3):** `API::BoardsController#check_board_create_permissions` enqueues the `hit_limit` journey when a Free user trips the board cap on `create` / `clone` / `create_from_template`. Free-only; deduped per user for 14 days via `Rails.cache`. Guarded so a Mailchimp/Redis blip can't 500 the API request.
- **First-board nudge (#2):** New `MailchimpFirstBoardNudgeJob` (Sidekiq-cron, daily at 4am UTC — after Downgrade @ 2am and Refresh @ 3am). Finds non-admin users who signed up 48-72h ago with no boards and enqueues the `first_board_nudge` journey. Per-user dedupe via `user.settings["first_board_nudge_sent"]`. 24h slop on the window so a missed cron run catches up.

## Inert until configured

Both keys no-op until the matching ENV vars are set on Hatchbox:

- `MAILCHIMP_JOURNEY_HIT_LIMIT_ID` / `_STEP`
- `MAILCHIMP_JOURNEY_FIRST_BOARD_NUDGE_ID` / `_STEP`

Journeys stay prod-only by default (`MAILCHIMP_JOURNEYS_ENABLED=true` to override in staging/dev). Mailchimp UI side is already built — IDs tracked in `marketing/drafts/mailchimp-journey-ids.md`.

## Design calls (per #291 discussion)

- **Q1 enqueue scope:** all three paths via the shared gate. One line covers create/clone/template.
- **Q2 dedupe window:** 14 days.
- **Q3 flag storage:** `user.settings["first_board_nudge_sent"]` (mirrors `welcome_email_sent`).
- **Q4 schedule shape:** daily batch, not per-user `perform_in`.

## Test plan

- [x] `bundle exec rspec spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb` — **8 examples, 0 failures.** Covers eligible / has-board / already-nudged / admin / outside-window (both sides) / one-user-raises-others-continue.
- [x] `bundle exec rspec spec/requests/api/boards_spec.rb` — **47 examples, 0 failures**, including 3 new ones for the hit_limit enqueue + dedupe + error-swallow paths.
- [x] `bundle exec rspec spec/sidekiq/mailchimp_event_job_spec.rb spec/sidekiq/downgrade_soft_trial_job_spec.rb` — green; no regressions in adjacent specs.
- [ ] Post-merge: configure the two ENV pairs on Hatchbox, smoke-test by hitting the board cap as a Free user and watching `bin/prod-logs worker | grep -i mailchimp` for the trigger log line; wait for the 4am cron and confirm the nudge job log line.

Refs #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)