### PR TITLE
feat(board-builder): expand interest categories + categorized picker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Board Builder: expanded interest categories + categorized picker endpoint
+- Expanded interest dictionary from 4 categories (~120 words) to 18 categories
+  (~504 words). New categories: Animals, Art & Craft, Clothing, Family & People,
+  Health & Body, Home, Music, Nature & Outdoors, Places, School, Social, Sports,
+  Technology, Transportation.
+- New `GET /api/v1/board_builder/interest_categories` endpoint returns the full
+  category dictionary for the frontend's categorized interest picker.
+- Interest cap raised from 12 to 20.
+- `create` now accepts interests as `[{ word, category }]` hashes for explicit
+  routing from the picker (plain strings still work via dictionary lookup).
+
 ### Improved — Admin dashboard: light/dark toggle + engagement metrics
 - **Light mode default** with a toggle in the top-right nav. Preference persists
   in localStorage. All admin pages (Dashboard, Mission Control, Users) use CSS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -821,7 +821,9 @@ Three seams (input contract tightens left→right):
   `Boards::InterestCategories` (apple→Food, trains→Play). Routing is dynamic
   by template (only into a folder the chosen template has); anything unmatched
   falls through to one appended **"My Favorites"** folder, deduped, nothing
-  dropped. Interests are normalized + capped at 12.
+  dropped. Interests are normalized + capped at 20. When the frontend sends
+  `[{ word, category }]` entries, the explicit category overrides the dictionary
+  lookup — so the categorized picker's selections route deterministically.
 - `Boards::BoardTreeBuilder` (#259) — persists the tree from a blueprint of
   **already-resolved `image_id`s only**. Keep it dumb; all resolution lives in
   the assembler.
@@ -834,8 +836,13 @@ Endpoints (`API::V1::BoardBuilderController`, both auth-gated):
   `recommended_template` (Core 60's slug for young/emerging, else Core 84's —
   only if that set is seeded here) and a `recommendation_reason` string. No
   profile → both `null`.
+- `GET /api/v1/board_builder/interest_categories` — returns the full category
+  dictionary (`{ categories: [{ name, words }], max_interests }`) for the
+  frontend's categorized interest picker. 18 categories, ~504 words.
 - `POST /api/v1/board_builder` `{ communicator_id, template, interests }` —
-  ownership check (**404 `communicator_not_found`** for a communicator not in
+  `interests` accepts plain strings or `[{ word, category }]` hashes; explicit
+  categories override the dictionary lookup. Ownership check (**404
+  `communicator_not_found`** for a communicator not in
   `current_user.communicator_accounts`), assemble → build → persist normalized
   interests to `child_account.details["interests"]` (jsonb merge), return the
   favorited root board's `api_view` (**201**). **422 `unknown_template`** /

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -38,6 +38,16 @@ module API
                status: :ok
       end
 
+      def interest_categories
+        categories = Boards::InterestCategories::KEYWORDS.map do |name, words|
+          { name: name, words: words.sort }
+        end.sort_by { |c| c[:name] }
+
+        render json: { categories: categories,
+                       max_interests: Boards::InterestWords::MAX_INTERESTS },
+               status: :ok
+      end
+
       def create
         communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
         unless communicator
@@ -95,8 +105,10 @@ module API
         owner = communicator.owner || communicator.user
         raise Boards::BoardTreeBuilder::BuildError, "communicator has no owning user" unless owner
 
-        interests = Boards::InterestWords.normalize_list(params[:interests])
-        root_name = robust_root ? robust_root.name : starter_tree[:name]
+        raw_interests = params[:interests]
+        interests  = Boards::InterestWords.normalize_list(raw_interests)
+        categories = Boards::InterestWords.extract_categories(raw_interests)
+        root_name  = robust_root ? robust_root.name : starter_tree[:name]
 
         # Create the root in-request so the 201 payload (and the duplicate
         # guard, and the board-limit count) see it immediately; the job adopts
@@ -129,7 +141,7 @@ module API
         # which was ALREADY queued asynchronously (GenerateImagesJob) and is
         # paid where it always was. So there is nothing to refund if
         # BuildBoardSetJob fails — no refund path needed, by decision.
-        BuildBoardSetJob.perform_async(root.id, communicator.id, params[:template].to_s, interests)
+        BuildBoardSetJob.perform_async(root.id, communicator.id, params[:template].to_s, interests, categories)
 
         render json: serialize_built_root(root), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e

--- a/app/services/boards/blueprint_assembler.rb
+++ b/app/services/boards/blueprint_assembler.rb
@@ -27,16 +27,17 @@
 module Boards
   class BlueprintAssembler
     FAVORITES_NAME = "My Favorites"
-    MAX_INTERESTS  = 12
+    MAX_INTERESTS  = Boards::InterestWords::MAX_INTERESTS
 
     class UnknownTemplate < StandardError; end
 
     attr_reader :interests
 
-    def initialize(template:, user:, interests: [])
-      @template_key = template.to_s
-      @user         = user
-      @interests    = normalize_interests(interests)
+    def initialize(template:, user:, interests: [], explicit_categories: {})
+      @template_key        = template.to_s
+      @user                = user
+      @interests           = normalize_interests(interests)
+      @explicit_categories = explicit_categories || {}
     end
 
     # Returns a builder-ready blueprint: the resolved template with interests
@@ -59,7 +60,7 @@ module Boards
       unrouted = []
 
       @interests.each do |word|
-        category = Boards::InterestCategories.category_for(word)
+        category = @explicit_categories[word] || Boards::InterestCategories.category_for(word)
         folder   = category && folders[category]
         folder ? add_interest_to_folder(folder, word) : unrouted << word
       end

--- a/app/services/boards/interest_categories.rb
+++ b/app/services/boards/interest_categories.rb
@@ -9,37 +9,106 @@
 # the assembler checks folder presence and falls anything else through to the
 # single "My Favorites" catch-all. So a word mapped to "Bathroom" still lands in
 # Favorites on a template (like HOME) that has no Bathroom folder.
-#
-# The lexicon is deliberately small and hand-curated for v1; extend the lists as
-# real usage shows what kids actually ask for. Adding a brand-new category here
-# is inert until a template grows a folder with the matching label.
 module Boards
   module InterestCategories
     # Folder label => the words that route into it. Words are matched
     # case-insensitively (stored lowercase). Keep words in exactly one list so
     # the reverse index below is unambiguous.
     KEYWORDS = {
+      "Animals" => %w[
+        dog cat horse fish bird rabbit snake bear turtle frog duck cow pig
+        monkey elephant lion tiger shark whale dolphin puppy kitten hamster
+        giraffe zebra penguin owl parrot spider ant bee butterfly octopus seal
+        panda
+      ],
+      "Art & Craft" => %w[
+        crayon marker paper stamp fold cut tape create make glue scissors
+        stickers clay glitter sketch sculpt weave sew bead origami collage
+        mosaic print
+      ],
+      "Bathroom" => %w[
+        toilet potty wash soap towel bath shower brush teeth flush wipe diaper
+        pee poop sink handwashing shampoo toothbrush toothpaste mirror
+      ],
+      "Clothing" => %w[
+        shirt pants shoes hat socks jacket dress pajamas coat boots gloves
+        scarf zipper button snap shorts skirt sweater hoodie uniform belt
+        sandals slippers
+      ],
+      "Family & People" => %w[
+        mom dad brother sister grandma grandpa friend teacher baby uncle aunt
+        cousin neighbor therapist nurse helper caregiver nanny classmate
+        teammate principal
+      ],
+      "Feelings" => %w[
+        happy sad tired angry mad scared silly calm frustrated nervous proud
+        shy sleepy sick hurt love worried surprised bored lonely grumpy excited
+        cranky frightened upset jealous confused embarrassed brave gentle kind
+        mean grateful hopeful anxious peaceful
+      ],
       "Food" => %w[
         apple banana orange grapes grape strawberry strawberries watermelon
         water juice milk snack snacks cookie cookies pizza cracker crackers
         cheese yogurt cereal bread pasta noodles chicken rice carrot candy
         chocolate icecream sandwich soup egg eggs fruit drink hungry eat
+        breakfast lunch dinner plate fork spoon cup bowl hot cold
       ],
-      "Feelings" => %w[
-        happy sad tired angry mad scared silly calm frustrated nervous proud
-        shy sleepy sick hurt love worried surprised bored lonely grumpy excited
-        cranky frightened upset
+      "Health & Body" => %w[
+        doctor medicine stomach head hand foot eye ear nose mouth arm leg knee
+        tummy back shoulder finger toe elbow wrist ankle chest belly throat
+        neck brain heart
       ],
-      "Bathroom" => %w[
-        toilet potty wash soap towel bath shower brush teeth flush wipe diaper
-        pee poop sink handwashing
+      "Home" => %w[
+        bed table chair door window couch kitchen room floor stairs light
+        fridge oven microwave blanket pillow lamp closet shelf drawer cabinet
+        garage basement roof
+      ],
+      "Music" => %w[
+        sing singing drum guitar piano song listen clap loud quiet music beat
+        rhythm instrument tambourine xylophone trumpet flute violin ukulele
+        maracas harmonica whistle choir band concert melody
+      ],
+      "Nature & Outdoors" => %w[
+        tree flower sun rain snow garden rock dirt sky cloud wind leaf grass
+        mud puddle pond river mountain camping hiking lake forest beach ocean
+        sand wave shell star moon rainbow seed plant bug
+      ],
+      "Places" => %w[
+        school store library hospital church pool playground zoo aquarium
+        restaurant mall gym farm museum theater airport hotel market cafe
+        bakery
       ],
       "Play" => %w[
         train trains dinosaur dinosaurs ball blocks block painting paint cars
-        car music books book puzzle puzzles doll dolls lego legos bike swing
-        slide park game games drawing draw dance dancing sing singing bubbles
-        animals truck trucks robot robots superhero princess art color colors
-        coloring outside run toys
+        car books book puzzle puzzles doll dolls lego legos bike swing slide
+        park game games drawing draw dance dancing bubbles animals truck trucks
+        robot robots superhero princess art color colors coloring outside run
+        toys pretend hide seek chase tag build climb
+      ],
+      "School" => %w[
+        read write pencil homework class desk backpack recess test learn spell
+        count alphabet number letter grade report project science history
+        geography
+      ],
+      "Social" => %w[
+        hi bye please thankyou sorry share turn wait mine yours stop go come
+        look help want need like welcome together alone invite join agree
+        disagree ask tell promise
+      ],
+      "Sports" => %w[
+        swim kick throw catch jump race soccer basketball baseball football
+        tennis gymnastics skateboard scooter yoga stretch wrestle hockey
+        volleyball bowling karate surfing skiing snowboarding
+      ],
+      "Technology" => %w[
+        tablet phone video computer movie app screen watch show headphones
+        camera remote charge keyboard mouse printer internet website email
+        message text photo selfie
+      ],
+      "Transportation" => %w[
+        bus plane boat walk ride drive ambulance firetruck helicopter
+        motorcycle subway taxi van wagon canoe ferry rocket sled tractor
+        trolley
       ],
     }.freeze
 

--- a/app/services/boards/interest_words.rb
+++ b/app/services/boards/interest_words.rb
@@ -8,12 +8,29 @@
 # other single chars lowercased, multi-char words kept as typed.
 module Boards
   module InterestWords
-    MAX_INTERESTS = 12
+    MAX_INTERESTS = 20
 
     module_function
 
+    # Accepts either plain strings or { "word" => "pizza", "category" => "Food" }
+    # hashes (from the categorized interest picker). Returns a flat list of
+    # normalized word strings — the category info is extracted separately by
+    # `extract_categories`.
     def normalize_list(list, max: MAX_INTERESTS)
-      Array(list).map { |s| normalize_word(s) }.reject(&:blank?).uniq.first(max)
+      Array(list).map { |entry| normalize_word(word_from(entry)) }.reject(&:blank?).uniq.first(max)
+    end
+
+    # Builds a { normalized_word => explicit_category } map from the raw input.
+    # Only entries that carried a `category` key contribute; plain strings and
+    # entries without a category are absent (fall back to dictionary lookup).
+    def extract_categories(list)
+      Array(list).each_with_object({}) do |entry, map|
+        next unless entry.is_a?(Hash) || entry.is_a?(ActionController::Parameters)
+
+        word = normalize_word(word_from(entry))
+        cat  = entry["category"].to_s.strip.presence || entry[:category].to_s.strip.presence
+        map[word] = cat if word.present? && cat
+      end
     end
 
     def normalize_word(string)
@@ -22,6 +39,16 @@ module Boards
       return "I" if word.casecmp("i").zero?
 
       word.length > 1 ? word : word.downcase
+    end
+
+    def word_from(entry)
+      case entry
+      when String then entry
+      when Hash, ActionController::Parameters
+        entry["word"].presence || entry[:word].presence || entry.to_s
+      else
+        entry.to_s
+      end
     end
   end
 end

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -23,7 +23,7 @@
 module Boards
   class SeededSetCloner
     MAX_DEPTH      = 2 # mirror Boards::BoardTreeBuilder — root + 2 levels
-    MAX_INTERESTS  = 12 # mirror Boards::BlueprintAssembler
+    MAX_INTERESTS  = Boards::InterestWords::MAX_INTERESTS
     FAVORITES_NAME = "My Favorites"
 
     class CloneError < StandardError; end
@@ -39,13 +39,14 @@ module Boards
     # When a root is adopted, the source root's CONTENT (tiles, layout columns)
     # is cloned INTO it instead of dup-ing a fresh board, and the caller owns
     # the ChildBoard attach/favorite.
-    def initialize(source_root, communicator:, interests: [], favorite_root: true, root: nil)
-      @source_root   = source_root
-      @communicator  = communicator
-      @owner         = communicator.owner || communicator.user
-      @interests     = normalize_interests(interests)
-      @favorite_root = favorite_root
-      @root          = root
+    def initialize(source_root, communicator:, interests: [], favorite_root: true, root: nil, explicit_categories: {})
+      @source_root          = source_root
+      @communicator         = communicator
+      @owner                = communicator.owner || communicator.user
+      @interests            = normalize_interests(interests)
+      @favorite_root        = favorite_root
+      @root                 = root
+      @explicit_categories  = explicit_categories || {}
     end
 
     # Clones the whole linked set + routes interests in a single transaction so a
@@ -225,7 +226,7 @@ module Boards
       unrouted = []
 
       @interests.each do |word|
-        category = Boards::InterestCategories.category_for(word)
+        category = @explicit_categories[word] || Boards::InterestCategories.category_for(word)
         fringe   = category && fringe_by_name[category.to_s.downcase]
         fringe ? add_interest_to_board(fringe, word) : unrouted << word
       end

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -27,7 +27,7 @@ class BuildBoardSetJob
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :default
 
-  def perform(root_board_id, communicator_id, template, interests = [])
+  def perform(root_board_id, communicator_id, template, interests = [], categories = {})
     root = Board.find_by(id: root_board_id)
     unless root
       Rails.logger.error "BuildBoardSetJob: Board with ID #{root_board_id} not found."
@@ -53,10 +53,13 @@ class BuildBoardSetJob
     begin
       robust_root = Boards::RobustSets.find_root(template)
 
+      explicit_categories = categories.is_a?(Hash) ? categories : {}
+
       if robust_root
         Boards::SeededSetCloner.new(
           robust_root, communicator: communicator,
           interests: interests, root: root,
+          explicit_categories: explicit_categories,
         ).call
       else
         owner = communicator.owner || communicator.user
@@ -64,6 +67,7 @@ class BuildBoardSetJob
           template:  template,
           interests: interests,
           user:      owner,
+          explicit_categories: explicit_categories,
         )
         blueprint = assembler.call
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,8 +397,9 @@ Rails.application.routes.draw do
       end
 
       # Board Builder wizard (hybrid: pick a starter template + add interests).
-      get  "board_builder/templates", to: "board_builder#templates"
-      post "board_builder",           to: "board_builder#create"
+      get  "board_builder/templates",           to: "board_builder#templates"
+      get  "board_builder/interest_categories", to: "board_builder#interest_categories"
+      post "board_builder",                     to: "board_builder#create"
 
       resource :auth, only: [:create, :destroy]
       delete "/child_accounts/logout", to: "child_auths#destroy"

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -123,6 +123,27 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
     end
   end
 
+  describe "GET /api/v1/board_builder/interest_categories" do
+    it "returns all categories with sorted words and max_interests" do
+      get "/api/v1/board_builder/interest_categories", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body["max_interests"]).to eq(20)
+      categories = body["categories"]
+      expect(categories.size).to be >= 15
+
+      names = categories.map { |c| c["name"] }
+      expect(names).to eq(names.sort)
+      expect(names).to include("Food", "Animals", "Music", "Play")
+
+      food = categories.find { |c| c["name"] == "Food" }
+      expect(food["words"]).to eq(food["words"].sort)
+      expect(food["words"]).to include("pizza", "apple")
+    end
+  end
+
   describe "POST /api/v1/board_builder" do
     before do
       seed_template_images!
@@ -169,7 +190,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "grandma"])
 
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"]])
+          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"], {}])
       end
 
       it "builds a linked set, routes interests into category vs favorites folders, and completes (job drained)" do
