### PR TITLE
fix: replace deprecated :unprocessable_entity with :unprocessable_content

### DIFF
--- a/app/controllers/api/account/boards_controller.rb
+++ b/app/controllers/api/account/boards_controller.rb
@@ -37,7 +37,7 @@ class API::Account::BoardsController < API::Account::ApplicationController
       elsif params[:filter].present?
         filter = params[:filter]
         unless Board::SAFE_FILTERS.include?(filter)
-          render json: { error: "Invalid filter" }, status: :unprocessable_entity
+          render json: { error: "Invalid filter" }, status: :unprocessable_content
           return
         end
 

--- a/app/controllers/api/account/profiles_controller.rb
+++ b/app/controllers/api/account/profiles_controller.rb
@@ -9,7 +9,7 @@ class API::Account::ProfilesController < API::Account::ApplicationController
     if @profile.update(profile_params)
       render json: @profile.api_view
     else
-      render json: @profile.errors, status: :unprocessable_entity
+      render json: @profile.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/admin/events_controller.rb
+++ b/app/controllers/api/admin/events_controller.rb
@@ -41,7 +41,7 @@ class API::Admin::EventsController < API::Admin::ApplicationController
   # POST /events or /events.json
   def create
     @event = Event.new(event_params)
-    render json: { success: @event.save ? @event.persisted? : @event.errors }, status: @event.save ? :created : :unprocessable_entity
+    render json: { success: @event.save ? @event.persisted? : @event.errors }, status: @event.save ? :created : :unprocessable_content
   end
 
   # PATCH/PUT /events/1 or /events/1.json
@@ -50,7 +50,7 @@ class API::Admin::EventsController < API::Admin::ApplicationController
       if @event.update(event_params)
         format.json { render :show, status: :ok, location: @event }
       else
-        format.json { render json: @event.errors, status: :unprocessable_entity }
+        format.json { render json: @event.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/admin/organizations_controller.rb
+++ b/app/controllers/api/admin/organizations_controller.rb
@@ -14,7 +14,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
     if @organization.save
       render json: @organization.api_view(current_admin), status: :created
     else
-      render json: @organization.errors, status: :unprocessable_entity
+      render json: @organization.errors, status: :unprocessable_content
     end
   end
 
@@ -23,7 +23,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
     if @organization.update(organization_params)
       render json: @organization.api_view(current_admin)
     else
-      render json: @organization.errors, status: :unprocessable_entity
+      render json: @organization.errors, status: :unprocessable_content
     end
   end
 
@@ -43,7 +43,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
       @user.organization_id = @organization.id
       @user.save
     else
-      render json: { error: "Failed to invite user" }, status: :unprocessable_entity
+      render json: { error: "Failed to invite user" }, status: :unprocessable_content
       return
     end
     render json: @user.api_view
@@ -51,7 +51,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
     # if @organization.users << @user
     #   render json: @organization.api_view(current_admin)
     # else
-    #   render json: { error: "Failed to assign user" }, status: :unprocessable_entity
+    #   render json: { error: "Failed to assign user" }, status: :unprocessable_content
     # end
   end
 
@@ -61,7 +61,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
     if @organization.users.delete(@user)
       render json: @organization.api_view(current_admin)
     else
-      render json: { error: "Failed to remove user" }, status: :unprocessable_entity
+      render json: { error: "Failed to remove user" }, status: :unprocessable_content
     end
   end
 
@@ -70,7 +70,7 @@ class API::Admin::OrganizationsController < API::Admin::ApplicationController
     if @organization.destroy
       render json: { message: "Organization deleted successfully" }, status: :ok
     else
-      render json: { error: "Failed to delete organization" }, status: :unprocessable_entity
+      render json: { error: "Failed to delete organization" }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -95,7 +95,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     if @user.save
       render json: @user.admin_api_view, status: :ok
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render json: @user.errors, status: :unprocessable_content
     end
   end
 
@@ -113,7 +113,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     if @user.send_welcome_email(plan_nickname)
       render json: { success: true }, status: :ok
     else
-      render json: { error: "Failed to send welcome email" }, status: :unprocessable_entity
+      render json: { error: "Failed to send welcome email" }, status: :unprocessable_content
     end
   end
 
@@ -131,7 +131,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     if @user.send_setup_email
       render json: { success: true }, status: :ok
     else
-      render json: { error: "Failed to send set up email" }, status: :unprocessable_entity
+      render json: { error: "Failed to send set up email" }, status: :unprocessable_content
     end
   end
 
@@ -145,7 +145,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     if @user.send_partner_welcome_email
       render json: { success: true }, status: :ok
     else
-      render json: { error: "Failed to send partner welcome email" }, status: :unprocessable_entity
+      render json: { error: "Failed to send partner welcome email" }, status: :unprocessable_content
     end
   end
 
@@ -163,7 +163,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     if @user.send_temp_login_email
       render json: { success: true }, status: :ok
     else
-      render json: { error: "Failed to send temporary login email" }, status: :unprocessable_entity
+      render json: { error: "Failed to send temporary login email" }, status: :unprocessable_content
     end
   end
 
@@ -204,7 +204,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
   #     if @user.save
   #       format.json { render json: @user, status: :ok }
   #     else
-  #       format.json { render json: @user.errors, status: :unprocessable_entity }
+  #       format.json { render json: @user.errors, status: :unprocessable_content }
   #     end
   #   end
   # end
@@ -216,13 +216,13 @@ class API::Admin::UsersController < API::Admin::ApplicationController
       return
     end
     if @user.admin?
-      render json: { error: "Cannot delete an admin user" }, status: :unprocessable_entity
+      render json: { error: "Cannot delete an admin user" }, status: :unprocessable_content
       return
     end
     begin
       @user.soft_delete_account!(reason: "admin_deleted", actor_id: current_admin.id) unless @user.soft_deleted?
     rescue StripeHelper::AccountDeletionError => e
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { error: e.message }, status: :unprocessable_content
       return
     end
     Rails.logger.info "User #{@user.id} deleted by #{current_admin.display_name}"
@@ -237,7 +237,7 @@ class API::Admin::UsersController < API::Admin::ApplicationController
       return
     end
     unless params[:user_ids].present?
-      render json: { error: "No user_ids provided" }, status: :unprocessable_entity
+      render json: { error: "No user_ids provided" }, status: :unprocessable_content
       return
     end
     users = User.where(id: params[:user_ids]).where.not(role: "admin")

--- a/app/controllers/api/beta_requests_controller.rb
+++ b/app/controllers/api/beta_requests_controller.rb
@@ -27,7 +27,7 @@ class API::BetaRequestsController < API::ApplicationController
     @beta_request = BetaRequest.new(beta_request_params)
     client_ip = params["ip"] || request.remote_ip
     @beta_request.details = { client_ip: client_ip }
-    render json: { success: @beta_request.save ? @beta_request.persisted? : @beta_request.errors }, status: @beta_request.save ? :created : :unprocessable_entity
+    render json: { success: @beta_request.save ? @beta_request.persisted? : @beta_request.errors }, status: @beta_request.save ? :created : :unprocessable_content
   end
 
   # PATCH/PUT /beta_requests/1 or /beta_requests/1.json
@@ -36,7 +36,7 @@ class API::BetaRequestsController < API::ApplicationController
       if @beta_request.update(beta_request_params)
         format.json { render :show, status: :ok, location: @beta_request }
       else
-        format.json { render json: @beta_request.errors, status: :unprocessable_entity }
+        format.json { render json: @beta_request.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/billing_controller.rb
+++ b/app/controllers/api/billing_controller.rb
@@ -49,7 +49,7 @@ class API::BillingController < API::ApplicationController
       render json: { success: true, plan_key: plan_key }
     rescue StandardError => e
       Rails.logger.error "Failed to update subscription for User ID: #{current_user.id}, Plan Key: #{plan_key} - Error: #{e.message}"
-      render json: { error: "Failed to update subscription: #{e.message}" }, status: :unprocessable_entity
+      render json: { error: "Failed to update subscription: #{e.message}" }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/board_groups_controller.rb
+++ b/app/controllers/api/board_groups_controller.rb
@@ -48,7 +48,7 @@ class API::BoardGroupsController < API::ApplicationController
         error: "You've reached your plan's board set limit. Upgrade to create more.",
         limit: current_user.board_group_limit,
         count: current_user.countable_board_group_count,
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
       return
     end
 
@@ -77,7 +77,7 @@ class API::BoardGroupsController < API::ApplicationController
       # board_group.calculate_grid_layout_for_screen_size(screen_size)
       render json: board_group.api_view_with_boards(current_user), status: :created
     else
-      render json: { errors: board_group.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: board_group.errors.full_messages }, status: :unprocessable_content
     end
     if boards.blank?
       Rails.logger.debug "No boards provided, saving empty board group"
@@ -193,7 +193,7 @@ class API::BoardGroupsController < API::ApplicationController
       Rails.logger.debug "Board Group updated successfully: #{board_group.id}"
       render json: board_group.api_view_with_boards(current_user)
     else
-      render json: { errors: board_group.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: board_group.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -269,7 +269,7 @@ class API::BoardGroupsController < API::ApplicationController
       layout = params[:layout].to_unsafe_h
     else
       Rails.logger.error "Invalid layout format: #{params[:layout].class}"
-      render json: { error: "Invalid layout format" }, status: :unprocessable_entity and return
+      render json: { error: "Invalid layout format" }, status: :unprocessable_content and return
     end
 
     Rails.logger.debug "Received layout: #{layout.inspect}"

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -27,7 +27,7 @@ class API::BoardImagesController < API::ApplicationController
       render json: @board_image.api_view(current_user)
     else
       Rails.logger.error "Failed to set current audio for BoardImage ID: #{params[:id]} - #{@board_image.errors.full_messages}"
-      render json: @board_image.errors, status: :unprocessable_entity
+      render json: @board_image.errors, status: :unprocessable_content
     end
   end
 
@@ -43,7 +43,7 @@ class API::BoardImagesController < API::ApplicationController
       @board.broadcast_board_update!
       render json: @board_image.api_view(current_user)
     else
-      render json: @board_image.errors, status: :unprocessable_entity
+      render json: @board_image.errors, status: :unprocessable_content
     end
   end
 
@@ -51,12 +51,12 @@ class API::BoardImagesController < API::ApplicationController
     board_image_ids = params[:board_image_ids]
     @board = Board.includes(:board_images).find(params[:board_id])
     if @board.nil?
-      render json: { error: "Board not found" }, status: :unprocessable_entity
+      render json: { error: "Board not found" }, status: :unprocessable_content
       return
     end
     payload = params[:payload]
     if payload.nil?
-      render json: { error: "No payload provided" }, status: :unprocessable_entity
+      render json: { error: "No payload provided" }, status: :unprocessable_content
       return
     end
     layout_updates = payload[:layout_updates] if payload[:layout_updates]
@@ -64,7 +64,7 @@ class API::BoardImagesController < API::ApplicationController
       board_image_ids = layout_updates.map { |item| item[:board_image_id].to_i }.compact
     end
     if board_image_ids.nil? || board_image_ids.empty?
-      render json: { error: "No board image IDs provided" }, status: :unprocessable_entity
+      render json: { error: "No board image IDs provided" }, status: :unprocessable_content
       return
     end
     board_images = @board.board_images.where(id: board_image_ids)
@@ -167,7 +167,7 @@ class API::BoardImagesController < API::ApplicationController
       @board.broadcast_board_update!
       render json: { board: @board.api_view_with_predictive_images(current_user, true) }
     else
-      render json: { error: "Failed to update some board images" }, status: :unprocessable_entity
+      render json: { error: "Failed to update some board images" }, status: :unprocessable_content
     end
   end
 
@@ -175,12 +175,12 @@ class API::BoardImagesController < API::ApplicationController
     board_image_ids = params[:board_image_ids]
     @board = Board.find(params[:board_id])
     if @board.nil?
-      render json: { error: "Board not found" }, status: :unprocessable_entity
+      render json: { error: "Board not found" }, status: :unprocessable_content
       return
     end
     board_images = BoardImage.where(id: board_image_ids, board_id: @board.id)
     if board_images.empty?
-      render json: { error: "No board images found" }, status: :unprocessable_entity
+      render json: { error: "No board images found" }, status: :unprocessable_content
       return
     end
     results = []
@@ -195,14 +195,14 @@ class API::BoardImagesController < API::ApplicationController
       @board.broadcast_board_update!
       render json: { board: @board.api_view_with_predictive_images(current_user, true) }
     else
-      render json: { error: "Failed to remove some board images" }, status: :unprocessable_entity
+      render json: { error: "Failed to remove some board images" }, status: :unprocessable_content
     end
   end
 
   def create_image_edit
     @board_image = BoardImage.find(params[:id])
     if @board_image.nil?
-      render json: { error: "Board image not found" }, status: :unprocessable_entity
+      render json: { error: "Board image not found" }, status: :unprocessable_content
       return
     end
     begin
@@ -212,7 +212,7 @@ class API::BoardImagesController < API::ApplicationController
       EditBoardImageJob.perform_async(@board_image.id, prompt, transparent_background)
     rescue => e
       Rails.logger.error "Error while creating image edit for BoardImage ID #{@board_image.id}: #{e.message}"
-      render json: { error: "Failed to create image edit" }, status: :unprocessable_entity
+      render json: { error: "Failed to create image edit" }, status: :unprocessable_content
       return
     end
 
@@ -220,14 +220,14 @@ class API::BoardImagesController < API::ApplicationController
     if @board_image.update(status: "editing")
       render json: @board_image.api_view(current_user) and return
     else
-      render json: { error: "Failed to create image edit" }, status: :unprocessable_entity
+      render json: { error: "Failed to create image edit" }, status: :unprocessable_content
     end
   end
 
   def create_image_variation
     @board_image = BoardImage.find(params[:id])
     if @board_image.nil?
-      render json: { error: "Board image not found" }, status: :unprocessable_entity
+      render json: { error: "Board image not found" }, status: :unprocessable_content
       return
     end
     return unless check_credits!(feature_key: "image_variation", feature_name: "AI Image Variations")
@@ -238,7 +238,7 @@ class API::BoardImagesController < API::ApplicationController
     if @image_variation
       render json: @board_image.api_view(current_user)
     else
-      render json: { error: "Failed to create image variation" }, status: :unprocessable_entity
+      render json: { error: "Failed to create image variation" }, status: :unprocessable_content
     end
   end
 
@@ -268,7 +268,7 @@ class API::BoardImagesController < API::ApplicationController
       @board_image.reload
       render json: @board_image.api_view(current_user)
     else
-      render json: @board_image.errors, status: :unprocessable_entity
+      render json: @board_image.errors, status: :unprocessable_content
     end
   end
 
@@ -285,7 +285,7 @@ class API::BoardImagesController < API::ApplicationController
     if @board_image.update(audio_url: default_audio_url)
       render json: @board_image.api_view(current_user)
     else
-      render json: @board_image.errors, status: :unprocessable_entity
+      render json: @board_image.errors, status: :unprocessable_content
     end
   end
 
@@ -296,25 +296,25 @@ class API::BoardImagesController < API::ApplicationController
 
     @board = Board.find(@board_id)
     if @board.nil?
-      render json: { error: "Board not found" }, status: :unprocessable_entity
+      render json: { error: "Board not found" }, status: :unprocessable_content
       return
     end
 
     @board_image = BoardImage.find_by(board_id: @board_id, image_id: @image_id)
     if @board_image.nil?
-      render json: { error: "Board image not found" }, status: :unprocessable_entity
+      render json: { error: "Board image not found" }, status: :unprocessable_content
       return
     end
     @new_image = Image.find(params[:new_image_id]&.to_i)
     @board_image.image = @new_image
     if @new_image.user_id != current_user.id
-      render json: { error: "You do not have permission to move this image" }, status: :unprocessable_entity
+      render json: { error: "You do not have permission to move this image" }, status: :unprocessable_content
     end
 
     if @board_image.save
       render json: @board_image.api_view(current_user)
     else
-      render json: @board_image.errors, status: :unprocessable_entity
+      render json: @board_image.errors, status: :unprocessable_content
     end
   end
 
@@ -375,7 +375,7 @@ class API::BoardImagesController < API::ApplicationController
     @board_image = BoardImage.includes(:audio_files_attachments).find_by(id: params[:id])
     if @board_image.nil?
       Rails.logger.error "BoardImage with ID #{params[:id]} not found."
-      render json: { error: "Board image not found" }, status: :unprocessable_entity
+      render json: { error: "Board image not found" }, status: :unprocessable_content
       return
     end
   end

--- a/app/controllers/api/board_screenshot_imports_controller.rb
+++ b/app/controllers/api/board_screenshot_imports_controller.rb
@@ -30,7 +30,7 @@ class API::BoardScreenshotImportsController < API::ApplicationController
     elsif image.present?
       import.image.attach(image)
     else
-      render json: { error: "No image provided" }, status: :unprocessable_entity
+      render json: { error: "No image provided" }, status: :unprocessable_content
       return
     end
     import.save!
@@ -62,7 +62,7 @@ class API::BoardScreenshotImportsController < API::ApplicationController
       if import.update(status: "needs_review")
         render json: { ok: true }
       else
-        render json: { error: "Failed to update import" }, status: :unprocessable_entity
+        render json: { error: "Failed to update import" }, status: :unprocessable_content
       end
     end
   end

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -37,7 +37,7 @@ class API::BoardsController < API::ApplicationController
       .uniq
 
     if filter_param.present? && !Board::SAFE_FILTERS.include?(filter_param)
-      render json: { error: "Invalid filter" }, status: :unprocessable_entity
+      render json: { error: "Invalid filter" }, status: :unprocessable_content
       return
     end
     filter = filter_param
@@ -375,7 +375,7 @@ class API::BoardsController < API::ApplicationController
         end
         format.json { render json: @board, status: :created }
       else
-        format.json { render json: @board.errors, status: :unprocessable_entity }
+        format.json { render json: @board.errors, status: :unprocessable_content }
       end
     end
   end
@@ -486,7 +486,7 @@ class API::BoardsController < API::ApplicationController
           broadcast_board_update!
           format.json { render json: @board.api_view_with_images(current_user), status: :ok }
         else
-          format.json { render json: @board.errors, status: :unprocessable_entity }
+          format.json { render json: @board.errors, status: :unprocessable_content }
         end
       end
     end
@@ -497,12 +497,12 @@ class API::BoardsController < API::ApplicationController
     return unless check_credits!(feature_key: "image_generation", feature_name: "AI Image Regeneration")
     board_image_ids = params[:board_image_ids]
     if board_image_ids.blank? || !board_image_ids.is_a?(Array)
-      render json: { error: "board_image_ids parameter is required and must be an array" }, status: :unprocessable_entity
+      render json: { error: "board_image_ids parameter is required and must be an array" }, status: :unprocessable_content
       return
     end
     board_images = @board.board_images.where(id: board_image_ids)
     if board_images.empty?
-      render json: { error: "No valid board images found for the provided IDs" }, status: :unprocessable_entity
+      render json: { error: "No valid board images found for the provided IDs" }, status: :unprocessable_content
       return
     end
     image_ids = board_images.pluck(:image_id)
@@ -546,7 +546,7 @@ class API::BoardsController < API::ApplicationController
       render json: @board.api_view_with_images(current_user)
     else
       Rails.logger.error "Setting colors failed for some images: #{results.inspect}"
-      render json: { error: "Setting colors failed for some images" }, status: :unprocessable_entity
+      render json: { error: "Setting colors failed for some images" }, status: :unprocessable_content
     end
   end
 
@@ -554,7 +554,7 @@ class API::BoardsController < API::ApplicationController
     set_board
     image_data = board_params[:preset_display_image]
     if image_data.blank?
-      render json: { error: "No image data provided" }, status: :unprocessable_entity
+      render json: { error: "No image data provided" }, status: :unprocessable_content
       return
     end
 
@@ -603,7 +603,7 @@ class API::BoardsController < API::ApplicationController
           ).import!
         rescue => e
           Rails.logger.error "OBZ import failed: #{e.message}"
-          render json: { error: "OBZ import failed: #{e.message}" }, status: :unprocessable_entity
+          render json: { error: "OBZ import failed: #{e.message}" }, status: :unprocessable_content
           return
         end
 
@@ -615,7 +615,7 @@ class API::BoardsController < API::ApplicationController
           include_images: import_options[:include_images],
         }
       else
-        render json: { error: "Unsupported file format" }, status: :unprocessable_entity
+        render json: { error: "Unsupported file format" }, status: :unprocessable_content
       end
     elsif params[:data].present?
       boardData = params[:data]&.to_json
@@ -627,7 +627,7 @@ class API::BoardsController < API::ApplicationController
 
       json_data = JSON.parse(boardData) rescue nil
       unless json_data
-        render json: { error: "Invalid JSON data" }, status: :unprocessable_entity
+        render json: { error: "Invalid JSON data" }, status: :unprocessable_content
         return
       end
       board_name = json_data["name"] || "Imported Board"
@@ -640,7 +640,7 @@ class API::BoardsController < API::ApplicationController
         include_images: import_options[:include_images],
       }
     else
