### PR TITLE
fix(communicators): only auto-promote sandboxes for plans with zero sandbox entitlement (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - A communicator created while a user was on the Free plan was forced into
   no-login **sandbox** mode, and upgrading to Basic/Pro never converted it — so
   paying users could be walled off with "Sign-in disabled for Sandbox
-  Communicators". Upgrading to a paid plan now automatically promotes sandbox
-  communicators to full **active** accounts (with sign-in), up to the plan's
-  slot limit, most-recently-active first.
+  Communicators". Upgrading to **Basic** (which grants no sandbox slots) now
+  automatically promotes those leftover sandbox communicators to full **active**
+  accounts (with sign-in), up to the plan's slot limit, most-recently-active
+  first. **Pro** is left alone — it includes an intentional sandbox/demo slot.
 - Existing affected users can be fixed with the idempotent
   `rake communicators:promote_paid_sandboxes` (dry-run by default; `DRY_RUN=false`
   to apply, `USER_ID=N` to scope to one user).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,12 +604,18 @@ sandbox" UI — even after the user became a paying Basic/Pro subscriber.
 
 - **Reconciler:** `User#reconcile_paid_sandbox_promotions!` runs on the **same**
   `after_save … if: :saved_change_to_plan_type?` trigger as the fallback
-  reconciler. When the user is now `paid_plan?` (admins skipped — unlimited and
-  already sign in to any account), it promotes sandbox communicators →
+  reconciler. When the user is now `paid_plan?` **and their plan grants zero
+  sandbox slots** (admins skipped), it promotes sandbox communicators →
   `active`, **most-recently-active first**, up to the free paid slots
   (`slot_limit_for(settings) - owned_slot_count`). Idempotent. Because the
   subscription-upsert webhook does `plan_type=` → `setup_limits` → one `save!`,
   the new slot limit is already in `settings` when the callback fires.
+- **Basic-only by design.** `BASIC_PLAN_LIMITS["demo_communicator_limit"] == 0`
+  (no sandbox entitlement), so a Basic user's sandbox is always a stuck Free-era
+  leftover and is promoted. **Pro grants 1 sandbox slot**
+  (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 1`), so a Pro user's sandbox
+  is an intentional scratch/demo account and is left untouched — the guard is
+  `sandbox_limit_for(settings) > 0 → skip`.
 - **`ChildAccount#promote_to_active!`** — mirror of `promote_to_loaner!`: flips
   status to `active`, **mints a passcode if blank** (so sign-in actually works),
   and deletes the per-account `demo_board_limit` cap. Idempotent on an active

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1494,13 +1494,18 @@ class User < ApplicationRecord
 
   # Promote sandbox communicators to full (active) accounts up to the number of
   # free paid slots (issue #359). A Free user's self-creates are forced to
-  # sandbox; on upgrade to Basic/Pro those should become full communicators with
-  # sign-in. Promotes most-recently-active first so the user's primary
-  # communicator is converted before any extras. No-op for Free/unpaid users and
-  # admins (admins are unlimited and already sign in to any account). Idempotent.
+  # sandbox; on upgrade to a plan that grants NO sandbox slots, those leftovers
+  # should become full communicators with sign-in. Promotes most-recently-active
+  # first so the user's primary communicator is converted before any extras.
+  #
+  # Gated to plans with **zero sandbox entitlement** (Basic — see
+  # BASIC_PLAN_LIMITS["demo_communicator_limit"] == 0). Pro grants 1 sandbox
+  # slot, so a Pro user's sandbox is an intentional scratch/demo account and is
+  # left untouched. No-op for Free/unpaid users and admins. Idempotent.
   def reconcile_paid_sandbox_promotions!
     return if admin?
     return unless paid_plan?
+    return if Permissions::CommunicatorLimits.sandbox_limit_for(settings || {}) > 0
 
     slot_limit = Permissions::CommunicatorLimits.slot_limit_for(settings || {})
     available = slot_limit - Permissions::CommunicatorLimits.owned_slot_count(self)

--- a/lib/tasks/communicators.rake
+++ b/lib/tasks/communicators.rake
@@ -47,11 +47,14 @@ namespace :communicators do
   # disabled. The forward fix (User#reconcile_paid_sandbox_promotions!) only
   # runs when plan_type changes, so existing affected users need this one-off.
   #
-  # Promotes each paid user's sandbox communicators to full `active` accounts,
-  # most-recently-active first, up to their available paid slots — exactly what
-  # the upgrade callback now does. promote_to_active! mints a passcode so
-  # sign-in works and lifts the sandbox board cap. Idempotent. Admins skipped
-  # (unlimited; already sign in to any account).
+  # Promotes each affected paid user's sandbox communicators to full `active`
+  # accounts, most-recently-active first, up to their available paid slots —
+  # exactly what the upgrade callback now does. promote_to_active! mints a
+  # passcode so sign-in works and lifts the sandbox board cap. Idempotent.
+  #
+  # Scoped to plans with ZERO sandbox entitlement (Basic). Pro grants 1 sandbox
+  # slot, so Pro users' sandboxes are intentional scratch/demo accounts and are
+  # left untouched. Admins skipped (unlimited; already sign in to any account).
   #
   # Dry-run by default. Apply with DRY_RUN=false. Optionally scope to one user:
   #   rake communicators:promote_paid_sandboxes                       # preview all
@@ -67,6 +70,8 @@ namespace :communicators do
 
     users.find_each do |user|
       next if user.admin? || !user.paid_plan?
+      # Plans that grant any sandbox slot (Pro) keep their intentional sandboxes.
+      next if Permissions::CommunicatorLimits.sandbox_limit_for(user.settings || {}) > 0
 
       slot_limit = Permissions::CommunicatorLimits.slot_limit_for(user.settings || {})
       available = slot_limit - Permissions::CommunicatorLimits.owned_slot_count(user)

--- a/spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb
+++ b/spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe "communicators:promote_paid_sandboxes rake task", type: :task do
     expect(free_sandbox.reload.status).to eq("sandbox")
   end
 
+  it "leaves Pro users' sandboxes untouched (Pro is entitled to a sandbox slot)" do
+    pro_user = create(:user, plan_type: "pro")
+    pro_sandbox = create(:child_account, user: pro_user, status: ChildAccount::SANDBOX, passcode: nil)
+
+    ENV["DRY_RUN"] = "false"
+    ENV.delete("USER_ID")
+    run_task
+
+    expect(pro_sandbox.reload.status).to eq("sandbox")
+  end
+
   it "scopes to a single user via USER_ID" do
     other_paid = create(:user, plan_type: "basic")
     other_sandbox = create(:child_account, user: other_paid, status: ChildAccount::SANDBOX, passcode: nil)

--- a/spec/models/communicator_sandbox_promotion_spec.rb
+++ b/spec/models/communicator_sandbox_promotion_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe "Paid sandbox promotion (#359)", type: :model do
       expect(accounts.first.reload.status).to eq("sandbox")
     end
 
+    it "leaves Pro users' sandboxes alone (Pro is entitled to a sandbox slot)" do
+      owner, accounts = free_owner_with_sandboxes(1)
+
+      owner.update!(plan_type: "pro") # Pro grants 1 sandbox slot
+
+      expect(accounts.first.reload.status).to eq("sandbox")
+    end
+
     it "is a no-op for admins (unlimited; already sign in to any account)" do
       admin = create(:admin_user)
       account = create(:child_account, user: admin, status: ChildAccount::SANDBOX, passcode: nil)


### PR DESCRIPTION
## Summary

Follow-up to #360. The original fix promoted **all** paid users' stuck sandboxes, but that's too broad: **Pro grants 1 intentional sandbox/demo slot** (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 1`). Running the backfill on prod wrongly flipped **12 Pro demo accounts** (named "Jesse Demo", "my demo acct", "trial 1", etc.) to active with minted passcodes.

Only **Basic** (`demo_communicator_limit == 0`) has zero sandbox entitlement, so only a Basic user's sandbox is guaranteed to be a stuck Free-era leftover.

## What changed

- Gate `User#reconcile_paid_sandbox_promotions!` and the `communicators:promote_paid_sandboxes` task on `Permissions::CommunicatorLimits.sandbox_limit_for(settings) == 0` — skip any plan that grants a sandbox slot (Pro).
- Pro-skip specs for both the model reconciler and the rake task.
- CLAUDE.md + CHANGELOG updated to state Basic-only.

## Plan entitlements (for reference)

| Plan | `demo_communicator_limit` | auto-promote sandboxes? |
|------|---|---|
| Free | 1 | n/a (not paid) |
| Basic | **0** | **yes** — stuck Free-era leftover |
| Pro | 1 | **no** — intentional scratch/demo slot |

## Prod cleanup (separate, manual)

The 12 Pro communicators wrongly promoted by the first backfill run need reverting to sandbox — handled out-of-band via console (see PR discussion), not by this PR.

## Test plan

- `spec/models/communicator_sandbox_promotion_spec.rb` (12 examples) + `spec/lib/tasks/communicators_promote_paid_sandboxes_spec.rb` (5 examples) — **17 examples, 0 failures**, including the new Pro-skip cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)