### PR TITLE
feat(beta): read-only entitlement audit task (beta:audit_entitlements)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,6 +577,22 @@ Tasks:
   and `plan_credits_balance = 0`, then re-grants their tier allowance with
   `period_end = 30.days.from_now`.
 
+## Beta-end entitlement audit
+
+- `bin/rails beta:audit_entitlements` — **read-only** sweep comparing every
+  user's persisted `settings` limits (`board_limit`, effective communicator
+  slot limit, `ai_monthly_limit`) and actual usage (`countable_board_count`,
+  owned loaner+active communicators) against the entitlement for their
+  `plan_type` (the `FREE/BASIC/PRO_PLAN_LIMITS` hashes). Prints summary counts
+  and writes flagged users to `tmp/beta_audit_<date>.csv` (path overridable
+  via `BETA_AUDIT_CSV`). Admin/partner accounts are listed but marked
+  `exempt`. Closes the gap where beta-era users kept Pro-level `settings`
+  while `plan_type` stayed `free` (enforcement reads `settings`; the
+  reconcile callback only fires on `plan_type` change). Phase 2 — a
+  reconciliation task (`beta:end_beta`) — gets built only if this audit
+  finds over-entitled users. See
+  `.claude-notes/beta-end-founding-rate-handoff.md`.
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/lib/tasks/beta_audit.rake
+++ b/lib/tasks/beta_audit.rake
@@ -1,0 +1,126 @@
+require "csv"
+
+# Phase 1 of the beta-end sweep (.claude-notes/beta-end-founding-rate-handoff.md).
+# READ-ONLY: compares every user's persisted settings limits and actual usage
+# against the entitlement for their plan_type. Phase 2 (beta:end_beta) is only
+# built/run if this audit finds over-entitled users.
+namespace :beta do
+  desc "Read-only audit: persisted limits + actual usage vs. plan entitlement. Writes tmp/beta_audit_<date>.csv, no DB writes."
+  task audit_entitlements: :environment do
+    csv_path = ENV["BETA_AUDIT_CSV"].presence ||
+      Rails.root.join("tmp", "beta_audit_#{Date.current.strftime("%Y-%m-%d")}.csv").to_s
+
+    # Mirrors User#setup_limits' plan_type → limits routing. Unknown/blank
+    # plan types get the Free entitlement, matching how enforcement falls
+    # back (User#board_limit etc. default to FREE_PLAN_LIMITS).
+    entitlement_for = lambda do |plan_type|
+      case plan_type.to_s
+      when "basic", "basic_yearly", "basic_trial"
+        ["basic", User::BASIC_PLAN_LIMITS]
+      when "pro", "pro_yearly", "partner_pro"
+        ["pro", User::PRO_PLAN_LIMITS]
+      when "free"
+        ["free", User::FREE_PLAN_LIMITS]
+      else
+        ["free (fallback)", User::FREE_PLAN_LIMITS]
+      end
+    end
+
+    # Same counting rules as the enforcement paths:
+    #   boards — User#countable_board_count (own, non-template, non-predefined,
+    #            non-builder_child)
+    #   communicators — Permissions::CommunicatorLimits.owned_slot_count
+    #            (owned loaner + active)
+    board_counts = Board.where(is_template: false, predefined: false)
+      .not_builder_child.group(:user_id).count
+    slot_counts = ChildAccount
+      .where(status: [ChildAccount::LOANER, ChildAccount::ACTIVE])
+      .group(:owner_id).count
+
+    scanned = 0
+    flagged_rows = []
+    over_settings_by_plan = Hash.new(0)
+    over_usage_by_plan = Hash.new(0)
+    exempt_flagged = 0
+    unknown_plan_types = Hash.new(0)
+
+    User.find_each do |user|
+      scanned += 1
+      settings = user.settings || {}
+      plan = user.plan_type.to_s
+      entitlement_plan, entitled = entitlement_for.call(plan)
+      unknown_plan_types[plan] += 1 if entitlement_plan == "free (fallback)"
+
+      board_limit_setting = settings["board_limit"]
+      # Effective persisted slot limit, exactly as enforcement reads it
+      # (communicator_slot_limit overrides paid_communicator_limit).
+      communicator_limit_setting = Permissions::CommunicatorLimits.slot_limit_for(settings)
+      ai_limit_setting = settings["ai_monthly_limit"]
+
+      board_count = board_counts[user.id].to_i
+      communicator_count = slot_counts[user.id].to_i
+
+      over_settings =
+        (board_limit_setting.present? && board_limit_setting.to_i > entitled["board_limit"]) ||
+        communicator_limit_setting > entitled["paid_communicator_limit"] ||
+        (ai_limit_setting.present? && ai_limit_setting.to_i > entitled["ai_monthly_limit"])
+      over_usage =
+        board_count > entitled["board_limit"] ||
+        communicator_count > entitled["paid_communicator_limit"]
+
+      next unless over_settings || over_usage
+
+      # Reconciliation (phase 2) must not touch admin/partner accounts —
+      # surface them in the CSV but keep them out of the actionable counts.
+      exempt =
+        if user.admin?
+          "admin"
+        elsif plan == "partner_pro" || user.role == "partner"
+          "partner_pro"
+        end
+
+      if exempt
+        exempt_flagged += 1
+      else
+        over_settings_by_plan[plan.presence || "(blank)"] += 1 if over_settings
+        over_usage_by_plan[plan.presence || "(blank)"] += 1 if over_usage
+      end
+
+      flagged_rows << [
+        user.id, user.email, plan, exempt, entitlement_plan,
+        board_limit_setting, entitled["board_limit"],
+        communicator_limit_setting, entitled["paid_communicator_limit"],
+        ai_limit_setting, entitled["ai_monthly_limit"],
+        board_count, communicator_count,
+        over_settings, over_usage,
+      ]
+    end
+
+    FileUtils.mkdir_p(File.dirname(csv_path))
+    CSV.open(csv_path, "w") do |csv|
+      csv << %w[
+        user_id email plan_type exempt entitlement_plan
+        board_limit_setting board_limit_entitled
+        communicator_limit_setting communicator_limit_entitled
+        ai_monthly_limit_setting ai_monthly_limit_entitled
+        board_count communicator_count
+        over_settings over_usage
+      ]
+      flagged_rows.each { |row| csv << row }
+    end
+
+    summary = lambda do |counts|
+      counts.empty? ? "none" : counts.sort.map { |plan, n| "#{plan}=#{n}" }.join(" ")
+    end
+
+    puts "Scanned #{scanned} users."
+    puts "Over-entitled settings by plan: #{summary.call(over_settings_by_plan)}"
+    puts "Over actual usage by plan: #{summary.call(over_usage_by_plan)}"
+    puts "Exempt (admin/partner_pro) flagged: #{exempt_flagged}"
+    unless unknown_plan_types.empty?
+      puts "Unknown plan_type values (audited against Free entitlement): #{summary.call(unknown_plan_types)}"
+    end
+    puts "CSV: #{csv_path} (#{flagged_rows.size} flagged users)"
+    puts "No writes performed."
+  end
+end