-      render json: { error: "No file or data provided" }, status: :unprocessable_entity
+      render json: { error: "No file or data provided" }, status: :unprocessable_content
     end
   end
 
@@ -685,15 +685,15 @@ class API::BoardsController < API::ApplicationController
 
   def words
     if params[:name].blank?
-      render json: { error: "Name parameter is required" }, status: :unprocessable_entity
+      render json: { error: "Name parameter is required" }, status: :unprocessable_content
       return
     end
     if params[:num_of_words].blank? || params[:num_of_words].to_i <= 0
-      render json: { error: "num_of_words parameter must be a positive integer" }, status: :unprocessable_entity
+      render json: { error: "num_of_words parameter must be a positive integer" }, status: :unprocessable_content
       return
     end
     if params[:num_of_words].to_i > 50
-      render json: { error: "num_of_words parameter cannot exceed 50" }, status: :unprocessable_entity
+      render json: { error: "num_of_words parameter cannot exceed 50" }, status: :unprocessable_content
     end
     if params[:board_id].present?
       @board = Board.find_by(id: params[:board_id])
@@ -733,12 +733,12 @@ class API::BoardsController < API::ApplicationController
     end
     if additional_words.blank?
       Rails.logger.error "No additional words found for prompt: #{prompt} - creation_type: #{creation_type}"
-      render json: { error: "No additional words found" }, status: :unprocessable_entity
+      render json: { error: "No additional words found" }, status: :unprocessable_content
       return
     end
     unless additional_words.is_a?(Array)
       Rails.logger.error "Invalid response from word suggestion service: #{additional_words.inspect}"
-      render json: { error: "Invalid response from word suggestion service" }, status: :unprocessable_entity
+      render json: { error: "Invalid response from word suggestion service" }, status: :unprocessable_content
       return
     end
     normalize_words = additional_words.map do |word|
@@ -810,7 +810,7 @@ class API::BoardsController < API::ApplicationController
 
       render json: @board_with_images
     else
