### PR TITLE
feat(auth): email-only paid signup + billing portal for free accounts

### DIFF
--- a/.claude-notes/frictionless-paid-signup-handoff.md
+++ b/.claude-notes/frictionless-paid-signup-handoff.md
@@ -1,0 +1,147 @@
+# Handoff: Frictionless paid signup + billing portal for free accounts (backend)
+
+**Date:** 2026-06-10 · **Status:** IMPLEMENTED 2026-06-11 (this PR) — frontend counterpart is now unblocked
+**Full plan:** `speakanyway/drafts/frictionless-paid-signup-plan.md` (this doc is self-contained; the plan adds context)
+**Counterpart:** `itty-bitty-frontend/.claude-notes/frictionless-paid-signup-handoff.md` (blocked on THIS repo's PR)
+**Issue:** itty-bitty-frontend#367
+
+## Implementation deviations (discovered while building — the contract is unchanged)
+
+1. **`needs_password` is `invited_to_sign_up?`, not `encrypted_password.blank?`.**
+   devise_invitable assigns a *random password* inside `invite!` (`_invite`,
+   models.rb:314-315), so `encrypted_password` is never blank for invited users.
+   The real "passwordless" signal is the pending invitation — `valid_password?`
+   returns nil until it's accepted, so no password works anyway. Same change in
+   `set_password`'s already-set gate: it rejects anyone NOT `invited_to_sign_up?`.
+   The API contract is unaffected (`needs_password: true` after email_signup,
+   self-clears after set_password / magic link).
+2. **The legacy `POST /api/set-password` (`API::UsersController#set_password`,
+   force-password-reset flow) had the same invited-user trap** — naive `save`
+   stored a password that could never sign in. Patched to route invited users
+   through `accept_invitation!` (Brittany approved including it).
+3. The basic/pro welcome mailers got the same magic-link fix as free
+   (Brittany approved including them).
+4. The welcome email is sent through the `User#send_welcome_email` wrapper (with
+   a `raw_invitation_token:` kwarg), not the mailer directly — preserving the
+   `welcome_email_sent` guard, AdminMailer notification, and Mailchimp upsert.
+
+## Decisions (already made — don't re-litigate)
+
+- **Email-only signup** for paid-intent visitors: they type just an email, get a passwordless account via `User.invite!`, are signed in immediately, and proceed to Stripe Checkout. Name/password/confirmation are NOT collected.
+- Password is set later: optional prompt on the frontend's `/billing/success` page (new authenticated endpoint below) or via the welcome email's magic link.
+- **Lazy** Stripe-customer creation at the billing-portal endpoint — no backfill task.
+- Default-on, no feature flag. Free signups, partner/demo/myspeak variants, RevenueCat/IAP, and the 14-day no-card reverse trial are all unchanged.
+- This PR ships independently: the new endpoints are inert until the frontend calls them.
+
+## Current state
+
+- `app/controllers/api/v1/auths_controller.rb#sign_up` (lines 6-49): requires email+password+confirmation; creates a Stripe customer unless `platform` is ios/android (lines 21-26); partner_pro special-casing; sends `welcome_free_email` + Mailchimp `welcome` journey + `sign_up` event; renders `{ token: user.authentication_token, user: user.api_view }`.
+- `User` has Devise `:invitable` (among others). `User.invite!(email:, skip_invitation: true)` is a proven pattern — 3 call sites: `app/controllers/api/webhooks_controller.rb#handle_customer_created` (~line 118), `User.create_from_invitation` (user.rb:411), and user.rb:~372. `invite!` saves with `validate: false` (`config.validate_on_invite` unset in `config/initializers/devise.rb`), and runs `before_create :setup_new_user_free_plan`, generates `authentication_token`, and fires the `after_create` credit grant (`CreditService.ensure_initial_grant!`) — so an invited user has a usable token, free plan, and credits. devise_invitable does NOT override `active_for_authentication?`, so `sign_in user` works on a pending-invite user.
+- `User.create_stripe_customer(email)` — user.rb:547.
+- `reset_password_invite` (auths_controller.rb:95-117) already accepts `invitation_token` + password via `accept_invitation!` — this backs the frontend's existing `/welcome/token/:token` route. Don't change it.
+- `forgot_password` works for passwordless users too: devise_invitable's `clear_reset_password_token` override auto-accepts a valid invitation after a password reset, and invitations never expire (`invite_for` unset).
+- Billing portal: `app/controllers/api/subscriptions_controller.rb#billing_portal` (lines 11-18) passes `current_user.stripe_customer_id` blindly with no rescue.
+- Checkout: `app/controllers/api/stripe/checkout_sessions_controller.rb` — private `ensure_customer!` at lines 227-232 lazily creates a customer; line 131 sets `paid_plan_type` (checkout owns that — email_signup must NOT).
+
+### Known bugs being fixed here
+
+1. **(High — plan depends on it) Dead welcome-email magic link.** `UserMailer#welcome_free_email` (`app/mailers/user_mailer.rb:55-76`) branches on `@user.raw_invitation_token`, but all callers use `deliver_later`; ActiveJob round-trips the User through GlobalID, so the virtual attribute is always nil → the `/welcome/token/<token>` link NEVER renders; everyone gets the `/users/sign-in` fallback. (Same latent bug in `welcome_basic_email`/`welcome_pro_email` — out of scope, leave them.)
+2. **devise_invitable `valid_password?` trap** (gem 2.0.11, verified in vendored source): while `invitation_token` is present, `valid_password?` returns nil. A naive `current_user.update(password:)` stores a password the user can never sign in with. Set-password MUST route through `accept_invitation!`.
+3. **`billing_portal` 500s** on nil `stripe_customer_id` or any `Stripe::StripeError`.
+4. **`handle_customer_created` re-invite race** (`webhooks_controller.rb:113-127`): looks up by `stripe_customer_id` only, then `User.invite!(email:)`. When email_signup creates the Stripe customer, the `customer.created` webhook can race the `stripe_customer_id` save; `invite!` on an existing pending-invite user RE-invites — regenerating `invitation_token` and invalidating the magic link just emailed.
+
+## Work items
+
+### 1. `POST /api/v1/users/email_signup`
+
+`config/routes.rb` (next to `post "users", to: "auths#sign_up"`, ~line 403):
+
+```ruby
+post "users/email_signup", to: "auths#email_signup"
+```
+
+`auths_controller.rb`: add `:email_signup` to the `skip_before_action :authenticate_token!` list (line 4). Implementation:
+
+1. `email = params[:email].to_s.strip.downcase`. Reject blank or `!Devise.email_regexp.match?(email)` → 422 (invite! skips validations, so format must be checked here).
+2. Duplicate: `User.exists?(email: email)` → 422 `{ error: "Email has already been taken", error_code: "email_taken" }` (the `error_code` is the frontend's contract — keep it exact). Also `rescue ActiveRecord::RecordNotUnique` around the create, rendering the same body (DB has a unique index).
+3. `user = User.invite!(email: email, skip_invitation: true)`; capture `raw = user.raw_invitation_token` immediately (in-memory only — never render it to the client).
+4. Stripe customer with the same platform gate as `sign_up` lines 21-26: skip when `params[:platform]` is `"ios"`/`"android"`, else `user.update(stripe_customer_id: User.create_stripe_customer(user.email))`.
+5. Mirror `sign_up`'s bookkeeping: `sign_in user`; `user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)`; `user.ensure_minimum_communicator_slot!`.
+6. Emails/CRM (guarded by `user.should_send_welcome_email?` like sign_up): `welcome_free_email` **passing `raw`** (see item 2), Mailchimp `welcome` journey + `sign_up` event:
+   ```ruby
+   MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "welcome" })
+   MailchimpEventJob.perform_async(user.id, "sign_up")
+   ```
+7. Render `{ token: user.authentication_token, user: user.api_view }` — identical envelope to `sign_up`.
+8. Do NOT set `paid_plan_type` (checkout_sessions#create line 131 owns it). No partner_pro/myspeak handling — this endpoint serves the paid-intent path only.
+
+### 2. Fix the mailer magic link (bug 1)
+
+`app/mailers/user_mailer.rb`: change to `welcome_free_email(user, raw_invitation_token = nil)`; prefer the argument when present (build `/welcome/token/#{raw_invitation_token}` link), keep the existing nil fallback to `/users/sign-in`. A String arg survives ActiveJob serialization, unlike the virtual attr. Existing callers (`user.rb:841`, `user.rb:893`) pass nothing → behavior unchanged. Delete the now-pointless `User.find(user.id)` reload and the dead `raw_invitation_token` branch logging. Check how `send_welcome_email` (user.rb:~841/893) wraps the mailer — pass the token through whichever seam is cleanest (an optional arg on the wrapper is fine), preserving the `should_send_welcome_email?` / `settings["welcome_email_sent"]` guard.
+
+### 3. `POST /api/v1/users/set_password` (authenticated)
+
+`config/routes.rb`: `post "users/set_password", to: "auths#set_password"` — do NOT add to `skip_before_action`, so `authenticate_token!` guards it.
+
+```ruby
+def set_password
+  if current_user.encrypted_password.present?
+    render json: { error: "Password already set", error_code: "password_already_set" }, status: :unprocessable_entity
+    return
+  end
+  current_user.password = params[:password]
+  current_user.password_confirmation = params[:password_confirmation]
+  saved = current_user.invited_to_sign_up? ? current_user.accept_invitation! : current_user.save
+  if saved && current_user.errors.empty?
+    render json: { user: current_user.api_view }
+  else
+    render json: { error: current_user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+  end
+end
+```
+
+The `accept_invitation!` call is load-bearing (bug 2): it clears `invitation_token`, sets `invitation_accepted_at`, and runs validations (length/confirmation). Verify the exact return semantics of `accept_invitation!` in the vendored gem and adjust the success check accordingly.
+
+### 4. `needs_password` on `api_view`
+
+`app/models/user.rb` `api_view` hash (~line 1488): add `needs_password: encrypted_password.blank?`. Drives the frontend's success-page prompt; self-clears after set_password.
+
+### 5. Billing portal: lazy customer + rescue (bug 3)
+
+- New `User#ensure_stripe_customer!` next to `create_stripe_customer` (user.rb:547):
+  ```ruby
+  def ensure_stripe_customer!
+    return stripe_customer_id if stripe_customer_id.present?
+    update!(stripe_customer_id: User.create_stripe_customer(email))
+    stripe_customer_id
+  end
+  ```
+- Delegate the checkout controller's private `ensure_customer!` (checkout_sessions_controller.rb:227-232) to it — two callers, one implementation.
+- `subscriptions_controller.rb#billing_portal`: call `current_user.ensure_stripe_customer!` first; pass `configuration: ENV["STRIPE_PORTAL_CONFIG_ID"]` only when that env is present; wrap in `rescue Stripe::StripeError` → log + 400 `{ error: "Failed to create billing portal session" }` (don't leak the Stripe message — repo rule: no internal errors in API responses).
+
+### 6. Webhook re-invite race fix (bug 4)
+
+`webhooks_controller.rb#handle_customer_created`: before `User.invite!`, also try `User.find_by(email: customer.email&.downcase)`; invite only if BOTH the customer-id and email lookups miss.
+
+## Testing
+
+Patterns: `spec/requests/api/auth_spec.rb` (auth flows), `spec/requests/api/stripe/checkout_sessions_spec.rb` (Stripe stubbing). FactoryBot.build over create where possible. Run `bundle exec rspec` — zero failures before PR.
+
+| Spec | Cases |
+|---|---|
+| `spec/requests/api/v1/email_signup_spec.rb` (new) | passwordless user created (`encrypted_password` blank, `invitation_token` present, plan_type free, initial credits granted); response has `token` + `user`; Stripe customer created+persisted; skipped for `platform=ios`/`android`; `welcome_free_email` enqueued WITH a raw-token arg; Mailchimp journey + sign_up jobs enqueued; duplicate email → 422 `email_taken`; `RecordNotUnique` race → 422 `email_taken`; invalid format → 422 |
+| set_password spec | 401 unauthenticated; success → password works (`User.valid_credentials?(email, pw)` returns the user — THE regression guard for the `valid_password?` trap), `invitation_accepted_at` set, `invitation_token` nil; mismatch/short password → 422 AND user still passwordless+invited; existing password → 422 `password_already_set` |
+| billing portal spec (new) | existing customer → session URL, no `Stripe::Customer.create`; nil customer → created once, id persisted, session created; `Stripe::InvalidRequestError` → 400 not 500; `STRIPE_PORTAL_CONFIG_ID` set → passed as `configuration:` |
+| mailer spec | `welcome_free_email(user, raw)` body contains `/welcome/token/<raw>`; without arg → `/users/sign-in` (pins current behavior) |
+| webhook spec | `customer.created` whose email matches an existing user does NOT regenerate `invitation_token` |
+
+## Deploy notes
+
+- No migrations. No required ENV. Optional: `STRIPE_PORTAL_CONFIG_ID` (Hatchbox, prod + staging) if a dedicated portal config is wanted — default unset uses the dashboard default config.
+- **Stripe dashboard prerequisite (manual, Brittany):** save a Customer-portal default configuration in BOTH test and live mode — invoice history ON, customer info update ON, payment-method update ON; don't regress paid users' cancel/update-subscription settings (shared portal). Test mode likely has no default config saved → `BillingPortal::Session.create` errors there until saved once. Document the checklist in `docs/stripe-setup.md`.
+- Ships independently of the frontend; deploy staging → prod whenever green.
+- `CHANGELOG.md` entry (user-facing: billing portal for free accounts; email-only signup API).
+
+## Git rules (Brittany's)
+
+Branch off origin/main in a worktree. Never push to main or merge PRs — open the PR and stop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Email-only signup API + billing portal for free accounts (frictionless paid signup)
+- `POST /api/v1/users/email_signup`: paid-intent visitors create an account with
+  just an email (passwordless via invitation), get signed in immediately, and
+  proceed to Stripe Checkout. Duplicate emails return 422 `email_taken`.
+- `POST /api/v1/users/set_password` (authenticated): sets the initial password on
+  a passwordless account, routed through `accept_invitation!` so the password
+  actually works (devise_invitable ignores `valid_password?` while an invitation
+  is pending). The legacy `POST /api/set-password` endpoint got the same fix.
+- `user.api_view` now exposes `needs_password` (pending-invite accounts), driving
+  the frontend's post-checkout "set a password" prompt.
+- `POST /api/subscriptions/billing_portal` now works for accounts with no Stripe
+  customer (lazily creates one) and returns 400 with a generic message on Stripe
+  errors instead of 500. Optional `STRIPE_PORTAL_CONFIG_ID` env pins a dedicated
+  portal configuration.
+
+### Fixed — Welcome email magic link never rendered
+- `UserMailer.welcome_free_email` / `welcome_basic_email` / `welcome_pro_email`
+  always fell back to the `/users/sign-in` link: the raw invitation token is a
+  virtual attribute that doesn't survive `deliver_later`'s GlobalID round-trip.
+  The token now travels as an explicit argument, so invited users get the
+  `/welcome/token/<token>` one-click sign-in link.
+- The `customer.created` Stripe webhook now matches existing users by email
+  before inviting, so it can no longer rotate a just-issued invitation token
+  (which invalidated the magic link emailed seconds earlier).
+
 ### Changed — Demo/internal accounts receive Mailchimp journey emails again (temporary)
 - Reverted #297 for now: the `user.demo_user?` guards in `MailchimpEventJob`,
   `MailchimpTrialWrapJob`, and the cohort-sweep jobs are removed, so demo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,41 @@ the non-active→active transition in the upsert; guarded so renewals don't
 double-count). Primary A/B metric is **net paid users per 100 signups**, not
 trial→paid rate.
 
+### Email-only (passwordless) signup — paid-intent path
+
+`POST /api/v1/users/email_signup` (itty-bitty-frontend#367): a paid-intent
+visitor types just an email → passwordless account via
+`User.invite!(skip_invitation: true)` → signed in (same `{ token, user }`
+envelope as `sign_up`) → frontend proceeds to Stripe Checkout. Free/partner/
+demo/myspeak signups keep using `sign_up`. Key invariants:
+
+- **"Passwordless" = pending invitation, NOT blank `encrypted_password`.**
+  devise_invitable assigns a random password inside `invite!`; what makes the
+  account passwordless is that `valid_password?` returns nil while
+  `invitation_token` is present. `user.api_view`'s `needs_password` flag is
+  `invited_to_sign_up?` for this reason.
+- **Setting the initial password must go through `accept_invitation!`** — a
+  naive `update(password:)` on an invited user stores a password that can
+  never sign in. Both `POST /api/v1/users/set_password` (new, 422
+  `password_already_set` for non-invited users) and the legacy
+  `POST /api/set-password` honor this.
+- **Welcome-email magic link:** the raw invitation token must be passed as an
+  explicit String argument down the
+  `send_welcome_email(raw_invitation_token:)` → `UserMailer.welcome_*_email`
+  chain — the virtual attr on User is nil after `deliver_later`'s GlobalID
+  round-trip (this bug made the `/welcome/token/` link never render).
+- **`customer.created` webhook** matches existing users by email before
+  inviting, so it can't rotate a just-issued invitation token when the
+  webhook races email_signup's `stripe_customer_id` save.
+- `email_signup` never sets `paid_plan_type` (checkout owns it) and skips
+  Stripe-customer creation for `platform=ios/android`, like `sign_up`.
+- **Billing portal for everyone:** `POST /api/subscriptions/billing_portal`
+  lazily creates the Stripe customer via `User#ensure_stripe_customer!`
+  (shared with checkout's `ensure_customer!`) and rescues `Stripe::StripeError`
+  → 400 generic message. Requires a saved Customer-portal default config in
+  the Stripe dashboard (test + live) — see `docs/stripe-setup.md` §4b.
+  Optional `STRIPE_PORTAL_CONFIG_ID` pins a dedicated config.
+
 ### `paid_plan?` semantics
 
 `User#paid_plan?` is the single gate for paid-tier checks. It considers

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -225,10 +225,7 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
   private
 
   def ensure_customer!
-    return if current_user.stripe_customer_id.present?
-
-    customer = Stripe::Customer.create(email: current_user.email)
-    current_user.update!(stripe_customer_id: customer.id)
+    current_user.ensure_stripe_customer!
   end
 
   # Prefer the request's Origin (then Referer) when it points at a trusted

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -9,12 +9,19 @@ class API::SubscriptionsController < API::ApplicationController
   end
 
   def billing_portal
-    # Create a billing portal
-    session = Stripe::BillingPortal::Session.create({
-      customer: current_user.stripe_customer_id,
+    # Free accounts (mobile signups, legacy users) may not have a Stripe
+    # customer yet — create one lazily so the portal works for everyone.
+    customer_id = current_user.ensure_stripe_customer!
+    portal_params = {
+      customer: customer_id,
       return_url: "#{DOMAIN}/dashboard",
-    })
+    }
+    portal_params[:configuration] = ENV["STRIPE_PORTAL_CONFIG_ID"] if ENV["STRIPE_PORTAL_CONFIG_ID"].present?
+    session = Stripe::BillingPortal::Session.create(portal_params)
     render json: { url: session&.url }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "billing_portal: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to create billing portal session" }, status: :bad_request
   end
 
   def create_customer_session

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -46,7 +46,11 @@ class API::UsersController < API::ApplicationController
     @user.password = password
     @user.password_confirmation = password_confirmation
     @user.force_password_reset = false
-    if @user.save
+    # Invited accounts must accept the invitation here: devise_invitable's
+    # valid_password? returns nil while invitation_token is present, so a
+    # plain save would store a password the user can never sign in with.
+    saved = @user.invited_to_sign_up? ? @user.accept_invitation! : @user.save
+    if saved && @user.errors.empty?
       render json: { success: true }, status: :ok
     else
       render json: @user.errors, status: :unprocessable_entity

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -1,7 +1,7 @@
 module API
   module V1
     class AuthsController < ApplicationController
-      skip_before_action :authenticate_token!, only: [:create, :sign_up, :current, :destroy, :forgot_password, :reset_password, :reset_password_invite]
+      skip_before_action :authenticate_token!, only: [:create, :sign_up, :email_signup, :current, :destroy, :forgot_password, :reset_password, :reset_password_invite]
 
       def sign_up
         name = params["name"] || (params["user"] && params["user"]["name"]) || ""
@@ -45,6 +45,80 @@ module API
           render json: { token: user.authentication_token, user: user.api_view }
         else
           render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        end
+      end
+
+      # Email-only signup for the paid-intent path (frictionless paid signup,
+      # itty-bitty-frontend#367). Creates a passwordless account via invite!
+      # and signs the user in; password is set later via set_password or the
+      # welcome email's magic link. Free/partner/demo/myspeak signups keep
+      # using sign_up.
+      def email_signup
+        email = params[:email].to_s.strip.downcase
+        platform = params["platform"] || ""
+
+        # invite! saves with validate: false, so email format must be checked here.
+        unless Devise.email_regexp.match?(email)
+          render json: { error: "A valid email is required" }, status: :unprocessable_entity
+          return
+        end
+
+        if User.exists?(email: email)
+          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_entity
+          return
+        end
+
+        begin
+          user = User.invite!(email: email, skip_invitation: true)
+        rescue ActiveRecord::RecordNotUnique
+          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_entity
+          return
+        end
+        unless user.persisted?
+          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+          return
+        end
+        # The raw token only exists in memory on this instance — capture it for
+        # the welcome email's magic link. Never rendered to the client.
+        raw_invitation_token = user.raw_invitation_token
+
+        if platform != "ios" && platform != "android"
+          user.update(stripe_customer_id: User.create_stripe_customer(user.email))
+        else
+          Rails.logger.warn "Mobile platform email signup for user #{user.email}, skipping Stripe customer creation for platform: #{platform}"
+        end
+
+        sign_in user
+        user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
+        user.ensure_minimum_communicator_slot!
+        if user.should_send_welcome_email?
+          user.send_welcome_email("free", nil, raw_invitation_token: raw_invitation_token)
+          MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "welcome" })
+        end
+        MailchimpEventJob.perform_async(user.id, "sign_up")
+        render json: { token: user.authentication_token, user: user.api_view }
+      end
+
+      # Sets the initial password on a passwordless (invited) account.
+      # Authenticated — not in the skip_before_action list. Must go through
+      # accept_invitation! while an invitation is pending: devise_invitable's
+      # valid_password? returns nil while invitation_token is present, so a
+      # plain update would store a password the user can never sign in with.
+      def set_password
+        # Only pending invites qualify — anyone else already has a working
+        # password (devise_invitable assigns a random one on invite!, so
+        # encrypted_password.present? can't tell the two apart).
+        unless current_user.invited_to_sign_up?
+          render json: { error: "Password already set", error_code: "password_already_set" }, status: :unprocessable_entity
+          return
+        end
+        current_user.password = params[:password]
+        current_user.password_confirmation = params[:password_confirmation]
+        saved = current_user.accept_invitation!
+        if saved && current_user.errors.empty?
+          render json: { user: current_user.api_view }
+        else
+          render json: { error: current_user.errors.full_messages.join(", ") }, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -113,6 +113,11 @@ class API::WebhooksController < API::ApplicationController
   def handle_customer_created(customer)
     stripe_customer_id = customer.id
     user = User.find_by(stripe_customer_id: stripe_customer_id)
+    # Also match by email before inviting: when email_signup creates the
+    # Stripe customer, this webhook can race the stripe_customer_id save, and
+    # invite! on the existing pending-invite user would rotate the
+    # invitation_token — invalidating the magic link just emailed.
+    user ||= User.find_by(email: customer.email&.downcase) if customer.email.present?
     if !user && customer.email.present?
       Rails.logger.error "[StripeWebhook] customer.created: no user found for customer #{stripe_customer_id} - Creating one"
       user = User.invite!(email: customer.email, skip_invitation: true)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -52,66 +52,33 @@ class UserMailer < BaseMailer
     end
   end
 
-  def welcome_free_email(user)
+  # raw_invitation_token must be passed explicitly as a String: the virtual
+  # attr on @user is always nil here because deliver_later round-trips the
+  # User through GlobalID. Without the arg, links fall back to /users/sign-in.
+  def welcome_free_email(user, raw_invitation_token = nil)
     @user = user
     @user_name = @user.name
-    @login_link = ENV["FRONT_END_URL"] || "http://localhost:8100"
-    if @user.raw_invitation_token.nil?
-      @user = User.find(user.id) # Reload user to ensure raw_invitation_token is up-to-date
-      @login_link += "/users/sign-in"
-    else
-      Rails.logger.info "User #{@user.id} already has a raw_invitation_token, using it for welcome link"
-      token = @user.raw_invitation_token
-      Rails.logger.info "User #{@user.id} has raw_invitation_token: #{token}"
-      @login_link += "/welcome/token/#{token}"
-    end
-
-    encoded_email = ERB::Util.url_encode(@user.email)
-    @login_link += "?email=#{encoded_email}"
+    @login_link = welcome_login_link(user, raw_invitation_token)
     Rails.logger.info "Sending welcome free email to #{@user.email} with login link: #{@login_link}"
     with_user_locale(@user) do
       mail(to: @user.email, subject: I18n.t("user_mailer.welcome_free_email.subject"))
     end
   end
 
-  def welcome_basic_email(user)
+  def welcome_basic_email(user, raw_invitation_token = nil)
     @user = user
     @user_name = @user.name
-    @login_link = ENV["FRONT_END_URL"] || "http://localhost:8100"
-    if @user.raw_invitation_token.nil?
-      @user = User.find(user.id) # Reload user to ensure raw_invitation_token is up-to-date
-      @login_link += "/users/sign-in"
-    else
-      Rails.logger.info "User #{@user.id} already has a raw_invitation_token, using it for welcome link"
-      token = @user.raw_invitation_token
-      Rails.logger.info "User #{@user.id} has raw_invitation_token: #{token}"
-      @login_link += "/welcome/token/#{token}"
-    end
-
-    encoded_email = ERB::Util.url_encode(@user.email)
-    @login_link += "?email=#{encoded_email}"
+    @login_link = welcome_login_link(user, raw_invitation_token)
     Rails.logger.info "Sending welcome basic email to #{@user.email} with login link: #{@login_link}"
     with_user_locale(@user) do
       mail(to: @user.email, subject: I18n.t("user_mailer.welcome_basic_email.subject"))
     end
   end
 
-  def welcome_pro_email(user)
+  def welcome_pro_email(user, raw_invitation_token = nil)
     @user = user
     @user_name = @user.name
-    @login_link = ENV["FRONT_END_URL"] || "http://localhost:8100"
-    if @user.raw_invitation_token.nil?
-      @user = User.find(user.id) # Reload user to ensure raw_invitation_token is up-to-date
-      @login_link += "/users/sign-in"
-    else
-      Rails.logger.info "User #{@user.id} already has a raw_invitation_token, using it for welcome link"
-      token = @user.raw_invitation_token
-      Rails.logger.info "User #{@user.id} has raw_invitation_token: #{token}"
-      @login_link += "/welcome/token/#{token}"
-    end
-
-    encoded_email = ERB::Util.url_encode(@user.email)
-    @login_link += "?email=#{encoded_email}"
+    @login_link = welcome_login_link(user, raw_invitation_token)
     Rails.logger.info "Sending welcome pro email to #{@user.email} with login link: #{@login_link}"
     with_user_locale(@user) do
       mail(to: @user.email, subject: I18n.t("user_mailer.welcome_pro_email.subject"))
@@ -239,5 +206,13 @@ class UserMailer < BaseMailer
         subject: I18n.t("user_mailer.message_notification_email.subject", sender_name: @sender.name),
       )
     end
+  end
+
+  private
+
+  def welcome_login_link(user, raw_invitation_token)
+    link = ENV["FRONT_END_URL"] || "http://localhost:8100"
+    link += raw_invitation_token.present? ? "/welcome/token/#{raw_invitation_token}" : "/users/sign-in"
+    link + "?email=#{ERB::Util.url_encode(user.email)}"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -554,6 +554,15 @@ class User < ApplicationRecord
     result["id"]
   end
 
+  # Lazily create the Stripe customer on first billing touch. Mobile signups
+  # and legacy accounts have no customer until they hit checkout or the
+  # billing portal.
+  def ensure_stripe_customer!
+    return stripe_customer_id if stripe_customer_id.present?
+    update!(stripe_customer_id: User.create_stripe_customer(email))
+    stripe_customer_id
+  end
+
   def all_required_settings
     %w[wait_to_speak disable_audit_logging enable_image_display enable_text_display show_labels show_tutorial]
   end
@@ -836,35 +845,38 @@ class User < ApplicationRecord
     end
   end
 
-  def send_welcome_email_free
+  def send_welcome_email_free(raw_invitation_token = nil)
     Rails.logger.info "Sending free welcome email to #{email}"
-    UserMailer.welcome_free_email(self).deliver_later
+    UserMailer.welcome_free_email(self, raw_invitation_token).deliver_later
   end
 
-  def send_welcome_email_basic
+  def send_welcome_email_basic(raw_invitation_token = nil)
     Rails.logger.info "Sending basic welcome email to #{email}"
-    UserMailer.welcome_basic_email(self).deliver_later
+    UserMailer.welcome_basic_email(self, raw_invitation_token).deliver_later
   end
 
-  def send_welcome_email_pro
+  def send_welcome_email_pro(raw_invitation_token = nil)
     Rails.logger.info "Sending pro welcome email to #{email}"
-    UserMailer.welcome_pro_email(self).deliver_later
+    UserMailer.welcome_pro_email(self, raw_invitation_token).deliver_later
   end
 
-  def send_welcome_email(plan_nickname = nil, slug = nil)
+  # raw_invitation_token: pass the in-memory token from invite! so the welcome
+  # email can render the /welcome/token/ magic link — the virtual attr doesn't
+  # survive deliver_later's GlobalID round-trip, so it must travel as a String.
+  def send_welcome_email(plan_nickname = nil, slug = nil, raw_invitation_token: nil)
     unless plan_nickname
       plan_nickname = settings["plan_nickname"] || plan_type
     end
     begin
       if plan_nickname.nil? || plan_nickname.include?("free")
-        send_welcome_email_free
+        send_welcome_email_free(raw_invitation_token)
       elsif plan_nickname.include?("basic")
-        send_welcome_email_basic
+        send_welcome_email_basic(raw_invitation_token)
       elsif plan_nickname.include?("pro") || plan_nickname.include?("plus")
-        send_welcome_email_pro
+        send_welcome_email_pro(raw_invitation_token)
       else
         Rails.logger.error "Unknown plan nickname: #{plan_nickname}, sending free welcome email"
-        send_welcome_email_free
+        send_welcome_email_free(raw_invitation_token)
       end
       self.settings["welcome_email_sent"] = true
       self.save
@@ -1488,6 +1500,12 @@ class User < ApplicationRecord
     {
       id: id,
       organization_id: organization_id,
+      # Pending-invite accounts (email_signup, webhook-invited) — drives the
+      # frontend's post-checkout "set a password" prompt. Not
+      # encrypted_password.blank?: devise_invitable assigns a random password
+      # on invite!, but valid_password? is nil until the invitation is
+      # accepted, so a pending invite is effectively passwordless.
+      needs_password: invited_to_sign_up?,
       profile: profile&.user_api_view,
       delete_account_token: delete_account_token,
       public_page_url: public_page_url,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,8 @@ Rails.application.routes.draw do
       get "/child_accounts/current", to: "child_auths#current"
       get "users/current", to: "auths#current"
       post "users", to: "auths#sign_up"
+      post "users/email_signup", to: "auths#email_signup"
+      post "users/set_password", to: "auths#set_password"
       post "users/sign_in", to: "auths#create"
       post "users/sign_out", to: "auths#destroy"
       post "login", to: "auths#create"

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -95,6 +95,27 @@ point at the staging marketing site).
 If you add a new trusted frontend host, update both the allowlist and
 this section.
 
+## 4b. Customer portal configuration (billing portal for free accounts)
+
+`POST /api/subscriptions/billing_portal` works for **every** account —
+free users included (the backend lazily creates a Stripe customer on
+first billing touch). `Stripe::BillingPortal::Session.create` requires a
+**default portal configuration** saved in the dashboard, in **both test
+and live mode** — a mode with no saved default errors until you save one
+once.
+
+Checklist (Settings → Billing → Customer portal, each mode):
+
+- Invoice history: **ON** (receipts are the main value for free users)
+- Customer information update: **ON**
+- Payment method update: **ON**
+- Don't regress paid users' cancel/update-subscription settings — the
+  portal config is shared by free and paid customers.
+
+Optional: a dedicated portal configuration can be pinned via
+`STRIPE_PORTAL_CONFIG_ID` (Hatchbox env). Default unset — the dashboard
+default config is used.
+
 ## 5. Staging-specific setup (Stripe Sandbox)
 
 Staging has its own webhook endpoint pointing at the staging app. To set

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body.decoded).to include("Plan Gratis")
       expect(mail.html_part.body.decoded).to include("Inicia sesión y empieza a explorar")
     end
