### PR TITLE
fix(board-builder): clean built-set grid (no overflow / dead tiles) + curated category tile images

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -284,15 +284,41 @@ Cost: 2 credits per page (`ai_board_page` feature key in `CreditService`).
 When the build key is a StructurePlanner level (starter/standard/extended), the
 job runs the hybrid path:
 
-1. **Plan** via `StructurePlanner` → fringe page list + exclusions
-2. **Clone seed set** via `SeededSetCloner` with `exclude_fringe:` (drops
-   unneeded seed set pages from the clone)
-3. **Clone prebuilt templates** — for each `:prebuilt` page, clone the admin
-   template, link from root, route interests into it
-4. **AI-generate** — for each `:ai_generated` page, check credits → generate →
-   build board → link from root. Falls back to My Favorites on insufficient
-   credits or generation failure
-5. **Catch-all** — remaining unmatched interests → "My Favorites"
+1. **Plan** via `StructurePlanner` → fringe page list (+ catch-all)
+2. **Clone seed set INTACT** via `SeededSetCloner` with `exclude_fringe: []`.
+   The authored core set is cloned whole — every authored folder tile
+   (People…Describe, including **More**) stays linked to a real board, and
+   seed-category interests route into the matching cloned folders.
+3. **Add prebuilt / AI fringe pages within the grid** — `add_fringe_pages_within_grid!`.
+   Each `:prebuilt`/`:ai_generated` page becomes a *new* top-level folder tile,
+   but only while open cells remain on the authored grid (see the grid-cap note
+   below). `:prebuilt` clones the admin template + routes interests; `:ai_generated`
+   checks credits → generates → builds → links (falls back when out of credits).
+4. **Catch-all** — interests with no fitted page (initial unmatched + any pages
+   that didn't fit the grid + AI pages that fell back) → a single "My Favorites".
+
+#### Grid cap: never overflow the authored core grid
+
+The authored core board fills its grid with a few intentional empty cells
+(Core 84 = 7×12 = 84 cells, 81 tiles, 3 gaps). `Board#add_image` drops a tile
+into the first open cell and only starts a **new row** once the grid is full
+(`BoardsHelper#next_available_cell`). So naively adding one folder tile per
+fringe page overflowed onto a stray extra row — the "85th tile" bug.
+
+`add_fringe_pages_within_grid!` caps the top-level folder tiles it adds to the
+number of open cells (`root_open_cells`), reserving one cell for "My Favorites"
+whenever leftovers are expected. Interest-bearing pages are placed first, so a
+nearly-full grid still gets the pages the child actually asked for; anything
+that doesn't fit folds into My Favorites — nothing typed is dropped. Net result:
+a built robust set never exceeds its authored grid and never leaves a dead
+(unlinked) folder tile behind.
+
+> The old hybrid path *excluded* "unplanned" seed pages via
+> `StructurePlanner#excluded_fringe_pages` + `SeededSetCloner(exclude_fringe:)`.
+> That stripped authored sub-boards while leaving their root folder tiles
+> behind — dead tiles (More/School/Time/Describe) that opened nothing. The job
+> no longer excludes; `excluded_fringe_pages` is still computed on the plan but
+> unused by the build.
 
 Legacy template keys (`core-60`, `home`, etc.) route to the original
 clone-only or blueprint-only paths, unchanged.

--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -81,9 +81,35 @@ into a matching **category folder the chosen template actually has**:
 Interests are normalized first: trimmed, blanks dropped, deduped, lone `i` →
 `I`, capped at `MAX_INTERESTS` (12). An interest word with no existing `Image`
 gets a freshly-created one (`is_private: false`, **blank art** for v1 — art
-can be generated later). Resolution order mirrors
-`Board#find_or_create_images_from_word_list`: the user's own image → a
-public/admin image → create.
+can be generated later).
+
+### Image resolution (`Boards::ImageResolver`) — prefer art
+
+All three build paths (cloner, assembler, `BuildBoardSetJob`) resolve a tile
+label to an `Image` through `Boards::ImageResolver.resolve(label, owner:)`,
+which **prefers an image that actually has artwork**:
+
+1. the owner's own image for the label that has a `Doc`,
+2. a curated public/admin image for the label that has a `Doc`,
+3. else any existing image for the label, else a freshly-created blank.
+
+Two subtleties it fixes:
+
+- **Art over blank.** A naive `find_by(label:)` returns the lowest-id match,
+  which is often a blank, art-less image the OBF seed created for that label —
+  so a folder tile (Animals, People, Feelings…) rendered empty even though a
+  curated image with art existed. `Image#display_doc` has no label fallback, so
+  once a tile points at a blank image it stays blank.
+- **Case-insensitive matching.** Folder labels are capitalized ("Animals")
+  while curated library art is often lowercase ("animals"); a case-sensitive
+  match would miss it. Matching is case-insensitive, but a newly-created image
+  keeps the normalized label's casing.
+
+Because `BoardImage#set_defaults` derives the tile `label` from its image,
+pointing a folder at a lowercase art image would rename the tile. So the
+curated folder name is pinned explicitly: `SeededSetCloner#copy_tiles!` restores
+the authored label/display_label post-save, and `BuildBoardSetJob#add_folder_tile!`
+sets the tile text to the category name.
 
 ## Endpoint contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board Builder: extra "85th tile" and dead folder tiles on built sets
