### PR TITLE
feat(admin): demo user cleanup + expandable event details

### DIFF
--- a/app/controllers/admin/mission_control_controller.rb
+++ b/app/controllers/admin/mission_control_controller.rb
@@ -6,6 +6,57 @@ module Admin
       @usage    = MissionControl::UsageMetrics.call
       @health   = MissionControl::SystemHealthMetrics.call
       @recent_events = AnalyticsEvent.recent.limit(25).includes(:user)
+
+      demo_users = User.demo_accounts.includes(:boards)
+      @demo_user_count = demo_users.count
+      @demo_users_preview = demo_users.sort_by { |u| -u.boards.size }.first(10).map do |u|
+        { id: u.id, email: u.email, boards: u.boards.size, created_at: u.created_at }
+      end
+    end
+
+    def cleanup_demo
+      keep_count = (params[:keep_count] || 5).to_i
+      exclude_ids = params[:exclude_ids].to_s.split(",").map(&:strip).select(&:present?).map(&:to_i)
+
+      demo_users = User.demo_accounts.includes(:boards)
+      excluded = demo_users.where(id: exclude_ids)
+      candidates = demo_users.where.not(id: exclude_ids)
+
+      ranked = candidates.sort_by { |u| -u.boards.size }
+      kept = ranked.first(keep_count)
+      to_delete = ranked.drop(keep_count)
+
+      deleted_count = 0
+      errors = []
+      to_delete.each do |user|
+        destroy_demo_user!(user)
+        deleted_count += 1
+      rescue => e
+        errors << "#{user.email}: #{e.message}"
+      end
+
+      flash_msg = "Deleted #{deleted_count} demo user#{"s" unless deleted_count == 1}."
+      flash_msg += " Kept #{kept.size + excluded.size} (top #{keep_count} by boards + #{excluded.size} excluded)." if kept.any? || excluded.any?
+      flash_msg += " Errors: #{errors.join("; ")}" if errors.any?
+
+      redirect_to admin_mission_control_path, notice: flash_msg
+    end
+
+    private
+
+    def destroy_demo_user!(user)
+      User.transaction do
+        user.boards.destroy_all
+        user.communicator_accounts.destroy_all
+        user.board_groups.destroy_all
+        user.word_events.delete_all
+        user.credit_transactions.delete_all
+        user.openai_prompts.delete_all
+        user.team_users.delete_all
+        user.subscriptions.delete_all
+        user.profile&.destroy
+        user.delete
+      end
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class UsersController < Admin::ApplicationController
+    def index
+      @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count boards]) || "created_at"
+      @dir = params[:dir].presence_in(%w[asc desc]) || "desc"
+      @filter = params[:filter]
+      @search = params[:search]
+
+      scope = User.all
+      scope = apply_filter(scope)
+      scope = scope.where("email ILIKE ? OR name ILIKE ?", "%#{@search}%", "%#{@search}%") if @search.present?
+
+      if @sort == "boards"
+        @users = scope.includes(:boards).sort_by { |u| u.boards.size }
+        @users.reverse! if @dir == "desc"
+      else
+        @users = scope.order(@sort => @dir.to_sym)
+      end
+
+      @total_count = scope.count
+    end
+
+    def show
+      @user = User.find(params[:id])
+      @boards = @user.boards.order(updated_at: :desc).limit(50)
+      @communicators = @user.communicator_accounts.order(:created_at)
+      @recent_events = AnalyticsEvent.where(user_id: @user.id).recent.limit(20)
+      @credit_balance = CreditService.balance(@user)
+    end
+
+    private
+
+    def apply_filter(scope)
+      case @filter
+      when "admin"  then scope.where(role: "admin")
+      when "pro"    then scope.where(plan_type: "pro")
+      when "basic"  then scope.where(plan_type: "basic")
+      when "free"   then scope.where(plan_type: "free")
+      when "trial"  then scope.where(plan_type: "basic_trial")
+      when "demo"   then scope.demo_accounts
+      when "locked" then scope.where(locked: true)
+      else scope
+      end
+    end
+  end
+end

--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -245,7 +245,58 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     render json: response
   end
 
