### PR TITLE
feat(analytics): server-side checkout_completed capture + fix dead sign-in route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Server-side `checkout_completed` PostHog event (upgrade funnel)
+- The Stripe `checkout.session.completed` webhook now captures a
+  `checkout_completed` PostHog event `{ plan, kind, amount_total, currency,
+  source: "stripe_webhook" }` for both subscription checkouts and credit
+  topups (`kind: "topup"`), making checkout outcomes visible in the upgrade
+  funnel even when the user never returns to the success page. No new ENV
+  vars — activates in production via the existing PostHog gate.
+
+### Fixed — Dead `POST /api/v1/users/sign_in` route
+- The route pointed at a non-existent `auths#sign_in` action, so any caller
+  got a server error. It now routes to `auths#create`, identical to
+  `POST /api/v1/login`.
+
 ### Changed — Transactional free welcome slimmed to a receipt (dual-welcome, #293 option A)
 - `UserMailer.welcome_free_email` is now a short **receipt** — account-ready
   confirmation + sign-in link, with a closing line that hands off to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,17 @@ PostHog events (which fire intent + `checkout_started`); the backend completes
 the money-path funnel (itty-bitty-frontend#307). Fired from
 `API::WebhooksController`:
 
+- **`checkout_completed`** `{ plan, kind, amount_total, currency, source }` —
+  on `checkout.session.completed`, the **authoritative** purchase-completion
+  event (fires even if the user never returns to the success page; the frontend
+  adds a client-side echo separately). Subscription checkouts capture in
+  `handle_checkout_completed` (`plan` from `paid_plan_type` — the plan picked at
+  session create, since the subscription upsert may not have run yet;
+  `kind: "subscription"`); topups capture in `handle_topup_completed` after the
+  credit grant succeeds (`kind: "topup"`, `plan` = current `plan_type`). No
+  event-id guard (matching the handler), so a Stripe webhook retry may
+  re-capture — acceptable for analytics; the topup credit grant itself stays
+  idempotent.
 - **`trial_started`** `{ plan }` — `handle_trial_started_analytics`, on
   `customer.subscription.created` when `status == "trialing"`. PostHog-only —
   the internal `trial_started` AnalyticsEvent already fires at checkout, so we

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -166,6 +166,23 @@ class API::WebhooksController < API::ApplicationController
       },
     )
     Rails.logger.info "[StripeWebhook][topup] credited user=#{user.id} amount=#{credit_amount} session=#{session.id}"
+
+    # Checkout-completion analytics for topups (itty-bitty-frontend#307). The
+    # credit grant above is idempotent on the event id, but a webhook retry may
+    # re-capture this event; acceptable for analytics. `plan` is the user's
+    # current plan — a topup doesn't pick one.
+    PosthogService.capture_for_user(
+      user,
+      "checkout_completed",
+      properties: {
+        plan: user.plan_type,
+        kind: "topup",
+        amount_total: session.amount_total,
+        currency: session.currency,
+        source: "stripe_webhook",
+      },
+    )
+
     true
   rescue => e
     Rails.logger.error "[StripeWebhook][topup] error: #{e.class} - #{e.message}"
@@ -213,6 +230,25 @@ class API::WebhooksController < API::ApplicationController
     )
 
     Rails.logger.info "[StripeWebhook] Linked checkout.session #{session.id} to user #{user.id}"
+
+    # Authoritative checkout-completion event (itty-bitty-frontend#307) — fires
+    # even when the user never returns to the success page. The frontend adds a
+    # client-side echo separately. No event-id guard here (matching this
+    # handler), so a Stripe webhook retry may re-capture; acceptable for
+    # analytics. `paid_plan_type` is the plan picked at session create — the
+    # subscription upsert may not have updated `plan_type` yet.
+    PosthogService.capture_for_user(
+      user,
+      "checkout_completed",
+      properties: {
+        plan: user.paid_plan_type.presence || user.plan_type,
+        kind: metadata["kind"].presence || "subscription",
+        amount_total: session.amount_total,
+        currency: session.currency,
+        source: "stripe_webhook",
+      },
+    )
+
     user
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_checkout_completed error: #{e.class} - #{e.message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,7 +401,7 @@ Rails.application.routes.draw do
       get "/child_accounts/current", to: "child_auths#current"
       get "users/current", to: "auths#current"
       post "users", to: "auths#sign_up"
