### PR TITLE
feat(revenuecat): daily trial-ending reminder job for iOS/Apple trials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — iOS/Apple trial-ending reminder email
+- New `RevenueCatTrialEndingJob` (daily cron, 5am UTC) sends the "trial wrapping
+  up" reminder to RevenueCat trialists ~`REVENUECAT_TRIAL_REMINDER_LEAD_DAYS`
+  (default 3) before their trial ends. Apple/RevenueCat send no `trial_will_end`
+  webhook (unlike Stripe), so this computes the reminder from the
+  `settings["trial_ends_at"]` the webhook persists and enqueues the shared
+  `MailchimpTrialWrapJob` (same `trial_wrap` journey + merge fields as web).
+  Flags `settings["rc_trial_wrap_sent"]` so each trial is nudged once (re-armed
+  when a new trial starts). Keying on `trial_ends_at` scopes it to RC trials, so
+  Stripe trialists are never double-nudged. This completes iOS/Stripe trial
+  parity.
+
 ### Added — RevenueCat (iOS/Apple) free trials are now first-class
 - The RevenueCat webhook reads `period_type`: a `TRIAL`/`INTRO`
   `INITIAL_PURCHASE` now marks the user `plan_status="trialing"` (was always
@@ -17,9 +29,8 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - `BillingController#update_subscription` (the client confirmation call)
   preserves an in-progress `trialing` status for the same plan so it can't
   race-clobber the trial the webhook recorded.
-- Not included yet: a 3-days-before trial-ending reminder. Apple/RevenueCat send
-  no `trial_will_end` webhook, so this needs a scheduled job keyed on
-  `trial_ends_at` (tracked as a follow-up).
+- The 3-days-before trial-ending reminder is delivered by the new
+  `RevenueCatTrialEndingJob` (see the entry above).
 
 ### Fixed — RevenueCat product-id mapping didn't match the real App Store ids
 - `RevenueCat::PlanMapping::PRODUCT_TO_PLAN` keyed on bare package names

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,10 @@ GitHub build). Two distinct uses:
       nudge weeks earlier (the two flags are independent), but only ever once.
     - `trial_wrap` — enqueued by `MailchimpTrialWrapJob`, triggered from the
       `customer.subscription.trial_will_end` Stripe webhook (~3 days before a
-      Stripe no-card reverse trial ends; soft `basic_trial` was retired).
+      Stripe no-card reverse trial ends; soft `basic_trial` was retired). The
+      **iOS/Apple equivalent** is `RevenueCatTrialEndingJob` (daily cron) — Apple
+      sends no trial_will_end webhook, so it computes the ~3-day reminder from
+      `settings["trial_ends_at"]` and enqueues this same job.
       **Personalized:** the job first pushes merge fields `TRIAL_END` (formatted
       date) / `BOARDS` (`countable_board_count`) / `COMMS`
       (`communicator_accounts.count`) via `MailchimpService#update_merge_fields`,
@@ -300,9 +303,13 @@ the Stripe webhook semantics in `API::WebhooksController`. **RevenueCat's
   its `subscription_canceled` analytics `reason: "trial_expired"` (vs
   `"expiration"` for paid churn). The client `update_subscription` call preserves
   an in-progress `trialing` status for the same plan so it can't clobber the
