### PR TITLE
fix(revenuecat): map real App Store product ids in PlanMapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — RevenueCat product-id mapping didn't match the real App Store ids
+- `RevenueCat::PlanMapping::PRODUCT_TO_PLAN` keyed on bare package names
+  (`basic_monthly`, `pro_yearly`), but Apple/RevenueCat emit reverse-DNS product
+  ids (`com.speakanyway.basic.monthly`, …). As a result the product-id fallback
+  for plan resolution never matched, and `settings["billing_interval"]` was never
+  set for IAP subscribers (analytics gap + a latent failure if a webhook ever
+  arrived without entitlement ids). Added the real App Store ids (confirmed
+  against the RevenueCat catalog) while keeping the bare names as a defensive
+  fallback. MySpeak products are intentionally left unmapped.
+
 ### Fixed — iOS/Apple (RevenueCat) buyers could get no welcome email; Stripe webhook replays polluted the credit ledger
 - **IAP welcome email is now webhook-driven.**
   `RevenueCat::WebhookProcessor#handle_purchase` now sends the plan-correct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,8 +293,14 @@ the Stripe webhook semantics in `API::WebhooksController`. **RevenueCat's
 - **Sandbox gating:** SANDBOX events are ignored only in real production
   (`Rails.env.production? && !AppEnv.staging?`); honored in dev/test/staging.
 - **Mapping:** `RevenueCat::PlanMapping` (entitlement/product → normalized
-  `basic`/`pro`). ⚠️ `PRODUCT_TO_PLAN` keys must match the exact App Store
-  Connect product ids — confirm against a real sandbox webhook.
+  `basic`/`pro`). Entitlement ids (`basic`/`pro`) are the primary signal; the
+  store product id is a fallback (and the only source of `billing_interval`).
+  `PRODUCT_TO_PLAN` keys are the **real reverse-DNS App Store ids** confirmed
+  against the RevenueCat catalog (`com.speakanyway.{basic,pro}.{monthly,yearly}`),
+  plus the legacy bare package names (`basic_monthly`, …) kept as a defensive
+  fallback and a `com.test.basic.monthly` QA product. MySpeak products
+  (`com.speakanyway.myspeak.*`) are intentionally **unmapped** (separate feature,
+  not a plan tier). Confirm Google Play ids when that store goes live.
 - **Timestamps differ by surface:** webhooks send epoch **ms**
   (`expiration_at_ms`); the v1 REST API sends ISO8601 strings.
 - `Billing::PlanTransitions.apply_free_plan` is the shared downgrade path for

--- a/app/services/revenue_cat/plan_mapping.rb
+++ b/app/services/revenue_cat/plan_mapping.rb
@@ -6,12 +6,18 @@ module RevenueCat
   # (see itty-bitty-frontend/src/services/iap.ts), so entitlement ids are the
   # primary signal; the store product id is a fallback.
   #