+
+    # The raw invitation token must travel as an explicit argument — the
+    # virtual attr on the user is nil after deliver_later's GlobalID
+    # round-trip, which is why the magic link never rendered before.
+    it "links to the magic-link welcome page when a raw invitation token is passed" do
+      use_locale(user, "en-US")
+      mail = described_class.welcome_free_email(user, "RAWTOKEN123").deliver_now
+      expect(mail.html_part.body.decoded).to include("/welcome/token/RAWTOKEN123")
+    end
+
+    it "falls back to the sign-in link without a token (pins current behavior)" do
+      use_locale(user, "en-US")
+      mail = described_class.welcome_free_email(user).deliver_now
+      body = mail.html_part.body.decoded
+      expect(body).to include("/users/sign-in")
+      expect(body).not_to include("/welcome/token/")
+    end
   end
 
   describe "#welcome_basic_email" do

--- a/spec/models/user_mailer_dispatch_spec.rb
+++ b/spec/models/user_mailer_dispatch_spec.rb
@@ -10,22 +10,31 @@ RSpec.describe "User lifecycle mailers enqueue instead of delivering inline" do
 
   let(:user) { FactoryBot.create(:user) }
 
+  # The second arg is the raw invitation token (nil for normal signups) —
+  # it must travel as an explicit argument because the virtual attr doesn't
+  # survive deliver_later's GlobalID round-trip.
   it "enqueues the welcome (free) email" do
     expect {
       user.send_welcome_email_free
-    }.to have_enqueued_mail(UserMailer, :welcome_free_email).with(user)
+    }.to have_enqueued_mail(UserMailer, :welcome_free_email).with(user, nil)
   end
 
   it "enqueues the welcome (basic) email" do
     expect {
       user.send_welcome_email_basic
-    }.to have_enqueued_mail(UserMailer, :welcome_basic_email).with(user)
+    }.to have_enqueued_mail(UserMailer, :welcome_basic_email).with(user, nil)
   end
 
   it "enqueues the welcome (pro) email" do
     expect {
       user.send_welcome_email_pro
-    }.to have_enqueued_mail(UserMailer, :welcome_pro_email).with(user)
+    }.to have_enqueued_mail(UserMailer, :welcome_pro_email).with(user, nil)
+  end
+
+  it "threads the raw invitation token through send_welcome_email" do
+    expect {
+      user.send_welcome_email("free", nil, raw_invitation_token: "RAW123")
+    }.to have_enqueued_mail(UserMailer, :welcome_free_email).with(user, "RAW123")
   end
 
   it "enqueues the team invitation email from invite_to_team!" do

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -64,8 +64,10 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
     it "creates a Stripe customer when the user has none yet" do
       user.update!(stripe_customer_id: nil)
 