+- A built robust set (e.g. Extended / Core 84) no longer overflows its authored
+  grid. The build added one folder tile per fringe page via `Board#add_image`,
+  which fills the authored grid's open cells and then spills onto a stray extra
+  row — so a 7×12 (84-cell) Core 84 came out with 85+ tiles. The build now caps
+  the top-level folder tiles it adds to the open cells on the authored grid and
+  folds the remainder into a single "My Favorites" page (nothing the child
+  selected is dropped).
+- Authored folders are no longer left **dead** (unlinked). The hybrid path used
+  to *exclude* "unplanned" seed pages from the clone while leaving their folder
+  tiles on the root, so **More / School / Time / Describe** opened nothing when
+  tapped. The build now clones the authored core set intact — every folder links
+  to a real board.
+
 ### Added — Board Builder: complexity levels, AI fringe pages, hybrid build (Phase 2)
 - **Complexity levels** replace raw template keys in the wizard: Starter (4-6
   fringe pages), Standard (8-10), Extended (10-15). Legacy `template` param

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board Builder: category folder tiles render blank
+- Category folder tiles (Animals, People, Feelings, Food…) on a built set now
+  show a curated symbol by default instead of a blank tile. Resolution grabbed
+  the first image matching the label, which was often a blank, art-less image
+  the OBF seed created for that label — even though a curated image with art
+  existed. New `Boards::ImageResolver` prefers an art-bearing image (matching
+  the label **case-insensitively**, since folder labels are capitalized while
+  library art is often lowercase), used by the cloner, blueprint assembler, and
+  `BuildBoardSetJob`. The authored/curated folder name ("Animals") is preserved
+  as the tile text even when the art image is stored lowercase ("animals").
+
 ### Fixed — Board Builder: extra "85th tile" and dead folder tiles on built sets
 - A built robust set (e.g. Extended / Core 84) no longer overflows its authored
   grid. The build added one folder tile per fringe page via `Board#add_image`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -876,10 +876,24 @@ still works for backward compat.
   generation fails.
 - **`BuildBoardSetJob`** routes between the hybrid path (when `level` is a
   `StructurePlanner::LEVELS` key) and the legacy path (direct template keys like
-  `core-60`, `home`). The hybrid path: plan → clone seed set with exclusions →
-  clone prebuilt templates → AI-generate niche pages → route catch-all.
-- **`SeededSetCloner`** now accepts `exclude_fringe:` — a list of page names to
-  skip during the clone (the planner's excluded pages).
+  `core-60`, `home`). The hybrid path: plan → clone seed set **intact** →
+  add prebuilt/AI fringe pages **within the authored grid** → route catch-all to
+  "My Favorites".
+- **Grid cap (no overflow / no dead tiles).** The authored core board fills its
+  grid with a few intentional empty cells (Core 84 = 7×12 = 84 cells, 81 tiles,
+  3 gaps). `Board#add_image` fills the next open cell and only starts a new row
+  once the grid is full, so adding one folder tile per fringe page used to spill
+  onto a stray extra row (the "85th tile"). `BuildBoardSetJob#add_fringe_pages_within_grid!`
+  caps the top-level folder tiles it adds to `root_open_cells`, reserving a cell
+  for "My Favorites" when leftovers are expected; interest-bearing pages go first,
+  the rest fold into My Favorites (nothing dropped). The job clones the seed set
+  **intact** (`exclude_fringe: []`) so every authored folder — People…Describe,
+  **including More** — stays linked to a real board; the prior exclusion path left
+  stripped pages as dead, unlinked folder tiles.
+- **`SeededSetCloner`** accepts `exclude_fringe:` — a list of page names to skip
+  during the clone. Still used by callers that want a trimmed clone; the hybrid
+  build now passes `[]` (clone intact). `StructurePlanner#excluded_fringe_pages`
+  is still computed on the plan but no longer consumed by the build.
 - **Level recommendation heuristic:** young/emerging → Starter,
   developing/young_teen → Standard, proficient/older → Extended. Based on
   `CommunicatorProfile` helpers (`developing?`, `young_teen?`). **Not clinically

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,6 +894,17 @@ still works for backward compat.
   during the clone. Still used by callers that want a trimmed clone; the hybrid
   build now passes `[]` (clone intact). `StructurePlanner#excluded_fringe_pages`
   is still computed on the plan but no longer consumed by the build.