-  # NOTE: PRODUCT_TO_PLAN keys must match the EXACT product identifiers that
-  # App Store Connect / Google Play emit in webhook + REST payloads (usually
-  # reverse-DNS, e.g. "com.speakanyway.basic.monthly"). The bare names below
-  # mirror the RevenueCat *package* identifiers the app uses today; confirm
-  # against a real sandbox webhook and adjust. resolve_plan_type logs when it
-  # can't resolve so a wrong/missing key is loud, not silent.
+  # PRODUCT_TO_PLAN keys must match the EXACT product identifiers App Store
+  # Connect / Google Play emit in webhook + REST payloads. Apple sends reverse-DNS
+  # ids (e.g. "com.speakanyway.basic.monthly"); these are confirmed against the
+  # RevenueCat product catalog (Offerings → default). The bare names
+  # ("basic_monthly", …) are the RevenueCat *package* identifiers the app
+  # references and a plausible Google Play base-plan id shape — kept as a
+  # defensive fallback so a payload carrying the short id still resolves. Confirm
+  # the Play ids when that store goes live. resolve_plan_type logs when it can't
+  # resolve, so a wrong/missing key is loud, not silent.
+  #
+  # MySpeak subscriptions (com.speakanyway.myspeak.*) are intentionally NOT mapped
+  # — MySpeak is a separate feature, not a basic/pro plan tier.
   module PlanMapping
     ENTITLEMENT_TO_PLAN = {
       "basic" => "basic",
@@ -19,6 +25,15 @@ module RevenueCat
     }.freeze
 
     PRODUCT_TO_PLAN = {
+      # App Store product identifiers (the ids Apple/RevenueCat actually send).
+      "com.speakanyway.basic.monthly" => { plan_type: "basic", billing_interval: "monthly" },
+      "com.speakanyway.basic.yearly" => { plan_type: "basic", billing_interval: "yearly" },
+      "com.speakanyway.pro.monthly" => { plan_type: "pro", billing_interval: "monthly" },
+      "com.speakanyway.pro.yearly" => { plan_type: "pro", billing_interval: "yearly" },
+      # QA/test product. Sandbox-only in practice — real production ignores
+      # SANDBOX events — but mapping it lets sandbox webhooks resolve fully.
+      "com.test.basic.monthly" => { plan_type: "basic", billing_interval: "monthly" },
+      # Legacy/defensive bare names (RevenueCat package ids; plausible Play shape).
       "basic_monthly" => { plan_type: "basic", billing_interval: "monthly" },
       "basic_yearly" => { plan_type: "basic", billing_interval: "yearly" },
       "pro_monthly" => { plan_type: "pro", billing_interval: "monthly" },

--- a/spec/requests/api/revenue_cat_webhook_spec.rb
+++ b/spec/requests/api/revenue_cat_webhook_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe "POST /api/billing/webhooks (RevenueCat)", type: :request do
       expect(user.plan_credits_reset_at).to be_within(1.day).of(Time.current + CreditService::MAX_GRANT_WINDOW)
     end
 
+    it "records billing_interval from the real reverse-DNS App Store product id" do
+      # Apple/RevenueCat send dotted product ids (com.speakanyway.pro.yearly), not
+      # the bare package names. Guards against the mapping silently failing to set
+      # billing_interval for IAP subscribers.
+      event = rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id,
+                       entitlement_ids: ["pro"], product_id: "com.speakanyway.pro.yearly")
+
+      post_rc_webhook(event)
+
+      user.reload
+      expect(user.plan_type).to eq("pro")
+      expect(user.settings["billing_interval"]).to eq("yearly")
+    end
+
     it "is idempotent: a replayed event id grants once and records one event row" do
       event = rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id, id: "rc_evt_dupe")
 

--- a/spec/services/revenue_cat/plan_mapping_spec.rb
+++ b/spec/services/revenue_cat/plan_mapping_spec.rb
@@ -14,6 +14,20 @@ RSpec.describe RevenueCat::PlanMapping do
       expect(described_class.resolve_plan_type(product_id: "pro_yearly")).to eq("pro")
     end
 
+    it "resolves the real reverse-DNS App Store product ids via the fallback" do
+      # These are the ids Apple/RevenueCat actually send; the entitlement path is
+      # the primary signal, but the product fallback must work when it's absent.
+      expect(described_class.resolve_plan_type(product_id: "com.speakanyway.basic.monthly")).to eq("basic")
+      expect(described_class.resolve_plan_type(product_id: "com.speakanyway.basic.yearly")).to eq("basic")
+      expect(described_class.resolve_plan_type(product_id: "com.speakanyway.pro.monthly")).to eq("pro")
+      expect(described_class.resolve_plan_type(product_id: "com.speakanyway.pro.yearly")).to eq("pro")
+    end
+
+    it "does NOT map MySpeak products (separate feature, not a plan tier)" do
+      expect(Rails.logger).to receive(:warn).with(/could not resolve/)
+      expect(described_class.resolve_plan_type(product_id: "com.speakanyway.myspeak.monthly")).to be_nil
+    end
+
     it "returns nil (and logs) when nothing maps" do
       expect(Rails.logger).to receive(:warn).with(/could not resolve/)
       expect(described_class.resolve_plan_type(entitlement_ids: ["mystery"], product_id: "unknown")).to be_nil