--- a/spec/lib/tasks/beta_audit_rake_spec.rb
+++ b/spec/lib/tasks/beta_audit_rake_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+require "rake"
+require "csv"
+
+RSpec.describe "beta:audit_entitlements", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["beta:audit_entitlements"] }
+  let(:csv_path) { Rails.root.join("tmp", "beta_audit_spec_#{Process.pid}.csv").to_s }
+
+  after do
+    task.reenable
+    FileUtils.rm_f(csv_path)
+  end
+
+  def invoke_task
+    ENV["BETA_AUDIT_CSV"] = csv_path
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    task.invoke
+    output.string
+  ensure
+    $stdout = original_stdout
+    ENV.delete("BETA_AUDIT_CSV")
+  end
+
+  def csv_rows
+    CSV.read(csv_path, headers: true)
+  end
+
+  def row_for(user)
+    csv_rows.find { |row| row["user_id"] == user.id.to_s }
+  end
+
+  # Beta-era shape: plan_type stayed "free" but Pro-level limits were written
+  # into settings. Use update_columns so no callbacks rewrite the fixture.
+  def give_pro_settings!(user)
+    user.update_columns(settings: user.settings.merge(
+      "board_limit" => User::PRO_PLAN_LIMITS["board_limit"],
+      "paid_communicator_limit" => User::PRO_PLAN_LIMITS["paid_communicator_limit"],
+      "ai_monthly_limit" => User::PRO_PLAN_LIMITS["ai_monthly_limit"],
+    ))
+    user
+  end
+
+  it "flags a free user with pro-level settings as over_settings" do
+    user = give_pro_settings!(FactoryBot.create(:user, plan_type: "free"))
+
+    output = invoke_task
+
+    row = row_for(user)
+    expect(row).to be_present
+    expect(row["over_settings"]).to eq("true")
+    expect(row["over_usage"]).to eq("false")
+    expect(row["board_limit_setting"]).to eq(User::PRO_PLAN_LIMITS["board_limit"].to_s)
+    expect(row["board_limit_entitled"]).to eq(User::FREE_PLAN_LIMITS["board_limit"].to_s)
+    expect(row["exempt"]).to be_nil
+    expect(output).to include("free=1")
+  end
+
+  it "flags a free user whose actual usage exceeds the free entitlement" do
+    user = FactoryBot.create(:user, plan_type: "free")
+    FactoryBot.create_list(:board, 2, user: user)
+    FactoryBot.create_list(:child_account, 2, user: user, status: ChildAccount::ACTIVE)
+
+    invoke_task
+
+    row = row_for(user)
+    expect(row).to be_present
+    expect(row["over_usage"]).to eq("true")
+    expect(row["board_count"]).to eq("2")
+    expect(row["communicator_count"]).to eq("2")
+  end
+
+  it "does not list compliant users" do
+    user = FactoryBot.create(:user, plan_type: "free")
+
+    invoke_task
+
+    expect(row_for(user)).to be_nil
+  end
+
+  it "audits paid users against their own plan's entitlement" do
+    basic = FactoryBot.create(:user, plan_type: "basic")
+    basic.update_columns(settings: basic.settings.merge(
+      "board_limit" => User::PRO_PLAN_LIMITS["board_limit"],
+    ))
+    compliant_pro = FactoryBot.create(:user, plan_type: "pro")
+
+    invoke_task
+
+    row = row_for(basic)
+    expect(row["over_settings"]).to eq("true")
+    expect(row["board_limit_entitled"]).to eq(User::BASIC_PLAN_LIMITS["board_limit"].to_s)
+    expect(row_for(compliant_pro)).to be_nil
+  end
+
+  it "respects a communicator_slot_limit settings override, matching enforcement" do
+    user = FactoryBot.create(:user, plan_type: "free")
+    user.update_columns(settings: user.settings.merge("communicator_slot_limit" => 5))
+
+    invoke_task
+
+    row = row_for(user)
+    expect(row["over_settings"]).to eq("true")
+    expect(row["communicator_limit_setting"]).to eq("5")
+  end
+
+  it "marks admin and partner accounts exempt and keeps them out of actionable counts" do
+    admin = give_pro_settings!(FactoryBot.create(:user, plan_type: "free", role: "admin"))
+
+    output = invoke_task
+
+    expect(row_for(admin)["exempt"]).to eq("admin")
+    expect(output).to include("Exempt (admin/partner_pro) flagged: 1")
+    expect(output).to include("Over-entitled settings by plan: none")
+  end
+
+  it "excludes builder_child and predefined boards from the board count" do
+    user = FactoryBot.create(:user, plan_type: "free")
+    FactoryBot.create(:board, user: user)
+    FactoryBot.create(:board, user: user, predefined: true)
+    FactoryBot.create(:board, user: user, settings: { "builder_child" => true })
+
+    invoke_task
+
+    # 1 countable board == free limit, so not over and not in the CSV.
+    expect(row_for(user)).to be_nil
+  end
+
+  it "performs no writes" do
+    user = give_pro_settings!(FactoryBot.create(:user, plan_type: "free"))
+    settings_before = user.reload.settings
+    updated_at_before = user.updated_at
+
+    invoke_task
+
+    user.reload
+    expect(user.settings).to eq(settings_before)
+    expect(user.updated_at).to eq(updated_at_before)
+  end
+
+  it "prints a summary and the CSV path" do
+    give_pro_settings!(FactoryBot.create(:user, plan_type: "free"))
+
+    output = invoke_task
+
+    expect(output).to include("Scanned")
+    expect(output).to include("CSV: #{csv_path}")
+    expect(output).to include("No writes performed.")
+  end
+end