+  def cleanup_demo
+    unless current_admin&.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    keep_count = (params[:keep_count] || 5).to_i
+    exclude_ids = Array(params[:exclude_ids]).map(&:to_i)
+
+    demo_users = User.demo_accounts.includes(:boards)
+    excluded = demo_users.where(id: exclude_ids)
+    candidates = demo_users.where.not(id: exclude_ids)
+
+    ranked = candidates.sort_by { |u| -u.boards.size }
+    kept = ranked.first(keep_count)
+    to_delete = ranked.drop(keep_count)
+
+    deleted_count = 0
+    errors = []
+    to_delete.each do |user|
+      destroy_demo_user!(user)
+      deleted_count += 1
+    rescue => e
+      errors << { id: user.id, email: user.email, error: e.message }
+    end
+
+    preserved = (kept + excluded.to_a).map { |u| { id: u.id, email: u.email, boards: u.boards.size } }
+
+    render json: {
+      deleted_count: deleted_count,
+      preserved_count: preserved.size,
+      preserved: preserved,
+      errors: errors.presence
+    }.compact
+  end
+
   private
+
+  def destroy_demo_user!(user)
+    User.transaction do
+      user.boards.destroy_all
+      user.communicator_accounts.destroy_all
+      user.board_groups.destroy_all
+      user.word_events.delete_all
+      user.credit_transactions.delete_all
+      user.openai_prompts.delete_all
+      user.team_users.delete_all
+      user.subscriptions.delete_all
+      user.profile&.destroy
+      user.delete
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_user

--- a/app/helpers/admin/mission_control_helper.rb
+++ b/app/helpers/admin/mission_control_helper.rb
@@ -14,5 +14,17 @@ module Admin
     def event_badge_class(event_type)
       EVENT_BADGE_CLASSES.fetch(event_type, "bg-gray-800 text-gray-400")
     end
+
+    PLAN_BADGE_CLASSES = {
+      "pro"         => "bg-purple-900/60 text-purple-300",
+      "basic"       => "bg-blue-900/60 text-blue-300",
+      "basic_trial" => "bg-teal-900/60 text-teal-300",
+      "free"        => "bg-gray-800 text-gray-400",
+      "partner_pro" => "bg-green-900/60 text-green-300",
+    }.freeze
+
+    def plan_badge_class(user)
+      PLAN_BADGE_CLASSES.fetch(user.plan_type.to_s, "bg-gray-800 text-gray-400")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,6 +147,7 @@ class User < ApplicationRecord
   scope :partner, -> { where(role: "partner") }
 
   scope :non_admin, -> { where.not(role: "admin") }
+  scope :demo_accounts, -> { non_admin.where("email LIKE ? OR email LIKE ?", "%bhannajohns+%", "%@speakanyway.com") }
   scope :with_artifacts, -> { includes(user_docs: { doc: { image_attachment: :blob } }, docs: { image_attachment: :blob }) }
 
   include WordEventsHelper

--- a/app/views/admin/mission_control/show.html.erb
+++ b/app/views/admin/mission_control/show.html.erb
@@ -165,13 +165,62 @@
   </div>
 </section>
 
+<%# ─── Demo user cleanup ───────────────────────────────────── %>
+<section class="mb-10">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Demo Users</h2>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <div class="flex items-center justify-between mb-4">
+      <p class="text-sm text-gray-300">
+        <span class="text-2xl font-semibold text-white"><%= @demo_user_count %></span>
+        <span class="text-gray-500 ml-1">demo accounts</span>
+      </p>
+    </div>
+
+    <% if @demo_users_preview.any? %>
+      <div class="mb-5">
+        <p class="text-xs text-gray-500 mb-2">Top demo users by board count:</p>
+        <div class="flex flex-wrap gap-2">
+          <% @demo_users_preview.each do |u| %>
+            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
+              <span class="text-gray-400"><%= u[:email] %></span>
+              <span class="text-indigo-400 font-medium"><%= u[:boards] %> boards</span>
+            </span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @demo_user_count > 0 %>
+      <%= form_tag cleanup_demo_admin_mission_control_path, method: :post, class: "border-t border-gray-800 pt-4",
+            data: { turbo: false } do %>
+        <div class="flex flex-wrap items-end gap-4">
+          <div>
+            <label for="keep_count" class="block text-xs text-gray-500 mb-1">Keep top N by boards</label>
+            <input type="number" name="keep_count" id="keep_count" value="5" min="0" max="<%= @demo_user_count %>"
+                   class="w-20 bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:border-indigo-500 focus:outline-none">
+          </div>
+          <div class="flex-1 min-w-[200px]">
+            <label for="exclude_ids" class="block text-xs text-gray-500 mb-1">Exclude IDs (comma-separated, optional)</label>
+            <input type="text" name="exclude_ids" id="exclude_ids" placeholder="e.g. 42, 99"
+                   class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white placeholder-gray-600 focus:border-indigo-500 focus:outline-none">
+          </div>
+          <button type="submit" onclick="return confirm('This will permanently delete demo users. Continue?')"
+                  class="bg-red-600 hover:bg-red-500 text-white text-sm font-medium rounded px-4 py-1.5 transition-colors">
+            Clean Up Demo Users
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</section>
+
 <%# ─── Recent events ──────────────────────────────────────── %>
 <section>
   <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Recent Events</h2>
 
   <% if @recent_events.any? %>
     <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-      <table class="w-full text-sm">
