### PR TITLE
feat(admin): add AI credit adjustment to admin user detail page

### DIFF
--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class API::Admin::UsersController < API::Admin::ApplicationController
-  before_action :set_user, only: %i[ show destroy update ]
+  before_action :set_user, only: %i[ show destroy update adjust_credits ]
 
   # GET /users or /users.json
   ALLOWED_SORT_FIELDS = %w[created_at updated_at email name board_count].freeze
@@ -97,6 +97,38 @@ class API::Admin::UsersController < API::Admin::ApplicationController
     else
       render json: @user.errors, status: :unprocessable_content
     end
+  end
+
+  def adjust_credits
+    unless current_admin&.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    amount = params[:amount].to_i
+    source = params[:source].presence_in(%w[plan topup]) || "plan"
+    reason = params[:reason].presence
+
+    if amount.zero?
+      render json: { error: "Amount must not be zero" }, status: :unprocessable_content
+      return
+    end
+
+    txn = CreditService.admin_adjust!(
+      @user,
+      amount: amount,
+      source: source,
+      admin: current_admin,
+      reason: reason,
+    )
+
+    render json: {
+      success: true,
+      transaction_id: txn.id,
+      balance: CreditService.balance(@user.reload),
+    }
+  rescue ArgumentError => e
+    render json: { error: e.message }, status: :unprocessable_content
   end
 
   def send_welcome_email

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -284,6 +284,35 @@ class CreditService
       end
     end
 
+    # Admin-only adjustment. Positive amount adds credits, negative removes them.
+    # Records an admin_adjust transaction for audit trail.
+    def admin_adjust!(user, amount:, source: "plan", admin:, reason: nil)
+      raise ArgumentError, "amount must not be zero" if amount.zero?
+      raise ArgumentError, "invalid source" unless %w[plan topup].include?(source)
+
+      ActiveRecord::Base.transaction do
+        user.lock!
+
+        if source == "plan"
+          new_balance = user.plan_credits_balance.to_i + amount
+          raise ArgumentError, "adjustment would make plan balance negative (#{new_balance})" if new_balance < 0
+          user.update_columns(plan_credits_balance: new_balance)
+        else
+          new_balance = user.topup_credits_balance.to_i + amount
+          raise ArgumentError, "adjustment would make topup balance negative (#{new_balance})" if new_balance < 0
+          user.update_columns(topup_credits_balance: new_balance)
+        end
+
+        CreditTransaction.create!(
+          user: user,
+          amount: amount,
+          kind: "admin_adjust",
+          source: source,
+          metadata: { admin_id: admin.id, admin_email: admin.email, reason: reason }.compact,
+        )
+      end
+    end
+
     # Shadow-mode: try to spend, but never raise. Returns true if it would have succeeded.
     # Used during Phase 1 rollout for telemetry.
     def shadow_spend(user, feature_key:, amount: nil, metadata: {})

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -40,13 +40,101 @@
   </div>
   <div class="admin-card border rounded-xl p-4">
     <p class="text-xs text-t2 mb-1">Credits</p>
-    <p class="text-2xl font-semibold text-t1"><%= @credit_balance %></p>
+    <p class="text-2xl font-semibold text-t1"><%= @credit_balance[:total] %></p>
+    <p class="text-[10px] text-t3 mt-1">
+      Plan: <%= @credit_balance[:plan] %> · Topup: <%= @credit_balance[:topup] %>
+    </p>
   </div>
   <div class="admin-card border rounded-xl p-4">
     <p class="text-xs text-t2 mb-1">Sign-ins</p>
     <p class="text-2xl font-semibold text-t1"><%= @user.sign_in_count %></p>
   </div>
 </div>
