### PR TITLE
fix(wt-clean): don't die on worktrees whose branch has no upstream

### DIFF
--- a/bin/wt-clean
+++ b/bin/wt-clean
@@ -62,7 +62,14 @@ for wt in "${REGISTERED[@]}"; do
     continue
   fi
   dirty=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-  unpushed=$(git -C "$wt" log '@{u}..' --oneline 2>/dev/null | wc -l | tr -d ' ')
+  if git -C "$wt" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+    unpushed=$(git -C "$wt" log '@{u}..' --oneline 2>/dev/null | wc -l | tr -d ' ')
+  else
+    # No upstream: nothing is on the remote, so any commits beyond
+    # origin/main count as unpushed work. (Without this branch, the
+    # failing @{u} lookup + pipefail silently killed the whole script.)
+    unpushed=$(git -C "$wt" log origin/main..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ' || echo 1)
+  fi
   if [[ "$dirty" != "0" || "$unpushed" != "0" ]]; then
     PROTECTED+=("$wt  (dirty=$dirty, unpushed=$unpushed)")
   else


### PR DESCRIPTION
## Summary
`git log '@{u}..'` exits 128 when a worktree's branch has no upstream; under `set -euo pipefail` that killed the whole script after the first such worktree — it printed the header and silently stopped. Reproduced in itty-bitty-frontend (where most `claude/*` worktree branches have no upstream). Fix: detect missing upstream and fall back to counting commits beyond `origin/main` as unpushed, which conservatively protects the worktree.

Same fix is included in the wt-clean copies being added to the other repos ([itty-bitty-frontend#368](https://github.com/brittanyjohns/itty-bitty-frontend/pull/368), [speakanyway-printables#154](https://github.com/brittanyjohns/speakanyway-printables/pull/154)).

## Test plan
Shell tooling only, no app code (test-irrelevant per global rules). Verified by execution: `bin/wt-clean --audit` and `--prune` now run to completion in this repo and the frontend repo where the bug reproduced; no-upstream worktrees with local commits show as Protected (unpushed=N).

🤖 Generated with [Claude Code](https://claude.com/claude-code)