### PR TITLE
fix(stripe): harden checkout-session reconcile + customer.created linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Stripe checkout/signup hardening (entitlement bypass + customer linking)
+- **`POST /api/stripe/update_user_from_session` could grant a paid plan for an
+  unpaid checkout.** It set `plan_type`/`plan_status=active` straight from the
+  session's `plan_key` metadata without checking the checkout completed, so
+  hitting the success URL with an abandoned/expired session's id flipped the
+  user to a paid tier for free. It now requires `session.status == "complete"`,
+  only lets the authenticated **owner** of the session reconcile from it (403
+  otherwise), and reads the **real subscription status** (`trialing`/`active`)
+  so a no-card trial is no longer recorded as `active` (and can't clobber the
+  webhook's `trialing`). Credits remain webhook-only.
+- **`customer.created` webhook now links the Stripe customer to the user**
+  (fills a blank `stripe_customer_id`, never repoints an existing one) instead
+  of relying on `email_signup`'s separate save winning the race, and the
+  invite-fallback is race-safe (re-finds by email on a unique violation rather
+  than duplicating the account).
+
 ### Added — iOS/Apple trial-ending reminder email
 - New `RevenueCatTrialEndingJob` (daily cron, 5am UTC) sends the "trial wrapping
   up" reminder to RevenueCat trialists ~`REVENUECAT_TRIAL_REMINDER_LEAD_DAYS`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,21 @@ demo/myspeak signups keep using `sign_up`. Key invariants:
   round-trip (this bug made the `/welcome/token/` link never render).
 - **`customer.created` webhook** matches existing users by email before
   inviting, so it can't rotate a just-issued invitation token when the
-  webhook races email_signup's `stripe_customer_id` save.
+  webhook races email_signup's `stripe_customer_id` save. It then **links**
+  the customer (`update_columns(stripe_customer_id:)` when blank — never
+  repoints an existing id; `update_columns` avoids touching the token), so the
+  link is self-healing rather than depending on email_signup's separate save.
+  The invite! fallback is race-safe: a unique-violation re-finds by email
+  instead of duplicating.
+- **`POST /api/stripe/update_user_from_session`** is a best-effort fast-path the
+  frontend hits on the Stripe success redirect; the webhook stays the source of
+  truth for plan + credits. It **only reflects a plan when the session actually
+  completed** (`session.status == "complete"`) — an abandoned/expired session
+  can't grant a paid tier without payment — and only the authenticated **owner**
+  of the session may call it (403 otherwise). It reads the real subscription
+  status (`trialing`/`active`) so a no-card trial isn't recorded as `active`
+  (and can't clobber the webhook's `trialing`); it grants **no credits** (webhook
+  authority).
 - `email_signup` never sets `paid_plan_type` (checkout owns it) and skips
   Stripe-customer creation for `platform=ios/android`, like `sign_up`.
 - **Billing portal for everyone:** `POST /api/subscriptions/billing_portal`

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -200,29 +200,64 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     render json: { error: "Failed to create top-up session" }, status: :bad_request
   end
 
+  # Best-effort fast-path the frontend calls on the Stripe success redirect to
+  # reflect the new plan without waiting for the webhook. The Stripe webhook
+  # remains the source of truth for plan + credits — this only mirrors what it
+  # will set, and grants NOTHING for a checkout that didn't actually complete.
   def update_user_from_session
-    session_id = params[:session_id].to_s
-    session = Stripe::Checkout::Session.retrieve(session_id)
-    user_id = session.metadata.user_id
-    plan_key = session.metadata.plan_key
-    user = User.find_by(id: user_id)
-    if user.nil?
-      render json: { error: "User not found" }, status: :not_found
+    session = Stripe::Checkout::Session.retrieve(params[:session_id].to_s)
+
+    # Only the authenticated owner may reconcile from their own checkout —
+    # don't let one user act on another's session.
+    if session.metadata&.user_id.to_s != current_user.id.to_s
+      render json: { error: "Session does not belong to this user" }, status: :forbidden
       return
     end
-    normalized_plan_key = normalize_plan_key(plan_key)
-    user.plan_type = normalized_plan_key
-    user.plan_status = "active"
-    user.setup_limits
-    user.save!
-    MailchimpEventJob.perform_async(user.id, "sign_up")
+
+    # CRITICAL: only a COMPLETED checkout grants a plan. An abandoned/expired
+    # session is "open"/"expired" — reflecting its plan_key would hand a paid
+    # tier to someone who never paid. No-op (not an error) so the frontend can
+    # retry while the webhook catches up.
+    unless session.status == "complete"
+      render json: { success: true, status: session.status }
+      return
+    end
+
+    plan_type, plan_status = plan_and_status_from_session(session)
+    if plan_type.present?
+      current_user.plan_type = plan_type
+      current_user.plan_status = plan_status
+      current_user.setup_limits
+      current_user.save!
+      MailchimpEventJob.perform_async(current_user.id, "sign_up")
+    end
     render json: { success: true }
-  rescue StandardError => e
+  rescue Stripe::StripeError, StandardError => e
     Rails.logger.error "Error updating user from session: #{e.class} - #{e.message}"
     render json: { error: "Failed to update user from session" }, status: :bad_request
   end
 
   private
+
+  # Plan tier + status for a COMPLETED checkout. Prefers the real subscription
+  # (status-correct: trialing vs active, plan from the price metadata) so a
+  # no-card trial isn't recorded as "active" and clobbering the webhook's
+  # "trialing"; falls back to the session's plan_key. Credits are NOT granted
+  # here — the webhook (invoice.payment_succeeded / subscription.created) is the
+  # sole credit-grant authority.
+  def plan_and_status_from_session(session)
+    plan_key = session.metadata&.plan_key
+    status = "active"
+
+    if session.subscription.present?
+      sub = Stripe::Subscription.retrieve(session.subscription.to_s)
+      status = %w[trialing active].include?(sub.status.to_s) ? sub.status.to_s : "active"
+      price = sub.items&.data&.first&.price
+      plan_key = (price&.metadata || {})["plan_type"].presence || plan_key
+    end
+
+    [normalize_plan_key(plan_key).presence, status]
+  end
 
   def ensure_customer!
     current_user.ensure_stripe_customer!

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -142,21 +142,42 @@ class API::WebhooksController < API::ApplicationController
 
   def handle_customer_created(customer)
     stripe_customer_id = customer.id
+    email = customer.email&.downcase
+
     user = User.find_by(stripe_customer_id: stripe_customer_id)
-    # Also match by email before inviting: when email_signup creates the
-    # Stripe customer, this webhook can race the stripe_customer_id save, and
-    # invite! on the existing pending-invite user would rotate the
-    # invitation_token — invalidating the magic link just emailed.
-    user ||= User.find_by(email: customer.email&.downcase) if customer.email.present?
-    if !user && customer.email.present?
-      Rails.logger.error "[StripeWebhook] customer.created: no user found for customer #{stripe_customer_id} - Creating one"
-      user = User.invite!(email: customer.email, skip_invitation: true)
+    # Match by email before inviting: when email_signup creates the Stripe
+    # customer, this webhook can race the stripe_customer_id save, and invite!
+    # on the existing pending-invite user would rotate the invitation_token —
+    # invalidating the magic link just emailed.
+    user ||= User.find_by(email: email) if email.present?
+
+    if !user && email.present?
+      # No account for this customer. Create one, but stay race-safe: a
+      # concurrent delivery (or this webhook racing email_signup's own user
+      # save) could try the same email, so re-find on a unique violation
+      # instead of raising/duplicating.
+      Rails.logger.error "[StripeWebhook] customer.created: no user for customer #{stripe_customer_id} - inviting #{email}"
+      begin
+        user = User.invite!(email: email, skip_invitation: true)
+      rescue ActiveRecord::RecordNotUnique
+        user = User.find_by(email: email)
+      end
     elsif !user
       Rails.logger.error "[StripeWebhook] customer.created: no user found for customer #{stripe_customer_id} and no email present"
       return
     end
     return unless user
-    Rails.logger.info "[StripeWebhook] customer.created: customer #{customer.id} created"
+
+    # Link the customer to the user so subsequent subscription/invoice webhooks
+    # resolve by stripe_customer_id and we don't depend on email_signup's
+    # separate save winning the race. Only fill a blank id (never repoint an
+    # existing customer); update_columns avoids touching the invitation_token.
+    if user.stripe_customer_id.blank?
+      user.update_columns(stripe_customer_id: stripe_customer_id)
+      Rails.logger.info "[StripeWebhook] customer.created: linked customer #{stripe_customer_id} to user #{user.id}"
+    else
+      Rails.logger.info "[StripeWebhook] customer.created: user #{user.id} already linked (#{user.stripe_customer_id})"
+    end
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_customer_created error: #{e.class} - #{e.message}"
   end

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -220,22 +220,25 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
 
   describe "#update_user_from_session" do
     let(:session_id) { "cs_test_session_xyz" }
-    let(:fake_session) do
+
+    def fake_session(status: "complete", plan_key: "basic_yearly", subscription: nil, user_id: user.id)
       OpenStruct.new(
         id: session_id,
-        metadata: OpenStruct.new(user_id: user.id, plan_key: "basic_yearly"),
+        status: status,
+        subscription: subscription,
+        metadata: OpenStruct.new(user_id: user_id, plan_key: plan_key),
       )
     end
 
-    before do
-      allow(Stripe::Checkout::Session).to receive(:retrieve).with(session_id).and_return(fake_session)
+    def stub_session(**opts)
+      allow(Stripe::Checkout::Session).to receive(:retrieve).with(session_id).and_return(fake_session(**opts))
     end
 
-    it "normalizes plan_key, sets plan_status=active, and enqueues a Mailchimp event" do
+    it "on a completed session: normalizes plan_key, sets plan_status=active, enqueues Mailchimp" do
+      stub_session(status: "complete", plan_key: "basic_yearly")
+
       expect {
-        post "/api/stripe/update_user_from_session",
-             params: { session_id: session_id },
-             headers: auth_headers(user)
+        post "/api/stripe/update_user_from_session", params: { session_id: session_id }, headers: auth_headers(user)
       }.to change { MailchimpEventJob.jobs.size }.by(1)
 
       expect(response).to have_http_status(:ok)
@@ -244,15 +247,42 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       expect(user.plan_status).to eq("active")
     end
 
-    it "404s when the session metadata.user_id resolves to no user" do
-      bad_session = OpenStruct.new(id: session_id, metadata: OpenStruct.new(user_id: 99_999_999, plan_key: "basic"))
-      allow(Stripe::Checkout::Session).to receive(:retrieve).with(session_id).and_return(bad_session)
+    it "does NOT grant a plan for an incomplete/abandoned session (no payment)" do
+      user.update!(plan_type: "free", plan_status: nil)
+      stub_session(status: "open", plan_key: "pro")
 
-      post "/api/stripe/update_user_from_session",
-           params: { session_id: session_id },
-           headers: auth_headers(user)
+      expect {
+        post "/api/stripe/update_user_from_session", params: { session_id: session_id }, headers: auth_headers(user)
+      }.not_to change { MailchimpEventJob.jobs.size }
 
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.plan_type).to eq("free")
+    end
+
+    it "reflects the real subscription status (trialing), not a blanket 'active'" do
+      sub = OpenStruct.new(
+        status: "trialing",
+        items: OpenStruct.new(data: [OpenStruct.new(price: OpenStruct.new(metadata: { "plan_type" => "pro" }))]),
+      )
+      allow(Stripe::Subscription).to receive(:retrieve).with("sub_123").and_return(sub)
+      stub_session(status: "complete", plan_key: "basic", subscription: "sub_123")
+
+      post "/api/stripe/update_user_from_session", params: { session_id: session_id }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      user.reload
+      expect(user.plan_type).to eq("pro")       # from the subscription's price metadata
+      expect(user.plan_status).to eq("trialing") # status-correct, doesn't clobber the webhook
+    end
+
+    it "403s when the session belongs to a different user" do
+      stub_session(status: "complete", user_id: 99_999_999, plan_key: "pro")
+
+      expect {
+        post "/api/stripe/update_user_from_session", params: { session_id: session_id }, headers: auth_headers(user)
+      }.not_to change { user.reload.plan_type }
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 end

