### PR TITLE
feat(admin): light/dark toggle + engagement metrics for Mission Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Improved — Admin dashboard: light/dark toggle + engagement metrics
+- **Light mode default** with a toggle in the top-right nav. Preference persists
+  in localStorage. All admin pages (Dashboard, Mission Control, Users) use CSS
+  variable theming that works in both modes.
+- **New Engagement section** on Mission Control: Active Users (7d), Active Users
+  (30d), Trial Users (currently trialing), and Communicator accounts.
+- **Signup Trend chart** showing daily signups for the last 7 days as a bar chart.
+- All admin views (Dashboard, Mission Control, Users list, User detail) updated
+  from hard-coded dark-only colors to CSS-variable theming.
+
 ### Added — Expose plan_status and persist Stripe trial_ends_at (#324, #325)
 - `User#api_view` now includes `plan_status` so the frontend can distinguish a
   payment-provider trial (`"trialing"`) from an active paid plan.

--- a/app/services/mission_control/overview_metrics.rb
+++ b/app/services/mission_control/overview_metrics.rb
@@ -7,12 +7,17 @@ module MissionControl
         signups_today:        User.non_admin.where(created_at: today).count,
         signups_7d:           User.non_admin.where(created_at: 7.days.ago..).count,
         signups_30d:          User.non_admin.where(created_at: 30.days.ago..).count,
+        signups_daily_7d:     signups_daily_7d,
         total_users:          User.non_admin.count,
+        active_users_7d:      User.non_admin.where(last_sign_in_at: 7.days.ago..).count,
+        active_users_30d:     User.non_admin.where(last_sign_in_at: 30.days.ago..).count,
+        trial_users:          User.non_admin.where(plan_status: "trialing").count,
         boards_today:         Board.non_templates.where(created_at: today).count,
         boards_7d:            Board.non_templates.where(created_at: 7.days.ago..).count,
         total_boards:         Board.non_templates.count,
         word_events_today:    WordEvent.where(created_at: today).count,
         word_events_7d:       WordEvent.where(created_at: 7.days.ago..).count,
+        communicator_accounts: ChildAccount.where.not(status: "archived").count,
         myspeak_profiles:     Profile.where(profileable_type: "ChildAccount").count,
       }
     end
@@ -21,6 +26,14 @@ module MissionControl
 
     def today
       Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
+    end
+
+    def signups_daily_7d
+      User.non_admin
+          .where(created_at: 7.days.ago.beginning_of_day..)
+          .group("DATE(created_at)")
+          .count
+          .transform_keys(&:to_s)
     end
   end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -2,47 +2,47 @@
 
 <div class="flex items-center justify-between mb-8">
   <div>
-    <h1 class="text-2xl font-semibold text-white tracking-tight">Admin Dashboard</h1>
-    <p class="text-sm text-gray-500 mt-0.5"><%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %></p>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Admin Dashboard</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %></p>
   </div>
 </div>
 
 <%# Quick stats %>
 <section class="mb-10">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">At a Glance</h2>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">At a Glance</h2>
   <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-    <div class="bg-gray-900 border border-gray-800 rounded-xl p-5">
-      <p class="text-xs text-gray-500 mb-1">Total Users</p>
-      <p class="text-2xl font-semibold text-white"><%= number_with_delimiter(@user_count) %></p>
-      <p class="text-xs text-gray-600 mt-0.5"><%= @today_signups %> today</p>
+    <div class="admin-card border rounded-xl p-5">
+      <p class="text-xs text-t2 mb-1">Total Users</p>
+      <p class="text-2xl font-semibold text-t1"><%= number_with_delimiter(@user_count) %></p>
+      <p class="text-xs text-t3 mt-0.5"><%= @today_signups %> today</p>
     </div>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl p-5">
-      <p class="text-xs text-gray-500 mb-1">Total Boards</p>
-      <p class="text-2xl font-semibold text-white"><%= number_with_delimiter(@board_count) %></p>
+    <div class="admin-card border rounded-xl p-5">
+      <p class="text-xs text-t2 mb-1">Total Boards</p>
+      <p class="text-2xl font-semibold text-t1"><%= number_with_delimiter(@board_count) %></p>
     </div>
   </div>
 </section>
 
 <%# Navigation cards %>
 <section>
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Admin Areas</h2>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Admin Areas</h2>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     <%= link_to admin_mission_control_path,
-          class: "group bg-gray-900 border border-gray-800 hover:border-indigo-600 rounded-xl p-5 transition-colors" do %>
-      <p class="text-sm font-medium text-white group-hover:text-indigo-300 transition-colors">Mission Control</p>
-      <p class="text-xs text-gray-500 mt-1">Metrics, revenue, system health, and recent events</p>
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Mission Control</p>
+      <p class="text-xs text-t2 mt-1">Metrics, revenue, system health, and recent events</p>
     <% end %>
 
     <%= link_to "/sidekiq",
-          class: "group bg-gray-900 border border-gray-800 hover:border-indigo-600 rounded-xl p-5 transition-colors" do %>
-      <p class="text-sm font-medium text-white group-hover:text-indigo-300 transition-colors">Sidekiq</p>
-      <p class="text-xs text-gray-500 mt-1">Background job queues, retries, and dead jobs</p>
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>
+      <p class="text-xs text-t2 mt-1">Background job queues, retries, and dead jobs</p>
     <% end %>
 
     <%= link_to "/rails/performance",
-          class: "group bg-gray-900 border border-gray-800 hover:border-indigo-600 rounded-xl p-5 transition-colors" do %>
-      <p class="text-sm font-medium text-white group-hover:text-indigo-300 transition-colors">Rails Performance</p>
-      <p class="text-xs text-gray-500 mt-1">Request profiling and slow query analysis</p>
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Rails Performance</p>
+      <p class="text-xs text-t2 mt-1">Request profiling and slow query analysis</p>
     <% end %>
   </div>
 </section>

--- a/app/views/admin/mission_control/_health_row.html.erb
+++ b/app/views/admin/mission_control/_health_row.html.erb
@@ -1,8 +1,8 @@
 <div class="flex items-center justify-between">
-  <dt class="text-sm text-gray-400"><%= label %></dt>
+  <dt class="text-sm text-t2"><%= label %></dt>
   <dd class="flex items-center gap-1.5">
     <span class="w-2 h-2 rounded-full <%= ok ? "bg-green-500" : "bg-red-500" %>"></span>
-    <span class="text-sm font-medium <%= ok ? "text-green-400" : "text-red-400" %>">
+    <span class="text-sm font-medium <%= ok ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400" %>">
       <%= ok ? "Connected" : "Unavailable" %>
     </span>
   </dd>

--- a/app/views/admin/mission_control/_metric_row.html.erb
+++ b/app/views/admin/mission_control/_metric_row.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-between">
-  <dt class="text-sm text-gray-400"><%= label %></dt>
-  <dd class="text-sm font-medium <%= defined?(danger) && danger ? "text-red-400" : "text-white" %>">
+  <dt class="text-sm text-t2"><%= label %></dt>
+  <dd class="text-sm font-medium <%= defined?(danger) && danger ? "text-red-500" : "text-t1" %>">
     <%= value %>
   </dd>
 </div>

