### PR TITLE
feat(mailchimp): exclude demo/internal accounts from lifecycle journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Mailchimp lifecycle journeys never email demo/internal accounts
+- All Customer Journey sends now skip `user.demo_user?` accounts (email contains
+  `bhannajohns+` or `@speakanyway.com` — the same definition behind the
+  `DEMO_USER` merge field). A single guard in `MailchimpEventJob`'s journey
+  branch covers welcome / first_board_nudge / hit_limit / legacy_signup_nudge /
+  win_back; `MailchimpTrialWrapJob` has its own guard. The cohort-sweep jobs
+  also skip demo users so they aren't flagged. CRM contact sync is unchanged —
+  demo contacts remain in the audience, tagged as demo.
+
 ### Added — Mailchimp trial-wrap (#5) and win-back (#6) lifecycle journeys
 - **Trial wrapping up (#5).** The `customer.subscription.trial_will_end` Stripe
   webhook now enqueues `MailchimpTrialWrapJob`, which **personalizes** the email

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,16 @@ GitHub build). Two distinct uses:
     `MailchimpClient.journeys_enabled?` returns true in production (and only
     production — staging is excluded via `AppEnv.staging?`); dev/staging fire
     only when `MAILCHIMP_JOURNEYS_ENABLED=true`. CRM sync is **not** gated.
+  - **Demo/internal accounts never get journey emails.** `MailchimpEventJob`'s
+    `"journey"` branch returns early for `user.demo_user?` (email contains
+    `bhannajohns+` or `@speakanyway.com` — the same definition that sets the
+    `DEMO_USER` merge field), so all journeys routed through it (welcome,
+    first_board_nudge, hit_limit, legacy_signup_nudge, win_back) are covered by
+    that one guard. `MailchimpTrialWrapJob` (the only journey not routed through
+    `MailchimpEventJob`) has its own `demo_user?` early-return. The cohort-sweep
+    jobs also `next if user.demo_user?` so demo accounts aren't even flagged.
+    **CRM sync is still NOT gated** — demo contacts stay in the audience, tagged
+    as demo.
 
 App transactional email (welcome, password reset) still goes through
 ActionMailer/Gmail SMTP, **not** Mailchimp. True 1:1 transactional via Mailchimp

--- a/app/sidekiq/mailchimp_event_job.rb
+++ b/app/sidekiq/mailchimp_event_job.rb
@@ -16,6 +16,14 @@ class MailchimpEventJob
       mailchimp.record_new_subscriber(user, tags: tags)
     when "journey"
       key = options["journey_key"] || options[:journey_key]
+      # Never send lifecycle journey emails to demo/internal accounts
+      # (same definition that drives the Mailchimp DEMO_USER merge field).
+      # CRM sync (sign_up/sign_in) is intentionally NOT gated — we still
+      # want demo contacts in the audience, tagged as demo.
+      if user.demo_user?
+        Rails.logger.info("[Mailchimp] Skipping journey '#{key}' for demo user #{user_id}")
+        return
+      end
       unless MailchimpClient.journeys_enabled?
         Rails.logger.info("[Mailchimp] Journeys disabled; skipping '#{key}' for user #{user_id}")
         return

--- a/app/sidekiq/mailchimp_first_board_nudge_job.rb
+++ b/app/sidekiq/mailchimp_first_board_nudge_job.rb
@@ -23,6 +23,7 @@ class MailchimpFirstBoardNudgeJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
+      next if user.demo_user?
       next if user.boards.any?
 
       enqueue_and_flag(user)

--- a/app/sidekiq/mailchimp_legacy_signup_nudge_job.rb
+++ b/app/sidekiq/mailchimp_legacy_signup_nudge_job.rb
@@ -28,6 +28,7 @@ class MailchimpLegacySignupNudgeJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
+      next if user.demo_user?
       next if recently_active?(user)
       next if user.boards.any?
 

--- a/app/sidekiq/mailchimp_trial_wrap_job.rb
+++ b/app/sidekiq/mailchimp_trial_wrap_job.rb
@@ -23,6 +23,7 @@ class MailchimpTrialWrapJob
   def perform(user_id, trial_end_epoch = nil)
     user = User.find_by(id: user_id)
     return unless user
+    return if user.demo_user? # never email demo/internal accounts
 
     unless MailchimpClient.journeys_enabled?
       Rails.logger.info("[Mailchimp] Journeys disabled; skipping #{JOURNEY_KEY} for user #{user_id}")

--- a/app/sidekiq/mailchimp_win_back_job.rb
+++ b/app/sidekiq/mailchimp_win_back_job.rb
@@ -26,6 +26,7 @@ class MailchimpWinBackJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
+      next if user.demo_user?
       next unless user.boards.any?
 
       enqueue_and_flag(user)

