### PR TITLE
perf(ci): parallelize RSpec across 3 CI workers and harden test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  rspec:
+  rspec-shard:
     runs-on: ubuntu-latest
 
     strategy:
@@ -83,3 +83,15 @@ jobs:
           fi
           echo "Running $(echo "$FILES" | wc -l | tr -d ' ') spec files (shard ${{ matrix.ci_node_index }})"
           bundle exec rspec $FAIL_FAST $FILES
+
+  rspec:
+    needs: rspec-shard
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check shard results
+        run: |
+          if [ "${{ needs.rspec-shard.result }}" != "success" ]; then
+            echo "One or more RSpec shards failed"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_index: [0, 1, 2]
+        ci_node_total: [3]
+
     services:
       postgres:
         image: postgres:15
@@ -36,7 +42,7 @@ jobs:
 
     env:
       RAILS_ENV: test
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/itty_bitty_boards_test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/itty_bitty_boards_test_${{ matrix.ci_node_index }}
       # Dummy secrets so boot doesn't require config/master.key or real keys
       # in CI. Initializers that ENV.fetch these will read the dummies.
       SECRET_KEY_BASE: dummy-ci-secret-key-base-not-used-in-prod
@@ -61,8 +67,19 @@ jobs:
           ruby-version: 3.3.0
           bundler-cache: true
 
+      - name: Create test database
+        run: |
+          PGPASSWORD=postgres createdb -h localhost -U postgres itty_bitty_boards_test_${{ matrix.ci_node_index }}
+
       - name: Prepare test database
         run: bin/rails db:schema:load
 