+      <table class="w-full text-sm" id="events-table">
         <thead>
           <tr class="border-b border-gray-800">
             <th class="text-left text-xs font-medium text-gray-500 px-5 py-3 w-36">When</th>
@@ -181,8 +230,8 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-800/60">
-          <% @recent_events.each do |event| %>
-            <tr class="hover:bg-gray-800/40 transition-colors">
+          <% @recent_events.each_with_index do |event, idx| %>
+            <tr class="hover:bg-gray-800/40 transition-colors cursor-pointer event-row" data-event-idx="<%= idx %>">
               <td class="px-5 py-3 text-xs text-gray-500 whitespace-nowrap">
                 <%= time_ago_in_words(event.occurred_at) %> ago
               </td>
@@ -194,16 +243,58 @@
               <td class="px-5 py-3 text-xs text-gray-400">
                 <%= event.user&.email || "—" %>
               </td>
-              <td class="px-5 py-3 text-xs text-gray-600 font-mono truncate max-w-xs">
+              <td class="px-5 py-3 text-xs text-gray-600 font-mono">
                 <% if event.metadata.present? %>
-                  <%= event.metadata.map { |k, v| "#{k}: #{v}" }.join(" · ") %>
+                  <span class="truncate block max-w-xs"><%= event.metadata.map { |k, v| "#{k}: #{v}" }.join(" · ") %></span>
+                  <span class="text-indigo-400 text-[10px] ml-1">▸ click to expand</span>
                 <% end %>
+              </td>
+            </tr>
+            <tr class="event-detail hidden" id="event-detail-<%= idx %>">
+              <td colspan="4" class="px-5 py-4 bg-gray-800/30">
+                <div class="grid grid-cols-1 gap-1.5">
+                  <div class="flex items-baseline gap-2 text-xs">
+                    <span class="text-gray-500 font-medium shrink-0 w-24">Event ID</span>
+                    <span class="text-gray-300 font-mono"><%= event.id %></span>
+                  </div>
+                  <div class="flex items-baseline gap-2 text-xs">
+                    <span class="text-gray-500 font-medium shrink-0 w-24">Occurred at</span>
+                    <span class="text-gray-300"><%= event.occurred_at.strftime("%Y-%m-%d %H:%M:%S %Z") %></span>
+                  </div>
+                  <div class="flex items-baseline gap-2 text-xs">
+                    <span class="text-gray-500 font-medium shrink-0 w-24">User</span>
+                    <span class="text-gray-300"><%= event.user&.email || "—" %> <% if event.user_id %><span class="text-gray-600">(id: <%= event.user_id %>)</span><% end %></span>
+                  </div>
+                  <% if event.metadata.present? %>
+                    <div class="mt-2 pt-2 border-t border-gray-700/50">
+                      <p class="text-xs text-gray-500 font-medium mb-1.5">Metadata</p>
+                      <% event.metadata.each do |key, value| %>
+                        <div class="flex items-baseline gap-2 text-xs py-0.5">
+                          <span class="text-indigo-400 font-mono shrink-0 min-w-[120px]"><%= key %></span>
+                          <span class="text-gray-300 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% else %>
+                    <p class="text-xs text-gray-600 mt-2">No metadata.</p>
+                  <% end %>
+                </div>
               </td>
             </tr>
           <% end %>
         </tbody>
       </table>
     </div>
