### PR TITLE
fix(mailchimp): correct customer journeys gem accessor (NoMethodError, journeys never sent)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,10 @@ GitHub build). Two distinct uses:
   `sign_in`) from `API::V1::AuthsController` and the Stripe checkout controller.
 - **Customer Journey triggers (email):** `MailchimpService#trigger_journey`
   enrols a contact into a journey's **API-trigger step**
-  (`@client.customer_journeys.trigger`), so Mailchimp sends the email designed
-  in that journey. The contact is upserted-and-retried-once if Mailchimp 404s.
+  (`@client.customerJourneys.trigger` — the gem accessor is camelCase; there is
+  **no** snake_case `customer_journeys` alias, so it raises NoMethodError), so
+  Mailchimp sends the email designed in that journey. The contact is
+  upserted-and-retried-once if Mailchimp 404s.
   Wired through the `MailchimpEventJob` `"journey"` event type, which takes a
   `journey_key`.
 

--- a/app/models/mailchimp_service.rb
+++ b/app/models/mailchimp_service.rb
@@ -107,7 +107,10 @@ class MailchimpService
   def trigger_journey(user, journey_id:, step_id:)
     attempted_subscribe = false
     begin
-      @client.customer_journeys.trigger(
+      # NOTE: the MailchimpMarketing gem exposes this API as `customerJourneys`
+      # (camelCase) — there is no snake_case `customer_journeys` accessor, so
+      # using it raises NoMethodError at runtime.
+      @client.customerJourneys.trigger(
         journey_id,
         step_id,
         { email_address: user.email }

--- a/spec/models/mailchimp_service_spec.rb
+++ b/spec/models/mailchimp_service_spec.rb
@@ -2,12 +2,13 @@ require "rails_helper"
 
 RSpec.describe MailchimpService do
   let(:client) { double("MailchimpClient") }
-  let(:journeys) { double("customer_journeys") }
+  let(:journeys) { double("customerJourneys") }
   let(:user) { FactoryBot.build(:user, email: "parent@example.com") }
 
   before do
     allow(MailchimpClient).to receive(:client).and_return(client)
-    allow(client).to receive(:customer_journeys).and_return(journeys)
+    # Gem accessor is camelCase `customerJourneys` (no snake_case alias).
+    allow(client).to receive(:customerJourneys).and_return(journeys)
   end
 
   describe "#update_merge_fields" do
@@ -81,6 +82,16 @@ RSpec.describe MailchimpService do
 
       expect(Rails.logger).to receive(:error).with(/Failed to trigger journey 10\/20/)
       expect(service.trigger_journey(user, journey_id: 10, step_id: 20)).to be_nil
+    end
+
+    # Regression guard for the NoMethodError that the mocked tests above can't
+    # catch: the real MailchimpMarketing::Client exposes the journeys API as
+    # camelCase `customerJourneys`, with no snake_case `customer_journeys`.
+    # Using the wrong name 500s every trigger in production.
+    it "calls the gem's real camelCase journeys accessor" do
+      bare_client = MailchimpMarketing::Client.new
+      expect(bare_client).to respond_to(:customerJourneys)
+      expect(bare_client).not_to respond_to(:customer_journeys)
     end
   end
 end


### PR DESCRIPTION
## The bug

`MailchimpService#trigger_journey` called `@client.customer_journeys.trigger(...)` (snake_case). The `MailchimpMarketing` gem only exposes that API as **`@client.customerJourneys`** (camelCase) — there is no snake_case alias. So every journey trigger raised:

```
NoMethodError: undefined method `customer_journeys' for an instance of MailchimpMarketing::Client
```

**Impact:** no Customer Journey email has ever actually sent — welcome, first-board nudge, hit-limit, legacy, trial-wrap, win-back all hit this the moment they fire. The CRM sync path (`lists`) was unaffected, which is why contact upserts worked but journey sends silently failed.

## Why tests didn't catch it

The original spec (from #257) mocked `client.customer_journeys`, matching the buggy code, so it passed against a double. The real gem object was never exercised.

## The fix

- `trigger_journey` → `@client.customerJourneys.trigger(...)`.
- Spec updated to stub the correct accessor.
- **New regression guard** instantiates the real `MailchimpMarketing::Client` and asserts it `respond_to?(:customerJourneys)` and NOT `:customer_journeys` — so a future rename (in code or gem) fails loudly instead of silently 500ing in prod.
- CLAUDE.md note added.

## Test plan

- [x] `bundle exec rspec spec/models/mailchimp_service_spec.rb` — **7 examples, 0 failures**, including the new real-client regression guard.
- [ ] Post-merge: re-trigger a journey (e.g. `MailchimpEventJob.new.perform(user.id, "journey", { "journey_key" => "welcome" })` for a real non-demo user) and confirm no NoMethodError + the email lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)