-      render json: img_saved.errors, status: :unprocessable_entity
+      render json: img_saved.errors, status: :unprocessable_content
     end
   end
 
@@ -818,11 +818,11 @@ class API::BoardsController < API::ApplicationController
     @image = Image.find(params[:image_id])
     screen_size = params[:screen_size] || "lg"
     if @board.images.include?(@image)
-      render json: { error: "Image already associated with board" }, status: :unprocessable_entity
+      render json: { error: "Image already associated with board" }, status: :unprocessable_content
       return
     end
     if @board.predefined && !current_user.admin?
-      render json: { error: "Cannot add images to predefined boards" }, status: :unprocessable_entity
+      render json: { error: "Cannot add images to predefined boards" }, status: :unprocessable_content
       return
     end
 
@@ -832,7 +832,7 @@ class API::BoardsController < API::ApplicationController
       broadcast_board_update!
       render json: @board.api_view_with_images(current_user), notice: notice
     else
-      render json: { error: "Error adding image to board" }, status: :unprocessable_entity
+      render json: { error: "Error adding image to board" }, status: :unprocessable_content
     end
   end
 
@@ -840,12 +840,12 @@ class API::BoardsController < API::ApplicationController
     images = Image.where(id: params[:image_ids])
     screen_size = params[:screen_size] || "lg"
     if @board.images.include?(images)
-      render json: { error: "Image already associated with board" }, status: :unprocessable_entity
+      render json: { error: "Image already associated with board" }, status: :unprocessable_content
       return
     end
 
     if @board.predefined && !current_user.admin?
-      render json: { error: "Cannot add images to predefined boards" }, status: :unprocessable_entity
+      render json: { error: "Cannot add images to predefined boards" }, status: :unprocessable_content
       return
     end
 
@@ -868,14 +868,14 @@ class API::BoardsController < API::ApplicationController
     @board = Board.find(params[:id])
 
     if params[:board_group_ids].blank?
-      render json: { error: "No board group IDs provided" }, status: :unprocessable_entity
+      render json: { error: "No board group IDs provided" }, status: :unprocessable_content
       return
     elsif params[:board_group_ids].is_a?(String)
       board_group_ids = params[:board_group_ids].split(",").map(&:strip).map(&:to_i)
     elsif params[:board_group_ids].is_a?(Array)
       board_group_ids = params[:board_group_ids].map(&:to_i)
     else
-      render json: { error: "Invalid board group IDs format" }, status: :unprocessable_entity
+      render json: { error: "Invalid board group IDs format" }, status: :unprocessable_content
       return
     end
     board_group_ids.each do |board_group_id|
@@ -926,16 +926,16 @@ class API::BoardsController < API::ApplicationController
         @board.reload
         render json: @board.api_view_with_predictive_images(current_user, true), status: :ok
       else
-        render json: { error: { message: record_errors } }, status: :unprocessable_entity
+        render json: { error: { message: record_errors } }, status: :unprocessable_content
       end
     else
-      render json: { error: { message: "No board_ids provided" } }, status: :unprocessable_entity
+      render json: { error: { message: "No board_ids provided" } }, status: :unprocessable_content
     end
   end
 
   def remove_image
     if @board.predefined && !current_user.admin?
-      render json: { error: "Cannot remove images from predefined boards" }, status: :unprocessable_entity
+      render json: { error: "Cannot remove images from predefined boards" }, status: :unprocessable_content
       return
     end
     @board_image = BoardImage.find_by(id: params[:board_image_id])
@@ -1099,7 +1099,7 @@ class API::BoardsController < API::ApplicationController
     # Fresh instance so the count isn't stale from earlier in the request.
     refreshed_user = User.find(current_user.id)
     if refreshed_user.at_board_limit?