+
+    <script>
+      document.querySelectorAll('.event-row').forEach(function(row) {
+        row.addEventListener('click', function() {
+          var idx = this.dataset.eventIdx;
+          var detail = document.getElementById('event-detail-' + idx);
+          detail.classList.toggle('hidden');
+        });
+      });
+    </script>
   <% else %>
     <div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-10 text-center text-sm text-gray-600">
       No events recorded yet. Events will appear here as activity happens.

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,112 @@
+<% content_for :page_title, "Users" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-white tracking-tight">Users</h1>
+    <p class="text-sm text-gray-500 mt-0.5"><%= @total_count %> total</p>
+  </div>
+</div>
+
+<%# ─── Search + filter bar ─────────────────────────────────── %>
+<div class="flex flex-wrap items-center gap-3 mb-6">
+  <%= form_tag admin_dashboard_users_path, method: :get, class: "flex items-center gap-3 flex-wrap", data: { turbo: false } do %>
+    <input type="text" name="search" value="<%= @search %>" placeholder="Search by email or name…"
+           class="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white placeholder-gray-600 w-64 focus:border-indigo-500 focus:outline-none">
+
+    <select name="filter"
+            class="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:border-indigo-500 focus:outline-none">
+      <option value="" <%= "selected" if @filter.blank? %>>All users</option>
+      <option value="admin" <%= "selected" if @filter == "admin" %>>Admins</option>
+      <option value="pro" <%= "selected" if @filter == "pro" %>>Pro</option>
+      <option value="basic" <%= "selected" if @filter == "basic" %>>Basic</option>
+      <option value="free" <%= "selected" if @filter == "free" %>>Free</option>
+      <option value="trial" <%= "selected" if @filter == "trial" %>>Trial</option>
+      <option value="demo" <%= "selected" if @filter == "demo" %>>Demo accounts</option>
+      <option value="locked" <%= "selected" if @filter == "locked" %>>Locked</option>
+    </select>
+
+    <input type="hidden" name="sort" value="<%= @sort %>">
+    <input type="hidden" name="dir" value="<%= @dir %>">
+
+    <button type="submit"
+            class="bg-indigo-600 hover:bg-indigo-500 text-white text-sm rounded px-4 py-1.5 transition-colors">
+      Search
+    </button>
+    <% if @search.present? || @filter.present? %>
+      <%= link_to "Clear", admin_dashboard_users_path,
+            class: "text-xs text-gray-400 hover:text-white transition-colors" %>
+    <% end %>
+  <% end %>
+</div>
+
+<%# ─── Users table ─────────────────────────────────────────── %>
+<div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b border-gray-800">
+        <% [
+          ["Email",      "email"],
+          ["Name",       "name"],
+          ["Plan",       "plan_type"],
+          ["Boards",     "boards"],
+          ["Sign-ins",   "sign_in_count"],
+          ["Created",    "created_at"],
+        ].each do |label, col| %>
+          <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">
+            <% next_dir = (@sort == col && @dir == "asc") ? "desc" : "asc" %>
+            <%= link_to admin_dashboard_users_path(sort: col, dir: next_dir, search: @search, filter: @filter),
+                  class: "hover:text-white transition-colors inline-flex items-center gap-1" do %>
+              <%= label %>
+              <% if @sort == col %>
+                <span class="text-indigo-400"><%= @dir == "asc" ? "↑" : "↓" %></span>
+              <% end %>
+            <% end %>
+          </th>
+        <% end %>
+        <th class="px-5 py-3"></th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-800/60">
+      <% @users.each do |user| %>
+        <tr class="hover:bg-gray-800/40 transition-colors">
+          <td class="px-5 py-3 text-xs text-gray-300 font-mono">
+            <%= link_to user.email, admin_dashboard_user_path(user), class: "hover:text-indigo-400 transition-colors" %>
+          </td>
+          <td class="px-5 py-3 text-xs text-gray-400">
+            <%= user.name.presence || "—" %>
+          </td>
+          <td class="px-5 py-3">
+            <span class="<%= plan_badge_class(user) %> inline-block text-xs rounded px-2 py-0.5">
+              <%= user.plan_type || "none" %>
+            </span>
+            <% if user.admin? %>
+              <span class="bg-yellow-900/60 text-yellow-300 inline-block text-xs rounded px-2 py-0.5 ml-1">admin</span>
+            <% end %>
+            <% if user.locked? %>
+              <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5 ml-1">locked</span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-gray-400 text-center">
+            <%= user.boards.size %>
+          </td>
+          <td class="px-5 py-3 text-xs text-gray-500 text-center">
+            <%= user.sign_in_count %>
+          </td>
+          <td class="px-5 py-3 text-xs text-gray-500 whitespace-nowrap">
+            <%= user.created_at.strftime("%b %-d, %Y") %>
+          </td>
+          <td class="px-5 py-3 text-right">
+            <%= link_to "View", admin_dashboard_user_path(user),
+                  class: "text-xs text-indigo-400 hover:text-indigo-300 transition-colors" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @users.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-gray-600">
+      No users found.
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,237 @@
+<% content_for :page_title, @user.email %>
+
+<div class="mb-6">
+  <%= link_to "← Users", admin_dashboard_users_path, class: "text-xs text-gray-400 hover:text-white transition-colors" %>
+</div>
+
+<%# ─── Header ─────────────────────────────────────────────── %>
+<div class="flex items-start justify-between mb-8">
+  <div>
+    <h1 class="text-2xl font-semibold text-white tracking-tight"><%= @user.email %></h1>
+    <p class="text-sm text-gray-500 mt-0.5">
+      <%= @user.name.presence || "No name" %> · ID <%= @user.id %>
+      <% if @user.demo_user? %>
+        <span class="text-yellow-400 ml-1">(demo account)</span>
+      <% end %>
+    </p>
+  </div>
+  <div class="flex items-center gap-2">
+    <span class="<%= plan_badge_class(@user) %> inline-block text-xs rounded px-2.5 py-1">
+      <%= @user.plan_type || "none" %>
+    </span>
+    <% if @user.admin? %>
+      <span class="bg-yellow-900/60 text-yellow-300 inline-block text-xs rounded px-2.5 py-1">admin</span>
+    <% end %>
+    <% if @user.locked? %>
+      <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2.5 py-1">locked</span>
+    <% end %>
+  </div>
+</div>
+
+<%# ─── Stats cards ────────────────────────────────────────── %>
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <p class="text-xs text-gray-500 mb-1">Boards</p>
+    <p class="text-2xl font-semibold text-white"><%= @boards.size %></p>
+  </div>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <p class="text-xs text-gray-500 mb-1">Communicators</p>
+    <p class="text-2xl font-semibold text-white"><%= @communicators.size %></p>
+  </div>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <p class="text-xs text-gray-500 mb-1">Credits</p>
+    <p class="text-2xl font-semibold text-white"><%= @credit_balance %></p>
+  </div>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <p class="text-xs text-gray-500 mb-1">Sign-ins</p>
+    <p class="text-2xl font-semibold text-white"><%= @user.sign_in_count %></p>
+  </div>
+</div>
+
+<%# ─── Two-column: Account + Activity ────────────────────── %>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+
+  <%# Account details ──────────────────────────────────────── %>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Account</h2>
+    <dl class="space-y-2.5 text-xs">
+      <% [
+        ["Role",             @user.role],
+        ["Plan type",        @user.plan_type],
+        ["Plan status",      @user.plan_status],
+        ["Paid plan type",   @user.paid_plan_type.presence || "—"],
+        ["Stripe customer",  @user.stripe_customer_id.presence || "—"],
+        ["Stripe sub",       @user.stripe_subscription_id.presence || "—"],
+        ["Created",          @user.created_at.strftime("%b %-d, %Y %H:%M %Z")],
+        ["Last sign-in",     @user.last_sign_in_at&.strftime("%b %-d, %Y %H:%M %Z") || "Never"],
+        ["Last sign-in IP",  @user.last_sign_in_ip.presence || "—"],
+      ].each do |label, value| %>
+        <div class="flex justify-between">
+          <dt class="text-gray-500"><%= label %></dt>
+          <dd class="text-gray-300 font-mono text-right"><%= value %></dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+
+  <%# Settings snapshot ────────────────────────────────────── %>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Settings</h2>
+    <% if @user.settings.present? %>
+      <dl class="space-y-2 text-xs">
+        <% @user.settings.each do |key, value| %>
+          <% next if key == "voice" %>
+          <div class="flex justify-between gap-4">
+            <dt class="text-gray-500 shrink-0"><%= key %></dt>
+            <dd class="text-gray-300 font-mono text-right truncate max-w-[200px]" title="<%= value %>">
+              <%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %>
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    <% else %>
+      <p class="text-xs text-gray-600">No settings.</p>
+    <% end %>
+  </div>
+</div>
+
+<%# ─── Boards ─────────────────────────────────────────────── %>
+<section class="mb-8">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
+    Boards <span class="text-gray-600">(<%= @boards.size %>)</span>
+  </h2>
+
+  <% if @boards.any? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-800">
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Name</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Images</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Updated</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800/60">
+          <% @boards.each do |board| %>
+            <tr class="hover:bg-gray-800/40 transition-colors">
+              <td class="px-5 py-2.5 text-xs text-gray-300"><%= board.name %></td>
+              <td class="px-5 py-2.5 text-xs text-gray-500"><%= board.board_images.size %></td>
+              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap"><%= board.updated_at.strftime("%b %-d, %Y") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-xs text-gray-600">No boards.</p>
+  <% end %>
+</section>
+
+<%# ─── Communicators ──────────────────────────────────────── %>
+<section class="mb-8">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
+    Communicators <span class="text-gray-600">(<%= @communicators.size %>)</span>
+  </h2>
+
+  <% if @communicators.any? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-800">
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Name</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Username</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Status</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Created</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800/60">
+          <% @communicators.each do |ca| %>
+            <tr class="hover:bg-gray-800/40 transition-colors">
+              <td class="px-5 py-2.5 text-xs text-gray-300"><%= ca.name.presence || "—" %></td>
+              <td class="px-5 py-2.5 text-xs text-gray-400 font-mono"><%= ca.username.presence || "—" %></td>
+              <td class="px-5 py-2.5">
+                <span class="inline-block text-xs rounded px-2 py-0.5
+                  <%= ca.status == "active" ? "bg-green-900/60 text-green-300" :
+                      ca.status == "loaner" ? "bg-blue-900/60 text-blue-300" :
+                      "bg-gray-800 text-gray-400" %>">
+                  <%= ca.status %>
+                </span>
+              </td>
+              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap"><%= ca.created_at.strftime("%b %-d, %Y") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-xs text-gray-600">No communicators.</p>
+  <% end %>
+</section>
+
+<%# ─── Recent events ──────────────────────────────────────── %>
+<section>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
+    Recent Events <span class="text-gray-600">(<%= @recent_events.size %>)</span>
+  </h2>
+
+  <% if @recent_events.any? %>
+    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-800">
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">When</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Event</th>
+            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Details</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800/60">
+          <% @recent_events.each_with_index do |event, idx| %>
+            <tr class="hover:bg-gray-800/40 transition-colors cursor-pointer user-event-row" data-event-idx="<%= idx %>">
+              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">
+                <%= time_ago_in_words(event.occurred_at) %> ago
+              </td>
+              <td class="px-5 py-2.5">
+                <span class="<%= event_badge_class(event.event_type) %> inline-block text-xs font-mono rounded px-2 py-0.5">
+                  <%= event.event_type %>
+                </span>
+              </td>
+              <td class="px-5 py-2.5 text-xs text-gray-600 font-mono">
+                <% if event.metadata.present? %>
+                  <span class="truncate block max-w-sm"><%= event.metadata.map { |k, v| "#{k}: #{v}" }.join(" · ") %></span>
+                  <span class="text-indigo-400 text-[10px]">▸ expand</span>
+                <% end %>
+              </td>
+            </tr>
+            <tr class="hidden user-event-detail" id="user-event-detail-<%= idx %>">
+              <td colspan="3" class="px-5 py-3 bg-gray-800/30">
+                <div class="text-xs space-y-1">
+                  <% if event.metadata.present? %>
+                    <% event.metadata.each do |key, value| %>
+                      <div class="flex gap-2">
+                        <span class="text-indigo-400 font-mono shrink-0 min-w-[120px]"><%= key %></span>
+                        <span class="text-gray-300 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <p class="text-gray-600">No metadata.</p>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <script>
+      document.querySelectorAll('.user-event-row').forEach(function(row) {
+        row.addEventListener('click', function() {
+          var idx = this.dataset.eventIdx;
+          document.getElementById('user-event-detail-' + idx).classList.toggle('hidden');
+        });
+      });
+    </script>
+  <% else %>
+    <p class="text-xs text-gray-600">No events recorded for this user.</p>
+  <% end %>
+</section>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -26,6 +26,8 @@
                 class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_root_path) ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
           <%= link_to "Mission Control", admin_mission_control_path,
                 class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_mission_control_path) ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
