### PR TITLE
fix(billing): webhook-driven + idempotent welcome emails for IAP; Stripe webhook idempotency gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — iOS/Apple (RevenueCat) buyers could get no welcome email; Stripe webhook replays polluted the credit ledger
+- **IAP welcome email is now webhook-driven.**
+  `RevenueCat::WebhookProcessor#handle_purchase` now sends the plan-correct
+  welcome (`User#send_plan_welcome_email_once!`) on purchase/upgrade. Previously
+  the welcome only fired from the client's `POST /api/billing/update_subscription`
+  call, so a dropped request (backgrounded app, crash, flaky network) after a
+  completed App Store purchase left a paying user with no welcome email. The
+  webhook is now the source of truth, matching the Stripe path.
+- **IAP welcome is now idempotent.** `BillingController#update_subscription`
+  switched from `send_welcome_email` to the idempotent
+  `send_plan_welcome_email_once!`, so a retried client call (or the webhook +
+  client both firing) can't double-email.
+- **Stripe webhook is now idempotent end-to-end.**
+  `API::WebhooksController#webhooks` records each handled event in
+  `processed_webhook_events` and skips a replayed event id. Credit grants were
+  already deduped on `stripe_event_id`; this extends the guard to non-credit
+  handlers (downgrade on delete/pause, `past_due` on payment failure) so Stripe
+  retries and dashboard replays no longer add duplicate ledger rows. The event
+  is recorded only after a clean run, so genuine failures still get retried.
+
 ### Fixed — Paid-trial signups got the "Free account" welcome email
 - `email_signup` (paid-intent path) was hardcoded to send `welcome_free_email`
   ("You're on the Free plan") before the user reached Stripe checkout, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,10 +191,24 @@ That helper is idempotent per `plan_type` (recorded in
 `settings["plan_welcome_sent_for"]`), so `subscription.updated` re-fires and
 `trialing→active` for the same plan don't re-email, but a real plan change
 (`basic → pro`) still re-welcomes. This is the only path that delivers the
-Basic/Pro welcome to **web** subscribers — mobile IAP still goes through
-`BillingController#update_subscription`. The Mailchimp `welcome` journey is
-still enqueued from `email_signup` today (Free-flavored copy) — making the
-journey plan-aware is tracked as a follow-up.
+Basic/Pro welcome to **web** subscribers. **Mobile IAP delivers the same
+plan-correct welcome from `RevenueCat::WebhookProcessor#handle_purchase`** (also
+via `send_plan_welcome_email_once!`), so the RC **webhook** is the source of
+truth — a dropped `BillingController#update_subscription` client call no longer
+strands a paying user without a welcome. That client endpoint also calls
+`send_plan_welcome_email_once!` (was the non-idempotent `send_welcome_email`),
+so the webhook + client paths can't double-email. The Mailchimp `welcome`
+journey is still enqueued from `email_signup` today (Free-flavored copy) —
+making the journey plan-aware is tracked as a follow-up.
+
+**Stripe webhook idempotency gate.** `API::WebhooksController#webhooks` records
+each handled event in `processed_webhook_events` (`provider: "stripe"`) and
+short-circuits a replayed event id with `{ status: "already_processed" }` —
+mirroring the RevenueCat processor. The record is written **only after a clean
+run**, so a handler that raises still returns 4xx and lets Stripe retry. Credit
+grants were already deduped on `stripe_event_id`; this extends idempotency to
+the non-credit handlers (`apply_free_plan` on delete/pause, `past_due` on
+`payment_failed`) so retries/dashboard replays don't pollute the credit ledger.
 
 ## PostHog server-side analytics
 

--- a/app/controllers/api/billing_controller.rb
+++ b/app/controllers/api/billing_controller.rb
@@ -37,7 +37,10 @@ class API::BillingController < API::ApplicationController
       current_user.settings["purchase_platform"] = purchase_platform
       # setup_limits runs as a before_save callback when plan_type changes.
       current_user.save!
-      current_user.send_welcome_email(current_user.plan_type)
+      # Idempotent per plan_type: a retried client call (or a later upgrade that
+      # re-hits this endpoint for the same plan) won't re-email. Matches the
+      # Stripe webhook path, which also uses send_plan_welcome_email_once!.
+      current_user.send_plan_welcome_email_once!(current_user.plan_type)
       render json: { success: true, plan_key: plan_key }
     rescue StandardError => e
       Rails.logger.error "Failed to update subscription for User ID: #{current_user.id}, Plan Key: #{plan_key} - Error: #{e.message}"

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -24,6 +24,19 @@ class API::WebhooksController < API::ApplicationController
 
     Rails.logger.info "[StripeWebhook] Received event #{event.id} (#{event.type})"
 