-      render json: { error: "Maximum number of boards reached (#{refreshed_user.countable_board_count}/#{refreshed_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
+      render json: { error: "Maximum number of boards reached (#{refreshed_user.countable_board_count}/#{refreshed_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_content
       notify_mailchimp_hit_limit(refreshed_user)
     end
   end

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -46,7 +46,7 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     unless @child_account.sandbox?
-      render json: account_error_payload("Only sandbox communicators can be promoted to loaner"), status: :unprocessable_entity
+      render json: account_error_payload("Only sandbox communicators can be promoted to loaner"), status: :unprocessable_content
       return
     end
 
@@ -64,7 +64,7 @@ class API::ChildAccountsController < API::ApplicationController
       @child_account.promote_to_loaner!(passcode: params[:passcode])
       render json: @child_account.api_view(current_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
-      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_entity
+      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_content
     end
   end
 
@@ -85,7 +85,7 @@ class API::ChildAccountsController < API::ApplicationController
     unless @child_account.owner_id == current_user.id || current_user.admin?
       if @child_account.active?
         render json: account_error_payload("This communicator is owned by someone else and can't be lent."),
-               status: :unprocessable_entity
+               status: :unprocessable_content
       else
         render json: account_error_payload("Unauthorized"), status: :unauthorized
       end
@@ -119,7 +119,7 @@ class API::ChildAccountsController < API::ApplicationController
       render json: @child_account.api_view(current_user), status: :ok
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.warn "[lend] validation failed for child_account=#{@child_account.id}: #{e.record.errors.full_messages.join(", ")}"
-      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_entity
+      render json: account_error_payload(e.record.errors.full_messages.join(", ")), status: :unprocessable_content
     end
   end
 
@@ -133,7 +133,7 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     unless @child_account.loaner?
-      render json: { error: "Only loaners can issue a claim link" }, status: :unprocessable_entity
+      render json: { error: "Only loaners can issue a claim link" }, status: :unprocessable_content
       return
     end
 
@@ -155,13 +155,13 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     unless @child_account.loaner?
-      render json: account_error_payload("Only loaners can issue a claim link"), status: :unprocessable_entity
+      render json: account_error_payload("Only loaners can issue a claim link"), status: :unprocessable_content
       return
     end
 
     email = params[:email].to_s.strip
     if email.blank? || !email.include?("@")
-      render json: account_error_payload("A valid email is required"), status: :unprocessable_entity
+      render json: account_error_payload("A valid email is required"), status: :unprocessable_content
       return
     end
 
@@ -234,9 +234,9 @@ class API::ChildAccountsController < API::ApplicationController
         error: "slot_full",
         message: e.message,
         upgrade_url: "/account/billing/upgrade",
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     rescue ActiveRecord::RecordInvalid => e
-      render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_content
     end
   end
 
@@ -249,7 +249,7 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     unless @child_account.loaner?
-      render json: account_error_payload("Only loaners can be reclaimed"), status: :unprocessable_entity
+      render json: account_error_payload("Only loaners can be reclaimed"), status: :unprocessable_content
       return
     end
 
@@ -270,7 +270,7 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     if @child_account.loaner?
-      render json: account_error_payload("End the loan first via end_loan."), status: :unprocessable_entity
+      render json: account_error_payload("End the loan first via end_loan."), status: :unprocessable_content
       return
     end
 
@@ -292,7 +292,7 @@ class API::ChildAccountsController < API::ApplicationController
     render json: @child_account.api_view(current_user), status: :ok
   rescue ChildAccount::SlotFull => e
     render json: account_error_payload(e.message.presence || "At your communicator slot limit. Free a slot before restoring."),
-           status: :unprocessable_entity
+           status: :unprocessable_content
   end
 
   # POST /child_accounts
@@ -334,7 +334,7 @@ class API::ChildAccountsController < API::ApplicationController
     password_confirmation = params[:password_confirmation]
 
     if password.present? && password_confirmation.present? && password != password_confirmation
-      render json: { error: "Passwords do not match" }, status: :unprocessable_entity
+      render json: { error: "Passwords do not match" }, status: :unprocessable_content
       return
     end
 
@@ -369,7 +369,7 @@ class API::ChildAccountsController < API::ApplicationController
           @child_account.create_profile!
         rescue => e
           Rails.logger.error "Failed to create profile for ChildAccount #{@child_account.id}: #{e.message}"
-          render json: { error: "Error creating profile for child account: #{e.message}" }, status: :unprocessable_entity
+          render json: { error: "Error creating profile for child account: #{e.message}" }, status: :unprocessable_content
           return
         end
       end
@@ -385,7 +385,7 @@ class API::ChildAccountsController < API::ApplicationController
     else
       Rails.logger.info "Invalid Child Account: errors: #{@child_account.errors.inspect}"
       message = @child_account.errors.full_messages.join(", ")
-      render json: { error: message, errors: message }, status: :unprocessable_entity
+      render json: { error: message, errors: message }, status: :unprocessable_content
     end
   end
 
@@ -426,7 +426,7 @@ class API::ChildAccountsController < API::ApplicationController
 
     if params[:password] && params[:password_confirmation]
       if params[:password] != params[:password_confirmation]
-        render json: { error: "Passwords do not match" }, status: :unprocessable_entity
+        render json: { error: "Passwords do not match" }, status: :unprocessable_content
         return
       end
       passcode = params[:password]
@@ -459,14 +459,14 @@ class API::ChildAccountsController < API::ApplicationController
       render json: @child_account.api_view(current_user), status: :ok
     else
       message = @child_account.errors.full_messages.join(", ")
-      render json: account_error_payload(message), status: :unprocessable_entity
+      render json: account_error_payload(message), status: :unprocessable_content
     end
   end
 
   def assign_boards
     board_ids = params[:board_ids]
     if board_ids.blank?
-      render json: { error: "No board_ids provided" }, status: :unprocessable_entity
+      render json: { error: "No board_ids provided" }, status: :unprocessable_content
       return
     end
 
@@ -479,7 +479,7 @@ class API::ChildAccountsController < API::ApplicationController
     if @child_account.sandbox?
       demo_limit = (@child_account.settings["demo_board_limit"] || ChildAccount::DEMO_ACCOUNT_BOARD_LIMIT).to_i
       if total_boards > demo_limit
-        render json: { error: "Demo board limit exceeded. You can have up to #{demo_limit} boards." }, status: :unprocessable_entity
+        render json: { error: "Demo board limit exceeded. You can have up to #{demo_limit} boards." }, status: :unprocessable_content
         return
       end
     end

--- a/app/controllers/api/child_boards_controller.rb
+++ b/app/controllers/api/child_boards_controller.rb
@@ -32,7 +32,7 @@ class API::ChildBoardsController < API::ApplicationController
   def toggle_favorite
     result = @child_board.toggle_favorite
     unless result
-      render json: { error: "You can only favorite 80 boards" }, status: :unprocessable_entity
+      render json: { error: "You can only favorite 80 boards" }, status: :unprocessable_content
       return
     end
     @child_account = ChildAccount.includes(child_boards: :board).find(@child_board.child_account_id)
@@ -43,7 +43,7 @@ class API::ChildBoardsController < API::ApplicationController
     if @child_board.update(board_params)
       render json: @child_board.api_view
     else
-      render json: @child_board.errors, status: :unprocessable_entity
+      render json: @child_board.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/coaching_prompts_controller.rb
+++ b/app/controllers/api/coaching_prompts_controller.rb
@@ -16,7 +16,7 @@ class API::CoachingPromptsController < API::ApplicationController
     end
 
     if text.length > 500
-      render json: { error: "text too long" }, status: :unprocessable_entity
+      render json: { error: "text too long" }, status: :unprocessable_content
       return
     end
 
@@ -68,7 +68,7 @@ class API::CoachingPromptsController < API::ApplicationController
     if set.save
       render json: set.api_view_for(current_user), status: :created
     else
-      render json: { errors: set.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: set.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -82,7 +82,7 @@ class API::CoachingPromptsController < API::ApplicationController
     if @set.update(update_params)
       render json: @set.api_view_for(current_user)
     else
-      render json: { errors: @set.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: @set.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -76,8 +76,8 @@ class API::DocsController < API::ApplicationController
         format.html { redirect_to @doc.documentable, notice: "Doc was successfully created." }
         format.json { render :show, status: :created, location: @doc }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @doc.errors, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @doc.errors, status: :unprocessable_content }
       end
     end
   end
@@ -89,8 +89,8 @@ class API::DocsController < API::ApplicationController
         format.html { redirect_to doc_url(@doc), notice: "Doc was successfully updated." }
         format.json { render :show, status: :ok, location: @doc }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @doc.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @doc.errors, status: :unprocessable_content }
       end
     end
   end
@@ -157,7 +157,7 @@ class API::DocsController < API::ApplicationController
       # @image_with_display_doc = @image.with_display_doc(current_user)
     rescue => e
       puts "Error: #{e.message}"
-      render json: { error: e.message }, status: :unprocessable_entity
+      render json: { error: e.message }, status: :unprocessable_content
       return
     end
     # @image_with_display_doc = @image.with_display_doc(@current_user, @board, @board_image)

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -16,7 +16,7 @@ class API::EventsController < API::ApplicationController
     if new_entry.persisted?
       render json: { success: true, entry: new_entry.api_view }, status: :created
     else
-      render json: { success: false, errors: new_entry.errors }, status: :unprocessable_entity
+      render json: { success: false, errors: new_entry.errors }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/feedback_controller.rb
+++ b/app/controllers/api/feedback_controller.rb
@@ -9,7 +9,7 @@ class API::FeedbackController < API::ApplicationController
     if @item.save
       render json: { ok: true }, status: :created
     else
-      render json: { ok: false, errors: @item.errors.full_messages }, status: :unprocessable_entity
+      render json: { ok: false, errors: @item.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/generated_boards_controller.rb
+++ b/app/controllers/api/generated_boards_controller.rb
@@ -10,7 +10,7 @@ class API::GeneratedBoardsController < API::ApplicationController
     word_count = params[:wordCount].presence || params[:word_count].presence || 12
     board_name = params[:name].presence || generated_board_name(topic, age_range)
     if topic.blank?
-      render json: { error: "Topic is required" }, status: :unprocessable_entity
+      render json: { error: "Topic is required" }, status: :unprocessable_content
       return
     end
     now = Time.now
@@ -47,12 +47,12 @@ class API::GeneratedBoardsController < API::ApplicationController
                }, status: :created
       else
         Rails.logger.error("GeneratedBoardsController#create failed to save board #{board.id}: #{board.errors.full_messages.join(", ")}")
-        render json: { error: board.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        render json: { error: board.errors.full_messages.join(", ") }, status: :unprocessable_content
       end
     rescue => e
       Rails.logger.error("GeneratedBoardsController#create failed for board #{board.id}: #{e.class} - #{e.message}")
       board.destroy if board.persisted?
-      render json: { error: "Unable to generate board" }, status: :unprocessable_entity
+      render json: { error: "Unable to generate board" }, status: :unprocessable_content
     end
   end
 
@@ -68,12 +68,12 @@ class API::GeneratedBoardsController < API::ApplicationController
       return
     end
     if current_user.at_board_limit?
-      render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_entity
+      render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." }, status: :unprocessable_content
       return
     end
 
     if !@board.generated?
-      render json: { error: "This board is not claimable" }, status: :unprocessable_entity
+      render json: { error: "This board is not claimable" }, status: :unprocessable_content
       return
     end
 

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -87,7 +87,7 @@ class API::ImagesController < API::ApplicationController
       @image.reload
       render json: @image.api_view(@current_user), status: :created
     else
-      render json: @image.errors, status: :unprocessable_entity
+      render json: @image.errors, status: :unprocessable_content
     end
   end
 
@@ -123,7 +123,7 @@ class API::ImagesController < API::ApplicationController
         render json: { image_url: saved_image_url, id: @image.id, doc_id: @doc.id }
       end
     else
-      render json: @image.errors, status: :unprocessable_entity
+      render json: @image.errors, status: :unprocessable_content
     end
   end
 
@@ -215,7 +215,7 @@ class API::ImagesController < API::ApplicationController
       @image_with_display_doc = @image.with_display_doc(current_user)
       render json: { status: "ok", image: @image_with_display_doc, audio_file: @audio_file.first, audio_url: new_audio_file_url, filename: @file_name_to_save, voice: @image.voice_from_filename(@file_name_to_save) }
     else
-      render json: @image.errors, status: :unprocessable_entity
+      render json: @image.errors, status: :unprocessable_content
     end
   end
 
@@ -336,7 +336,7 @@ class API::ImagesController < API::ApplicationController
         @image_with_display_doc = @image.attributes.merge({ display_doc: doc.attributes, src: doc.tile_url })
         render json: @image.with_display_doc(@current_user), status: :created
       else
-        render json: @image.errors, status: :unprocessable_entity
+        render json: @image.errors, status: :unprocessable_content
       end
     else
       if @image.save
@@ -345,7 +345,7 @@ class API::ImagesController < API::ApplicationController
         @image_with_display_doc = @image.with_display_doc(@current_user)
         render json: @image_with_display_doc, status: :created
       else
-        render json: @image.errors, status: :unprocessable_entity
+        render json: @image.errors, status: :unprocessable_content
       end
     end
   end
@@ -358,7 +358,7 @@ class API::ImagesController < API::ApplicationController
     if @doc.save
       render json: @image, status: :created
     else
-      render json: @image.errors, status: :unprocessable_entity
+      render json: @image.errors, status: :unprocessable_content
     end
   end
 
@@ -432,7 +432,7 @@ class API::ImagesController < API::ApplicationController
   def create_symbol
     @image = Image.find(params[:id])
     if @image.open_symbol_status == "disabled"
-      render json: { status: "error", message: "Symbol generation is disabled for this image." }, status: :unprocessable_entity
+      render json: { status: "error", message: "Symbol generation is disabled for this image." }, status: :unprocessable_content
       return
     end
     limit = current_user.admin? ? ADMIN_SYMBOL_LIMIT : SYMBOL_LIMMIT
@@ -446,7 +446,7 @@ class API::ImagesController < API::ApplicationController
     @image_with_display_doc = @image.with_display_doc(@current_user, @board, @board_image)
     if result[:total] == 0
       @image.update(open_symbol_status: "disabled")
-      render json: { status: "error", message: "No symbols created for image.", image: @image_with_display_doc, board: @board&.api_view(@current_user), board_image: @board_image&.api_view(@current_user) }, status: :unprocessable_entity
+      render json: { status: "error", message: "No symbols created for image.", image: @image_with_display_doc, board: @board&.api_view(@current_user), board_image: @board_image&.api_view(@current_user) }, status: :unprocessable_content
       return
     end
     render json: { image: @image_with_display_doc, board: @board&.api_view(@current_user), board_image: @board_image&.api_view(@current_user), status: "ok", created: result[:created], skipped: result[:skipped], total: result[:total] }
@@ -604,7 +604,7 @@ class API::ImagesController < API::ApplicationController
     if @image.update(image_params)
       render json: @image.with_display_doc(current_user)
     else
-      render json: @image.errors, status: :unprocessable_entity
+      render json: @image.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -3,7 +3,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     @board = Board.find(params[:board_id])
 
     image = resolve_image_from(params)
-    return render json: { error: "image_id or label is required" }, status: :unprocessable_entity if image.nil?
+    return render json: { error: "image_id or label is required" }, status: :unprocessable_content if image.nil?
 
     board_image = @board.add_image(image.id)
 
@@ -12,7 +12,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
       render json: board_image.api_view(current_user), status: :created
     else
       errors = board_image&.errors&.full_messages&.join(", ") || "Unable to add image to board"
-      render json: { error: errors }, status: :unprocessable_entity
+      render json: { error: errors }, status: :unprocessable_content
     end
   end
 
@@ -21,7 +21,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
 
     raw_cells = params[:cells]
     unless raw_cells.is_a?(Array) && raw_cells.any?
-      return render json: { error: "cells must be a non-empty array" }, status: :unprocessable_entity
+      return render json: { error: "cells must be a non-empty array" }, status: :unprocessable_content
     end
 
     created = []
@@ -60,7 +60,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     end
 
     if errors.any?
-      render json: { errors: errors }, status: :unprocessable_entity
+      render json: { errors: errors }, status: :unprocessable_content
     else
       render json: created.map { |bi| bi.api_view(current_user) }, status: :created
     end

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -36,7 +36,7 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       enqueue_generation_job!(creation_type)
       render json: @board, status: :created
     else
-      render json: { errors: @board.errors }, status: :unprocessable_entity
+      render json: { errors: @board.errors }, status: :unprocessable_content
     end
   end
 
@@ -109,7 +109,7 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       apply_layout_if_present!
       render json: @board.api_view_with_images(current_user)
     else
-      render json: { errors: @board.errors }, status: :unprocessable_entity
+      render json: { errors: @board.errors }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/internal/generated_boards_controller.rb
+++ b/app/controllers/api/internal/generated_boards_controller.rb
@@ -8,7 +8,7 @@ class API::Internal::GeneratedBoardsController < API::Internal::ApplicationContr
     board_name = params[:name].presence || generated_board_name(topic, age_range)
 
     if topic.blank?
-      render json: { error: "Topic is required" }, status: :unprocessable_entity
+      render json: { error: "Topic is required" }, status: :unprocessable_content
       return
     end
 
@@ -33,12 +33,12 @@ class API::Internal::GeneratedBoardsController < API::Internal::ApplicationContr
         render json: { id: board.id, name: board.name, status: board.status }, status: :created
       else
         Rails.logger.error("API::Internal::GeneratedBoardsController#create save failed: #{board.errors.full_messages.join(", ")}")
-        render json: { error: board.errors.full_messages.join(", ") }, status: :unprocessable_entity
+        render json: { error: board.errors.full_messages.join(", ") }, status: :unprocessable_content
       end
     rescue => e
       Rails.logger.error("API::Internal::GeneratedBoardsController#create raised: #{e.class} - #{e.message}")
       board.destroy if board&.persisted?
-      render json: { error: "Unable to generate board" }, status: :unprocessable_entity
+      render json: { error: "Unable to generate board" }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/internal/images_controller.rb
+++ b/app/controllers/api/internal/images_controller.rb
@@ -3,7 +3,7 @@ class API::Internal::ImagesController < API::Internal::ApplicationController
     label = image_params[:label]
 
     if label.blank?
-      render json: { error: "label is required" }, status: :unprocessable_entity
+      render json: { error: "label is required" }, status: :unprocessable_content
       return
     end
 
@@ -16,7 +16,7 @@ class API::Internal::ImagesController < API::Internal::ApplicationController
     if @image.persisted?
       render json: @image.with_display_doc(current_user), status: :created
     else
-      render json: { errors: @image.errors }, status: :unprocessable_entity
+      render json: { errors: @image.errors }, status: :unprocessable_content
     end
   end
 
@@ -25,7 +25,7 @@ class API::Internal::ImagesController < API::Internal::ApplicationController
     prompt = image_params[:image_prompt].to_s.gsub("[[REPLACE_LABEL]]", "").strip
 
     if label.blank?
-      render json: { error: "label or image_prompt is required" }, status: :unprocessable_entity
+      render json: { error: "label or image_prompt is required" }, status: :unprocessable_content
       return
     end
 

--- a/app/controllers/api/internal/profiles_controller.rb
+++ b/app/controllers/api/internal/profiles_controller.rb
@@ -17,7 +17,7 @@ class API::Internal::ProfilesController < API::Internal::ApplicationController
       render json: {
         error: "Profile update failed",
         details: @profile.errors.full_messages,
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -61,7 +61,7 @@ class API::MenusController < API::ApplicationController
     @board.status = "pending"
     unless @board.save
       Rails.logger.error "Failed to create board for menu: #{@menu.id} - #{@menu.name}"
-      render json: { error: "Failed to create board for menu. #{@board.errors.full_messages.join(", ")}" }, status: :unprocessable_entity
+      render json: { error: "Failed to create board for menu. #{@board.errors.full_messages.join(", ")}" }, status: :unprocessable_content
       return
     end
 
@@ -69,20 +69,20 @@ class API::MenusController < API::ApplicationController
     message = "Re-running image description job."
     unless @board
       message = "No board found for this menu."
-      render json: { message: message }, status: :unprocessable_entity
+      render json: { message: message }, status: :unprocessable_content
       # redirect_to menu_url(@menu), notice: "No board found for this menu."
       return
     end
     # if current_user.tokens < 1 && !current_user.admin?
     #   message = "Not enough tokens to re-run image description job."
-    #   render json: { error: message }, status: :unprocessable_entity
+    #   render json: { error: message }, status: :unprocessable_content
     #   # redirect_to menu_url(@menu), notice: "Not enough tokens to re-run image description job."
     #   return
     # end
     # if @board.cost >= @menu.token_limit && !current_user.admin?
     #   Rails.logger.info "Board cost: #{@board.cost} >= Menu token limit: #{@menu.token_limit}"
     #   message = "This menu has already used all of its tokens. Menu token limit: #{@menu.token_limit}"
-    #   render json: { error: message }, status: :unprocessable_entity
+    #   render json: { error: message }, status: :unprocessable_content
     #   # redirect_to menu_url(@menu), notice: "This menu has already used all of its tokens."
     #   return
     # end
@@ -106,7 +106,7 @@ class API::MenusController < API::ApplicationController
     @menu.user = @current_user
     @menu.menu_image.attach(menu_params[:docs][:image]) if menu_params[:docs] && menu_params[:docs][:image]
     unless @menu.save
-      render json: @menu.errors, status: :unprocessable_entity
+      render json: @menu.errors, status: :unprocessable_content
       return
     end
     doc = @menu.docs.new(menu_params[:docs])
@@ -118,12 +118,12 @@ class API::MenusController < API::ApplicationController
       @board.preview_image.attach(menu_params[:docs][:image]) if menu_params[:docs] && menu_params[:docs][:image]
       if @board.nil?
         Rails.logger.error "Failed to create board for menu: #{@menu.id} - #{@menu.name}"
-        render json: { error: "Failed to create board for menu." }, status: :unprocessable_entity
+        render json: { error: "Failed to create board for menu." }, status: :unprocessable_content
         return
       end
       unless @board.save
         Rails.logger.error "Failed to save board for menu: #{@menu.id} - #{@menu.name} - Errors: #{@board.errors.full_messages.join(", ")}"
-        render json: { error: "Failed to save board for menu. #{@board.errors.full_messages.join(", ")}" }, status: :unprocessable_entity
+        render json: { error: "Failed to save board for menu. #{@board.errors.full_messages.join(", ")}" }, status: :unprocessable_content
         return
       end
       @menu.run_image_description_job(@board.id, screen_size)
@@ -145,7 +145,7 @@ class API::MenusController < API::ApplicationController
       }
       render json: @menu_with_display_doc, status: :created
     else
-      render json: @menu.errors, status: :unprocessable_entity
+      render json: @menu.errors, status: :unprocessable_content
     end
   end
 
@@ -158,7 +158,7 @@ class API::MenusController < API::ApplicationController
     if @menu.update(menu_params)
       render json: @menu, status: :ok
     else
-      render json: @menu.errors, status: :unprocessable_entity
+      render json: @menu.errors, status: :unprocessable_content
     end
   end
 
@@ -190,7 +190,7 @@ class API::MenusController < API::ApplicationController
       return
     end
     if current_user.at_board_limit?
-      render json: { error: "Maximum number of boards reached. Please upgrade to add more." }, status: :unprocessable_entity
+      render json: { error: "Maximum number of boards reached. Please upgrade to add more." }, status: :unprocessable_content
       return
     end
     return true

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -52,7 +52,7 @@ class API::MessagesController < API::ApplicationController
       @message.notify_recipient
       render json: @message.show_api_view(current_user), status: :created, location: @message
     else
-      render json: @message.errors, status: :unprocessable_entity
+      render json: @message.errors, status: :unprocessable_content
     end
   end
 
@@ -61,7 +61,7 @@ class API::MessagesController < API::ApplicationController
     if @message.update(message_params)
       render json: @message, status: :ok, location: @message
     else
-      render json: @message.errors, status: :unprocessable_entity
+      render json: @message.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/open_symbols_controller.rb
+++ b/app/controllers/api/open_symbols_controller.rb
@@ -20,7 +20,7 @@ class API::OpenSymbolsController < API::ApplicationController
     if @symbol.persisted?
       render json: @symbol, status: :created
     else
-      render json: { errors: @symbol.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: @symbol.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/openai_prompts_controller.rb
+++ b/app/controllers/api/openai_prompts_controller.rb
@@ -33,8 +33,8 @@ class API::OpenaiPromptsController < API::ApplicationController
 
         format.json { render json: @board.api_view_with_images(current_user), status: :created }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @openai_prompt.errors, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @openai_prompt.errors, status: :unprocessable_content }
       end
     end
   end
@@ -46,8 +46,8 @@ class API::OpenaiPromptsController < API::ApplicationController
         format.html { redirect_to openai_prompt_url(@openai_prompt), notice: "Openai prompt was successfully updated." }
         format.json { render :show, status: :ok, location: @openai_prompt }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @openai_prompt.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @openai_prompt.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -11,7 +11,7 @@ class API::OrganizationsController < API::ApplicationController
     if @organization.update(organization_params)
       render json: @organization.api_view(current_user)
     else
-      render json: @organization.errors, status: :unprocessable_entity
+      render json: @organization.errors, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/page_follows_controller.rb
+++ b/app/controllers/api/page_follows_controller.rb
@@ -14,7 +14,7 @@ class API::PageFollowsController < API::ApplicationController
     if follow.save
       render json: { ok: true }, status: :created
     else
-      render json: { ok: false, errors: follow.errors.full_messages }, status: :unprocessable_entity
+      render json: { ok: false, errors: follow.errors.full_messages }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/profiles/assets_controller.rb
+++ b/app/controllers/api/profiles/assets_controller.rb
@@ -12,7 +12,7 @@ class API::Profiles::AssetsController < API::ApplicationController
     if attachment.attached?
       render json: { url: @profile.url_for_attachment(attachment) }
     else
-      render json: { error: "Unable to generate safety ID." }, status: :unprocessable_entity
+      render json: { error: "Unable to generate safety ID." }, status: :unprocessable_content
     end
   end
 
@@ -26,7 +26,7 @@ class API::Profiles::AssetsController < API::ApplicationController
     if attachment.attached?
       render json: { url: @profile.url_for_attachment(attachment) }
     else
-      render json: { error: "Unable to generate device tag." }, status: :unprocessable_entity
+      render json: { error: "Unable to generate device tag." }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -95,7 +95,7 @@ class API::ProfilesController < API::ApplicationController
       render json: {
         error: "Profile creation failed",
         details: profile.errors.full_messages,
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 
@@ -121,7 +121,7 @@ class API::ProfilesController < API::ApplicationController
           error: "slug_locked",
           next_edit_at: next_at,
           message: "You can change your link again on #{next_at&.to_date&.iso8601}.",
-        }, status: :unprocessable_entity
+        }, status: :unprocessable_content
         return
       end
 
@@ -134,7 +134,7 @@ class API::ProfilesController < API::ApplicationController
       end
 
       if reason
-        render json: slug_error_for(reason), status: :unprocessable_entity
+        render json: slug_error_for(reason), status: :unprocessable_content
         return
       end
 
@@ -158,7 +158,7 @@ class API::ProfilesController < API::ApplicationController
       render json: {
         error: "Profile update failed",
         details: profile.errors.full_messages,
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 
@@ -189,11 +189,11 @@ class API::ProfilesController < API::ApplicationController
     slug = username.parameterize
     @profile = Profile.find_by(slug: slug) if @profile.nil?
     if @profile
-      render json: { error: "This username has been taken. Please try again." }, status: :unprocessable_entity
+      render json: { error: "This username has been taken. Please try again." }, status: :unprocessable_content
       return
     end
     if params[:user_email].blank?
-      render json: { error: "Email is required" }, status: :unprocessable_entity
+      render json: { error: "Email is required" }, status: :unprocessable_content
       return
     end
     if params[:user_email].present?
@@ -204,7 +204,7 @@ class API::ProfilesController < API::ApplicationController
         params[:user_id] = user.id
         params[:user_email] = user.email
       else
-        render json: { error: "Failed to invite user" }, status: :unprocessable_entity
+        render json: { error: "Failed to invite user" }, status: :unprocessable_content
         return
       end
     end
@@ -213,7 +213,7 @@ class API::ProfilesController < API::ApplicationController
     if @profile
       render json: @profile.placeholder_view
     else
-      render json: { error: "Failed to generate placeholder" }, status: :unprocessable_entity
+      render json: { error: "Failed to generate placeholder" }, status: :unprocessable_content
     end
   end
 
@@ -222,7 +222,7 @@ class API::ProfilesController < API::ApplicationController
   #   if @profile.update(profile_params)
   #     render json: @profile.api_view(current_user)
   #   else
-  #     render json: @profile.errors, status: :unprocessable_entity
+  #     render json: @profile.errors, status: :unprocessable_content
   #   end
   # end
 
@@ -239,7 +239,7 @@ class API::ProfilesController < API::ApplicationController
 
   def claim_placeholder
     if params[:claim_token].blank?
-      render json: { error: "Claim token is required" }, status: :unprocessable_entity
+      render json: { error: "Claim token is required" }, status: :unprocessable_content
       return
     end
     @profile = Profile.find_by(claim_token: params[:claim_token]) if params[:claim_token].present?
@@ -250,7 +250,7 @@ class API::ProfilesController < API::ApplicationController
     email = params[:email]
     slug = params[:slug]
     if email.blank?
-      render json: { error: "Email is required" }, status: :unprocessable_entity
+      render json: { error: "Email is required" }, status: :unprocessable_content
       return
     end
     if slug.blank?
@@ -271,7 +271,7 @@ class API::ProfilesController < API::ApplicationController
       @profile = @profile.claim!(slug, @user)
     rescue StandardError => e
       Rails.logger.error "Failed to claim profile: #{e.message}"
-      render json: { errors: e.message }, status: :unprocessable_entity and return
+      render json: { errors: e.message }, status: :unprocessable_content and return
     end
     @profile.reload
     @slug = @profile.slug

--- a/app/controllers/api/scenarios_controller.rb
+++ b/app/controllers/api/scenarios_controller.rb
@@ -34,7 +34,7 @@ class API::ScenariosController < API::ApplicationController
     Rails.logger.debug "PARAMS: #{scenario_params}"
     initial_description = params[:prompt_text]
     if initial_description.blank?
-      render json: { error: "Initial description cannot be blank" }, status: :unprocessable_entity
+      render json: { error: "Initial description cannot be blank" }, status: :unprocessable_content
       return
     end
     token_limit = params[:token_limit] || 10
@@ -57,7 +57,7 @@ class API::ScenariosController < API::ApplicationController
         # CreateScenarioBoardJob.perform_async(@open_prompt.id)
         format.json { render json: @scenario, status: :created }
       else
-        format.json { render json: @scenario.errors, status: :unprocessable_entity }
+        format.json { render json: @scenario.errors, status: :unprocessable_content }
       end
     end
   end
@@ -65,7 +65,7 @@ class API::ScenariosController < API::ApplicationController
   def answer
     answer = params[:answer]
     if answer.blank?
-      render json: { error: "Answer cannot be blank" }, status: :unprocessable_entity
+      render json: { error: "Answer cannot be blank" }, status: :unprocessable_content
       return
     end
     question_number = params[:question_number]
@@ -113,7 +113,7 @@ class API::ScenariosController < API::ApplicationController
     @age_range = params[:age_range]
     @num_of_images = params[:number_of_images] || 12
     if @name.blank? || @age_range.blank?
-      render json: { error: "Name and age range cannot be blank" }, status: :unprocessable_entity
+      render json: { error: "Name and age range cannot be blank" }, status: :unprocessable_content
       return
     end
     @description = params[:prompt_text]
@@ -130,7 +130,7 @@ class API::ScenariosController < API::ApplicationController
     name = params[:name]
     age_range = params[:age_range]
     if name.blank? || age_range.blank?
-      render json: { error: "Name and age range cannot be blank" }, status: :unprocessable_entity
+      render json: { error: "Name and age range cannot be blank" }, status: :unprocessable_content
       return
     end
     resolved_language = params[:language].presence || current_user.i18n_locale.to_s
@@ -164,8 +164,8 @@ class API::ScenariosController < API::ApplicationController
         format.html { redirect_to scenario_url(@scenario), notice: "Scenario was successfully updated." }
         format.json { render :show, status: :ok, location: @scenario }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @scenario.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @scenario.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -44,7 +44,7 @@ class API::SubscriptionsController < API::ApplicationController
     price_id = API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS[plan_key]
 
     if price_id.blank?
-      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_entity
+      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_content
       return
     end
 
@@ -52,13 +52,13 @@ class API::SubscriptionsController < API::ApplicationController
     if customer_id.blank?
       # No Stripe customer means no subscription to update — these users
       # belong in checkout, not here.
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
     subscription = active_subscription_for(customer_id)
     if subscription.nil?
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
@@ -99,25 +99,25 @@ class API::SubscriptionsController < API::ApplicationController
     price_id = API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS[plan_key]
 
     if price_id.blank?
-      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_entity
+      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_content
       return
     end
 
     customer_id = current_user.stripe_customer_id
     if customer_id.blank?
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
     subscription = active_subscription_for(customer_id)
     if subscription.nil?
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
     current_price = subscription.items.data.first.price
     if current_price.id == price_id
-      render json: { error: "Already on this plan" }, status: :unprocessable_entity
+      render json: { error: "Already on this plan" }, status: :unprocessable_content
       return
     end
 
@@ -167,25 +167,25 @@ class API::SubscriptionsController < API::ApplicationController
     price_id = API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS[plan_key]
 
     if price_id.blank?
-      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_entity
+      render json: { error: "Unknown or unsupported plan" }, status: :unprocessable_content
       return
     end
 
     customer_id = current_user.stripe_customer_id
     if customer_id.blank?
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
     subscription = active_subscription_for(customer_id)
     if subscription.nil?
-      render json: { error: "No active subscription to change" }, status: :unprocessable_entity
+      render json: { error: "No active subscription to change" }, status: :unprocessable_content
       return
     end
 
     current_price = subscription.items.data.first.price
     if current_price.id == price_id
-      render json: { error: "Already on this plan" }, status: :unprocessable_entity
+      render json: { error: "Already on this plan" }, status: :unprocessable_content
       return
     end
 

--- a/app/controllers/api/team_accounts_controller.rb
+++ b/app/controllers/api/team_accounts_controller.rb
@@ -22,7 +22,7 @@ class API::TeamAccountsController < API::ApplicationController
         @team.reload
         format.json { render json: @team.show_api_view, status: :created }
       else
-        format.json { render json: @team_account.errors, status: :unprocessable_entity }
+        format.json { render json: @team_account.errors, status: :unprocessable_content }
       end
     end
   end
@@ -34,8 +34,8 @@ class API::TeamAccountsController < API::ApplicationController
         format.html { redirect_to team_account_url(@team_account), notice: "TeamAccount was successfully updated." }
         format.json { render :show, status: :ok, location: @team_account }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @team_account.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @team_account.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -65,13 +65,13 @@ class API::TeamsController < API::ApplicationController
 
     @user = User.invite_new_user_to_team!(user_email, current_user, @team, user_role)
     unless @user
-      return render json: { error: "User not invited. Something went wrong." }, status: :unprocessable_entity
+      return render json: { error: "User not invited. Something went wrong." }, status: :unprocessable_content
     end
     @team.upsert_member!(@user, user_role)
 
     render json: @team.show_api_view(current_user), status: :created
   rescue ActiveRecord::RecordInvalid => e
-    render json: { errors: e.record.errors }, status: :unprocessable_entity
+    render json: { errors: e.record.errors }, status: :unprocessable_content
   end
 
   def remove_member
@@ -112,7 +112,7 @@ class API::TeamsController < API::ApplicationController
 
         format.json { render json: @team.show_api_view(current_user), status: :created }
       else
-        format.json { render json: @team.errors, status: :unprocessable_entity }
+        format.json { render json: @team.errors, status: :unprocessable_content }
       end
     end
   end
@@ -136,7 +136,7 @@ class API::TeamsController < API::ApplicationController
     if @team_board.save
       render json: @team.show_api_view(current_user)
     else
-      render json: @team_board.errors, status: :unprocessable_entity
+      render json: @team_board.errors, status: :unprocessable_content
     end
   end
 
@@ -154,8 +154,8 @@ class API::TeamsController < API::ApplicationController
         format.html { redirect_to team_url(@team), notice: "Team was successfully updated." }
         format.json { render :show, status: :ok, location: @team }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @team.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @team.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -30,7 +30,7 @@ class API::UsersController < API::ApplicationController
     if @user.save
       render json: @user, status: :ok
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render json: @user.errors, status: :unprocessable_content
     end
   end
 
@@ -40,7 +40,7 @@ class API::UsersController < API::ApplicationController
     password = params[:password]
     password_confirmation = params[:password_confirmation]
     if password != password_confirmation
-      render json: { error: "Password confirmation does not match" }, status: :unprocessable_entity
+      render json: { error: "Password confirmation does not match" }, status: :unprocessable_content
       return
     end
     @user.password = password
@@ -53,7 +53,7 @@ class API::UsersController < API::ApplicationController
     if saved && @user.errors.empty?
       render json: { success: true }, status: :ok
     else
-      render json: @user.errors, status: :unprocessable_entity
+      render json: @user.errors, status: :unprocessable_content
     end
   end
 
@@ -64,7 +64,7 @@ class API::UsersController < API::ApplicationController
     new_email = params[:email].to_s.strip.downcase
 
     if new_email.blank?
-      return render json: { error: "Email can't be blank" }, status: :unprocessable_entity
+      return render json: { error: "Email can't be blank" }, status: :unprocessable_content
     end
 
     if new_email == current_user.email
@@ -76,7 +76,7 @@ class API::UsersController < API::ApplicationController
 
     if User.where.not(id: current_user.id).exists?(email: new_email) ||
        User.where.not(id: current_user.id).exists?(unconfirmed_email: new_email)
-      return render json: { error: "Email is already taken" }, status: :unprocessable_entity
+      return render json: { error: "Email is already taken" }, status: :unprocessable_content
     end
 
     if current_user.update(unconfirmed_email: new_email)
@@ -89,10 +89,10 @@ class API::UsersController < API::ApplicationController
                  pending_email: current_user.unconfirmed_email,
                }, status: :ok
       else
-        render json: { error: "Failed to update email" }, status: :unprocessable_entity
+        render json: { error: "Failed to update email" }, status: :unprocessable_content
       end
     else
-      render json: { errors: current_user.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: current_user.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -101,7 +101,7 @@ class API::UsersController < API::ApplicationController
     user = User.find_by(confirmation_token: token)
 
     if user.nil? || user.confirmation_token != token
-      return render json: { error: "Invalid or expired token" }, status: :unprocessable_entity
+      return render json: { error: "Invalid or expired token" }, status: :unprocessable_content
     end
     user.email = user.unconfirmed_email
     user.unconfirmed_email = nil
@@ -110,7 +110,7 @@ class API::UsersController < API::ApplicationController
     if user.save
       render json: { message: "Email change confirmed", email: user.email }, status: :ok
     else
-      render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: user.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -118,7 +118,7 @@ class API::UsersController < API::ApplicationController
     pending_email = current_user.unconfirmed_email
 
     if pending_email.blank?
-      return render json: { error: "No pending email change." }, status: :unprocessable_entity
+      return render json: { error: "No pending email change." }, status: :unprocessable_content
     end
 
     # current_user.send_confirmation_instructions
@@ -141,7 +141,7 @@ class API::UsersController < API::ApplicationController
 
       render json: { message: "Pending email change canceled." }, status: :ok
     else
-      render json: { error: "No pending email change." }, status: :unprocessable_entity
+      render json: { error: "No pending email change." }, status: :unprocessable_content
     end
   end
 
@@ -160,7 +160,7 @@ class API::UsersController < API::ApplicationController
       if @user.save
         format.json { render json: @user, status: :ok }
       else
-        format.json { render json: @user.errors, status: :unprocessable_entity }
+        format.json { render json: @user.errors, status: :unprocessable_content }
       end
     end
   end
@@ -183,12 +183,12 @@ class API::UsersController < API::ApplicationController
     # so we skip token verification for Apple users
 
     # if @user.nil? || @user.email != params[:email] || @user.delete_account_token != params[:token]
-    #   render json: { error: "Invalid or expired token" }, status: :unprocessable_entity
+    #   render json: { error: "Invalid or expired token" }, status: :unprocessable_content
     #   return
     # end
 
     # if @user.nil? || @user.delete_account_token_expires_at.nil? || @user.delete_account_token_expires_at < Time.current
-    #   render json: { error: "Invalid or expired token" }, status: :unprocessable_entity
+    #   render json: { error: "Invalid or expired token" }, status: :unprocessable_content
     #   return
     # end
     if @user.admin?
@@ -198,7 +198,7 @@ class API::UsersController < API::ApplicationController
     if @user.soft_delete_account!(reason: "user_requested", actor_id: @user.id)
       render json: { success: true }, status: :ok
     else
-      render json: { error: "Failed to delete account" }, status: :unprocessable_entity
+      render json: { error: "Failed to delete account" }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -10,7 +10,7 @@ module API
         password = params["password"] || (params["auth"] && params["auth"]["password"])
         password_confirmation = params["password_confirmation"] || (params["auth"] && params["auth"]["password_confirmation"])
         if email.blank? || password.blank? || password_confirmation.blank?
-          render json: { error: "Email, password, and password confirmation are required" }, status: :unprocessable_entity
+          render json: { error: "Email, password, and password confirmation are required" }, status: :unprocessable_content
           return
         end
 
@@ -44,7 +44,7 @@ module API
           MailchimpEventJob.perform_async(user.id, "sign_up")
           render json: { token: user.authentication_token, user: user.api_view }
         else
-          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_content
         end
       end
 
@@ -59,23 +59,23 @@ module API
 
         # invite! saves with validate: false, so email format must be checked here.
         unless Devise.email_regexp.match?(email)
-          render json: { error: "A valid email is required" }, status: :unprocessable_entity
+          render json: { error: "A valid email is required" }, status: :unprocessable_content
           return
         end
 
         if User.exists?(email: email)
-          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_entity
+          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_content
           return
         end
 
         begin
           user = User.invite!(email: email, skip_invitation: true)
         rescue ActiveRecord::RecordNotUnique
-          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_entity
+          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_content
           return
         end
         unless user.persisted?
-          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_content
           return
         end
         # The raw token only exists in memory on this instance — capture it for
@@ -122,7 +122,7 @@ module API
         # password (devise_invitable assigns a random one on invite!, so
         # encrypted_password.present? can't tell the two apart).
         unless current_user.invited_to_sign_up?
-          render json: { error: "Password already set", error_code: "password_already_set" }, status: :unprocessable_entity
+          render json: { error: "Password already set", error_code: "password_already_set" }, status: :unprocessable_content
           return
         end
         current_user.password = params[:password]
@@ -131,7 +131,7 @@ module API
         if saved && current_user.errors.empty?
           render json: { user: current_user.api_view }
         else
-          render json: { error: current_user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+          render json: { error: current_user.errors.full_messages.join(", ") }, status: :unprocessable_content
         end
       end
 

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -62,7 +62,7 @@ module API
         # only when the user is already at/over their limit.
         if current_user.at_board_limit?
           render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." },
-                 status: :unprocessable_entity
+                 status: :unprocessable_content
           return
         end
 
@@ -148,12 +148,12 @@ module API
         Rails.logger.warn "[BoardBuilder] #{e.message}"
         render json: { error: "unknown_template",
                        message: "That template isn't available. Pick one from the list and try again." },
-               status: :unprocessable_entity
+               status: :unprocessable_content
       rescue Boards::BoardTreeBuilder::BuildError, Boards::SeededSetCloner::CloneError => e
         Rails.logger.warn "[BoardBuilder] build failed: #{e.message}"
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },
-               status: :unprocessable_entity
+               status: :unprocessable_content
       rescue StandardError => e
         # Last-resort guard: never leak an internal error (or a 500) to the
         # client. Core symbols now self-heal, so this should be rare.
@@ -166,7 +166,7 @@ module API
         root.update_column(:status, "failed") if defined?(root) && root&.persisted?
         render json: { error: "build_failed",
                        message: "Something went wrong building the board set — your info is safe, give it another try." },
-               status: :unprocessable_entity
+               status: :unprocessable_content
       end
 
       private

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -38,7 +38,7 @@ module API
           name = params[:name].to_s.strip
           if name.blank?
             render json: { error: "Onboarding failed", details: ["Name can't be blank"] },
-                   status: :unprocessable_entity
+                   status: :unprocessable_content
             return
           end
 
@@ -58,7 +58,7 @@ module API
           if requested_slug
             reason = Profile.slug_unavailable_reason(requested_slug)
             if reason
-              render json: slug_error_payload(reason), status: :unprocessable_entity
+              render json: slug_error_payload(reason), status: :unprocessable_content
               return
             end
             unique = requested_slug
@@ -120,7 +120,7 @@ module API
           render json: {
             error: "Onboarding failed",
             details: e.record.errors.full_messages,
-          }, status: :unprocessable_entity
+          }, status: :unprocessable_content
         end
 
         private

--- a/app/controllers/api/vendors_controller.rb
+++ b/app/controllers/api/vendors_controller.rb
@@ -37,7 +37,7 @@ class API::VendorsController < API::ApplicationController
     if @vendor
       render json: @vendor.api_view(current_user), status: :created
     else
-      render json: { error: "Failed to create vendor" }, status: :unprocessable_entity
+      render json: { error: "Failed to create vendor" }, status: :unprocessable_content
     end
   end
 
@@ -45,14 +45,14 @@ class API::VendorsController < API::ApplicationController
     email = params[:user_email]
     business_name = params[:business_name]
     if email.blank? || business_name.blank?
-      render json: { error: "Email and business name are required" }, status: :unprocessable_entity
+      render json: { error: "Email and business name are required" }, status: :unprocessable_content
       return
     end
     @vendor = Vendor.create_from_email(email, business_name, params[:business_email], params[:website])
     if @vendor
       render json: @vendor.api_view(current_user), status: :created
     else
-      render json: { error: "Failed to generate vendor" }, status: :unprocessable_entity
+      render json: { error: "Failed to generate vendor" }, status: :unprocessable_content
     end
   end
 
@@ -61,7 +61,7 @@ class API::VendorsController < API::ApplicationController
     if @vendor.update(vendor_params)
       render json: @vendor.api_view(current_user)
     else
-      render json: @vendor.errors, status: :unprocessable_entity
+      render json: @vendor.errors, status: :unprocessable_content
     end
   end
 
@@ -74,7 +74,7 @@ class API::VendorsController < API::ApplicationController
     if @vendor.destroy
       render json: { message: "Vendor deleted successfully" }, status: :ok
     else
-      render json: { error: "Failed to delete vendor" }, status: :unprocessable_entity
+      render json: { error: "Failed to delete vendor" }, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/board_images_controller.rb
+++ b/app/controllers/board_images_controller.rb
@@ -32,8 +32,8 @@ class BoardImagesController < ApplicationController
         format.html { redirect_to board_image_url(@board_image), notice: "Board image was successfully created." }
         format.json { render :show, status: :created, location: @board_image }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @board_image.errors, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @board_image.errors, status: :unprocessable_content }
       end
     end
   end
@@ -45,8 +45,8 @@ class BoardImagesController < ApplicationController
         format.html { redirect_to board_image_url(@board_image), notice: "Board image was successfully updated." }
         format.json { render :show, status: :ok, location: @board_image }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @board_image.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @board_image.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -22,8 +22,8 @@ class TeamsController < ApplicationController
         format.html { redirect_to team_url(@team), notice: "Your current team has been set to: #{current_user.current_team&.name}. You can change this at any time from your profile page." }
         format.json { render :show, status: :ok, location: @team }
       else
-        format.html { render :show, status: :unprocessable_entity }
-        format.json { render json: current_user.errors, status: :unprocessable_entity }
+        format.html { render :show, status: :unprocessable_content }
+        format.json { render json: current_user.errors, status: :unprocessable_content }
       end
     end
   end
@@ -48,8 +48,8 @@ class TeamsController < ApplicationController
         format.html { redirect_to team_url(@team), notice: "Team was successfully created." }
         format.json { render :show, status: :created, location: @team }
       else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @team.errors, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_content }
+        format.json { render json: @team.errors, status: :unprocessable_content }
       end
     end
   end
@@ -89,8 +89,8 @@ class TeamsController < ApplicationController
         format.html { redirect_to team_url(@team), notice: "Team was successfully updated." }
         format.json { render :show, status: :ok, location: @team }
       else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @team.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.json { render json: @team.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -77,7 +77,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     else
       render json: {
         status: { code: 422, message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" },
-      }, status: :unprocessable_entity
+      }, status: :unprocessable_content
     end
   end
 end

--- a/app/helpers/permissions/communicator_limits.rb
+++ b/app/helpers/permissions/communicator_limits.rb
@@ -27,7 +27,7 @@ module Permissions
       when ChildAccount::LOANER, ChildAccount::ACTIVE
         check_slot_self_create(user, settings)
       else
-        [false, :unprocessable_entity, "Unknown communicator status: #{status}"]
+        [false, :unprocessable_content, "Unknown communicator status: #{status}"]
       end
     end
 
@@ -42,7 +42,7 @@ module Permissions
       owned_count = owned_slot_count(user)
 
       return [false, :forbidden, "Your plan does not include communicator accounts."] if slot_limit <= 0
-      return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if owned_count >= slot_limit
+      return [false, :unprocessable_content, "Maximum number of communicator accounts reached."] if owned_count >= slot_limit
 
       [true, :ok, nil]
     end
@@ -86,7 +86,7 @@ module Permissions
       count = user.communicator_accounts.where(status: ChildAccount::SANDBOX).count
 
       return [false, :forbidden, "Your plan does not include sandbox communicators."] if limit <= 0
-      return [false, :unprocessable_entity, "Sandbox communicator limit reached."] if count >= limit
+      return [false, :unprocessable_content, "Sandbox communicator limit reached."] if count >= limit
 
       [true, :ok, nil]
     end
@@ -96,7 +96,7 @@ module Permissions
       count = owned_slot_count(user)
 
       return [false, :forbidden, "Your plan does not include communicator accounts."] if limit <= 0
-      return [false, :unprocessable_entity, "Maximum number of communicator accounts reached."] if count >= limit
+      return [false, :unprocessable_content, "Maximum number of communicator accounts reached."] if count >= limit
 
       [true, :ok, nil]
     end

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Permissions::CommunicatorLimits do
         allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::SANDBOX)
 
         expect(allowed).to be(false)
-        expect(http_status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_content)
         expect(error).to match(/limit reached/i)
       end
 
@@ -52,7 +52,7 @@ RSpec.describe Permissions::CommunicatorLimits do
         allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
 
         expect(allowed).to be(false)
-        expect(http_status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_content)
         expect(error).to match(/maximum.*reached/i)
       end
 
@@ -72,7 +72,7 @@ RSpec.describe Permissions::CommunicatorLimits do
         allowed, http_status, error = described_class.can_create?(user: user, status: ChildAccount::ACTIVE)
 
         expect(allowed).to be(false)
-        expect(http_status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_content)
         expect(error).to match(/maximum.*reached/i)
       end
 
@@ -90,7 +90,7 @@ RSpec.describe Permissions::CommunicatorLimits do
 
         allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::LOANER)
         expect(allowed).to be(false)
