### PR TITLE
fix(board-builder): build GLP templates instead of rejecting them

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -150,8 +150,11 @@ module API
         elsif params[:template].present?
           template = params[:template].to_s
           robust_root  = Boards::RobustSets.find_root(template)
-          starter_tree = robust_root ? nil : Boards::StarterBlueprints.tree_for(template)
-          if robust_root.nil? && starter_tree.nil?
+          # GLP templates are seeded DB boards keyed by slug — the catalog
+          # advertises them, so the build path must accept them too.
+          glp_template = robust_root ? false : Boards::GlpTemplates.template_slug?(template)
+          starter_tree = robust_root || glp_template ? nil : Boards::StarterBlueprints.tree_for(template)
+          if robust_root.nil? && !glp_template && starter_tree.nil?
             raise Boards::BlueprintAssembler::UnknownTemplate,
                   "unknown template #{template.inspect}"
           end
@@ -169,7 +172,10 @@ module API
           robust_root&.name || "Communication Board"
         else
           robust_root = Boards::RobustSets.find_root(build_key)
-          robust_root&.name || Boards::StarterBlueprints.tree_for(build_key)&.dig(:name) || "Communication Board"
+          robust_root&.name ||
+            Boards::GlpTemplates.find_board(build_key)&.name ||
+            Boards::StarterBlueprints.tree_for(build_key)&.dig(:name) ||
+            "Communication Board"
         end
       end
 

--- a/app/services/boards/glp_templates.rb
+++ b/app/services/boards/glp_templates.rb
@@ -82,6 +82,24 @@ module Boards
       Board.where(is_template: true, category: CATEGORY).order(:name)
     end
 
+    # The seeded GLP template board for a slug (e.g. "glp-greetings-social"),
+    # or nil. The Board Builder build path uses this to resolve and clone a
+    # GLP template — the catalog keys templates by slug, so this is what the
+    # frontend sends back as `template`.
+    def find_board(slug)
+      return nil if slug.blank?
+
+      boards.find_by(slug: slug)
+    end
+
+    # True when `slug` is a seeded GLP template board — used by the build path
+    # to branch GLP templates away from robust sets / starter blueprints.
+    def template_slug?(slug)
+      return false if slug.blank?
+
+      boards.exists?(slug: slug)
+    end
+
     # Picker catalog entries (same shape family as StarterBlueprints#catalog,
     # with `kind: "glp"` so the frontend can group/badge them).
     def catalog

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -49,6 +49,8 @@ class BuildBoardSetJob
 
       if complexity_level?(level_or_template)
         build_with_structure_planner(root, communicator, level_or_template, interests, explicit_categories)
+      elsif glp_template?(level_or_template)
+        build_glp(root, communicator, level_or_template, interests)
       else
         build_legacy(root, communicator, level_or_template, interests, explicit_categories)
       end
@@ -66,6 +68,25 @@ class BuildBoardSetJob
 
   def complexity_level?(value)
     Boards::StructurePlanner::LEVELS.key?(value.to_s.downcase)
