### PR TITLE
feat(gestalt): GLP stage profile field, templates, and script-collector metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Gestalt language (GLP) support
+- Communicators can now carry an optional **NLA stage** (`glp_stage`, 1–6),
+  stored in `child_accounts.details` alongside the existing AAC profile fields
+  (`aac_level`/`vocab_type`/`age_band`) — it measures something different, so it
+  doesn't replace them. Set it via the existing communicator-update `details`
+  param; it's exposed on the communicator `api_view`. Drives gestalt-aware AI
+  word-suggestion prompts (whole phrases at early stages → full sentences at
+  advanced stages) via `CommunicatorProfile`.
+- Six predefined **GLP board templates** of whole-phrase tiles — Greetings &
+  Social, Requests & Wants, Protests & Boundaries, Comments & Observations,
+  Feelings & Emotions, Transitions & Routines — available on all plans. Seed
+  with `bin/rails glp_templates:seed` (idempotent). They surface in
+  `GET /api/v1/board_builder/templates` (with `glp_templates` + a stage-aware
+  `recommended_template`), and `?template_type=glp` narrows the picker to GLP
+  only.
+- **Script Collector** support on `POST /api/boards/:id/add_image`: a tile can
+  be marked `part_of_speech: "phrase"` (a whole-phrase gestalt tile, no longer
+  re-categorized as a single word) and carry free-form `gestalt_source` /
+  `utterance_function` metadata, stored on `board_images.data`.
+
 ### Fixed — Board Builder: category folder tiles render blank
 - Category folder tiles (Animals, People, Feelings, Food…) on a built set now
   show a curated symbol by default instead of a blank tile. Resolution grabbed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1001,6 +1001,41 @@ caller doesn't own is silently ignored. Personalization reaches **AI
 word-suggestion prompts and the template recommendation only** — the Board
 Builder's deterministic build path is unchanged.
 
+### Gestalt language support (GLP)
+
+A communicator may also carry an optional **NLA stage** for gestalt language
+processors: `glp_stage` (integer 1–6), stored in `child_accounts.details` next
+to the AAC fields. It **measures something different from `aac_level`** — it
+doesn't replace it; both can be set independently. Wiring:
+
+- `glp_stage` is in `ChildAccount::AAC_PROFILE_FIELDS` (so it rides the same
+  typed accessor + wholesale-`details=` validation), but listed in
+  `INTEGER_PROFILE_FIELDS` so normalization coerces it to an **integer** instead
+  of downcasing it to a string (which would fail the `GLP_STAGES` inclusion
+  check). Validated against `CommunicatorProfile::GLP_STAGES` (`(1..6)`). Exposed
+  on the ChildAccount `api_view` / `vendor_api_view`.
+- `CommunicatorProfile` gains `glp_stage`, the predicates `gestalt_early?`
+  (1–2) / `gestalt_emerging?` (3–4) / `gestalt_advanced?` (5–6), and appends
+  stage-specific `prompt_guidance` (whole phrases at early stages → full
+  sentences at advanced). A glp-only profile is `present?`, so `.for` returns
+  it. No `glp_stage` ⇒ no gestalt guidance (backward compatible).
+- **GLP board templates** (`Boards::GlpTemplates`): six predefined, admin-owned
+  whole-phrase template boards, identified by `category: "glp"` +
+  `is_template: true` (not starter blueprints or robust sets). `TEMPLATES` is the
+  single source of truth for both the idempotent seed (`bin/rails
+  glp_templates:seed`, via `.seed!`) and the stage-aware recommendation
+  (`.recommended_for`). They surface in `GET /api/v1/board_builder/templates`
+  (`kind: "glp"`, a `glp_templates` array, and a stage-driven
+  `recommended_template`); `?template_type=glp` returns only GLP templates. They
+  are **catalog/recommendation metadata** — the wizard `create` build path still
+  only builds starter/robust keys.
+- **Whole-phrase tiles:** `part_of_speech: "phrase"` marks a gestalt script
+  tile. `Image#ensure_defaults` preserves an explicit `"phrase"` POS instead of
+  re-categorizing it as a single word (every other label is still categorized as
+  before). Script Collector adds tiles via `POST /api/boards/:id/add_image` with
+  `image[part_of_speech]=phrase` and optional free-form `data[gestalt_source]` /
+  `data[utterance_function]`, stored on `board_images.data`.
+
 ## Do not
 
 - Do not install new gems without asking first

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -774,6 +774,10 @@ class API::BoardsController < API::ApplicationController
       @image = Image.new
       @image.user = current_user
       @image.label = image_params[:label]
+      # part_of_speech: "phrase" distinguishes gestalt whole-phrase tiles
+      # (Script Collector) from single-word tiles. Optional; falls back to the
+      # model default otherwise.
+      @image.part_of_speech = image_params[:part_of_speech] if image_params[:part_of_speech].present?
       img_saved = @image.save!
     end
 
@@ -800,6 +804,15 @@ class API::BoardsController < API::ApplicationController
       if new_doc&.persisted? && @board
         board_image ||= @board.board_images.find_by(image_id: @image.id)
         board_image&.update(display_image_url: new_doc.tile_url)
