### PR TITLE
fix(analytics): add source tag to subscription_started PostHog event (#313)

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -424,6 +424,7 @@ class API::WebhooksController < API::ApplicationController
         properties: {
           plan: user.plan_type,
           billing_interval: billing_interval_from_price(price),
+          source: "stripe_webhook",
         },
       )
     end

--- a/spec/requests/api/webhooks_analytics_spec.rb
+++ b/spec/requests/api/webhooks_analytics_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "POST /api/webhooks (PostHog analytics)", type: :request do
       expect(PosthogService).to receive(:capture_for_user).with(
         an_object_having_attributes(id: user.id),
         "subscription_started",
-        properties: { plan: "basic", billing_interval: "monthly" },
+        properties: { plan: "basic", billing_interval: "monthly", source: "stripe_webhook" },
       )
 
       post_webhook("{}", header_with_signature)


### PR DESCRIPTION
## Summary

- All four acceptance criteria from #313 were already implemented in PRs #280 (subscription lifecycle events) and #301 (checkout_completed capture)
- This adds the missing `source: "stripe_webhook"` property to the `subscription_started` PostHog capture, matching the proposed fix in the issue and aligning with `checkout_completed` which already carries it
- `distinct_id` continuity is already solved: both frontend (`String(user.id)`) and backend (`user.id.to_s`) resolve to the same value, and the checkout session metadata already threads `user_id`

Closes #313

## Test plan

- [x] `bundle exec rspec spec/requests/api/webhooks_analytics_spec.rb` — 14 examples, 0 failures
- [x] `bundle exec rspec spec/models/posthog_service_spec.rb` — 10 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)