### PR TITLE
feat(revenuecat): make iOS/Apple free trials first-class in the webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — RevenueCat (iOS/Apple) free trials are now first-class
+- The RevenueCat webhook reads `period_type`: a `TRIAL`/`INTRO`
+  `INITIAL_PURCHASE` now marks the user `plan_status="trialing"` (was always
+  `active`), persists `settings["trial_ends_at"]`, and fires a distinct
+  `trial_started` analytics event (internal + PostHog) instead of
+  `subscription_started`. `subscription_started` now fires on **conversion**
+  (a normal-period renewal/product-change out of a trial), and an unconverted
+  trial `EXPIRATION` is tagged `reason: "trial_expired"` — so iOS trial→paid
+  conversion is measurable, matching the Stripe path.
+- `BillingController#update_subscription` (the client confirmation call)
+  preserves an in-progress `trialing` status for the same plan so it can't
+  race-clobber the trial the webhook recorded.
+- Not included yet: a 3-days-before trial-ending reminder. Apple/RevenueCat send
+  no `trial_will_end` webhook, so this needs a scheduled job keyed on
+  `trial_ends_at` (tracked as a follow-up).
+
 ### Fixed — RevenueCat product-id mapping didn't match the real App Store ids
 - `RevenueCat::PlanMapping::PRODUCT_TO_PLAN` keyed on bare package names
   (`basic_monthly`, `pro_yearly`), but Apple/RevenueCat emit reverse-DNS product

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,22 @@ the Stripe webhook semantics in `API::WebhooksController`. **RevenueCat's
   **no downgrade** (still entitled until expiry); `BILLING_ISSUE` →
   `plan_status="past_due"`, access kept; `UNCANCELLATION` → back to active;
   `TRANSFER` → downgrade losing ids, REST-re-verify gaining ids.