@@ -202,6 +223,42 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                          .where("COALESCE((settings->>'builder_child')::boolean, false)")
         expect(sub_boards).to be_present
         expect(sub_boards.pluck(:status)).not_to include("building_board", "complete", "failed")
+      end
+
+      it "accepts interests as { word, category } hashes and routes by explicit category" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home",
+                       interests: [
+                         { word: "pizza", category: "Food" },
+                         { word: "grandma", category: "Play" },
+                       ] }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        body = JSON.parse(response.body)
+        expect(communicator.reload.details["interests"]).to eq(["pizza", "grandma"])
+
+        BuildBoardSetJob.drain
+
+        root = Board.find(body["id"])
+        # "grandma" has no dictionary category but was explicitly routed to Play
+        play_tile = root.board_images.find { |bi| bi.label == "Play" }
+        play_board = Board.find(play_tile.predictive_board_id)
+        expect(play_board.board_images.map(&:label)).to include("grandma")
+
+        # No "My Favorites" needed — everything was explicitly routed
+        expect(root.board_images.map(&:label)).not_to include("My Favorites")
+      end
+
+      it "accepts more than 12 interests (new max is 20)" do
+        interests = (1..15).map { |n| "word#{n}" }
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home",
+                       interests: interests }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        expect(communicator.reload.details["interests"].size).to eq(15)
       end
 
       it "builds the core template with no favorites folder when interests are empty" do