-        expect(http_status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_content)
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe Permissions::CommunicatorLimits do
 
         allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::LOANER)
         expect(allowed).to be(false)
-        expect(http_status).to eq(:unprocessable_entity)
+        expect(http_status).to eq(:unprocessable_content)
       end
     end
   end
@@ -153,7 +153,7 @@ RSpec.describe Permissions::CommunicatorLimits do
 
       allowed, http_status, error = described_class.can_claim?(user: user)
       expect(allowed).to be(false)
-      expect(http_status).to eq(:unprocessable_entity)
+      expect(http_status).to eq(:unprocessable_content)
       expect(error).to match(/maximum/i)
     end
   end

--- a/spec/requests/api/board_groups_spec.rb
+++ b/spec/requests/api/board_groups_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "API::BoardGroups", type: :request do
 
       post "/api/board_groups", params: { board_group: { name: "Second" } }, headers: auth_headers(user)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       body = JSON.parse(response.body)
       expect(body["error"]).to match(/board set limit/i)
       expect(body["limit"]).to eq(1)

--- a/spec/requests/api/boards/create_from_template_limit_spec.rb
+++ b/spec/requests/api/boards/create_from_template_limit_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "API::Boards create_from_template board-limit gate", type: :reque
              headers: auth_headers(user)
       }.not_to change { Board.count }
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
     end
 

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       post "/api/boards/import_obf",
            params: { file: txt },
            headers: auth_headers(user)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to match(/unsupported/i)
     end
 