+- **Tile images prefer art (`Boards::ImageResolver`).** All three build paths
+  (cloner, `BlueprintAssembler`, `BuildBoardSetJob`) resolve a tile label via
+  `Boards::ImageResolver.resolve(label, owner:)`, which prefers an image that
+  has a `Doc` (artwork) over a blank same-label image and matches labels
+  **case-insensitively** (folder labels are capitalized, curated art is often
+  lowercase). Without this, category folder tiles (Animals, People, Feelings…)
+  rendered blank because resolution grabbed a label-only image the OBF seed
+  created. Because `BoardImage#set_defaults` derives the tile label from its
+  image, the curated folder name is pinned explicitly so an upgraded lowercase
+  art image doesn't rename the tile (`copy_tiles!` restores the authored label;
+  `BuildBoardSetJob#add_folder_tile!` sets the category name).
 - **Level recommendation heuristic:** young/emerging → Starter,
   developing/young_teen → Standard, proficient/older → Extended. Based on
   `CommunicatorProfile` helpers (`developing?`, `young_teen?`). **Not clinically

--- a/app/services/boards/blueprint_assembler.rb
+++ b/app/services/boards/blueprint_assembler.rb
@@ -98,16 +98,11 @@ module Boards
       }
     end
 
-    # Mirrors Board#find_or_create_images_from_word_list resolution order:
-    # the user's own image, then a public/admin image, else create a new one.
-    # A freshly-created image starts with no symbol art — acceptable for v1
-    # (blank tile, art can be generated later). See the plan doc's symbol note.
+    # Prefer an art-bearing image (shared with the cloner / BuildBoardSetJob) so
+    # category folder tiles (Food, Feelings, Play…) and routed interests render
+    # with a picture by default instead of blank.
     def resolve_or_create_image(label)
-      word = normalize_word(label)
-      image = @user.images.find_by(label: word)
-      image ||= Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil])
-      image ||= Image.create!(label: word, user_id: @user.id)
-      image
+      Boards::ImageResolver.resolve(label, owner: @user)
     end
 
     # Normalization lives in Boards::InterestWords (shared with the cloner
@@ -116,10 +111,6 @@ module Boards
     # kept as typed, lone "i" -> "I", other single chars lowercased.
     def normalize_interests(list)
       Boards::InterestWords.normalize_list(list, max: MAX_INTERESTS)
-    end
-
-    def normalize_word(string)
-      Boards::InterestWords.normalize_word(string)
     end
   end
 end

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -1,0 +1,55 @@
+# app/services/boards/image_resolver.rb
+#
+# Resolves a tile label to the best Image to display, PREFERRING one that
+# actually has artwork.
+#
+# The Board Builder seeds and clones a lot of folder tiles (Animals, People,
+# Feelings, Food, …) whose labels match curated library art. But a naive
+# `find_by(label:)` returns the lowest-id match, which is often a blank,
+# art-less Image the OBF seed created for that same label — so the folder tile
+# renders empty even though a curated image with art exists. `Image#display_doc`
+# has no label fallback, so once a tile points at a blank image it stays blank.
+#
+# This picks an art-bearing image when one exists for the label, only
+# falling back to (or creating) a blank image as a last resort.
+module Boards
+  module ImageResolver
+    module_function
+
+    # Returns a persisted Image for `label`. `owner` is the User who owns any
+    # newly-created image and whose private images are preferred.
+    #
+    # Matching is case-INSENSITIVE: folder labels are capitalized ("Animals",
+    # "People") while curated library art is often stored lowercase, and a
+    # case-sensitive `find_by(label:)` would miss it and fall through to a blank.
+    # A newly-created image keeps the normalized label's original casing.
+    def resolve(label, owner:)
+      word = Boards::InterestWords.normalize_word(label)
+
+      # 1. The owner's own image for this label, if it already has art.
+      owner_arted = owner.images.with_docs.where(ci_label, word).first
+      return owner_arted if owner_arted
+
+      # 2. A curated public/admin image for this label that has art.
+      public_arted = Image.public_img.with_docs
+        .where(user_id: [User::DEFAULT_ADMIN_ID, nil]).where(ci_label, word).first
+      return public_arted if public_arted
+
+      # 3. No art anywhere — keep an existing (blank) image, else create one.
+      owner.images.where(ci_label, word).first ||
+        Image.public_img.where(user_id: [User::DEFAULT_ADMIN_ID, nil]).where(ci_label, word).first ||
+        Image.create!(label: word, user_id: owner.id)
+    end
+
+    # True when the image has displayable artwork (at least one Doc). Cheap SQL,
+    # no S3 — mirrors the `image.docs.any?` notion used elsewhere in the builder.
+    def art?(image)
+      image.present? && image.docs.exists?
+    end
+
+    # Case-insensitive label match fragment for `where`.
+    def ci_label
+      "LOWER(label) = LOWER(?)"
+    end
+  end
+end

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -177,6 +177,16 @@ module Boards
         end
         image ||= Image.create(label: original_image.label, user_id: target.user_id)
 
+        # The seed often points folder tiles (Animals, People, Feelings…) and
+        # some core words at a blank, art-less Image for that label. When the
+        # resolved image has no art, upgrade to a curated art-bearing image for
+        # the same label so the tile isn't blank. Only ever blank -> art, never
+        # the reverse (a tile that already has art is left untouched).
+        unless Boards::ImageResolver.art?(image)
+          arted = Boards::ImageResolver.resolve(original_image.label, owner: @owner)
+          image = arted if Boards::ImageResolver.art?(arted)
+        end
+
         new_board_image = board_image.dup
         new_board_image.board_id = target.id
         new_board_image.image_id = image.id
