### PR TITLE
feat: raise free plan AI credits from 5 to 25/month

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -61,6 +61,18 @@ module API
       true
     rescue CreditService::InsufficientCredits => e
       balance = CreditService.balance(current_user)
+
+      PosthogService.capture_for_user(
+        current_user,
+        "credits_exhausted",
+        properties: {
+          feature_key: feature_key.to_s,
+          needed: e.needed,
+          balance: balance[:total],
+          plan_type: current_user.plan_type,
+        },
+      )
+
       render json: {
         error: "insufficient_credits",
         message: "You don't have enough AI credits for #{feature_name || feature_key.to_s.titleize}. Buy more credits or upgrade your plan.",

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -33,7 +33,7 @@ class CreditService
 
   # Default monthly grant by plan_type. Stripe Price metadata overrides at grant time.
   PLAN_MONTHLY_CREDITS = {
-    "free" => 5,
+    "free" => 25,
     "basic_trial" => 400, # Soft 14-day Basic trial set by User#set_soft_trial_plan
     "basic" => 400,
     "pro" => 1500,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe User, type: :model do
   end
 
   context "initial plan-credit grant on signup" do
-    it "grants the free allowance (5) by default since new users land on free" do
+    it "grants the free allowance (25) by default since new users land on free" do
       user = FactoryBot.create(:user)
       expect(user.plan_type).to eq("free")
-      expect(user.plan_credits_balance).to eq(5)
+      expect(user.plan_credits_balance).to eq(25)
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
 
@@ -158,9 +158,9 @@ RSpec.describe User, type: :model do
 
   # Regression guard for drafts/drop-basic-trial-option-a.md: the no-CC
   # basic_trial soft trial was removed, so every brand-new signup must land on
-  # Free with Free limits and the 5-credit initial grant — no 400-credit trial.
+  # Free with Free limits and the 25-credit initial grant — no 400-credit trial.
   context "fresh signup (no-CC soft trial removed)" do
-    it "lands on free with Free limits, a communicator slot, and a 5-credit grant" do
+    it "lands on free with Free limits, a communicator slot, and a 25-credit grant" do
       user = FactoryBot.create(:user)
 
       expect(user.plan_type).to eq("free")
@@ -171,7 +171,7 @@ RSpec.describe User, type: :model do
         .to eq(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
       expect(user.settings["paid_communicator_limit"].to_i).to be >= 1
 
-      expect(user.plan_credits_balance).to eq(5)
+      expect(user.plan_credits_balance).to eq(25)
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
   end

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CreditService, type: :service do
 
   describe ".monthly_credits_for" do
     it "returns the configured allowance per plan" do
-      expect(described_class.monthly_credits_for("free")).to eq(5)
+      expect(described_class.monthly_credits_for("free")).to eq(25)
       expect(described_class.monthly_credits_for("basic")).to eq(400)
       expect(described_class.monthly_credits_for("basic_trial")).to eq(400)
       expect(described_class.monthly_credits_for("pro")).to eq(1500)

--- a/spec/sidekiq/downgrade_soft_trial_job_spec.rb
+++ b/spec/sidekiq/downgrade_soft_trial_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DowngradeSoftTrialJob, type: :job do
         # Pretend they spent most of their basic_trial allowance.
         user.update_columns(plan_credits_balance: 12, plan_credits_reset_at: 1.day.ago)
 
-        expect { job.perform }.to change { user.reload.plan_credits_balance }.to(5)
+        expect { job.perform }.to change { user.reload.plan_credits_balance }.to(25)
         expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
         tx = user.credit_transactions.where(kind: "plan_grant").order(created_at: :desc).first
         expect(tx.metadata["source"]).to eq("soft_trial_downgrade")

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
       expect {
         described_class.new.perform
-      }.to change { user.reload.plan_credits_balance }.from(0).to(5)
+      }.to change { user.reload.plan_credits_balance }.from(0).to(25)
       expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
     end
 
@@ -86,7 +86,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
       described_class.new.perform
       user.reload
-      expect(user.plan_credits_balance).to eq(5)
+      expect(user.plan_credits_balance).to eq(25)
       expect(user.credit_transactions.where(kind: "expire", source: "plan").count).to be >= 1
     end
 


### PR DESCRIPTION
## Summary

Raises the free plan monthly AI credit allowance from 5 → 25. With the soft trial removed, free users land with only 5 credits — not enough to sample even one high-cost feature (image edit or scenario = 5 credits). 25 lets them try nearly everything once, costs <$0.25/user/month, and builds the habit that drives Basic upgrades.

Also adds a `credits_exhausted` PostHog event so we have real data on how often free users hit the wall.

## Changes

- `credit_service.rb`: `PLAN_MONTHLY_CREDITS["free"]` 5 → 25
- `application_controller.rb`: fire `credits_exhausted` PostHog event in the `InsufficientCredits` rescue block (captures feature_key, needed, balance, plan_type)
- `credit_service_spec.rb`: updated assertion to expect 25

## Test plan

- `credit_service_spec.rb` assertions updated (`.monthly_credits_for("free")` now expects 25)
- Existing spend/grant/refund specs unchanged — they use explicit amounts, not the plan constant
- PostHog event uses the established `PosthogService.capture_for_user` pattern (production-only, rescue-wrapped)

## Companion PR

Frontend copy update: brittanyjohns/itty-bitty-frontend feat/free-credits-25