+      end
+
+      # Gestalt-specific tile metadata (Script Collector). Free-form: where the
+      # phrase came from and what communicative function it serves. Stored on
+      # board_images.data jsonb alongside any existing keys.
+      gestalt = gestalt_metadata
+      if gestalt.present? && @board
+        board_image ||= @board.board_images.find_by(image_id: @image.id)
+        board_image&.update(data: (board_image.data || {}).merge(gestalt))
       end
 
       screen_size = params[:screen_size] || "lg"
@@ -1267,7 +1280,19 @@ class API::BoardsController < API::ApplicationController
   end
 
   def image_params
-    params.require(:image).permit(:label, :image_prompt, :display_image, audio_files: [], docs: [:id, :user_id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
+    params.require(:image).permit(:label, :image_prompt, :display_image, :part_of_speech, audio_files: [], docs: [:id, :user_id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
+  end
+
+  # Optional gestalt tile metadata for add_image (Script Collector). Free-form
+  # strings stored on board_images.data; returns {} when absent so the merge is
+  # a no-op for non-gestalt tiles.
+  def gestalt_metadata
+    return {} if params[:data].blank?
+
+    params.require(:data)
+          .permit(:gestalt_source, :utterance_function)
+          .to_h
+          .reject { |_k, v| v.blank? }
   end
 
   # Optional communicator-profile fields passed by the frontend's

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -20,15 +20,35 @@ module API
       ].freeze
 
       def templates
+        glp_catalog = Boards::GlpTemplates.catalog
+
+        # `?template_type=glp` narrows the picker to GLP templates only. Omit it
+        # for the full (backward-compatible) catalog.
+        if params[:template_type].to_s.downcase == "glp"
+          glp_template, glp_reason = recommend_glp_template
+          render json: {
+            templates: glp_catalog,
+            glp_templates: glp_catalog,
+            recommended_template: glp_template,
+            recommendation_reason: glp_reason,
+          }, status: :ok
+          return
+        end
+
         catalog = Boards::StarterBlueprints.catalog
         recommended_tmpl, tmpl_reason = recommend_template(catalog)
         level_rec = recommend_level
+        glp_template, glp_reason = recommend_glp_template
+
         render json: {
           levels: COMPLEXITY_LEVELS,
           recommended_level: level_rec&.dig(:key),
-          recommendation_reason: level_rec&.dig(:reason) || tmpl_reason,
-          templates: catalog,
-          recommended_template: recommended_tmpl,
+          # A GLP-stage communicator gets the gestalt recommendation; otherwise
+          # fall back to the existing level/template reasons.
+          recommendation_reason: glp_reason || level_rec&.dig(:reason) || tmpl_reason,
+          templates: catalog + glp_catalog,
+          glp_templates: glp_catalog,
+          recommended_template: glp_template || recommended_tmpl,
         }, status: :ok
       end
 
@@ -170,6 +190,25 @@ module API
         return [nil, nil] unless catalog.any? { |t| t[:key] == slug }
 
         [slug, reason]
+      end
+
+      # Stage-appropriate GLP template recommendation for the requested
+      # communicator. Returns [slug, reason] when the communicator has a
+      # glp_stage AND a matching template board is actually seeded; nil
+      # otherwise (no communicator, no stage, or unseeded environment).
+      def recommend_glp_template
+        return nil if params[:communicator_id].blank?
+
+        communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
+        return nil unless communicator
+
+        stage = CommunicatorProfile.for(communicator: communicator)&.glp_stage
+        return nil if stage.blank?
+
+        slug = Boards::GlpTemplates.recommended_for(stage)
+        return nil if slug.blank? || !Boards::GlpTemplates.boards.exists?(slug: slug)
+
+        [slug, "Recommended for gestalt language processors at NLA Stage #{stage}."]
       end
 
       def recommend_level

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -127,7 +127,13 @@ class ChildAccount < ApplicationRecord
     "aac_level" => CommunicatorProfile::AAC_LEVELS,
     "vocab_type" => CommunicatorProfile::VOCAB_TYPES,
     "age_band" => CommunicatorProfile::AGE_BANDS,
+    "glp_stage" => CommunicatorProfile::GLP_STAGES,
   }.freeze
+
+  # glp_stage is the lone integer profile field (NLA stage 1–6); the rest are
+  # string enums. Normalization/validation below branch on this so an integer
+  # isn't downcased into a string that fails the GLP_STAGES inclusion check.
+  INTEGER_PROFILE_FIELDS = %w[glp_stage].freeze
 
   AAC_PROFILE_FIELDS.each_key do |field|
     define_method(field) { details&.dig(field) }
@@ -148,19 +154,31 @@ class ChildAccount < ApplicationRecord
   end
 
   # Runs on every save path (typed setter or wholesale details= from the
-  # update controller): downcases/strips the three profile keys and drops
-  # blank ones, so clearing a field is always allowed.
+  # update controller): normalizes each profile key (downcases/strips the
+  # string enums; coerces glp_stage to an integer) and drops blank ones, so
+  # clearing a field is always allowed.
   def normalize_aac_profile_fields
     return if details.blank?
 
     AAC_PROFILE_FIELDS.each_key do |field|
       next unless details.key?(field)
 
-      value = details[field].to_s.strip.downcase
-      if value.blank?
-        details.delete(field)
+      if INTEGER_PROFILE_FIELDS.include?(field)
+        # Coerce to integer (handles "3" and 3). Blank clears the key; an
+        # out-of-range value survives to fail validation below.
+        value = details[field]
+        if value.blank?
+          details.delete(field)
+        else
+          details[field] = value.to_i
+        end
       else
-        details[field] = value
+        value = details[field].to_s.strip.downcase
+        if value.blank?
+          details.delete(field)
+        else
+          details[field] = value
+        end
       end
     end
   end
@@ -607,6 +625,7 @@ class ChildAccount < ApplicationRecord
       aac_level: aac_level,
       vocab_type: vocab_type,
       age_band: age_band,
+      glp_stage: glp_stage,
       user_id: user_id,
       go_to_words: go_to_words,
       go_to_boards: cached_go_to_boards.map do |board|
@@ -969,6 +988,7 @@ class ChildAccount < ApplicationRecord
       aac_level: aac_level,
       vocab_type: vocab_type,
       age_band: age_band,
+      glp_stage: glp_stage,
       user_id: user_id,
       go_to_words: go_to_words,
       go_to_boards: cached_go_to_boards.map do |board|

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -241,6 +241,12 @@ class Image < ApplicationRecord
   def ensure_defaults
     if image_type == "menu"
       self.part_of_speech = "noun"
+    elsif part_of_speech == "phrase"
+      # Whole-phrase gestalt tiles (Script Collector / GLP templates) keep their
+      # explicit "phrase" part of speech instead of being re-categorized as a
+      # single word. Only set colors if they haven't been chosen yet.
+      self.bg_color = background_color_for(part_of_speech) if bg_color.blank?
+      self.text_color = text_color_for(bg_color) if text_color.blank?
     else
       pos = AacWordCategorizer.categorize(label)
       self.part_of_speech = pos

--- a/app/services/boards/glp_templates.rb
+++ b/app/services/boards/glp_templates.rb
@@ -1,0 +1,168 @@
+# app/services/boards/glp_templates.rb
+#
+# Gestalt Language Processing (GLP) board templates. Six predefined,
+# admin-owned template boards of WHOLE-PHRASE tiles — one per communicative
+# function — for communicators who are gestalt language processors (NLA).
+#
+# Unlike the starter blueprints (label-only trees) and robust sets (OBF-seeded
+# vocabulary), these are plain predefined boards identified by
+# `category: "glp"` + `is_template: true`. They surface in the Board Builder
+# `templates` response and the Script Collector frontend; the catalog +
+# recommendation read them straight from the DB.
+#
+# Seeding (idempotent) lives in `.seed!`, driven by `glp_templates:seed`. The
+# TEMPLATES table below is the single source of truth for both seeding and the
+# stage-aware recommendation, so the two never drift.
+module Boards
+  module GlpTemplates
+    CATEGORY = "glp".freeze
+    BOARD_TYPE = "glp_template".freeze
+    TILE_PART_OF_SPEECH = "phrase".freeze
+
+    # Each entry: a board slug + display name, the communicative function it
+    # serves, the NLA stage range (Range) it best supports, and its whole-phrase
+    # tiles. Order matters: `recommended_for` picks the FIRST entry whose stage
+    # range covers the communicator's stage.
+    TEMPLATES = [
+      {
+        slug: "glp-greetings-social",
+        name: "Greetings & Social",
+        function: "greetings",
+        stages: (1..2),
+        description: "Whole-phrase greetings and social scripts for gestalt language processors.",
+        tiles: ["hi there!", "see you later", "how are you?", "I love that!", "nice to see you", "good morning"],
+      },
+      {
+        slug: "glp-requests-wants",
+        name: "Requests & Wants",
+        function: "requests",
+        stages: (1..2),
+        description: "Whole-phrase requests and wants for gestalt language processors.",
+        tiles: ["I want more", "can I have that?", "let's go!", "help me please", "I need a break", "give me that"],
+      },
+      {
+        slug: "glp-protests-boundaries",
+        name: "Protests & Boundaries",
+        function: "protests",
+        stages: (1..2),
+        description: "Whole-phrase protests and boundary scripts for gestalt language processors.",
+        tiles: ["no thank you", "stop please", "I don't want that", "not right now", "go away", "leave me alone"],
+      },
+      {
+        slug: "glp-comments-observations",
+        name: "Comments & Observations",
+        function: "comments",
+        stages: (1..3),
+        description: "Whole-phrase comments and observations for gestalt language processors.",
+        tiles: ["look at that!", "that's so funny", "I see it", "wow!", "that's cool", "what happened?"],
+      },
+      {
+        slug: "glp-feelings-emotions",
+        name: "Feelings & Emotions",
+        function: "feelings",
+        stages: (2..3),
+        description: "Whole-phrase feelings and emotions for gestalt language processors.",
+        tiles: ["I'm happy", "that makes me sad", "I feel mad", "I'm scared", "I'm excited", "I don't feel good"],
+      },
+      {
+        slug: "glp-transitions-routines",
+        name: "Transitions & Routines",
+        function: "transitions",
+        stages: (1..2),
+        description: "Whole-phrase transition and routine scripts for gestalt language processors.",
+        tiles: ["time to go", "all done", "what's next?", "first this then that", "almost time", "let's clean up"],
+      },
+    ].freeze
+
+    module_function
+
+    # Seeded GLP template boards, alphabetical. Empty in environments where the
+    # seed hasn't run.
+    def boards
+      Board.where(is_template: true, category: CATEGORY).order(:name)
+    end
+
+    # Picker catalog entries (same shape family as StarterBlueprints#catalog,
+    # with `kind: "glp"` so the frontend can group/badge them).
+    def catalog
+      boards.map { |board| catalog_entry(board) }
+    end
+
+    def catalog_entry(board)
+      {
+        key: board.slug,
+        name: board.name,
+        kind: "glp",
+        category: CATEGORY,
+        tags: board.tags,
+        tiles: board.board_images.order(:position).map(&:label),
+      }
+    end
+
+    # Slug of the most stage-appropriate template for a given NLA stage, or nil.
+    # Definition-driven, so it works even before the boards are seeded; callers
+    # that need a real board should also check `boards.exists?(slug:)`.
+    def recommended_for(stage)
+      return nil if stage.blank?
+
+      defn = TEMPLATES.find { |t| t[:stages].include?(stage.to_i) }
+      defn&.dig(:slug)
+    end
+
+    # Tags for a template definition: ["glp", "stage_1", "stage_2",
+    # "communicative_function:<fn>"].
+    def tags_for(defn)
+      stage_tags = defn[:stages].map { |n| "stage_#{n}" }
+      ["glp", *stage_tags, "communicative_function:#{defn[:function]}"]
+    end
+
+    # Create/refresh all six GLP template boards. Idempotent: upserts each board
+    # by slug and only adds tiles whose phrase isn't already present.
+    def seed!(admin: default_admin)
+      raise "No admin user available for GLP template seeding" unless admin
+
+      TEMPLATES.map { |defn| seed_board!(defn, admin) }
+    end
+
+    def seed_board!(defn, admin)
+      board = Board.find_by(slug: defn[:slug]) || Board.new(slug: defn[:slug])
+      board.assign_attributes(
+        name: defn[:name],
+        description: defn[:description],
+        category: CATEGORY,
+        user: admin,
+        parent: admin,
+        predefined: true,
+        published: true,
+        is_template: true,
+        sub_board: false,
+        board_type: BOARD_TYPE,
+      )
+      board.tags = tags_for(defn)
+      board.save!
+
+      existing = board.board_images.pluck(:label).compact.map(&:downcase)
+      defn[:tiles].each do |phrase|
+        next if existing.include?(phrase.downcase)
+
+        image = find_or_create_phrase_image(phrase, admin)
+        board.add_image(image.id)
+      end
+
+      board
+    end
+
+    # A whole-phrase Image tagged part_of_speech: "phrase" so the tile renders
+    # (and downstream gating reads) as a gestalt script, not a single word.
+    def find_or_create_phrase_image(phrase, admin)
+      image = Image.find_by(label: phrase, user_id: admin.id) || Image.new(label: phrase, user_id: admin.id)
+      image.part_of_speech = TILE_PART_OF_SPEECH
+      image.save!
+      image
+    end
+
+    def default_admin
+      User.find_by(id: User::DEFAULT_ADMIN_ID) || User.where(role: "admin").order(:id).first
+    end
+  end
+end

--- a/app/services/communicator_profile.rb
+++ b/app/services/communicator_profile.rb
@@ -10,8 +10,12 @@ class CommunicatorProfile
   AAC_LEVELS = %w[emerging developing proficient].freeze
   VOCAB_TYPES = %w[core fringe balanced].freeze
   AGE_BANDS = %w[4-6 7-10 11-14 15-18 adult].freeze
+  # Natural Language Acquisition (NLA) stages for gestalt language processors,
+  # 1–6. Optional metadata stored as an INTEGER (unlike the string enums above)
+  # — see ChildAccount#normalize_aac_profile_fields for the int handling.
+  GLP_STAGES = (1..6).to_a.freeze
 
-  attr_reader :age, :age_band, :aac_level, :vocab_type
+  attr_reader :age, :age_band, :aac_level, :vocab_type, :glp_stage
 
   # Build from a params-like hash (string or symbol keys). Returns nil when no
   # usable profile data is present, so callers can do `CommunicatorProfile.from_params(...)`
@@ -25,6 +29,7 @@ class CommunicatorProfile
       age_band: fetch.call(:age_band),
       aac_level: fetch.call(:aac_level),
       vocab_type: fetch.call(:vocab_type),
+      glp_stage: fetch.call(:glp_stage),
       age_range: fetch.call(:age_range)
     )
     profile.present? ? profile : nil
@@ -43,6 +48,7 @@ class CommunicatorProfile
       age_band: fetch.call(:age_band) || stored["age_band"],
       aac_level: fetch.call(:aac_level) || stored["aac_level"],
       vocab_type: fetch.call(:vocab_type) || stored["vocab_type"],
+      glp_stage: fetch.call(:glp_stage) || stored["glp_stage"],
       age_range: fetch.call(:age_range)
     )
     profile.present? ? profile : nil