@@ -186,6 +196,13 @@ module Boards
         new_board_image.predictive_board_id = board_image.predictive_board_id
         new_board_image.audio_url = board_image.audio_url
         new_board_image.save!
+
+        # BoardImage#set_defaults (before_create) derives label from the image,
+        # so an upgraded art image stored under different casing ("people") would
+        # rename the tile. Restore the AUTHORED tile text ("People") post-save.
+        if new_board_image.label != board_image.label || new_board_image.display_label != board_image.display_label
+          new_board_image.update_columns(label: board_image.label, display_label: board_image.display_label)
+        end
       end
     end
 
@@ -293,29 +310,23 @@ module Boards
       favorites.save!
 
       folder_tile = root.add_image(resolve_or_create_image(FAVORITES_NAME).id)
-      folder_tile&.update!(predictive_board_id: favorites.id)
+      # Pin the tile text to FAVORITES_NAME — an art image may be stored under
+      # different casing and BoardImage#set_defaults derives label from it.
+      folder_tile&.update!(predictive_board_id: favorites.id,
+                           label: FAVORITES_NAME, display_label: FAVORITES_NAME)
       favorites
     end
 
-    # Mirror Board#find_or_create_images_from_word_list / BlueprintAssembler:
-    # the owner's own image, then a public/admin image, else create. A fresh
-    # image starts with no art — acceptable for v1 (blank tile, AI art later).
+    # Prefer an art-bearing image (shared with BuildBoardSetJob) so folder tiles
+    # and routed interests render with a picture by default instead of blank.
     def resolve_or_create_image(label)
-      word  = normalize_word(label)
-      image = @owner.images.find_by(label: word)
-      image ||= Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil])
-      image ||= Image.create!(label: word, user_id: @owner.id)
-      image
+      Boards::ImageResolver.resolve(label, owner: @owner)
     end
 
     # Normalization lives in Boards::InterestWords (shared with the assembler
     # and the controller, which persists the list and feeds BuildBoardSetJob).
     def normalize_interests(list)
       Boards::InterestWords.normalize_list(list, max: MAX_INTERESTS)
-    end
-
-    def normalize_word(string)
-      Boards::InterestWords.normalize_word(string)
     end
   end
 end

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -170,9 +170,7 @@ class BuildBoardSetJob
     cloned.settings = (cloned.settings || {}).merge("builder_child" => true)
     cloned.save!
 
-    folder_image = resolve_or_create_image(owner, page_plan[:name])
-    folder_tile = root.add_image(folder_image.id)
-    folder_tile&.update!(predictive_board_id: cloned.id)
+    add_folder_tile!(root, owner, page_plan[:name], cloned.id)
 
     Array(page_plan[:interests]).each { |word| add_interest_to_board(owner, cloned, word) }
     true
@@ -235,9 +233,7 @@ class BuildBoardSetJob
       generate_art_if_blank(owner, image, fringe)
     end
 
-    folder_image = resolve_or_create_image(owner, blueprint[:name])
-    folder_tile = root.add_image(folder_image.id)
-    folder_tile&.update!(predictive_board_id: fringe.id)
+    add_folder_tile!(root, owner, blueprint[:name], fringe.id)
 
     fringe
   end
@@ -262,9 +258,7 @@ class BuildBoardSetJob
       favorites.settings = (favorites.settings || {}).merge("builder_child" => true)
       favorites.save!
 
-      folder_image = resolve_or_create_image(owner, "My Favorites")
-      folder_tile = root.add_image(folder_image.id)
-      folder_tile&.update!(predictive_board_id: favorites.id)
+      add_folder_tile!(root, owner, "My Favorites", favorites.id)
     end
 
     words.each do |word|
@@ -282,12 +276,22 @@ class BuildBoardSetJob
     generate_art_if_blank(owner, image, board)
   end
 
+  # Prefer an art-bearing image so category folder tiles (Animals, Music, …)
+  # and routed interests render with a picture by default instead of blank.
   def resolve_or_create_image(owner, label)
-    word = Boards::InterestWords.normalize_word(label)
-    image = owner.images.find_by(label: word)
-    image ||= Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil])
-    image ||= Image.create!(label: word, user_id: owner.id)
-    image
+    Boards::ImageResolver.resolve(label, owner: owner)
+  end
+
+  # Adds a category folder tile linking to `predictive_board_id`. Resolves an
+  # art-bearing image for `name`, then pins the tile text to `name` — the art
+  # image may be stored under different casing ("animals"), and BoardImage's
+  # set_defaults derives the label from the image, so the curated folder name
+  # ("Animals") is restored explicitly.
+  def add_folder_tile!(root, owner, name, predictive_board_id)
+    image = resolve_or_create_image(owner, name)
+    tile = root.add_image(image.id)
+    tile&.update!(predictive_board_id: predictive_board_id, label: name, display_label: name)
+    tile
   end
 
   def generate_art_if_blank(owner, image, board)

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -88,13 +88,14 @@ class BuildBoardSetJob
         robust_root, communicator: communicator,
         interests: seed_set_interests, root: root,
         explicit_categories: explicit_categories,