+- **Trials (period_type).** A 14-day App Store free trial arrives as
+  `INITIAL_PURCHASE` with `period_type=TRIAL` (`TRIAL_PERIOD_TYPES = TRIAL/INTRO`).
+  `handle_purchase` then sets `plan_status="trialing"` (not `active`; `paid_plan?`
+  treats both as paid, so gating is unaffected), persists `settings["trial_ends_at"]`
+  (ISO8601, from `expiration_at_ms`), and fires **`trial_started`** analytics
+  (internal `AnalyticsEvent` + PostHog — both, since IAP has no checkout to
+  originate the internal one) **instead of** `subscription_started`.
+  `subscription_started` fires on **conversion**: a normal-period `RENEWAL`/
+  `PRODUCT_CHANGE` when the user was `trialing` (status → `active`,
+  `trial_ends_at` cleared). An unconverted `EXPIRATION` of a `trialing` user tags
+  its `subscription_canceled` analytics `reason: "trial_expired"` (vs
+  `"expiration"` for paid churn). The client `update_subscription` call preserves
+  an in-progress `trialing` status for the same plan so it can't clobber the
+  trial the webhook recorded. **No trial-ending reminder yet** — Apple/RevenueCat
+  send no `trial_will_end` webhook; a scheduled job keyed on `trial_ends_at` is a
+  pending follow-up (mirrors Stripe's `MailchimpTrialWrapJob`).
 - **Idempotency + audit:** `processed_webhook_events` (unique `provider`+`event_id`)
   gates the whole handler (covers non-credit events); the credit grant also
   reuses `credit_transactions.stripe_event_id` with an `rc_<event_id>` token.

--- a/app/controllers/api/billing_controller.rb
+++ b/app/controllers/api/billing_controller.rb
@@ -32,8 +32,13 @@ class API::BillingController < API::ApplicationController
     end
 
     begin
+      # Don't clobber an in-progress trial. The RC webhook marks a trialist
+      # "trialing" (period_type=TRIAL); this client call races it after the same
+      # purchase and verified_plan_for can't see the trial flag, so preserve the
+      # trialing status for the same plan and let the webhook own trial→active.
+      keep_trialing = current_user.plan_status == "trialing" && current_user.plan_type == normalized_plan_key
       current_user.plan_type = normalized_plan_key
-      current_user.plan_status = "active"
+      current_user.plan_status = keep_trialing ? "trialing" : "active"
       current_user.settings["purchase_platform"] = purchase_platform
       # setup_limits runs as a before_save callback when plan_type changes.
       current_user.save!

--- a/app/services/revenue_cat/webhook_processor.rb
+++ b/app/services/revenue_cat/webhook_processor.rb
@@ -12,6 +12,11 @@ module RevenueCat
   class WebhookProcessor
     PROVIDER = "revenuecat"
 
+    # RevenueCat `period_type` values that mean the user is in a free/intro trial
+    # (as opposed to NORMAL paid or a PROMOTIONAL grant). A 14-day App Store free
+    # trial arrives as period_type=TRIAL on the INITIAL_PURCHASE.
+    TRIAL_PERIOD_TYPES = %w[TRIAL INTRO].freeze
+
     Result = Struct.new(:status, :http_status, keyword_init: true)
 
     # RevenueCat authenticates webhooks with a shared secret it sends verbatim
@@ -91,10 +96,27 @@ module RevenueCat
       plan_type = resolve_plan_type
       return unless plan_type
 
+      # Capture the prior status BEFORE mutating it so we can detect a
+      # trial→paid conversion (was trialing, now a normal-period RENEWAL).
+      was_trialing = user.plan_status == "trialing"
+      trialing = trial_period?
+
       user.plan_type = plan_type
-      user.plan_status = "active"
+      # RevenueCat sends period_type=TRIAL/INTRO during a free/intro trial. Mark
+      # the user "trialing" (matching the Stripe path) instead of "active" so a
+      # trialist is distinguishable from a payer. paid_plan? treats both as paid,
+      # so access/credit gates are unaffected.
+      user.plan_status = trialing ? "trialing" : "active"
       interval = RevenueCat::PlanMapping.billing_interval_for_product(@event["product_id"])
       user.settings["billing_interval"] = interval if interval.present?
+      # Persist the trial end so RevenueCatTrialEndingJob can nudge ~3 days out —
+      # Apple/RevenueCat send no trial_will_end webhook, so we compute it. Cleared
+      # once the trial resolves (converts or expires).
+      if trialing
+        user.settings["trial_ends_at"] = expiration_time&.iso8601
+      else
+        user.settings.delete("trial_ends_at")
+      end
       user.setup_limits
       user.save!
 
@@ -119,12 +141,19 @@ module RevenueCat
       # a no-op while a real upgrade (basic→pro) re-welcomes, matching Stripe.
       user.send_plan_welcome_email_once!(plan_type)
 
-      # fire_started distinguishes a genuine start (INITIAL/NON_RENEWING) from a
-      # renewal/product-change. An IAP user goes straight from free(active) to
-      # paid(active) with no intermediate status, so we can't guard on a status
-      # transition the way Stripe does — the flag is the signal. Event-level
-      # idempotency prevents a re-delivered purchase from double-firing.
-      fire_subscription_started(user, plan_type) if fire_started
+      # Analytics. fire_started marks a genuine start (INITIAL/NON_RENEWING) vs a
+      # renewal/product-change. On a trial start we fire trial_started (parity
+      # with Stripe); on a paid start, subscription_started. A RENEWAL that
+      # converts a trial (was trialing, now normal) fires subscription_started so
+      # trial→paid is measurable. Event-level idempotency stops re-deliveries from
+      # double-firing.
+      if fire_started && trialing
+        fire_trial_started(user, plan_type)
+      elsif fire_started
+        fire_subscription_started(user, plan_type)
+      elsif was_trialing && !trialing
+        fire_subscription_started(user, plan_type)
+      end
     end
 
     # Auto-renew turned off but the user keeps access until the period ends — no
@@ -143,15 +172,19 @@ module RevenueCat
 
     def handle_expiration(user)
       cancelled_plan = user.plan_type
+      # A trial that lapsed without converting vs a paid sub that churned — same
+      # downgrade, but distinct analytics reason so trial conversion is measurable.
+      reason = user.plan_status == "trialing" ? "trial_expired" : "expiration"
+      user.settings.delete("trial_ends_at")
       Billing::PlanTransitions.apply_free_plan(user, "canceled")
       AnalyticsEvent.track(
         "subscription_canceled",
         user_id: user.id,
-        metadata: { plan_type: cancelled_plan, provider: PROVIDER, reason: "expiration" },
+        metadata: { plan_type: cancelled_plan, provider: PROVIDER, reason: reason },
       )
       PosthogService.capture_for_user(
         user, "subscription_cancelled",
-        properties: { plan: cancelled_plan, reason: "expiration" }
+        properties: { plan: cancelled_plan, reason: reason }
       )
     end
 
@@ -203,7 +236,31 @@ module RevenueCat
       )
     end
 
