### PR TITLE
feat(board-builder): stored communicator profile + template recommend…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,7 +674,12 @@ Three seams (input contract tightens left→right):
 
 Endpoints (`API::V1::BoardBuilderController`, both auth-gated):
 
-- `GET /api/v1/board_builder/templates` — label-only picker catalog.
+- `GET /api/v1/board_builder/templates` — label-only picker catalog. Accepts an
+  optional `communicator_id` (scoped to `current_user.communicator_accounts`);
+  when that communicator has a usable stored profile, the response includes
+  `recommended_template` (Core 60's slug for young/emerging, else Core 84's —
+  only if that set is seeded here) and a `recommendation_reason` string. No
+  profile → both `null`.
 - `POST /api/v1/board_builder` `{ communicator_id, template, interests }` —
   ownership check (**404 `communicator_not_found`** for a communicator not in
   `current_user.communicator_accounts`), assemble → build → persist normalized
@@ -728,6 +733,27 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
 - v1 is **synchronous** (DB-bound work; previews/audio/AI art already async).
   If a finalized set is materially larger than the placeholder, move the clone
   to a background job + "building" state — see `.claude-notes/board-builder.md`.
+
+### Stored communicator profile (AAC personalization)
+
+`aac_level` / `vocab_type` / `age_band` live in **`child_accounts.details`**
+(jsonb, same pattern as `details["interests"]` — no columns). `ChildAccount`
+defines typed accessors over them, normalizes (downcase/strip, blank clears the
+key), and validates against `CommunicatorProfile::AAC_LEVELS / VOCAB_TYPES /
+AGE_BANDS` on every save — including the wholesale `details=` assignment in the
+communicator update controller. Exposed top-level (next to `details`) in the
+ChildAccount `api_view` / `vendor_api_view`.
+
+`CommunicatorProfile.for(params:, communicator:)` is the merge constructor:
+explicit request params override stored fields **field by field**; returns nil
+when both sources are empty (no profile = unchanged behavior). Consumers:
+`boards#words`, `boards#additional_words`, and `GenerateBoardJob` all accept an
+optional `communicator_id` — always resolved via
+`current_user.communicator_accounts` (controller-side for the job; the id in
+job options is pre-validated), never a bare `ChildAccount.find`. An id the
+caller doesn't own is silently ignored. Personalization reaches **AI
+word-suggestion prompts and the template recommendation only** — the Board
+Builder's deterministic build path is unchanged.
 
 ## Do not
 

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -363,12 +363,15 @@ class API::BoardsController < API::ApplicationController
             "age_range"  => age_range,
             "word_count" => word_count,
             "profile"    => communicator_profile_params,
+            # Ownership is checked here (profile_communicator scopes to the
+            # caller); the job receives a pre-validated id.
+            "communicator_id" => profile_communicator&.id,
           }
           job_args["word_list"] = word_list if word_list.present?
 
           GenerateBoardJob.perform_async(@board.id, creation_type, job_args)
         else
-          GenerateBoardJob.perform_async(@board.id, creation_type, { "word_count" => word_count, "profile" => communicator_profile_params })
+          GenerateBoardJob.perform_async(@board.id, creation_type, { "word_count" => word_count, "profile" => communicator_profile_params, "communicator_id" => profile_communicator&.id })
         end
         format.json { render json: @board, status: :created }
       else
@@ -668,7 +671,7 @@ class API::BoardsController < API::ApplicationController
     num_of_words = params[:num_of_words].to_i || 10
     board_words = @board.board_images.map(&:label).uniq
     name_to_send = params[:prompt] || params[:name] || @board.name
-    profile = CommunicatorProfile.from_params(params)
+    profile = CommunicatorProfile.for(params: params, communicator: profile_communicator)
     resolved_language = params[:language].presence || @board.language.presence || "en"
     additional_words = @board.get_words(name_to_send, num_of_words, board_words, current_user.admin?, language: resolved_language, profile: profile)
     render json: additional_words
@@ -701,7 +704,7 @@ class API::BoardsController < API::ApplicationController
     prompt = params[:prompt].presence || params[:name]
     num_of_words = params[:num_of_words].to_i || 24
     words_to_exclude = params[:words_to_exclude].is_a?(Array) ? params[:words_to_exclude] : @board&.current_word_list || []