+    # Idempotency gate. Stripe resends the same event id on delivery retries and
+    # dashboard replays. Credit grants are already deduped on stripe_event_id,
+    # but the non-credit handlers (apply_free_plan on delete/pause, past_due on
+    # payment_failed) have no such guard and re-running them pollutes the credit
+    # ledger with repeated expire/grant rows. This extends idempotency to the
+    # whole handler, mirroring the RevenueCat processor. We record the event only
+    # AFTER a clean run (see end of method), so a mid-handler crash still returns
+    # a 4xx and lets Stripe retry the delivery.
+    if ProcessedWebhookEvent.exists?(provider: STRIPE_PROVIDER, event_id: event.id)
+      Rails.logger.info "[StripeWebhook] event #{event.id} already processed; skipping"
+      return render json: { success: true, status: "already_processed" }
+    end
+
     case event.type
     when "customer.created"
       handle_customer_created(event.data.object)
@@ -61,6 +74,7 @@ class API::WebhooksController < API::ApplicationController
       Rails.logger.info "[StripeWebhook] Ignoring unhandled event type=#{event.type}"
     end
 
+    record_processed_event!(event)
     render json: result
   rescue => e
     Rails.logger.error "[StripeWebhook] Unexpected error: #{e.class} - #{e.message}\n#{e.backtrace.join("\n")}"
@@ -68,6 +82,22 @@ class API::WebhooksController < API::ApplicationController
   end
 
   private
+
+  STRIPE_PROVIDER = "stripe"
+
+  # Record a fully-processed event for idempotency + audit. Called only after the
+  # handler runs without raising. Swallows the unique-index race from a
+  # concurrent duplicate delivery — either way the event is processed.
+  def record_processed_event!(event)
+    ProcessedWebhookEvent.create!(
+      provider: STRIPE_PROVIDER,
+      event_id: event.id,
+      event_type: event.type,
+      processed_at: Time.current,
+    )
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    Rails.logger.info "[StripeWebhook] event #{event.id} recorded concurrently; skipping duplicate insert"
+  end
 
   # Terminal Stripe subscription statuses that mean "the trial/subscription
   # ended without a successful payment." A no-card reverse trial (issue #264)

--- a/app/services/revenue_cat/webhook_processor.rb
+++ b/app/services/revenue_cat/webhook_processor.rb
@@ -111,6 +111,14 @@ module RevenueCat
         },
       )
 
+      # Deliver the plan-correct welcome email. The webhook — not the client's
+      # update_subscription call — is the source of truth here: previously an IAP
+      # buyer only got a welcome if the app successfully POSTed back, so a dropped
+      # request (backgrounded app, crash, network) left a paying user with none.
+      # send_plan_welcome_email_once! is idempotent per plan_type, so a RENEWAL is
+      # a no-op while a real upgrade (basic→pro) re-welcomes, matching Stripe.
+      user.send_plan_welcome_email_once!(plan_type)
+
       # fire_started distinguishes a genuine start (INITIAL/NON_RENEWING) from a
       # renewal/product-change. An IAP user goes straight from free(active) to
       # paid(active) with no intermediate status, so we can't guard on a status

--- a/spec/requests/api/billing_controller_spec.rb
+++ b/spec/requests/api/billing_controller_spec.rb
@@ -104,6 +104,24 @@ RSpec.describe "POST /api/billing/update_subscription", type: :request do
          headers: auth_headers(user)
   end
 
+  it "only sends the welcome email once across repeated verified calls (idempotent)" do
+    stub_rc_verified(plan_type: "basic")
+    # Override the global no-op stub so the real send_plan_welcome_email_once!
+    # guard runs; spy on the mailer to count actual sends.
+    allow_any_instance_of(User).to receive(:send_welcome_email).and_call_original
+    allow(UserMailer).to receive(:welcome_basic_email).and_return(double(deliver_later: true))
+
+    2.times do
+      post "/api/billing/update_subscription",
+           params: { plan_key: "basic", purchase_platform: "ios" },
+           headers: auth_headers(user)
+    end
+
+    expect(response).to have_http_status(:ok)
+    expect(UserMailer).to have_received(:welcome_basic_email).once
+    expect(user.reload.settings["plan_welcome_sent_for"]).to include("basic")
+  end
+
   it "is auth-gated (no token → unauthorized)" do
     post "/api/billing/update_subscription",
          params: { plan_key: "basic" }

