### PR TITLE
fix(communicators): promote paid users' stuck sandbox communicators on upgrade (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Paid users' communicators stuck in sandbox mode (#359)
+- A communicator created while a user was on the Free plan was forced into
+  no-login **sandbox** mode, and upgrading to Basic/Pro never converted it — so
+  paying users could be walled off with "Sign-in disabled for Sandbox
+  Communicators". Upgrading to a paid plan now automatically promotes sandbox
+  communicators to full **active** accounts (with sign-in), up to the plan's
+  slot limit, most-recently-active first.
+- Existing affected users can be fixed with the idempotent
+  `rake communicators:promote_paid_sandboxes` (dry-run by default; `DRY_RUN=false`
+  to apply, `USER_ID=N` to scope to one user).
+
 ### Added — Gestalt language (GLP) support
 - Communicators can now carry an optional **NLA stage** (`glp_stage`, 1–6),
   stored in `child_accounts.details` alongside the existing AAC profile fields

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,6 +594,31 @@ nonspeaking child is never stranded mid-use.
   `api_view` / `index_api_view` / `vendor_api_view`, letting the frontend tell
   "exists but in fallback" from "doesn't exist."
 
+### Sandbox → active promotion on upgrade (issue #359)
+
+The upgrade-direction counterpart to fallback mode. A Free user's self-creates
+are **forced to `sandbox`** (`Permissions::CommunicatorLimits.self_create_status`
+hard-returns SANDBOX when `user.free?`), so a communicator created before
+upgrading was left stuck in sandbox mode — sign-in disabled, "Promote this
+sandbox" UI — even after the user became a paying Basic/Pro subscriber.
+
+- **Reconciler:** `User#reconcile_paid_sandbox_promotions!` runs on the **same**
+  `after_save … if: :saved_change_to_plan_type?` trigger as the fallback
+  reconciler. When the user is now `paid_plan?` (admins skipped — unlimited and
+  already sign in to any account), it promotes sandbox communicators →
+  `active`, **most-recently-active first**, up to the free paid slots
+  (`slot_limit_for(settings) - owned_slot_count`). Idempotent. Because the
+  subscription-upsert webhook does `plan_type=` → `setup_limits` → one `save!`,
+  the new slot limit is already in `settings` when the callback fires.
+- **`ChildAccount#promote_to_active!`** — mirror of `promote_to_loaner!`: flips
+  status to `active`, **mints a passcode if blank** (so sign-in actually works),
+  and deletes the per-account `demo_board_limit` cap. Idempotent on an active
+  account; never demotes a loaner.
+- **Backfill:** the forward fix only fires on a plan change, so existing
+  affected users need `rake communicators:promote_paid_sandboxes` (dry-run by
+  default; `DRY_RUN=false` to apply, `USER_ID=N` to scope to one user). It
+  promotes paid users' stuck sandboxes exactly like the callback.
+
 ## Team permissions — owner protection
 
 Communicators (`child_account`) have an `owner_id` (the family/parent

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -342,6 +342,29 @@ class ChildAccount < ApplicationRecord
     self
   end
 
+  # Promote a sandbox communicator to a full, owned `active` account.
+  #
+  # Used when a Free user (whose self-creates are forced to sandbox) upgrades
+  # to a paid plan — their sandbox communicators become full communicators with
+  # sign-in (see User#reconcile_paid_sandbox_promotions!, issue #359). Mints a
+  # passcode if none exists so sign-in actually works, and lifts the per-account
+  # sandbox board cap so the owner's plan board limit applies.
+  #
+  # Idempotent on an already-active account; never demotes a loaner.
+  def promote_to_active!
+    return self if active?
+    return self if loaner?
+
+    self.status = ACTIVE
+    self.passcode = SecureRandom.alphanumeric(8) if passcode.blank?
+
+    self.settings ||= {}
+    self.settings.delete("demo_board_limit")
+
+    save!
+    self
+  end
+
   # Generate (or rotate) the claim token the parent uses to take over
   # this loaner. Loaner-only. The claim URL is built by the controller.
   def generate_claim_token!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,6 +195,14 @@ class User < ApplicationRecord
   # restores them as slots free up. See reconcile_communicator_fallback!.
   after_save :reconcile_communicator_fallback!, if: :saved_change_to_plan_type?
 
+  # Promote sandbox communicators to full (active) accounts when the user lands
+  # on a paid plan (issue #359). A Free user's self-creates are forced to
+  # sandbox; without this, upgrading to Basic/Pro left those communicators stuck
+  # in sandbox mode with sign-in disabled. Runs after save (new slot limits are
+  # already in `settings`) on every plan change. See
+  # reconcile_paid_sandbox_promotions!.
+  after_save :reconcile_paid_sandbox_promotions!, if: :saved_change_to_plan_type?
+
   # Grant the user's tier's monthly AI credit allowance on signup so the
   # very first AI call doesn't 402. Idempotent in CreditService — safe to
   # call again if a callback runs twice.
@@ -1482,6 +1490,27 @@ class User < ApplicationRecord
         account.enter_fallback! unless account.fallback_mode?
       end
     end
+  end
+
+  # Promote sandbox communicators to full (active) accounts up to the number of
+  # free paid slots (issue #359). A Free user's self-creates are forced to
+  # sandbox; on upgrade to Basic/Pro those should become full communicators with
+  # sign-in. Promotes most-recently-active first so the user's primary
+  # communicator is converted before any extras. No-op for Free/unpaid users and
+  # admins (admins are unlimited and already sign in to any account). Idempotent.
+  def reconcile_paid_sandbox_promotions!
+    return if admin?
+    return unless paid_plan?
+
+    slot_limit = Permissions::CommunicatorLimits.slot_limit_for(settings || {})
+    available = slot_limit - Permissions::CommunicatorLimits.owned_slot_count(self)
+    return if available <= 0
+
+    communicator_accounts
+      .where(status: ChildAccount::SANDBOX)
+      .order(Arel.sql("last_sign_in_at DESC NULLS LAST, updated_at DESC, id DESC"))
+      .limit(available)
+      .each(&:promote_to_active!)
   end
 
   # How long a user must wait between editable-board switches. Closes the

--- a/lib/tasks/communicators.rake
+++ b/lib/tasks/communicators.rake
@@ -41,4 +41,58 @@ namespace :communicators do
       puts "Converted #{converted} communicator(s) to sandbox."
     end
   end
+
+  # Backfill for issue #359: a paid user (Basic/Pro) whose communicator was
+  # created while they were still Free is stuck in sandbox mode with sign-in
+  # disabled. The forward fix (User#reconcile_paid_sandbox_promotions!) only
+  # runs when plan_type changes, so existing affected users need this one-off.
+  #
+  # Promotes each paid user's sandbox communicators to full `active` accounts,
+  # most-recently-active first, up to their available paid slots — exactly what
+  # the upgrade callback now does. promote_to_active! mints a passcode so
+  # sign-in works and lifts the sandbox board cap. Idempotent. Admins skipped
+  # (unlimited; already sign in to any account).
+  #
+  # Dry-run by default. Apply with DRY_RUN=false. Optionally scope to one user:
+  #   rake communicators:promote_paid_sandboxes                       # preview all
+  #   DRY_RUN=false rake communicators:promote_paid_sandboxes         # apply all
+  #   DRY_RUN=false USER_ID=740 rake communicators:promote_paid_sandboxes
+  desc "Promote paid users' stuck sandbox communicators to full active (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task promote_paid_sandboxes: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    users = ENV["USER_ID"].present? ? User.where(id: ENV["USER_ID"]) : User.all
+    promoted = 0
+    affected_users = 0
+
+    users.find_each do |user|
+      next if user.admin? || !user.paid_plan?
+
+      slot_limit = Permissions::CommunicatorLimits.slot_limit_for(user.settings || {})
+      available = slot_limit - Permissions::CommunicatorLimits.owned_slot_count(user)
+      next if available <= 0
+
+      sandboxes = user.communicator_accounts
+        .where(status: ChildAccount::SANDBOX)
+        .order(Arel.sql("last_sign_in_at DESC NULLS LAST, updated_at DESC, id DESC"))
+        .limit(available)
+        .to_a
+      next if sandboxes.empty?
+
+      affected_users += 1
+      sandboxes.each do |ca|
+        puts "#{dry_run ? '[DRY RUN] ' : ''}user #{user.id} (#{user.plan_type}): communicator ##{ca.id} #{ca.name.inspect} sandbox -> active"
+        unless dry_run
+          ca.promote_to_active!
+          promoted += 1
+        end
+      end
+    end
+
+    if dry_run
+      puts "Dry run only — re-run with DRY_RUN=false to apply."
+    else
+      puts "Promoted #{promoted} communicator(s) across #{affected_users} user(s)."
+    end
+  end
 end

--- a/spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb
+++ b/spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# Backfill task for issue #359 — promote paid users' stuck sandbox
+# communicators to full `active` accounts.
+RSpec.describe "communicators:promote_paid_sandboxes rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["communicators:promote_paid_sandboxes"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    original = ENV.to_hash.slice("DRY_RUN", "USER_ID")
+    example.run
+    ENV["DRY_RUN"] = original["DRY_RUN"]
+    ENV["USER_ID"] = original["USER_ID"]
+  end
+
+  # A paid user whose communicator is stuck in sandbox (created while Free, then
+  # upgraded without the reconcile ever running).
+  let!(:paid_user) { create(:user, plan_type: "basic") }
+  let!(:stuck_sandbox) do
+    create(:child_account, user: paid_user, status: ChildAccount::SANDBOX, passcode: nil)
+  end
+
+  it "previews without changing anything in dry-run (default)" do
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+    run_task
+    expect(stuck_sandbox.reload.status).to eq("sandbox")
+  end
+
+  it "promotes the sandbox to active when applied" do
+    ENV["DRY_RUN"] = "false"
+    ENV.delete("USER_ID")
+    run_task
+
+    stuck_sandbox.reload
+    expect(stuck_sandbox.status).to eq("active")
+    expect(stuck_sandbox.passcode).to be_present
+  end
+
+  it "leaves Free users' sandboxes untouched" do
+    free_user = create(:user, plan_type: "free")
+    free_sandbox = create(:child_account, user: free_user, status: ChildAccount::SANDBOX, passcode: nil)
+
+    ENV["DRY_RUN"] = "false"
+    ENV.delete("USER_ID")
+    run_task
+
+    expect(free_sandbox.reload.status).to eq("sandbox")
+  end
+
+  it "scopes to a single user via USER_ID" do
+    other_paid = create(:user, plan_type: "basic")
+    other_sandbox = create(:child_account, user: other_paid, status: ChildAccount::SANDBOX, passcode: nil)
+
+    ENV["DRY_RUN"] = "false"
+    ENV["USER_ID"] = paid_user.id.to_s
+    run_task
+
+    expect(stuck_sandbox.reload.status).to eq("active")
+    expect(other_sandbox.reload.status).to eq("sandbox")
+  end
+end

--- a/spec/models/communicator_sandbox_promotion_spec.rb
+++ b/spec/models/communicator_sandbox_promotion_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #359 — a Free user's self-created communicators are forced to sandbox.
+# When the user upgrades to a paid plan, those sandboxes should become full
+# `active` communicators (with sign-in), up to the plan's slot limit. Without
+# this, a paying Basic user was stuck with a sandbox communicator and "sign-in
+# disabled" messaging.
+RSpec.describe "Paid sandbox promotion (#359)", type: :model do
+  describe "ChildAccount#promote_to_active!" do
+    let(:user) { create(:user, plan_type: "basic") }
+
+    it "flips status sandbox -> active and mints a passcode" do
+      account = create(:child_account, user: user, status: ChildAccount::SANDBOX, passcode: nil)
+      expect { account.promote_to_active! }
+        .to change { account.status }.from("sandbox").to("active")
+      expect(account.passcode).to be_present
+    end
+
+    it "preserves an existing passcode" do
+      account = create(:child_account, user: user, status: ChildAccount::SANDBOX, passcode: "keepme12")
+      account.promote_to_active!
+      expect(account.passcode).to eq("keepme12")
+    end
+
+    it "lifts the per-account sandbox board cap" do
+      account = create(:child_account, user: user, status: ChildAccount::SANDBOX,
+                                       settings: { "demo_board_limit" => 1 })
+      account.promote_to_active!
+      expect(account.settings).not_to have_key("demo_board_limit")
+    end
+
+    it "is idempotent on an already-active account and doesn't rotate its passcode" do
+      account = create(:child_account, user: user, status: ChildAccount::ACTIVE, passcode: "active12")
+      expect { account.promote_to_active! }.not_to change { account.reload.status }
+      expect(account.passcode).to eq("active12")
+    end
+
+    it "never demotes a loaner" do
+      account = create(:child_account, user: user, status: ChildAccount::LOANER, passcode: "loaner12")
+      account.promote_to_active!
+      expect(account.status).to eq("loaner")
+    end
+  end
+
+  describe "User#reconcile_paid_sandbox_promotions! on upgrade" do
+    # Build a Free owner with `count` sandbox communicators, each stamped with a
+    # distinct last_sign_in_at so the promotion ordering is deterministic
+    # (index 0 = most recently active).
+    def free_owner_with_sandboxes(count)
+      owner = create(:user, plan_type: "free")
+      accounts = Array.new(count) do |i|
+        acct = create(:child_account, user: owner, status: ChildAccount::SANDBOX,
+                                      passcode: nil, username: "comm_#{owner.id}_#{i}")
+        acct.update_column(:last_sign_in_at, (i + 1).hours.ago)
+        acct
+      end
+      [owner, accounts]
+    end
+
+    it "promotes a Free user's sandbox to active when they upgrade to Basic" do
+      owner, accounts = free_owner_with_sandboxes(1)
+      account = accounts.first
+
+      owner.update!(plan_type: "basic") # fires the callback
+
+      account.reload
+      expect(account.status).to eq("active")
+      expect(account.passcode).to be_present
+    end
+
+    it "promotes only up to the available paid slots, most-recently-active first" do
+      owner, accounts = free_owner_with_sandboxes(3)
+
+      owner.update!(plan_type: "basic") # Basic slot limit = 2
+
+      a0, a1, a2 = accounts.map(&:reload)
+      expect(a0.status).to eq("active") # most recently active
+      expect(a1.status).to eq("active")
+      expect(a2.status).to eq("sandbox") # over the Basic limit of 2
+    end
+
+    it "accounts for slots already occupied by existing active communicators" do
+      owner, sandboxes = free_owner_with_sandboxes(2)
+      create(:child_account, user: owner, status: ChildAccount::ACTIVE,
+                             passcode: "existing", username: "comm_#{owner.id}_active")
+
+      owner.update!(plan_type: "basic") # limit 2, one slot already taken
+
+      statuses = sandboxes.map { |s| s.reload.status }
+      expect(statuses).to contain_exactly("active", "sandbox")
+    end
+
+    it "does nothing while the user stays on Free" do
+      owner, accounts = free_owner_with_sandboxes(1)
+      owner.reconcile_paid_sandbox_promotions!
+      expect(accounts.first.reload.status).to eq("sandbox")
+    end
+
+    it "is a no-op for admins (unlimited; already sign in to any account)" do
+      admin = create(:admin_user)
+      account = create(:child_account, user: admin, status: ChildAccount::SANDBOX, passcode: nil)
+      admin.reconcile_paid_sandbox_promotions!
+      expect(account.reload.status).to eq("sandbox")
+    end
+
+    it "is idempotent — re-running promotes nothing new" do
+      owner, _accounts = free_owner_with_sandboxes(1)
+      owner.update!(plan_type: "basic")
+      expect { owner.reconcile_paid_sandbox_promotions! }
+        .not_to change { owner.communicator_accounts.where(status: ChildAccount::SANDBOX).count }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #359 — a paying Basic user (`477288@bsd48.org`, distinct_id `740`) had a communicator stuck in **sandbox** mode with sign-in disabled.

**Root cause (issue's cause #1):** a Free user's self-creates are hard-forced to `sandbox` (`Permissions::CommunicatorLimits.self_create_status` returns SANDBOX when `user.free?`). On upgrade, the only plan-change reconciler (`reconcile_communicator_fallback!`) manages **loaner/active** slots and never touches sandboxes — so the communicator stayed `sandbox` forever. The backend `can_sign_in?` actually returns `true` for paid users, but the frontend gates its "Sign-in disabled / Promote this sandbox" UI on `status == "sandbox"`, walling off the paying user.

## What changed

- **`ChildAccount#promote_to_active!`** — mirror of `promote_to_loaner!`: flips status to `active`, mints a passcode if blank (so sign-in works), deletes the per-account `demo_board_limit` cap. Idempotent; never demotes a loaner.
- **`User#reconcile_paid_sandbox_promotions!`** — runs on the **same** `after_save … if: :saved_change_to_plan_type?` trigger as the fallback reconciler. When the user is now `paid_plan?` (admins skipped), promotes sandboxes → active, most-recently-active first, up to the free paid slots (`slot_limit_for - owned_slot_count`). The subscription-upsert webhook does `plan_type=` → `setup_limits` → one `save!`, so the new slot limit is already in `settings` when the callback fires.
- **`rake communicators:promote_paid_sandboxes`** — backfill for existing affected users (the forward fix only fires on a plan change). Dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope to one user.
- **Docs** — CLAUDE.md "Sandbox → active promotion on upgrade" subsection + CHANGELOG entry.

## Frontend note

No frontend change needed — the backend now reports `status: "active"` / `is_demo: false` after promotion, which is what the React UI keys off. The promoted communicator gets a random passcode; the user should set their own via the communicator edit form.

## Fixing user 740 in production

The forward fix won't retroactively run for 740 (their plan won't change again). Run the backfill on the prod host:

```bash
USER_ID=740 bin/rails communicators:promote_paid_sandboxes              # preview
DRY_RUN=false USER_ID=740 bin/rails communicators:promote_paid_sandboxes # apply
```

## Test plan

- New: `spec/models/communicator_sandbox_promotion_spec.rb` (11 examples) — `promote_to_active!` + the upgrade reconciler (free→basic promotes, slot-cap, existing-active slots, free no-op, admin skip, idempotent).
- New: `spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb` (4 examples) — dry-run, apply, free-user skip, USER_ID scoping.
- Regression: ran `communicator_fallback_spec`, `child_account_promote_to_loaner_spec`, `child_account_status_spec`, `webhooks_plan_type_spec` — **58 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)