+          <%= link_to "Users", admin_dashboard_users_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",
                 class: "text-xs px-3 py-1.5 rounded text-gray-400 hover:text-white hover:bg-gray-800/60 transition-colors" %>
         </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,9 @@ Rails.application.routes.draw do
   # HTML admin area (Mission Control dashboard)
   namespace :admin do
     root "dashboard#index"
-    resource :mission_control, only: [:show], controller: 'mission_control'
+    resource :mission_control, only: [:show], controller: 'mission_control' do
+      post :cleanup_demo
+    end
   end
 
   get "main/index", as: :home
@@ -463,6 +465,7 @@ Rails.application.routes.draw do
         end
         collection do
           delete "destroy_users"
+          delete "cleanup_demo"
           get "export"
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     resource :mission_control, only: [:show], controller: 'mission_control' do
       post :cleanup_demo
     end
+    resources :users, only: [:index, :show], as: :dashboard_users
   end
 
   get "main/index", as: :home

--- a/spec/requests/admin/mission_control_spec.rb
+++ b/spec/requests/admin/mission_control_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe "Admin::MissionControl", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let!(:admin) { create(:admin_user) }
+
+  before do
+    # The admin layout references application.css which isn't compiled in test
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "GET /admin/mission_control" do
+    before { sign_in admin }
+
+    it "renders the dashboard" do
+      get admin_mission_control_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "shows demo user count" do
+      create(:user, email: "bhannajohns+test1@gmail.com")
+      create(:user, email: "test@speakanyway.com")
+
+      get admin_mission_control_path
+      expect(response.body).to include("demo accounts")
+    end
+
+    context "when not signed in" do
+      before { sign_out admin }
+
+      it "redirects" do
+        get admin_mission_control_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as non-admin" do
+      let(:regular_user) { create(:user) }
+
+      before do
+        sign_out admin
+        sign_in regular_user
+      end
+
+      it "redirects to root" do
+        get admin_mission_control_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "POST /admin/mission_control/cleanup_demo" do
+    before { sign_in admin }
+
+    let!(:demo1) { create(:user, email: "bhannajohns+one@gmail.com") }
+    let!(:demo2) { create(:user, email: "bhannajohns+two@gmail.com") }
+    let!(:demo3) { create(:user, email: "bhannajohns+three@gmail.com") }
+    let!(:demo_with_boards) { create(:user, email: "bhannajohns+boards@gmail.com") }
+    let!(:real_user) { create(:user, email: "real@example.com") }
+
+    before do
+      3.times { create(:board, user: demo_with_boards) }
+      1.times { create(:board, user: demo1) }
+    end
+
+    it "deletes demo users keeping top N by board count" do
+      expect {
+        post cleanup_demo_admin_mission_control_path, params: { keep_count: 1 }
+      }.to change(User, :count).by(-3)
+
+      expect(User.exists?(demo_with_boards.id)).to be true
+      expect(User.exists?(real_user.id)).to be true
+      expect(User.exists?(admin.id)).to be true
+    end
+
+    it "respects exclude_ids" do
+      expect {
+        post cleanup_demo_admin_mission_control_path, params: { keep_count: 1, exclude_ids: demo2.id.to_s }
+      }.to change(User, :count).by(-2)
+
+      expect(User.exists?(demo_with_boards.id)).to be true
+      expect(User.exists?(demo2.id)).to be true
+    end
+
+    it "never deletes admin accounts" do
+      admin_demo = create(:admin_user, email: "bhannajohns+admin@gmail.com")
+
+      post cleanup_demo_admin_mission_control_path, params: { keep_count: 0 }
+
+      expect(User.exists?(admin_demo.id)).to be true
+    end
+
+    it "never deletes non-demo users" do
+      post cleanup_demo_admin_mission_control_path, params: { keep_count: 0 }
+
+      expect(User.exists?(real_user.id)).to be true
+    end
+
+    it "redirects with a flash message" do
+      post cleanup_demo_admin_mission_control_path, params: { keep_count: 1 }
+
+      expect(response).to redirect_to(admin_mission_control_path)
+      follow_redirect!
+      expect(response.body).to include("Deleted")
+    end
+
+    it "defaults keep_count to 5" do
+      post cleanup_demo_admin_mission_control_path
+
+      expect(User.exists?(demo_with_boards.id)).to be true
+      expect(User.exists?(demo1.id)).to be true
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Users", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let!(:admin) { create(:admin_user) }
+  let!(:user1) { create(:user, email: "alice@example.com", name: "Alice") }
+  let!(:user2) { create(:user, email: "bob@example.com", name: "Bob", plan_type: "pro") }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:javascript_include_tag).and_return("")
+    sign_in admin
+  end
+
+  describe "GET /admin/users" do
+    it "renders the users list" do
+      get admin_dashboard_users_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("alice@example.com")
+      expect(response.body).to include("bob@example.com")
+    end
+
+    it "filters by plan type" do
+      get admin_dashboard_users_path(filter: "pro")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("bob@example.com")
+      expect(response.body).not_to include("alice@example.com")
+    end
+
+    it "searches by email" do
+      get admin_dashboard_users_path(search: "alice")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("alice@example.com")
+      expect(response.body).not_to include("bob@example.com")
+    end
+
+    it "sorts by column" do
+      get admin_dashboard_users_path(sort: "email", dir: "asc")
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "filters demo accounts" do
+      demo = create(:user, email: "bhannajohns+test@gmail.com")
+      get admin_dashboard_users_path(filter: "demo")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("bhannajohns+test@gmail.com")
+      expect(response.body).not_to include("alice@example.com")
+    end
+
+    context "when not signed in" do
+      before { sign_out admin }
+
+      it "redirects" do
+        get admin_dashboard_users_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in user1
+      end
+
+      it "redirects to root" do
+        get admin_dashboard_users_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "GET /admin/users/:id" do
+    it "renders the user show page" do
+      get admin_dashboard_user_path(user1)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("alice@example.com")
+      expect(response.body).to include("Account")
+      expect(response.body).to include("Boards")
+    end
+
+    it "shows boards for the user" do
+      create(:board, user: user1, name: "Test Board")
+      get admin_dashboard_user_path(user1)
+      expect(response.body).to include("Test Board")
+    end
+
+    it "shows communicators for the user" do
+      ca = create(:child_account, user: user1, name: "Kid", status: "active")
+      get admin_dashboard_user_path(user1)
+      expect(response.body).to include("Kid")
+    end
+
+    it "shows user settings" do
+      user1.update(settings: { "board_limit" => 10 })
+      get admin_dashboard_user_path(user1)
+      expect(response.body).to include("board_limit")
+    end
+  end
+end