--- a/app/views/admin/mission_control/_stat_card.html.erb
+++ b/app/views/admin/mission_control/_stat_card.html.erb
@@ -1,7 +1,7 @@
-<div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4">
-  <p class="text-xs text-gray-500 mb-1"><%= label %></p>
-  <p class="text-3xl font-semibold text-white tracking-tight"><%= value %></p>
+<div class="admin-card border rounded-xl px-5 py-4">
+  <p class="text-xs text-t2 mb-1"><%= label %></p>
+  <p class="text-3xl font-semibold text-t1 tracking-tight"><%= value %></p>
   <% if defined?(sub) && sub.present? %>
-    <p class="text-xs text-gray-600 mt-1"><%= sub %></p>
+    <p class="text-xs text-t3 mt-1"><%= sub %></p>
   <% end %>
 </div>

--- a/app/views/admin/mission_control/show.html.erb
+++ b/app/views/admin/mission_control/show.html.erb
@@ -3,18 +3,19 @@
 <%# ─── Page header ─────────────────────────────────────────── %>
 <div class="flex items-center justify-between mb-8">
   <div>
-    <h1 class="text-2xl font-semibold text-white tracking-tight">Overview</h1>
-    <p class="text-sm text-gray-500 mt-0.5"><%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %></p>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Overview</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %></p>
   </div>
   <a href="<%= admin_mission_control_path %>"
-     class="text-xs text-gray-400 hover:text-white border border-gray-700 hover:border-gray-500 rounded px-3 py-1.5 transition-colors">
+     class="text-xs text-t2 hover:text-t1 border rounded px-3 py-1.5 transition-colors"
+     style="border-color: var(--border);">
     ↺ Refresh
   </a>
 </div>
 
 <%# ─── Today at a glance ───────────────────────────────────── %>
 <section class="mb-10">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Today</h2>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Today</h2>
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%= render "stat_card", label: "Signups",      value: @overview[:signups_today],     sub: "#{@overview[:signups_7d]} last 7d" %>
     <%= render "stat_card", label: "Boards",       value: @overview[:boards_today],      sub: "#{@overview[:boards_7d]} last 7d" %>
@@ -23,16 +24,50 @@
   </div>
 </section>
 
+<%# ─── Engagement ─────────────────────────────────────────── %>
+<section class="mb-10">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Engagement</h2>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <%= render "stat_card", label: "Active Users (7d)",  value: @overview[:active_users_7d],  sub: "signed in last 7 days" %>
+    <%= render "stat_card", label: "Active Users (30d)", value: @overview[:active_users_30d], sub: "signed in last 30 days" %>
+    <%= render "stat_card", label: "Trial Users",        value: @overview[:trial_users],      sub: "currently trialing" %>
+    <%= render "stat_card", label: "Communicators",      value: @overview[:communicator_accounts], sub: "active accounts" %>
+  </div>
+</section>
+
+<%# ─── Signup trend (last 7 days) ──────────────────────────── %>
+<% daily = @overview[:signups_daily_7d] || {} %>
+<% if daily.any? || @overview[:signups_7d].to_i > 0 %>
+  <section class="mb-10">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Signup Trend (Last 7 Days)</h2>
+    <div class="admin-card border rounded-xl p-6">
+      <div class="flex items-end gap-2" style="height: 120px;">
+        <% max_val = [daily.values.max.to_i, 1].max %>
+        <% 7.times do |i| %>
+          <% date = (6 - i).days.ago.to_date.to_s %>
+          <% count = daily[date].to_i %>
+          <% height_pct = (count.to_f / max_val * 100).round %>
+          <div class="flex-1 flex flex-col items-center gap-1">
+            <span class="text-xs font-medium text-t1"><%= count %></span>
+            <div class="w-full rounded-t" style="height: <%= [height_pct, 4].max %>%; min-height: 4px; background: <%= count > 0 ? "var(--text-accent)" : "var(--border)" %>;"></div>
+            <span class="text-[10px] text-t3"><%= (6 - i).days.ago.strftime("%-m/%-d") %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </section>
+<% end %>
+
 <%# ─── Two-column grid: Revenue + Health ──────────────────── %>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
 
   <%# Revenue ─────────────────────────────────────────────── %>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-5">
       Subscriptions &amp; Revenue
     </h2>
     <% if @revenue[:revenue_error] %>
-      <p class="text-xs text-red-400 mb-3">Stripe error: <%= @revenue[:revenue_error] %></p>
+      <p class="text-xs text-red-500 mb-3">Stripe error: <%= @revenue[:revenue_error] %></p>
     <% end %>
     <dl class="space-y-3">
       <%= render "metric_row", label: "Active subscriptions (total)", value: @revenue[:active_subscriptions] %>
@@ -52,13 +87,13 @@
     <%# ── Per-source plan breakdowns ── %>
     <% stripe_plans = @revenue.dig(:stripe, :plan_breakdown) %>
     <% if stripe_plans.present? %>
-      <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">Stripe plan breakdown</p>
+      <div class="mt-5 pt-4" style="border-top: 1px solid var(--border);">
+        <p class="text-xs text-t2 mb-3">Stripe plan breakdown</p>
         <div class="flex flex-wrap gap-2">
           <% stripe_plans.each do |plan, count| %>
-            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
-              <span class="text-gray-300"><%= plan.presence || "unknown" %></span>
-              <span class="text-indigo-400 font-medium"><%= count %></span>
+            <span class="inline-flex items-center gap-1.5 text-xs admin-badge rounded px-2.5 py-1">
+              <span class="text-t2"><%= plan.presence || "unknown" %></span>
+              <span class="text-accent font-medium"><%= count %></span>
             </span>
           <% end %>
         </div>
@@ -67,13 +102,13 @@
 
     <% rc_plans = @revenue.dig(:revenuecat, :plan_breakdown) %>
     <% if rc_plans.present? %>
-      <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">App Store plan breakdown (local DB)</p>
+      <div class="mt-5 pt-4" style="border-top: 1px solid var(--border);">
+        <p class="text-xs text-t2 mb-3">App Store plan breakdown (local DB)</p>
         <div class="flex flex-wrap gap-2">
           <% rc_plans.each do |plan, count| %>
-            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
-              <span class="text-gray-300"><%= plan.presence || "unknown" %></span>
-              <span class="text-indigo-400 font-medium"><%= count %></span>
+            <span class="inline-flex items-center gap-1.5 text-xs admin-badge rounded px-2.5 py-1">
+              <span class="text-t2"><%= plan.presence || "unknown" %></span>
+              <span class="text-accent font-medium"><%= count %></span>
             </span>
           <% end %>
         </div>