--- a/spec/requests/api/webhooks_customer_created_spec.rb
+++ b/spec/requests/api/webhooks_customer_created_spec.rb
@@ -15,11 +15,12 @@ RSpec.describe "POST /api/webhooks (customer.created)", type: :request do
     event
   end
 
-  context "when a user with that email already exists (id not yet persisted)" do
-    it "does not re-invite or rotate their invitation token" do
+  context "when a user with that email already exists (stripe_customer_id not yet saved)" do
+    it "does not re-invite or rotate their invitation token, and links the customer id" do
       user = User.invite!(email: "racer@example.com", skip_invitation: true)
       original_token = user.invitation_token
       expect(original_token).to be_present
+      expect(user.stripe_customer_id).to be_blank
 
       stub_event(OpenStruct.new(id: "cus_race", email: "racer@example.com"), type: "customer.created")
 
@@ -28,12 +29,23 @@ RSpec.describe "POST /api/webhooks (customer.created)", type: :request do
       }.not_to change(User, :count)
 
       expect(response).to have_http_status(:ok)
-      expect(user.reload.invitation_token).to eq(original_token)
+      user.reload
+      expect(user.invitation_token).to eq(original_token)
+      expect(user.stripe_customer_id).to eq("cus_race") # webhook self-heals the link
+    end
+
+    it "does not repoint a user who already has a different stripe_customer_id" do
+      user = create(:user, email: "linked@example.com", stripe_customer_id: "cus_existing")
+      stub_event(OpenStruct.new(id: "cus_new", email: "linked@example.com"), type: "customer.created")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.stripe_customer_id).to eq("cus_existing")
     end
   end
 
   context "when no user matches by customer id or email" do