@@ -50,15 +56,17 @@ class CommunicatorProfile
 
   # `age_range` is the legacy free-text param already used by the scenario flow;
   # it's accepted as a fallback when no structured age/age_band is given.
-  def initialize(age: nil, age_band: nil, aac_level: nil, vocab_type: nil, age_range: nil)
+  def initialize(age: nil, age_band: nil, aac_level: nil, vocab_type: nil, glp_stage: nil, age_range: nil)
     @age = normalize_age(age)
     @age_band = normalize_age_band(age_band) || band_for_age(@age) || normalize_age_band(age_range)
     @aac_level = normalize_enum(aac_level, AAC_LEVELS)
     @vocab_type = normalize_enum(vocab_type, VOCAB_TYPES)
+    @glp_stage = normalize_glp_stage(glp_stage)
   end
 
   def present?
-    age.present? || age_band.present? || aac_level.present? || vocab_type.present?
+    age.present? || age_band.present? || aac_level.present? ||
+      vocab_type.present? || glp_stage.present?
   end
 
   def blank?
@@ -86,11 +94,25 @@ class CommunicatorProfile
     age_band == "11-14"
   end
 
+  # Gestalt language processing (NLA) stage predicates. All false when no
+  # glp_stage is set, so non-GLP communicators behave exactly as before.
+  def gestalt_early?
+    glp_stage.present? && glp_stage <= 2
+  end
+
+  def gestalt_emerging?
+    glp_stage.present? && glp_stage.between?(3, 4)
+  end
+
+  def gestalt_advanced?
+    glp_stage.present? && glp_stage >= 5
+  end
+
   # Single string appended to AI prompts. Empty when the profile is blank.
   def prompt_guidance
     return "" if blank?
 