@@ -81,13 +116,13 @@
     <% end %>
 
     <% if @revenue[:plan_breakdown].present? %>
-      <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">All users by plan (local DB)</p>
+      <div class="mt-5 pt-4" style="border-top: 1px solid var(--border);">
+        <p class="text-xs text-t2 mb-3">All users by plan (local DB)</p>
         <div class="flex flex-wrap gap-2">
           <% @revenue[:plan_breakdown].each do |plan, count| %>
-            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
-              <span class="text-gray-300"><%= plan.presence || "none" %></span>
-              <span class="text-indigo-400 font-medium"><%= count %></span>
+            <span class="inline-flex items-center gap-1.5 text-xs admin-badge rounded px-2.5 py-1">
+              <span class="text-t2"><%= plan.presence || "none" %></span>
+              <span class="text-accent font-medium"><%= count %></span>
             </span>
           <% end %>
         </div>
@@ -96,8 +131,8 @@
   </div>
 
   <%# System Health ─────────────────────────────────────────── %>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">System Health</h2>
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-5">System Health</h2>
     <dl class="space-y-3">
       <%= render "health_row", label: "Database",   ok: @health[:db_connected] %>
       <%= render "health_row", label: "Redis",       ok: @health[:redis_connected] %>
@@ -113,13 +148,13 @@
     </dl>
 
     <% if @health[:sidekiq_queues].present? %>
-      <div class="mt-5 pt-4 border-t border-gray-800">
-        <p class="text-xs text-gray-500 mb-3">Queue depths</p>
+      <div class="mt-5 pt-4" style="border-top: 1px solid var(--border);">
+        <p class="text-xs text-t2 mb-3">Queue depths</p>
         <div class="flex flex-wrap gap-2">
           <% @health[:sidekiq_queues].each do |queue, depth| %>
-            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
-              <span class="text-gray-300"><%= queue %></span>
-              <span class="<%= depth.to_i > 0 ? "text-yellow-400" : "text-gray-500" %> font-medium"><%= depth %></span>
+            <span class="inline-flex items-center gap-1.5 text-xs admin-badge rounded px-2.5 py-1">
+              <span class="text-t2"><%= queue %></span>
+              <span class="<%= depth.to_i > 0 ? "text-yellow-500" : "text-t3" %> font-medium"><%= depth %></span>
             </span>
           <% end %>
         </div>
@@ -130,25 +165,25 @@
 
 <%# ─── AI usage ───────────────────────────────────────────── %>
 <section class="mb-10">
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-5">AI Usage</h2>
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-5">AI Usage</h2>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-6">
       <div>
-        <p class="text-xs text-gray-500 mb-1">Boards generated</p>
-        <p class="text-2xl font-semibold text-white"><%= @usage[:ai_boards_today] %><span class="text-sm text-gray-500 ml-1">today</span></p>
-        <p class="text-xs text-gray-600 mt-0.5"><%= @usage[:ai_boards_7d] %> last 7d · <%= @usage[:ai_boards_30d] %> last 30d</p>
+        <p class="text-xs text-t2 mb-1">Boards generated</p>
+        <p class="text-2xl font-semibold text-t1"><%= @usage[:ai_boards_today] %><span class="text-sm text-t3 ml-1">today</span></p>
+        <p class="text-xs text-t3 mt-0.5"><%= @usage[:ai_boards_7d] %> last 7d · <%= @usage[:ai_boards_30d] %> last 30d</p>
       </div>
       <div>
-        <p class="text-xs text-gray-500 mb-1">AI prompts sent</p>
-        <p class="text-2xl font-semibold text-white"><%= @usage[:ai_prompts_today] %><span class="text-sm text-gray-500 ml-1">today</span></p>
-        <p class="text-xs text-gray-600 mt-0.5"><%= @usage[:ai_prompts_30d] %> last 30d</p>
+        <p class="text-xs text-t2 mb-1">AI prompts sent</p>
+        <p class="text-2xl font-semibold text-t1"><%= @usage[:ai_prompts_today] %><span class="text-sm text-t3 ml-1">today</span></p>
+        <p class="text-xs text-t3 mt-0.5"><%= @usage[:ai_prompts_30d] %> last 30d</p>
       </div>
       <div>
-        <p class="text-xs text-gray-500 mb-1">Generation failures</p>
-        <p class="text-2xl font-semibold <%= @usage[:ai_failures_today].to_i > 0 ? "text-red-400" : "text-white" %>">
-          <%= @usage[:ai_failures_today] %><span class="text-sm text-gray-500 ml-1">today</span>
+        <p class="text-xs text-t2 mb-1">Generation failures</p>
+        <p class="text-2xl font-semibold <%= @usage[:ai_failures_today].to_i > 0 ? "text-red-500" : "text-t1" %>">
+          <%= @usage[:ai_failures_today] %><span class="text-sm text-t3 ml-1">today</span>
         </p>
-        <p class="text-xs text-gray-600 mt-0.5"><%= @usage[:ai_failures_7d] %> last 7d</p>
+        <p class="text-xs text-t3 mt-0.5"><%= @usage[:ai_failures_7d] %> last 7d</p>
       </div>
     </div>
   </div>
@@ -156,7 +191,7 @@
 
 <%# ─── Totals ─────────────────────────────────────────────── %>
 <section class="mb-10">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">All-Time Totals</h2>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">All-Time Totals</h2>
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
     <%= render "stat_card", label: "Total Users",       value: number_with_delimiter(@overview[:total_users]) %>
     <%= render "stat_card", label: "Total Boards",      value: number_with_delimiter(@overview[:total_boards]) %>
@@ -167,23 +202,23 @@
 
 <%# ─── Demo user cleanup ───────────────────────────────────── %>
 <section class="mb-10">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Demo Users</h2>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Demo Users</h2>
+  <div class="admin-card border rounded-xl p-6">
     <div class="flex items-center justify-between mb-4">
-      <p class="text-sm text-gray-300">
-        <span class="text-2xl font-semibold text-white"><%= @demo_user_count %></span>
-        <span class="text-gray-500 ml-1">demo accounts</span>
+      <p class="text-sm text-t2">
+        <span class="text-2xl font-semibold text-t1"><%= @demo_user_count %></span>
+        <span class="text-t3 ml-1">demo accounts</span>
       </p>
     </div>
 
     <% if @demo_users_preview.any? %>
       <div class="mb-5">
-        <p class="text-xs text-gray-500 mb-2">Top demo users by board count:</p>
+        <p class="text-xs text-t2 mb-2">Top demo users by board count:</p>
         <div class="flex flex-wrap gap-2">
           <% @demo_users_preview.each do |u| %>
-            <span class="inline-flex items-center gap-1.5 text-xs bg-gray-800 rounded px-2.5 py-1">
-              <span class="text-gray-400"><%= u[:email] %></span>
-              <span class="text-indigo-400 font-medium"><%= u[:boards] %> boards</span>
+            <span class="inline-flex items-center gap-1.5 text-xs admin-badge rounded px-2.5 py-1">
+              <span class="text-t2"><%= u[:email] %></span>
+              <span class="text-accent font-medium"><%= u[:boards] %> boards</span>
             </span>
           <% end %>
         </div>