--- a/spec/sidekiq/mailchimp_event_job_spec.rb
+++ b/spec/sidekiq/mailchimp_event_job_spec.rb
@@ -35,5 +35,14 @@ RSpec.describe MailchimpEventJob, type: :sidekiq do
 
       described_class.new.perform(user.id, "journey", { "journey_key" => "mystery" })
     end
+
+    it "skips (no trigger) for a demo/internal user even when enabled + configured" do
+      demo = FactoryBot.create(:user, email: "qa@speakanyway.com")
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+      allow(MailchimpClient).to receive(:journey).with("welcome").and_return(journey_id: 10, step_id: 20)
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      described_class.new.perform(demo.id, "journey", { "journey_key" => "welcome" })
+    end
   end
 end

--- a/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
+++ b/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe MailchimpFirstBoardNudgeJob, type: :job do
       end
     end
 
+    context "when the user is a demo/internal account" do
+      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
+        user = create_eligible_user(email: "qa@speakanyway.com")
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+        expect(user.reload.settings["first_board_nudge_sent"]).not_to eq(true)
+      end
+    end
+
     context "when the user signed up less than 48h ago" do
       it "is skipped" do
         create_eligible_user(created_at: 24.hours.ago)

--- a/spec/sidekiq/mailchimp_legacy_signup_nudge_job_spec.rb
+++ b/spec/sidekiq/mailchimp_legacy_signup_nudge_job_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe MailchimpLegacySignupNudgeJob, type: :job do
       end
     end
 
+    context "when the user is a demo/internal account" do
+      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
+        user = create_legacy_user(email: "qa@speakanyway.com")
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+        expect(user.reload.settings["legacy_signup_nudge_sent"]).not_to eq(true)
+      end
+    end
+
     context "ENV threshold overrides" do
       it "honors LEGACY_SIGNUP_NUDGE_AGE_DAYS" do
         create_legacy_user(created_at: 20.days.ago, last_sign_in_at: nil)

--- a/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
+++ b/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe MailchimpTrialWrapJob, type: :job do
       job.perform(user.id, nil)
     end
 
+    it "skips (no merge-field sync, no trigger) for a demo/internal user" do
+      demo = create(:user, email: "qa@speakanyway.com")
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+      allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(journey_id: 50, step_id: 60)
+      expect(mailchimp).not_to receive(:update_merge_fields)
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      job.perform(demo.id, 1_781_000_000)
+    end
+
     it "skips when the trial_wrap journey isn't configured" do
       allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
       allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(nil)

--- a/spec/sidekiq/mailchimp_win_back_job_spec.rb
+++ b/spec/sidekiq/mailchimp_win_back_job_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe MailchimpWinBackJob, type: :job do
       end
     end
 
+    context "when the user is a demo/internal account" do
+      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
+        user = create_dormant_user(email: "qa@speakanyway.com")
+        create(:board, user: user)
+        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
+        expect(user.reload.settings["win_back_nudge_sent"]).not_to eq(true)
+      end
+    end
+
     context "when one user's save raises" do
       it "logs and continues processing the rest" do
         user_a = create_dormant_user


### PR DESCRIPTION
## Summary

Demo/internal accounts (your test logins) should never receive lifecycle journey emails. This adds that exclusion using the **same `user.demo_user?` definition** that drives the Mailchimp `DEMO_USER` merge field — email contains `bhannajohns+` or `@speakanyway.com`.

## How

One high-leverage guard plus a couple of belt-and-suspenders skips:

- **`MailchimpEventJob` journey branch** → `return if user.demo_user?`. Because welcome, first_board_nudge, hit_limit, legacy_signup_nudge, and win_back all route through this job, this single guard covers 5 of the 6 journeys.
- **`MailchimpTrialWrapJob`** → its own `demo_user?` early-return (the only journey not routed through `MailchimpEventJob`).
- **Cohort-sweep jobs** (`first_board`, `legacy`, `win_back`) → `next if user.demo_user?` in their loops, so demo accounts aren't even enqueued or flagged with a `*_nudge_sent` setting.

**CRM sync is intentionally untouched** — `sign_up` / `sign_in` still upsert demo contacts into the audience (tagged demo). We only suppress the *journey emails*.

## Why it matters now

Relevant before running the legacy backfill (`MailchimpLegacySignupNudgeJob`) — without this, an internal `@speakanyway.com` account in the cold-signup cohort could get the re-engagement email.

## Test plan

- [x] `bundle exec rspec spec/sidekiq/mailchimp_event_job_spec.rb spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb spec/sidekiq/mailchimp_legacy_signup_nudge_job_spec.rb spec/sidekiq/mailchimp_win_back_job_spec.rb spec/sidekiq/mailchimp_trial_wrap_job_spec.rb` — **40 examples, 0 failures**, including 5 new demo-skip cases (central guard + each sweep job not flagging + trial-wrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)