+      # ensure_customer! delegates to User.create_stripe_customer, which
+      # passes an options hash (not kwargs) — match accordingly.
       expect(Stripe::Customer).to receive(:create)
-        .with(email: user.email)
+        .with({ email: user.email })
         .and_return(OpenStruct.new(id: "cus_new_123"))
       expect(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://stripe.test/x"))
 

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
 
   it "creates a stripe customer if the user does not have one yet" do
     expect(user.stripe_customer_id).to be_blank
-    expect(Stripe::Customer).to receive(:create).with(email: user.email).and_return(OpenStruct.new(id: "cus_new"))
+    expect(Stripe::Customer).to receive(:create).with({ email: user.email }).and_return(OpenStruct.new(id: "cus_new"))
     expect(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://example/cs"))
 
     post "/api/stripe/checkout_sessions/topup",

--- a/spec/requests/api/subscriptions_billing_portal_spec.rb
+++ b/spec/requests/api/subscriptions_billing_portal_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+# Billing portal for everyone (frictionless paid signup work): lazy
+# Stripe-customer creation for accounts that don't have one yet, and a
+# rescue so Stripe failures return 400 instead of 500.
+RSpec.describe "POST /api/subscriptions/billing_portal", type: :request do
+  let(:portal_session) { OpenStruct.new(url: "https://billing.stripe.com/p/session_test") }
+
+  def do_post(user)
+    post "/api/subscriptions/billing_portal", headers: auth_headers(user)
+  end
+
+  context "when the user already has a Stripe customer" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+    it "creates a portal session without creating a customer" do
+      allow(User).to receive(:create_stripe_customer)
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["url"]).to eq(portal_session.url)
+      expect(captured[:customer]).to eq("cus_existing")
+      expect(User).not_to have_received(:create_stripe_customer)
+    end
+  end
+
+  context "when the user has no Stripe customer" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+    it "lazily creates one, persists it, and opens the portal" do
+      expect(User).to receive(:create_stripe_customer).with(user.email).once.and_return("cus_lazy")
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.stripe_customer_id).to eq("cus_lazy")
+      expect(captured[:customer]).to eq("cus_lazy")
+    end
+  end
+
+  context "when Stripe raises" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+    it "returns 400 with a generic message, not 500" do
+      allow(Stripe::BillingPortal::Session).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("No configuration provided", nil))
+
+      do_post(user)
+
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Failed to create billing portal session")
+      expect(body["error"]).not_to include("configuration")
+    end
+  end
+
+  context "with STRIPE_PORTAL_CONFIG_ID set" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+    around do |example|
+      ENV["STRIPE_PORTAL_CONFIG_ID"] = "bpc_test_config"
+      example.run
+    ensure
+      ENV.delete("STRIPE_PORTAL_CONFIG_ID")
+    end
+
+    it "passes it as configuration" do
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post(user)
+
+      expect(captured[:configuration]).to eq("bpc_test_config")
+    end
+  end
+end