-    profile = CommunicatorProfile.from_params(params)
+    profile = CommunicatorProfile.for(params: params, communicator: profile_communicator)
     @board ||= Board.new(name: prompt) # create a temporary board object to use the word suggestion methods if no board_id is provided
     # Source language from explicit param first, then board.language, then user
     # locale — so a Spanish-language board produces Spanish suggestions even
@@ -1274,6 +1277,15 @@ class API::BoardsController < API::ApplicationController
   # All fields are optional.
   def communicator_profile_params
     params.permit(:age, :age_band, :aac_level, :vocab_type).to_h.to_hash
+  end
+
+  # Optional communicator for profile-aware AI calls. Scoped to the caller's
+  # own communicator_accounts — an id belonging to another user resolves to
+  # nil (ignored), never a bare ChildAccount.find.
+  def profile_communicator
+    return nil if params[:communicator_id].blank?
+
+    current_user.communicator_accounts.find_by(id: params[:communicator_id])
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -18,9 +18,24 @@ module API
     # create returns HTTP 409 `board_builder_set_exists` instead of silently
     # duplicating it; the client re-sends with `confirm=true` to build another.
     class BoardBuilderController < API::ApplicationController
-      # Label-only template catalog for the picker grid.
+      # Robust-set slugs used for the server-side template recommendation.
+      # These are the keys vocab_sets:seed stamps on the seeded roots; the
+      # recommendation is only emitted when the slug is actually in the
+      # catalog (i.e. seeded in this environment).
+      RECOMMENDED_SMALL_SET = "core-60"
+      RECOMMENDED_LARGE_SET = "core-84"
+
+      # Label-only template catalog for the picker grid. With an optional
+      # communicator_id (scoped to the caller's own communicators), a stored
+      # profile yields a server-side template recommendation: young/emerging
+      # communicators get the smaller core set, everyone else the larger one.
       def templates
-        render json: { templates: Boards::StarterBlueprints.catalog }, status: :ok
+        catalog = Boards::StarterBlueprints.catalog
+        recommended, reason = recommend_template(catalog)
+        render json: { templates: catalog,
+                       recommended_template: recommended,
+                       recommendation_reason: reason },
+               status: :ok
       end
 
       def create
@@ -143,6 +158,29 @@ module API
       end
 
       private
+
+      # [recommended_template_key, reason] for the optional communicator_id
+      # param, or [nil, nil] when there's no usable stored profile (or the
+      # recommended set isn't seeded in this environment). Ownership-scoped:
+      # someone else's communicator id resolves to nil and is ignored.
+      def recommend_template(catalog)
+        return [nil, nil] if params[:communicator_id].blank?
+
+        communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
+        profile = CommunicatorProfile.for(communicator: communicator)
+        return [nil, nil] unless profile
+
+        if profile.young? || profile.emerging?
+          slug = RECOMMENDED_SMALL_SET
+          reason = "A smaller core vocabulary is a good starting point for young or emerging communicators."
+        else
+          slug = RECOMMENDED_LARGE_SET
+          reason = "A larger core vocabulary gives this communicator more room to grow."
+        end
+        return [nil, nil] unless catalog.any? { |t| t[:key] == slug }
+
+        [slug, reason]
+      end
 
       # Board#api_view walks images/attachments and can trip on transient
       # ActiveStorage/variant races. By this point the root is committed and

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -119,11 +119,62 @@ class ChildAccount < ApplicationRecord
   before_save :set_owner_if_missing, if: -> { owner.nil? && user.present? }
   before_validation :set_username_if_missing, if: -> { username.blank? }
 