+
+<%# ─── Credit adjustment ──────────────────────────────────── %>
+<div class="admin-card border rounded-xl p-6 mb-8">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Adjust Credits</h2>
+
+  <div id="credit-flash" class="hidden text-xs rounded px-3 py-2 mb-4"></div>
+
+  <form id="credit-adjust-form" class="flex flex-wrap items-end gap-3">
+    <div>
+      <label class="block text-[10px] text-t3 mb-1">Amount</label>
+      <input type="number" name="amount" required
+             class="admin-input w-28 text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1"
+             placeholder="e.g. 100 or -50">
+    </div>
+    <div>
+      <label class="block text-[10px] text-t3 mb-1">Source</label>
+      <select name="source" class="admin-input text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1">
+        <option value="plan">Plan</option>
+        <option value="topup">Topup</option>
+      </select>
+    </div>
+    <div class="flex-1 min-w-[140px]">
+      <label class="block text-[10px] text-t3 mb-1">Reason (optional)</label>
+      <input type="text" name="reason"
+             class="admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1"
+             placeholder="e.g. support request, testing">
+    </div>
+    <button type="submit"
+            class="text-sm font-medium px-4 py-1.5 rounded transition-colors"
+            style="background: var(--accent); color: var(--bg);">
+      Apply
+    </button>
+  </form>
+
+  <p class="text-[10px] text-t3 mt-2">Positive = add credits, negative = remove. Recorded as admin_adjust in the ledger.</p>
+</div>
+
+<script>
+  document.getElementById('credit-adjust-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    var form = e.target;
+    var flash = document.getElementById('credit-flash');
+    var btn = form.querySelector('button[type="submit"]');
+    btn.disabled = true;
+    btn.textContent = '…';
+
+    var data = {
+      amount: parseInt(form.amount.value, 10),
+      source: form.source.value,
+      reason: form.reason.value || null
+    };
+
+    fetch('/api/admin/users/<%= @user.id %>/adjust_credits', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify(data)
+    })
+    .then(function(r) { return r.json().then(function(j) { return { ok: r.ok, body: j }; }); })
+    .then(function(res) {
+      flash.classList.remove('hidden', 'bg-green-900/60', 'text-green-300', 'bg-red-900/60', 'text-red-300');
+      if (res.ok) {
+        flash.classList.add('bg-green-900/60', 'text-green-300');
+        flash.textContent = 'Credits adjusted. Plan: ' + res.body.balance.plan + ' · Topup: ' + res.body.balance.topup + ' · Total: ' + res.body.balance.total;
+        form.amount.value = '';
+        form.reason.value = '';
+      } else {
+        flash.classList.add('bg-red-900/60', 'text-red-300');
+        flash.textContent = res.body.error || 'Something went wrong.';
+      }
+    })
+    .catch(function(err) {
+      flash.classList.remove('hidden', 'bg-green-900/60', 'text-green-300', 'bg-red-900/60', 'text-red-300');
+      flash.classList.add('bg-red-900/60', 'text-red-300');
+      flash.textContent = 'Network error: ' + err.message;
+    })
+    .finally(function() {
+      btn.disabled = false;
+      btn.textContent = 'Apply';
+    });
+  });
+</script>
 
 <%# ─── Two-column: Account + Activity ────────────────────── %>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -466,6 +466,7 @@ Rails.application.routes.draw do
           post "send_setup_email"
           post "send_temp_login_email"
           post "send_partner_welcome_email"
+          post "adjust_credits"
         end
         collection do
           delete "destroy_users"

--- a/spec/requests/api/admin/users_spec.rb
+++ b/spec/requests/api/admin/users_spec.rb
@@ -64,6 +64,87 @@ RSpec.describe "API::Admin::Users", type: :request do
     end
   end
 
+  describe "POST /api/admin/users/:id/adjust_credits" do
+    before { reset_user_credits!(user) }
+
+    context "when unauthenticated" do
+      it "returns 401" do
+        post "/api/admin/users/#{user.id}/adjust_credits", params: { amount: 100 }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated as non-admin" do
+      it "returns 401" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: 100 },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "when authenticated as admin" do
+      it "adds plan credits" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: 100, source: "plan", reason: "testing" },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["success"]).to be true
+        expect(body["balance"]["plan"]).to eq(100)
+        expect(user.reload.plan_credits_balance).to eq(100)
+      end
+
+      it "adds topup credits" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: 50, source: "topup" },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["balance"]["topup"]).to eq(50)
+      end
+
+      it "removes credits with negative amount" do
+        CreditService.grant_plan!(user, amount: 200, period_end: 30.days.from_now)
+
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: -50, source: "plan" },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.plan_credits_balance).to eq(150)
+      end
+
+      it "defaults source to plan" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: 25 },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["balance"]["plan"]).to eq(25)
+      end
+
+      it "rejects zero amount" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: 0 },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "rejects adjustment that would make balance negative" do
+        post "/api/admin/users/#{user.id}/adjust_credits",
+             params: { amount: -999, source: "plan" },
+             headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
   describe "DELETE /api/admin/users/cleanup_demo" do
     let!(:demo1) { create(:user, email: "bhannajohns+one@gmail.com") }
     let!(:demo2) { create(:user, email: "bhannajohns+two@gmail.com") }

