### PR TITLE
feat(mailchimp): trial-wrap (#5) and win-back (#6) lifecycle journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Mailchimp trial-wrap (#5) and win-back (#6) lifecycle journeys
+- **Trial wrapping up (#5).** The `customer.subscription.trial_will_end` Stripe
+  webhook now enqueues `MailchimpTrialWrapJob`, which **personalizes** the email
+  before triggering: it pushes the contact's `TRIAL_END` (formatted date),
+  `BOARDS` (board count), and `COMMS` (communicator count) merge fields via the
+  new `MailchimpService#update_merge_fields`, then fires the `trial_wrap`
+  Customer Journey — so the copy can say "you made N boards and M communicators;
+  keep them by continuing." Fires ~3 days before a Stripe no-card reverse trial
+  ends (soft `basic_trial` was retired, so all trials are Stripe trials).
+- **Win-back (#6).** New `MailchimpWinBackJob` (Sidekiq-cron, daily at 4:30am
+  UTC) re-engages recently-dormant active users: non-admin, **≥1 board**, last
+  sign-in 14–30 days ago (`WIN_BACK_DORMANT_MIN_DAYS` / `_MAX_DAYS`, tunable).
+  Per-user dedupe via `user.settings["win_back_nudge_sent"]`. Requiring ≥1 board
+  keeps it cleanly distinct from the legacy never-made-a-board journey (#7).
+- Inert until configured: both no-op until `MAILCHIMP_JOURNEY_TRIAL_WRAP_ID` /
+  `_STEP` and `MAILCHIMP_JOURNEY_WIN_BACK_ID` / `_STEP` are set, and journeys
+  stay prod-only by default. #5 also needs the 3 merge fields created in the
+  Mailchimp audience. (Issue #291.)
+
 ### Added — Mailchimp legacy stalled-signup re-engagement journey (#7)
 - **Monthly re-engagement.** New `MailchimpLegacySignupNudgeJob` (Sidekiq-cron,
   5am UTC on the 1st of each month) finds non-admin users who created an account

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,21 @@ GitHub build). Two distinct uses:
       It's a **second touch** distinct from `first_board_nudge` — different copy
       ("a while back you said yes…") and it *may* fire for a user who got the 48h
       nudge weeks earlier (the two flags are independent), but only ever once.
+    - `trial_wrap` — enqueued by `MailchimpTrialWrapJob`, triggered from the
+      `customer.subscription.trial_will_end` Stripe webhook (~3 days before a
+      Stripe no-card reverse trial ends; soft `basic_trial` was retired).
+      **Personalized:** the job first pushes merge fields `TRIAL_END` (formatted
+      date) / `BOARDS` (`countable_board_count`) / `COMMS`
+      (`communicator_accounts.count`) via `MailchimpService#update_merge_fields`,
+      then triggers — so the copy can say "you made N boards, M communicators;
+      keep them by continuing." Requires those 3 merge fields to exist in the
+      Mailchimp audience (tag names ≤10 chars: `TRIAL_END`, `BOARDS`, `COMMS`).
+    - `win_back` — enqueued by `MailchimpWinBackJob` (daily, 4:30am UTC)
+      re-engaging recently-dormant active users: non-admin, **≥1 board**, last
+      sign-in `WIN_BACK_DORMANT_MIN_DAYS`–`WIN_BACK_DORMANT_MAX_DAYS` (default
+      14–30) days ago. The `user.settings["win_back_nudge_sent"]` flag makes it
+      once-only. Requiring ≥1 board keeps it distinct from `legacy_signup_nudge`
+      (never made a board).
   - **Env-gated to avoid emailing real users from non-prod.**
     `MailchimpClient.journeys_enabled?` returns true in production (and only
     production — staging is excluded via `AppEnv.staging?`); dev/staging fire

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -99,6 +99,12 @@ class API::WebhooksController < API::ApplicationController
         trial_end: trial_end,
       },
     )
+
+    # Mailchimp "trial wrapping up" Customer Journey (#291, journey #5).
+    # Personalizes with board/communicator counts + the trial end date.
+    # Inert until the journey ENV vars are configured.
+    MailchimpTrialWrapJob.perform_async(user.id, trial_end)
+
     Rails.logger.info "[StripeWebhook] trial_will_end: user=#{user.id} sub=#{subscription.id}"
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_trial_will_end error: #{e.class} - #{e.message}"

--- a/app/models/mailchimp_service.rb
+++ b/app/models/mailchimp_service.rb
@@ -122,6 +122,28 @@ class MailchimpService
     end
   end
 
+  # Upsert merge fields on a contact (e.g. trial-wrap personalization:
+  # TRIAL_END / BOARDS / COMMS). Uses set_list_member so it creates the
+  # contact if missing (status_if_new: subscribed) and updates merge fields
+  # if present. Guarded — a Mailchimp blip logs and returns nil rather than
+  # raising into the caller (which is usually a journey-trigger job).
+  def update_merge_fields(user, fields)
+    list_id = ENV.fetch("MAILCHIMP_AUDIENCE_ID")
+    subscriber_hash_email = subscriber_hash(user.email)
+    @client.lists.set_list_member(
+      list_id,
+      subscriber_hash_email,
+      {
+        email_address: user.email,
+        status_if_new: "subscribed",
+        merge_fields: fields,
+      }
+    )
+  rescue MailchimpMarketing::ApiError => e
+    Rails.logger.warn "[Mailchimp] update_merge_fields failed for #{user.email}: #{e.message}"
+    nil
+  end
+
   def update_subscriber_tags(email, tags_to_add = [], tags_to_remove = [])
     list_id = ENV.fetch("MAILCHIMP_AUDIENCE_ID")
     subscriber_hash_email = subscriber_hash(email)

--- a/app/sidekiq/mailchimp_trial_wrap_job.rb
+++ b/app/sidekiq/mailchimp_trial_wrap_job.rb
@@ -1,0 +1,60 @@
+# Triggers the Mailchimp "trial_wrap" Customer Journey ~3 days before a
+# Stripe trial ends (enqueued from the `customer.subscription.trial_will_end`
+# webhook). Personalizes the email by first pushing the contact's merge
+# fields — TRIAL_END (formatted date), BOARDS, COMMS — so the journey copy
+# can say "you made N boards and M communicators; keep them by continuing."
+#
+# Soft trials (basic_trial) were retired — every new signup lands on Free —
+# so the only trials are Stripe no-card reverse trials (#264), which this
+# webhook path covers.
+#
+# Merge-field tags (create these in the Mailchimp audience, ≤10 chars each):
+#   TRIAL_END · BOARDS · COMMS
+#
+# Self-contained gating (mirrors MailchimpEventJob's journey path) so it
+# no-ops cleanly when journeys are disabled or the key isn't configured.
+class MailchimpTrialWrapJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :default, retry: 3
+
+  JOURNEY_KEY = "trial_wrap".freeze
+
+  def perform(user_id, trial_end_epoch = nil)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    unless MailchimpClient.journeys_enabled?
+      Rails.logger.info("[Mailchimp] Journeys disabled; skipping #{JOURNEY_KEY} for user #{user_id}")
+      return
+    end
+
+    journey = MailchimpClient.journey(JOURNEY_KEY)
+    unless journey
+      Rails.logger.warn("[Mailchimp] No journey configured for '#{JOURNEY_KEY}'; skipping")
+      return
+    end
+
+    mailchimp = MailchimpService.new
+    mailchimp.update_merge_fields(user, {
+      "TRIAL_END" => format_trial_end(trial_end_epoch),
+      "BOARDS" => user.countable_board_count.to_s,
+      "COMMS" => user.communicator_accounts.count.to_s,
+    })
+    mailchimp.trigger_journey(user, journey_id: journey[:journey_id], step_id: journey[:step_id])
+  rescue => e
+    Rails.logger.error "MailchimpTrialWrapJob: failed for user #{user_id} - #{e.message}"
+  end
+
+  private
+
+  # Stripe sends trial_end as epoch seconds. Render as e.g. "June 20".
+  # Falls back to "soon" so the copy reads cleanly if the date is missing.
+  def format_trial_end(epoch)
+    return "soon" if epoch.blank?
+
+    Time.at(epoch.to_i).utc.strftime("%B %-d")
+  rescue StandardError
+    "soon"
+  end
+end

--- a/app/sidekiq/mailchimp_win_back_job.rb
+++ b/app/sidekiq/mailchimp_win_back_job.rb
@@ -1,0 +1,66 @@
+# Daily Sidekiq-cron job that re-engages recently-dormant active users:
+# people who made at least one board, then went quiet for 14-30 days.
+# Enqueues the Mailchimp "win_back" Customer Journey ("your boards are
+# still here") and flags user.settings["win_back_nudge_sent"] so each
+# user is nudged once.
+#
+# Requiring >=1 board keeps this cleanly distinct from the legacy
+# stalled-signup journey (#7), which targets users who NEVER made a board.
+# The 14-30 day window is the recently-dormant sweet spot — past 30 days
+# they fall out of the window (not re-nudged repeatedly).
+#
+# Thresholds ENV-tunable to match the repo's other limit knobs:
+#   WIN_BACK_DORMANT_MIN_DAYS  (default 14)
+#   WIN_BACK_DORMANT_MAX_DAYS  (default 30)
+#
+# Failure-isolated per user (a bad row logs and continues).
+class MailchimpWinBackJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :default, retry: 3
+
+  SETTINGS_FLAG = "win_back_nudge_sent".freeze
+
+  def perform
+    count = 0
+
+    eligible_users.find_each do |user|
+      next if already_nudged?(user)
+      next unless user.boards.any?
+
+      enqueue_and_flag(user)
+      count += 1
+    rescue => e
+      Rails.logger.error "MailchimpWinBackJob: failed for user #{user.id} - #{e.message}"
+    end
+
+    Rails.logger.info "MailchimpWinBackJob: completed — #{count} user(s) nudged"
+  end
+
+  private
+
+  def dormant_min
+    (ENV["WIN_BACK_DORMANT_MIN_DAYS"] || 14).to_i.days
+  end
+
+  def dormant_max
+    (ENV["WIN_BACK_DORMANT_MAX_DAYS"] || 30).to_i.days
+  end
+
+  # last_sign_in_at between (max ago) and (min ago) — i.e. dormant 14-30 days.
+  def eligible_users
+    User
+      .where.not(role: "admin")
+      .where(last_sign_in_at: dormant_max.ago..dormant_min.ago)
+  end
+
+  def already_nudged?(user)
+    user.settings.is_a?(Hash) && user.settings[SETTINGS_FLAG] == true
+  end
+
+  def enqueue_and_flag(user)
+    MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "win_back" })
+    user.settings = (user.settings || {}).merge(SETTINGS_FLAG => true)
+    user.save!
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -54,5 +54,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Monthly Mailchimp Customer Journey trigger (5am UTC on the 1st) re-engaging legacy stalled signups: non-admin users created over LEGACY_SIGNUP_NUDGE_AGE_DAYS (default 30) ago, no boards, no sign-in within LEGACY_SIGNUP_NUDGE_INACTIVE_DAYS (default 30). Flags user.settings[\"legacy_signup_nudge_sent\"] so each user is only nudged once. Second-touch — may fire for users who got the 48h first_board_nudge weeks earlier.",
     },