@@ -191,18 +226,20 @@
     <% end %>
 
     <% if @demo_user_count > 0 %>
-      <%= form_tag cleanup_demo_admin_mission_control_path, method: :post, class: "border-t border-gray-800 pt-4",
+      <%= form_tag cleanup_demo_admin_mission_control_path, method: :post, class: "pt-4",
+            style: "border-top: 1px solid var(--border);",
             data: { turbo: false } do %>
         <div class="flex flex-wrap items-end gap-4">
           <div>
-            <label for="keep_count" class="block text-xs text-gray-500 mb-1">Keep top N by boards</label>
+            <label for="keep_count" class="block text-xs text-t2 mb-1">Keep top N by boards</label>
             <input type="number" name="keep_count" id="keep_count" value="5" min="0" max="<%= @demo_user_count %>"
-                   class="w-20 bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:border-indigo-500 focus:outline-none">
+                   class="w-20 admin-input border rounded px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none">
           </div>
           <div class="flex-1 min-w-[200px]">
-            <label for="exclude_ids" class="block text-xs text-gray-500 mb-1">Exclude IDs (comma-separated, optional)</label>
+            <label for="exclude_ids" class="block text-xs text-t2 mb-1">Exclude IDs (comma-separated, optional)</label>
             <input type="text" name="exclude_ids" id="exclude_ids" placeholder="e.g. 42, 99"
-                   class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white placeholder-gray-600 focus:border-indigo-500 focus:outline-none">
+                   class="w-full admin-input border rounded px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+                   style="::placeholder { color: var(--text-muted); }">
           </div>
           <button type="submit" onclick="return confirm('This will permanently delete demo users. Continue?')"
                   class="bg-red-600 hover:bg-red-500 text-white text-sm font-medium rounded px-4 py-1.5 transition-colors">
@@ -216,23 +253,24 @@
 
 <%# ─── Recent events ──────────────────────────────────────── %>
 <section>
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Recent Events</h2>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Recent Events</h2>
 
   <% if @recent_events.any? %>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+    <div class="admin-card border rounded-xl overflow-hidden">
       <table class="w-full text-sm" id="events-table">
         <thead>
-          <tr class="border-b border-gray-800">
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3 w-36">When</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3 w-56">Event</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">User</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Details</th>
+          <tr style="border-bottom: 1px solid var(--border);">
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3 w-36">When</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3 w-56">Event</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">User</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Details</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-800/60">
+        <tbody>
           <% @recent_events.each_with_index do |event, idx| %>
-            <tr class="hover:bg-gray-800/40 transition-colors cursor-pointer event-row" data-event-idx="<%= idx %>">
-              <td class="px-5 py-3 text-xs text-gray-500 whitespace-nowrap">
+            <tr class="admin-hover-row transition-colors cursor-pointer event-row" data-event-idx="<%= idx %>"
+                style="border-bottom: 1px solid var(--border-light);">
+              <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap">
                 <%= time_ago_in_words(event.occurred_at) %> ago
               </td>
               <td class="px-5 py-3">
@@ -240,43 +278,43 @@
                   <%= event.event_type %>
                 </span>
               </td>
-              <td class="px-5 py-3 text-xs text-gray-400">
+              <td class="px-5 py-3 text-xs text-t2">
                 <%= event.user&.email || "—" %>
               </td>
-              <td class="px-5 py-3 text-xs text-gray-600 font-mono">
+              <td class="px-5 py-3 text-xs text-t3 font-mono">
                 <% if event.metadata.present? %>
                   <span class="truncate block max-w-xs"><%= event.metadata.map { |k, v| "#{k}: #{v}" }.join(" · ") %></span>
-                  <span class="text-indigo-400 text-[10px] ml-1">▸ click to expand</span>
+                  <span class="text-accent text-[10px] ml-1">▸ click to expand</span>
                 <% end %>
               </td>
             </tr>
             <tr class="event-detail hidden" id="event-detail-<%= idx %>">
-              <td colspan="4" class="px-5 py-4 bg-gray-800/30">
+              <td colspan="4" class="px-5 py-4" style="background: var(--hover-row);">
                 <div class="grid grid-cols-1 gap-1.5">
                   <div class="flex items-baseline gap-2 text-xs">
-                    <span class="text-gray-500 font-medium shrink-0 w-24">Event ID</span>
-                    <span class="text-gray-300 font-mono"><%= event.id %></span>
+                    <span class="text-t2 font-medium shrink-0 w-24">Event ID</span>
+                    <span class="text-t1 font-mono"><%= event.id %></span>
                   </div>
                   <div class="flex items-baseline gap-2 text-xs">
-                    <span class="text-gray-500 font-medium shrink-0 w-24">Occurred at</span>
-                    <span class="text-gray-300"><%= event.occurred_at.strftime("%Y-%m-%d %H:%M:%S %Z") %></span>
+                    <span class="text-t2 font-medium shrink-0 w-24">Occurred at</span>
+                    <span class="text-t1"><%= event.occurred_at.strftime("%Y-%m-%d %H:%M:%S %Z") %></span>
                   </div>
                   <div class="flex items-baseline gap-2 text-xs">
-                    <span class="text-gray-500 font-medium shrink-0 w-24">User</span>
-                    <span class="text-gray-300"><%= event.user&.email || "—" %> <% if event.user_id %><span class="text-gray-600">(id: <%= event.user_id %>)</span><% end %></span>
+                    <span class="text-t2 font-medium shrink-0 w-24">User</span>
+                    <span class="text-t1"><%= event.user&.email || "—" %> <% if event.user_id %><span class="text-t3">(id: <%= event.user_id %>)</span><% end %></span>
                   </div>
                   <% if event.metadata.present? %>
-                    <div class="mt-2 pt-2 border-t border-gray-700/50">
-                      <p class="text-xs text-gray-500 font-medium mb-1.5">Metadata</p>
+                    <div class="mt-2 pt-2" style="border-top: 1px solid var(--border-light);">
+                      <p class="text-xs text-t2 font-medium mb-1.5">Metadata</p>
                       <% event.metadata.each do |key, value| %>
                         <div class="flex items-baseline gap-2 text-xs py-0.5">
-                          <span class="text-indigo-400 font-mono shrink-0 min-w-[120px]"><%= key %></span>
-                          <span class="text-gray-300 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
+                          <span class="text-accent font-mono shrink-0 min-w-[120px]"><%= key %></span>
+                          <span class="text-t1 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
                         </div>
                       <% end %>
                     </div>
                   <% else %>
-                    <p class="text-xs text-gray-600 mt-2">No metadata.</p>
+                    <p class="text-xs text-t3 mt-2">No metadata.</p>
                   <% end %>
                 </div>
               </td>