-        exclude_fringe: plan.excluded_fringe_pages,
+        # Clone the authored core set INTACT. Excluding "unplanned" seed pages
+        # used to strip their sub-boards while leaving the root's folder tiles
+        # behind — dead tiles that open nothing (More/School/Time/Describe).
+        exclude_fringe: [],
       ).call
     end
 
-    clone_prebuilt_fringe_pages!(root, communicator, plan)
-    generate_ai_fringe_pages!(root, communicator, owner, plan, profile)
-    add_to_favorites!(root, communicator, plan.catch_all_interests) if plan.catch_all_interests.any?
+    add_fringe_pages_within_grid!(root, communicator, owner, profile, plan)
   end
 
   def collect_seed_set_interests(plan)
@@ -103,45 +104,120 @@ class BuildBoardSetJob
       .flat_map { |p| p[:interests] || [] }
   end
 
-  def clone_prebuilt_fringe_pages!(root, communicator, plan)
-    owner = communicator.owner || communicator.user
-    plan.fringe_pages.select { |p| p[:source] == :prebuilt }.each do |page_plan|
-      fringe_source = Boards::FringeTemplates.find(page_plan[:name])
-      next unless fringe_source
+  # The authored core board fills its grid, with a few intentional empty cells.
+  # Board#add_image drops a new tile into the first open cell and only starts a
+  # NEW row once the grid is full (see BoardsHelper#next_available_cell). So
+  # adding one folder tile per fringe page overflows the authored grid onto a
+  # stray extra row — the "85th tile" on a 7x12 (84-cell) Core 84 board.
+  #
+  # Cap the top-level folder tiles we add to the number of open cells. Pages we
+  # can't fit fold their interests into the single "My Favorites" catch-all
+  # (one tile, deduped) so nothing the child asked for is dropped — it just
+  # lands in Favorites instead of its own page.
+  def add_fringe_pages_within_grid!(root, communicator, owner, profile, plan)
+    root.reload
+    open_cells = root_open_cells(root)
 
-      cloned = fringe_source.clone_with_images(owner.id)
-      next unless cloned
+    # Seed-set pages already live in the clone; they need no new tile. Only
+    # prebuilt/AI pages add a top-level folder. Interest-bearing pages first so
+    # a nearly-full grid still gets the pages the child actually asked for.
+    new_pages = plan.fringe_pages
+      .reject { |p| p[:source] == :seed_set }
+      .sort_by { |p| (p[:interests] || []).any? ? 0 : 1 }
 
-      cloned.settings = (cloned.settings || {}).merge("builder_child" => true)
-      cloned.save!
+    catch_all = Array(plan.catch_all_interests).dup
 
-      folder_image = resolve_or_create_image(owner, page_plan[:name])
-      folder_tile = root.add_image(folder_image.id)
-      folder_tile&.update!(predictive_board_id: cloned.id)
+    # The total tiles we add (standalone pages + a possible My Favorites) must
+    # fit the open cells. We need a My Favorites cell whenever something will
+    # be left over — an initial catch-all, OR more pages than will fit. Reserve
+    # that cell up front so a page can't claim it and push Favorites onto a
+    # stray new row.
+    needs_favorites = catch_all.any? || new_pages.size > open_cells
+    max_pages = open_cells - (needs_favorites ? 1 : 0)
+    max_pages = 0 if max_pages.negative?
 
-      (page_plan[:interests] || []).each do |word|
-        add_interest_to_board(owner, cloned, word)
+    placed = 0
+    new_pages.each do |page_plan|
+      if placed < max_pages && add_single_fringe_page!(root, communicator, owner, profile, page_plan)
+        placed += 1
+      else
+        catch_all.concat(Array(page_plan[:interests]))
       end
+    end
+
+    add_to_favorites!(root, communicator, catch_all) if catch_all.any?
+  end
+
+  # Adds one fringe page as a top-level folder tile. Returns true only when a
+  # tile was actually added, so the caller decrements its grid budget for real
+  # placements only (an AI page that falls back to Favorites for lack of
+  # credits adds no tile and returns false).
+  def add_single_fringe_page!(root, communicator, owner, profile, page_plan)
+    case page_plan[:source]
+    when :prebuilt     then clone_one_prebuilt_page!(root, owner, page_plan)
+    when :ai_generated then generate_one_ai_page!(root, communicator, owner, profile, page_plan)
+    else false
     end
   end
 
-  def generate_ai_fringe_pages!(root, communicator, owner, plan, profile)
-    plan.fringe_pages.select { |p| p[:source] == :ai_generated }.each do |page_plan|
-      if CreditService.can_spend?(owner, feature_key: "ai_board_page")
-        blueprint = Boards::AiPageGenerator.new(
-          interests: page_plan[:interests],
-          profile: profile,
-        ).call
+  def clone_one_prebuilt_page!(root, owner, page_plan)
+    fringe_source = Boards::FringeTemplates.find(page_plan[:name])
+    return false unless fringe_source
 