@@ -467,7 +524,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(communicator.reload.details["interests"]).to eq(["pizza"])
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "core-60", ["pizza"]])
+          .to eq([root.id, communicator.id, "core-60", ["pizza"], {}])
 
         BuildBoardSetJob.drain
         root.reload

--- a/spec/services/boards/interest_categories_spec.rb
+++ b/spec/services/boards/interest_categories_spec.rb
@@ -9,12 +9,29 @@ RSpec.describe Boards::InterestCategories, type: :service do
       expect(described_class.category_for("dinosaurs")).to eq("Play")
     end
 
+    it "maps words in the new expanded categories" do
+      expect(described_class.category_for("dog")).to eq("Animals")
+      expect(described_class.category_for("crayon")).to eq("Art & Craft")
+      expect(described_class.category_for("shirt")).to eq("Clothing")
+      expect(described_class.category_for("grandma")).to eq("Family & People")
+      expect(described_class.category_for("medicine")).to eq("Health & Body")
+      expect(described_class.category_for("couch")).to eq("Home")
+      expect(described_class.category_for("guitar")).to eq("Music")
+      expect(described_class.category_for("flower")).to eq("Nature & Outdoors")
+      expect(described_class.category_for("library")).to eq("Places")
+      expect(described_class.category_for("pencil")).to eq("School")
+      expect(described_class.category_for("please")).to eq("Social")
+      expect(described_class.category_for("soccer")).to eq("Sports")
+      expect(described_class.category_for("tablet")).to eq("Technology")
+      expect(described_class.category_for("bus")).to eq("Transportation")
+    end
+
     it "is case- and whitespace-insensitive" do
       expect(described_class.category_for("  ApPlE ")).to eq("Food")
     end
 
     it "returns nil for a word with no category" do
