### PR TITLE
feat(api): expose plan_status and persist Stripe trial_ends_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Expose plan_status and persist Stripe trial_ends_at (#324, #325)
+- `User#api_view` now includes `plan_status` so the frontend can distinguish a
+  payment-provider trial (`"trialing"`) from an active paid plan.
+- Stripe webhook (`handle_subscription_upsert`) persists
+  `settings["trial_ends_at"]` (ISO8601) when a subscription is trialing, and
+  clears it on conversion or cancellation — matching the RevenueCat path.
+  The frontend's trial countdown now works for both web and iOS trials.
+- `GET /api/v1/users/current` calls `reconcile_stranded_plan!` so a stale
+  plan_status self-heals on the user-fetch path, not only at sign-in.
+
 ### Added — Promo-aware one-click plan switch for existing subscribers (#308)
 - **`POST /api/subscriptions/change_plan_portal_session`** lets an existing
   subscriber switch plans (e.g. basic-monthly → the yearly Founding rate) with

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -211,11 +211,13 @@ module API
       def current
         @current_user = current_user
         if @current_user
+          @current_user.reconcile_stranded_plan!
           @view = @current_user.api_view
           render json: { user: @view }
         else
           @current_user = user_from_token
           if @current_user
+            @current_user.reconcile_stranded_plan!
             render json: { user: @current_user.api_view }
           else
             render json: { error: "Unauthorized - No user signed in" }, status: :unauthorized

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -383,6 +383,12 @@ class API::WebhooksController < API::ApplicationController
     interval = billing_interval_from_price(price)
     user.settings["billing_interval"] = interval if interval.present?
 
+    if subscription.status == "trialing" && subscription.trial_end.present?
+      user.settings["trial_ends_at"] = Time.at(subscription.trial_end).iso8601
+    else
+      user.settings.delete("trial_ends_at")
+    end
+
     user.setup_limits
 
     user.save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1615,6 +1615,7 @@ class User < ApplicationRecord
       basic_vendor: vendor? && basic?,
       vendor: vendor?,
       plan_type: plan_type,
+      plan_status: plan_status,
       plan_expires_at: plan_exp,
       free_trial: free_trial?,
       trial_expired: trial_expired?,

--- a/app/services/billing/plan_transitions.rb
+++ b/app/services/billing/plan_transitions.rb
@@ -22,6 +22,7 @@ module Billing
       user.plan_status = status
       user.setup_free_limits
       user.stripe_subscription_id = nil
+      user.settings.delete("trial_ends_at")
       user.save!
       user.pin_default_editable_board!
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -312,6 +312,19 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#api_view plan_status" do
+    it "includes plan_status in the response" do
+      user = FactoryBot.create(:user, plan_type: "basic", plan_status: "trialing")
+      expect(user.api_view[:plan_status]).to eq("trialing")
+    end
+
+    it "returns nil plan_status when not set" do
+      user = FactoryBot.create(:user, plan_status: nil)
+      expect(user.api_view).to have_key(:plan_status)
+      expect(user.api_view[:plan_status]).to be_nil
+    end
+  end
+
   describe "#api_view has_boards flag" do
     it "is false when the user has no boards" do
       user = FactoryBot.create(:free_user)

--- a/spec/requests/api/v1/auths_current_spec.rb
+++ b/spec/requests/api/v1/auths_current_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v1/users/current", type: :request do
+  include AuthHelpers
+
+  let!(:user) { FactoryBot.create(:user, plan_type: "basic", plan_status: "active") }
+
+  it "returns plan_status in the response" do
+    get "/api/v1/users/current", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    json = JSON.parse(response.body)
+    expect(json["user"]["plan_status"]).to eq("active")
+  end
+
+  it "returns plan_status = trialing for a trial user" do
+    user.update!(plan_status: "trialing")
+
+    get "/api/v1/users/current", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    json = JSON.parse(response.body)
+    expect(json["user"]["plan_status"]).to eq("trialing")
+  end
+
+  it "reconciles a stranded plan on the current endpoint" do
+    user.update!(plan_type: "basic", plan_status: "canceled")
+
+    get "/api/v1/users/current", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    user.reload
+    expect(user.plan_type).to eq("free")
+    json = JSON.parse(response.body)
+    expect(json["user"]["plan_type"]).to eq("free")
+  end
+end

--- a/spec/requests/api/webhooks_plan_type_spec.rb
+++ b/spec/requests/api/webhooks_plan_type_spec.rb
@@ -79,6 +79,28 @@ RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
 
       expect(user.reload.plan_status).to eq("trialing")
     end
+
+    it "persists trial_ends_at when subscription is trialing" do
+      trial_end = 14.days.from_now
+      sub = build_subscription(status: "trialing", trial_end: trial_end)
+      stub_event(sub, type: "customer.subscription.updated")
+
+      post_webhook("{}", header_with_signature)
+
+      user.reload
+      expect(user.settings["trial_ends_at"]).to eq(Time.at(trial_end.to_i).iso8601)
+    end
+
+    it "clears trial_ends_at when subscription transitions to active" do
+      user.update!(settings: { "trial_ends_at" => 7.days.from_now.iso8601 })
+      sub = build_subscription(status: "active")
+      stub_event(sub, type: "customer.subscription.updated")
+
+      post_webhook("{}", header_with_signature)
+
+      user.reload
+      expect(user.settings["trial_ends_at"]).to be_nil
+    end
   end
 
   describe "customer.subscription.updated (Price metadata MISSING)" do
@@ -261,6 +283,16 @@ RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
       expect(user.paid_plan_type).to eq("pro")
       expect(user.plan_status).to eq("canceled")
       expect(user.stripe_subscription_id).to be_nil
+    end
+
+    it "clears trial_ends_at on cancellation" do
+      user.update!(plan_type: "pro", settings: { "trial_ends_at" => 7.days.from_now.iso8601 })
+      sub = build_subscription
+      stub_event(sub, type: "customer.subscription.deleted")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.settings["trial_ends_at"]).to be_nil
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #324, closes #325.

