### PR TITLE
fix(boards): persist margins on spacing-only edits

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -461,6 +461,21 @@ class API::BoardsController < API::ApplicationController
 
       @board.set_current_word_list
 
+      # Persist spacing/margins here so changing only the spacing sliders is
+      # saved. Margins used to ride along inside save_layout!, which the update
+      # action only invokes when the tile layout itself changed — so a
+      # margins-only edit (no tile moved) was silently dropped and snapped back
+      # to the stored/default value on refetch.
+      if params[:xMargin].present? && params[:yMargin].present?
+        margin_screen_size = params[:screen_size] || "lg"
+        margins = @board.margin_settings || {}
+        margins[margin_screen_size] = {
+          "x" => params[:xMargin].to_i,
+          "y" => params[:yMargin].to_i,
+        }
+        @board.margin_settings = margins
+      end
+
       respond_to do |format|
         if @board.save
           if params[:layout].present?

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -306,6 +306,40 @@ RSpec.describe "API::Boards", type: :request do
         expect(board.reload.large_screen_columns).to eq(8)
       end
 
+      it "persists margins when only the spacing changed (no layout move)" do
+        patch "/api/boards/#{board.id}",
+              params: { board: { name: board.name }, xMargin: 12, yMargin: 7, screen_size: "lg" },
+              headers: auth_headers(user),
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(board.reload.margin_settings["lg"]).to eq("x" => 12, "y" => 7)
+      end
+
+      it "returns the updated margins in the response body without a refetch" do
+        patch "/api/boards/#{board.id}",
+              params: { board: { name: board.name }, xMargin: 5, yMargin: 9, screen_size: "md" },
+              headers: auth_headers(user),
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["margin_settings"]["md"]).to eq("x" => 5, "y" => 9)
+      end
+
+      it "leaves margins for other screen sizes untouched" do
+        board.update!(margin_settings: { "sm" => { "x" => 2, "y" => 2 } })
+
+        patch "/api/boards/#{board.id}",
+              params: { board: { name: board.name }, xMargin: 10, yMargin: 10, screen_size: "lg" },
+              headers: auth_headers(user),
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        board.reload
+        expect(board.margin_settings["sm"]).to eq("x" => 2, "y" => 2)
+        expect(board.margin_settings["lg"]).to eq("x" => 10, "y" => 10)
+      end
+
       it "clears the display_image_url column when settings.display_follows_preview is true" do
         board.update_column(:display_image_url, "https://example.com/old-preview.png")
 


### PR DESCRIPTION
## Summary

Fixes the bug where margins on the board layout editor (`/edit/layout?mode=arrange`) appear to change but **revert to the default on Save** when only the spacing sliders were touched.

### Root cause
The editor sends `xMargin`/`yMargin` to `PUT /api/boards/:id`, but `Api::BoardsController#update` only persisted margins as a side-effect of `save_layout!`. That helper runs **only when the tile layout itself changed** (`params[:layout].present? && @board.layout[screen_size] != layout`). A margins-only edit leaves the layout unchanged, so `save_layout!` was skipped and the margins were never written — on refetch the board returned its old margins and the slider snapped back (to the `3` default the frontend falls back to).

`margin_settings` is permitted in `board_params` but never actually assigned in `#update`, so the payload's margin field was ignored too.

### Fix
Persist `margin_settings[screen_size]` directly in `#update` whenever `xMargin` and `yMargin` are present, independent of any layout change. Margins for other screen sizes are left untouched. The layout-save path is unchanged (and remains idempotent — `apply_layout!` sets the same value when a tile also moved).

## Test plan
Added 3 request specs to `spec/requests/api/boards_spec.rb`:
- persists margins when only the spacing changed (no layout move)
- returns the updated margins in the response body without a refetch
- leaves margins for other screen sizes untouched

```
RAILS_ENV=test ... bundle exec rspec spec/requests/api/boards_spec.rb
# 56 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)