-        fringe = build_fringe_from_blueprint!(root, owner, communicator, blueprint)
-        CreditService.spend!(owner, feature_key: "ai_board_page")
-      else
-        add_to_favorites!(root, communicator, page_plan[:interests] || [])
-      end
-    rescue Boards::AiPageGenerator::GenerationError => e
-      Rails.logger.warn "[BuildBoardSetJob] AI page generation failed for #{page_plan[:name]}: #{e.message}"
-      add_to_favorites!(root, communicator, page_plan[:interests] || [])
+    cloned = fringe_source.clone_with_images(owner.id)
+    return false unless cloned
+
+    cloned.settings = (cloned.settings || {}).merge("builder_child" => true)
+    cloned.save!
+
+    folder_image = resolve_or_create_image(owner, page_plan[:name])
+    folder_tile = root.add_image(folder_image.id)
+    folder_tile&.update!(predictive_board_id: cloned.id)
+
+    Array(page_plan[:interests]).each { |word| add_interest_to_board(owner, cloned, word) }
+    true
+  end
+
+  # Returns true when an AI page tile was added; false when it fell back (no
+  # credits, or generation failed) so the caller folds the interests into My
+  # Favorites instead.
+  def generate_one_ai_page!(root, communicator, owner, profile, page_plan)
+    return false unless CreditService.can_spend?(owner, feature_key: "ai_board_page")
+
+    blueprint = Boards::AiPageGenerator.new(
+      interests: page_plan[:interests],
+      profile: profile,
+    ).call
+
+    build_fringe_from_blueprint!(root, owner, communicator, blueprint)
+    CreditService.spend!(owner, feature_key: "ai_board_page")
+    true
+  rescue Boards::AiPageGenerator::GenerationError => e
+    Rails.logger.warn "[BuildBoardSetJob] AI page generation failed for #{page_plan[:name]}: #{e.message}"
+    false
+  end
+
+  # Open cells on the authored core grid before a new tile would spill onto a
+  # fresh row — mirrors BoardsHelper#next_available_cell's placement rule
+  # (fill gaps in the existing rows first, only then start a new row).
+  def root_open_cells(board, screen_size = "lg")
+    board.update_board_layout(screen_size)
+    grid = board.layout[screen_size] || {}
+    return 0 if grid.empty?
+
+    columns = board.get_number_of_columns(screen_size)
+    occupied = []
+    max_row = 0
+    grid.each_value do |cell|
+      x = cell["x"] || 0
+      y = cell["y"] || 0
+      w = cell["w"] || 1
+      h = cell["h"] || 1
+      h.times { |dy| w.times { |dx| occupied << [x + dx, y + dy] } }
+      max_row = [max_row, y + h - 1].max
     end
+
+    [(columns * (max_row + 1)) - occupied.uniq.size, 0].max
   end
 
   def build_fringe_from_blueprint!(root, owner, communicator, blueprint)

--- a/spec/services/boards/image_resolver_spec.rb
+++ b/spec/services/boards/image_resolver_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Boards::ImageResolver do
+  let(:owner) { create(:user) }
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  def with_art(image)
+    create(:doc, documentable: image, user: image.user || admin)
+    image
+  end
+
+  describe ".resolve" do
+    it "prefers a public/admin image that has art over a blank same-label image" do
+      blank = create(:image, label: "animals", user_id: admin.id)         # lower id, no art
+      arted = with_art(create(:image, label: "animals", user_id: admin.id)) # higher id, has art
+
+      result = described_class.resolve("Animals", owner: owner)
+
+      expect(result).to eq(arted)
+      expect(result).not_to eq(blank)
+    end
+
+    it "prefers the owner's own art-bearing image over a public one" do
+      with_art(create(:image, label: "dog", user_id: admin.id))
+      owner_art = with_art(create(:image, label: "dog", user_id: owner.id))
+
+      expect(described_class.resolve("dog", owner: owner)).to eq(owner_art)
+    end
+
+    it "falls back to an existing blank image when no art exists for the label" do
+      blank = create(:image, label: "zzz_niche", user_id: admin.id)
+
+      expect(described_class.resolve("zzz_niche", owner: owner)).to eq(blank)
+    end
+
+    it "creates an owner-owned blank image when none exists for the label" do
+      expect {
+        result = described_class.resolve("brand_new_word", owner: owner)
+        expect(result.label).to eq("brand_new_word")
+        expect(result.user_id).to eq(owner.id)
+      }.to change(Image, :count).by(1)
+    end
+
+    it "normalizes the label before resolving" do
+      arted = with_art(create(:image, label: "feelings", user_id: admin.id))
+      expect(described_class.resolve("Feelings", owner: owner)).to eq(arted)
+    end
+  end
+
+  describe ".art?" do
+    it "is true when the image has a doc" do
+      expect(described_class.art?(with_art(create(:image, user_id: admin.id)))).to be(true)
+    end
+
+    it "is false for a blank image and for nil" do
+      expect(described_class.art?(create(:image, user_id: admin.id))).to be(false)
+      expect(described_class.art?(nil)).to be(false)
+    end
+  end
+end

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -100,4 +100,23 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
     expect(dead_folder_tiles(root)).to be_empty
   end
