### PR TITLE
fix(credits): don't charge for first-time AI image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — AI image generation no longer charges credits for first-time fills
+- `POST /api/images/generate` only spends `image_generation` credits when the image
+  **already has a picture** (the user is replacing/customizing it). Generating an image
+  for a tile/label that has **no picture yet** now generates the image for **free** — we
+  don't charge users to build the shared image library. The credit gate moved from an
+  unconditional check at the top of the action to `Image#display_image_url(user).present?`.
+  Regenerate / image-edit / image-variation are unchanged (they always act on an existing
+  image, so they keep charging).
+
 ### Changed — Transactional free welcome slimmed to a receipt (dual-welcome, #293 option A)
 - `UserMailer.welcome_free_email` is now a short **receipt** — account-ready
   confirmation + sign-in link, with a closing line that hands off to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,15 @@ Full permissions matrix and the rationale for the split lives in
 topup_credits, reset_at, topup_url }`. Admins (`current_user.admin?`) bypass.
 - Reserve **HTTP 429** for true rate limiting (rapid-fire abuse), not credit
   exhaustion.
+- **`image_generation` is free for first-time fills.** `API::ImagesController#generate`
+  (`POST /api/images/generate`) only calls `check_credits!` when the image **already
+  has a displayable picture** for the user (`Image#display_image_url(user).present?` —
+  the same "is there a doc to set?" notion as `Board#find_or_create_images_from_word_list`).
+  Generating an image for an empty tile/label (no doc yet) still enqueues
+  `GenerateImageJob` but is **not billed** — we don't charge users to build the shared
+  image library. Charging only applies when they're replacing/customizing an existing
+  image. `regenerate_images`, `create_image_edit`, and `create_image_variation` act on
+  images that already have a picture, so they keep charging unconditionally.
 - `MonthlyFeatureLimiter` is no longer in the AI hot path. It remains in the
   codebase as a generic Redis-counter helper for any future non-AI rate
   limits, but no controller currently calls it.

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -458,7 +458,6 @@ class API::ImagesController < API::ApplicationController
 
   def generate
     @current_user = current_user
-    return unless check_credits!(feature_key: "image_generation", feature_name: "AI Image Generation")
     label = image_params[:label].present? ? image_params[:label] : image_params[:image_prompt]
     image_prompt = image_params[:image_prompt]
     stripped_prompt = image_prompt.gsub("[[REPLACE_LABEL]]", "").strip
@@ -467,6 +466,13 @@ class API::ImagesController < API::ApplicationController
       @image = Image.find(params[:id])
     else
       @image = Image.find_or_create_by(label: label, user_id: @current_user.id, private: false, image_prompt: stripped_prompt, image_type: "Generated")
+    end
+
+    # Building the library is free: only charge when the image already has a
+    # displayable picture for this user (i.e. they're replacing/customizing it).
+    # First-time generation for an empty tile generates the image but isn't billed.
+    if @image.display_image_url(@current_user).present?
+      return unless check_credits!(feature_key: "image_generation", feature_name: "AI Image Generation")
     end
 
     if needs_replacement?(label, stripped_prompt)

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -36,10 +36,22 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
   describe "spending the configured weight per feature" do
     before { CreditService.grant_plan!(user, amount: 1000, period_end: 30.days.from_now) }
 
-    it "image_generation costs 3" do
+    it "image_generation costs 3 when the image already has a picture" do
+      # Only replacing/customizing an existing image is billed; stub a displayable
+      # doc so the charge path is exercised (S3-safe, no real ActiveStorage blob).
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
       expect {
         post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
       }.to change { user.reload.plan_credits_balance }.by(-3)
+    end
+
+    it "image_generation is free when there is no existing image (building the library)" do
+      before_balance = user.reload.plan_credits_balance
+      # The image is still generated (job enqueued) — just not billed.
+      expect {
+        post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
+      }.to change(GenerateImageJob.jobs, :size).by(1)
+      expect(user.reload.plan_credits_balance).to eq(before_balance)
     end
 
     it "word_suggestion costs 1" do
@@ -70,6 +82,26 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
     end
   end
 
+  describe "image_generation gating depends on whether a picture already exists" do
+    # `user` starts at a zero balance here — the global before clears the grant
+    # and this block adds none.
+
+    it "returns 402 (and does not generate) when replacing an existing image with no credits" do
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
+      expect {
+        post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
+      }.not_to change(GenerateImageJob.jobs, :size)
+      expect(response).to have_http_status(402)
+    end
+
+    it "still generates a first-time image for free at a zero balance" do
+      expect {
+        post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
+      }.to change(GenerateImageJob.jobs, :size).by(1)
+      expect(response).not_to have_http_status(402)
+    end
+  end
+
   describe "drains plan credits before top-up" do
     before do
       CreditService.grant_plan!(user, amount: 2, period_end: 30.days.from_now)
@@ -77,6 +109,8 @@ RSpec.describe "Credit enforcement on AI endpoints", type: :request do
     end
 
     it "uses plan balance first for an image_generation call" do
+      # Billed path requires an existing picture to replace/customize.
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
       post "/api/images/generate", params: { image: { label: "cat", image_prompt: "cat" } }, headers: auth
       user.reload
       # cost 3 — plan had 2, topup absorbs 1


### PR DESCRIPTION
## Summary

We shouldn't charge AI credits for generating an image when a tile/label has **no picture yet** — that's the user building SpeakAnyWay's shared image library, and they were getting billed 3 credits for it.

`POST /api/images/generate` (`API::ImagesController#generate`) charged `image_generation` **unconditionally** at the top of the action, before it even loaded the image. The frontend hits this endpoint only on the explicit "Generate Image" button (`ViewImageScreen`, `BoardImageModal`) — but that button is also how a user fills an empty tile.

### What changed

- The credit gate is now **conditional**: charge only when the image **already has a displayable picture** for the user (`Image#display_image_url(@current_user).present?` — the same "is there a doc to set?" notion used in `Board#find_or_create_images_from_word_list`).
- First-time generation (no doc yet) still enqueues `GenerateImageJob` and generates the image — it just isn't billed.
- Charging applies only when the user is **replacing/customizing** an image that already exists.

### Scope (left unchanged)

- `regenerate_images`, `create_image_edit`, `create_image_variation` always operate on an image that already has a picture, so they keep charging.
- `API::Internal::ImagesController#generate` (admin/internal) and the legacy `tokens`-based `find_or_create` path were never credit-charged.
- The genuinely automatic library-building paths (board generation, `images#create`, `images#find_or_create`) were already free.

## Test plan

- Updated the two `credit_enforcement_spec` specs that posted a brand-new label and asserted a charge — they now stub an existing picture so the billed path is exercised.
- Added specs: free first-time generate (job still enqueued, balance unchanged), 402 when replacing an existing image with no credits (no job enqueued), and free generate at a zero balance.
- `bundle exec rspec spec/requests/api/credit_enforcement_spec.rb spec/services/credit_service_spec.rb spec/requests/api/images_spec.rb spec/requests/api/internal/images_spec.rb spec/requests/api/boards_spec.rb` → **104 examples, 0 failures**.

## Docs

- `CLAUDE.md` — note in the AI credit-ledger section describing the first-time-free gating rule.
- `CHANGELOG.md` — user-facing `[Unreleased]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)