- **`plan_status` in `api_view`** — the frontend can now distinguish `"trialing"` from `"active"` without heuristics.
- **Stripe `trial_ends_at` persistence** — `handle_subscription_upsert` writes `settings["trial_ends_at"]` (ISO8601) when the subscription is trialing, mirroring RevenueCat. Cleared on conversion to active, cancellation, or any downgrade via `Billing::PlanTransitions.apply_free_plan`.
- **Self-heal on `/current`** — `reconcile_stranded_plan!` now runs on `GET /api/v1/users/current`, not only at sign-in, so a stale `plan_status` (canceled-but-webhook-missed) heals on the next user fetch.

## Changed files

| File | Change |
|------|--------|
| `app/models/user.rb` | Add `plan_status:` to `api_view` hash |
| `app/controllers/api/v1/auths_controller.rb` | Call `reconcile_stranded_plan!` in `current` |
| `app/controllers/api/webhooks_controller.rb` | Persist/clear `trial_ends_at` in `handle_subscription_upsert` |
| `app/services/billing/plan_transitions.rb` | Clear `trial_ends_at` on downgrade |
| `CHANGELOG.md` | Entry for both issues |

## Test plan

- [x] `spec/models/user_spec.rb` — `api_view` includes `plan_status` (2 new examples)
- [x] `spec/requests/api/webhooks_plan_type_spec.rb` — persists `trial_ends_at` when trialing, clears on active transition, clears on cancellation (3 new examples)
- [x] `spec/requests/api/v1/auths_current_spec.rb` — returns `plan_status`, reconciles stranded plan (3 new examples, new file)
- [x] All 31 targeted tests pass; full user model suite (51 examples) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)