### PR TITLE
docs: note order-dependent vocab_sets re-seed spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -899,6 +899,14 @@ Builder's deterministic build path is unchanged.
 - Rails test environment uses `:null_store` for Rails.cache — stub `Rails.cache` in specs that depend on caching behavior
 - Avoid `travel_to` with past timestamps for Redis keys (TTLs expire immediately); use future times or freeze time instead
 - After spec changes, run the tests that depend on the changed code to ensure no regressions. Use `bin/rspec --only-failures` to rerun only failed specs.
+- **Known order-dependent spec:** `spec/services/vocab_sets_spec.rb` "keeps
+  authored tiles intact across a re-seed" counts `board_images` on the shared
+  seeded `core-60` root and assumes no other example writes to it. Under RSpec's
+  random order it can fail (`expected N, got N+k`) when an unrelated spec runs
+  first. CI runs `bundle exec rspec` with no pinned seed, so a red on this test
+  for an unrelated PR is almost always order-flakiness — rerun the job (fresh
+  seed) before suspecting your diff. Real fix: scope the count to the root the
+  test created, or clean up the polluting spec.
 
 ## Rules for Editing This File
 


### PR DESCRIPTION
## Summary

Captures a session learning: `spec/services/vocab_sets_spec.rb` "keeps authored tiles intact across a re-seed" is **order-dependent**. It counts `board_images` on the shared seeded `core-60` root and assumes no other example writes to it, so under RSpec's random order it can fail (`expected N, got N+k`) when an unrelated spec runs first.

Observed on PR #321's CI (`expected 57, got 61`) — a change touching only the Stripe webhook/checkout controllers. The same commit went **green on rerun** (fresh seed), confirming order-flakiness rather than a real regression. CI runs `bundle exec rspec` with no pinned seed, so this can surface on any PR.

The note tells the next agent to **rerun before suspecting their diff**, and points at the real fix (scope the count to the root the test created, or clean up the polluting spec).

## Test plan
Docs-only — no code or tests changed. Test-irrelevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)