### PR TITLE
fix(email): plan-correct welcome email for paid-trial signups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Paid-trial signups got the "Free account" welcome email
+- `email_signup` (paid-intent path) was hardcoded to send `welcome_free_email`
+  ("You're on the Free plan") before the user reached Stripe checkout, so
+  Basic/Pro trialists got the wrong email. It now sends a plan-neutral
+  `welcome_email_receipt` ("Your account is ready") tracked under
+  `settings["receipt_email_sent"]`.
+- The plan-correct `welcome_basic_email` / `welcome_pro_email` now ship from
+  `API::WebhooksController#handle_subscription_upsert` on the first transition
+  into `trialing` or `active`, via the new
+  `User#send_plan_welcome_email_once!` (idempotent per `plan_type` via
+  `settings["plan_welcome_sent_for"]`). This is the first path that delivers a
+  Basic/Pro welcome to web subscribers; mobile IAP is unchanged.
+- The Mailchimp `welcome` journey enqueue at signup is unchanged here — a
+  plan-aware journey is tracked as a follow-up.
+
 ### Added — Email-only signup API + billing portal for free accounts (frictionless paid signup)
 - `POST /api/v1/users/email_signup`: paid-intent visitors create an account with
   just an email (passwordless via invitation), get signed in immediately, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,23 @@ carries the warm "let's make your first board" story. The receipt's closing line
 they complement rather than duplicate. If you ever want only one, gate the
 transactional send in `auths#sign_up` or unset the welcome journey ENV vars.
 