@@ -21,10 +35,16 @@ RSpec.describe RevenueCat::PlanMapping do
   end
 
   describe ".billing_interval_for_product" do
-    it "maps product ids to monthly/yearly" do
+    it "maps the bare package ids to monthly/yearly" do
       expect(described_class.billing_interval_for_product("pro_monthly")).to eq("monthly")
       expect(described_class.billing_interval_for_product("basic_yearly")).to eq("yearly")
       expect(described_class.billing_interval_for_product("unknown")).to be_nil
+    end
+
+    it "maps the real reverse-DNS App Store product ids to monthly/yearly" do
+      expect(described_class.billing_interval_for_product("com.speakanyway.pro.monthly")).to eq("monthly")
+      expect(described_class.billing_interval_for_product("com.speakanyway.basic.yearly")).to eq("yearly")
+      expect(described_class.billing_interval_for_product("com.speakanyway.pro.yearly")).to eq("yearly")
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to #317. While reviewing the RevenueCat/IAP path I flagged `RevenueCat::PlanMapping::PRODUCT_TO_PLAN` as **unverified** ("keys must match the exact App Store Connect product ids — confirm against a real sandbox webhook"). The RevenueCat product catalog confirms the keys were wrong.

**The mismatch:** `PRODUCT_TO_PLAN` keyed on bare package names (`basic_monthly`, `pro_yearly`), but Apple/RevenueCat emit **reverse-DNS** product ids:

| Real product id (App Store) | plan | interval |
|---|---|---|
| `com.speakanyway.basic.monthly` | basic | monthly |
| `com.speakanyway.basic.yearly` | basic | yearly |
| `com.speakanyway.pro.monthly` | pro | monthly |
| `com.speakanyway.pro.yearly` | pro | yearly |

**Consequences (latent, not a visible outage):**
- `plan_type_for_product` returned `nil` for every real product id — the plan-resolution fallback was **dead code**. Entitlement ids (`basic`/`pro`) are the primary signal and kept resolution working, so purchases weren't dropped in practice, but the safety net wasn't there.
- `billing_interval_for_product` returned `nil` for every IAP purchase, so `settings["billing_interval"]` was **never set** for RevenueCat subscribers → the `billing_interval` property on `subscription_started` analytics was always null for IAP, and the field was simply wrong in stored settings.

**Fix:** add the real App Store ids (confirmed against the catalog) and a `com.test.basic.monthly` QA product, while keeping the legacy bare names as a defensive fallback (RevenueCat package ids / plausible Google Play base-plan shape). **MySpeak** products (`com.speakanyway.myspeak.*`) are intentionally left unmapped — confirmed with the team that MySpeak is a separate feature, not a basic/pro tier.

## Test plan

Ran the affected specs locally — **40 examples, 0 failures**:
```
spec/services/revenue_cat/plan_mapping_spec.rb
spec/requests/api/revenue_cat_webhook_spec.rb
spec/requests/api/billing_controller_spec.rb
```
New coverage:
- `plan_mapping_spec`: the four real reverse-DNS ids resolve `plan_type` + `billing_interval`; MySpeak stays unmapped (logs + nil).
- `revenue_cat_webhook_spec`: a real dotted product id (`com.speakanyway.pro.yearly`) through the webhook sets `settings["billing_interval"] = "yearly"`.

Docs: `CLAUDE.md` mapping note updated (⚠️ → confirmed) and `CHANGELOG.md`.

## Note for reviewers
Google Play product ids aren't verifiable from the App Store catalog — the bare-name fallback covers a plausible Play base-plan shape, but confirm the exact Play ids when that store goes live (left a code comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)