### PR TITLE
feat(board-builder): add grid dimensions to complexity levels API

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -7,13 +7,16 @@ module API
       COMPLEXITY_LEVELS = [
         { key: "starter", name: "Starter",
           description: "A focused set with essential categories — great for beginning communicators.",
-          fringe_page_range: "4-6" },
+          fringe_page_range: "4-6",
+          grid_rows: 6, grid_columns: 10 },
         { key: "standard", name: "Standard",
           description: "A solid vocabulary foundation with a good range of categories.",
-          fringe_page_range: "8-10" },
+          fringe_page_range: "8-10",
+          grid_rows: 6, grid_columns: 10 },
         { key: "extended", name: "Extended",
           description: "A full vocabulary set with broad category coverage.",
-          fringe_page_range: "10-15" },
+          fringe_page_range: "10-15",
+          grid_rows: 7, grid_columns: 12 },
       ].freeze
 
       def templates

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    it "includes grid dimensions in levels" do
+      get "/api/v1/board_builder/templates", headers: headers
+      levels = JSON.parse(response.body)["levels"]
+      starter = levels.find { |l| l["key"] == "starter" }
+      expect(starter["grid_rows"]).to eq(6)
+      expect(starter["grid_columns"]).to eq(10)
+      extended = levels.find { |l| l["key"] == "extended" }
+      expect(extended["grid_rows"]).to eq(7)
+      expect(extended["grid_columns"]).to eq(12)
+    end
+
     describe "recommended_level" do
       it "is null without a communicator_id" do
         get "/api/v1/board_builder/templates", headers: headers


### PR DESCRIPTION
## Summary
- Adds `grid_rows` and `grid_columns` to each entry in `COMPLEXITY_LEVELS` in the board builder controller
- Starter/Standard → 6×10 (core-60), Extended → 7×12 (core-84)
- Frontend complexity cards need these to show grid size; this ships independently

## Test plan
- Added spec asserting `grid_rows`/`grid_columns` values for starter and extended levels
- Postgres not running locally (worktree env) — CI will run the full board builder spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)