+  # AAC personalization fields, stored in the details jsonb (same pattern as
+  # details["interests"] — no columns). They feed CommunicatorProfile.for so
+  # word-suggestion AI calls and the Board Builder's template recommendation
+  # can be personalized without the picker being re-filled every time.
+  AAC_PROFILE_FIELDS = {
+    "aac_level" => CommunicatorProfile::AAC_LEVELS,
+    "vocab_type" => CommunicatorProfile::VOCAB_TYPES,
+    "age_band" => CommunicatorProfile::AGE_BANDS,
+  }.freeze
+
+  AAC_PROFILE_FIELDS.each_key do |field|
+    define_method(field) { details&.dig(field) }
+    define_method("#{field}=") do |value|
+      self.details = (details || {}).merge(field => value)
+    end
+  end
+
+  before_validation :normalize_aac_profile_fields
+  validate :validate_aac_profile_fields
+
   def set_username_if_missing
     if name.present?
       self.username = name.parameterize
     else
       self.username = "comm#{SecureRandom.hex(4)}"
+    end
+  end
+
+  # Runs on every save path (typed setter or wholesale details= from the
+  # update controller): downcases/strips the three profile keys and drops
+  # blank ones, so clearing a field is always allowed.
+  def normalize_aac_profile_fields
+    return if details.blank?
+
+    AAC_PROFILE_FIELDS.each_key do |field|
+      next unless details.key?(field)
+
+      value = details[field].to_s.strip.downcase
+      if value.blank?
+        details.delete(field)
+      else
+        details[field] = value
+      end
+    end
+  end
+
+  def validate_aac_profile_fields
+    return if details.blank?
+
+    AAC_PROFILE_FIELDS.each do |field, allowed|
+      value = details[field]
+      next if value.blank?
+
+      unless allowed.include?(value)
+        errors.add(field.to_sym, "must be one of: #{allowed.join(', ')}")
+      end
     end
   end
 
@@ -553,6 +604,9 @@ class ChildAccount < ApplicationRecord
       teams: teams.map { |t| t.index_api_view(viewing_user) },
       settings: settings,
       details: details,
+      aac_level: aac_level,
+      vocab_type: vocab_type,
+      age_band: age_band,
       user_id: user_id,
       go_to_words: go_to_words,
       go_to_boards: cached_go_to_boards.map do |board|
@@ -912,6 +966,9 @@ class ChildAccount < ApplicationRecord
       teams: teams.map { |t| t.index_api_view(viewing_user) },
       settings: settings,
       details: details,
+      aac_level: aac_level,
+      vocab_type: vocab_type,
+      age_band: age_band,
       user_id: user_id,
       go_to_words: go_to_words,
       go_to_boards: cached_go_to_boards.map do |board|

--- a/app/services/communicator_profile.rb
+++ b/app/services/communicator_profile.rb
@@ -30,6 +30,24 @@ class CommunicatorProfile
     profile.present? ? profile : nil
   end
 
+  # Merge constructor: request params override the communicator's stored
+  # profile (child_accounts.details), field by field — an explicit picker value
+  # wins, anything the picker left blank falls back to what's stored on the
+  # communicator. Returns nil when neither source has usable data, preserving
+  # the "no profile = unchanged behavior" contract of from_params.
+  def self.for(params: nil, communicator: nil)
+    fetch = ->(key) { params && (params[key] || params[key.to_s]).presence }
+    stored = communicator&.details || {}
+    profile = new(
+      age: fetch.call(:age) || stored["age"],
+      age_band: fetch.call(:age_band) || stored["age_band"],
+      aac_level: fetch.call(:aac_level) || stored["aac_level"],
+      vocab_type: fetch.call(:vocab_type) || stored["vocab_type"],
+      age_range: fetch.call(:age_range)
+    )
+    profile.present? ? profile : nil
+  end
+
   # `age_range` is the legacy free-text param already used by the scenario flow;
   # it's accepted as a fallback when no structured age/age_band is given.
   def initialize(age: nil, age_band: nil, aac_level: nil, vocab_type: nil, age_range: nil)

--- a/app/sidekiq/generate_board_job.rb
+++ b/app/sidekiq/generate_board_job.rb
@@ -10,7 +10,11 @@ class GenerateBoardJob
       words = []
       begin
         board.update_column(:status, "generating_words")