-    [descriptor_sentence, level_guidance, vocab_guidance].compact.join(" ")
+    [descriptor_sentence, level_guidance, vocab_guidance, gestalt_guidance].compact.join(" ")
   end
 
   private
@@ -114,6 +136,13 @@ class CommunicatorProfile
 
     normalized = value.to_s.strip.downcase
     allowed.include?(normalized) ? normalized : nil
+  end
+
+  def normalize_glp_stage(value)
+    return nil if value.blank?
+
+    stage = value.to_i
+    GLP_STAGES.include?(stage) ? stage : nil
   end
 
   def band_for_age(age)
@@ -160,6 +189,26 @@ class CommunicatorProfile
       "Favor topic-specific fringe vocabulary relevant to the board's theme."
     when "balanced"
       "Aim for a balanced mix of core and fringe vocabulary."
+    end
+  end
+
+  # Gestalt-language-processor guidance, keyed to the NLA stage. Nil (and so
+  # dropped from prompt_guidance) when no glp_stage is set — keeps prompts for
+  # non-GLP communicators unchanged.
+  def gestalt_guidance
+    return nil if glp_stage.blank?
+
+    intro = "This communicator is a gestalt language processor at NLA Stage #{glp_stage}."
+    if gestalt_early?
+      "#{intro} Use whole familiar phrases and scripts, not single words. " \
+        "Prioritize phrases from their daily routines, favorite shows, and songs. " \
+        "Avoid isolated vocabulary."
+    elsif gestalt_emerging?
+      "#{intro} Mix single words with short phrases. Support novel 2-3 word " \
+        "combinations. Include both whole phrases and individual high-frequency words."
+    else
+      "#{intro} Use full sentences with varied grammar. Support complex sentence " \
+        "construction with verb tenses and modifiers."
     end
   end
 end

