### PR TITLE
fix(subscriptions): use subscription_details for Invoice.upcoming preview

### DIFF
--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -122,19 +122,21 @@ class API::SubscriptionsController < API::ApplicationController
     end
 
     item = subscription.items.data.first
-    invoice_params = {
-      customer: customer_id,
-      subscription: subscription.id,
-      subscription_items: [{ id: item.id, price: price_id }],
-      subscription_proration_behavior: "create_prorations",
+    details = {
+      items: [{ id: item.id, price: price_id }],
+      proration_behavior: "create_prorations",
     }
 
     promo = resolve_promotion_code(params[:promo_code])
     if promo.present?
-      invoice_params[:subscription_details] = {
-        discounts: [{ promotion_code: promo.id }],
-      }
+      details[:discounts] = [{ promotion_code: promo.id }]
     end
+
+    invoice_params = {
+      customer: customer_id,
+      subscription: subscription.id,
+      subscription_details: details,
+    }
 
     upcoming = Stripe::Invoice.upcoming(invoice_params)
     new_price = Stripe::Price.retrieve(price_id)

--- a/spec/requests/api/subscriptions_preview_plan_change_spec.rb
+++ b/spec/requests/api/subscriptions_preview_plan_change_spec.rb
@@ -62,12 +62,13 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
       expect(body["discount"]).to be_nil
     end
 
-    it "calls Invoice.upcoming with proration params" do
+    it "calls Invoice.upcoming with subscription_details params" do
       expect(Stripe::Invoice).to receive(:upcoming) do |params|
         expect(params[:customer]).to eq("cus_existing")
         expect(params[:subscription]).to eq("sub_active")
-        expect(params[:subscription_items]).to eq([{ id: "si_123", price: "price_pro" }])
-        expect(params[:subscription_proration_behavior]).to eq("create_prorations")
+        expect(params[:subscription_details][:items]).to eq([{ id: "si_123", price: "price_pro" }])
+        expect(params[:subscription_details][:proration_behavior]).to eq("create_prorations")
+        expect(params).not_to have_key(:subscription_items)
         upcoming_invoice
       end
 


### PR DESCRIPTION
## Summary

- **Fix Stripe `InvalidRequestError`** in `preview_plan_change` — the endpoint was passing both `subscription_items` (legacy) and `subscription_details` (modern) params to `Stripe::Invoice.upcoming` when a promo code was present, which Stripe rejects
- Moved all params (`items`, `proration_behavior`, `discounts`) into the `subscription_details` structure so only one param style is used

## Context

Surfaced in staging logs as:
```
preview_plan_change: Stripe::InvalidRequestError - You may only specify one of these parameters: subscription_details, subscription_items. (user 18)
```

The `change_plan` endpoint (which uses `Stripe::Subscription.update`) was unaffected — only the preview used the conflicting param mix.

## Test plan

- `bundle exec rspec spec/requests/api/subscriptions_preview_plan_change_spec.rb` — 11 examples, 0 failures
- Updated spec asserts `subscription_details` structure and absence of legacy `subscription_items` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)