-        profile = CommunicatorProfile.from_params(options["profile"] || {})
+        # communicator_id arrives pre-validated (boards#create scopes it to
+        # the caller's own communicator_accounts before enqueueing). Explicit
+        # profile params still override the stored fields, field by field.
+        communicator = ChildAccount.find_by(id: options["communicator_id"]) if options["communicator_id"].present?
+        profile = CommunicatorProfile.for(params: options["profile"] || {}, communicator: communicator)
         case board_creation_type
         when "default", "scenario"
           # The merged "Build a board" form can send seed words (word_list)

--- a/spec/models/child_account_aac_profile_spec.rb
+++ b/spec/models/child_account_aac_profile_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+# AAC personalization fields (aac_level / vocab_type / age_band) stored in the
+# details jsonb — typed accessors + validation against CommunicatorProfile's
+# enums. No columns, no migration.
+RSpec.describe ChildAccount, type: :model do
+  let(:account) { FactoryBot.build(:child_account) }
+
+  describe "typed accessors" do
+    it "write into and read from details" do
+      account.aac_level = "emerging"
+      account.vocab_type = "core"
+      account.age_band = "4-6"
+
+      expect(account.details["aac_level"]).to eq("emerging")
+      expect(account.aac_level).to eq("emerging")
+      expect(account.vocab_type).to eq("core")
+      expect(account.age_band).to eq("4-6")
+    end
+
+    it "preserve other details keys (interests pattern)" do
+      account.details = { "interests" => ["trains"] }
+      account.aac_level = "developing"
+      expect(account.details["interests"]).to eq(["trains"])
+    end
+  end
+
+  describe "validation" do
+    it "accepts valid values and normalizes case/whitespace" do
+      account.aac_level = " Emerging "
+      expect(account).to be_valid
+      expect(account.aac_level).to eq("emerging")
+    end
+
+    it "rejects an invalid aac_level" do
+      account.aac_level = "wizard"
+      expect(account).not_to be_valid
+      expect(account.errors[:aac_level]).to be_present
+    end
+
+    it "rejects an invalid vocab_type and age_band" do
+      account.vocab_type = "everything"
+      account.age_band = "99-100"
+      expect(account).not_to be_valid
+      expect(account.errors[:vocab_type]).to be_present
+      expect(account.errors[:age_band]).to be_present
+    end
+
+    it "allows clearing a field with nil/blank (key is dropped)" do
+      account.aac_level = "emerging"
+      account.aac_level = ""
+      expect(account).to be_valid
+      expect(account.details).not_to have_key("aac_level")
+      expect(account.aac_level).to be_nil
+    end
+
+    it "validates wholesale details assignment too (the update controller path)" do
+      account.details = { "aac_level" => "bogus" }
+      expect(account).not_to be_valid
+    end
+
+    it "leaves accounts without profile fields untouched" do
+      account.details = { "interests" => ["dinosaurs"] }
+      expect(account).to be_valid
+      expect(account.details).to eq({ "interests" => ["dinosaurs"] })
+    end
+  end
+end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -464,6 +464,51 @@ RSpec.describe "API::Boards", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    describe "stored communicator profile (communicator_id)" do
+      let!(:communicator) do
+        create(:child_account, user: user,
+                               details: { "aac_level" => "emerging", "age_band" => "4-6" })
+      end
+
+      it "builds the profile from the communicator's stored details" do
+        expect_any_instance_of(Board).to receive(:get_word_suggestions) do |_b, _p, _n, _excl, profile:, **|
+          expect(profile.aac_level).to eq("emerging")
+          expect(profile.age_band).to eq("4-6")
+          %w[more help go]
+        end
+        get "/api/boards/words",
+            params: { name: "Doctor Visit", num_of_words: 3, communicator_id: communicator.id },
+            headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "lets explicit params override stored fields, field by field" do
+        expect_any_instance_of(Board).to receive(:get_word_suggestions) do |_b, _p, _n, _excl, profile:, **|
+          expect(profile.aac_level).to eq("proficient") # param wins
+          expect(profile.age_band).to eq("4-6")         # stored field kept
+          %w[volcano excavate]
+        end
+        get "/api/boards/words",
+            params: { name: "Doctor Visit", num_of_words: 3,
+                      communicator_id: communicator.id, aac_level: "proficient" },
+            headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ignores another user's communicator_id (no cross-account leak)" do
+        other = create(:child_account, user: create(:user),
+                                       details: { "aac_level" => "emerging" })
+        expect_any_instance_of(Board).to receive(:get_word_suggestions) do |_b, _p, _n, _excl, profile:, **|
+          expect(profile).to be_nil
+          %w[doctor nurse]
+        end
+        get "/api/boards/words",
+            params: { name: "Doctor Visit", num_of_words: 3, communicator_id: other.id },
+            headers: auth_headers(user)
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "GET /api/boards/:id/additional_words" do