-      post "users/sign_in", to: "auths#sign_in"
+      post "users/sign_in", to: "auths#create"
       post "users/sign_out", to: "auths#destroy"
       post "login", to: "auths#create"
       post "forgot_password", to: "auths#forgot_password"

--- a/spec/requests/api/auth_spec.rb
+++ b/spec/requests/api/auth_spec.rb
@@ -30,6 +30,24 @@ RSpec.describe "API::V1::Auth", type: :request do
     end
   end
 
+  # Regression: this route used to point at the non-existent auths#sign_in
+  # action, so every request raised ActionNotFound. It now routes to
+  # auths#create, same as /api/v1/login.
+  describe "POST /api/v1/users/sign_in" do
+    it "signs in with valid credentials" do
+      post "/api/v1/users/sign_in", params: { email: user.email, password: "password123" }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["token"]).to eq(user.authentication_token)
+      expect(body["user"]).to be_present
+    end
+
+    it "returns 401 with invalid credentials" do
+      post "/api/v1/users/sign_in", params: { email: user.email, password: "wrongpassword" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
   describe "POST /api/v1/forgot_password" do
     context "when the email belongs to a registered user" do
       it "returns 200" do

--- a/spec/requests/api/webhooks_analytics_spec.rb
+++ b/spec/requests/api/webhooks_analytics_spec.rb
@@ -53,6 +53,115 @@ RSpec.describe "POST /api/webhooks (PostHog analytics)", type: :request do
     )
   end
 
+  def build_checkout_session(metadata: { "user_id" => user.id.to_s }, **overrides)
+    OpenStruct.new(
+      {
+        id: "cs_test_#{SecureRandom.hex(4)}",
+        customer: user.stripe_customer_id,
+        customer_details: OpenStruct.new(email: user.email),
+        subscription: "sub_#{SecureRandom.hex(3)}",
+        amount_total: 999,
+        currency: "usd",
+        metadata: metadata,
+      }.merge(overrides),
+    )
+  end
+
+  describe "checkout_completed (checkout.session.completed)" do
+    context "subscription checkout" do
+      it "captures checkout_completed with the picked plan, kind, amount and currency" do
+        user.update!(paid_plan_type: "pro", plan_type: "free")
+        session = build_checkout_session
+        stub_event(session, type: "checkout.session.completed")
+
+        expect(PosthogService).to receive(:capture_for_user).with(
+          an_object_having_attributes(id: user.id),
+          "checkout_completed",
+          properties: {
+            plan: "pro",
+            kind: "subscription",
+            amount_total: 999,
+            currency: "usd",
+            source: "stripe_webhook",
+          },
+        )
+
+        post_webhook("{}", header_with_signature)
+      end
+
+      it "falls back to plan_type when no paid_plan_type is set" do
+        user.update!(paid_plan_type: nil, plan_type: "basic")
+        session = build_checkout_session
+        stub_event(session, type: "checkout.session.completed")
+
+        expect(PosthogService).to receive(:capture_for_user).with(
+          anything, "checkout_completed",
+          properties: hash_including(plan: "basic"),
+        )
+
+        post_webhook("{}", header_with_signature)
+      end
+
+      it "does not capture when no user can be resolved" do
+        session = build_checkout_session(
+          metadata: { "user_id" => "0" },
+          customer: "cus_nobody",
+          customer_details: nil,
+        )
+        stub_event(session, type: "checkout.session.completed")
+
+        expect(PosthogService).not_to receive(:capture_for_user)
+
+        post_webhook("{}", header_with_signature)
+      end
+    end
+
+    context "topup checkout" do
+      let(:topup_metadata) do
+        {
+          "kind" => "topup",
+          "user_id" => user.id.to_s,
+          "pack_key" => "small",
+          "credit_amount" => "100",
+        }
+      end
+
+      it "captures checkout_completed with kind=topup after the credits are granted" do
+        session = build_checkout_session(metadata: topup_metadata, amount_total: 499)
+        stub_event(session, type: "checkout.session.completed")
+
+        expect(PosthogService).to receive(:capture_for_user).with(
+          an_object_having_attributes(id: user.id),
+          "checkout_completed",
+          properties: {
+            plan: "basic",
+            kind: "topup",
+            amount_total: 499,
+            currency: "usd",
+            source: "stripe_webhook",
+          },
+        )
+
+        expect {
+          post_webhook("{}", header_with_signature)
+        }.to change { user.reload.topup_credits_balance }.by(100)
+      end
+
+      it "does not capture when the topup is not credited" do
+        session = build_checkout_session(
+          metadata: { "kind" => "topup" },
+          customer: nil,
+          customer_details: nil,
+        )
+        stub_event(session, type: "checkout.session.completed")
+
+        expect(PosthogService).not_to receive(:capture_for_user)
+
+        post_webhook("{}", header_with_signature)
+      end
+    end
+  end
+
   describe "subscription_started (non-active → active)" do
     it "captures subscription_started with plan + billing_interval" do
       user.update!(plan_status: "trialing")