--- a/lib/tasks/glp_templates.rake
+++ b/lib/tasks/glp_templates.rake
@@ -1,0 +1,14 @@
+namespace :glp_templates do
+  desc "Seed the 6 gestalt-language (GLP) whole-phrase template boards (idempotent)"
+  task seed: :environment do
+    admin = Boards::GlpTemplates.default_admin
+    abort "No admin user found (User::DEFAULT_ADMIN_ID=#{User::DEFAULT_ADMIN_ID})." unless admin
+
+    puts "[glp_templates:seed] Seeding #{Boards::GlpTemplates::TEMPLATES.size} GLP template boards..."
+    boards = Boards::GlpTemplates.seed!(admin: admin)
+    boards.each do |board|
+      puts "  - #{board.name}: board ##{board.id} (#{board.board_images.count} tiles, tags=#{board.tags.inspect})"
+    end
+    puts "[glp_templates:seed] done"
+  end
+end

--- a/spec/models/child_account_aac_profile_spec.rb
+++ b/spec/models/child_account_aac_profile_spec.rb
@@ -65,4 +65,51 @@ RSpec.describe ChildAccount, type: :model do
       expect(account.details).to eq({ "interests" => ["dinosaurs"] })
     end
   end
+
+  # glp_stage is the integer profile field — NLA stage 1–6, stored alongside the
+  # string enums but normalized/validated as an integer.
+  describe "glp_stage (integer profile field)" do
+    it "coerces a string stage to an integer and stays valid" do
+      account.glp_stage = "3"
+      expect(account).to be_valid
+      expect(account.details["glp_stage"]).to eq(3)
+      expect(account.glp_stage).to eq(3)
+    end
+
+    it "accepts an integer stage as-is" do
+      account.glp_stage = 2
+      expect(account).to be_valid
+      expect(account.details["glp_stage"]).to eq(2)
+    end
+
+    it "rejects an out-of-range stage" do
+      account.glp_stage = 7
+      expect(account).not_to be_valid
+      expect(account.errors[:glp_stage]).to be_present
+    end
+
+    it "allows clearing the stage with nil/blank (key dropped)" do
+      account.glp_stage = 3
+      account.glp_stage = nil
+      expect(account).to be_valid
+      expect(account.details).not_to have_key("glp_stage")
+      expect(account.glp_stage).to be_nil
+    end
+
+    it "saves independently of the string profile fields" do
+      account.glp_stage = 2
+      account.aac_level = "developing"
+      expect(account).to be_valid
+      expect(account.glp_stage).to eq(2)
+      expect(account.aac_level).to eq("developing")
+    end
+
+    it "validates a wholesale details assignment of glp_stage too" do
+      account.details = { "glp_stage" => 9 }
+      expect(account).not_to be_valid
+      account.details = { "glp_stage" => 4 }
+      expect(account).to be_valid
+      expect(account.details["glp_stage"]).to eq(4)
+    end
+  end
 end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -606,6 +606,38 @@ RSpec.describe "API::Boards", type: :request do
       board_image = board.board_images.find_by(image_id: foreign_image.id)
       expect(board_image.display_image_url).to eq(new_doc.tile_url)
     end