--- a/spec/requests/api/child_accounts_aac_profile_spec.rb
+++ b/spec/requests/api/child_accounts_aac_profile_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# AAC personalization fields (aac_level / vocab_type / age_band) ride the
+# existing wholesale `details` param on communicator update — same pattern as
+# details["interests"]. Model-level validation rejects invalid values.
+RSpec.describe "API::ChildAccounts AAC profile", type: :request do
+  let(:user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user) }
+  let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
+
+  describe "PATCH /api/child_accounts/:id" do
+    it "persists valid profile fields via details and exposes them in the api_view" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { aac_level: "emerging", vocab_type: "core", age_band: "4-6" } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["aac_level"]).to eq("emerging")
+      expect(body["vocab_type"]).to eq("core")
+      expect(body["age_band"]).to eq("4-6")
+
+      communicator.reload
+      expect(communicator.aac_level).to eq("emerging")
+      expect(communicator.details["age_band"]).to eq("4-6")
+    end
+
+    it "rejects an invalid aac_level with a validation error" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { aac_level: "wizard" } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(communicator.reload.aac_level).to be_nil
+    end
+
+    it "allows clearing a stored field" do
+      communicator.update!(details: { "aac_level" => "emerging" })
+
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { aac_level: "" } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(communicator.reload.aac_level).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -60,6 +60,67 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       expect(robust["name"]).to eq("Core 60")
       expect(robust["tiles"]).to include("I", "Food")
     end
+
+    describe "recommended_template" do
+      it "is null without a communicator_id" do
+        seed_robust_set!
+        get "/api/v1/board_builder/templates", headers: headers
+
+        body = JSON.parse(response.body)
+        expect(body["recommended_template"]).to be_nil
+        expect(body["recommendation_reason"]).to be_nil
+      end
+
+      it "is null when the communicator has no stored profile" do
+        seed_robust_set!
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: communicator.id }, headers: headers
+
+        expect(JSON.parse(response.body)["recommended_template"]).to be_nil
+      end
+
+      it "recommends the small core set for a young/emerging communicator" do
+        seed_robust_set!(slug: "core-60")
+        communicator.update!(details: { "aac_level" => "emerging", "age_band" => "4-6" })
+
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: communicator.id }, headers: headers
+
+        body = JSON.parse(response.body)
+        expect(body["recommended_template"]).to eq("core-60")
+        expect(body["recommendation_reason"]).to be_present
+      end
+
+      it "recommends the large core set for an older proficient communicator" do
+        seed_robust_set!(slug: "core-84")
+        communicator.update!(details: { "aac_level" => "proficient", "age_band" => "15-18" })
+
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: communicator.id }, headers: headers
+
+        expect(JSON.parse(response.body)["recommended_template"]).to eq("core-84")
+      end
+
+      it "is null when the recommended set isn't seeded in this environment" do
+        communicator.update!(details: { "aac_level" => "emerging" })
+
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: communicator.id }, headers: headers
+
+        expect(JSON.parse(response.body)["recommended_template"]).to be_nil
+      end
+
+      it "ignores another user's communicator_id" do
+        seed_robust_set!
+        other = create(:child_account, user: create(:user),
+                                       details: { "aac_level" => "emerging" })
+
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: other.id }, headers: headers
+
+        expect(JSON.parse(response.body)["recommended_template"]).to be_nil
+      end
+    end
   end
 
   describe "POST /api/v1/board_builder" do

--- a/spec/services/communicator_profile_spec.rb
+++ b/spec/services/communicator_profile_spec.rb
@@ -25,6 +25,49 @@ RSpec.describe CommunicatorProfile do
     end
   end
 
