### PR TITLE
fix: prevent stale/broken tile image URLs after board cloning

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1062,6 +1062,13 @@ class Board < ApplicationRecord
         new_board_image.predictive_board_id = board_image.predictive_board_id
         new_board_image.audio_url = board_image.audio_url
         new_board_image.save
+
+        # When the resolved image is a newly created stub (no docs yet),
+        # set_defaults leaves display_image_url blank. Fall back to the
+        # source image's URL so the tile isn't broken on first render.
+        if new_board_image.persisted? && new_board_image.display_image_url.blank? && original_image.src_url.present?
+          new_board_image.update_column(:display_image_url, original_image.src_url)
+        end
       end
     end
     @cloned_board.run_generate_preview_job if @cloned_board.board_images.any? && @cloned_board.valid?

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -226,7 +226,11 @@ class BoardImage < ApplicationRecord
   end
 
   def tile_image_url(viewing_user = nil)
-    display_image_url || image.display_tile_url(viewing_user) || image.display_image_url(viewing_user) || image.src_url
+    display_image_url.presence ||
+      image.display_tile_url(viewing_user) ||
+      image.display_image_url(viewing_user) ||
+      image.src_url.presence ||
+      Image.find_by(label: image.label, user_id: [nil, User::DEFAULT_ADMIN_ID])&.src_url
   end
 
   def get_predictive_image_for(viewing_user)

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -95,7 +95,7 @@ class Image < ApplicationRecord
   before_save :ensure_defaults
 
   after_save :update_board_images_audio, if: -> { need_to_update_board_images_audio? }
-  after_save :update_board_images_display_image, if: -> { src_url_changed? }
+  after_save :update_board_images_display_image, if: -> { saved_change_to_src_url? }
   # after_save :update_board_images_next_words, if: -> { next_words_changed? }
   after_save :update_background_color, if: -> { part_of_speech_changed? }
 
@@ -128,7 +128,7 @@ class Image < ApplicationRecord
   end
 
   def update_board_images_display_image
-    old_url = src_url_previously_was
+    old_url = src_url_before_last_save
     board_images.each do |bi|
       if bi.display_image_url.blank?
         bi.update!(display_image_url: src_url)

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -128,8 +128,15 @@ class Image < ApplicationRecord
   end
 
   def update_board_images_display_image
+    old_url = src_url_previously_was
     board_images.each do |bi|
-      bi.update!(display_image_url: src_url) if bi.display_image_url.blank?
+      if bi.display_image_url.blank?
+        bi.update!(display_image_url: src_url)
+      elsif old_url.present? && bi.display_image_url == old_url
+        # Tile was tracking the previous default — update it.
+        # User-custom tiles point to their own doc's URL and are skipped.
+        bi.update!(display_image_url: src_url)
+      end
     end
   end
 

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -139,4 +139,35 @@ RSpec.describe BoardImage, type: :model do
       expect(SaveAudioJob.jobs).to be_empty
     end
   end