### PR DESCRIPTION
## Summary

Phase 1 (work item 1) of `.claude-notes/beta-end-founding-rate-handoff.md`: a **read-only** audit task, `bin/rails beta:audit_entitlements`, that finds beta-era users whose persisted `settings` limits or actual usage exceed the entitlement for their `plan_type`. No DB writes anywhere in the task.

Phase 2 (the `beta:end_beta` reconciliation task) is intentionally **not** in this PR — it gets built after we review the audit results, per the handoff.

For every user it compares:

- **Persisted settings vs. entitlement** — `settings["board_limit"]`, the effective communicator slot limit (`Permissions::CommunicatorLimits.slot_limit_for`, so a `communicator_slot_limit` override is honored the same way enforcement honors it), and `settings["ai_monthly_limit"]`, against the `FREE/BASIC/PRO_PLAN_LIMITS` hash for their plan.
- **Actual usage vs. entitlement** — countable boards (same rules as `User#countable_board_count`: own, non-template, non-predefined, non-`builder_child`) and owned loaner+active communicators.

Output:

- stdout summary (over-entitled-settings users by plan, over-actual-usage users by plan, exempt count) via `puts` — console-friendly.
- CSV of flagged users at `tmp/beta_audit_<date>.csv` (override path with `BETA_AUDIT_CSV`) with persisted vs. entitled limits and actual counts per user.
- Admin and partner accounts that trip a check are listed in the CSV but marked `exempt` and kept out of the actionable counts, since phase 2 must not touch them.
- Unknown/blank plan types are audited against the Free entitlement (matching how enforcement falls back) and called out in the summary.