--- a/spec/requests/api/revenue_cat_webhook_spec.rb
+++ b/spec/requests/api/revenue_cat_webhook_spec.rb
@@ -100,6 +100,52 @@ RSpec.describe "POST /api/billing/webhooks (RevenueCat)", type: :request do
     end
   end
 
+  describe "plan-correct welcome email" do
+    # The webhook — not the client's update_subscription call — is the source of
+    # truth for the IAP welcome email, so a dropped client request can't strand a
+    # paying user with no welcome. Idempotent per plan_type, mirroring Stripe.
+    before do
+      allow(UserMailer).to receive(:welcome_basic_email).and_return(double(deliver_later: true))
+      allow(UserMailer).to receive(:welcome_pro_email).and_return(double(deliver_later: true))
+    end
+
+    it "sends the Pro welcome on INITIAL_PURCHASE and records the plan as sent" do
+      post_rc_webhook(rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id,
+                               entitlement_ids: ["pro"], product_id: "pro_monthly"))
+
+      expect(UserMailer).to have_received(:welcome_pro_email).once
+      expect(user.reload.settings["plan_welcome_sent_for"]).to include("pro")
+    end
+
+    it "does NOT re-send on a RENEWAL of the same plan" do
+      user.update!(plan_type: "pro", plan_status: "active",
+                   settings: user.settings.merge("plan_welcome_sent_for" => ["pro"]))
+
+      post_rc_webhook(rc_event(type: "RENEWAL", app_user_id: user.id, entitlement_ids: ["pro"]))
+
+      expect(UserMailer).not_to have_received(:welcome_pro_email)
+    end
+
+    it "sends the Pro welcome on a PRODUCT_CHANGE upgrade even after Basic was sent" do
+      user.update!(plan_type: "basic", plan_status: "active",
+                   settings: user.settings.merge("plan_welcome_sent_for" => ["basic"]))
+
+      post_rc_webhook(rc_event(type: "PRODUCT_CHANGE", app_user_id: user.id,
+                               entitlement_ids: ["pro"], product_id: "pro_monthly"))
+
+      expect(UserMailer).to have_received(:welcome_pro_email).once
+      expect(UserMailer).not_to have_received(:welcome_basic_email)
+    end
+
+    it "does not send a welcome email for admins" do
+      user.update!(role: "admin")
+
+      post_rc_webhook(rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id, entitlement_ids: ["pro"]))
+
+      expect(UserMailer).not_to have_received(:welcome_pro_email)
+    end
+  end
+
   describe "CANCELLATION" do
     it "does NOT downgrade (still entitled until expiry) and records the analytics event" do
       user.update!(plan_type: "pro", plan_status: "active")

--- a/spec/requests/api/webhooks_idempotency_spec.rb
+++ b/spec/requests/api/webhooks_idempotency_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Covers the whole-handler idempotency gate on the Stripe webhook
+# (API::WebhooksController#webhooks). Stripe resends the same event id on
+# delivery retries and dashboard replays; the gate records an event only after a
+# clean run and short-circuits any later delivery of that id, so non-credit
+# handlers (apply_free_plan on delete/pause) don't re-run and pollute the ledger.
+RSpec.describe "POST /api/webhooks (Stripe idempotency gate)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_idem",
+      stripe_subscription_id: "sub_idem",
+      plan_type: "pro",
+      plan_status: "active")
+  end
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id:)
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def deleted_sub
+    OpenStruct.new(id: "sub_idem", customer: user.stripe_customer_id, status: "canceled")
+  end
+
+  it "processes a new event once and records it for audit" do
+    stub_event(deleted_sub, type: "customer.subscription.deleted", event_id: "evt_idem_new")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.plan_type).to eq("free")
+    row = ProcessedWebhookEvent.where(provider: "stripe", event_id: "evt_idem_new")
+    expect(row.count).to eq(1)
+    expect(row.first.event_type).to eq("customer.subscription.deleted")
+  end
+
+  it "skips a replayed event id without re-running the downgrade handler" do
+    stub_event(deleted_sub, type: "customer.subscription.deleted", event_id: "evt_idem_dup")
+
+    post_webhook("{}", header_with_signature)
+    expect(user.reload.plan_type).to eq("free")
+
+    # Replay the identical event — apply_free_plan must NOT run again, so no new
+    # expire/grant rows land on the ledger.
+    expect {
+      post_webhook("{}", header_with_signature)
+    }.not_to change { user.reload.credit_transactions.count }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["status"]).to eq("already_processed")
+    expect(ProcessedWebhookEvent.where(provider: "stripe", event_id: "evt_idem_dup").count).to eq(1)
+  end
+
+  it "processes two distinct event ids independently" do
+    stub_event(deleted_sub, type: "customer.subscription.deleted", event_id: "evt_idem_a")
+    post_webhook("{}", header_with_signature)
+
+    stub_event(deleted_sub, type: "customer.subscription.deleted", event_id: "evt_idem_b")
+    post_webhook("{}", header_with_signature)
+
+    expect(ProcessedWebhookEvent.where(provider: "stripe").pluck(:event_id))
+      .to contain_exactly("evt_idem_a", "evt_idem_b")
+  end
+end