+  end
+
+  def glp_template?(value)
+    Boards::GlpTemplates.template_slug?(value.to_s)
+  end
+
+  # GLP templates are flat, admin-owned whole-phrase boards (one communicative
+  # function each). Build = copy each phrase tile onto the pre-created root,
+  # preserving order and part_of_speech ("phrase"). Any interests the caregiver
+  # picked in the wizard fold into a "My Favorites" page so nothing is dropped.
+  def build_glp(root, communicator, slug, interests)
+    source = Boards::GlpTemplates.find_board(slug)
+    raise Boards::BlueprintAssembler::UnknownTemplate, "unknown glp template #{slug.inspect}" unless source
+
+    source.board_images.order(:position).each do |board_image|
+      root.add_image(board_image.image_id)
+    end
+
+    add_to_favorites!(root, communicator, interests) if interests.present?
   end
 
   # Phase 2: StructurePlanner-driven hybrid build.

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -391,6 +391,56 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    context "with a GLP template" do
+      def seed_glp_templates!
+        Boards::GlpTemplates.seed!(admin: create(:admin_user))
+      end
+
+      it "accepts a GLP template slug (regression: used to 422 unknown_template)" do
+        seed_glp_templates!
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { communicator_id: communicator.id,
+                         template: "glp-greetings-social" }.to_json,
+               headers: headers
+        }.to change { BuildBoardSetJob.jobs.size }.by(1)
+
+        expect(response).to have_http_status(:created)
+        root = Board.find(JSON.parse(response.body)["id"])
+        # Root takes the GLP template's name, and the slug rides through to the job.
+        expect(root.name).to eq("Greetings & Social")
+        expect(BuildBoardSetJob.jobs.last["args"][2]).to eq("glp-greetings-social")
+      end
+
+      it "builds the whole-phrase tiles onto the root and completes (job drained)" do
+        seed_glp_templates!
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id,
+                       template: "glp-greetings-social" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        BuildBoardSetJob.drain
+
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.status).to eq("complete")
+        expect(root.board_images.map(&:label)).to include("hi there!", "see you later")
+        expect(root.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
+      end
+
+      it "still 422s unknown_template for a bogus glp-looking slug" do
+        seed_glp_templates!
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id,
+                       template: "glp-does-not-exist" }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("unknown_template")
+      end
+    end
+
     context "with no core symbols seeded (the staging 500 regression)" do
       # Reproduces the outage: a build used to 500 with
       # RuntimeError("no Image for label \"Food\"") when the curated symbols

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -131,6 +131,41 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
+  describe "#perform with a GLP template" do
+    def seed_glp_templates!
+      Boards::GlpTemplates.seed!(admin: create(:admin_user))
+    end
+
+    it "copies the whole-phrase tiles onto the pre-created root and completes" do
+      seed_glp_templates!
+      root = precreate_root!(name: "Greetings & Social")
+
+      described_class.new.perform(root.id, communicator.id, "glp-greetings-social", [])
+
+      root.reload
+      expect(root.status).to eq("complete")
+      labels = root.board_images.map(&:label)
+      expect(labels).to include("hi there!", "see you later", "good morning")
+      # part_of_speech carries over so tiles render as gestalt scripts, not words.
+      expect(root.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
+      # Flat board — no sub-board folder tiles.
+      expect(root.board_images.map(&:predictive_board_id).compact).to be_empty
+    end
+
+    it "folds picked interests into a My Favorites page (nothing dropped)" do
+      seed_glp_templates!
+      root = precreate_root!(name: "Greetings & Social")
+
+      described_class.new.perform(root.id, communicator.id, "glp-greetings-social", ["grandma"])
+
+      root.reload
+      favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+      expect(favorites_tile&.predictive_board_id).to be_present
+      favorites = Board.find(favorites_tile.predictive_board_id)
+      expect(favorites.board_images.map(&:label)).to include("grandma")
+    end
+  end
+
   describe "#perform with a complexity level (hybrid path)" do
     before { seed_robust_set! }
 


### PR DESCRIPTION
## Problem

Building a board from a **GLP template** (e.g. "Greetings & Social") fails on staging with:

```
error: "unknown_template"
message: "That template isn't available. Pick one from the list and try again."
```

…even though the seed ran and the templates show in the picker.

## Root cause

The `templates` catalog advertises the 6 GLP templates keyed by **board slug** (`glp-greetings-social`, …), and the frontend sends that slug back as `template`. But the build path only ever recognized **RobustSets** and **StarterBlueprints** keys:

- `BoardBuilderController#resolve_build_key` raised `UnknownTemplate` for any slug not in those two sources.
- `BuildBoardSetJob` had no GLP branch.

So GLP templates were visible but un-buildable.

## Fix

- **`Boards::GlpTemplates`** — add `find_board(slug)` and `template_slug?(slug)` lookups against the seeded GLP boards.
- **`BoardBuilderController`** — `resolve_build_key` accepts a GLP slug; `resolve_root_name` names the root after the GLP board.
- **`BuildBoardSetJob`** — new GLP branch: GLP templates are flat, admin-owned whole-phrase boards, so the build copies each phrase tile onto the pre-created root (preserving order and `part_of_speech: "phrase"`), then folds any interests the caregiver picked into a **My Favorites** page so nothing is dropped.

## Test plan

Added specs (not run locally this session — please let CI run them, or run `RAILS_ENV=test SECRET_KEY_BASE=dummy DEVISE_JWT_SECRET_KEY=dummy RAILS_MASTER_KEY="" bundle exec rspec spec/requests/api/v1/board_builder_spec.rb spec/sidekiq/build_board_set_job_spec.rb`):

- **Request:** posting `template: "glp-greetings-social"` returns 201 (regression: used to 422), the slug rides through to the job, the root is named "Greetings & Social", drained job builds the whole-phrase tiles; a bogus `glp-*` slug still 422s `unknown_template`.
- **Job:** GLP build copies the phrase tiles onto the root (flat, no folder tiles, `part_of_speech: "phrase"`) and routes picked interests into My Favorites.

## Deploy note

Backend-only. After merge + deploy to staging, the existing seeded GLP boards work as-is — no re-seed needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)