### PR TITLE
feat(billing): promo-aware plan switch for existing subscribers (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Promo-aware one-click plan switch for existing subscribers (#308)
+- **`POST /api/subscriptions/change_plan_portal_session`** lets an existing
+  subscriber switch plans (e.g. basic-monthly → the yearly Founding rate) with
+  the promo pre-applied — no fresh checkout (which would double-bill an active
+  sub), no manually typed code. Params: `plan_key` (required), `promo_code`
+  (optional). It resolves the plan to a Stripe price (shared `PLAN_PRICE_IDS`),
+  looks up the active promotion code the same graceful way checkout does, finds
+  the user's own active/trialing/past_due subscription, and opens a Stripe
+  Customer-portal **deep link** (`flow_data.subscription_update_confirm`) that
+  pre-selects the new price + discount. Stripe renders its own confirm page
+  (price change + proration), so we never mutate the subscription directly; the
+  resulting `customer.subscription.updated` webhook applies the new entitlements
+  exactly like a manual portal switch. Returns 422 when the user has no
+  active subscription (those users belong in checkout) or an unknown plan, and
+  400 (generic message) on any Stripe error. Frontend wiring lands separately.
+
 ### Fixed — Stripe checkout/signup hardening (entitlement bypass + customer linking)
 - **`POST /api/stripe/update_user_from_session` could grant a paid plan for an
   unpaid checkout.** It set `plan_type`/`plan_status=active` straight from the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,24 @@ demo/myspeak signups keep using `sign_up`. Key invariants:
   → 400 generic message. Requires a saved Customer-portal default config in
   the Stripe dashboard (test + live) — see `docs/stripe-setup.md` §4b.
   Optional `STRIPE_PORTAL_CONFIG_ID` pins a dedicated config.
+- **Promo-aware plan switch for existing subscribers (#308):**
+  `POST /api/subscriptions/change_plan_portal_session` (`plan_key` required,
+  `promo_code` optional) lets a current subscriber switch plans with a promo
+  pre-applied — the path free users get via a fresh Checkout session, which
+  existing subscribers can't use (a new checkout on an active sub double-bills).
+  It resolves `plan_key` via the shared `API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS`,
+  looks up the active promotion code the same graceful way checkout does, finds
+  the user's own active/trialing/past_due subscription, and opens a portal
+  **deep link** (`flow_data.subscription_update_confirm`) pre-selecting the new
+  price + discount. Stripe renders its own confirm page (price change +
+  proration) — we never call `Stripe::Subscription.update` directly — and the
+  resulting `customer.subscription.updated` webhook applies entitlements exactly
+  like a manual portal switch (`Price.metadata["plan_type"]` → `handle_subscription_upsert`).
+  422 when there's no active subscription (those users belong in checkout) or an
+  unknown/`free` plan; 400 generic on Stripe error; honors `STRIPE_PORTAL_CONFIG_ID`.
+  The Stripe portal config must permit subscription updates for the relevant
+  products for the flow to render. Frontend CTA wiring is a separate PR
+  (itty-bitty-frontend#369 keeps the portal fallback until it lands).
 
 ### `paid_plan?` semantics
 

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -24,6 +24,70 @@ class API::SubscriptionsController < API::ApplicationController
     render json: { error: "Failed to create billing portal session" }, status: :bad_request
   end
 
+  # Promo-aware one-click plan switch for EXISTING subscribers (issue #308).
+  #
+  # Free users get a discounted upgrade via a fresh Checkout session
+  # (checkout_sessions_controller). Existing subscribers can't — a new
+  # checkout on an active subscription would double-bill. Instead we open a
+  # Stripe Customer-portal *deep link* (`flow_data.subscription_update_confirm`)
+  # that pre-selects the target price and pre-applies the promotion code, so
+  # Stripe renders its own confirm page (price change + discount + proration)
+  # and we never mutate the subscription directly. The resulting
+  # `customer.subscription.updated` webhook flows through `handle_subscription_upsert`
+  # exactly like a manual portal switch — `Price.metadata["plan_type"]` drives
+  # the new entitlements.
+  #
+  # POST /api/subscriptions/change_plan_portal_session
+  #   params: plan_key (required), promo_code (optional)
+  def change_plan_portal_session
+    plan_key = params[:plan_key].to_s
+    price_id = API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS[plan_key]
+
+    if price_id.blank?
+      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_entity
+      return
+    end
+
+    customer_id = current_user.stripe_customer_id
+    if customer_id.blank?
+      # No Stripe customer means no subscription to update — these users
+      # belong in checkout, not here.
+      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      return
+    end
+
+    subscription = active_subscription_for(customer_id)
+    if subscription.nil?
+      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      return
+    end
+
+    item = subscription.items.data.first
+    update_confirm = {
+      subscription: subscription.id,
+      items: [{ id: item.id, price: price_id, quantity: 1 }],
+    }
+
+    promo = resolve_promotion_code(params[:promo_code])
+    update_confirm[:discounts] = [{ promotion_code: promo.id }] if promo.present?
+
+    portal_params = {
+      customer: customer_id,
+      return_url: "#{DOMAIN}/dashboard",
+      flow_data: {
+        type: "subscription_update_confirm",
+        subscription_update_confirm: update_confirm,
+      },
+    }
+    portal_params[:configuration] = ENV["STRIPE_PORTAL_CONFIG_ID"] if ENV["STRIPE_PORTAL_CONFIG_ID"].present?
+
+    session = Stripe::BillingPortal::Session.create(portal_params)
+    render json: { url: session&.url }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "change_plan_portal_session: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to create plan change session" }, status: :bad_request
+  end
+
   def create_customer_session
     customer_id = current_user.stripe_customer_id
     customer_session =
@@ -67,5 +131,27 @@ class API::SubscriptionsController < API::ApplicationController
     end
 
     render json: { subscription: subscription }, status: 200
+  end
+
+  private
+
+  # The subscription a plan-change should act on: the customer's current
+  # active/trialing/past_due subscription. Trialing is included so a no-card
+  # reverse-trial user can switch to the founding-rate plan; Stripe's confirm
+  # flow handles whether a payment method is required.
+  def active_subscription_for(customer_id)
+    Stripe::Subscription
+      .list(customer: customer_id, status: "all", limit: 10)
+      .data
+      .find { |s| %w[active trialing past_due].include?(s.status) }
+  end
+
+  # Mirror the checkout controller's graceful promo lookup: resolve an active
+  # promotion code to its Stripe object, or nil (silently skip) if blank/unknown.
+  def resolve_promotion_code(raw_code)
+    code = raw_code.to_s.strip
+    return nil if code.blank?
+
+    Stripe::PromotionCode.list(code: code, active: true, limit: 1).data.first
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
     resources :subscriptions do
       collection do
         post "billing_portal"
+        post "change_plan_portal_session"
         post "add_item"
         post "create_customer_session"
         get "list"

--- a/spec/requests/api/subscriptions_change_plan_portal_session_spec.rb
+++ b/spec/requests/api/subscriptions_change_plan_portal_session_spec.rb
@@ -1,0 +1,195 @@
+require "rails_helper"
+
+# Promo-aware one-click plan switch for existing subscribers (issue #308).
+# Opens a Stripe Customer-portal deep link (flow_data.subscription_update_confirm)
+# that pre-selects the target price and pre-applies the promotion code.
+RSpec.describe "POST /api/subscriptions/change_plan_portal_session", type: :request do
+  let(:portal_session) { OpenStruct.new(url: "https://billing.stripe.com/p/session_test") }
+  let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+  let(:sub_item) { OpenStruct.new(id: "si_123") }
+  let(:active_sub) do
+    OpenStruct.new(id: "sub_active", status: "active",
+                   items: OpenStruct.new(data: [sub_item]))
+  end
+
+  def stub_price_ids
+    stub_const(
+      "API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS",
+      { "free" => nil, "basic_yearly" => "price_basic_year", "pro" => "price_pro" },
+    )
+  end
+
+  def stub_subscription_list(subscriptions)
+    allow(Stripe::Subscription).to receive(:list)
+      .and_return(OpenStruct.new(data: subscriptions))
+  end
+
+  def do_post(params = { plan_key: "basic_yearly" })
+    post "/api/subscriptions/change_plan_portal_session", params: params, headers: auth_headers(user)
+  end
+
+  before { stub_price_ids }
+
+  context "with a valid plan and an active subscription" do
+    it "opens a subscription_update_confirm portal session for the user's item" do
+      stub_subscription_list([active_sub])
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["url"]).to eq(portal_session.url)
+      expect(captured[:customer]).to eq("cus_existing")
+      expect(captured[:flow_data][:type]).to eq("subscription_update_confirm")
+      confirm = captured[:flow_data][:subscription_update_confirm]
+      expect(confirm[:subscription]).to eq("sub_active")
+      expect(confirm[:items]).to eq([{ id: "si_123", price: "price_basic_year", quantity: 1 }])
+      expect(confirm).not_to have_key(:discounts)
+    end
+  end
+
+  context "with a promo code" do
+    it "looks it up and pre-applies the promotion code to the flow" do
+      stub_subscription_list([active_sub])
+      promo = OpenStruct.new(id: "promo_founding")
+      expect(Stripe::PromotionCode).to receive(:list)
+        .with(code: "FOUNDING", active: true, limit: 1)
+        .and_return(OpenStruct.new(data: [promo]))
+
+      captured = nil
+      allow(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post(plan_key: "basic_yearly", promo_code: " FOUNDING ")
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:flow_data][:subscription_update_confirm][:discounts])
+        .to eq([{ promotion_code: "promo_founding" }])
+    end
+
+    it "silently skips an unknown promo code (no discount)" do
+      stub_subscription_list([active_sub])
+      allow(Stripe::PromotionCode).to receive(:list)
+        .and_return(OpenStruct.new(data: []))
+
+      captured = nil
+      allow(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post(plan_key: "basic_yearly", promo_code: "NOPE")
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:flow_data][:subscription_update_confirm]).not_to have_key(:discounts)
+    end
+  end
+
+  context "trialing subscription (no-card reverse trial)" do
+    it "is eligible for the switch" do
+      trialing = OpenStruct.new(id: "sub_trial", status: "trialing",
+                                items: OpenStruct.new(data: [sub_item]))
+      stub_subscription_list([trialing])
+      captured = nil
+      allow(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:flow_data][:subscription_update_confirm][:subscription]).to eq("sub_trial")
+    end
+  end
+
+  context "unknown plan_key" do
+    it "returns 422 without touching Stripe" do
+      expect(Stripe::BillingPortal::Session).not_to receive(:create)
+
+      do_post(plan_key: "nonsense")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("Unknown or unsupported plan")
+    end
+  end
+
+  context "free plan_key (nil price)" do
+    it "returns 422 (downgrades to free go through cancellation, not here)" do
+      expect(Stripe::BillingPortal::Session).not_to receive(:create)
+
+      do_post(plan_key: "free")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  context "user with no Stripe customer" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+    it "returns 422 — they belong in checkout" do
+      expect(Stripe::Subscription).not_to receive(:list)
+
+      do_post
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
+    end
+  end
+
+  context "user with a customer but no active subscription" do
+    it "returns 422" do
+      stub_subscription_list([OpenStruct.new(id: "sub_old", status: "canceled",
+                                             items: OpenStruct.new(data: [sub_item]))])
+
+      do_post
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
+    end
+  end
+
+  context "with STRIPE_PORTAL_CONFIG_ID set" do
+    around do |example|
+      ENV["STRIPE_PORTAL_CONFIG_ID"] = "bpc_test_config"
+      example.run
+    ensure
+      ENV.delete("STRIPE_PORTAL_CONFIG_ID")
+    end
+
+    it "passes it as configuration" do
+      stub_subscription_list([active_sub])
+      captured = nil
+      allow(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      do_post
+
+      expect(captured[:configuration]).to eq("bpc_test_config")
+    end
+  end
+
+  context "when Stripe raises" do
+    it "returns 400 with a generic message, not 500" do
+      stub_subscription_list([active_sub])
+      allow(Stripe::BillingPortal::Session).to receive(:create)
+        .and_raise(Stripe::InvalidRequestError.new("No flow config", nil))
+
+      do_post
+
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("Failed to create plan change session")
+      expect(body["error"]).not_to include("flow")
+    end
+  end
+end


### PR DESCRIPTION
Closes #308.

## Summary

Existing subscribers had no one-click discounted-upgrade path. Free users get the discount via a fresh Stripe Checkout session, but a new checkout on an *active* subscription would double-bill — so the interim path sent subscribers to the plain billing portal where they had to switch plans and **manually type** the promo code (`?promo=` dies at the portal boundary).

This adds **`POST /api/subscriptions/change_plan_portal_session`** (`plan_key` required, `promo_code` optional). Per the approach refined on the issue, it opens a Stripe Customer-portal **deep link** (`flow_data.subscription_update_confirm`) that pre-selects the target price and pre-applies the promotion code. Stripe renders its own confirm page (price change + discount + proration) — we never call `Stripe::Subscription.update` directly, which sidesteps the proration / unpayable-invoice decisions in the original issue.

The resulting `customer.subscription.updated` webhook flows through `handle_subscription_upsert` (`Price.metadata["plan_type"]` → entitlements) **exactly like a manual portal switch** — the path today's interim portal CTA already exercises — so no webhook changes were needed.

Implementation notes:
- Reuses `API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS` and the checkout controller's graceful promo lookup (`Stripe::PromotionCode.list(code:, active:)`, silently skip if not found).
- Acts on the user's **own** active/trialing/past_due subscription (`current_user.stripe_customer_id`). Trialing is included so a no-card reverse-trial user can switch; Stripe's confirm flow handles whether a payment method is required.
- **422** when the user has no active subscription (those users belong in checkout) or an unknown/`free` plan; **400** generic message on any Stripe error; honors `STRIPE_PORTAL_CONFIG_ID`.

## Scope / follow-ups (not in this PR)
- **Frontend wiring is separate** — itty-bitty-frontend#369 keeps the portal fallback until the paid-subscriber CTA is pointed at this endpoint. Backend alone is not user-visible yet (by design).
- **Stripe dashboard:** the Customer-portal config must permit subscription updates for the relevant products for the `subscription_update_confirm` flow to render — verify in the live dashboard before the Founding email send (~July 1, 2026).

## Test plan
- New request spec `spec/requests/api/subscriptions_change_plan_portal_session_spec.rb` — **10 examples, 0 failures**. Covers: happy path (item + price in `flow_data`), promo applied / unknown promo skipped, trialing eligible, unknown plan & free plan → 422, no customer → 422, no active sub → 422, `STRIPE_PORTAL_CONFIG_ID` passthrough, and Stripe error → 400 generic.
- `bin/rails routes` confirms the route is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)