### PR TITLE
fix: make OBF image lookup deterministic to prevent flaky re-seed tile counts

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2581,8 +2581,8 @@ class Board < ApplicationRecord
     if item["ext_saw_image_id"]
       image = Image.find_by(id: item["ext_saw_image_id"].to_i, user_id: user.id)
     end
-    image ||= Image.find_by(user_id: user.id, label: label, obf_id: item["image_id"])
-    image ||= Image.find_by(user_id: user.id, label: label)
+    image ||= Image.where(user_id: user.id, label: label, obf_id: item["image_id"]).order(:id).first
+    image ||= Image.where(user_id: user.id, label: label).order(:id).first
     image ||= Image.create!(label: label, user_id: user.id, obf_id: item["image_id"], is_private: true)
     image
   end


### PR DESCRIPTION
## Summary

- Fixes the flaky `VocabSets` spec (`spec/services/vocab_sets_spec.rb:128`) that intermittently failed in CI with `expected: 57, got: 59`
- Root cause: `Board.find_or_create_image_for_button` used `find_by` without ordering when multiple Image records matched the same `(user_id, label, obf_id)` — PostgreSQL returned a non-deterministic row, and when it picked the "wrong" Image, `upsert_board_image` created a duplicate BoardImage instead of finding the existing one
- Fix: replace `find_by` with `.where(...).order(:id).first` so the earliest-created Image is always returned

## Why this happens

Vocab-set boards (core-60) have buttons like `"play"` (verb) and `"Play"` (folder link). The `assign_parent` method creates a `category`-type Image for "Play", while the button loop creates a `static`-type Image for "Play". On re-seed, the unordered `find_by` could return either one — when it returned the category Image instead of the static one, the BoardImage lookup by `image_id` missed and created a new row.

## Test plan

- [x] `rspec spec/services/vocab_sets_spec.rb:128` passes (previously flaky)
- [x] Ran twice consecutively — both green
- CI run on this PR confirms the full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)