+
+  it "gives category folder tiles a curated image instead of a blank one" do
+    admin = User.find_by(id: User::DEFAULT_ADMIN_ID)
+    # Curated, art-bearing admin images for an authored folder (People, cloned)
+    # and a new fringe folder (Animals, added by the build). Lowercase labels to
+    # prove case-insensitive matching against the capitalized folder labels.
+    people_art = create(:image, label: "people", user_id: admin.id)
+    create(:doc, documentable: people_art, user: admin)
+    animals_art = create(:image, label: "animals", user_id: admin.id)
+    create(:doc, documentable: animals_art, user: admin)
+
+    root = build!([{ "word" => "dog", "category" => "Animals" }])
+
+    people_tile = root.board_images.find { |bi| bi.label == "People" }
+    animals_tile = root.board_images.find { |bi| bi.label == "Animals" }
+
+    expect(Boards::ImageResolver.art?(people_tile.image)).to be(true)
+    expect(Boards::ImageResolver.art?(animals_tile.image)).to be(true)
+  end
 end

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+# Regression coverage for the Board Builder grid-overflow / dead-tile bug:
+# an Extended build over the real Core 84 seed must (a) keep every authored
+# folder tile working (no dead More/School/Time/Describe tiles) and (b) never
+# push tiles past the authored 7x12 (84-cell) grid onto a stray extra row.
+#
+# Uses the real seeded set (slow ~10s) because the bug is specific to a full,
+# nearly-grid-filling authored board — the tiny synthetic seed used elsewhere
+# in build_board_set_job_spec can't reproduce it.
+RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
+  CORE_84_GRID_CELLS = 84 # 7 rows x 12 cols, authored layout
+
+  before do
+    allow_any_instance_of(Grover).to receive(:to_png).and_return(ChunkyPNG::Image.new(1, 1).to_blob)
+    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+    VocabSets.seed_slug!("core-84")
+    Dir.glob(Boards::FringeTemplates::SEED_DIR.join("*.obf")).sort.each do |p|
+      Boards::FringeTemplates.seed_obf!(p)
+    end
+  end
+
+  let(:user) { create(:user, id: 9001) }
+  let(:communicator) { create(:child_account, user: user) }
+
+  def precreate_root!(name: "Core 84")
+    root = Board.new(name: name, user: user)
+    root.board_type = "dynamic"
+    root.assign_parent
+    root.voice = VoiceService.normalize_voice(communicator.voice)
+    root.generate_unique_slug
+    root.settings = (root.settings || {}).merge("builder_root" => true)
+    root.status = "building_board"
+    root.save!
+    cb = communicator.child_boards.create!(board: root, created_by_id: user.id)
+    cb.update!(favorite: true)
+    root
+  end
+
+  def build!(interests)
+    root = precreate_root!
+    norm = Boards::InterestWords.normalize_list(interests)
+    cats = Boards::InterestWords.extract_categories(interests)
+    described_class.new.perform(root.id, communicator.id, "extended", norm, cats)
+    root.reload
+  end
+
+  # Every capitalized, multi-letter tile (a folder label like "Animals") must
+  # carry a predictive link — a dead folder tile opens nothing when tapped.
+  def dead_folder_tiles(board)
+    board.board_images.select do |bi|
+      label = bi.label.to_s
+      label.length > 2 && label[0] == label[0].upcase && bi.predictive_board_id.nil?
+    end
+  end
+
+  it "keeps every authored folder working and stays within the grid" do
+    # More non-seed interest categories than the grid has open cells, to force
+    # the overflow/cap path.
+    root = build!([
+      { "word" => "dog", "category" => "Animals" },
+      { "word" => "guitar", "category" => "Music" },
+      { "word" => "soccer", "category" => "Sports" },
+      { "word" => "train", "category" => "Transportation" },
+      { "word" => "shirt", "category" => "Clothing" },
+    ])
+
+    expect(root.status).to eq("complete")
+
+    # No overflow: the build never spills onto a stray extra row.
+    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
+
+    # No dead tiles: the authored folders the planner used to strip are intact.
+    expect(dead_folder_tiles(root)).to be_empty
+
+    labels = root.board_images.map(&:label)
+    expect(labels).to include("More", "School", "Time", "Describe")
+    %w[More School Time Describe].each do |name|
+      tile = root.board_images.find { |bi| bi.label == name }
+      expect(tile.predictive_board_id).to be_present, "#{name} folder tile has no linked board"
+    end
+
+    # Nothing the child asked for is dropped: overflow interests land in a
+    # working "My Favorites" rather than disappearing.
+    favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+    expect(favorites_tile&.predictive_board_id).to be_present
+    favorites = Board.find(favorites_tile.predictive_board_id)
+    routed = root.board_images
+      .select(&:predictive_board_id)
+      .flat_map { |bi| Board.find(bi.predictive_board_id).board_images.map { |t| t.label.to_s.downcase } }
+    %w[dog guitar soccer train shirt].each do |word|
+      expect(routed).to include(word), "interest '#{word}' was dropped"
+    end
+  end
+
+  it "builds a clean set with no interests (defaults only) within the grid" do
+    root = build!([])
+
+    expect(root.status).to eq("complete")
+    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
+    expect(dead_folder_tiles(root)).to be_empty
+  end
+end

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -148,18 +148,21 @@ RSpec.describe BuildBoardSetJob do
       expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
     end
 