--- a/spec/requests/api/admin/users_spec.rb
+++ b/spec/requests/api/admin/users_spec.rb
@@ -63,4 +63,74 @@ RSpec.describe "API::Admin::Users", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/admin/users/cleanup_demo" do
+    let!(:demo1) { create(:user, email: "bhannajohns+one@gmail.com") }
+    let!(:demo2) { create(:user, email: "bhannajohns+two@gmail.com") }
+    let!(:demo_with_boards) { create(:user, email: "test@speakanyway.com") }
+
+    before do
+      2.times { create(:board, user: demo_with_boards) }
+    end
+
+    context "when unauthenticated" do
+      it "returns 401" do
+        delete "/api/admin/users/cleanup_demo"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated as non-admin" do
+      it "returns 401" do
+        delete "/api/admin/users/cleanup_demo", headers: auth_headers(user)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated as admin" do
+      it "deletes demo users keeping top N by board count" do
+        expect {
+          delete "/api/admin/users/cleanup_demo",
+                 params: { keep_count: 1 },
+                 headers: auth_headers(admin)
+        }.to change(User, :count).by(-2)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["deleted_count"]).to eq(2)
+        expect(body["preserved_count"]).to eq(1)
+        expect(User.exists?(demo_with_boards.id)).to be true
+      end
+
+      it "respects exclude_ids" do
+        expect {
+          delete "/api/admin/users/cleanup_demo",
+                 params: { keep_count: 1, exclude_ids: [demo1.id] },
+                 headers: auth_headers(admin)
+        }.to change(User, :count).by(-1)
+
+        expect(User.exists?(demo1.id)).to be true
+        expect(User.exists?(demo_with_boards.id)).to be true
+      end
+
+      it "never includes admin accounts in demo cleanup" do
+        admin_demo = create(:admin_user, email: "bhannajohns+admin@gmail.com")
+
+        delete "/api/admin/users/cleanup_demo",
+               params: { keep_count: 0 },
+               headers: auth_headers(admin)
+
+        expect(User.exists?(admin_demo.id)).to be true
+      end
+
+      it "never touches non-demo users" do
+        delete "/api/admin/users/cleanup_demo",
+               params: { keep_count: 0 },
+               headers: auth_headers(admin)
+
+        expect(User.exists?(user.id)).to be true
+        expect(User.exists?(admin.id)).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Demo user cleanup button** on Mission Control — configurable "keep top N by board count" + optional exclude-IDs, with confirm dialog and flash summary
- **Expandable event details** — click any event row to inline-expand full metadata (event ID, timestamp, user ID, all key/value pairs)
- **Admin users list + detail pages** — sortable/searchable/filterable table at `/admin/users` with plan badges, board counts, sign-in stats; each row links to a detail page showing account info, settings, boards, communicators, and expandable event history
- `User.demo_accounts` scope (non-admin, `bhannajohns+*` or `*@speakanyway.com`)
- Both HTML (Mission Control form) and JSON API (`DELETE /api/admin/users/cleanup_demo`) cleanup endpoints
- Safe deletion via manual association cleanup in a transaction (avoids the missing `Order` model class issue)

## Test plan

- 35 examples across 3 spec files — all pass
  - `spec/requests/admin/mission_control_spec.rb` — dashboard rendering, demo cleanup (counts, admin protection, exclude-IDs, flash)
  - `spec/requests/admin/users_spec.rb` — index (render, filter, search, sort, demo filter, auth), show (render, boards, communicators, settings)
  - `spec/requests/api/admin/users_spec.rb` — API cleanup endpoint (auth, counts, excludes, admin/non-demo protection)

```
bundle exec rspec spec/requests/admin/ spec/requests/api/admin/users_spec.rb
35 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)