### PR TITLE
fix(auth): make email_signup resilient to Stripe customer creation failures

### DIFF
--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -83,7 +83,16 @@ module API
         raw_invitation_token = user.raw_invitation_token
 
         if platform != "ios" && platform != "android"
-          user.update(stripe_customer_id: User.create_stripe_customer(user.email))
+          # Best-effort: the user is already persisted (invite! above), so a
+          # Stripe hiccup here must not 500 the request — that would strand a
+          # created account and the frontend would fall back to the full
+          # sign-up form, which then fails with "email taken". Checkout and the
+          # billing portal lazily ensure the customer via ensure_stripe_customer!.
+          begin
+            user.update(stripe_customer_id: User.create_stripe_customer(user.email))
+          rescue => e
+            Rails.logger.error "email_signup: Stripe customer creation failed for #{user.email}: #{e.message} — continuing; customer will be ensured at checkout"
+          end
         else
           Rails.logger.warn "Mobile platform email signup for user #{user.email}, skipping Stripe customer creation for platform: #{platform}"
         end

--- a/spec/requests/api/v1/email_signup_spec.rb
+++ b/spec/requests/api/v1/email_signup_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
       expect(User.find_by(email: "buyer@example.com").stripe_customer_id).to eq("cus_email_signup")
     end
 
+    it "still succeeds (200) and returns the user when Stripe customer creation fails" do
+      # Regression: a Stripe hiccup must not 500 after invite! has persisted the
+      # user — that stranded created accounts and the frontend fell back to the
+      # full sign-up form, which then failed with "email taken". The customer is
+      # lazily ensured at checkout instead.
+      allow(User).to receive(:create_stripe_customer)
+        .and_raise(Stripe::APIConnectionError.new("boom"))
+
+      expect {
+        do_post(email: "buyer@example.com")
+      }.to change(User, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      user = User.find_by(email: "buyer@example.com")
+      body = JSON.parse(response.body)
+      expect(body["token"]).to eq(user.authentication_token)
+      expect(body["user"]["id"]).to eq(user.id)
+      expect(user.stripe_customer_id).to be_nil
+    end
+
     it "does not set paid_plan_type (checkout owns it)" do
       do_post(email: "buyer@example.com")
       expect(User.find_by(email: "buyer@example.com").paid_plan_type).to be_blank


### PR DESCRIPTION
## What

`POST /api/v1/users/email_signup` (the paid-intent passwordless signup, PR #312) created the user via `invite!` and then **eagerly** created the Stripe customer with an un-rescued `User.create_stripe_customer` call. A Stripe error raised **after** the user was already persisted, 500-ing the request.

This change wraps that eager creation in `begin/rescue` + log and continues, so `email_signup` always returns `200` with `{ token, user }` even when Stripe is down. The Stripe customer is ensured later anyway — checkout (`ensure_customer!`) and the billing portal both call `User#ensure_stripe_customer!` lazily.

## Why (the bug Brittany hit on staging)

Symptom: *"it made a user but sent me to the sign up page to make a password but then told me my email was taken."*

Sequence:
1. `email_signup` creates the passwordless user ✓
2. eager Stripe customer creation raises → request 500s (user already exists)
3. the frontend reads the 5xx as a failed signup and falls back to the **full sign-up form** (which has a password field)
4. submitting it re-runs `sign_up` → **"Email has already been taken"** — the account already exists

Corroborated by staging logs: no `welcome receipt` log line for any `email_signup` (that line fires immediately after user creation), consistent with a raise between creation and the receipt.

## Companion fix (frontend)

This removes the most likely **trigger**. The actual stranding **mechanism** is in `itty-bitty-frontend` — `handleEmailOnlySignUp` treated a post-account-creation checkout failure as a total signup failure and fell back to the full form. That's fixed in a separate PR (branch `claude/email-signup-fallback-fix`): the checkout handoff is isolated in its own try/catch and routes the already-signed-in user to `/onboarding` instead of the full form. Both are needed for full resolution; either alone reduces the failure window.

## Test plan

- `bundle exec rspec spec/requests/api/v1/email_signup_spec.rb` → **18 examples, 0 failures**
- New spec: "still succeeds (200) and returns the user when Stripe customer creation fails" — asserts `200`, token+user returned, `stripe_customer_id` nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)