### PR TITLE
fix(revenue): Mission Control MRR from Stripe + RevenueCat (#331)

### DIFF
--- a/app/services/mission_control/revenue_metrics.rb
+++ b/app/services/mission_control/revenue_metrics.rb
@@ -3,23 +3,24 @@ module MissionControl
     def self.call = new.call
 
     def call
+      stripe = StripeRevenueSource.call
+
       {
-        active_subscriptions:   Subscription.active.count,
-        new_subs_today:         Subscription.where(created_at: today).count,
-        new_subs_30d:           Subscription.where(created_at: 30.days.ago..).count,
-        canceled_30d:           Subscription.canceled.where(updated_at: 30.days.ago..).count,
+        active_subscriptions:   stripe[:active_subscriptions],
+        estimated_mrr_cents:    stripe[:mrr_cents],
+        mrr_usd:                stripe[:mrr_usd],
+        new_subs_7d:            stripe[:new_subs_7d],
+        revenue_source:         stripe[:source],
+        revenue_cached_at:      stripe[:cached_at],
+        revenue_error:          stripe[:error],
+        stripe_plan_breakdown:  stripe[:plan_breakdown],
         paid_users:             User.non_admin.where.not(plan_type: ["free", nil]).count,
         free_users:             User.non_admin.where(plan_type: "free").count,
         plan_breakdown:         plan_breakdown,
-        estimated_mrr_cents:    estimated_mrr_cents,
       }
     end
 
     private
-
-    def today
-      Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
-    end
 
     def plan_breakdown
       User.non_admin
@@ -27,10 +28,6 @@ module MissionControl
           .count
           .sort_by { |_, v| -v }
           .to_h
-    end
-
-    def estimated_mrr_cents
-      Subscription.active.sum(:price_in_cents)
     end
   end
 end

--- a/app/services/mission_control/revenue_metrics.rb
+++ b/app/services/mission_control/revenue_metrics.rb
@@ -4,16 +4,36 @@ module MissionControl
 
     def call
       stripe = StripeRevenueSource.call
+      rc = RevenuecatRevenueSource.call
+
+      stripe_subs = stripe[:active_subscriptions]
+      rc_subs = rc[:active_subscriptions]
+      combined_subs = safe_add(stripe_subs, rc_subs)
+
+      stripe_mrr = stripe[:mrr_cents]
+      rc_mrr = rc[:estimated_mrr_cents]
+      combined_mrr = safe_add(stripe_mrr, rc_mrr)
 
       {
-        active_subscriptions:   stripe[:active_subscriptions],
-        estimated_mrr_cents:    stripe[:mrr_cents],
-        mrr_usd:                stripe[:mrr_usd],
+        active_subscriptions:   combined_subs,
+        estimated_mrr_cents:    combined_mrr,
+        mrr_usd:                combined_mrr ? (combined_mrr / 100.0).round(2) : nil,
         new_subs_7d:            stripe[:new_subs_7d],
-        revenue_source:         stripe[:source],
+        revenue_source:         "stripe+revenuecat",
         revenue_cached_at:      stripe[:cached_at],
         revenue_error:          stripe[:error],
-        stripe_plan_breakdown:  stripe[:plan_breakdown],
+        stripe:                 {
+          active_subscriptions: stripe_subs,
+          mrr_cents:            stripe_mrr,
+          mrr_usd:              stripe[:mrr_usd],
+          plan_breakdown:       stripe[:plan_breakdown],
+        },
+        revenuecat:             {
+          active_subscriptions: rc_subs,
+          estimated_mrr_cents:  rc_mrr,
+          estimated_mrr_usd:    rc[:estimated_mrr_usd],
+          plan_breakdown:       rc[:plan_breakdown],
+        },
         paid_users:             User.non_admin.where.not(plan_type: ["free", nil]).count,
         free_users:             User.non_admin.where(plan_type: "free").count,
         plan_breakdown:         plan_breakdown,
@@ -28,6 +48,11 @@ module MissionControl
           .count
           .sort_by { |_, v| -v }
           .to_h
+    end
+
+    def safe_add(a, b)
+      return nil if a.nil? && b.nil?
+      (a || 0) + (b || 0)
     end
   end
 end

--- a/app/services/mission_control/revenuecat_revenue_source.rb
+++ b/app/services/mission_control/revenuecat_revenue_source.rb
@@ -1,0 +1,58 @@
+module MissionControl
+  class RevenuecatRevenueSource
+    # Estimated monthly prices (cents) for App Store plans. App Store prices
+    # generally match Stripe; these are fallbacks when the Stripe Price lookup
+    # isn't worth the API call. Override via ENV if they drift.
+    ESTIMATED_MONTHLY_PRICES_CENTS = {
+      "basic"  => ENV.fetch("RC_ESTIMATED_BASIC_MONTHLY_CENTS", "499").to_i,
+      "pro"    => ENV.fetch("RC_ESTIMATED_PRO_MONTHLY_CENTS", "999").to_i,
+    }.freeze
+
+    ESTIMATED_YEARLY_PRICES_CENTS = {
+      "basic"  => ENV.fetch("RC_ESTIMATED_BASIC_YEARLY_CENTS", "4999").to_i,
+      "pro"    => ENV.fetch("RC_ESTIMATED_PRO_YEARLY_CENTS", "9999").to_i,
+    }.freeze
+
+    ACTIVE_STATUSES = %w[active trialing].freeze
+
+    def self.call = new.call
+
+    def call
+      users = revenuecat_paid_users
+      plan_counts = Hash.new(0)
+      total_monthly_cents = 0
+
+      users.find_each do |user|
+        plan = user.plan_type
+        plan_counts[plan] += 1
+        total_monthly_cents += estimated_monthly_cents(plan, user.settings["billing_interval"])
+      end
+
+      {
+        source: "revenuecat_local",
+        active_subscriptions: users.count,
+        estimated_mrr_cents: total_monthly_cents,
+        estimated_mrr_usd: (total_monthly_cents / 100.0).round(2),
+        plan_breakdown: plan_counts.sort_by { |_, v| -v }.to_h,
+      }
+    end
+
+    private
+
+    def revenuecat_paid_users
+      User.non_admin
+          .where(plan_type: %w[basic pro])
+          .where(plan_status: ACTIVE_STATUSES)
+          .where(stripe_subscription_id: [nil, ""])
+    end
+
+    def estimated_monthly_cents(plan_type, billing_interval)
+      if billing_interval == "yearly"
+        yearly = ESTIMATED_YEARLY_PRICES_CENTS[plan_type] || 0
+        (yearly / 12.0).round
+      else
+        ESTIMATED_MONTHLY_PRICES_CENTS[plan_type] || 0
+      end
+    end
+  end
+end

--- a/app/services/mission_control/stripe_revenue_source.rb
+++ b/app/services/mission_control/stripe_revenue_source.rb
@@ -1,0 +1,108 @@
+module MissionControl
+  class StripeRevenueSource
+    CACHE_KEY = "mission_control/stripe_revenue".freeze
+    CACHE_TTL = 10.minutes
+
+    def self.call = new.call
+
+    def self.clear_cache
+      Rails.cache.delete(CACHE_KEY)
+    end
+
+    def call
+      Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { fetch_from_stripe }
+    rescue Stripe::StripeError => e
+      Rails.logger.error("[MissionControl::StripeRevenueSource] Stripe error: #{e.message}")
+      fallback_response(error: e.message)
+    end
+
+    private
+
+    def fetch_from_stripe
+      subs = fetch_all_active_subscriptions
+      now = Time.current
+
+      plan_counts = Hash.new(0)
+      total_monthly_cents = 0
+      new_in_7d = 0
+
+      subs.each do |sub|
+        plan_name = extract_plan_name(sub)
+        plan_counts[plan_name] += 1
+        total_monthly_cents += monthly_amount_cents(sub)
+        new_in_7d += 1 if Time.at(sub.created) > 7.days.ago
+      end
+
+      {
+        source: "stripe",
+        cached_at: now.iso8601,
+        active_subscriptions: subs.size,
+        mrr_cents: total_monthly_cents,
+        mrr_usd: (total_monthly_cents / 100.0).round(2),
+        new_subs_7d: new_in_7d,
+        plan_breakdown: plan_counts.sort_by { |_, v| -v }.to_h,
+      }
+    end
+
+    def fetch_all_active_subscriptions
+      all = []
+      params = { status: "active", limit: 100, expand: ["data.items.data.price"] }
+
+      loop do
+        batch = Stripe::Subscription.list(params)
+        all.concat(batch.data)
+        break unless batch.has_more
+        params[:starting_after] = batch.data.last.id
+      end
+
+      trialing_params = { status: "trialing", limit: 100, expand: ["data.items.data.price"] }
+      loop do
+        batch = Stripe::Subscription.list(trialing_params)
+        all.concat(batch.data)
+        break unless batch.has_more
+        trialing_params[:starting_after] = batch.data.last.id
+      end
+
+      all
+    end
+
+    def extract_plan_name(sub)
+      item = sub.items.data.first
+      return "unknown" unless item
+
+      price = item.price
+      price.metadata["plan_type"].presence || price.lookup_key.presence || price.id
+    end
+
+    def monthly_amount_cents(sub)
+      item = sub.items.data.first
+      return 0 unless item
+
+      price = item.price
+      amount = price.unit_amount || 0
+      interval = price.recurring&.interval
+
+      case interval
+      when "year"
+        (amount / 12.0).round
+      when "month"
+        amount
+      else
+        amount
+      end
+    end
+
+    def fallback_response(error:)
+      {
+        source: "stripe",
+        cached_at: nil,
+        active_subscriptions: nil,
+        mrr_cents: nil,
+        mrr_usd: nil,
+        new_subs_7d: nil,
+        plan_breakdown: {},
+        error: error,
+      }
+    end
+  end
+end

--- a/app/views/admin/mission_control/show.html.erb
+++ b/app/views/admin/mission_control/show.html.erb
@@ -30,29 +30,47 @@
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
     <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">
       Subscriptions &amp; Revenue
-      <% if @revenue[:revenue_source] == "stripe" %>
-        <span class="text-green-500 ml-2">● Stripe</span>
-      <% end %>
     </h2>
     <% if @revenue[:revenue_error] %>
       <p class="text-xs text-red-400 mb-3">Stripe error: <%= @revenue[:revenue_error] %></p>
     <% end %>
     <dl class="space-y-3">
-      <%= render "metric_row", label: "Active subscriptions", value: @revenue[:active_subscriptions] %>
-      <%= render "metric_row", label: "New (last 7d)",         value: @revenue[:new_subs_7d] %>
+      <%= render "metric_row", label: "Active subscriptions (total)", value: @revenue[:active_subscriptions] %>
+      <% if @revenue.dig(:stripe, :active_subscriptions).to_i > 0 || @revenue.dig(:revenuecat, :active_subscriptions).to_i > 0 %>
+        <%= render "metric_row", label: "  ↳ Stripe", value: @revenue.dig(:stripe, :active_subscriptions) %>
+        <%= render "metric_row", label: "  ↳ App Store (est.)", value: @revenue.dig(:revenuecat, :active_subscriptions) %>
+      <% end %>
+      <%= render "metric_row", label: "New Stripe (last 7d)", value: @revenue[:new_subs_7d] %>
       <%= render "metric_row", label: "Paid users",            value: @revenue[:paid_users] %>
       <%= render "metric_row", label: "Free users",            value: @revenue[:free_users] %>
       <% if @revenue[:estimated_mrr_cents].to_i > 0 %>
-        <%= render "metric_row", label: "Est. MRR",
+        <%= render "metric_row", label: "Est. MRR (combined)",
               value: number_to_currency(@revenue[:estimated_mrr_cents].to_f / 100, precision: 2) %>
       <% end %>
     </dl>
 
-    <% if @revenue[:stripe_plan_breakdown].present? %>
+    <%# ── Per-source plan breakdowns ── %>
+    <% stripe_plans = @revenue.dig(:stripe, :plan_breakdown) %>
+    <% if stripe_plans.present? %>
       <div class="mt-5 pt-4 border-t border-gray-800">
         <p class="text-xs text-gray-500 mb-3">Stripe plan breakdown</p>
         <div class="flex flex-wrap gap-2">
-          <% @revenue[:stripe_plan_breakdown].each do |plan, count| %>
+          <% stripe_plans.each do |plan, count| %>
+            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
+              <span class="text-gray-300"><%= plan.presence || "unknown" %></span>
+              <span class="text-indigo-400 font-medium"><%= count %></span>
+            </span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% rc_plans = @revenue.dig(:revenuecat, :plan_breakdown) %>
+    <% if rc_plans.present? %>
+      <div class="mt-5 pt-4 border-t border-gray-800">
+        <p class="text-xs text-gray-500 mb-3">App Store plan breakdown (local DB)</p>
+        <div class="flex flex-wrap gap-2">
+          <% rc_plans.each do |plan, count| %>
             <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
               <span class="text-gray-300"><%= plan.presence || "unknown" %></span>
               <span class="text-indigo-400 font-medium"><%= count %></span>
@@ -64,7 +82,7 @@
 
     <% if @revenue[:plan_breakdown].present? %>
       <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">User plan breakdown (local)</p>
+        <p class="text-xs text-gray-500 mb-3">All users by plan (local DB)</p>
         <div class="flex flex-wrap gap-2">
           <% @revenue[:plan_breakdown].each do |plan, count| %>
             <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">

--- a/app/views/admin/mission_control/show.html.erb
+++ b/app/views/admin/mission_control/show.html.erb
@@ -28,22 +28,43 @@
 
   <%# Revenue ─────────────────────────────────────────────── %>
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">Subscriptions &amp; Revenue</h2>
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">
+      Subscriptions &amp; Revenue
+      <% if @revenue[:revenue_source] == "stripe" %>
+        <span class="text-green-500 ml-2">● Stripe</span>
+      <% end %>
+    </h2>
+    <% if @revenue[:revenue_error] %>
+      <p class="text-xs text-red-400 mb-3">Stripe error: <%= @revenue[:revenue_error] %></p>
+    <% end %>
     <dl class="space-y-3">
       <%= render "metric_row", label: "Active subscriptions", value: @revenue[:active_subscriptions] %>
-      <%= render "metric_row", label: "New this month",        value: @revenue[:new_subs_30d] %>
-      <%= render "metric_row", label: "Canceled this month",   value: @revenue[:canceled_30d] %>
+      <%= render "metric_row", label: "New (last 7d)",         value: @revenue[:new_subs_7d] %>
       <%= render "metric_row", label: "Paid users",            value: @revenue[:paid_users] %>
       <%= render "metric_row", label: "Free users",            value: @revenue[:free_users] %>
       <% if @revenue[:estimated_mrr_cents].to_i > 0 %>
         <%= render "metric_row", label: "Est. MRR",
-              value: number_to_currency(@revenue[:estimated_mrr_cents].to_f / 100, precision: 0) %>
+              value: number_to_currency(@revenue[:estimated_mrr_cents].to_f / 100, precision: 2) %>
       <% end %>
     </dl>
 
+    <% if @revenue[:stripe_plan_breakdown].present? %>
+      <div class="mt-5 pt-4 border-t border-gray-800">
+        <p class="text-xs text-gray-500 mb-3">Stripe plan breakdown</p>
+        <div class="flex flex-wrap gap-2">
+          <% @revenue[:stripe_plan_breakdown].each do |plan, count| %>
+            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
+              <span class="text-gray-300"><%= plan.presence || "unknown" %></span>
+              <span class="text-indigo-400 font-medium"><%= count %></span>
+            </span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
     <% if @revenue[:plan_breakdown].present? %>
       <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">Plan breakdown</p>
+        <p class="text-xs text-gray-500 mb-3">User plan breakdown (local)</p>
         <div class="flex flex-wrap gap-2">
           <% @revenue[:plan_breakdown].each do |plan, count| %>
             <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">

--- a/spec/services/mission_control/revenue_metrics_spec.rb
+++ b/spec/services/mission_control/revenue_metrics_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe MissionControl::RevenueMetrics do
+  let(:stripe_data) do
+    {
+      source: "stripe",
+      cached_at: Time.current.iso8601,
+      active_subscriptions: 85,
+      mrr_cents: 5967,
+      mrr_usd: 59.67,
+      new_subs_7d: 3,
+      plan_breakdown: { "basic_plan" => 4, "pro_plan" => 1 },
+    }
+  end
+
+  before do
+    allow(MissionControl::StripeRevenueSource).to receive(:call).and_return(stripe_data)
+  end
+
+  describe ".call" do
+    it "pulls subscription counts from Stripe, not the local table" do
+      user = create(:user)
+      Subscription.create!(user: user, status: "active", price_in_cents: 999,
+                           stripe_subscription_id: "sub_local")
+
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(85)
+      expect(result[:estimated_mrr_cents]).to eq(5967)
+      expect(result[:mrr_usd]).to eq(59.67)
+    end
+
+    it "includes Stripe plan breakdown separately from user plan breakdown" do
+      result = described_class.call
+      expect(result[:stripe_plan_breakdown]).to eq("basic_plan" => 4, "pro_plan" => 1)
+      expect(result[:revenue_source]).to eq("stripe")
+    end
+
+    it "counts paid and free users from the local database" do
+      create(:user, plan_type: "basic")
+      create(:user, plan_type: "pro")
+      create(:user, plan_type: "free")
+      create(:admin_user, plan_type: "basic")
+
+      result = described_class.call
+
+      expect(result[:paid_users]).to eq(2)
+      expect(result[:free_users]).to eq(1)
+    end
+
+    it "provides a user plan_breakdown from the local database" do
+      create(:user, plan_type: "basic")
+      create(:user, plan_type: "free")
+
+      result = described_class.call
+
+      expect(result[:plan_breakdown]).to include("basic" => 1, "free" => 1)
+    end
+
+    it "surfaces Stripe errors without raising" do
+      allow(MissionControl::StripeRevenueSource).to receive(:call).and_return(
+        stripe_data.merge(active_subscriptions: nil, mrr_cents: nil, error: "Stripe down")
+      )
+
+      result = described_class.call
+      expect(result[:active_subscriptions]).to be_nil
+      expect(result[:revenue_error]).to eq("Stripe down")
+    end
+  end
+end

--- a/spec/services/mission_control/revenue_metrics_spec.rb
+++ b/spec/services/mission_control/revenue_metrics_spec.rb
@@ -13,27 +13,57 @@ RSpec.describe MissionControl::RevenueMetrics do
     }
   end
 
+  let(:rc_data) do
+    {
+      source: "revenuecat_local",
+      active_subscriptions: 5,
+      estimated_mrr_cents: 2995,
+      estimated_mrr_usd: 29.95,
+      plan_breakdown: { "basic" => 3, "pro" => 2 },
+    }
+  end
+
   before do
     allow(MissionControl::StripeRevenueSource).to receive(:call).and_return(stripe_data)
+    allow(MissionControl::RevenuecatRevenueSource).to receive(:call).and_return(rc_data)
   end
 
   describe ".call" do
-    it "pulls subscription counts from Stripe, not the local table" do
+    it "combines Stripe and RevenueCat subscription counts" do
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(90)
+      expect(result.dig(:stripe, :active_subscriptions)).to eq(85)
+      expect(result.dig(:revenuecat, :active_subscriptions)).to eq(5)
+    end
+
+    it "combines MRR from both sources" do
+      result = described_class.call
+
+      expect(result[:estimated_mrr_cents]).to eq(5967 + 2995)
+      expect(result[:mrr_usd]).to eq(((5967 + 2995) / 100.0).round(2))
+    end
+
+    it "ignores the local Subscription table" do
       user = create(:user)
       Subscription.create!(user: user, status: "active", price_in_cents: 999,
                            stripe_subscription_id: "sub_local")
 
       result = described_class.call
 
-      expect(result[:active_subscriptions]).to eq(85)
-      expect(result[:estimated_mrr_cents]).to eq(5967)
-      expect(result[:mrr_usd]).to eq(59.67)
+      expect(result[:active_subscriptions]).to eq(90)
     end
 
-    it "includes Stripe plan breakdown separately from user plan breakdown" do
+    it "nests per-source breakdowns under :stripe and :revenuecat" do
       result = described_class.call
-      expect(result[:stripe_plan_breakdown]).to eq("basic_plan" => 4, "pro_plan" => 1)
-      expect(result[:revenue_source]).to eq("stripe")
+
+      expect(result.dig(:stripe, :plan_breakdown)).to eq("basic_plan" => 4, "pro_plan" => 1)
+      expect(result.dig(:revenuecat, :plan_breakdown)).to eq("basic" => 3, "pro" => 2)
+    end
+
+    it "sets revenue_source to stripe+revenuecat" do
+      result = described_class.call
+      expect(result[:revenue_source]).to eq("stripe+revenuecat")
     end
 
     it "counts paid and free users from the local database" do
@@ -57,13 +87,15 @@ RSpec.describe MissionControl::RevenueMetrics do
       expect(result[:plan_breakdown]).to include("basic" => 1, "free" => 1)
     end
 
-    it "surfaces Stripe errors without raising" do
+    it "handles Stripe error gracefully with RC still counted" do
       allow(MissionControl::StripeRevenueSource).to receive(:call).and_return(
         stripe_data.merge(active_subscriptions: nil, mrr_cents: nil, error: "Stripe down")
       )
 
       result = described_class.call
-      expect(result[:active_subscriptions]).to be_nil
+
+      expect(result[:active_subscriptions]).to eq(5)
+      expect(result[:estimated_mrr_cents]).to eq(2995)
       expect(result[:revenue_error]).to eq("Stripe down")
     end
   end

--- a/spec/services/mission_control/revenuecat_revenue_source_spec.rb
+++ b/spec/services/mission_control/revenuecat_revenue_source_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe MissionControl::RevenuecatRevenueSource do
+  describe ".call" do
+    it "counts paid users without a stripe_subscription_id" do
+      create(:user, plan_type: "basic", plan_status: "active", stripe_subscription_id: nil)
+      create(:user, plan_type: "pro", plan_status: "trialing", stripe_subscription_id: nil)
+      create(:user, plan_type: "basic", plan_status: "active", stripe_subscription_id: "sub_stripe")
+
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(2)
+    end
+
+    it "excludes canceled and free users" do
+      create(:user, plan_type: "basic", plan_status: "canceled", stripe_subscription_id: nil)
+      create(:user, plan_type: "free", plan_status: "active", stripe_subscription_id: nil)
+      create(:user, plan_type: "pro", plan_status: "active", stripe_subscription_id: nil)
+
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(1)
+    end
+
+    it "excludes admin users" do
+      create(:admin_user, plan_type: "pro", plan_status: "active", stripe_subscription_id: nil)
+      create(:user, plan_type: "basic", plan_status: "active", stripe_subscription_id: nil)
+
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(1)
+    end
+
+    it "estimates MRR from plan type and billing interval" do
+      create(:user, plan_type: "basic", plan_status: "active",
+             stripe_subscription_id: nil, settings: { "billing_interval" => "monthly" })
+      create(:user, plan_type: "pro", plan_status: "active",
+             stripe_subscription_id: nil, settings: { "billing_interval" => "yearly" })
+
+      result = described_class.call
+
+      basic_monthly = 499
+      pro_yearly_monthly = (9999 / 12.0).round
+      expect(result[:estimated_mrr_cents]).to eq(basic_monthly + pro_yearly_monthly)
+    end
+
+    it "defaults to monthly price when billing_interval is absent" do
+      create(:user, plan_type: "basic", plan_status: "active",
+             stripe_subscription_id: nil, settings: {})
+
+      result = described_class.call
+
+      expect(result[:estimated_mrr_cents]).to eq(499)
+    end
+
+    it "returns plan breakdown" do
+      create(:user, plan_type: "basic", plan_status: "active", stripe_subscription_id: nil)
+      create(:user, plan_type: "basic", plan_status: "active", stripe_subscription_id: nil)
+      create(:user, plan_type: "pro", plan_status: "active", stripe_subscription_id: nil)
+
+      result = described_class.call
+
+      expect(result[:plan_breakdown]).to eq("basic" => 2, "pro" => 1)
+    end
+
+    it "returns zero counts when no RC subscribers exist" do
+      result = described_class.call
+
+      expect(result[:active_subscriptions]).to eq(0)
+      expect(result[:estimated_mrr_cents]).to eq(0)
+      expect(result[:plan_breakdown]).to eq({})
+    end
+  end
+end

--- a/spec/services/mission_control/stripe_revenue_source_spec.rb
+++ b/spec/services/mission_control/stripe_revenue_source_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+
+RSpec.describe MissionControl::StripeRevenueSource do
+  let(:monthly_price) do
+    double("Price",
+      unit_amount: 999,
+      recurring: double(interval: "month"),
+      metadata: { "plan_type" => "basic_plan" },
+      lookup_key: nil,
+      id: "price_basic_monthly")
+  end
+
+  let(:yearly_price) do
+    double("Price",
+      unit_amount: 9999,
+      recurring: double(interval: "year"),
+      metadata: { "plan_type" => "pro_plan" },
+      lookup_key: nil,
+      id: "price_pro_yearly")
+  end
+
+  let(:monthly_sub) do
+    double("Subscription",
+      id: "sub_monthly",
+      created: 2.days.ago.to_i,
+      items: double(data: [double(price: monthly_price)]))
+  end
+
+  let(:yearly_sub) do
+    double("Subscription",
+      id: "sub_yearly",
+      created: 10.days.ago.to_i,
+      items: double(data: [double(price: yearly_price)]))
+  end
+
+  let(:active_list) do
+    double("List", data: [monthly_sub, yearly_sub], has_more: false)
+  end
+
+  let(:trialing_list) do
+    double("List", data: [], has_more: false)
+  end
+
+  before do
+    stub_rails_cache
+
+    allow(Stripe::Subscription).to receive(:list)
+      .with(hash_including(status: "active"))
+      .and_return(active_list)
+
+    allow(Stripe::Subscription).to receive(:list)
+      .with(hash_including(status: "trialing"))
+      .and_return(trialing_list)
+  end
+
+  describe ".call" do
+    it "returns active subscription count from Stripe" do
+      result = described_class.call
+      expect(result[:active_subscriptions]).to eq(2)
+    end
+
+    it "computes MRR normalizing yearly to monthly" do
+      result = described_class.call
+      expected_monthly = 999 + (9999 / 12.0).round
+      expect(result[:mrr_cents]).to eq(expected_monthly)
+      expect(result[:mrr_usd]).to eq((expected_monthly / 100.0).round(2))
+    end
+
+    it "counts new subscriptions in the last 7 days" do
+      result = described_class.call
+      expect(result[:new_subs_7d]).to eq(1)
+    end
+
+    it "breaks down by plan name from price metadata" do
+      result = described_class.call
+      expect(result[:plan_breakdown]).to include("basic_plan" => 1, "pro_plan" => 1)
+    end
+
+    it "sets source to stripe" do
+      result = described_class.call
+      expect(result[:source]).to eq("stripe")
+    end
+
+    it "includes cached_at timestamp" do
+      result = described_class.call
+      expect(result[:cached_at]).to be_present
+    end
+
+    it "includes trialing subscriptions" do
+      trialing_price = double("Price",
+        unit_amount: 499,
+        recurring: double(interval: "month"),
+        metadata: { "plan_type" => "basic_plan" },
+        lookup_key: nil,
+        id: "price_trial")
+
+      trialing_sub = double("Subscription",
+        id: "sub_trial",
+        created: 1.day.ago.to_i,
+        items: double(data: [double(price: trialing_price)]))
+
+      allow(Stripe::Subscription).to receive(:list)
+        .with(hash_including(status: "trialing"))
+        .and_return(double("List", data: [trialing_sub], has_more: false))
+
+      result = described_class.call
+      expect(result[:active_subscriptions]).to eq(3)
+    end
+  end
+
+  describe "Stripe error handling" do
+    before do
+      allow(Stripe::Subscription).to receive(:list)
+        .and_raise(Stripe::APIError.new("Service unavailable"))
+    end
+
+    it "returns a fallback response with nil values" do
+      result = described_class.call
+      expect(result[:active_subscriptions]).to be_nil
+      expect(result[:mrr_cents]).to be_nil
+      expect(result[:error]).to include("Service unavailable")
+      expect(result[:source]).to eq("stripe")
+    end
+  end
+
+  describe "pagination" do
+    let(:page1) do
+      double("List", data: [monthly_sub], has_more: true)
+    end
+
+    let(:page2) do
+      double("List", data: [yearly_sub], has_more: false)
+    end
+
+    before do
+      call_count = 0
+      allow(Stripe::Subscription).to receive(:list)
+        .with(hash_including(status: "active")) do
+          call_count += 1
+          call_count == 1 ? page1 : page2
+        end
+    end
+
+    it "fetches all pages of active subscriptions" do
+      result = described_class.call
+      expect(result[:active_subscriptions]).to eq(2)
+    end
+  end
+
+  private
+
+  def stub_rails_cache
+    allow(Rails.cache).to receive(:fetch) do |_key, **_opts, &block|
+      block.call
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **New `MissionControl::StripeRevenueSource`** — queries `Stripe::Subscription.list` for active + trialing subscriptions (paginated), computes active-sub count, MRR (yearly normalized to monthly), plan breakdown from price metadata. Cached 10 min via `Rails.cache`. Rescues Stripe errors gracefully.
- **New `MissionControl::RevenuecatRevenueSource`** — queries the local DB for paid users without a `stripe_subscription_id` (active/trialing, non-admin, basic/pro) and estimates MRR from plan type + billing interval using ENV-configurable price fallbacks (`RC_ESTIMATED_BASIC_MONTHLY_CENTS`, etc.).
- **Rewrote `MissionControl::RevenueMetrics`** to combine both sources into a single total with per-source breakdowns nested under `:stripe` and `:revenuecat`. No longer reads from the sparsely-populated local `subscriptions` table.
- **Updated admin Mission Control view** — shows combined totals, Stripe/App Store sub split, per-source plan breakdowns, and error state.

Closes #331

## Test plan

- [x] 24 specs across all three services: `StripeRevenueSource` (count, MRR normalization, 7d window, plan breakdown, trialing, pagination, error fallback), `RevenuecatRevenueSource` (count, exclusions, MRR estimation, interval handling, plan breakdown), `RevenueMetrics` (combined totals, per-source nesting, local table ignored, user counts, Stripe error with RC fallback)
- [x] `bundle exec rspec spec/services/mission_control/` — 24 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)