+
+    # Script Collector (gestalt) support: a whole-phrase tile carries its source
+    # and communicative function, stored on board_images.data.
+    it "stores gestalt metadata and a phrase part_of_speech on the tile" do
+      post "/api/boards/#{board.id}/add_image",
+           params: {
+             image: { label: "I want more", part_of_speech: "phrase" },
+             data: { gestalt_source: "Bluey S3E4", utterance_function: "request" },
+           },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+
+      new_image = Image.find_by(label: "I want more")
+      expect(new_image.part_of_speech).to eq("phrase")
+
+      board_image = board.reload.board_images.find_by(image_id: new_image.id)
+      expect(board_image.part_of_speech).to eq("phrase")
+      expect(board_image.data["gestalt_source"]).to eq("Bluey S3E4")
+      expect(board_image.data["utterance_function"]).to eq("request")
+    end
+
+    it "leaves board_images.data untouched when no gestalt metadata is sent" do
+      post "/api/boards/#{board.id}/add_image",
+           params: { image: { label: "plain word" } },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      new_image = Image.find_by(label: "plain word")
+      board_image = board.reload.board_images.find_by(image_id: new_image.id)
+      expect(board_image.data).not_to have_key("gestalt_source")
+    end
   end
 
   # Mailchimp "hit_limit" Customer Journey trigger (issue #291, journey #3).

--- a/spec/requests/api/child_accounts_aac_profile_spec.rb
+++ b/spec/requests/api/child_accounts_aac_profile_spec.rb
@@ -44,5 +44,37 @@ RSpec.describe "API::ChildAccounts AAC profile", type: :request do
       expect(response).to have_http_status(:ok)
       expect(communicator.reload.aac_level).to be_nil
     end
+
+    it "persists glp_stage as an integer and exposes it in the api_view" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { glp_stage: 3, aac_level: "developing" } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["glp_stage"]).to eq(3)
+      expect(body["aac_level"]).to eq("developing")
+      expect(communicator.reload.details["glp_stage"]).to eq(3)
+    end
+
+    it "rejects an out-of-range glp_stage" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { glp_stage: 7 } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(communicator.reload.glp_stage).to be_nil
+    end
+
+    it "clears glp_stage when sent blank" do
+      communicator.update!(details: { "glp_stage" => 2 })
+
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { glp_stage: nil } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(communicator.reload.glp_stage).to be_nil
+    end
   end
 end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -196,6 +196,48 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(JSON.parse(response.body)["recommended_template"]).to be_nil
       end
     end
+
+    describe "GLP templates (gestalt language support)" do
+      def seed_glp_templates!
+        Boards::GlpTemplates.seed!(admin: create(:admin_user))
+      end
+
+      it "includes seeded GLP templates (kind=glp), with no recommendation absent a communicator" do
+        seed_glp_templates!
+        get "/api/v1/board_builder/templates", headers: headers
+
+        body = JSON.parse(response.body)
+        glp = body["templates"].find { |t| t["key"] == "glp-greetings-social" }
+        expect(glp).to be_present
+        expect(glp["kind"]).to eq("glp")
+        expect(body["glp_templates"].map { |t| t["key"] }).to include("glp-greetings-social")
+        # No communicator → no GLP recommendation.
+        expect(body["recommended_template"]).to be_nil
+      end
+
+      it "recommends a stage-appropriate GLP template when the communicator has a glp_stage" do
+        seed_glp_templates!
+        communicator.update!(details: { "glp_stage" => 1 })
+
+        get "/api/v1/board_builder/templates",
+            params: { communicator_id: communicator.id }, headers: headers
+
+        body = JSON.parse(response.body)
+        expect(body["recommended_template"]).to eq("glp-greetings-social")
+        expect(body["recommendation_reason"]).to match(/gestalt|NLA Stage 1/i)
+      end
+
+      it "returns only GLP templates with ?template_type=glp" do
+        seed_glp_templates!
+        get "/api/v1/board_builder/templates",
+            params: { template_type: "glp" }, headers: headers
+
+        body = JSON.parse(response.body)
+        kinds = body["templates"].map { |t| t["kind"] }.uniq
+        expect(kinds).to eq(["glp"])
+        expect(body["templates"].map { |t| t["key"] }).not_to include("home")
+      end
+    end
   end
 
   describe "GET /api/v1/board_builder/interest_categories" do