@@ -46,7 +46,7 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
                headers: auth_headers(user)
         }.not_to change { user.boards.count }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
       end
     end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe "API::Boards", type: :request do
              headers: auth_headers(free_user)
       }.to change(MailchimpEventJob.jobs, :size).by(1)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(MailchimpEventJob.jobs.last["args"]).to eq(
         [free_user.id, "journey", { "journey_key" => "hit_limit" }],
       )
@@ -658,7 +658,7 @@ RSpec.describe "API::Boards", type: :request do
            headers: auth_headers(free_user)
 
       # The 422 response itself is unaffected.
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 end

--- a/spec/requests/api/child_accounts_aac_profile_spec.rb
+++ b/spec/requests/api/child_accounts_aac_profile_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "API::ChildAccounts AAC profile", type: :request do
             params: { details: { aac_level: "wizard" } }.to_json,
             headers: headers
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(communicator.reload.aac_level).to be_nil
     end
 

--- a/spec/requests/api/child_accounts_archive_spec.rb
+++ b/spec/requests/api/child_accounts_archive_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "API::ChildAccounts archive", type: :request do
     it "refuses on loaner with end_loan guidance" do
       loaner = create(:child_account, user: user, owner: user, status: "loaner", username: "ln-#{SecureRandom.hex(2)}")
       post "/api/child_accounts/#{loaner.id}/archive", headers: auth_headers(user)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to match(/end_loan/i)
     end
 