+    "mailchimp_win_back" => {
+      "cron" => "30 4 * * *",
+      "class" => "MailchimpWinBackJob",
+      "queue" => "default",
+      "description" => "Daily Mailchimp Customer Journey trigger (4:30am UTC) re-engaging recently-dormant active users: non-admin users with >=1 board whose last sign-in is WIN_BACK_DORMANT_MIN_DAYS-WIN_BACK_DORMANT_MAX_DAYS (default 14-30) days ago. Flags user.settings[\"win_back_nudge_sent\"] so each user is only nudged once.",
+    },
   })
 end

--- a/spec/models/mailchimp_service_spec.rb
+++ b/spec/models/mailchimp_service_spec.rb
@@ -10,6 +10,37 @@ RSpec.describe MailchimpService do
     allow(client).to receive(:customer_journeys).and_return(journeys)
   end
 
+  describe "#update_merge_fields" do
+    let(:lists) { double("lists") }
+
+    before do
+      allow(client).to receive(:lists).and_return(lists)
+      stub_const("ENV", ENV.to_h.merge("MAILCHIMP_AUDIENCE_ID" => "aud_123"))
+    end
+
+    it "upserts the contact's merge fields by subscriber hash" do
+      hash = Digest::MD5.hexdigest("parent@example.com")
+      expect(lists).to receive(:set_list_member).with(
+        "aud_123",
+        hash,
+        {
+          email_address: "parent@example.com",
+          status_if_new: "subscribed",
+          merge_fields: { "BOARDS" => "3" },
+        },
+      )
+
+      described_class.new.update_merge_fields(user, { "BOARDS" => "3" })
+    end
+
+    it "swallows Mailchimp API errors and returns nil" do
+      allow(lists).to receive(:set_list_member)
+        .and_raise(MailchimpMarketing::ApiError.new(status: 500, message: "boom"))
+
+      expect(described_class.new.update_merge_fields(user, { "BOARDS" => "3" })).to be_nil
+    end
+  end
+
   describe "#trigger_journey" do
     it "triggers the journey for the contact by email" do
       expect(journeys).to receive(:trigger).with(10, 20, { email_address: "parent@example.com" })