--- a/spec/services/boards/glp_templates_spec.rb
+++ b/spec/services/boards/glp_templates_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe Boards::GlpTemplates do
+  let(:admin) { create(:admin_user) }
+
+  describe ".seed!" do
+    it "creates the six GLP template boards with the expected metadata" do
+      boards = described_class.seed!(admin: admin)
+
+      expect(boards.size).to eq(6)
+      boards.each do |board|
+        expect(board).to be_persisted
+        expect(board.is_template).to be(true)
+        expect(board.predefined).to be(true)
+        expect(board.category).to eq("glp")
+        expect(board.board_type).to eq("glp_template")
+        expect(board.user_id).to eq(admin.id)
+        expect(board.tags).to include("glp")
+        expect(board.board_images.count).to be > 0
+      end
+    end
+
+    it "tags each board with its stages and communicative function" do
+      described_class.seed!(admin: admin)
+      greetings = Board.find_by(slug: "glp-greetings-social")
+
+      expect(greetings.tags).to include("glp", "stage_1", "stage_2", "communicative_function:greetings")
+    end
+
+    it "marks tiles as whole-phrase (part_of_speech: phrase)" do
+      described_class.seed!(admin: admin)
+      greetings = Board.find_by(slug: "glp-greetings-social")
+
+      phrase_images = greetings.board_images.map(&:image)
+      expect(phrase_images.map(&:part_of_speech).uniq).to eq(["phrase"])
+      expect(greetings.board_images.map(&:label)).to include("hi there!")
+    end
+
+    it "is idempotent — re-running creates no duplicate boards or tiles" do
+      described_class.seed!(admin: admin)
+      first_counts = Board.where(category: "glp").order(:slug).map { |b| [b.slug, b.board_images.count] }
+
+      described_class.seed!(admin: admin)
+      second_counts = Board.where(category: "glp").order(:slug).map { |b| [b.slug, b.board_images.count] }
+
+      expect(Board.where(category: "glp").count).to eq(6)
+      expect(second_counts).to eq(first_counts)
+    end
+
+    it "raises a clear error when no admin is available" do
+      expect { described_class.seed!(admin: nil) }
+        .to raise_error(/No admin user available/)
+    end
+  end
+
+  describe ".catalog" do
+    it "returns one entry per seeded board with key/name/kind/tiles" do
+      described_class.seed!(admin: admin)
+      catalog = described_class.catalog
+
+      expect(catalog.size).to eq(6)
+      entry = catalog.find { |c| c[:key] == "glp-greetings-social" }
+      expect(entry[:kind]).to eq("glp")
+      expect(entry[:category]).to eq("glp")
+      expect(entry[:name]).to eq("Greetings & Social")
+      expect(entry[:tiles]).to include("hi there!")
+    end
+
+    it "is empty when no GLP boards are seeded" do
+      expect(described_class.catalog).to eq([])
+    end
+  end
+
+  describe ".recommended_for" do
+    it "returns a stage-appropriate template slug" do
+      expect(described_class.recommended_for(1)).to eq("glp-greetings-social")
+      expect(described_class.recommended_for(3)).to eq("glp-comments-observations")
+    end
+
+    it "coerces a string stage" do
+      expect(described_class.recommended_for("2")).to eq("glp-greetings-social")
+    end
+
+    it "returns nil for a blank stage" do
+      expect(described_class.recommended_for(nil)).to be_nil
+      expect(described_class.recommended_for("")).to be_nil
+    end
+  end
+end

--- a/spec/services/communicator_profile_spec.rb
+++ b/spec/services/communicator_profile_spec.rb
@@ -162,4 +162,67 @@ RSpec.describe CommunicatorProfile do
       expect(described_class.new(age_band: "7-10")).not_to be_young_teen
     end
   end