### PR DESCRIPTION
## Summary

Implements `.claude-notes/upgrade-funnel-fixes-handoff.md` (upgrade-funnel fixes, backend half — ships independently of the frontend counterpart).

**1. Server-side `checkout_completed` PostHog event.** The Stripe `checkout.session.completed` webhook now captures `checkout_completed` `{ plan, kind, amount_total, currency, source: "stripe_webhook" }` — the authoritative purchase-completion event, firing even when the user never returns to the success page (PostHog analysis 2026-06-10 showed checkout outcomes were entirely invisible).
- Subscription checkouts: in `handle_checkout_completed`, `plan` from `paid_plan_type` (the plan picked at session create — the subscription upsert may not have updated `plan_type` yet), `kind: "subscription"`.
- Topups: in `handle_topup_completed` after the credit grant succeeds, `kind: "topup"`, `plan` = current `plan_type`.
- **Idempotency note (per handoff):** `handle_checkout_completed` has no Stripe event-id guard (matching the existing handler), so a webhook retry may re-capture the analytics event. The topup *credit grant* stays idempotent on the event id; only the capture can double-fire. Acceptable for analytics.

**2. Dead `POST /api/v1/users/sign_in` route.** It pointed at `auths#sign_in`, which doesn't exist — every caller got `ActionNotFound`. Now routes to `auths#create` (same as `/api/v1/login`), per the handoff's preferred one-line routes fix. Grepped first: nothing else references `auths#sign_in`.

Docs: CLAUDE.md PostHog section + CHANGELOG.md updated.

## Test plan

- Added `checkout_completed` coverage to `spec/requests/api/webhooks_analytics_spec.rb`: subscription variant (plan from `paid_plan_type`, fallback to `plan_type`, no-user → no capture) and topup variant (captures after credits granted, no capture when not credited).
- Added request specs for `POST /api/v1/users/sign_in` (valid → 200 + token, invalid → 401) in `spec/requests/api/auth_spec.rb`.
- Ran all webhooks specs + auth specs + directly-related specs (`posthog_service`, `revenue_cat_webhook`, `lifecycle_integration`): **95 examples, 0 failures**.

## Deploy notes

No migrations, no new ENV vars. Capture activates in production via the existing PostHog gate (`POSTHOG_API_KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)