-      expect(described_class.category_for("grandma")).to be_nil
+      expect(described_class.category_for("spaceship")).to be_nil
       expect(described_class.category_for("")).to be_nil
     end
   end
@@ -25,8 +42,17 @@ RSpec.describe Boards::InterestCategories, type: :service do
       expect(all_words).to eq(all_words.uniq)
     end
 
+    it "has at least 15 categories" do
+      expect(described_class.categories.size).to be >= 15
+    end
+
     it "exposes the category labels" do
-      expect(described_class.categories).to include("Food", "Feelings", "Bathroom", "Play")
+      expect(described_class.categories).to include(
+        "Food", "Feelings", "Bathroom", "Play",
+        "Animals", "Art & Craft", "Clothing", "Family & People",
+        "Health & Body", "Home", "Music", "Nature & Outdoors",
+        "Places", "School", "Social", "Sports", "Technology", "Transportation"
+      )
     end
   end
 end

--- a/spec/services/boards/interest_words_spec.rb
+++ b/spec/services/boards/interest_words_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe Boards::InterestWords, type: :service do
+  describe "MAX_INTERESTS" do
+    it "is 20" do
+      expect(described_class::MAX_INTERESTS).to eq(20)
+    end
+  end
+
+  describe ".normalize_list" do
+    it "normalizes plain string interests" do
+      result = described_class.normalize_list(["pizza", " Trains ", ""])
+      expect(result).to eq(["pizza", "Trains"])
+    end
+
+    it "deduplicates after normalization" do
+      result = described_class.normalize_list(["pizza", "pizza", " pizza "])
+      expect(result).to eq(["pizza"])
+    end
+
+    it "caps at MAX_INTERESTS" do
+      words = (1..25).map { |n| "word#{n}" }
+      result = described_class.normalize_list(words)
+      expect(result.size).to eq(20)
+    end
+
+    it "handles { word, category } hash entries" do
+      result = described_class.normalize_list([
+        { "word" => "pizza", "category" => "Food" },
+        { "word" => "dog", "category" => "Animals" },
+      ])
+      expect(result).to eq(["pizza", "dog"])
+    end
+
+    it "handles a mix of strings and hashes" do
+      result = described_class.normalize_list([
+        "trains",
+        { "word" => "pizza", "category" => "Food" },
+        "grandma",
+      ])
+      expect(result).to eq(["trains", "pizza", "grandma"])
+    end
+
+    it "handles ActionController::Parameters like hashes" do
+      entry = ActionController::Parameters.new("word" => "pizza", "category" => "Food")
+      result = described_class.normalize_list([entry])
+      expect(result).to eq(["pizza"])
+    end
+  end
+
+  describe ".extract_categories" do
+    it "returns an empty hash for plain strings" do
+      result = described_class.extract_categories(["pizza", "trains"])
+      expect(result).to eq({})
+    end
+
+    it "extracts category from hash entries" do
+      result = described_class.extract_categories([
+        { "word" => "pizza", "category" => "Food" },
+        { "word" => "dog", "category" => "Animals" },
+      ])
+      expect(result).to eq({ "pizza" => "Food", "dog" => "Animals" })
+    end
+
+    it "ignores entries without a category" do
+      result = described_class.extract_categories([
+        { "word" => "pizza", "category" => "Food" },
+        { "word" => "grandma" },
+      ])
+      expect(result).to eq({ "pizza" => "Food" })
+    end
+
+    it "handles a mix of strings and hashes" do
+      result = described_class.extract_categories([
+        "trains",
+        { "word" => "pizza", "category" => "Food" },
+      ])
+      expect(result).to eq({ "pizza" => "Food" })
+    end
+
+    it "handles ActionController::Parameters" do
+      entry = ActionController::Parameters.new("word" => "pizza", "category" => "Food")
+      result = described_class.extract_categories([entry])
+      expect(result).to eq({ "pizza" => "Food" })
+    end
+  end
+end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -61,18 +61,18 @@ RSpec.describe VocabSets do
 
     it "ships fringe pages for the interest categories it can route into" do
       # The set names some fringe pages after routable interest categories
