### PR TITLE
feat(api): add token-gated GET /api/stats business-health endpoint

### DIFF
--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -1,0 +1,21 @@
+module API
+  class StatsController < ApplicationController
+    skip_before_action :authenticate_token!
+    before_action :authenticate_stats_token!
+
+    def index
+      render json: Stats::Snapshot.call
+    end
+
+    private
+
+    def authenticate_stats_token!
+      expected = ENV["STATS_TOKEN"].to_s
+      given = request.headers.fetch("Authorization", "").split(" ").last.to_s
+
+      if expected.blank? || !ActiveSupport::SecurityUtils.secure_compare(given, expected)
+        render json: { error: "Unauthorized" }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/services/stats/snapshot.rb
+++ b/app/services/stats/snapshot.rb
@@ -1,0 +1,52 @@
+module Stats
+  class Snapshot
+    def self.call
+      new.call
+    end
+
+    def call
+      {
+        generated_at: Time.current.iso8601,
+        app: app_info,
+        users: user_counts,
+        communicators: communicator_counts,
+        boards: { total: Board.count },
+        revenue: Stats::StripeRevenue.call,
+      }
+    end
+
+    private
+
+    def app_info
+      version = ENV["GIT_REV"].presence ||
+                ENV["HEROKU_SLUG_COMMIT"].presence ||
+                revision_file ||
+                "unknown"
+      { status: "ok", version: version }
+    end
+
+    def revision_file
+      path = Rails.root.join("REVISION")
+      File.read(path).strip if File.exist?(path)
+    end
+
+    def user_counts
+      non_admin = User.non_admin
+      {
+        total: non_admin.count,
+        paid: non_admin.where.not(plan_type: ["free", nil]).count,
+        free: non_admin.where(plan_type: "free").count,
+      }
+    end
+
+    def communicator_counts
+      {
+        total: ChildAccount.with_archived.count,
+        sandbox: ChildAccount.sandbox.count,
+        loaner: ChildAccount.loaner.count,
+        active: ChildAccount.active.count,
+        archived: ChildAccount.archived.count,
+      }
+    end
+  end
+end