+    # Free/intro trial began. Mirrors the Stripe trial_started analytics, but
+    # fires both the internal AnalyticsEvent and the PostHog event since IAP has
+    # no checkout step to originate the internal one. subscription_started is
+    # fired later, on conversion, so a trial isn't counted as a paid start.
+    def fire_trial_started(user, plan_type)
+      AnalyticsEvent.track(
+        "trial_started",
+        user_id: user.id,
+        metadata: { plan_type: plan_type, provider: PROVIDER, product_id: @event["product_id"], store: @event["store"] },
+      )
+      PosthogService.capture_for_user(
+        user, "trial_started",
+        properties: {
+          plan: plan_type,
+          billing_interval: RevenueCat::PlanMapping.billing_interval_for_product(@event["product_id"]),
+        },
+        set: { plan: plan_type },
+      )
+    end
+
     # --- helpers -------------------------------------------------------------
+
+    def trial_period?
+      TRIAL_PERIOD_TYPES.include?(@event["period_type"].to_s.upcase)
+    end
 
     def resolve_plan_type
       RevenueCat::PlanMapping.resolve_plan_type(

--- a/spec/requests/api/billing_controller_spec.rb
+++ b/spec/requests/api/billing_controller_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe "POST /api/billing/update_subscription", type: :request do
     expect(user.settings["purchase_platform"]).to eq("android")
   end
 
+  it "does NOT clobber an in-progress trial to active for the same plan" do
+    # The RC webhook marked this trialist 'trialing'; the racing client call must
+    # not flip it to 'active' (which would mask the trial).
+    user.update!(plan_type: "pro", plan_status: "trialing")
+    stub_rc_verified(plan_type: "pro")
+
+    post "/api/billing/update_subscription",
+         params: { plan_key: "pro", purchase_platform: "ios" },
+         headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.plan_status).to eq("trialing")
+  end
+
   it "applies the plan's limits (Basic plan board_limit)" do
     stub_rc_verified(plan_type: "basic")
 

--- a/spec/requests/api/revenue_cat_webhook_spec.rb
+++ b/spec/requests/api/revenue_cat_webhook_spec.rb
@@ -160,6 +160,51 @@ RSpec.describe "POST /api/billing/webhooks (RevenueCat)", type: :request do
     end
   end
 
+  describe "free trial (period_type=TRIAL)" do
+    it "starts a trial: marks plan_status trialing, stores trial_ends_at, fires trial_started (not subscription_started)" do
+      trial_end_ms = ((Time.current + 14.days).to_f * 1000).to_i
+      event = rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id,
+                       entitlement_ids: ["pro"], product_id: "com.speakanyway.pro.monthly",
+                       period_type: "TRIAL", expiration_at_ms: trial_end_ms)
+
+      post_rc_webhook(event)
+
+      user.reload
+      expect(user.plan_type).to eq("pro")
+      expect(user.plan_status).to eq("trialing")
+      expect(user).to be_paid_plan # trialing counts as paid for gating
+      expect(Time.parse(user.settings["trial_ends_at"])).to be_within(60.seconds).of(Time.at(trial_end_ms / 1000.0))
+      expect(AnalyticsEvent.where(event_type: "trial_started", user_id: user.id).count).to eq(1)
+      expect(AnalyticsEvent.where(event_type: "subscription_started", user_id: user.id).count).to eq(0)
+    end
+
+    it "converts a trial to paid on a normal RENEWAL: active, clears trial_ends_at, fires subscription_started" do
+      user.update!(plan_type: "pro", plan_status: "trialing",
+                   settings: user.settings.merge("trial_ends_at" => 1.day.from_now.iso8601))
+
+      # A RENEWAL with no period_type is a normal (paid) period.
+      post_rc_webhook(rc_event(type: "RENEWAL", app_user_id: user.id, entitlement_ids: ["pro"]))
+
+      user.reload
+      expect(user.plan_status).to eq("active")
+      expect(user.settings).not_to have_key("trial_ends_at")
+      expect(AnalyticsEvent.where(event_type: "subscription_started", user_id: user.id).count).to eq(1)
+    end
+
+    it "expires an unconverted trial: downgrades to free and tags the churn reason trial_expired" do
+      user.update!(plan_type: "pro", plan_status: "trialing",
+                   settings: user.settings.merge("trial_ends_at" => 1.day.from_now.iso8601))
+
+      post_rc_webhook(rc_event(type: "EXPIRATION", app_user_id: user.id))
+
+      user.reload
+      expect(user.plan_type).to eq("free")
+      expect(user.settings).not_to have_key("trial_ends_at")
+      ev = AnalyticsEvent.where(event_type: "subscription_canceled", user_id: user.id).last
+      expect(ev.metadata["reason"]).to eq("trial_expired")
+    end
+  end
+
   describe "CANCELLATION" do
     it "does NOT downgrade (still entitled until expiry) and records the analytics event" do
       user.update!(plan_type: "pro", plan_status: "active")


