### PR TITLE
fix: lazily create Stripe customer for subscription read endpoints

### DIFF
--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -3,9 +3,14 @@ class API::SubscriptionsController < API::ApplicationController
   PRO_PLAN_PRICE_ID = ENV["PRO_PLAN_PRICE_ID"]
 
   def index
-    stripe_customer_id = current_user.stripe_customer_id
+    # Free/legacy/mobile accounts may not have a Stripe customer yet; create
+    # one lazily so listing subscriptions never blows up on a nil customer.
+    stripe_customer_id = current_user.ensure_stripe_customer!
     @subscriptions = Stripe::Subscription.list({ customer: stripe_customer_id })
     render json: { subscriptions: @subscriptions, stripe_customer_id: stripe_customer_id }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "subscriptions#index: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to load subscriptions" }, status: :bad_request
   end
 
   def billing_portal
@@ -218,21 +223,27 @@ class API::SubscriptionsController < API::ApplicationController
   end
 
   def create_customer_session
-    customer_id = current_user.stripe_customer_id
+    customer_id = current_user.ensure_stripe_customer!
     customer_session =
       Stripe::CustomerSession.create({
         customer: customer_id,
         components: { pricing_table: { enabled: true } },
       })
     render json: { client_secret: customer_session.client_secret }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "subscriptions#create_customer_session: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to create customer session" }, status: :bad_request
   end
 
   def list
-    customer_id = current_user.stripe_customer_id
+    customer_id = current_user.ensure_stripe_customer!
     subscriptions_result = Stripe::Subscription.list({ customer: customer_id })
     subscriptions = subscriptions_result.data
     has_more = subscriptions_result.has_more
     render json: { subscriptions: subscriptions, has_more: has_more }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "subscriptions#list: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to load subscriptions" }, status: :bad_request
   end
 
   def add_item
@@ -240,11 +251,16 @@ class API::SubscriptionsController < API::ApplicationController
     price_list = Stripe::Price.list({ lookup_keys: [lookup_key] })
     price = price_list.data.first
     price_id = price.id
-    customer_id = current_user.stripe_customer_id
+    customer_id = current_user.ensure_stripe_customer!
     subscriptions_result = Stripe::Subscription.list({ customer: customer_id })
 
     subscriptions = subscriptions_result["data"]
     subscription = subscriptions.first
+    # A customer with no subscription (e.g. a free user) has nothing to add to.
+    if subscription.nil?
+      render json: { error: "No active subscription to modify" }, status: :unprocessable_content
+      return
+    end
     existing_items = subscription["items"]["data"]
 
     existing_item = existing_items.find { |item| item["price"]["id"] == price_id }
@@ -260,6 +276,9 @@ class API::SubscriptionsController < API::ApplicationController
     end
 
     render json: { subscription: subscription }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "subscriptions#add_item: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to update subscription" }, status: :bad_request
   end
 
   private