@@ -296,11 +334,8 @@
       });
     </script>
   <% else %>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-10 text-center text-sm text-gray-600">
+    <div class="admin-card border rounded-xl px-5 py-10 text-center text-sm text-t3">
       No events recorded yet. Events will appear here as activity happens.
     </div>
   <% end %>
 </section>
-
-<%# ─── Partials ───────────────────────────────────────────── %>
-<% # stat_card partial is inlined below via content_for for simplicity %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class="flex items-center justify-between mb-6">
   <div>
-    <h1 class="text-2xl font-semibold text-white tracking-tight">Users</h1>
-    <p class="text-sm text-gray-500 mt-0.5"><%= @total_count %> total</p>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Users</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= @total_count %> total</p>
   </div>
 </div>
 
@@ -11,10 +11,10 @@
 <div class="flex flex-wrap items-center gap-3 mb-6">
   <%= form_tag admin_dashboard_users_path, method: :get, class: "flex items-center gap-3 flex-wrap", data: { turbo: false } do %>
     <input type="text" name="search" value="<%= @search %>" placeholder="Search by email or name…"
-           class="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white placeholder-gray-600 w-64 focus:border-indigo-500 focus:outline-none">
+           class="admin-input border rounded px-3 py-1.5 text-sm w-64 focus:border-indigo-500 focus:outline-none">
 
     <select name="filter"
-            class="bg-gray-800 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:border-indigo-500 focus:outline-none">
+            class="admin-input border rounded px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none">
       <option value="" <%= "selected" if @filter.blank? %>>All users</option>
       <option value="admin" <%= "selected" if @filter == "admin" %>>Admins</option>
       <option value="pro" <%= "selected" if @filter == "pro" %>>Pro</option>
@@ -34,16 +34,16 @@
     </button>
     <% if @search.present? || @filter.present? %>
       <%= link_to "Clear", admin_dashboard_users_path,
-            class: "text-xs text-gray-400 hover:text-white transition-colors" %>
+            class: "text-xs text-t3 hover:text-t1 transition-colors" %>
     <% end %>
   <% end %>
 </div>
 
 <%# ─── Users table ─────────────────────────────────────────── %>
-<div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+<div class="admin-card border rounded-xl overflow-hidden">
   <table class="w-full text-sm">
     <thead>
-      <tr class="border-b border-gray-800">
+      <tr style="border-bottom: 1px solid var(--border);">
         <% [
           ["Email",      "email"],
           ["Name",       "name"],
@@ -52,13 +52,13 @@
           ["Sign-ins",   "sign_in_count"],
           ["Created",    "created_at"],
         ].each do |label, col| %>
-          <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3">
             <% next_dir = (@sort == col && @dir == "asc") ? "desc" : "asc" %>
             <%= link_to admin_dashboard_users_path(sort: col, dir: next_dir, search: @search, filter: @filter),
-                  class: "hover:text-white transition-colors inline-flex items-center gap-1" do %>
+                  class: "hover:text-t1 transition-colors inline-flex items-center gap-1" do %>
               <%= label %>
               <% if @sort == col %>
-                <span class="text-indigo-400"><%= @dir == "asc" ? "↑" : "↓" %></span>
+                <span class="text-accent"><%= @dir == "asc" ? "↑" : "↓" %></span>
               <% end %>
             <% end %>
           </th>
@@ -66,13 +66,13 @@
         <th class="px-5 py-3"></th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-800/60">
+    <tbody>
       <% @users.each do |user| %>
-        <tr class="hover:bg-gray-800/40 transition-colors">
-          <td class="px-5 py-3 text-xs text-gray-300 font-mono">
-            <%= link_to user.email, admin_dashboard_user_path(user), class: "hover:text-indigo-400 transition-colors" %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-mono">
+            <%= link_to user.email, admin_dashboard_user_path(user), class: "hover:text-accent transition-colors" %>
           </td>
-          <td class="px-5 py-3 text-xs text-gray-400">
+          <td class="px-5 py-3 text-xs text-t2">
             <%= user.name.presence || "—" %>
           </td>
           <td class="px-5 py-3">
@@ -86,18 +86,18 @@
               <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5 ml-1">locked</span>
             <% end %>
           </td>
-          <td class="px-5 py-3 text-xs text-gray-400 text-center">
+          <td class="px-5 py-3 text-xs text-t2 text-center">
             <%= user.boards.size %>
           </td>
-          <td class="px-5 py-3 text-xs text-gray-500 text-center">
+          <td class="px-5 py-3 text-xs text-t3 text-center">
             <%= user.sign_in_count %>
           </td>
-          <td class="px-5 py-3 text-xs text-gray-500 whitespace-nowrap">
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap">
             <%= user.created_at.strftime("%b %-d, %Y") %>
           </td>
           <td class="px-5 py-3 text-right">
             <%= link_to "View", admin_dashboard_user_path(user),
-                  class: "text-xs text-indigo-400 hover:text-indigo-300 transition-colors" %>
+                  class: "text-xs text-accent hover:underline transition-colors" %>
           </td>
         </tr>
       <% end %>
@@ -105,7 +105,7 @@
   </table>
 
   <% if @users.empty? %>
-    <div class="px-5 py-10 text-center text-sm text-gray-600">
+    <div class="px-5 py-10 text-center text-sm text-t3">
       No users found.
     </div>
   <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,17 +1,17 @@
 <% content_for :page_title, @user.email %>
 
 <div class="mb-6">
-  <%= link_to "← Users", admin_dashboard_users_path, class: "text-xs text-gray-400 hover:text-white transition-colors" %>
+  <%= link_to "← Users", admin_dashboard_users_path, class: "text-xs text-t3 hover:text-t1 transition-colors" %>
 </div>
 
 <%# ─── Header ─────────────────────────────────────────────── %>
 <div class="flex items-start justify-between mb-8">
   <div>
-    <h1 class="text-2xl font-semibold text-white tracking-tight"><%= @user.email %></h1>
-    <p class="text-sm text-gray-500 mt-0.5">
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @user.email %></h1>
+    <p class="text-sm text-t3 mt-0.5">
       <%= @user.name.presence || "No name" %> · ID <%= @user.id %>
       <% if @user.demo_user? %>
-        <span class="text-yellow-400 ml-1">(demo account)</span>
+        <span class="text-yellow-500 ml-1">(demo account)</span>
       <% end %>
     </p>
   </div>
@@ -30,21 +30,21 @@
 
 <%# ─── Stats cards ────────────────────────────────────────── %>
 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
-    <p class="text-xs text-gray-500 mb-1">Boards</p>
-    <p class="text-2xl font-semibold text-white"><%= @boards.size %></p>
+  <div class="admin-card border rounded-xl p-4">
+    <p class="text-xs text-t2 mb-1">Boards</p>
+    <p class="text-2xl font-semibold text-t1"><%= @boards.size %></p>
   </div>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