--- a/spec/services/credit_service_spec.rb
+++ b/spec/services/credit_service_spec.rb
@@ -314,6 +314,69 @@ RSpec.describe CreditService, type: :service do
     end
   end
 
+  describe ".admin_adjust!" do
+    let(:admin_user) { FactoryBot.create(:admin_user) }
+
+    it "adds plan credits and records an admin_adjust transaction" do
+      described_class.grant_plan!(user, amount: 10, period_end: 30.days.from_now)
+
+      txn = described_class.admin_adjust!(user, amount: 50, source: "plan", admin: admin_user, reason: "support request")
+
+      user.reload
+      expect(user.plan_credits_balance).to eq(60)
+      expect(txn.kind).to eq("admin_adjust")
+      expect(txn.amount).to eq(50)
+      expect(txn.source).to eq("plan")
+      expect(txn.metadata["admin_id"]).to eq(admin_user.id)
+      expect(txn.metadata["reason"]).to eq("support request")
+    end
+
+    it "removes plan credits with a negative amount" do
+      described_class.grant_plan!(user, amount: 100, period_end: 30.days.from_now)
+
+      txn = described_class.admin_adjust!(user, amount: -30, source: "plan", admin: admin_user)
+
+      user.reload
+      expect(user.plan_credits_balance).to eq(70)
+      expect(txn.amount).to eq(-30)
+    end
+
+    it "adds topup credits" do
+      txn = described_class.admin_adjust!(user, amount: 200, source: "topup", admin: admin_user)
+
+      user.reload
+      expect(user.topup_credits_balance).to eq(200)
+      expect(txn.source).to eq("topup")
+    end
+
+    it "removes topup credits" do
+      described_class.grant_topup!(user, amount: 100)
+
+      txn = described_class.admin_adjust!(user, amount: -40, source: "topup", admin: admin_user)
+
+      user.reload
+      expect(user.topup_credits_balance).to eq(60)
+    end
+
+    it "raises when amount is zero" do
+      expect {
+        described_class.admin_adjust!(user, amount: 0, source: "plan", admin: admin_user)
+      }.to raise_error(ArgumentError, /must not be zero/)
+    end
+
+    it "raises when adjustment would make balance negative" do
+      expect {
+        described_class.admin_adjust!(user, amount: -10, source: "plan", admin: admin_user)
+      }.to raise_error(ArgumentError, /negative/)
+    end
+
+    it "raises for invalid source" do
+      expect {
+        described_class.admin_adjust!(user, amount: 10, source: "invalid", admin: admin_user)
+      }.to raise_error(ArgumentError, /invalid source/)
+    end
+  end
+
   describe ".shadow_spend" do
     it "returns true and decrements when there are enough credits" do
       described_class.grant_plan!(user, amount: 10, period_end: 30.days.from_now)


### PR DESCRIPTION
## Summary

- Adds `CreditService.admin_adjust!` for signed credit adjustments (plan or topup) with negative-balance guard and full audit trail (`admin_adjust` ledger kind)
- New `POST /api/admin/users/:id/adjust_credits` admin-only endpoint
- Admin user detail page now shows plan/topup credit breakdown and an inline AJAX form to adjust credits without page reload

## Test plan

- 7 new `CreditService` specs: add/remove plan credits, add/remove topup credits, zero-amount rejection, negative-balance guard, invalid source
- 8 new request specs: auth gates (unauthed, non-admin), add plan/topup credits, remove credits, default source, zero rejection, negative-balance rejection
- All 67 specs in the two touched files pass locally (`bundle exec rspec spec/services/credit_service_spec.rb spec/requests/api/admin/users_spec.rb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)