-    it "excludes fringe pages the planner drops and still completes" do
+    it "clones the authored core set intact (no dead folder tiles) and completes" do
       root = precreate_root!(name: "Core 60")
 
       described_class.new.perform(root.id, communicator.id, "starter", [])
 
       root.reload
       expect(root.status).to eq("complete")
-      # Starter only includes ~4-6 fringe pages; some seed set pages are excluded
-      cloned_names = user.boards
-        .where("COALESCE((settings->>'builder_child')::boolean, false)")
-        .pluck(:name)
-      expect(cloned_names.size).to be <= 6
+      # The authored set is cloned intact — every folder tile on the root links
+      # to a real board. None are left dead (excluding authored seed pages used
+      # to strip the sub-board while leaving its tile behind).
+      dead = root.board_images.select do |bi|
+        label = bi.label.to_s
+        label.length > 2 && label[0] == label[0].upcase && bi.predictive_board_id.nil?
+      end
+      expect(dead).to be_empty
     end
 
     it "falls back AI-generated pages to My Favorites when user has no credits" do


### PR DESCRIPTION
Fixes two Board Builder issues Brittany flagged on a freshly-built **Core 84** (Extended) set.

## 1. The "85th tile" + dead folder tiles

The authored core board fills its grid with a few intentional empty cells (Core 84 = 7×12 = **84 cells**, 81 tiles, 3 gaps). The hybrid build:

- **Overflowed the grid** — each fringe page (Animals, Social, AI pages, My Favorites) added a top-level folder tile via `Board#add_image`, which fills the open cells and then **starts a new row** once full (`BoardsHelper#next_available_cell`). With 3 gaps and 4+ additions, the 4th spilled to row 8 → the "85th tile".
- **Left dead tiles** — `StructurePlanner` *excluded* unplanned authored seed pages, so `SeededSetCloner` skipped cloning their sub-boards but their **root folder tiles remained** with their predictive link nulled. **More / School / Time / Describe** opened nothing.

**Fix (`BuildBoardSetJob`):**
- Clone the authored core set **intact** (`exclude_fringe: []`) — every authored folder (incl. **More**) stays linked to a real board.
- `add_fringe_pages_within_grid!` caps new folder tiles to the grid's open cells (`root_open_cells`), reserving a cell for "My Favorites" when leftovers are expected; interest-bearing pages go first, the rest fold into My Favorites — nothing the child selected is dropped.

Per a product decision in this session, **More stays as a working folder** (it was broken, not stray).

## 2. Category folder tiles rendered blank

Category folders (Animals, People, Feelings, Food…) showed no image. Resolution did `find_by(label:)` and grabbed the lowest-id match — often a **blank, art-less** image the OBF seed created for that label — even though a curated image *with* art existed. `Image#display_doc` has no label fallback, so the tile stayed blank.

**Fix:** new `Boards::ImageResolver.resolve(label, owner:)` (used by the cloner, `BlueprintAssembler`, and `BuildBoardSetJob`) prefers an art-bearing image and matches labels **case-insensitively** (folder labels are capitalized; curated art is often lowercase). Since `BoardImage#set_defaults` derives the tile label from its image, the curated folder name is pinned explicitly (`copy_tiles!` restores the authored label; `add_folder_tile!` sets the category name) so an upgraded lowercase art image doesn't rename the tile.

## Result (real Core 84 seed)
- **84 tiles**, clean 7×12 grid, **0 dead tiles**; every authored folder works; new category pages + My Favorites fit; category tiles show curated symbols.

## Test plan
- New `spec/sidekiq/build_board_set_job_grid_spec.rb` (real Core 84 seed): ≤ 84 tiles, no dead tiles, authored pages linked, interests routed, **category tiles get curated art**.
- New `spec/services/boards/image_resolver_spec.rb`: art-preference, case-insensitivity, fallbacks.
- Repurposed the now-misleading "excludes fringe pages" job spec to assert intact cloning.
- Ran the full board-builder suite — `build_board_set_job`, grid, `image_resolver`, `seeded_set_cloner`, `blueprint_assembler`, `structure_planner`, `board_tree_builder`, request spec: **122 examples, 0 failures**.
- Docs: `.claude-notes/board-builder.md`, `CLAUDE.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)