--- a/app/services/stats/stripe_revenue.rb
+++ b/app/services/stats/stripe_revenue.rb
@@ -1,0 +1,63 @@
+module Stats
+  class StripeRevenue
+    def self.call
+      Rails.cache.fetch("stats/stripe_revenue", expires_in: 10.minutes) do
+        new.fetch
+      end
+    end
+
+    def fetch
+      subscriptions = []
+      Stripe::Subscription.list(status: "active", limit: 100).auto_paging_each do |sub|
+        subscriptions << sub
+      end
+
+      seven_days_ago = 7.days.ago.to_i
+      plan_counts = Hash.new(0)
+      mrr_cents = 0
+
+      subscriptions.each do |sub|
+        item = sub.items.data.first
+        next unless item&.price&.recurring
+
+        price = item.price
+        unit = price.unit_amount || 0
+        qty = item.quantity || 1
+        interval = price.recurring.interval
+        interval_count = price.recurring.interval_count || 1
+
+        monthly = case interval
+                  when "month" then (unit * qty).to_f / interval_count
+                  when "year"  then (unit * qty).to_f / (12 * interval_count)
+                  when "week"  then (unit * qty).to_f * 52 / (12 * interval_count)
+                  when "day"   then (unit * qty).to_f * 365 / (12 * interval_count)
+                  else 0
+                  end
+
+        mrr_cents += monthly
+        name = price.nickname.presence || price.id
+        plan_counts[name] += 1
+      end
+
+      {
+        source: "stripe",
+        cached_at: Time.current.iso8601,
+        active_subscriptions: subscriptions.size,
+        mrr_usd: (mrr_cents / 100.0).round(2),
+        new_subs_7d: subscriptions.count { |s| s.created >= seven_days_ago },
+        plan_breakdown: plan_counts.sort_by { |_, v| -v }.to_h,
+      }
+    rescue Stripe::StripeError => e
+      Rails.logger.error("Stats::StripeRevenue failed: #{e.message}")
+      {
+        source: "stripe",
+        error: true,
+        cached_at: Time.current.iso8601,
+        active_subscriptions: nil,
+        mrr_usd: nil,
+        new_subs_7d: nil,
+        plan_breakdown: nil,
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
 
   #  API routes
   namespace :api, defaults: { format: :json } do
+    get "stats", to: "stats#index"
     namespace :stripe do
       resources :checkout_sessions, only: :create do
         collection do

--- a/spec/requests/api/stats_spec.rb
+++ b/spec/requests/api/stats_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/stats", type: :request do
+  let(:stats_token) { "test-stats-secret-token-12345" }
+  let(:auth_header) { { "Authorization" => "Bearer #{stats_token}" } }
+
+  let(:stripe_revenue_result) do
+    {
+      source: "stripe",
+      cached_at: Time.current.iso8601,
+      active_subscriptions: 85,
+      mrr_usd: 59.67,
+      new_subs_7d: 2,
+      plan_breakdown: { "free_plan" => 52, "basic_plan" => 14 },
+    }
+  end
+
+  before do
+    allow(Stats::StripeRevenue).to receive(:call).and_return(stripe_revenue_result)
+  end
+
+  context "without Authorization header" do
+    it "returns 401" do
+      with_env("STATS_TOKEN" => stats_token) do
+        get "/api/stats"
+        expect(response).to have_http_status(:unauthorized)
+        expect(parsed_body["error"]).to eq("Unauthorized")
+      end
+    end
+  end
+
+  context "with wrong token" do
+    it "returns 401" do
+      with_env("STATS_TOKEN" => stats_token) do
+        get "/api/stats", headers: { "Authorization" => "Bearer wrong-token" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  context "when STATS_TOKEN env is unset" do
+    it "returns 401 (fail-closed)" do
+      with_env("STATS_TOKEN" => nil) do
+        get "/api/stats", headers: auth_header
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  context "when STATS_TOKEN env is blank" do
+    it "returns 401 (fail-closed)" do
+      with_env("STATS_TOKEN" => "") do
+        get "/api/stats", headers: auth_header
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  context "with valid token" do
+    let!(:admin_user) { FactoryBot.create(:user, role: "admin") }
+    let!(:free_user) { FactoryBot.create(:user, plan_type: "free") }
+    let!(:paid_user) { FactoryBot.create(:user, plan_type: "basic") }
+    let!(:board) { FactoryBot.create(:board, user: free_user) }
+
+    it "returns 200 with expected JSON structure" do
+      with_env("STATS_TOKEN" => stats_token) do
+        get "/api/stats", headers: auth_header
+
+        expect(response).to have_http_status(:ok)
+        json = parsed_body
+
+        expect(json).to have_key("generated_at")
+        expect(json["app"]["status"]).to eq("ok")
+
+        expect(json["users"]["total"]).to eq(2)
+        expect(json["users"]["paid"]).to eq(1)
+        expect(json["users"]["free"]).to eq(1)
+
+        expect(json["boards"]["total"]).to be >= 1
+
+        expect(json["communicators"]).to have_key("total")
+        expect(json["communicators"]).to have_key("sandbox")
+        expect(json["communicators"]).to have_key("loaner")
+        expect(json["communicators"]).to have_key("active")
+        expect(json["communicators"]).to have_key("archived")
+
+        expect(json["revenue"]["source"]).to eq("stripe")
+        expect(json["revenue"]["active_subscriptions"]).to eq(85)
+        expect(json["revenue"]["mrr_usd"]).to eq(59.67)
+      end
+    end
+  end
+
+  context "with communicator status breakdown" do
+    let!(:user) { FactoryBot.create(:user) }
+
+    before do
+      FactoryBot.create(:child_account, user: user, status: "sandbox")
+      FactoryBot.create(:child_account, user: user, status: "active")
+      FactoryBot.create(:child_account, user: user, status: "active", archived_at: Time.current)
+    end
+
+    it "counts communicators correctly including archived in total" do
+      with_env("STATS_TOKEN" => stats_token) do
+        get "/api/stats", headers: auth_header
+
+        json = parsed_body
+        expect(json["communicators"]["total"]).to eq(3)
+        expect(json["communicators"]["sandbox"]).to eq(1)
+        expect(json["communicators"]["active"]).to eq(1)
+        expect(json["communicators"]["archived"]).to eq(1)
+      end
+    end
+  end
+
+  context "when Stripe is down" do
+    before do
+      allow(Stats::StripeRevenue).to receive(:call).and_return(
+        source: "stripe",
+        error: true,
+        cached_at: Time.current.iso8601,
+        active_subscriptions: nil,
+        mrr_usd: nil,
+        new_subs_7d: nil,
+        plan_breakdown: nil,
+      )
+    end
+
+    it "returns 200 with counts and degraded revenue" do
+      user = FactoryBot.create(:user, plan_type: "free")
+      with_env("STATS_TOKEN" => stats_token) do
+        get "/api/stats", headers: auth_header
+
+        expect(response).to have_http_status(:ok)
+        json = parsed_body
+        expect(json["revenue"]["error"]).to eq(true)
+        expect(json["users"]["total"]).to be >= 1
+      end
+    end
+  end
+
+  private
+
+  def parsed_body
+    JSON.parse(response.body)
+  end
+
+  def with_env(overrides, &block)
+    old_values = overrides.map { |k, _| [k, ENV[k]] }.to_h
+    overrides.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    old_values.each { |k, v| ENV[k] = v }
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/stats` — a read-only, token-gated endpoint returning business-health numbers in one compact JSON response
- User/communicator/board **counts** from local DB scopes (not the sparse `subscriptions` table)
- **Revenue** (active subs, MRR, plan breakdown, new-subs-7d) pulled live from Stripe and cached server-side for 10 minutes via `Stats::StripeRevenue`
- Auth via `ENV["STATS_TOKEN"]` checked with `secure_compare`; **fail-closed** when unset (401)
- Graceful Stripe degradation: if Stripe errors, the endpoint still 200s with counts and a `revenue.error: true` flag
- No migration. Consumer is the external production-snapshot tool, not the app frontend

## New files

- `app/controllers/api/stats_controller.rb` — controller with dedicated token auth
- `app/services/stats/snapshot.rb` — assembles the response hash (counts + revenue + app info)
- `app/services/stats/stripe_revenue.rb` — cached Stripe subscription pull with MRR normalization
- `spec/requests/api/stats_spec.rb` — request spec (7 cases)

## Deploy notes

- Set `STATS_TOKEN` in Hatchbox (long random secret). Endpoint returns 401 until set (intentional).

## Test plan

- `bundle exec rspec spec/requests/api/stats_spec.rb` — **7 examples, 0 failures**
  - 401 without token
  - 401 with wrong token
  - 401 when STATS_TOKEN env is unset (fail-closed)
  - 401 when STATS_TOKEN env is blank (fail-closed)
  - 200 with valid token + correct JSON structure and counts
  - Communicator status breakdown (including archived in total)
  - 200 with degraded revenue when Stripe is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)