### PR TITLE
chore: remove PreToolUse rspec/rubocop hook from Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,18 @@
       "Bash(bin/rails runner *)",
       "Skill(claude-api)",
       "Skill(claude-api:*)",
-      "Bash(grep -v \"^$\")"
+      "Bash(grep -v \"^$\")",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(grep:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
     ],
     "additionalDirectories": [
       "/Users/brittanyjohns/.claude",
@@ -33,23 +44,6 @@
     ]
   },
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bundle exec rspec",
-            "statusMessage": "Running RSpec tests before commit..."
-          },
-          {
-            "type": "command",
-            "command": "bundle exec rubocop",
-            "statusMessage": "Running rubocop before commit..."
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Summary

The committed `.claude/settings.json` had a **PreToolUse hook with matcher `Bash`** that ran the full RSpec suite **and** Rubocop before *every* shell command Claude Code executed. Since reads like `ls`, `cat`, `rg`, and `find` are all Bash tool calls, every routine command was gated behind a complete test+lint run — adding minutes of latency and making sessions appear to hang (a single-file `rg` was taking 6+ minutes; the search itself runs in ~3ms).

Changes:
- **Removed** the `PreToolUse` hook entirely. Test/lint enforcement is already covered by PR review and the `bin/install-hooks` block-main pre-commit guard, so this was redundant.
- **Added** read-only commands to the allowlist so routine reads stop prompting for approval: `rg`, `find`, `ls`, `cat`, `grep`, `head`, `tail`, `wc`, `git status`, `git diff`, `git log`.
- **Unchanged:** all existing `allow` rules, `additionalDirectories`, and the `PostToolUse` hooks (Rubocop on edit, conditional `bundle install` on Gemfile change).

## Test plan

test-irrelevant — this only changes Claude Code tooling configuration (`.claude/settings.json`), not application code. Verified the resulting file is valid JSON and that only the `PreToolUse` block was removed and the allowlist extended; everything else is byte-for-byte preserved.