+  describe ".for" do
+    let(:communicator) do
+      FactoryBot.build(:child_account,
+        details: { "aac_level" => "emerging", "age_band" => "4-6", "vocab_type" => "core" })
+    end
+
+    it "returns nil with no params and no communicator" do
+      expect(described_class.for(params: nil, communicator: nil)).to be_nil
+      expect(described_class.for(params: {})).to be_nil
+    end
+
+    it "builds entirely from the communicator's stored details" do
+      profile = described_class.for(communicator: communicator)
+      expect(profile.aac_level).to eq("emerging")
+      expect(profile.age_band).to eq("4-6")
+      expect(profile.vocab_type).to eq("core")
+    end
+
+    it "lets explicit params override stored values, field by field" do
+      profile = described_class.for(params: { "aac_level" => "proficient" }, communicator: communicator)
+      expect(profile.aac_level).to eq("proficient") # overridden
+      expect(profile.age_band).to eq("4-6")         # stored value kept
+      expect(profile.vocab_type).to eq("core")      # stored value kept
+    end
+
+    it "falls back to stored values when a param is blank" do
+      profile = described_class.for(params: { "aac_level" => "" }, communicator: communicator)
+      expect(profile.aac_level).to eq("emerging")
+    end
+
+    it "reads a stored age from details" do
+      comm = FactoryBot.build(:child_account, details: { "age" => 5 })
+      profile = described_class.for(communicator: comm)
+      expect(profile.age).to eq(5)
+      expect(profile.age_band).to eq("4-6")
+    end
+
+    it "returns nil when the communicator has no usable profile fields" do
+      comm = FactoryBot.build(:child_account, details: { "interests" => ["trains"] })
+      expect(described_class.for(communicator: comm)).to be_nil
+    end
+  end
+
   describe "normalization" do
     it "derives an age band from a raw age" do
       expect(described_class.new(age: 4).age_band).to eq("4-6")

--- a/spec/sidekiq/generate_board_job_spec.rb
+++ b/spec/sidekiq/generate_board_job_spec.rb
@@ -106,6 +106,28 @@ RSpec.describe GenerateBoardJob, type: :job do
         },
       )
     end
+
+    it "merges a stored communicator profile under explicit profile params (communicator_id)" do
+      communicator = create(:child_account, user: user,
+                                            details: { "aac_level" => "emerging", "age_band" => "4-6" })
+      expect(board).to receive(:get_words_for_scenario) do |_topic, _age_range, _word_count, profile:|
+        expect(profile.aac_level).to eq("proficient") # explicit param wins
+        expect(profile.age_band).to eq("4-6")         # stored field fills the gap
+        ["hi"]
+      end
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+
+      described_class.new.perform(
+        board.id,
+        "scenario",
+        {
+          "topic" => "doctor visit",
+          "word_count" => 20,
+          "profile" => { "aac_level" => "proficient" },
+          "communicator_id" => communicator.id,
+        },
+      )
+    end
   end
 
   describe "default creation with both seed words and a topic" do


### PR DESCRIPTION
…ation

Phase 1 of the board-builder next-phase handoff. AAC personalization fields (aac_level, vocab_type, age_band) now persist on child_accounts.details (jsonb, same pattern as details.interests — no migration):

- ChildAccount: typed accessors over details, normalization (downcase/strip, blank clears), and validation against CommunicatorProfile's enums on every save path — including the wholesale details= assignment in the update controller. Exposed top-level in api_view/vendor_api_view next to details.
- CommunicatorProfile.for(params:, communicator:): merge constructor — explicit params override stored fields field by field; nil when both sources are empty (no profile = unchanged behavior).
- boards#words / boards#additional_words / GenerateBoardJob accept an optional communicator_id, always scoped to current_user.communicator_accounts (ignored when not owned; the job receives a pre-validated id via options).
- board_builder#templates: optional communicator_id yields a server-side recommended_template (core-60 for young/emerging, else core-84, only when seeded) + recommendation_reason.

All new params optional and backward-compatible; no ENV vars, no migrations. Personalization reaches AI word-suggestion prompts and the template recommendation only — the deterministic build path is unchanged.