+
+  describe "glp_stage (gestalt language processing)" do
+    it "builds from params (string or integer) and stores an integer" do
+      expect(described_class.from_params({ "glp_stage" => "3" }).glp_stage).to eq(3)
+      expect(described_class.from_params({ glp_stage: 5 }).glp_stage).to eq(5)
+    end
+
+    it "makes a glp-only profile present (so .for returns it)" do
+      comm = FactoryBot.build(:child_account, details: { "glp_stage" => 2 })
+      profile = described_class.for(communicator: comm)
+      expect(profile).to be_present
+      expect(profile.glp_stage).to eq(2)
+    end
+
+    it "rejects out-of-range and non-numeric stages" do
+      expect(described_class.new(glp_stage: 7).glp_stage).to be_nil
+      expect(described_class.new(glp_stage: 0).glp_stage).to be_nil
+      expect(described_class.new(glp_stage: "abc").glp_stage).to be_nil
+      expect(described_class.new(glp_stage: nil).glp_stage).to be_nil
+    end
+
+    it "exposes stage-band predicates" do
+      expect(described_class.new(glp_stage: 1)).to be_gestalt_early
+      expect(described_class.new(glp_stage: 2)).to be_gestalt_early
+      expect(described_class.new(glp_stage: 3)).to be_gestalt_emerging
+      expect(described_class.new(glp_stage: 4)).to be_gestalt_emerging
+      expect(described_class.new(glp_stage: 5)).to be_gestalt_advanced
+      expect(described_class.new(glp_stage: 6)).to be_gestalt_advanced
+    end
+
+    it "leaves all gestalt predicates false when no stage is set" do
+      profile = described_class.new(aac_level: "developing")
+      expect(profile).not_to be_gestalt_early
+      expect(profile).not_to be_gestalt_emerging
+      expect(profile).not_to be_gestalt_advanced
+    end
+
+    describe "#prompt_guidance" do
+      it "adds whole-phrase guidance for early stages (1-2)" do
+        guidance = described_class.new(glp_stage: 1).prompt_guidance
+        expect(guidance).to match(/gestalt language processor at NLA Stage 1/i)
+        expect(guidance).to match(/whole familiar phrases|scripts/i)
+        expect(guidance).to match(/avoid isolated vocabulary/i)
+      end
+
+      it "adds mixed word-and-phrase guidance for emerging stages (3-4)" do
+        guidance = described_class.new(glp_stage: 4).prompt_guidance
+        expect(guidance).to match(/NLA Stage 4/i)
+        expect(guidance).to match(/single words with short phrases/i)
+      end
+
+      it "adds full-sentence guidance for advanced stages (5-6)" do
+        guidance = described_class.new(glp_stage: 6).prompt_guidance
+        expect(guidance).to match(/NLA Stage 6/i)
+        expect(guidance).to match(/full sentences|verb tenses/i)
+      end
+
+      it "adds no gestalt guidance when glp_stage is unset (backward compatible)" do
+        guidance = described_class.new(age: 4, aac_level: "emerging").prompt_guidance
+        expect(guidance).not_to match(/gestalt|NLA Stage/i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements the **Gestalt Language Support (backend)** handoff
(`.claude-notes/gestalt-language-support-handoff.md`). Ships independently; the
frontend GLP features depend on this PR but it works alone.

## What's in it

### 1. `glp_stage` on the communicator profile
- New optional **NLA stage** (`glp_stage`, integer 1–6) stored in
  `child_accounts.details` jsonb, **alongside** `aac_level`/`vocab_type`/`age_band`
  (it measures something different — doesn't replace them). No migration.
- Added to `ChildAccount::AAC_PROFILE_FIELDS`, but flagged in a new
  `INTEGER_PROFILE_FIELDS` so normalization coerces it to an integer instead of
  downcasing it to a string (which would fail the range check). Validated against
  `CommunicatorProfile::GLP_STAGES`. Exposed on `api_view` / `vendor_api_view`.
- `CommunicatorProfile` gains `glp_stage`, predicates `gestalt_early?` (1–2) /
  `gestalt_emerging?` (3–4) / `gestalt_advanced?` (5–6), and stage-specific
  `prompt_guidance` (whole phrases early → full sentences advanced). No stage ⇒
  no gestalt guidance (backward compatible).

### 2. GLP board templates
- `Boards::GlpTemplates`: six predefined, admin-owned whole-phrase template
  boards (`category: "glp"`, `is_template: true`) — Greetings & Social, Requests
  & Wants, Protests & Boundaries, Comments & Observations, Feelings & Emotions,
  Transitions & Routines. Idempotent seed: `bin/rails glp_templates:seed`.

### 3. Board Builder integration
- `GET /api/v1/board_builder/templates` now includes the GLP catalog, a separate
  `glp_templates` array, and a stage-aware `recommended_template` (with reason)
  when the communicator has a `glp_stage`. `?template_type=glp` narrows to GLP
  only. Fully backward compatible.

### 4. Script Collector API support
- `POST /api/boards/:id/add_image` accepts `image[part_of_speech]=phrase` (a
  whole-phrase gestalt tile — `Image#ensure_defaults` now preserves an explicit
  `"phrase"` POS instead of re-categorizing it) plus free-form
  `data[gestalt_source]` / `data[utterance_function]`, stored on
  `board_images.data`.

## Test plan
- New/extended specs: `communicator_profile_spec`, `child_account_aac_profile_spec`
  (model + request), `boards/glp_templates_spec`, `board_builder_spec` (GLP
  block), `boards_spec` (add_image gestalt metadata).
- **Full suite:** `bundle exec rspec` → `1810 examples, 2 failures, 10 pending`.
  Both failures are **pre-existing on `origin/main`** and unrelated to this work
  (a `PRO_PLAN_LIMITS` constant assertion in `user_plan_limits_spec` and an
  ActiveStorage/CloudFront URL assertion in `generate_board_preview_job_spec`) —
  confirmed by re-running them with the changes stashed.

## Deploy notes
- After merge, run `bin/rails glp_templates:seed` to create the 6 GLP template
  boards. No ENV vars, no migrations — all data in existing jsonb columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)