-    <p class="text-xs text-gray-500 mb-1">Communicators</p>
-    <p class="text-2xl font-semibold text-white"><%= @communicators.size %></p>
+  <div class="admin-card border rounded-xl p-4">
+    <p class="text-xs text-t2 mb-1">Communicators</p>
+    <p class="text-2xl font-semibold text-t1"><%= @communicators.size %></p>
   </div>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
-    <p class="text-xs text-gray-500 mb-1">Credits</p>
-    <p class="text-2xl font-semibold text-white"><%= @credit_balance %></p>
+  <div class="admin-card border rounded-xl p-4">
+    <p class="text-xs text-t2 mb-1">Credits</p>
+    <p class="text-2xl font-semibold text-t1"><%= @credit_balance %></p>
   </div>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
-    <p class="text-xs text-gray-500 mb-1">Sign-ins</p>
-    <p class="text-2xl font-semibold text-white"><%= @user.sign_in_count %></p>
+  <div class="admin-card border rounded-xl p-4">
+    <p class="text-xs text-t2 mb-1">Sign-ins</p>
+    <p class="text-2xl font-semibold text-t1"><%= @user.sign_in_count %></p>
   </div>
 </div>
 
@@ -52,8 +52,8 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
 
   <%# Account details ──────────────────────────────────────── %>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Account</h2>
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Account</h2>
     <dl class="space-y-2.5 text-xs">
       <% [
         ["Role",             @user.role],
@@ -67,127 +67,128 @@
         ["Last sign-in IP",  @user.last_sign_in_ip.presence || "—"],
       ].each do |label, value| %>
         <div class="flex justify-between">
-          <dt class="text-gray-500"><%= label %></dt>
-          <dd class="text-gray-300 font-mono text-right"><%= value %></dd>
+          <dt class="text-t2"><%= label %></dt>
+          <dd class="text-t1 font-mono text-right"><%= value %></dd>
         </div>
       <% end %>
     </dl>
   </div>
 
   <%# Settings snapshot ────────────────────────────────────── %>
-  <div class="bg-gray-900 border border-gray-800 rounded-xl p-6">
-    <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">Settings</h2>
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Settings</h2>
     <% if @user.settings.present? %>
       <dl class="space-y-2 text-xs">
         <% @user.settings.each do |key, value| %>
           <% next if key == "voice" %>
           <div class="flex justify-between gap-4">
-            <dt class="text-gray-500 shrink-0"><%= key %></dt>
-            <dd class="text-gray-300 font-mono text-right truncate max-w-[200px]" title="<%= value %>">
+            <dt class="text-t2 shrink-0"><%= key %></dt>
+            <dd class="text-t1 font-mono text-right truncate max-w-[200px]" title="<%= value %>">
               <%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %>
             </dd>
           </div>
         <% end %>
       </dl>
     <% else %>
-      <p class="text-xs text-gray-600">No settings.</p>
+      <p class="text-xs text-t3">No settings.</p>
     <% end %>
   </div>
 </div>
 
 <%# ─── Boards ─────────────────────────────────────────────── %>
 <section class="mb-8">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
-    Boards <span class="text-gray-600">(<%= @boards.size %>)</span>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">
+    Boards <span class="text-t3">(<%= @boards.size %>)</span>
   </h2>
 
   <% if @boards.any? %>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+    <div class="admin-card border rounded-xl overflow-hidden">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-gray-800">
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Name</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Images</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Updated</th>
+          <tr style="border-bottom: 1px solid var(--border);">
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Name</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Images</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Updated</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-800/60">
+        <tbody>
           <% @boards.each do |board| %>
-            <tr class="hover:bg-gray-800/40 transition-colors">
-              <td class="px-5 py-2.5 text-xs text-gray-300"><%= board.name %></td>
-              <td class="px-5 py-2.5 text-xs text-gray-500"><%= board.board_images.size %></td>
-              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap"><%= board.updated_at.strftime("%b %-d, %Y") %></td>
+            <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+              <td class="px-5 py-2.5 text-xs text-t1"><%= board.name %></td>
+              <td class="px-5 py-2.5 text-xs text-t3"><%= board.board_images.size %></td>
+              <td class="px-5 py-2.5 text-xs text-t3 whitespace-nowrap"><%= board.updated_at.strftime("%b %-d, %Y") %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
     </div>
   <% else %>
-    <p class="text-xs text-gray-600">No boards.</p>
+    <p class="text-xs text-t3">No boards.</p>
   <% end %>
 </section>
 
 <%# ─── Communicators ──────────────────────────────────────── %>
 <section class="mb-8">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
-    Communicators <span class="text-gray-600">(<%= @communicators.size %>)</span>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">
+    Communicators <span class="text-t3">(<%= @communicators.size %>)</span>
   </h2>
 
   <% if @communicators.any? %>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+    <div class="admin-card border rounded-xl overflow-hidden">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-gray-800">
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Name</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Username</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Status</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Created</th>
+          <tr style="border-bottom: 1px solid var(--border);">
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Name</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Username</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Status</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Created</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-800/60">
+        <tbody>
           <% @communicators.each do |ca| %>
-            <tr class="hover:bg-gray-800/40 transition-colors">
-              <td class="px-5 py-2.5 text-xs text-gray-300"><%= ca.name.presence || "—" %></td>
-              <td class="px-5 py-2.5 text-xs text-gray-400 font-mono"><%= ca.username.presence || "—" %></td>
+            <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+              <td class="px-5 py-2.5 text-xs text-t1"><%= ca.name.presence || "—" %></td>
+              <td class="px-5 py-2.5 text-xs text-t2 font-mono"><%= ca.username.presence || "—" %></td>
               <td class="px-5 py-2.5">
                 <span class="inline-block text-xs rounded px-2 py-0.5
                   <%= ca.status == "active" ? "bg-green-900/60 text-green-300" :
                       ca.status == "loaner" ? "bg-blue-900/60 text-blue-300" :
-                      "bg-gray-800 text-gray-400" %>">
+                      "admin-badge text-t3" %>">
                   <%= ca.status %>
                 </span>
               </td>
-              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap"><%= ca.created_at.strftime("%b %-d, %Y") %></td>
+              <td class="px-5 py-2.5 text-xs text-t3 whitespace-nowrap"><%= ca.created_at.strftime("%b %-d, %Y") %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
     </div>
   <% else %>
-    <p class="text-xs text-gray-600">No communicators.</p>
+    <p class="text-xs text-t3">No communicators.</p>
   <% end %>
 </section>
 
 <%# ─── Recent events ──────────────────────────────────────── %>
 <section>
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-4">
-    Recent Events <span class="text-gray-600">(<%= @recent_events.size %>)</span>
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">
+    Recent Events <span class="text-t3">(<%= @recent_events.size %>)</span>
   </h2>
 
   <% if @recent_events.any? %>
-    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+    <div class="admin-card border rounded-xl overflow-hidden">
       <table class="w-full text-sm">
         <thead>
