### PR TITLE
fix(board-builder): false 422 on post-enqueue failures, missing tile audio

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -116,7 +116,7 @@ module API
         # BuildBoardSetJob fails — no refund path needed, by decision.
         BuildBoardSetJob.perform_async(root.id, communicator.id, params[:template].to_s, interests)
 
-        render json: root.api_view(current_user), status: :created
+        render json: serialize_built_root(root), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e
         Rails.logger.warn "[BoardBuilder] #{e.message}"
         render json: { error: "unknown_template",
@@ -133,11 +133,29 @@ module API
         # If the root already committed (e.g. the enqueue itself raised), don't
         # strand it in "building_board" — mark it failed so the duplicate guard
         # offers the normal confirm-to-rebuild path instead of a stuck spinner.
-        Rails.logger.error "[BoardBuilder] unexpected error: #{e.class}: #{e.message}"
+        # Backtrace included because a message alone has proven too thin to
+        # locate post-commit failures (e.g. an image_processing tempfile race).
+        Rails.logger.error "[BoardBuilder] unexpected error: #{e.class}: #{e.message}\n#{e.backtrace&.first(15)&.join("\n")}"
         root.update_column(:status, "failed") if defined?(root) && root&.persisted?
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },
                status: :unprocessable_entity
+      end
+
+      private
+
+      # Board#api_view walks images/attachments and can trip on transient
+      # ActiveStorage/variant races. By this point the root is committed and
+      # BuildBoardSetJob is enqueued — failing the request here would report a
+      # false failure for a build that's running (and the rescue below would
+      # mark it "failed" out from under the job). Degrade to a minimal payload
+      # instead; the frontend polls GET /api/boards/:id for the full view.
+      def serialize_built_root(root)
+        root.api_view(current_user)
+      rescue StandardError => e
+        Rails.logger.warn "[BoardBuilder] api_view failed for board #{root.id}, returning minimal payload: #{e.class}: #{e.message}"
+        { id: root.id, board_id: root.id, name: root.name, slug: root.slug,
+          board_type: root.board_type, user_id: root.user_id, status: root.status }
       end
     end
   end

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -41,7 +41,12 @@ class BoardImage < ApplicationRecord
   # before_save :save_display_image_url, if: -> { display_image_url.blank? }
   before_save :check_predictive_board
   before_update :set_colors, if: :part_of_speech_changed?
-  after_create :create_voice_audio_after_create, unless: -> { skip_create_voice_audio }
+  # after_create_commit (not after_create): tiles are often created inside a
+  # larger transaction (Board Builder clones a whole linked set in one), and
+  # an after_create enqueue lets Sidekiq run SaveAudioJob before the commit —
+  # the job can't find the row ("BoardImage with ID ... not found") and the
+  # tile ends up with no audio_url.
+  after_create_commit :create_voice_audio_after_create, unless: -> { skip_create_voice_audio }
 
   include BoardsHelper
   include ImageHelper

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -101,4 +101,42 @@ RSpec.describe BoardImage, type: :model do
       expect(view[:display_label]).to eq("Hola")
     end
   end
+
+  describe "voice audio enqueue (after_create_commit)" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+    let(:image) { FactoryBot.create(:image, label: "hello", user_id: user.id) }
+
+    before do
+      # No pre-existing audio for the voice -> the callback takes the
+      # SaveAudioJob branch.
+      allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil)
+      SaveAudioJob.clear
+    end
+
+    it "defers SaveAudioJob until the enclosing transaction commits" do
+      # Board Builder clones a whole linked set in one transaction; an
+      # after_create enqueue let Sidekiq run SaveAudioJob before the row was
+      # visible ("BoardImage with ID ... not found") and the tile shipped
+      # without audio.
+      ActiveRecord::Base.transaction do
+        FactoryBot.create(:board_image, board: board, image: image)
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+      expect(SaveAudioJob.jobs.size).to eq(1)
+    end
+
+    it "does not enqueue when the transaction rolls back" do
+      ActiveRecord::Base.transaction do
+        FactoryBot.create(:board_image, board: board, image: image)
+        raise ActiveRecord::Rollback
+      end
+      expect(SaveAudioJob.jobs).to be_empty
+    end
+
+    it "respects skip_create_voice_audio" do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+      expect(SaveAudioJob.jobs).to be_empty
+    end
+  end
 end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -313,6 +313,30 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    context "when serializing the 201 payload fails after the job is enqueued" do
+      it "still returns 201 with a minimal payload and leaves the build running" do
+        # Board#api_view can trip on transient ActiveStorage/variant races.
+        # By then the root is committed and BuildBoardSetJob is enqueued —
+        # a 422 here would be a false failure (and would mark a running
+        # build "failed" out from under the job).
+        allow_any_instance_of(Board).to receive(:api_view).and_raise(StandardError, "variant race")
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id, template: "home" }.to_json,
+               headers: headers
+        }.to change { BuildBoardSetJob.jobs.size }.by(1)
+
+        expect(response).to have_http_status(:created)
+        body = JSON.parse(response.body)
+        expect(body["name"]).to eq("Home")
+        expect(body["status"]).to eq("building_board")
+
+        root = Board.find(body["id"])
+        expect(root.status).to eq("building_board") # not stomped to "failed"
+      end
+    end
+
     context "when something fails in-request after the root was created" do
       it "returns 422 build_failed and marks the root failed (no stuck building_board)" do
         allow(BuildBoardSetJob).to receive(:perform_async).and_raise(StandardError, "redis down")


### PR DESCRIPTION
## Summary

Fixes two live false-failure bugs in the Board Builder (Phase 0 of the board-builder next-phase handoff):

- **False build failures:** `Board#api_view` can trip on transient ActiveStorage/variant races while serializing the 201 response. By that point the root is committed and `BuildBoardSetJob` is already enqueued, so the old rescue reported a false 422 *and* marked the running build `failed` out from under the job. `serialize_built_root` now degrades to a minimal payload (id/name/slug/status) instead — the frontend polls `GET /api/boards/:id` for the full view anyway. The last-resort error log now includes a backtrace (a message alone proved too thin to locate post-commit failures).
- **Missing tile audio:** `BoardImage`'s `create_voice_audio_after_create` moved from `after_create` to `after_create_commit`. Tiles are often created inside a larger transaction (the builder clones a whole linked set in one); the old enqueue let Sidekiq run `SaveAudioJob` before the commit, the job couldn't find the row, and the tile shipped without audio.

The originally-staged stale-reseed-tile prune in `vocab_sets.rb` was **dropped during rebase**: #282 already landed a stronger sync pass (`prune_removed_tiles!` / `prune_removed_boards!`) on main.

## Test plan

- New request spec: `api_view` raising post-enqueue → 201 with minimal payload, job enqueued once, root stays `building_board` (not stomped to `failed`).
- New model specs: `SaveAudioJob` defers until the enclosing transaction commits, never enqueues on rollback, and `skip_create_voice_audio` is respected.
- CI runs the full suite.

## Deploy note

After merge, run `bundle exec rails vocab_sets:seed` on prod — refreshes Core 60/84 (revisions already on main via #275/#276) and prunes stale tiles (the bug where Core 60 shipped 57 authored + leftover "and"/"please"/"thank you").

🤖 Generated with [Claude Code](https://claude.com/claude-code)