-      - name: RSpec
-        run: bundle exec rspec
+      - name: RSpec (shard ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }})
+        run: |
+          FILES=$(find spec -name '*_spec.rb' | sort | awk "NR % ${{ matrix.ci_node_total }} == ${{ matrix.ci_node_index }}")
+          FAIL_FAST=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FAIL_FAST="--fail-fast"
+          fi
+          echo "Running $(echo "$FILES" | wc -l | tr -d ' ') spec files (shard ${{ matrix.ci_node_index }})"
+          bundle exec rspec $FAIL_FAST $FILES

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ spec/.DS_Store
 .DS_Store
 
 spec/data/*.obf
+spec/examples.txt
 

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--order random

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "test-prof", "~> 1.4"
+  gem "webmock"
 end
 
 #  User authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,9 @@ GEM
     chunky_png (1.4.0)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -237,6 +240,7 @@ GEM
       activesupport (>= 7)
     grover (1.2.3)
       nokogiri (~> 1)
+    hashdiff (1.2.1)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -521,6 +525,7 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.2.0)
     stripe (12.6.0)
+    test-prof (1.6.1)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -544,6 +549,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -621,8 +630,10 @@ DEPENDENCIES
   simple_form
   sprockets-rails
   stripe (~> 12.0)
+  test-prof (~> 1.4)
   tzinfo-data
   web-console
+  webmock
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/spec/models/coaching_prompt_set_spec.rb
+++ b/spec/models/coaching_prompt_set_spec.rb
@@ -27,20 +27,20 @@ RSpec.describe CoachingPromptSet, type: :model do
 
     let!(:snack_set) do
       create(:coaching_prompt_set,
-        slug: "snack_time_test",
-        match_tags: %w[snack snack_time food],
+        slug: "rspec_snack_set",
+        match_tags: %w[rspec_snack_tag rspec_food_tag],
         published: true)
     end
 
     let!(:car_set) do
       create(:coaching_prompt_set,
-        slug: "car_ride_test",
-        match_tags: %w[car drive],
+        slug: "rspec_car_set",
+        match_tags: %w[rspec_car_tag rspec_drive_tag],
         published: true)
     end
 
     it "returns the curated set that matches a board tag" do
-      board.update!(tags: ["snack_time"])
+      board.update!(tags: ["rspec_snack_tag"])
       expect(described_class.match_for(board)).to eq(snack_set)
     end
 
@@ -50,24 +50,24 @@ RSpec.describe CoachingPromptSet, type: :model do
     end
 
     it "falls back to matching against tokens in the board name" do
-      board.update!(tags: [], name: "Our Car Drive")
+      board.update!(tags: [], name: "Rspec_car_tag Vehicle")
       expect(described_class.match_for(board)).to eq(car_set)
     end
 
     it "ignores unpublished sets" do
       snack_set.update!(published: false)
-      board.update!(tags: ["snack"])
+      board.update!(tags: ["rspec_snack_tag"])
       expect(described_class.match_for(board)).to be_nil
     end
 
     it "ignores ai_generated sets even when tags match" do
       snack_set.update!(source: "ai_generated")
-      board.update!(tags: ["snack"])
+      board.update!(tags: ["rspec_snack_tag"])
       expect(described_class.match_for(board)).to be_nil
     end
 
     it "respects board language" do
-      board.update!(tags: ["snack"], language: "es")
+      board.update!(tags: ["rspec_snack_tag"], language: "es")
       expect(described_class.match_for(board)).to be_nil
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,10 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "sidekiq/testing"
 Sidekiq::Testing.fake!
+require "test_prof/recipes/rspec/let_it_be"
+require "test_prof/recipes/rspec/before_all"
+require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)
 
 Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe "Admin::Users", type: :request do
   include Devise::Test::IntegrationHelpers
 
-  let!(:admin) { create(:admin_user) }
-  let!(:user1) { create(:user, email: "alice@example.com", name: "Alice") }
-  let!(:user2) { create(:user, email: "bob@example.com", name: "Bob", plan_type: "pro") }
+  let_it_be(:admin) { create(:admin_user) }
+  let_it_be(:user1, reload: true) { create(:user, email: "alice@example.com", name: "Alice") }
+  let_it_be(:user2) { create(:user, email: "bob@example.com", name: "Bob", plan_type: "pro") }
 
   before do
     allow_any_instance_of(ActionView::Helpers::AssetTagHelper)

--- a/spec/requests/api/audits_public_word_click_spec.rb
+++ b/spec/requests/api/audits_public_word_click_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "API::Audits public word click", type: :request do
-  let!(:user) { create(:user) }
-  let!(:account) { create(:child_account, user: user) }
-  let!(:profile) { create(:profile, profileable: account) }
-  let!(:board) { create(:board, user: user) }
+  let_it_be(:user, reload: true) { create(:user) }
+  let_it_be(:account, reload: true) { create(:child_account, user: user) }
+  let_it_be(:profile) { create(:profile, profileable: account) }
+  let_it_be(:board) { create(:board, user: user) }
 
   before do
     allow_any_instance_of(API::AuditsController)

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "API::Boards", type: :request do
-  let!(:user)        { create(:user) }
-  let!(:other_user)  { create(:user) }
-  let!(:board)       { create(:board, user: user, name: "User Board Alpha") }
-  let!(:other_board) { create(:board, user: other_user, name: "Other Board Beta") }
+  let_it_be(:user)        { create(:user) }
+  let_it_be(:other_user)  { create(:user) }
+  let_it_be(:board, reload: true) { create(:board, user: user, name: "User Board Alpha") }
+  let_it_be(:other_board) { create(:board, user: other_user, name: "Other Board Beta") }
 
   describe "GET /api/boards" do
     it "returns 200 for unauthenticated requests (public boards are accessible)" do

--- a/spec/requests/api/coaching_prompts_spec.rb
+++ b/spec/requests/api/coaching_prompts_spec.rb
@@ -1,19 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "API::CoachingPrompts", type: :request do
-  let!(:user)  { create(:user) }
-  let!(:other) { create(:user) }
+  let_it_be(:user)  { create(:user) }
+  let_it_be(:other) { create(:user) }
 
-  let!(:snack) do
+  let_it_be(:snack) do
     create(:coaching_prompt_set,
-      slug: "snack_time_test",
-      name: "Snack Time Test",
-      match_tags: %w[snack snack_time],
+      slug: "rspec_snack_test",
+      name: "RSpec Snack Test",
+      match_tags: %w[rspec_snack_tag],
       published: true,
       user_id: nil)
   end
 
-  let!(:my_set) do
+  let_it_be(:my_set) do
     create(:coaching_prompt_set,
       slug: "user-mine",
       name: "My Custom Set",
@@ -22,7 +22,7 @@ RSpec.describe "API::CoachingPrompts", type: :request do
       published: true)
   end
 
-  let!(:other_user_set) do
+  let_it_be(:other_user_set) do
     create(:coaching_prompt_set,
       slug: "user-other",
       name: "Other User Set",
@@ -41,19 +41,19 @@ RSpec.describe "API::CoachingPrompts", type: :request do
       get "/api/coaching_prompts", headers: auth_headers(user)
       expect(response).to have_http_status(:ok)
       slugs = JSON.parse(response.body).map { |r| r["slug"] }
-      expect(slugs).to include("snack_time_test", "user-mine")
+      expect(slugs).to include("rspec_snack_test", "user-mine")
       expect(slugs).not_to include("user-other")
     end
   end
 
   describe "GET /api/coaching_prompts?board_id=:id" do
-    let(:board) { create(:board, user: user, tags: ["snack_time"]) }
+    let(:board) { create(:board, user: user, tags: ["rspec_snack_tag"]) }
 
     it "returns the curated prompt set when the board has a matching tag" do
       get "/api/coaching_prompts", params: { board_id: board.id }, headers: auth_headers(user)
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
-      expect(json["slug"]).to eq("snack_time_test")
+      expect(json["slug"]).to eq("rspec_snack_test")
     end
 
     it "404s when the board does not exist" do

--- a/spec/requests/api/revenue_cat_webhook_spec.rb
+++ b/spec/requests/api/revenue_cat_webhook_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 # downgrades to free, cancellation is analytics-only (still entitled until
 # expiry), billing issue keeps access during the grace period.
 RSpec.describe "POST /api/billing/webhooks (RevenueCat)", type: :request do
-  let!(:user) { FactoryBot.create(:user, plan_type: "free") }
+  let_it_be(:user, reload: true) { FactoryBot.create(:user, plan_type: "free") }
 
   before { reset_user_credits!(user) }
 

--- a/spec/requests/api/scenarios_spec.rb
+++ b/spec/requests/api/scenarios_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "API::Scenarios", type: :request do
-  let!(:user) { create(:user) }
+  let_it_be(:user, reload: true) { create(:user) }
 
   describe "POST /api/scenarios/suggestion" do
     let(:fake_client) { instance_double(OpenAI::Client) }

--- a/spec/requests/api/webhooks_plan_type_spec.rb
+++ b/spec/requests/api/webhooks_plan_type_spec.rb
@@ -6,7 +6,7 @@ require "rails_helper"
 RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
   include StripeHelpers
 
-  let!(:user) do
+  let_it_be(:user, reload: true) do
     FactoryBot.create(:user,
       stripe_customer_id: "cus_plan_type_user",
       plan_type: "basic",

--- a/spec/services/coaching_prompt_generator_spec.rb
+++ b/spec/services/coaching_prompt_generator_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe CoachingPromptGenerator do
   describe ".for" do
     let!(:snack_set) do
       create(:coaching_prompt_set,
-        slug: "snack_time_test",
-        match_tags: %w[snack snack_time],
+        slug: "rspec_gen_snack",
+        match_tags: %w[rspec_gen_snack_tag],
         published: true)
     end
 
     it "returns the curated set when one matches" do
-      board.update!(tags: ["snack_time"])
+      board.update!(tags: ["rspec_gen_snack_tag"])
       expect(described_class.for(board)).to eq(snack_set)
     end
 
@@ -30,10 +30,11 @@ RSpec.describe CoachingPromptGenerator do
     it "returns the seeded fallback set when staging is on" do
       board.update!(tags: ["unrelated"])
       allow(AppEnv).to receive(:staging?).and_return(true)
-      fallback = create(:coaching_prompt_set,
-        slug: CoachingPromptGenerator::FALLBACK_SLUG,
-        published: false,
-        match_tags: [])
+      fallback = CoachingPromptSet.find_or_create_by!(slug: CoachingPromptGenerator::FALLBACK_SLUG) do |set|
+        set.name = "Fallback"
+        set.published = false
+        set.match_tags = []
+      end
 
       expect(described_class.for(board)).to eq(fallback)
     end
@@ -79,10 +80,11 @@ RSpec.describe CoachingPromptGenerator do
     it "returns the fallback when OpenAI raises an error" do
       board.update!(tags: ["unknown_topic"])
       allow(AppEnv).to receive(:staging?).and_return(false)
-      fallback = create(:coaching_prompt_set,
-        slug: CoachingPromptGenerator::FALLBACK_SLUG,
-        published: false,
-        match_tags: [])
+      fallback = CoachingPromptSet.find_or_create_by!(slug: CoachingPromptGenerator::FALLBACK_SLUG) do |set|
+        set.name = "Fallback"
+        set.published = false
+        set.match_tags = []
+      end
 
       fake_client = instance_double(OpenAI::Client)
       allow(OpenAI::Client).to receive(:new).and_return(fake_client)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,14 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
   if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
     config.default_formatter = "doc"
   end
 
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
   config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end

--- a/spec/support/stub_aac_categorizer.rb
+++ b/spec/support/stub_aac_categorizer.rb
@@ -1,0 +1,19 @@
+OPENAI_STUB_BODY = { choices: [{ message: { content: '{"part_of_speech":"noun"}' } }] }.to_json.freeze
+
+# Global stub survives for before_all / let_it_be factory calls that trigger
+# AacWordCategorizer (via Image#ensure_defaults) before the first example runs.
+WebMock.stub_request(:post, "https://api.openai.com/v1/chat/completions")
+  .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: OPENAI_STUB_BODY)
+
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    # Re-register after webmock/rspec clears stubs between examples
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: OPENAI_STUB_BODY)
+
+    file = example.metadata[:file_path].to_s
+    unless file.include?("aac_word_categorizer")
+      allow(AacWordCategorizer).to receive(:categorize).and_return("noun")
+    end
+  end
+end

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -1,0 +1,36 @@
+# Default stubs for external APIs that callbacks/factories may hit.
+# webmock/rspec resets stubs between examples, so these must run in
+# before(:each) to survive across the suite.
+PLACEHOLDER_IMAGE = Rails.root.join("public/placeholder.jpeg").read.freeze
+
+RSpec.configure do |config|
+  config.before(:each) do
+    # Stripe API
+    stub_request(:any, /api\.stripe\.com/)
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { data: [], has_more: false, object: "list" }.to_json
+      )
+
+    # UI Avatars (Profile#set_fake_avatar)
+    stub_request(:get, /ui-avatars\.com/)
+      .to_return(status: 200, headers: { "Content-Type" => "image/png" }, body: PLACEHOLDER_IMAGE)
+
+    # Robohash (Profile#set_fake_avatar)
+    stub_request(:get, /robohash\.org/)
+      .to_return(status: 200, headers: { "Content-Type" => "image/png" }, body: PLACEHOLDER_IMAGE)
+
+    # CloudFront / S3 — image downloads
+    stub_request(:get, /cloudfront\.net/)
+      .to_return(status: 200, headers: { "Content-Type" => "image/png" }, body: PLACEHOLDER_IMAGE)
+
+    # PostHog capture
+    stub_request(:post, /posthog\.com/)
+      .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+
+    # Mailchimp API
+    stub_request(:any, /api\.mailchimp\.com/)
+      .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+  end
+end


### PR DESCRIPTION
## Summary

- **3-worker CI parallelism** via GitHub Actions matrix strategy — each shard gets its own database and runs ~1/3 of spec files (shell-based `find | sort | awk` splitting, no new gem)
- **`--fail-fast` on PR runs** so broken PRs surface failures quickly
- **Activated dormant RSpec config**: random ordering, `--only-failures` persistence, top-10 slowest profiling, `:focus` filter
- **Added `webmock` gem** — blocks real HTTP in tests; caught a real OpenAI API key leaking via `AacWordCategorizer` (now stubbed globally)
- **Added `test-prof` gem** — `let_it_be` conversions in 8 high-example request specs reduce per-example factory overhead
- **Fixed seeded-data collisions** in coaching prompt specs (unique `rspec_*` prefixed slugs)

## Test plan

- Ran all 154 examples across changed spec files — **0 failures**
- Full suite: 1667 examples, 2 failures (both **pre-existing**, unrelated to this PR):
  - `user_plan_limits_spec:25` — ENV override conflict
  - `generate_board_preview_job_spec:17` — CloudFront URL vs Active Storage URL assertion
- CI should run 3 parallel shards; expect ~2.5 min wall time (down from ~5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)