--- a/spec/requests/api/webhooks_trial_wrap_spec.rb
+++ b/spec/requests/api/webhooks_trial_wrap_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+# The customer.subscription.trial_will_end webhook should enqueue the
+# Mailchimp trial-wrap journey (#291, journey #5) alongside the existing
+# analytics event. Mirrors the stubbing pattern in webhooks_analytics_spec.
+RSpec.describe "POST /api/webhooks (trial_wrap enqueue)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user, stripe_customer_id: "cus_trialwrap", plan_type: "basic", plan_status: "trialing")
+  end
+
+  before do
+    ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy"
+    MailchimpTrialWrapJob.clear
+  end
+
+  def stub_event(object, type:)
+    event = OpenStruct.new(id: "evt_#{SecureRandom.hex(4)}", type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  it "enqueues MailchimpTrialWrapJob with the user id and trial_end epoch" do
+    trial_end = 1_781_000_000 # fixed epoch
+    sub = OpenStruct.new(
+      id: "sub_123",
+      customer: user.stripe_customer_id,
+      status: "trialing",
+      trial_end: trial_end,
+    )
+    stub_event(sub, type: "customer.subscription.trial_will_end")
+
+    expect { post_webhook("{}", header_with_signature) }
+      .to change(MailchimpTrialWrapJob.jobs, :size).by(1)
+
+    expect(MailchimpTrialWrapJob.jobs.last["args"]).to eq([user.id, trial_end])
+  end
+end

--- a/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
+++ b/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe MailchimpTrialWrapJob, type: :job do
+  subject(:job) { described_class.new }
+
+  let(:user) { create(:user) }
+  let(:mailchimp) { instance_double(MailchimpService) }
+
+  before { allow(MailchimpService).to receive(:new).and_return(mailchimp) }
+
+  describe "#perform" do
+    context "when journeys are enabled and trial_wrap is configured" do
+      before do
+        allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+        allow(MailchimpClient).to receive(:journey).with("trial_wrap")
+          .and_return(journey_id: 50, step_id: 60)
+        allow(mailchimp).to receive(:update_merge_fields)
+        allow(mailchimp).to receive(:trigger_journey)
+      end
+
+      it "syncs personalization merge fields (counts + formatted trial end), then triggers" do
+        create_list(:board, 2, user: user)
+        create(:child_account, owner_id: user.id)
+        epoch = Time.utc(2026, 6, 20, 12, 0, 0).to_i
+
+        expect(mailchimp).to receive(:update_merge_fields).with(
+          user,
+          { "TRIAL_END" => "June 20", "BOARDS" => "2", "COMMS" => "1" },
+        ).ordered
+        expect(mailchimp).to receive(:trigger_journey).with(
+          user, journey_id: 50, step_id: 60
+        ).ordered
+
+        job.perform(user.id, epoch)
+      end
+
+      it "falls back to 'soon' when no trial-end date is given" do
+        expect(mailchimp).to receive(:update_merge_fields).with(
+          user, hash_including("TRIAL_END" => "soon")
+        )
+        job.perform(user.id, nil)
+      end
+    end
+
+    it "skips (no merge-field sync, no trigger) when journeys are disabled" do
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(false)
+      expect(mailchimp).not_to receive(:update_merge_fields)
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      job.perform(user.id, nil)
+    end
+
+    it "skips when the trial_wrap journey isn't configured" do
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+      allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(nil)
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      job.perform(user.id, nil)
+    end
+
+    it "no-ops for an unknown user id" do
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      job.perform(-1, nil)
+    end
+  end
+end

--- a/spec/sidekiq/mailchimp_win_back_job_spec.rb
+++ b/spec/sidekiq/mailchimp_win_back_job_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe MailchimpWinBackJob, type: :job do
+  subject(:job) { described_class.new }
+
+  before { MailchimpEventJob.clear }
+
+  # Eligible by default: last sign-in 21 days ago (inside the 14-30d window),
+  # with one board. Caller adds boards as needed.
+  def create_dormant_user(overrides = {})
+    last_sign_in_at = overrides.key?(:last_sign_in_at) ? overrides.delete(:last_sign_in_at) : 21.days.ago
+    user = create(:user, **overrides)
+    user.update_column(:last_sign_in_at, last_sign_in_at)
+    user
+  end
+
+  describe "#perform" do
+    context "when a non-admin user with a board went dormant 14-30 days ago" do
+      it "enqueues MailchimpEventJob with journey_key=win_back" do
+        user = create_dormant_user
+        create(:board, user: user)
+
+        expect { job.perform }.to change(MailchimpEventJob.jobs, :size).by(1)
+        expect(MailchimpEventJob.jobs.last["args"]).to eq([user.id, "journey", { "journey_key" => "win_back" }])
+      end
+
+      it "flags the user so they aren't nudged again" do
+        user = create_dormant_user
+        create(:board, user: user)
+
+        job.perform
+        expect(user.reload.settings["win_back_nudge_sent"]).to eq(true)
+      end
+    end
+
+    context "when the user has no boards" do
+      it "is skipped (distinct from the legacy never-made-a-board journey)" do
+        create_dormant_user
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user was already win-back-nudged" do
+      it "does not re-enqueue" do
+        user = create_dormant_user(settings: { "win_back_nudge_sent" => true })
+        create(:board, user: user)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user signed in within the last 14 days" do
+      it "is skipped (not dormant yet)" do
+        user = create_dormant_user(last_sign_in_at: 5.days.ago)
+        create(:board, user: user)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user has been dormant longer than 30 days" do
+      it "is skipped (out of the recently-dormant window)" do
+        user = create_dormant_user(last_sign_in_at: 45.days.ago)
+        create(:board, user: user)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when the user is an admin" do
+      it "is skipped even if otherwise eligible" do
+        admin = create(:admin_user)
+        admin.update_column(:last_sign_in_at, 21.days.ago)
+        create(:board, user: admin)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+      end
+    end
+
+    context "when one user's save raises" do
+      it "logs and continues processing the rest" do
+        user_a = create_dormant_user
+        create(:board, user: user_a)
+        user_b = create_dormant_user
+        create(:board, user: user_b)
+
+        allow_any_instance_of(User).to receive(:save!).and_wrap_original do |original, *args|
+          raise "boom" if original.receiver.id == user_a.id
+
+          original.call(*args)
+        end
+        expect(Rails.logger).to receive(:error).with(/failed for user #{user_a.id}/)
+        allow(Rails.logger).to receive(:info)
+
+        expect { job.perform }.to change(MailchimpEventJob.jobs, :size).by(2)
+        expect(user_b.reload.settings["win_back_nudge_sent"]).to eq(true)
+        expect(user_a.reload.settings["win_back_nudge_sent"]).not_to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The final two journeys from #291 — completing the 6-email behavioral lifecycle sequence (plus the legacy journey #7 from #294).

### #5 Trial wrapping up — *personalized*
- The existing `customer.subscription.trial_will_end` Stripe webhook now enqueues **`MailchimpTrialWrapJob`** (~3 days before a trial ends).
- The job **personalizes before triggering**: pushes `TRIAL_END` (formatted date), `BOARDS` (`countable_board_count`), `COMMS` (`communicator_accounts.count`) via the new **`MailchimpService#update_merge_fields`**, then fires the `trial_wrap` journey — so the copy reads *"you made N boards and M communicators; keep them by continuing."*
- Note: soft `basic_trial` was retired (every signup lands on Free), so all trials are Stripe no-card reverse trials (#264) — this single webhook path covers them.

### #6 Win-back
- New **`MailchimpWinBackJob`** (Sidekiq-cron, daily 4:30am UTC) re-engages recently-dormant active users: non-admin, **≥1 board**, last sign-in **14–30 days** ago (`WIN_BACK_DORMANT_MIN_DAYS` / `_MAX_DAYS`, tunable).
- Per-user dedupe via `settings["win_back_nudge_sent"]`. Requiring ≥1 board keeps it cleanly distinct from the legacy never-made-a-board journey (#7).

## Inert until configured

- `MAILCHIMP_JOURNEY_TRIAL_WRAP_ID` / `_STEP`
- `MAILCHIMP_JOURNEY_WIN_BACK_ID` / `_STEP`
- **#5 also needs 3 merge fields created in the Mailchimp audience** (tag names ≤10 chars): `TRIAL_END`, `BOARDS`, `COMMS`.

Journeys stay prod-only by default. Email HTML drafted in the marketing repo (`trial-wrap-email.html`, `win-back-email.html`).

## Design calls (per #291 discussion)

- **#5 personalization:** chose the merge-field sync (vs generic copy) — the "look what you built" counts are the conversion lever.
- **#6 scope:** dormant-with-boards only (no trial-lapse hook) — a lapsed trial still gets caught once the user goes dormant.

## Test plan

- [x] `bundle exec rspec spec/sidekiq/mailchimp_trial_wrap_job_spec.rb` — 5 ex (merge-field sync + ordered trigger, "soon" fallback, disabled/unconfigured/unknown-user skips).
- [x] `bundle exec rspec spec/sidekiq/mailchimp_win_back_job_spec.rb` — 8 ex (eligible, no-board skip, already-nudged, too-recent, too-dormant, admin, failure isolation).
- [x] `bundle exec rspec spec/requests/api/webhooks_trial_wrap_spec.rb` — trial_will_end enqueues the job with `(user.id, trial_end)`.
- [x] `bundle exec rspec spec/models/mailchimp_service_spec.rb` — new `update_merge_fields` upsert + error-swallow; existing journey specs green.
- [x] `spec/requests/api/webhooks_analytics_spec.rb` + `spec/sidekiq/mailchimp_event_job_spec.rb` — no regressions. **23 examples, 0 failures** across the affected set.
- [ ] Post-merge: build the 2 journeys + 3 merge fields in Mailchimp, set ENV vars, smoke-test (start a trial → wait for `trial_will_end`; let a board-having user go dormant 14d).

Refs #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)