### PR DESCRIPTION
## Summary

iOS is configured for a **14-day free trial**, and those events already flow to the existing `/api/billing/webhooks` endpoint — but the processor treated a trial `INITIAL_PURCHASE` identically to a paid purchase (no `trialing` status, no trial analytics, no stored trial end). This closes the #3 parity gap by reading RevenueCat's `period_type` and giving trials the same lifecycle Stripe has.

**No RevenueCat config change is needed** — trials are a `period_type: TRIAL` flag on the normal event types, all delivered to the same forwarding URL.

### What changed
- **`handle_purchase`** — a `TRIAL`/`INTRO` period now:
  - sets `plan_status = "trialing"` (was always `"active"`; `paid_plan?` treats both as paid, so access/credit gating is unchanged)
  - persists `settings["trial_ends_at"]` (ISO8601, from `expiration_at_ms`)
  - fires **`trial_started`** (internal `AnalyticsEvent` **and** PostHog — both, since IAP has no checkout to originate the internal one) **instead of** `subscription_started`
- **Conversion** — `subscription_started` now fires when a normal-period `RENEWAL`/`PRODUCT_CHANGE` moves a user out of `trialing` (status → `active`, `trial_ends_at` cleared), so **trial→paid conversion is measurable**.
- **`handle_expiration`** — an unconverted trial's `subscription_canceled` analytics is tagged `reason: "trial_expired"` (vs `"expiration"` for paid churn).
- **`BillingController#update_subscription`** — preserves an in-progress `trialing` status for the same plan, so the racing client confirmation call can't clobber the trial the webhook just recorded.

### Lifecycle, end to end
| Moment | Event | Result |
|---|---|---|
| Trial starts | `INITIAL_PURCHASE` (`period_type: TRIAL`) | `trialing`, `trial_ends_at` set, `trial_started` fired, welcome email sent |
| Converts (day 14) | `RENEWAL` (`NORMAL`) | `active`, `trial_ends_at` cleared, `subscription_started` fired |
| Cancels in trial | `CANCELLATION` | analytics only, keeps access until expiry |
| Trial lapses | `EXPIRATION` | downgrade to free, `reason: "trial_expired"` |

## Test plan
Ran the affected specs locally — **61 examples, 0 failures**:
```
spec/requests/api/revenue_cat_webhook_spec.rb
spec/requests/api/billing_controller_spec.rb
spec/services/revenue_cat/
spec/models/user_mailer_dispatch_spec.rb
spec/requests/lifecycle_integration_spec.rb
```
New coverage: trial start (trialing + trial_ends_at + trial_started, no subscription_started), trial→paid conversion (active + cleared + subscription_started), trial expiry (free + `trial_expired`), and the billing-controller trial-preservation guard.

Docs: `CLAUDE.md` (new Trials bullet in the RC section) and `CHANGELOG.md`.

## Follow-up (next PR)
The **3-days-before trial-ending reminder** is intentionally out of scope here. Apple/RevenueCat send no `trial_will_end` webhook, so it needs a scheduled job keyed on the `settings["trial_ends_at"]` this PR now persists, enqueuing the existing `MailchimpTrialWrapJob` (Stripe's nudge). Happy to build it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)