-          <tr class="border-b border-gray-800">
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">When</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Event</th>
-            <th class="text-left text-xs font-medium text-gray-500 px-5 py-3">Details</th>
+          <tr style="border-bottom: 1px solid var(--border);">
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">When</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Event</th>
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">Details</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-800/60">
+        <tbody>
           <% @recent_events.each_with_index do |event, idx| %>
-            <tr class="hover:bg-gray-800/40 transition-colors cursor-pointer user-event-row" data-event-idx="<%= idx %>">
-              <td class="px-5 py-2.5 text-xs text-gray-500 whitespace-nowrap">
+            <tr class="admin-hover-row transition-colors cursor-pointer user-event-row" data-event-idx="<%= idx %>"
+                style="border-bottom: 1px solid var(--border-light);">
+              <td class="px-5 py-2.5 text-xs text-t3 whitespace-nowrap">
                 <%= time_ago_in_words(event.occurred_at) %> ago
               </td>
               <td class="px-5 py-2.5">
@@ -195,25 +196,25 @@
                   <%= event.event_type %>
                 </span>
               </td>
-              <td class="px-5 py-2.5 text-xs text-gray-600 font-mono">
+              <td class="px-5 py-2.5 text-xs text-t3 font-mono">
                 <% if event.metadata.present? %>
                   <span class="truncate block max-w-sm"><%= event.metadata.map { |k, v| "#{k}: #{v}" }.join(" · ") %></span>
-                  <span class="text-indigo-400 text-[10px]">▸ expand</span>
+                  <span class="text-accent text-[10px]">▸ expand</span>
                 <% end %>
               </td>
             </tr>
             <tr class="hidden user-event-detail" id="user-event-detail-<%= idx %>">
-              <td colspan="3" class="px-5 py-3 bg-gray-800/30">
+              <td colspan="3" class="px-5 py-3" style="background: var(--hover-row);">
                 <div class="text-xs space-y-1">
                   <% if event.metadata.present? %>
                     <% event.metadata.each do |key, value| %>
                       <div class="flex gap-2">
-                        <span class="text-indigo-400 font-mono shrink-0 min-w-[120px]"><%= key %></span>
-                        <span class="text-gray-300 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
+                        <span class="text-accent font-mono shrink-0 min-w-[120px]"><%= key %></span>
+                        <span class="text-t1 font-mono break-all"><%= value.is_a?(Hash) || value.is_a?(Array) ? value.to_json : value %></span>
                       </div>
                     <% end %>
                   <% else %>
-                    <p class="text-gray-600">No metadata.</p>
+                    <p class="text-t3">No metadata.</p>
                   <% end %>
                 </div>
               </td>
@@ -232,6 +233,6 @@
       });
     </script>
   <% else %>
-    <p class="text-xs text-gray-600">No events recorded for this user.</p>
+    <p class="text-xs text-t3">No events recorded for this user.</p>
   <% end %>
 </section>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-gray-950">
+<html lang="en" class="h-full">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,50 +8,144 @@
   <%= csp_meta_tag %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  <style>
+    /* Light mode (default) */
+    :root {
+      --bg-body: #f9fafb;       /* gray-50 */
+      --bg-surface: #ffffff;
+      --bg-surface-alt: #f3f4f6; /* gray-100 */
+      --bg-nav: #ffffff;
+      --border: #e5e7eb;         /* gray-200 */
+      --border-light: #f3f4f6;
+      --text-primary: #111827;   /* gray-900 */
+      --text-secondary: #6b7280; /* gray-500 */
+      --text-muted: #9ca3af;     /* gray-400 */
+      --text-accent: #6366f1;    /* indigo-500 */
+      --text-accent-hover: #4f46e5;
+      --badge-bg: #f3f4f6;
+      --input-bg: #ffffff;
+      --input-border: #d1d5db;
+      --hover-row: rgba(243, 244, 246, 0.6);
+    }
+    /* Dark mode */
+    html.dark {
+      --bg-body: #030712;       /* gray-950 */
+      --bg-surface: #111827;    /* gray-900 */
+      --bg-surface-alt: #1f2937; /* gray-800 */
+      --bg-nav: #111827;
+      --border: #1f2937;
+      --border-light: rgba(31, 41, 55, 0.6);
+      --text-primary: #f3f4f6;
+      --text-secondary: #9ca3af;
+      --text-muted: #6b7280;
+      --text-accent: #818cf8;
+      --badge-bg: #1f2937;
+      --input-bg: #1f2937;
+      --input-border: #374151;
+      --hover-row: rgba(31, 41, 55, 0.4);
+    }
+    body.admin-body {
+      background: var(--bg-body);
+      color: var(--text-primary);
+    }
+    .admin-nav { background: var(--bg-nav); border-color: var(--border); }
+    .admin-card { background: var(--bg-surface); border-color: var(--border); }
+    .admin-card-alt { background: var(--bg-surface-alt); }
+    .text-t1 { color: var(--text-primary); }
+    .text-t2 { color: var(--text-secondary); }
+    .text-t3 { color: var(--text-muted); }
+    .text-accent { color: var(--text-accent); }
+    .border-t { border-color: var(--border); }
+    .border-t-light { border-color: var(--border-light); }
+    .admin-badge { background: var(--badge-bg); }
+    .admin-input {
+      background: var(--input-bg);
+      border-color: var(--input-border);
+      color: var(--text-primary);
+    }
+    .admin-hover-row:hover { background: var(--hover-row); }
+    .admin-flash-ok { background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.2); color: #16a34a; }
+    .admin-flash-err { background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.2); color: #dc2626; }
+    html.dark .admin-flash-ok { background: rgba(34,197,94,0.15); color: #86efac; }
+    html.dark .admin-flash-err { background: rgba(239,68,68,0.15); color: #fca5a5; }
+
+    .theme-toggle {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 4px 10px; border-radius: 6px; cursor: pointer;
+      font-size: 12px; border: 1px solid var(--border);
+      background: var(--bg-surface); color: var(--text-secondary);
+      transition: all 0.15s;
+    }
+    .theme-toggle:hover { color: var(--text-primary); border-color: var(--text-secondary); }
+  </style>
+  <script>
+    (function() {
+      var t = localStorage.getItem('admin_theme');
+      if (t === 'dark') document.documentElement.classList.add('dark');
+    })();
+  </script>
 </head>
-<body class="h-full bg-gray-950 text-gray-100 font-sans antialiased">
+<body class="h-full admin-body font-sans antialiased">
 
   <%# Top nav %>
-  <header class="bg-gray-900 border-b border-gray-800">
+  <header class="admin-nav border-b">
     <div class="max-w-screen-2xl mx-auto px-6 h-14 flex items-center justify-between">
       <div class="flex items-center gap-6">
         <%= link_to admin_root_path, class: "flex items-center gap-3 group" do %>
-          <span class="text-xs font-semibold tracking-widest uppercase text-indigo-400 group-hover:text-indigo-300 transition-colors">SpeakAnyWay</span>
-          <span class="text-gray-700">/</span>
-          <span class="text-sm font-medium text-white">Admin</span>
+          <span class="text-xs font-semibold tracking-widest uppercase text-accent">SpeakAnyWay</span>
+          <span class="text-t3">/</span>
+          <span class="text-sm font-medium text-t1">Admin</span>
         <% end %>
 
         <nav class="hidden md:flex items-center gap-1">
           <%= link_to "Dashboard", admin_root_path,
-                class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_root_path) ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
+                class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_root_path) ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Mission Control", admin_mission_control_path,
-                class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_mission_control_path) ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
+                class: "text-xs px-3 py-1.5 rounded #{current_page?(admin_mission_control_path) ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
-                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "bg-gray-800 text-white" : "text-gray-400 hover:text-white hover:bg-gray-800/60"} transition-colors" %>
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",
-                class: "text-xs px-3 py-1.5 rounded text-gray-400 hover:text-white hover:bg-gray-800/60 transition-colors" %>
+                class: "text-xs px-3 py-1.5 rounded text-t2 hover:text-t1 transition-colors" %>
         </nav>
       </div>
 