Also adds a CLAUDE.md section documenting the task.

## Stripe dashboard steps (work item 3 — manual, no code)

For reference from the handoff — Brittany does this in the Stripe dashboard, test mode first, then live:

1. Create a Coupon: 50% off, duration **forever** (or two amount-off coupons if the $99/$49 option is chosen — pricing detail still pending).
2. Attach a Promotion code `FOUNDING`. Do **not** restrict to first-time orders — existing subscribers upgrading must be able to use it.
3. Verify a checkout session on `pro_yearly` with `promo_code=FOUNDING` shows the discount, and that the discount persists on the renewal preview.
4. Repeat in live mode before the Founding Family email sends.

No backend change needed: `checkout_sessions_controller` already passes `promo_code` through and sets `allow_promotion_codes` when none is passed.

## Test plan

- New spec file `spec/lib/tasks/beta_audit_rake_spec.rb` (9 examples) covering: free user with Pro-level settings flagged as over-settings; free user over actual usage (boards + communicators); compliant users absent from the CSV; paid (basic) user audited against Basic entitlement; `communicator_slot_limit` override respected; admin exemption; `builder_child`/predefined boards excluded from the count; **no-writes** assertion (settings + `updated_at` unchanged); summary output.
- Ran just the new spec file locally: **9 examples, 0 failures.** Per the handoff, the full suite runs in CI on this PR, not locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)