-    it "invites a new passwordless user" do
+    it "invites a new passwordless user and links the customer id" do
       stub_event(OpenStruct.new(id: "cus_fresh", email: "fresh@example.com"), type: "customer.created")
 
       expect {
@@ -43,6 +55,25 @@ RSpec.describe "POST /api/webhooks (customer.created)", type: :request do
       user = User.find_by(email: "fresh@example.com")
       expect(user.invitation_token).to be_present
       expect(user.invitation_accepted_at).to be_nil
+      expect(user.stripe_customer_id).to eq("cus_fresh")
+    end
+  end
+
+  context "when inviting races a concurrent delivery (unique violation)" do
+    it "re-finds the existing user instead of raising or duplicating" do
+      existing = User.invite!(email: "dupe@example.com", skip_invitation: true)
+      # Force the invite! branch (email lookup returns nil first), then have the
+      # DB unique index reject the duplicate insert; handler must recover.
+      allow(User).to receive(:find_by).and_call_original
+      allow(User).to receive(:find_by).with(email: "dupe@example.com").and_return(nil, existing)
+      allow(User).to receive(:invite!).and_raise(ActiveRecord::RecordNotUnique.new("dup"))
+
+      stub_event(OpenStruct.new(id: "cus_dupe", email: "dupe@example.com"), type: "customer.created")
+
+      expect {
+        post_webhook("{}", header_with_signature)
+      }.not_to change(User, :count)
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes the two remaining **web-only** integrity items from the billing-path review (#317 covered the rest). Investigating the actual code sharpened both findings.

### 1. `update_user_from_session` could grant a paid plan for an *unpaid* checkout (entitlement bypass)
`POST /api/stripe/update_user_from_session` set `plan_type` + `plan_status="active"` straight from the session's `plan_key` **metadata**, with no check that the checkout actually completed. Since `plan_key` is fixed when the session is *created*, a user could start a Pro checkout, abandon payment, then hit `/billing/success?session_id=…` with that id and get **Pro for free**. It also clobbered trial status (set `active` even for a no-card trial — the same bug we just fixed for RevenueCat in #319).

Now it:
- **requires `session.status == "complete"`** — an abandoned/expired session (`open`/`expired`) is a no-op, so it can't grant a tier without payment;
- only lets the **authenticated owner** of the session reconcile from it (**403** otherwise — was silently acting on whatever `metadata.user_id` said);
- reads the **real subscription** status (`trialing`/`active`) and plan from the price metadata, so a no-card trial is recorded as `trialing` (status-correct, doesn't clobber the webhook);
- still grants **no credits** — the webhook (`invoice.payment_succeeded` / `subscription.created`) remains the sole credit authority. The endpoint stays a best-effort fast-path for webhook lag.

### 2. `customer.created` didn't link the customer (race robustness)
The webhook found the user by email (good — avoids re-inviting and rotating the magic-link token) but **never linked `stripe_customer_id`**, leaving that to `email_signup`'s separate save. It now:
- **links the customer** when the user's id is blank (`update_columns`, so the invitation token is untouched; never repoints an existing id) — self-healing regardless of which write wins the race;
- makes the invite-fallback **race-safe** — a `RecordNotUnique` re-finds by email instead of raising/duplicating.

> Note: the email-lookup already prevented the *common* duplicate (the user exists before the Stripe call), so this is robustness + correct linking rather than a live duplicate-account bug.

## Test plan
Ran the affected + adjacent specs locally — **103 examples, 0 failures** (incl. `webhooks_customer_created`, `stripe/checkout_sessions`, `webhooks_*`, `auth`, `lifecycle_integration`).

New/updated coverage:
- `update_user_from_session`: completed happy-path; **incomplete session → no plan granted**; trialing-status reflection from the real subscription; **cross-user → 403**.
- `customer.created`: links the id; **doesn't repoint** an existing id; **race-safe** invite (unique-violation recovery).

Docs: `CLAUDE.md` (email-signup section) + `CHANGELOG.md`.

## Scope note
Kept `update_user_from_session` rather than deleting it — the frontend calls it on the success redirect, so removing it needs a coordinated frontend change. Hardening it in place closes the hole without touching the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)