### PR TITLE
revert(mailchimp): temporarily let demo accounts receive journey emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Demo/internal accounts receive Mailchimp journey emails again (temporary)
+- Reverted #297 for now: the `user.demo_user?` guards in `MailchimpEventJob`,
+  `MailchimpTrialWrapJob`, and the cohort-sweep jobs are removed, so demo
+  accounts (`bhannajohns+` / `@speakanyway.com` emails) can receive lifecycle
+  journey emails — useful for end-to-end testing of the journeys. Re-apply by
+  reverting this revert when testing is done.
+
 ### Changed — AI image generation no longer charges credits for first-time fills
 - `POST /api/images/generate` only spends `image_generation` credits when the image
   **already has a picture** (the user is replacing/customizing it). Generating an image
@@ -35,15 +42,6 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   badge, and the sign-in CTA are unchanged. EN + ES both updated. This lets the
   transactional receipt and the warm Mailchimp welcome coexist without
   overlapping (issue #293, option A).
-
-### Changed — Mailchimp lifecycle journeys never email demo/internal accounts
-- All Customer Journey sends now skip `user.demo_user?` accounts (email contains
-  `bhannajohns+` or `@speakanyway.com` — the same definition behind the
-  `DEMO_USER` merge field). A single guard in `MailchimpEventJob`'s journey
-  branch covers welcome / first_board_nudge / hit_limit / legacy_signup_nudge /
-  win_back; `MailchimpTrialWrapJob` has its own guard. The cohort-sweep jobs
-  also skip demo users so they aren't flagged. CRM contact sync is unchanged —
-  demo contacts remain in the audience, tagged as demo.
 
 ### Added — Mailchimp trial-wrap (#5) and win-back (#6) lifecycle journeys
 - **Trial wrapping up (#5).** The `customer.subscription.trial_will_end` Stripe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,16 +158,12 @@ GitHub build). Two distinct uses:
     `MailchimpClient.journeys_enabled?` returns true in production (and only
     production — staging is excluded via `AppEnv.staging?`); dev/staging fire
     only when `MAILCHIMP_JOURNEYS_ENABLED=true`. CRM sync is **not** gated.
-  - **Demo/internal accounts never get journey emails.** `MailchimpEventJob`'s
-    `"journey"` branch returns early for `user.demo_user?` (email contains
-    `bhannajohns+` or `@speakanyway.com` — the same definition that sets the
-    `DEMO_USER` merge field), so all journeys routed through it (welcome,
-    first_board_nudge, hit_limit, legacy_signup_nudge, win_back) are covered by
-    that one guard. `MailchimpTrialWrapJob` (the only journey not routed through
-    `MailchimpEventJob`) has its own `demo_user?` early-return. The cohort-sweep
-    jobs also `next if user.demo_user?` so demo accounts aren't even flagged.
-    **CRM sync is still NOT gated** — demo contacts stay in the audience, tagged
-    as demo.
+  - **Demo/internal accounts currently DO get journey emails (temporary).**
+    The #297 `user.demo_user?` guards were reverted on 2026-06-10 so Brittany
+    can end-to-end test the journeys with demo accounts. When testing is done,
+    restore by reverting the revert commit (`git log --grep "Revert.*demo"`).
+    CRM sync was never gated either way — demo contacts stay in the audience,
+    tagged via the `DEMO_USER` merge field.
 
 App transactional email (welcome, password reset) still goes through
 ActionMailer/Gmail SMTP, **not** Mailchimp. True 1:1 transactional via Mailchimp

--- a/app/sidekiq/mailchimp_event_job.rb
+++ b/app/sidekiq/mailchimp_event_job.rb
@@ -16,14 +16,6 @@ class MailchimpEventJob
       mailchimp.record_new_subscriber(user, tags: tags)
     when "journey"
       key = options["journey_key"] || options[:journey_key]
-      # Never send lifecycle journey emails to demo/internal accounts
-      # (same definition that drives the Mailchimp DEMO_USER merge field).
-      # CRM sync (sign_up/sign_in) is intentionally NOT gated — we still
-      # want demo contacts in the audience, tagged as demo.
-      if user.demo_user?
-        Rails.logger.info("[Mailchimp] Skipping journey '#{key}' for demo user #{user_id}")
-        return
-      end
       unless MailchimpClient.journeys_enabled?
         Rails.logger.info("[Mailchimp] Journeys disabled; skipping '#{key}' for user #{user_id}")
         return

--- a/app/sidekiq/mailchimp_first_board_nudge_job.rb
+++ b/app/sidekiq/mailchimp_first_board_nudge_job.rb
@@ -23,7 +23,6 @@ class MailchimpFirstBoardNudgeJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
-      next if user.demo_user?
       next if user.boards.any?
 
       enqueue_and_flag(user)

--- a/app/sidekiq/mailchimp_legacy_signup_nudge_job.rb
+++ b/app/sidekiq/mailchimp_legacy_signup_nudge_job.rb
@@ -28,7 +28,6 @@ class MailchimpLegacySignupNudgeJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
-      next if user.demo_user?
       next if recently_active?(user)
       next if user.boards.any?
 

--- a/app/sidekiq/mailchimp_trial_wrap_job.rb
+++ b/app/sidekiq/mailchimp_trial_wrap_job.rb
@@ -23,7 +23,6 @@ class MailchimpTrialWrapJob
   def perform(user_id, trial_end_epoch = nil)
     user = User.find_by(id: user_id)
     return unless user
-    return if user.demo_user? # never email demo/internal accounts
 
     unless MailchimpClient.journeys_enabled?
       Rails.logger.info("[Mailchimp] Journeys disabled; skipping #{JOURNEY_KEY} for user #{user_id}")

--- a/app/sidekiq/mailchimp_win_back_job.rb
+++ b/app/sidekiq/mailchimp_win_back_job.rb
@@ -26,7 +26,6 @@ class MailchimpWinBackJob
 
     eligible_users.find_each do |user|
       next if already_nudged?(user)
-      next if user.demo_user?
       next unless user.boards.any?
 
       enqueue_and_flag(user)

--- a/spec/sidekiq/mailchimp_event_job_spec.rb
+++ b/spec/sidekiq/mailchimp_event_job_spec.rb
@@ -35,14 +35,5 @@ RSpec.describe MailchimpEventJob, type: :sidekiq do
 
       described_class.new.perform(user.id, "journey", { "journey_key" => "mystery" })
     end
-
-    it "skips (no trigger) for a demo/internal user even when enabled + configured" do
-      demo = FactoryBot.create(:user, email: "qa@speakanyway.com")
-      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
-      allow(MailchimpClient).to receive(:journey).with("welcome").and_return(journey_id: 10, step_id: 20)
-      expect(mailchimp).not_to receive(:trigger_journey)
-
-      described_class.new.perform(demo.id, "journey", { "journey_key" => "welcome" })
-    end
   end
 end

--- a/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
+++ b/spec/sidekiq/mailchimp_first_board_nudge_job_spec.rb
@@ -54,14 +54,6 @@ RSpec.describe MailchimpFirstBoardNudgeJob, type: :job do
       end
     end
 
-    context "when the user is a demo/internal account" do
-      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
-        user = create_eligible_user(email: "qa@speakanyway.com")
-        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
-        expect(user.reload.settings["first_board_nudge_sent"]).not_to eq(true)
-      end
-    end
-
     context "when the user signed up less than 48h ago" do
       it "is skipped" do
         create_eligible_user(created_at: 24.hours.ago)

--- a/spec/sidekiq/mailchimp_legacy_signup_nudge_job_spec.rb
+++ b/spec/sidekiq/mailchimp_legacy_signup_nudge_job_spec.rb
@@ -82,14 +82,6 @@ RSpec.describe MailchimpLegacySignupNudgeJob, type: :job do
       end
     end
 
-    context "when the user is a demo/internal account" do
-      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
-        user = create_legacy_user(email: "qa@speakanyway.com")
-        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
-        expect(user.reload.settings["legacy_signup_nudge_sent"]).not_to eq(true)
-      end
-    end
-
     context "ENV threshold overrides" do
       it "honors LEGACY_SIGNUP_NUDGE_AGE_DAYS" do
         create_legacy_user(created_at: 20.days.ago, last_sign_in_at: nil)

--- a/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
+++ b/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
@@ -50,16 +50,6 @@ RSpec.describe MailchimpTrialWrapJob, type: :job do
       job.perform(user.id, nil)
     end
 
-    it "skips (no merge-field sync, no trigger) for a demo/internal user" do
-      demo = create(:user, email: "qa@speakanyway.com")
-      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
-      allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(journey_id: 50, step_id: 60)
-      expect(mailchimp).not_to receive(:update_merge_fields)
-      expect(mailchimp).not_to receive(:trigger_journey)
-
-      job.perform(demo.id, 1_781_000_000)
-    end
-
     it "skips when the trial_wrap journey isn't configured" do
       allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
       allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(nil)

--- a/spec/sidekiq/mailchimp_win_back_job_spec.rb
+++ b/spec/sidekiq/mailchimp_win_back_job_spec.rb
@@ -73,15 +73,6 @@ RSpec.describe MailchimpWinBackJob, type: :job do
       end
     end
 
-    context "when the user is a demo/internal account" do
-      it "is skipped (not enqueued, not flagged) even if otherwise eligible" do
-        user = create_dormant_user(email: "qa@speakanyway.com")
-        create(:board, user: user)
-        expect { job.perform }.not_to change(MailchimpEventJob.jobs, :size)
-        expect(user.reload.settings["win_back_nudge_sent"]).not_to eq(true)
-      end
-    end
-
     context "when one user's save raises" do
       it "logs and continues processing the rest" do
         user_a = create_dormant_user


### PR DESCRIPTION
## Summary

Temporarily reverts #297 ("never send lifecycle journey emails to demo/internal accounts") so demo accounts (`bhannajohns+` / `@speakanyway.com` emails) receive Mailchimp Customer Journey emails again — needed to end-to-end test the journeys (welcome, hit_limit, first_board_nudge, legacy_signup_nudge, win_back, trial_wrap) with demo accounts.

- Clean `git revert` of c5552161: removes the `demo_user?` guards from `MailchimpEventJob`, `MailchimpTrialWrapJob`, and the three cohort-sweep jobs, plus the specs that asserted the skip behavior.
- CHANGELOG + CLAUDE.md updated to flag this as **temporary**, with instructions to restore by reverting this revert when testing is done.
- CRM sync is unchanged (it was never gated) — demo contacts remain in the audience tagged `DEMO_USER`.

## Test plan

- Local suite intentionally not run (Brittany's call — straight revert of an additive commit; the only spec changes are deletions of the guard tests #297 added). CI will run the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)