--- a/spec/requests/api/v1/email_signup_spec.rb
+++ b/spec/requests/api/v1/email_signup_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+# Email-only signup for the paid-intent path (frictionless paid signup,
+# itty-bitty-frontend#367): one email field, passwordless account via
+# invite!, signed in immediately, straight to checkout.
+RSpec.describe "POST /api/v1/users/email_signup", type: :request do
+  before do
+    allow(User).to receive(:create_stripe_customer).and_return("cus_email_signup")
+    allow(MailchimpEventJob).to receive(:perform_async)
+  end
+
+  def do_post(params)
+    post "/api/v1/users/email_signup", params: params
+  end
+
+  describe "happy path" do
+    it "creates a passwordless invited user on the free plan with initial credits" do
+      expect {
+        do_post(email: "buyer@example.com")
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      user = User.find_by(email: "buyer@example.com")
+      # devise_invitable assigns a random password on invite!, so "passwordless"
+      # means a pending invitation: no password works until it's accepted.
+      expect(user.invitation_token).to be_present
+      expect(user.invitation_accepted_at).to be_nil
+      expect(user.valid_password?("anything")).to be_falsey
+      expect(user.plan_type).to eq("free")
+      expect(user.plan_credits_balance.to_i).to be > 0
+    end
+
+    it "returns the same envelope as sign_up, with needs_password true" do
+      do_post(email: "buyer@example.com")
+
+      body = JSON.parse(response.body)
+      user = User.find_by(email: "buyer@example.com")
+      expect(body["token"]).to eq(user.authentication_token)
+      expect(body["user"]["id"]).to eq(user.id)
+      expect(body["user"]["needs_password"]).to eq(true)
+      expect(body).not_to have_key("raw_invitation_token")
+    end
+
+    it "normalizes the email" do
+      do_post(email: "  Buyer@Example.COM ")
+      expect(response).to have_http_status(:ok)
+      expect(User.find_by(email: "buyer@example.com")).to be_present
+    end
+
+    it "creates and persists a Stripe customer" do
+      do_post(email: "buyer@example.com")
+      expect(User).to have_received(:create_stripe_customer).with("buyer@example.com")
+      expect(User.find_by(email: "buyer@example.com").stripe_customer_id).to eq("cus_email_signup")
+    end
+
+    it "does not set paid_plan_type (checkout owns it)" do
+      do_post(email: "buyer@example.com")
+      expect(User.find_by(email: "buyer@example.com").paid_plan_type).to be_blank
+    end
+
+    %w[ios android].each do |platform|
+      it "skips Stripe customer creation for platform=#{platform}" do
+        do_post(email: "buyer@example.com", platform: platform)
+        expect(response).to have_http_status(:ok)
+        expect(User).not_to have_received(:create_stripe_customer)
+        expect(User.find_by(email: "buyer@example.com").stripe_customer_id).to be_nil
+      end
+    end
+
+    it "sends the welcome email with the raw invitation token (magic link)" do
+      mail = double(deliver_later: true)
+      captured_args = nil
+      allow(UserMailer).to receive(:welcome_free_email) do |*args|
+        captured_args = args
+        mail
+      end
+
+      do_post(email: "buyer@example.com")
+
+      expect(captured_args[0].email).to eq("buyer@example.com")
+      expect(captured_args[1]).to be_a(String)
+      expect(captured_args[1]).to be_present
+    end
+
+    it "enqueues the Mailchimp welcome journey and sign_up event" do
+      do_post(email: "buyer@example.com")
+      user = User.find_by(email: "buyer@example.com")
+      expect(MailchimpEventJob).to have_received(:perform_async)
+        .with(user.id, "journey", { "journey_key" => "welcome" })
+      expect(MailchimpEventJob).to have_received(:perform_async).with(user.id, "sign_up")
+    end
+  end
+
+  describe "duplicate email" do
+    let!(:existing) { FactoryBot.create(:user, email: "taken@example.com") }
+
+    it "returns 422 with the email_taken error_code" do
+      expect {
+        do_post(email: "taken@example.com")
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["error_code"]).to eq("email_taken")
+      expect(body["error"]).to eq("Email has already been taken")
+    end
+
+    it "returns the same 422 body when the unique index catches a race" do
+      allow(User).to receive(:exists?).and_return(false)
+      allow(User).to receive(:invite!).and_raise(ActiveRecord::RecordNotUnique)
+
+      do_post(email: "taken@example.com")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error_code"]).to eq("email_taken")
+    end
+  end
+
+  describe "invalid email" do
+    ["", "   ", "not-an-email", "two@at@signs"].each do |bad|
+      it "returns 422 for #{bad.inspect}" do
+        expect {
+          do_post(email: bad)
+        }.not_to change(User, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error"]).to be_present
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/set_password_spec.rb
+++ b/spec/requests/api/v1/set_password_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+# Setting the initial password on a passwordless (invited) account.
+# THE regression guard here: the password must actually authenticate
+# afterwards. devise_invitable's valid_password? returns nil while
+# invitation_token is present, so a naive update(password:) stores a
+# password the user can never sign in with — both endpoints must route
+# invited users through accept_invitation!.
+RSpec.describe "set password endpoints", type: :request do
+  let(:invited_user) { User.invite!(email: "invited@example.com", skip_invitation: true) }
+
+  describe "POST /api/v1/users/set_password" do
+    it "returns 401 when unauthenticated" do
+      post "/api/v1/users/set_password", params: { password: "newpassword1", password_confirmation: "newpassword1" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "for an invited passwordless user" do
+      it "sets a password that actually signs in, and accepts the invitation" do
+        post "/api/v1/users/set_password",
+          params: { password: "newpassword1", password_confirmation: "newpassword1" },
+          headers: auth_headers(invited_user)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["user"]["needs_password"]).to eq(false)
+
+        invited_user.reload
+        expect(invited_user.invitation_token).to be_nil
+        expect(invited_user.invitation_accepted_at).to be_present
+        expect(User.valid_credentials?("invited@example.com", "newpassword1")).to eq(invited_user)
+      end
+
+      it "returns 422 on confirmation mismatch and stays passwordless + invited" do
+        post "/api/v1/users/set_password",
+          params: { password: "newpassword1", password_confirmation: "different1" },
+          headers: auth_headers(invited_user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        invited_user.reload
+        expect(invited_user.invitation_token).to be_present
+        expect(User.valid_credentials?("invited@example.com", "newpassword1")).to be_nil
+      end
+
+      it "returns 422 on a too-short password and stays passwordless + invited" do
+        post "/api/v1/users/set_password",
+          params: { password: "x", password_confirmation: "x" },
+          headers: auth_headers(invited_user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        invited_user.reload
+        expect(invited_user.invitation_token).to be_present
+        expect(User.valid_credentials?("invited@example.com", "x")).to be_nil
+      end
+    end
+
+    context "for a user who already has a password" do
+      let(:user) { FactoryBot.create(:user, password: "password123") }
+
+      it "returns 422 password_already_set" do
+        post "/api/v1/users/set_password",
+          params: { password: "newpassword1", password_confirmation: "newpassword1" },
+          headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)["error_code"]).to eq("password_already_set")
+      end
+    end
+  end
+
+  # Legacy endpoint (force-password-reset flow) — patched for the same
+  # invited-user trap in this change.
+  describe "POST /api/set-password" do
+    it "sets a sign-in-able password for an invited user" do
+      post "/api/set-password",
+        params: { password: "newpassword1", password_confirmation: "newpassword1" },
+        headers: auth_headers(invited_user)
+
+      expect(response).to have_http_status(:ok)
+      invited_user.reload
+      expect(invited_user.invitation_token).to be_nil
+      expect(User.valid_credentials?("invited@example.com", "newpassword1")).to eq(invited_user)
+    end
+
+    it "still works for a non-invited user changing their password" do
+      user = FactoryBot.create(:user, password: "password123")
+      post "/api/set-password",
+        params: { password: "newpassword9", password_confirmation: "newpassword9" },
+        headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(User.valid_credentials?(user.email, "newpassword9")).to eq(user)
+    end
+  end
+end

--- a/spec/requests/api/webhooks_customer_created_spec.rb
+++ b/spec/requests/api/webhooks_customer_created_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+# customer.created handling. The email-match guard matters for email_signup:
+# the webhook can race the stripe_customer_id save, and a re-invite! on the
+# existing pending-invite user would rotate invitation_token — invalidating
+# the magic link just emailed.
+RSpec.describe "POST /api/webhooks (customer.created)", type: :request do
+  include StripeHelpers
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  context "when a user with that email already exists (id not yet persisted)" do
+    it "does not re-invite or rotate their invitation token" do
+      user = User.invite!(email: "racer@example.com", skip_invitation: true)
+      original_token = user.invitation_token
+      expect(original_token).to be_present
+
+      stub_event(OpenStruct.new(id: "cus_race", email: "racer@example.com"), type: "customer.created")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.invitation_token).to eq(original_token)
+    end
+  end
+
+  context "when no user matches by customer id or email" do
+    it "invites a new passwordless user" do
+      stub_event(OpenStruct.new(id: "cus_fresh", email: "fresh@example.com"), type: "customer.created")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.to change(User, :count).by(1)
+
+      user = User.find_by(email: "fresh@example.com")
+      expect(user.invitation_token).to be_present
+      expect(user.invitation_accepted_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the frictionless paid signup plan ([itty-bitty-frontend#367](https://github.com/brittanyjohns/itty-bitty-frontend/issues/367)). New endpoints are inert until the frontend PR ships; the frontend counterpart handoff is now unblocked.

**New API**
- `POST /api/v1/users/email_signup` — paid-intent visitors create an account with just an email (passwordless via `User.invite!`), get signed in immediately (same `{ token, user }` envelope as `sign_up`), and proceed to Stripe Checkout. 422 `email_taken` on duplicates (including a `RecordNotUnique` race guard); Stripe-customer creation skipped for `platform=ios/android`; never sets `paid_plan_type` (checkout owns it).
- `POST /api/v1/users/set_password` (authenticated) — sets the initial password via `accept_invitation!`. **Load-bearing:** devise_invitable's `valid_password?` returns nil while an invitation is pending, so a naive `update(password:)` stores a password that can never sign in. Returns 422 `password_already_set` for non-invited users.
- `user.api_view` now exposes `needs_password`.

**Bug fixes**
- **Welcome-email magic link never rendered** — the raw invitation token is a virtual attr that doesn't survive `deliver_later`'s GlobalID round-trip, so every welcome email fell back to `/users/sign-in`. The token now travels as an explicit String argument through `send_welcome_email(raw_invitation_token:)`. Fixed in free, basic, and pro mailers (Brittany approved widening past the handoff's free-only scope).
- **`customer.created` re-invite race** — the webhook now matches existing users by email before inviting, so it can't rotate a just-emailed invitation token.
- **`billing_portal` 500s** — lazily creates the Stripe customer (`User#ensure_stripe_customer!`, shared with checkout's `ensure_customer!`), passes `STRIPE_PORTAL_CONFIG_ID` as `configuration:` when set, rescues `Stripe::StripeError` → 400 with a generic message.
- **Legacy `POST /api/set-password` invited-user trap** — same naive-save bug as above, patched to route invited users through `accept_invitation!` (approved addition).

**Deviation from the handoff (contract unchanged):** `needs_password` is `invited_to_sign_up?`, not `encrypted_password.blank?` — devise_invitable assigns a *random password* inside `invite!` (`_invite`, models.rb:314), so `encrypted_password` is never blank for invited users. The pending invitation is the real passwordless signal. Documented in the handoff doc + CLAUDE.md.

**Docs:** CHANGELOG entry, CLAUDE.md section, `docs/stripe-setup.md` §4b (Customer-portal config checklist — already saved in test + live per Brittany), handoff doc committed with status + deviations.

**Deploy notes:** no migrations, no required ENV. Optional `STRIPE_PORTAL_CONFIG_ID` (unset = dashboard default config, the chosen setup).

## Test plan

- New specs: `spec/requests/api/v1/email_signup_spec.rb`, `spec/requests/api/v1/set_password_spec.rb` (covers both endpoints; the key regression guard is `User.valid_credentials?` actually returning the user after set_password), `spec/requests/api/subscriptions_billing_portal_spec.rb`, `spec/requests/api/webhooks_customer_created_spec.rb`; extended `spec/mailers/user_mailer_spec.rb` (magic link with token, sign-in fallback without).
- Targeted suite run (auth, all Stripe checkout, all webhook specs, all new specs): **148 examples, 0 failures**.
- Two pre-existing checkout specs updated for the `ensure_customer!` delegation (kwargs→hash stub matching only; behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)