@@ -90,7 +90,7 @@ RSpec.describe "API::ChildAccounts archive", type: :request do
       pro_limit.times { create(:child_account, user: user, owner: user, status: "active") }
 
       post "/api/child_accounts/#{active.id}/unarchive", headers: auth_headers(user)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to match(/communicator/i)
     end
   end

--- a/spec/requests/api/child_accounts_claim_spec.rb
+++ b/spec/requests/api/child_accounts_claim_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "API::ChildAccounts claim flow", type: :request do
 
       post "/api/communicator_claims/#{loaner.claim_token}/claim", headers: auth_headers(parent)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("slot_full")
       expect(loaner.reload.status).to eq("loaner")
     end
@@ -163,7 +163,7 @@ RSpec.describe "API::ChildAccounts claim flow", type: :request do
 
         post "/api/child_accounts/#{slp_active.id}/lend", headers: auth_headers(slp)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to match(/owned by someone else/i)
         expect(slp_active.reload.status).to eq("active")
       end
@@ -194,7 +194,7 @@ RSpec.describe "API::ChildAccounts claim flow", type: :request do
       post "/api/child_accounts/#{loaner.id}/send_claim_link",
         params: { email: "not-an-email" },
         headers: auth_headers(slp)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
           params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", status: "sandbox", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "coerces a Free user's active self-create into a no-login sandbox" do