-  trial the webhook recorded. **No trial-ending reminder yet** — Apple/RevenueCat
-  send no `trial_will_end` webhook; a scheduled job keyed on `trial_ends_at` is a
-  pending follow-up (mirrors Stripe's `MailchimpTrialWrapJob`).
+  trial the webhook recorded. **Trial-ending reminder:** Apple/RevenueCat send no
+  `trial_will_end` webhook (unlike Stripe), so `RevenueCatTrialEndingJob` (daily,
+  5am UTC) computes it from `settings["trial_ends_at"]` and enqueues the shared
+  `MailchimpTrialWrapJob` ~`REVENUECAT_TRIAL_REMINDER_LEAD_DAYS` (default 3) out.
+  Flags `settings["rc_trial_wrap_sent"]` (once per trial; re-armed when a new
+  trial starts). Keying on `trial_ends_at` scopes it to RC trials — Stripe
+  trialists never have it set, so they can't be double-nudged.
 - **Idempotency + audit:** `processed_webhook_events` (unique `provider`+`event_id`)
   gates the whole handler (covers non-credit events); the credit grant also
   reuses `credit_transactions.stripe_event_id` with an `rc_<event_id>` token.

--- a/app/services/revenue_cat/webhook_processor.rb
+++ b/app/services/revenue_cat/webhook_processor.rb
@@ -111,9 +111,11 @@ module RevenueCat
       user.settings["billing_interval"] = interval if interval.present?
       # Persist the trial end so RevenueCatTrialEndingJob can nudge ~3 days out —
       # Apple/RevenueCat send no trial_will_end webhook, so we compute it. Cleared
-      # once the trial resolves (converts or expires).
+      # once the trial resolves (converts or expires). Starting a (new) trial also
+      # re-arms the once-per-trial nudge flag.
       if trialing
         user.settings["trial_ends_at"] = expiration_time&.iso8601
+        user.settings.delete("rc_trial_wrap_sent")
       else
         user.settings.delete("trial_ends_at")
       end

--- a/app/sidekiq/revenue_cat_trial_ending_job.rb
+++ b/app/sidekiq/revenue_cat_trial_ending_job.rb
@@ -1,0 +1,85 @@
+# Daily Sidekiq-cron job that sends the "trial wrapping up" reminder to
+# RevenueCat (iOS/Apple) trialists ~REVENUECAT_TRIAL_REMINDER_LEAD_DAYS (default
+# 3) before their free trial ends.
+#
+# Why a job instead of a webhook: Stripe fires a
+# `customer.subscription.trial_will_end` webhook ~3 days out, which triggers
+# MailchimpTrialWrapJob directly. Apple/RevenueCat send NO equivalent event, so
+# we compute the reminder from settings["trial_ends_at"] — persisted by
+# RevenueCat::WebhookProcessor on a TRIAL INITIAL_PURCHASE. Keying on that field
+# naturally scopes this to RC trials: Stripe trialists never have it set, so they
+# can't be double-nudged.
+#
+# Enqueues the shared MailchimpTrialWrapJob (same "trial_wrap" journey + merge
+# fields as the Stripe path) and flags user.settings["rc_trial_wrap_sent"] so each
+# trial is nudged once. The flag is cleared when a new trial starts (in the
+# webhook), so a genuinely new trial re-arms the reminder.
+#
+# Lead window ENV-tunable: REVENUECAT_TRIAL_REMINDER_LEAD_DAYS (default 3). The
+# daily cadence gives ~1 day of slop, so a single missed cron run doesn't
+# permanently skip a user. Failure-isolated per user (a bad row logs, continues).
+class RevenueCatTrialEndingJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :default, retry: 3
+
+  SETTINGS_FLAG = "rc_trial_wrap_sent".freeze
+
+  def perform
+    count = 0
+
+    eligible_users.find_each do |user|
+      next if user.admin?
+      next if already_nudged?(user)
+
+      ends_at = parse_trial_end(user)
+      next unless ends_at
+      # Only "ending soon": in the future but within the lead window. A past
+      # trial_ends_at on a still-trialing user (delayed EXPIRATION webhook) is
+      # stale, not a reminder candidate.
+      next unless ends_at > Time.current && ends_at <= reminder_cutoff
+
+      MailchimpTrialWrapJob.perform_async(user.id, ends_at.to_i)
+      flag_nudged!(user)
+      count += 1
+    rescue => e
+      Rails.logger.error "RevenueCatTrialEndingJob: failed for user #{user&.id} - #{e.message}"
+    end
+
+    Rails.logger.info "RevenueCatTrialEndingJob: completed — #{count} trial(s) nudged"
+  end
+
+  private
+
+  def lead_days
+    (ENV["REVENUECAT_TRIAL_REMINDER_LEAD_DAYS"] || 3).to_i.days
+  end
+
+  def reminder_cutoff
+    Time.current + lead_days
+  end
+
+  # Trialing users with a stored trial end — i.e. RevenueCat trials. Stripe
+  # trialists are excluded automatically (they never get trial_ends_at).
+  def eligible_users
+    User
+      .where(plan_status: "trialing")
+      .where("settings ->> 'trial_ends_at' IS NOT NULL")
+  end
+
+  def already_nudged?(user)
+    user.settings.is_a?(Hash) && user.settings[SETTINGS_FLAG] == true
+  end
+
+  def parse_trial_end(user)
+    raw = user.settings["trial_ends_at"]
+    raw.present? ? Time.parse(raw.to_s) : nil
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def flag_nudged!(user)
+    user.settings = (user.settings || {}).merge(SETTINGS_FLAG => true)
+    user.save!
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -60,5 +60,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Daily Mailchimp Customer Journey trigger (4:30am UTC) re-engaging recently-dormant active users: non-admin users with >=1 board whose last sign-in is WIN_BACK_DORMANT_MIN_DAYS-WIN_BACK_DORMANT_MAX_DAYS (default 14-30) days ago. Flags user.settings[\"win_back_nudge_sent\"] so each user is only nudged once.",
     },
+    "revenuecat_trial_ending" => {
+      "cron" => "0 5 * * *",
+      "class" => "RevenueCatTrialEndingJob",
+      "queue" => "default",
+      "description" => "Daily (5am UTC) trial-ending reminder for RevenueCat (iOS/Apple) trialists ~REVENUECAT_TRIAL_REMINDER_LEAD_DAYS (default 3) before settings[\"trial_ends_at\"]. Apple/RevenueCat send no trial_will_end webhook (unlike Stripe), so this computes it and enqueues the shared MailchimpTrialWrapJob. Flags user.settings[\"rc_trial_wrap_sent\"] so each trial is nudged once.",
+    },
   })
 end