### PR DESCRIPTION
## Summary

Closes two gaps found while reviewing the Stripe (web) vs RevenueCat (iOS/Android IAP) signup/payment/email paths. The two billing paths converge on shared credit + plan logic, but the **email and webhook-robustness halves were not at parity**.

**1. iOS/Apple (RevenueCat) buyers could get no welcome email.**
The IAP welcome only fired from the client's `POST /api/billing/update_subscription` call. If that request dropped (backgrounded app, crash, flaky network) *after* a completed App Store purchase, the RC webhook still granted the plan + credits but **no welcome email was ever sent**. Web users can't hit this because the Stripe webhook sends the email itself.
- `RevenueCat::WebhookProcessor#handle_purchase` now sends the plan-correct welcome via the idempotent `User#send_plan_welcome_email_once!`. The webhook is now the source of truth (parity with Stripe). Idempotent per `plan_type`, so a `RENEWAL` is a no-op while a real `basic→pro` upgrade re-welcomes.

**2. IAP welcome wasn't idempotent.**
`BillingController#update_subscription` switched from `send_welcome_email` to `send_plan_welcome_email_once!`, so the webhook + client paths (or a retried client call) can't double-email.

**3. Stripe webhook had no whole-handler idempotency gate.**
Credit grants were already deduped on `stripe_event_id`, but non-credit handlers (`apply_free_plan` on delete/pause, `past_due` on payment failure) had no guard — Stripe retries and dashboard replays re-ran them and polluted the credit ledger with repeated expire/grant rows.
- `API::WebhooksController#webhooks` now records each handled event in `processed_webhook_events` (`provider: "stripe"`) and short-circuits a replayed event id with `{ status: "already_processed" }`, mirroring the RevenueCat processor. **Recorded only after a clean run**, so a handler that raises still returns 4xx and lets Stripe retry the delivery.

## Test plan

Added:
- RC webhook welcome-email cases (initial purchase / renewal no-resend / upgrade re-welcome / admin skip) — `spec/requests/api/revenue_cat_webhook_spec.rb`
- Billing controller idempotency case (repeated verified call emails once) — `spec/requests/api/billing_controller_spec.rb`
- New `spec/requests/api/webhooks_idempotency_spec.rb` for the Stripe gate (process-once, skip-replay, distinct-ids-independent)

Ran the affected specs locally — **92 examples, 0 failures**:
```
spec/requests/api/billing_controller_spec.rb
spec/requests/api/revenue_cat_webhook_spec.rb
spec/requests/api/webhooks_idempotency_spec.rb
spec/requests/api/webhooks_plan_welcome_spec.rb
spec/requests/api/webhooks_plan_credits_spec.rb
spec/requests/api/webhooks_plan_type_spec.rb
spec/requests/api/webhooks_topup_spec.rb
spec/requests/api/webhooks_analytics_spec.rb
spec/requests/api/webhooks_customer_created_spec.rb
spec/requests/api/webhooks_trial_wrap_spec.rb
```
Plus adjacent specs (`user_mailer_dispatch_spec`, `lifecycle_integration_spec`, `spec/services/revenue_cat/`) — 22 examples, 0 failures.

Docs: `CLAUDE.md` (dual-welcome + new Stripe idempotency-gate notes) and `CHANGELOG.md` updated.

## Notes / out of scope
This is the #1/#2/#4 cluster from the path review. Not included (separate follow-ups): IAP trial lifecycle parity (RevenueCat has no trial concept in code), the `email_signup` ↔ `customer.created` duplicate-user race, and the bypass-prone `update_user_from_session` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)