@@ -50,7 +50,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
           params: { name: "Second", username: "second-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "still accepts the legacy is_demo=true param for backwards compat" do
@@ -86,7 +86,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
           params: { name: "Extra", username: "extra-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to match(/maximum/i)
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
           params: { name: "Third", username: "third-#{SecureRandom.hex(3)}", status: "active", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       # Regression for PR #163 review: the pre-save valid? check fired

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
              headers: auth_headers(parent)
       }.not_to change { sandbox.reload.child_boards.count }
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to match(/Demo board limit exceeded/)
     end
 
@@ -140,7 +140,7 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
       post "/api/child_accounts/#{sandbox.id}/assign_boards",
            headers: auth_headers(parent)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("No board_ids provided")
     end
   end

--- a/spec/requests/api/child_accounts_promote_spec.rb
+++ b/spec/requests/api/child_accounts_promote_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "API::ChildAccounts promote_to_loaner", type: :request do
       params: { passcode: "rentme01" },
       headers: auth_headers(user)
 
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:unprocessable_content)
     expect(sandbox.reload.status).to eq("sandbox")
   end
 
@@ -37,7 +37,7 @@ RSpec.describe "API::ChildAccounts promote_to_loaner", type: :request do
     post "/api/child_accounts/#{sandbox.id}/promote_to_loaner",
       headers: auth_headers(user)
 
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it "rejects unauthorized users" do

--- a/spec/requests/api/coaching_prompts_spec.rb
+++ b/spec/requests/api/coaching_prompts_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "API::CoachingPrompts", type: :request do
       get "/api/coaching_prompts/audio",
         params: { text: "x" * 501, voice: "polly:kevin" },
         headers: auth_headers(user)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "returns the audio URL and caches the row" do

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
            params: {}.to_json,
            headers: auth_headers
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to match(/image_id or label is required/)
     end
 
@@ -126,7 +126,7 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
            params: { cells: [] }.to_json,
            headers: auth_headers
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to match(/cells must be a non-empty array/)
     end
 
@@ -172,7 +172,7 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
              headers: auth_headers
       }.not_to change { board.reload.board_images.count }
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       errors = JSON.parse(response.body)["errors"]
       expect(errors).to be_an(Array)
       expect(errors.first["index"]).to eq(1)

--- a/spec/requests/api/internal/generated_boards_spec.rb
+++ b/spec/requests/api/internal/generated_boards_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "API::Internal::GeneratedBoards", type: :request do
              params: {}.to_json,
              headers: auth_headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("Topic is required")
       end
 

--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "API::Internal::Profiles", type: :request do
             params: { profile: { username: "" } }.to_json,
             headers: json_headers
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       body = JSON.parse(response.body)
       expect(body["error"]).to eq("Profile update failed")
       expect(body["details"]).to be_an(Array)

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "API::Profiles", type: :request do
 
       it "returns 422 slug_locked with next_edit_at" do
         put_slug("different-link")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         body = JSON.parse(response.body)
         expect(body["error"]).to eq("slug_locked")
         expect(body["next_edit_at"]).to be_present
@@ -145,13 +145,13 @@ RSpec.describe "API::Profiles", type: :request do
     context "validation errors" do
       it "returns slug_invalid for bad format" do
         put_slug("Bad_Slug!!")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_invalid")
       end
 
       it "returns slug_reserved for reserved words" do
         put_slug("admin")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_reserved")
       end
 
@@ -159,7 +159,7 @@ RSpec.describe "API::Profiles", type: :request do
         other_child = FactoryBot.create(:child_account, user: owner, owner: owner)
         Profile.new(profileable: other_child, username: "taken-name", slug: "taken-name").save!
         put_slug("taken-name")
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_taken")
       end
     end

--- a/spec/requests/api/subscriptions_change_plan_portal_session_spec.rb
+++ b/spec/requests/api/subscriptions_change_plan_portal_session_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "POST /api/subscriptions/change_plan_portal_session", type: :requ
 
       do_post(plan_key: "nonsense")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("Unknown or unsupported plan")
     end
   end
@@ -127,7 +127,7 @@ RSpec.describe "POST /api/subscriptions/change_plan_portal_session", type: :requ
 
       do_post(plan_key: "free")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe "POST /api/subscriptions/change_plan_portal_session", type: :requ
 
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
     end
   end
@@ -151,7 +151,7 @@ RSpec.describe "POST /api/subscriptions/change_plan_portal_session", type: :requ
 
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
     end
   end

--- a/spec/requests/api/subscriptions_change_plan_spec.rb
+++ b/spec/requests/api/subscriptions_change_plan_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
 
       do_post(plan_key: "basic")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("Already on this plan")
     end
   end
@@ -158,7 +158,7 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
 
       do_post(plan_key: "nonsense")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -166,7 +166,7 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
     it "returns 422" do
       do_post(plan_key: "free")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -176,7 +176,7 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
     it "returns 422" do
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
     end
   end
@@ -190,7 +190,7 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
     it "returns 422" do
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 

--- a/spec/requests/api/subscriptions_preview_plan_change_spec.rb
+++ b/spec/requests/api/subscriptions_preview_plan_change_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     it "returns 422" do
       do_post(plan_key: "basic")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("Already on this plan")
     end
   end
@@ -139,7 +139,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     it "returns 422" do
       do_post(plan_key: "nonsense")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("Unknown or unsupported plan")
     end
   end
@@ -148,7 +148,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     it "returns 422" do
       do_post(plan_key: "free")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 
@@ -158,7 +158,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     it "returns 422" do
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error"]).to eq("No active subscription to change")
     end
   end
@@ -172,7 +172,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     it "returns 422" do
       do_post
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                headers: headers
         }.not_to change { Board.count }
         expect(BuildBoardSetJob.jobs.size).to eq(jobs_before)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -329,7 +329,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         }.not_to change { Board.count }
         expect(BuildBoardSetJob.jobs.size).to eq(jobs_before)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
       end
 
@@ -349,7 +349,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "home" }.to_json,
              headers: headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "keeps the whole built set editable (no spurious board_locked)" do
@@ -463,7 +463,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
              params: { communicator_id: communicator.id, template: "home" }.to_json,
              headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("build_failed")
 
         root = communicator.reload.board_builder_root
@@ -556,7 +556,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                headers: headers
         }.not_to change { communicator.child_boards.count }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
       end
 

--- a/spec/requests/api/v1/email_signup_spec.rb
+++ b/spec/requests/api/v1/email_signup_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
         do_post(email: "taken@example.com")
       }.not_to change(User, :count)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       body = JSON.parse(response.body)
       expect(body["error_code"]).to eq("email_taken")
       expect(body["error"]).to eq("Email has already been taken")
@@ -153,7 +153,7 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
 
       do_post(email: "taken@example.com")
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(JSON.parse(response.body)["error_code"]).to eq("email_taken")
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
         expect {
           do_post(email: bad)
         }.not_to change(User, :count)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to be_present
       end
     end

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
       it "returns 422" do
         post "/api/v1/onboarding/myspeak",
              params: base_payload.merge(name: "").to_json, headers: headers
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["details"]).to include(/Name/)
       end
     end
@@ -151,7 +151,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         post "/api/v1/onboarding/myspeak",
              params: base_payload.merge(slug: "Bad_Slug!").to_json, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_invalid")
       end
 
@@ -159,7 +159,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         post "/api/v1/onboarding/myspeak",
              params: base_payload.merge(slug: "admin").to_json, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_reserved")
       end
 
@@ -169,7 +169,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         post "/api/v1/onboarding/myspeak",
              params: base_payload.merge(slug: "river-stone").to_json, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error"]).to eq("slug_taken")
       end
 
@@ -348,7 +348,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
 
         post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         body = JSON.parse(response.body)
         expect(body["error"]).to eq("communicator_slot_unavailable")
       end

--- a/spec/requests/api/v1/set_password_spec.rb
+++ b/spec/requests/api/v1/set_password_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "set password endpoints", type: :request do
           params: { password: "newpassword1", password_confirmation: "different1" },
           headers: auth_headers(invited_user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         invited_user.reload
         expect(invited_user.invitation_token).to be_present
         expect(User.valid_credentials?("invited@example.com", "newpassword1")).to be_nil
@@ -47,7 +47,7 @@ RSpec.describe "set password endpoints", type: :request do
           params: { password: "x", password_confirmation: "x" },
           headers: auth_headers(invited_user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         invited_user.reload
         expect(invited_user.invitation_token).to be_present
         expect(User.valid_credentials?("invited@example.com", "x")).to be_nil
@@ -62,7 +62,7 @@ RSpec.describe "set password endpoints", type: :request do
           params: { password: "newpassword1", password_confirmation: "newpassword1" },
           headers: auth_headers(user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)["error_code"]).to eq("password_already_set")
       end
     end


### PR DESCRIPTION
## Summary

- Replaced all 311 occurrences of `:unprocessable_entity` with `:unprocessable_content` across 68 files (controllers, helpers, and specs)
- Both symbols map to HTTP 422 — Rack deprecated the old name and will remove it in a future version
- No behavioral change; purely eliminates the deprecation warning

## Test plan

- [x] `rspec spec/requests/api/board_groups_spec.rb spec/requests/api/profiles_spec.rb` — 44 examples, 0 failures
- [x] `rspec spec/controllers/api/menus_controller_spec.rb` — 3 examples, 0 failures
- [x] Verified 0 remaining occurrences of `:unprocessable_entity` in `app/` and `spec/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)