--- a/spec/requests/api/revenue_cat_webhook_spec.rb
+++ b/spec/requests/api/revenue_cat_webhook_spec.rb
@@ -161,6 +161,17 @@ RSpec.describe "POST /api/billing/webhooks (RevenueCat)", type: :request do
   end
 
   describe "free trial (period_type=TRIAL)" do
+    it "re-arms the trial-ending nudge flag when a new trial starts" do
+      user.update!(plan_type: "free", plan_status: "free",
+                   settings: user.settings.merge("rc_trial_wrap_sent" => true))
+
+      post_rc_webhook(rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id,
+                               entitlement_ids: ["pro"], product_id: "com.speakanyway.pro.monthly",
+                               period_type: "TRIAL"))
+
+      expect(user.reload.settings).not_to have_key("rc_trial_wrap_sent")
+    end
+
     it "starts a trial: marks plan_status trialing, stores trial_ends_at, fires trial_started (not subscription_started)" do
       trial_end_ms = ((Time.current + 14.days).to_f * 1000).to_i
       event = rc_event(type: "INITIAL_PURCHASE", app_user_id: user.id,

--- a/spec/sidekiq/revenue_cat_trial_ending_job_spec.rb
+++ b/spec/sidekiq/revenue_cat_trial_ending_job_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe RevenueCatTrialEndingJob, type: :job do
+  subject(:job) { described_class.new }
+
+  before { MailchimpTrialWrapJob.clear }
+
+  # Eligible by default: a RevenueCat trialist whose trial ends in 2 days
+  # (inside the 3-day lead window).
+  def create_rc_trialist(trial_ends_at: 2.days.from_now, extra_settings: {})
+    create(:user,
+      plan_type: "pro",
+      plan_status: "trialing",
+      settings: { "trial_ends_at" => trial_ends_at&.iso8601 }.merge(extra_settings))
+  end
+
+  describe "#perform" do
+    it "enqueues MailchimpTrialWrapJob with the trial-end epoch and flags the user" do
+      ends_at = 2.days.from_now
+      user = create_rc_trialist(trial_ends_at: ends_at)
+
+      expect { job.perform }.to change(MailchimpTrialWrapJob.jobs, :size).by(1)
+      args = MailchimpTrialWrapJob.jobs.last["args"]
+      expect(args.first).to eq(user.id)
+      expect(args.last).to be_within(60).of(ends_at.to_i)
+      expect(user.reload.settings["rc_trial_wrap_sent"]).to eq(true)
+    end
+
+    it "does not re-nudge a user already flagged" do
+      create_rc_trialist(extra_settings: { "rc_trial_wrap_sent" => true })
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "skips a trial ending beyond the lead window" do
+      create_rc_trialist(trial_ends_at: 10.days.from_now)
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "skips a trial whose end is already in the past (stale)" do
+      create_rc_trialist(trial_ends_at: 1.day.ago)
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "skips non-trialing users even if they somehow carry trial_ends_at" do
+      user = create_rc_trialist
+      user.update!(plan_status: "active")
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "skips Stripe trialists (no trial_ends_at set)" do
+      create(:user, plan_type: "pro", plan_status: "trialing", settings: {})
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "skips admins" do
+      create_rc_trialist.update!(role: "admin")
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+    end
+
+    it "respects REVENUECAT_TRIAL_REMINDER_LEAD_DAYS" do
+      create_rc_trialist(trial_ends_at: 6.days.from_now)
+
+      # Default 3-day window: not yet eligible.
+      expect { job.perform }.not_to change(MailchimpTrialWrapJob.jobs, :size)
+
+      # Widen the lead to 7 days: now in range.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("REVENUECAT_TRIAL_REMINDER_LEAD_DAYS").and_return("7")
+      expect { job.perform }.to change(MailchimpTrialWrapJob.jobs, :size).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Completes iOS/Stripe trial parity (follow-up to #319). Stripe fires a `customer.subscription.trial_will_end` webhook ~3 days before a trial ends, which triggers the `MailchimpTrialWrapJob` "trial wrapping up" nudge. **Apple/RevenueCat send no equivalent webhook**, so iOS trialists got no reminder. This computes it from the `settings["trial_ends_at"]` that #319 now persists.

### What changed
- **`RevenueCatTrialEndingJob`** (new, daily cron @ 5am UTC): finds `trialing` users whose `settings["trial_ends_at"]` falls within `REVENUECAT_TRIAL_REMINDER_LEAD_DAYS` (default 3) and enqueues the shared **`MailchimpTrialWrapJob`** — same `trial_wrap` journey + `TRIAL_END`/`BOARDS`/`COMMS` merge fields as web. Flags `settings["rc_trial_wrap_sent"]` for once-per-trial delivery; admins, already-nudged, and stale (past-dated) trials are skipped.
- **Scoped to RevenueCat trials by construction.** Only the RC webhook sets `trial_ends_at`; Stripe trialists never have it, so they can't be double-nudged.
- **Re-arm on new trial.** The RC webhook now clears `rc_trial_wrap_sent` when a trial starts, so a genuinely new trial re-arms the reminder.
- Registered in `config/initializers/sidekiq.rb` (sidekiq-cron), slotted at 5am UTC after the other Mailchimp nudges (4 / 4:30am).

### Why a cron job (not a webhook)
There's simply no Apple/RevenueCat "trial will end" event to subscribe to — the only way to hit ~3 days out is to compute it from the stored trial end. The daily cadence gives ~1 day of slop so a single missed run doesn't permanently skip anyone.

## Test plan
Ran the affected specs locally — **45 examples, 0 failures**:
```
spec/sidekiq/revenue_cat_trial_ending_job_spec.rb
spec/requests/api/revenue_cat_webhook_spec.rb
spec/requests/api/billing_controller_spec.rb
```
Job coverage: in-window enqueue + epoch arg + flag set; dedup; beyond-window skip; past/stale skip; non-trialing skip; **Stripe-trialist exclusion**; admin skip; `REVENUECAT_TRIAL_REMINDER_LEAD_DAYS` override. Plus a webhook test that a new trial re-arms the flag. `ruby -c` on the cron config confirms the schedule hash still loads.

Docs: `CLAUDE.md` (RC Trials bullet + `trial_wrap` journey entry now note the iOS path) and `CHANGELOG.md`.

## Ops note
No env var required — `REVENUECAT_TRIAL_REMINDER_LEAD_DAYS` defaults to 3. The journey send is gated downstream by `MailchimpClient.journeys_enabled?` (prod-only), same as the other nudges, so this is a safe no-op until the `trial_wrap` journey ENV is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)