+**Paid-intent welcome — two-stage.** `email_signup` (the PR #312 path) runs
+**before** Stripe checkout, so the plan isn't known. It sends a **plan-neutral
+receipt** (`UserMailer.welcome_email_receipt`, "your account is ready / sign
+in") and tracks it under `settings["receipt_email_sent"]` — distinct from the
+`welcome_email_sent` flag so the later plan welcome isn't suppressed. The
+**plan-correct welcome** (`welcome_basic_email` / `welcome_pro_email`) ships
+from `API::WebhooksController#handle_subscription_upsert` on the first
+transition into `trialing` or `active`, via `User#send_plan_welcome_email_once!`.
+That helper is idempotent per `plan_type` (recorded in
+`settings["plan_welcome_sent_for"]`), so `subscription.updated` re-fires and
+`trialing→active` for the same plan don't re-email, but a real plan change
+(`basic → pro`) still re-welcomes. This is the only path that delivers the
+Basic/Pro welcome to **web** subscribers — mobile IAP still goes through
+`BillingController#update_subscription`. The Mailchimp `welcome` journey is
+still enqueued from `email_signup` today (Free-flavored copy) — making the
+journey plan-aware is tracked as a follow-up.
+
 ## PostHog server-side analytics
 
 `PosthogService` (`app/models/posthog_service.rb`) captures the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -91,8 +91,12 @@ module API
         sign_in user
         user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
         user.ensure_minimum_communicator_slot!
-        if user.should_send_welcome_email?
-          user.send_welcome_email("free", nil, raw_invitation_token: raw_invitation_token)
+        # email_signup is the paid-intent path: no plan picked yet, so send a
+        # plan-neutral receipt now. The real plan welcome ships from the Stripe
+        # webhook once trial/active. The Mailchimp `welcome` journey is still
+        # enqueued here (follow-up: make journey plan-aware too).
+        if user.should_send_welcome_receipt_email?
+          user.send_welcome_receipt_email(raw_invitation_token: raw_invitation_token)
           MailchimpEventJob.perform_async(user.id, "journey", { "journey_key" => "welcome" })
         end
         MailchimpEventJob.perform_async(user.id, "sign_up")

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -319,6 +319,16 @@ class API::WebhooksController < API::ApplicationController
 
     user.save!
 
+    # Send the plan-correct welcome once we know what plan they're on. This is
+    # the only path that delivers welcome_basic_email / welcome_pro_email to
+    # web subscribers (mobile IAP welcomes happen in BillingController). Fires
+    # on the first transition into `trialing` or `active`; idempotent per
+    # plan_type via send_plan_welcome_email_once!, so subscription.updated
+    # re-fires don't re-email and a real plan change still re-welcomes.
+    if %w[trialing active].include?(subscription.status) && previous_status != subscription.status
+      user.send_plan_welcome_email_once!(user.plan_type)
+    end
+
     # Fire `subscription_started` on the trial→paid (or any non-active→active)
     # conversion so trial→paid is measurable against `trial_started`. Guarded on
     # the status transition so renewals (active→active) don't double-count.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -52,6 +52,20 @@ class UserMailer < BaseMailer
     end
   end
 
+  # Plan-neutral "your account is ready" receipt for paid-intent signups
+  # (email_signup): the user hasn't reached Stripe checkout yet, so we don't
+  # know which plan to welcome them onto. The real plan welcome is sent later
+  # from the Stripe webhook (handle_subscription_upsert) once trial/active.
+  def welcome_email_receipt(user, raw_invitation_token = nil)
+    @user = user
+    @user_name = @user.name
+    @login_link = welcome_login_link(user, raw_invitation_token)
+    Rails.logger.info "Sending welcome receipt email to #{@user.email} with login link: #{@login_link}"
+    with_user_locale(@user) do
+      mail(to: @user.email, subject: I18n.t("user_mailer.welcome_email_receipt.subject"))
+    end
+  end
+
   # raw_invitation_token must be passed explicitly as a String: the virtual
   # attr on @user is always nil here because deliver_later round-trips the
   # User through GlobalID. Without the arg, links fall back to /users/sign-in.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1125,6 +1125,46 @@ class User < ApplicationRecord
     true
   end
 
+  # Receipt for paid-intent (email_signup) flows: confirms account creation
+  # without naming a plan, since the user hasn't picked one yet at Stripe
+  # checkout. Tracked under its own flag so the later plan-specific welcome
+  # (sent from the Stripe webhook on trial/active) isn't suppressed.
+  def should_send_welcome_receipt_email?
+    return false if admin?
+    return false if settings["receipt_email_sent"] == true
+    return false if settings["welcome_email_sent"] == true
+    true
+  end
+
+  def send_welcome_receipt_email(raw_invitation_token: nil)
+    Rails.logger.info "Sending welcome receipt email to #{email}"
+    begin
+      UserMailer.welcome_email_receipt(self, raw_invitation_token).deliver_later
+      self.settings["receipt_email_sent"] = true
+      save
+      AdminMailer.new_user_email(self).deliver_later
+      update_mailchimp_subscription
+      Rails.logger.info "Welcome receipt email sent to #{email}"
+    rescue => e
+      Rails.logger.error("Error sending welcome receipt email: #{e.message}")
+    end
+  end
+
+  # Called from the Stripe webhook on trial start / non-active→active. Sends
+  # the plan-correct welcome at most once per plan_type, so re-fires of
+  # subscription.updated don't re-email and a true plan change (basic→pro)
+  # still sends. Independent of the email_signup receipt flag.
+  def send_plan_welcome_email_once!(plan_nickname)
+    return if admin?
+    return if plan_nickname.blank?
+    plan_key = plan_nickname.to_s
+    sent_for = Array(settings["plan_welcome_sent_for"])
+    return if sent_for.include?(plan_key)
+    send_welcome_email(plan_key)
+    self.settings["plan_welcome_sent_for"] = (sent_for + [plan_key]).uniq
+    save
+  end
+
   def new_user?
     return false if admin?
     return false if created_at < 1.hour.ago

--- a/app/views/user_mailer/welcome_email_receipt.html.erb
+++ b/app/views/user_mailer/welcome_email_receipt.html.erb
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title><%= t("user_mailer.welcome_email_receipt.title") %></title>
+  <meta name="color-scheme" content="light only">
+  <style>
+    body { background-color: #f7f9fc; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .container { background-color: #ffffff; margin: auto; max-width: 620px; padding: 30px; border-radius: 12px; box-shadow: 0 6px 18px rgba(0,0,0,0.08); }
+    .logo img { max-width: 120px; display: block; margin: 0 auto 20px auto; }
+    h1 { font-size: 26px; color: #2a2a2a; text-align: center; margin: 10px 0 6px 0; }
+    .intro { font-size: 16px; color: #444444; line-height: 1.6; text-align: center; margin: 8px 0 22px 0; white-space: pre-line; }
+    .button { display: inline-block; margin: 14px auto 0 auto; padding: 14px 28px; background-color: #7645ef; text-decoration: none; border-radius: 8px; color: #ffffff !important; font-weight: bold; font-size: 16px; }
+    .subtext { font-size: 12px; color: #6b6b6b; text-align: center; margin-top: 8px; }
+    .section { margin: 28px 0; }
+    .footer { margin-top: 28px; font-size: 13px; text-align: center; color: #777777; }
+    .footer a { color: #7645ef; text-decoration: none; }
+    @media (max-width: 480px) { .container { padding: 22px; } h1 { font-size: 24px; } }
+  </style>
+</head>
+<body>
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+    <%= t("user_mailer.welcome_email_receipt.preheader") %>
+  </div>
+
+  <div class="container">
+    <div class="logo">
+      <a href="https://www.speakanyway.com" target="_blank" rel="noopener">
+        <%= image_tag @logo.url, alt: "SpeakAnyWay Logo" %>
+      </a>
+    </div>
+
+    <h1><%= t("user_mailer.welcome_email_receipt.title") %></h1>
+
+    <p class="intro">
+      <%= @user.name.blank? ? t("user_mailer.welcome_email_receipt.greeting_no_name") : t("user_mailer.welcome_email_receipt.greeting_with_name", name: @user.name) %>
+      <%= t("user_mailer.welcome_email_receipt.intro") %>
+    </p>
+
+    <p style="text-align:center;">
+      <a href="<%= @login_link %>" class="button"><%= t("user_mailer.welcome_email_receipt.cta") %></a>
+    </p>
+    <p class="subtext"><%= t("user_mailer.welcome_email_receipt.cta_fallback") %><br><span style="word-break:break-all;color:#6b6b6b;"><%= @login_link %></span></p>
+
+    <div class="section" style="text-align:center;">
+      <p style="font-size:14px;color:#444;line-height:1.6;margin:0;">
+        <%= t("user_mailer.welcome_email_receipt.ps_html").html_safe %>
+      </p>
+    </div>
+
+    <div class="footer">
+      <p><%= t("user_mailer.welcome_email_receipt.footer_thanks") %><br><%= t("user_mailer.welcome_email_receipt.footer_signature") %></p>
+      <p><a href="https://www.speakanyway.com" target="_blank"><%= t("user_mailer.welcome_email_receipt.footer_visit") %></a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -22,6 +22,20 @@ en:
       footer_signature: "— The SpeakAnyWay Team"
       footer_visit: "Visit our website"
 
+    welcome_email_receipt:
+      subject: "Your SpeakAnyWay account is ready"
+      preheader: "Sign in any time — your account is set up."
+      title: "Your account is ready"
+      greeting_with_name: "Hi %{name},"
+      greeting_no_name: "Hi there,"
+      intro: "Your SpeakAnyWay account is set up. Sign in any time to pick up where you left off."
+      cta: "Sign In"
+      cta_fallback: "If the button doesn't work, copy and paste this link:"
+      ps_html: "We'll follow up with a quick welcome once your plan is confirmed. Questions? Just reply — a real person reads these."
+      footer_thanks: "Thank you for choosing SpeakAnyWay 💜"
+      footer_signature: "— The SpeakAnyWay Team"
+      footer_visit: "Visit our website"
+
     welcome_free_email:
       subject: "Welcome to SpeakAnyWay AAC!"
       preheader: "Your account is ready — here's your sign-in link."

--- a/spec/requests/api/v1/email_signup_spec.rb
+++ b/spec/requests/api/v1/email_signup_spec.rb
@@ -67,19 +67,41 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
       end
     end
 
-    it "sends the welcome email with the raw invitation token (magic link)" do
+    it "sends the plan-neutral receipt email with the raw invitation token (magic link)" do
       mail = double(deliver_later: true)
       captured_args = nil
-      allow(UserMailer).to receive(:welcome_free_email) do |*args|
+      allow(UserMailer).to receive(:welcome_email_receipt) do |*args|
         captured_args = args
         mail
       end
+      allow(AdminMailer).to receive(:new_user_email).and_return(double(deliver_later: true))
 
       do_post(email: "buyer@example.com")
 
       expect(captured_args[0].email).to eq("buyer@example.com")
       expect(captured_args[1]).to be_a(String)
       expect(captured_args[1]).to be_present
+    end
+
+    it "does NOT send the Free welcome email at signup (plan unknown until checkout)" do
+      allow(UserMailer).to receive(:welcome_free_email).and_call_original
+      allow(UserMailer).to receive(:welcome_email_receipt).and_return(double(deliver_later: true))
+      allow(AdminMailer).to receive(:new_user_email).and_return(double(deliver_later: true))
+
+      do_post(email: "buyer@example.com")
+
+      expect(UserMailer).not_to have_received(:welcome_free_email)
+    end
+
+    it "marks receipt_email_sent but not welcome_email_sent" do
+      allow(UserMailer).to receive(:welcome_email_receipt).and_return(double(deliver_later: true))
+      allow(AdminMailer).to receive(:new_user_email).and_return(double(deliver_later: true))
+
+      do_post(email: "buyer@example.com")
+      user = User.find_by(email: "buyer@example.com")
+
+      expect(user.settings["receipt_email_sent"]).to eq(true)
+      expect(user.settings["welcome_email_sent"]).not_to eq(true)
     end
 
     it "enqueues the Mailchimp welcome journey and sign_up event" do

--- a/spec/requests/api/webhooks_plan_type_spec.rb
+++ b/spec/requests/api/webhooks_plan_type_spec.rb
@@ -102,7 +102,11 @@ RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
       sub = build_subscription(price: build_price(plan_type: "pro"))
       stub_event(sub, type: "customer.subscription.created")
 
-      expect_any_instance_of(User).not_to receive(:send_welcome_email)
+      # Plan welcome IS sent from this webhook now (the only path that
+      # delivers welcome_pro_email to web subscribers). Full per-plan
+      # idempotency coverage lives in webhooks_plan_welcome_spec.rb.
+      allow(UserMailer).to receive(:welcome_pro_email).and_return(double(deliver_later: true))
+      allow(AdminMailer).to receive(:new_user_email).and_return(double(deliver_later: true))
 
       post_webhook("{}", header_with_signature)
 

--- a/spec/requests/api/webhooks_plan_welcome_spec.rb
+++ b/spec/requests/api/webhooks_plan_welcome_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+# Covers the plan-correct welcome email triggered from the Stripe subscription
+# upsert webhook — the only path that delivers welcome_basic_email /
+# welcome_pro_email to web subscribers. See API::WebhooksController#handle_subscription_upsert.
+RSpec.describe "POST /api/webhooks (plan welcome email)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_plan_welcome",
+      plan_type: "free",
+      plan_status: nil,
+      settings: { "receipt_email_sent" => true })
+  end
+
+  before do
+    ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy"
+    allow(AdminMailer).to receive(:new_user_email).and_return(double(deliver_later: true))
+  end
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def build_metadata(hash)
+    Class.new do
+      def initialize(h) @h = h.transform_keys(&:to_s) end
+      def [](k) = @h[k.to_s]
+      def presence; @h.presence; end
+      def to_h; @h; end
+    end.new(hash)
+  end
+
+  def build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic")
+    OpenStruct.new(id: id, metadata: build_metadata({ "plan_type" => plan_type, "monthly_credits" => monthly_credits.to_s }))
+  end
+
+  def build_subscription(status: "trialing", price: build_price, current_period_end: 14.days.from_now, trial_end: 14.days.from_now, customer: user.stripe_customer_id)
+    OpenStruct.new(
+      id: "sub_#{SecureRandom.hex(3)}",
+      customer: customer,
+      status: status,
+      current_period_end: current_period_end.to_i,
+      trial_end: trial_end&.to_i,
+      items: OpenStruct.new(data: [OpenStruct.new(price: price, quantity: 1)]),
+    )
+  end
+
+  describe "first transition into trialing" do
+    it "sends the Basic plan welcome (not the Free one)" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:welcome_basic_email).and_return(mail)
+      allow(UserMailer).to receive(:welcome_free_email).and_return(mail)
+
+      sub = build_subscription(status: "trialing", price: build_price(plan_type: "basic"))
+      stub_event(sub, type: "customer.subscription.created")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:welcome_basic_email).once
+      expect(UserMailer).not_to have_received(:welcome_free_email)
+      expect(user.reload.settings["plan_welcome_sent_for"]).to include("basic")
+    end
+
+    it "sends the Pro plan welcome for a pro trial" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:welcome_pro_email).and_return(mail)
+
+      sub = build_subscription(status: "trialing", price: build_price(plan_type: "pro", monthly_credits: 1500, id: "price_pro"))
+      stub_event(sub, type: "customer.subscription.created")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:welcome_pro_email).once
+      expect(user.reload.settings["plan_welcome_sent_for"]).to include("pro")
+    end
+  end
+
+  describe "re-fires of subscription.updated" do
+    it "does NOT re-send the plan welcome when status stays trialing" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:welcome_basic_email).and_return(mail)
+
+      sub = build_subscription(status: "trialing", price: build_price(plan_type: "basic"))
+      stub_event(sub, type: "customer.subscription.created")
+      post_webhook("{}", header_with_signature)
+
+      sub2 = build_subscription(status: "trialing", price: build_price(plan_type: "basic"))
+      stub_event(sub2, type: "customer.subscription.updated")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:welcome_basic_email).once
+    end
+
+    it "does NOT re-send when trialing→active for the same plan" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:welcome_basic_email).and_return(mail)
+
+      sub = build_subscription(status: "trialing", price: build_price(plan_type: "basic"))
+      stub_event(sub, type: "customer.subscription.created")
+      post_webhook("{}", header_with_signature)
+
+      sub2 = build_subscription(status: "active", price: build_price(plan_type: "basic"))
+      stub_event(sub2, type: "customer.subscription.updated")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:welcome_basic_email).once
+    end
+  end
+
+  describe "real plan change (basic → pro)" do
+    it "sends the Pro welcome on upgrade after Basic was already sent" do
+      user.update!(settings: user.settings.merge("plan_welcome_sent_for" => ["basic"]))
+      basic_mail = double(deliver_later: true)
+      pro_mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:welcome_basic_email).and_return(basic_mail)
+      allow(UserMailer).to receive(:welcome_pro_email).and_return(pro_mail)
+
+      sub = build_subscription(status: "active", price: build_price(plan_type: "pro", monthly_credits: 1500, id: "price_pro"))
+      stub_event(sub, type: "customer.subscription.updated")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:welcome_pro_email).once
+      expect(UserMailer).not_to have_received(:welcome_basic_email)
+    end
+  end
+
+  describe "admin users" do
+    it "does NOT send any welcome email for admins" do
+      user.update!(role: "admin")
+      allow(UserMailer).to receive(:welcome_basic_email)
+      allow(UserMailer).to receive(:welcome_pro_email)
+      allow(UserMailer).to receive(:welcome_free_email)
+
+      sub = build_subscription(status: "trialing", price: build_price(plan_type: "basic"))
+      stub_event(sub, type: "customer.subscription.created")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).not_to have_received(:welcome_basic_email)
+      expect(UserMailer).not_to have_received(:welcome_pro_email)
+      expect(UserMailer).not_to have_received(:welcome_free_email)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a bug where Basic/Pro paid-trial signups via the email-only signup path (#312) received the **Free plan** welcome email ("You're on the Free plan"). They now get a plan-neutral receipt at signup, then the plan-correct `welcome_basic_email` / `welcome_pro_email` once Stripe confirms the plan.

## What changed

**Signup (paid-intent path — plan unknown):**
- `API::V1::AuthsController#email_signup` no longer calls `welcome_free_email`.
- New `UserMailer#welcome_email_receipt` ("Your SpeakAnyWay account is ready") — plan-neutral, single CTA to sign in, hands off ("we'll follow up once your plan is confirmed").
- Tracked under `settings["receipt_email_sent"]`, intentionally distinct from `welcome_email_sent` so the later plan welcome isn't suppressed.

**Plan confirmation (Stripe webhook — plan known):**
- `API::WebhooksController#handle_subscription_upsert` now fires the plan-correct welcome on the first transition into `trialing` or `active`.
- New `User#send_plan_welcome_email_once!(plan_type)` is idempotent per plan_type (tracked in `settings["plan_welcome_sent_for"]`), so:
  - `subscription.updated` re-fires → no re-email
  - `trialing → active` for the same plan → no re-email
  - real plan change (`basic → pro`) → re-welcomes with Pro copy
- Admins are skipped. This is the only path that delivers `welcome_basic_email` / `welcome_pro_email` to **web** subscribers — mobile IAP welcomes still go through `BillingController#update_subscription`.

**Docs:**
- `CHANGELOG.md` entry under Unreleased.
- `CLAUDE.md` "Mailchimp / welcome email" section gains a **Paid-intent welcome — two-stage** subsection covering the new flags and the idempotency contract.

## Test plan

- [x] `spec/requests/api/v1/email_signup_spec.rb` — receipt sent, NOT `welcome_free_email`, only `receipt_email_sent` flag flipped.
- [x] `spec/requests/api/webhooks_plan_welcome_spec.rb` (new, 4 contexts):
  - First `trialing` transition sends Basic / Pro welcome (not Free).
  - `subscription.updated` re-fires don't re-email.
  - `trialing → active` for the same plan doesn't re-email.
  - Real `basic → pro` upgrade sends the Pro welcome.
  - Admins get no welcome.
- [x] `spec/requests/api/webhooks_plan_type_spec.rb` updated — the "doesn't send welcome at upsert" assertion was inverted (welcome IS sent now); per-plan idempotency coverage moved to the new spec file.

Manual: paid signup → check inbox → see receipt; complete Stripe checkout → see Basic/Pro welcome. `subscription.updated` replay (Stripe CLI) → no duplicate.

## Follow-ups (intentionally out of scope)

- Mailchimp `welcome` Customer Journey is still enqueued at `email_signup` with the Free-flavored copy. Making the journey plan-aware (separate journeys per tier, or trigger after the webhook) is a separate piece of work.
- The internal `AdminMailer.new_user_email` ping now fires twice for a paid signup (once on receipt, once on plan welcome). Low-priority noise — can be guarded behind a `settings["admin_notified"]` flag if it becomes annoying.

## Notes

- Single commit on the branch is `wip` — happy to amend the message or squash-merge with a Conventional Commit subject on merge. Not force-pushing from a sibling worktree without an explicit go-ahead.