--- a/spec/requests/api/subscriptions_lazy_customer_spec.rb
+++ b/spec/requests/api/subscriptions_lazy_customer_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# Free/legacy/mobile accounts may not have a Stripe customer yet (e.g. a user
+# created outside the normal signup UI). The subscription read/list endpoints
+# must create one lazily rather than passing a nil customer to Stripe (which
+# 500s). See API::SubscriptionsController.
+RSpec.describe "API::SubscriptionsController lazy Stripe customer", type: :request do
+  let(:empty_list) { OpenStruct.new(data: [], has_more: false) }
+
+  describe "GET /api/subscriptions" do
+    context "when the user has no Stripe customer" do
+      let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+      it "lazily creates one, persists it, and lists subscriptions" do
+        expect(User).to receive(:create_stripe_customer).with(user.email).once.and_return("cus_lazy")
+        captured = nil
+        expect(Stripe::Subscription).to receive(:list) do |params|
+          captured = params
+          empty_list
+        end
+
+        get "/api/subscriptions", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.stripe_customer_id).to eq("cus_lazy")
+        expect(captured[:customer]).to eq("cus_lazy")
+        expect(JSON.parse(response.body)["stripe_customer_id"]).to eq("cus_lazy")
+      end
+    end
+
+    context "when the user already has a Stripe customer" do
+      let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+      it "does not create a new customer" do
+        allow(User).to receive(:create_stripe_customer)
+        allow(Stripe::Subscription).to receive(:list).and_return(empty_list)
+
+        get "/api/subscriptions", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User).not_to have_received(:create_stripe_customer)
+      end
+    end
+
+    context "when Stripe raises" do
+      let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+      it "returns 400, not 500" do
+        allow(Stripe::Subscription).to receive(:list)
+          .and_raise(Stripe::InvalidRequestError.new("boom", nil))
+
+        get "/api/subscriptions", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)["error"]).to eq("Failed to load subscriptions")
+      end
+    end
+  end
+
+  describe "GET /api/subscriptions/list" do
+    context "when the user has no Stripe customer" do
+      let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+      it "lazily creates one and returns an empty list" do
+        expect(User).to receive(:create_stripe_customer).with(user.email).once.and_return("cus_lazy")
+        captured = nil
+        expect(Stripe::Subscription).to receive(:list) do |params|
+          captured = params
+          empty_list
+        end
+
+        get "/api/subscriptions/list", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.stripe_customer_id).to eq("cus_lazy")
+        expect(captured[:customer]).to eq("cus_lazy")
+        expect(JSON.parse(response.body)["subscriptions"]).to eq([])
+      end
+    end
+  end
+
+  describe "POST /api/subscriptions/create_customer_session" do
+    context "when the user has no Stripe customer" do
+      let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+      it "lazily creates one before opening the session" do
+        expect(User).to receive(:create_stripe_customer).with(user.email).once.and_return("cus_lazy")
+        captured = nil
+        expect(Stripe::CustomerSession).to receive(:create) do |params|
+          captured = params
+          OpenStruct.new(client_secret: "cs_secret")
+        end
+
+        post "/api/subscriptions/create_customer_session", headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.stripe_customer_id).to eq("cus_lazy")
+        expect(captured[:customer]).to eq("cus_lazy")
+      end
+    end
+  end
+
+  describe "POST /api/subscriptions/add_item" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: nil) }
+
+    it "ensures a customer and returns 422 when there's no subscription to modify" do
+      expect(User).to receive(:create_stripe_customer).with(user.email).once.and_return("cus_lazy")
+      allow(Stripe::Price).to receive(:list)
+        .and_return(OpenStruct.new(data: [OpenStruct.new(id: "price_x")]))
+      allow(Stripe::Subscription).to receive(:list)
+        .and_return(OpenStruct.new("data" => []))
+
+      post "/api/subscriptions/add_item",
+        params: { lookup_key: "basic_extra_comm" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("No active subscription to modify")
+      expect(user.reload.stripe_customer_id).to eq("cus_lazy")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A free/legacy/mobile account with no `stripe_customer_id` (e.g. a user created outside the normal signup UI — the origin of this was bad data in staging) would 500 whenever the dashboard hit the subscription read endpoints. They passed `customer: nil` straight to Stripe with no rescue.

The fix routes those endpoints through the existing `User#ensure_stripe_customer!` helper — the same lazy-create path that **checkout** (`ensure_customer!`) and the **billing portal** already use — so a customer is created on the fly, and adds graceful `Stripe::StripeError` rescues.

## What changed

`app/controllers/api/subscriptions_controller.rb`:
- `index` — lazily creates the Stripe customer; 400 instead of 500 on Stripe error.
- `list` — same.
- `create_customer_session` — same.
- `add_item` — same, plus a clean **422 "No active subscription to modify"** instead of a `NoMethodError` when the customer has no subscription to add to.

The plan-change endpoints (`change_plan`, `preview_plan_change`, `change_plan_portal_session`) are intentionally left alone — they correctly treat "no customer" as "no subscription to change," and creating a customer there would be wrong.

## Test plan

New `spec/requests/api/subscriptions_lazy_customer_spec.rb` — 6 examples: lazy creation + persistence, no-op when a customer already exists, the 400 rescue path, and the add_item 422.

Verified locally:
- New spec: **6 examples, 0 failures**
- Existing subscription specs (change_plan, billing_portal, preview_plan_change, change_plan_portal_session): **38 examples, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)