+
+  describe "#tile_image_url" do
+    let(:user)  { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+    let(:image) { FactoryBot.create(:image, user: user) }
+    let(:board_image) do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    end
+
+    it "returns display_image_url when present" do
+      board_image.update_column(:display_image_url, "https://cdn.example.com/tile.webp")
+      expect(board_image.tile_image_url).to eq("https://cdn.example.com/tile.webp")
+    end
+
+    it "falls back to admin image src_url when all else is blank" do
+      admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      admin_image = FactoryBot.create(:image, label: image.label, user: admin)
+      admin_image.update_column(:src_url, "https://cdn.example.com/admin_fallback.webp")
+
+      board_image.update_column(:display_image_url, nil)
+      image.update_columns(src_url: nil)
+
+      expect(board_image.tile_image_url(user)).to eq("https://cdn.example.com/admin_fallback.webp")
+    end
+
+    it "does not hit the admin fallback when display_image_url is present" do
+      board_image.update_column(:display_image_url, "https://cdn.example.com/user_pick.webp")
+      expect(Image).not_to receive(:find_by).with(hash_including(user_id: [nil, User::DEFAULT_ADMIN_ID]))
+      expect(board_image.tile_image_url(user)).to eq("https://cdn.example.com/user_pick.webp")
+    end
+  end
 end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -103,10 +103,11 @@ RSpec.describe Board, type: :model do
       let(:other_user) { FactoryBot.create(:user) }
 
       it "backfills from the original image when the resolved image has no src_url" do
-        image.update_column(:src_url, "https://cdn.example.com/original.webp")
+        # Source image has no user_id so the clone creates a fresh stub
+        image.update_columns(src_url: "https://cdn.example.com/original.webp", user_id: nil)
 
         cloned = board.clone_with_images(other_user.id)
-        cloned_tile = cloned.board_images.first
+        cloned_tile = cloned.reload.board_images.first
 
         expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/original.webp")
       end
@@ -116,7 +117,7 @@ RSpec.describe Board, type: :model do
         existing.update_column(:src_url, "https://cdn.example.com/user_copy.webp")
 
         cloned = board.clone_with_images(other_user.id)
-        cloned_tile = cloned.board_images.first
+        cloned_tile = cloned.reload.board_images.first
 
         expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/user_copy.webp")
       end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -98,6 +98,29 @@ RSpec.describe Board, type: :model do
       cloned = board.clone_with_images(user.id)
       expect(cloned.settings["display_follows_preview"]).to be true
     end
+
+    context "tile display_image_url fallback on clone" do
+      let(:other_user) { FactoryBot.create(:user) }
+
+      it "backfills from the original image when the resolved image has no src_url" do
+        image.update_column(:src_url, "https://cdn.example.com/original.webp")
+
+        cloned = board.clone_with_images(other_user.id)
+        cloned_tile = cloned.board_images.first
+
+        expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/original.webp")
+      end
+
+      it "uses the resolved image's src_url when it exists" do
+        existing = FactoryBot.create(:image, label: image.label, user: other_user)
+        existing.update_column(:src_url, "https://cdn.example.com/user_copy.webp")
+
+        cloned = board.clone_with_images(other_user.id)
+        cloned_tile = cloned.board_images.first
+
+        expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/user_copy.webp")
+      end
+    end
   end
 
   describe "#update_grid_layout" do

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Board, type: :model do
 
       it "backfills from the original image when the resolved image has no src_url" do
         # Source image has no user_id so the clone creates a fresh stub
+        # (no docs, no src_url). The backfill uses the original image's URL.
         image.update_columns(src_url: "https://cdn.example.com/original.webp", user_id: nil)
 
         cloned = board.clone_with_images(other_user.id)
@@ -112,14 +113,14 @@ RSpec.describe Board, type: :model do
         expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/original.webp")
       end
 
-      it "uses the resolved image's src_url when it exists" do
-        existing = FactoryBot.create(:image, label: image.label, user: other_user)
-        existing.update_column(:src_url, "https://cdn.example.com/user_copy.webp")
+      it "picks up the source image's src_url via set_defaults" do
+        image.update_column(:src_url, "https://cdn.example.com/source.webp")
 
         cloned = board.clone_with_images(other_user.id)
         cloned_tile = cloned.reload.board_images.first
 
-        expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/user_copy.webp")
+        # Cross-user clone reuses the original image; set_defaults copies its src_url
+        expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/source.webp")
       end
     end
   end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -179,4 +179,38 @@ RSpec.describe Image, type: :model do
       expect(image.text_for_audio("fr")).to eq("hello")
     end
   end
+
+  describe "#update_board_images_display_image" do
+    let(:user)  { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+    let(:image) { FactoryBot.create(:image, user: user, src_url: "https://cdn.example.com/old.webp") }
+    let!(:board_image) do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true).tap do |bi|
+        bi.update_column(:display_image_url, "https://cdn.example.com/old.webp")
+      end
+    end
+
+    it "updates tiles that still show the previous default URL" do
+      image.update!(src_url: "https://cdn.example.com/new.webp")
+
+      board_image.reload
+      expect(board_image.display_image_url).to eq("https://cdn.example.com/new.webp")
+    end
+
+    it "fills tiles with a blank display_image_url" do
+      board_image.update_column(:display_image_url, nil)
+      image.update!(src_url: "https://cdn.example.com/new.webp")
+
+      board_image.reload
+      expect(board_image.display_image_url).to eq("https://cdn.example.com/new.webp")
+    end
+
+    it "does not overwrite a user-custom URL that differs from the old src_url" do
+      board_image.update_column(:display_image_url, "https://cdn.example.com/user_custom_doc.webp")
+      image.update!(src_url: "https://cdn.example.com/new.webp")
+
+      board_image.reload
+      expect(board_image.display_image_url).to eq("https://cdn.example.com/user_custom_doc.webp")
+    end
+  end
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -183,11 +183,15 @@ RSpec.describe Image, type: :model do
   describe "#update_board_images_display_image" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user) }
-    let(:image) { FactoryBot.create(:image, user: user, src_url: "https://cdn.example.com/old.webp") }
+    let(:image) { FactoryBot.create(:image, user: user) }
     let!(:board_image) do
-      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true).tap do |bi|
-        bi.update_column(:display_image_url, "https://cdn.example.com/old.webp")
-      end
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    end
+
+    before do
+      # Set starting state via update_columns to avoid triggering callbacks
+      image.update_columns(src_url: "https://cdn.example.com/old.webp")
+      board_image.update_column(:display_image_url, "https://cdn.example.com/old.webp")
     end
 
     it "updates tiles that still show the previous default URL" do
@@ -199,6 +203,8 @@ RSpec.describe Image, type: :model do
 
     it "fills tiles with a blank display_image_url" do
       board_image.update_column(:display_image_url, nil)
+      image.board_images.reset
+
       image.update!(src_url: "https://cdn.example.com/new.webp")
 
       board_image.reload
@@ -207,6 +213,7 @@ RSpec.describe Image, type: :model do
 
     it "does not overwrite a user-custom URL that differs from the old src_url" do
       board_image.update_column(:display_image_url, "https://cdn.example.com/user_custom_doc.webp")
+
       image.update!(src_url: "https://cdn.example.com/new.webp")
 
       board_image.reload


### PR DESCRIPTION
## Summary
- **Clone fallback**: when cloning a board for a different user, if the resolved image is a new stub (no docs yet), backfill `display_image_url` from the original image's `src_url` so the tile isn't broken on first render
- **Propagate src_url changes**: when a shared image's `src_url` changes (e.g. admin replaces artwork), update tiles still tracking the old default URL — tiles with user-custom URLs (their own doc) are never touched
- **Safety-net fallback**: add a final read-only fallback in `tile_image_url` to the admin/shared image with the same label, so a tile is never completely imageless

All three changes preserve user-uploaded/user-selected images — custom picks always win because they carry a URL distinct from the shared image's `src_url`.

## Test plan
- Added specs for `Board#clone_with_images` tile URL backfill (stub image + existing image paths)
- Added specs for `Image#update_board_images_display_image` (propagates to default tiles, fills blank tiles, skips user-custom tiles)
- Added specs for `BoardImage#tile_image_url` (user pick wins, admin fallback fires only when needed)
- Postgres not available locally — CI will run the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)