-      # (Food/Feelings/Play) so the wizard drops matching interests there. Other
-      # pages (People/Places/Body/Drinks/More) have no matching category yet —
-      # interests for those fall through to the auto "My Favorites" page by
-      # design (nothing is dropped). This guards the routable pages against drift:
-      # if Food/Feelings/Play were renamed, routing would silently break.
+      # so the wizard drops matching interests there. Other pages
+      # (People/Body/Drinks/More) have no matching category — interests for
+      # those fall through to the auto "My Favorites" page by design (nothing
+      # is dropped). This guards the routable pages against drift: if these
+      # were renamed, routing would silently break.
       VocabSets.seed_slug!("core-60")
 
       fringe_names = Board.where(user_id: admin.id).where.not(name: "Core 60").pluck(:name)
       routable = fringe_names.select { |name| Boards::InterestCategories.categories.include?(name) }
 
       # The authored set's routable category pages.
-      expect(routable).to contain_exactly("Food", "Feelings", "Play")
+      expect(routable).to contain_exactly("Food", "Feelings", "Places", "Play")
     end
 
     it "is idempotent — re-seeding doesn't duplicate boards or roots" do


### PR DESCRIPTION
## Summary

Phase 1 of the Board Builder AI-structured interest routing (work items 1–5 from `.claude-notes/board-builder-ai-structure-handoff.md`):