-      <div class="flex items-center gap-4 text-xs text-gray-400">
+      <div class="flex items-center gap-4 text-xs text-t2">
+        <button class="theme-toggle" onclick="toggleAdminTheme()" id="theme-btn" title="Toggle light/dark mode">
+          <span id="theme-icon">&#9788;</span>
+          <span id="theme-label">Light</span>
+        </button>
         <span><%= current_user.email %></span>
         <%= button_to "Sign out", destroy_user_session_path, method: :delete,
-              class: "text-gray-500 hover:text-white transition-colors bg-transparent border-0 cursor-pointer p-0" %>
+              class: "text-t3 hover:text-t1 transition-colors bg-transparent border-0 cursor-pointer p-0" %>
       </div>
     </div>
   </header>
 
   <%# Flash messages %>
   <% if notice.present? %>
-    <div class="bg-green-900/40 border-b border-green-800 text-green-300 text-sm px-6 py-2"><%= notice %></div>
+    <div class="admin-flash-ok border-b text-sm px-6 py-2"><%= notice %></div>
   <% end %>
   <% if alert.present? %>
-    <div class="bg-red-900/40 border-b border-red-800 text-red-300 text-sm px-6 py-2"><%= alert %></div>
+    <div class="admin-flash-err border-b text-sm px-6 py-2"><%= alert %></div>
   <% end %>
 
   <main class="max-w-screen-2xl mx-auto px-6 py-8">
     <%= yield %>
   </main>
 
+  <script>
+    function toggleAdminTheme() {
+      var html = document.documentElement;
+      var isDark = html.classList.toggle('dark');
+      localStorage.setItem('admin_theme', isDark ? 'dark' : 'light');
+      updateThemeButton();
+    }
+    function updateThemeButton() {
+      var isDark = document.documentElement.classList.contains('dark');
+      document.getElementById('theme-icon').innerHTML = isDark ? '&#9790;' : '&#9788;';
+      document.getElementById('theme-label').textContent = isDark ? 'Dark' : 'Light';
+    }
+    updateThemeButton();
+  </script>
 </body>
 </html>

--- a/spec/services/mission_control/overview_metrics_spec.rb
+++ b/spec/services/mission_control/overview_metrics_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe MissionControl::OverviewMetrics do
+  describe ".call" do
+    let!(:admin) { create(:user, role: "admin", created_at: 1.hour.ago) }
+    let!(:user_today) { create(:user, created_at: 1.hour.ago, last_sign_in_at: 1.hour.ago) }
+    let!(:user_3d) { create(:user, created_at: 3.days.ago, last_sign_in_at: 3.days.ago) }
+    let!(:user_10d) { create(:user, created_at: 10.days.ago, last_sign_in_at: 10.days.ago) }
+    let!(:user_old) { create(:user, created_at: 60.days.ago, last_sign_in_at: 60.days.ago) }
+    let!(:trialing_user) { create(:user, created_at: 2.days.ago, plan_status: "trialing") }
+
+    subject(:result) { described_class.call }
+
+    it "counts signups excluding admins" do
+      expect(result[:signups_today]).to eq(1)
+      expect(result[:signups_7d]).to eq(3)
+      expect(result[:signups_30d]).to eq(4)
+    end
+
+    it "counts active users by sign-in recency" do
+      expect(result[:active_users_7d]).to eq(2)
+      expect(result[:active_users_30d]).to eq(3)
+    end
+
+    it "counts trial users" do
+      expect(result[:trial_users]).to eq(1)
+    end
+
+    it "returns total non-admin user count" do
+      expect(result[:total_users]).to eq(5)
+    end
+
+    it "returns daily signup breakdown for last 7 days" do
+      daily = result[:signups_daily_7d]
+      expect(daily).to be_a(Hash)
+      today_key = Time.zone.today.to_s
+      expect(daily[today_key]).to eq(1)
+    end
+
+    it "returns board and word event counts" do
+      expect(result).to have_key(:boards_today)
+      expect(result).to have_key(:boards_7d)
+      expect(result).to have_key(:total_boards)
+      expect(result).to have_key(:word_events_today)
+      expect(result).to have_key(:word_events_7d)
+    end
+
+    it "returns communicator and profile counts" do
+      expect(result).to have_key(:communicator_accounts)
+      expect(result).to have_key(:myspeak_profiles)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Light mode default + toggle** — the admin dashboard was locked to dark mode, which is hard to read in some lighting conditions. Defaults to light now with a toggle in the top-right nav; preference persists in localStorage across sessions.
- **New Engagement section** on Mission Control: Active Users (7d/30d), Trial Users (currently trialing), Communicator accounts — the kind of at-a-glance engagement data that was missing.
- **Signup trend bar chart** — daily signups for the last 7 days, so you can spot patterns vs. just seeing a single "0 last 7d" number.
- **CSS variable theming** across all admin views (Dashboard, Mission Control, Users list, User detail) — replaced hard-coded `gray-900`/`gray-950` Tailwind classes with CSS custom properties that flip with the toggle.

### Data accuracy note

Investigated the "zero signups" report. The queries (`User.non_admin.where(created_at: today)`) are correct — they properly exclude admins, respect the `default_scope` for soft-deleted users, and use correct time ranges. The dev database genuinely has zero non-admin signups in the last 7 days. On production, real numbers will show. No query bug found.

## Test plan

- [x] `bundle exec rspec spec/services/mission_control/` — 31 examples, 0 failures (includes new `overview_metrics_spec.rb`)
- [x] `bundle exec rspec spec/requests/admin/` — 21 examples, 0 failures
- [x] Verified light mode renders correctly on Dashboard, Mission Control, and Users pages in browser
- [x] Verified dark mode toggle switches cleanly and back
- [x] Verified new Engagement section shows Active Users, Trial Users, Communicators
- [x] Verified signup trend chart renders (empty bars for days with no signups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)