- **Expanded InterestCategories** from 4 to 18 categories (~504 words): Animals, Art & Craft, Clothing, Family & People, Health & Body, Home, Music, Nature & Outdoors, Places, School, Social, Sports, Technology, Transportation (plus original Food, Feelings, Bathroom, Play)
- **New endpoint** `GET /api/v1/board_builder/interest_categories` — returns the full category dictionary for the frontend's categorized picker
- **Bumped `MAX_INTERESTS`** from 12 to 20
- **`{ word, category }` hash format** — the create action now accepts both plain strings and `{ word, category }` hashes; explicit categories from the frontend picker override the dictionary lookup
- **Threaded `explicit_categories`** through `BlueprintAssembler`, `SeededSetCloner`, and `BuildBoardSetJob`

## Test plan

- New `spec/services/boards/interest_words_spec.rb` (12 examples) covering normalize_list, extract_categories, and both input formats
- Updated `spec/services/boards/interest_categories_spec.rb` — covers all 18 categories, lexicon integrity, no duplicate words
- Updated `spec/requests/api/v1/board_builder_spec.rb` — new endpoint test, `{ word, category }` routing test, 15-interest test (exceeds old cap)
- Adjacent specs (build_board_set_job, seeded_set_cloner, blueprint_assembler): 40 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)