### PR TITLE
fix(board-builder): show artwork on fringe pages + pick most-docs default image

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -87,19 +87,24 @@ can be generated later).
 
 All three build paths (cloner, assembler, `BuildBoardSetJob`) resolve a tile
 label to an `Image` through `Boards::ImageResolver.resolve(label, owner:)`,
-which **prefers an image that actually has artwork**:
+which **prefers the curated "default" image — the one with the most artwork**:
 
-1. the owner's own image for the label that has a `Doc`,
-2. a curated public/admin image for the label that has a `Doc`,
+1. the owner's own image for the label with the most `Doc`s,
+2. the curated public/admin "default" image for the label — the admin
+   (`DEFAULT_ADMIN_ID`) / unowned image with the **most `Doc`s attached**,
 3. else any existing image for the label, else a freshly-created blank.
 
-Two subtleties it fixes:
+Three subtleties it fixes:
 
-- **Art over blank.** A naive `find_by(label:)` returns the lowest-id match,
-  which is often a blank, art-less image the OBF seed created for that label —
-  so a folder tile (Animals, People, Feelings…) rendered empty even though a
-  curated image with art existed. `Image#display_doc` has no label fallback, so
-  once a tile points at a blank image it stays blank.
+- **Most-docs default.** Several `Image` rows can share a label. The naive
+  `find_by(label:)` (and the earlier `with_docs…first`) returned the lowest-id
+  match — often a thin or blank image. We instead order art-bearing candidates
+  by `COUNT(docs) DESC, id ASC`, so the canonical symbol the library has built
+  the most artwork for (the admin's de-facto default) wins. `best_arted` /
+  `best_arted_for` are the read-only query helpers behind this.
+- **Art over blank.** `Image#display_doc` has no label fallback, so once a tile
+  points at a blank image it stays blank. Resolution only ever returns an
+  art-bearing image when one exists (folders like Animals/People/Feelings).
 - **Case-insensitive matching.** Folder labels are capitalized ("Animals")
   while curated library art is often lowercase ("animals"); a case-sensitive
   match would miss it. Matching is case-insensitive, but a newly-created image
@@ -110,6 +115,29 @@ pointing a folder at a lowercase art image would rename the tile. So the
 curated folder name is pinned explicitly: `SeededSetCloner#copy_tiles!` restores
 the authored label/display_label post-save, and `BuildBoardSetJob#add_folder_tile!`
 sets the tile text to the category name.
+
+#### Fringe boards get the upgrade too (`upgrade_board_tiles!`)
+
+Originally only the **root** board ran the blank→art upgrade (via
+`SeededSetCloner#copy_tiles!`). The seed's **fringe sub-boards** and the
+standalone **prebuilt fringe pages** are cloned through
+`Board#clone_with_images`, which has **no** art upgrade — so "the main board had
+images but the others didn't." `Boards::ImageResolver.upgrade_board_tiles!(board,
+owner:)` extracts that per-tile upgrade (blank→art only, authored label pinned)
+and is now called on every cloned fringe board:
+
+- `SeededSetCloner#clone_all` runs it on each non-root clone (the adopted root
+  still upgrades via `copy_tiles!`).
+- `BuildBoardSetJob#clone_one_prebuilt_page!` runs it after cloning a prebuilt
+  fringe template.
+
+It uses `best_arted_for` (read-only), so it never creates a stray blank image —
+it only re-points a tile when curated art for the label actually exists.
+
+**Backfill for already-built sets:** the forward fix only affects new builds.
+`rake board_builder:upgrade_tile_images` re-runs the upgrade across every
+existing built set (`builder_root`/`builder_child` boards). Dry-run by default;
+`DRY_RUN=false` to apply, `USER_ID=N` to scope to one owner.
 
 ## Endpoint contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Board Builder fringe pages now show tile artwork
+- A built board set's **main board** showed pictures on its tiles, but the
+  **fringe/category pages** (Food, Feelings, Animals…) often rendered blank. The
+  blank→art upgrade only ran on the root board; fringe pages cloned through a
+  path with no upgrade. Every cloned fringe page now gets the same upgrade, so
+  the whole set renders with images.
+- Image resolution now picks the **curated "default" image** — the admin library
+  image with the **most artwork attached** — when several images share a label,
+  instead of grabbing the lowest-id (often blank) one.
+- Existing built sets can be backfilled with the idempotent
+  `rake board_builder:upgrade_tile_images` (dry-run by default; `DRY_RUN=false`
+  to apply, `USER_ID=N` to scope to one owner).
+
 ### Fixed — Paid users' communicators stuck in sandbox mode (#359)
 - A communicator created while a user was on the Free plan was forced into
   no-login **sandbox** mode, and upgrading to Basic/Pro never converted it — so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -925,17 +925,30 @@ still works for backward compat.
   during the clone. Still used by callers that want a trimmed clone; the hybrid
   build now passes `[]` (clone intact). `StructurePlanner#excluded_fringe_pages`
   is still computed on the plan but no longer consumed by the build.
-- **Tile images prefer art (`Boards::ImageResolver`).** All three build paths
-  (cloner, `BlueprintAssembler`, `BuildBoardSetJob`) resolve a tile label via
-  `Boards::ImageResolver.resolve(label, owner:)`, which prefers an image that
-  has a `Doc` (artwork) over a blank same-label image and matches labels
-  **case-insensitively** (folder labels are capitalized, curated art is often
-  lowercase). Without this, category folder tiles (Animals, People, Feelings…)
-  rendered blank because resolution grabbed a label-only image the OBF seed
-  created. Because `BoardImage#set_defaults` derives the tile label from its
-  image, the curated folder name is pinned explicitly so an upgraded lowercase
-  art image doesn't rename the tile (`copy_tiles!` restores the authored label;
-  `BuildBoardSetJob#add_folder_tile!` sets the category name).
+- **Tile images prefer the curated "default" image (`Boards::ImageResolver`).**
+  All three build paths (cloner, `BlueprintAssembler`, `BuildBoardSetJob`)
+  resolve a tile label via `Boards::ImageResolver.resolve(label, owner:)`. When
+  several `Image` rows share a label, it picks the one with the **most `Doc`s
+  attached** (`COUNT(docs) DESC, id ASC`) — the admin's de-facto default symbol
+  — preferring the owner's own art, then the `DEFAULT_ADMIN_ID`/unowned public
+  library. Matching is **case-insensitive** (folder labels are capitalized,
+  curated art is often lowercase). Without this, category folder tiles (Animals,
+  People, Feelings…) rendered blank because resolution grabbed a label-only
+  image the OBF seed created. Because `BoardImage#set_defaults` derives the tile
+  label from its image, the curated folder name is pinned explicitly so an
+  upgraded lowercase art image doesn't rename the tile (`copy_tiles!` restores
+  the authored label; `BuildBoardSetJob#add_folder_tile!` sets the category name).
+- **Fringe boards get the same art upgrade as the root.** Only the root board
+  ran the blank→art upgrade originally; the seed's fringe sub-boards and
+  standalone prebuilt fringe pages clone through `Board#clone_with_images`
+  (no upgrade), so they rendered blank while the root had pictures.
+  `Boards::ImageResolver.upgrade_board_tiles!(board, owner:)` re-points every
+  blank tile to the curated default image for its label (blank→art only,
+  authored label preserved, never creates a stray image) and runs on each
+  cloned fringe board (`SeededSetCloner#clone_all`,
+  `BuildBoardSetJob#clone_one_prebuilt_page!`). Backfill existing built sets
+  with `rake board_builder:upgrade_tile_images` (dry-run by default;
+  `DRY_RUN=false` to apply, `USER_ID=N` to scope).
 - **Level recommendation heuristic:** young/emerging → Starter,
   developing/young_teen → Standard, proficient/older → Extended. Based on
   `CommunicatorProfile` helpers (`developing?`, `young_teen?`). **Not clinically

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -1,17 +1,19 @@
 # app/services/boards/image_resolver.rb
 #
-# Resolves a tile label to the best Image to display, PREFERRING one that
-# actually has artwork.
+# Resolves a tile label to the best Image to display, PREFERRING the curated
+# "default" image — the admin/public image for that label with the MOST docs
+# (artwork) attached.
 #
 # The Board Builder seeds and clones a lot of folder tiles (Animals, People,
-# Feelings, Food, …) whose labels match curated library art. But a naive
-# `find_by(label:)` returns the lowest-id match, which is often a blank,
-# art-less Image the OBF seed created for that same label — so the folder tile
-# renders empty even though a curated image with art exists. `Image#display_doc`
+# Feelings, Food, …) whose labels match curated library art. But several Image
+# rows can share a label, and a naive `find_by(label:)` returns the lowest-id
+# match — often a blank, art-less Image the OBF seed created — so the folder
+# tile renders empty even though a curated image with art exists. `Image#display_doc`
 # has no label fallback, so once a tile points at a blank image it stays blank.
 #
-# This picks an art-bearing image when one exists for the label, only
-# falling back to (or creating) a blank image as a last resort.
+# When more than one art-bearing image exists for a label, we pick the one with
+# the most docs: that's the established/canonical symbol the library has built
+# up the most artwork for, and the one an admin would consider the default.
 module Boards
   module ImageResolver
     module_function
@@ -26,25 +28,80 @@ module Boards
     def resolve(label, owner:)
       word = Boards::InterestWords.normalize_word(label)
 
-      # 1. The owner's own image for this label, if it already has art.
-      owner_arted = owner.images.with_docs.where(ci_label, word).first
-      return owner_arted if owner_arted
-
-      # 2. A curated public/admin image for this label that has art.
-      public_arted = Image.public_img.with_docs
-        .where(user_id: [User::DEFAULT_ADMIN_ID, nil]).where(ci_label, word).first
-      return public_arted if public_arted
+      # 1/2. The owner's own art image, else the curated public/admin "default"
+      #      image for this label (the one with the most docs attached).
+      arted = best_arted_for(word, owner)
+      return arted if arted
 
       # 3. No art anywhere — keep an existing (blank) image, else create one.
       owner.images.where(ci_label, word).first ||
-        Image.public_img.where(user_id: [User::DEFAULT_ADMIN_ID, nil]).where(ci_label, word).first ||
+        default_public_scope.where(ci_label, word).first ||
         Image.create!(label: word, user_id: owner.id)
+    end
+
+    # Re-points every blank (art-less) tile on `board` to the curated art-bearing
+    # image for the same label, leaving tiles that already have art untouched.
+    # This is the same blank->art upgrade `SeededSetCloner#copy_tiles!` does for
+    # the root board, extracted so the fringe/cloned boards (which clone through
+    # `Board#clone_with_images`, with no upgrade) render with pictures too.
+    #
+    # Only ever upgrades blank -> art, never the reverse. The authored tile text
+    # is preserved: a curated art image may be stored under different casing
+    # ("animals"), and we must not rename folder tiles ("Animals").
+    def upgrade_board_tiles!(board, owner:)
+      board.board_images.includes(:image).find_each do |bi|
+        image = bi.image
+        next if art?(image)
+
+        label = bi.label.presence || image&.label
+        next if label.blank?
+
+        # best_arted (not resolve) so we never create a stray blank image: we
+        # only re-point when curated art actually exists for the label.
+        arted = best_arted_for(label, owner)
+        next if arted.nil?
+        next if arted.id == image&.id
+
+        bi.image_id = arted.id
+        bi.display_image_url = arted.display_image_url(owner).presence || arted.src_url
+        # Pin the authored tile text — resolve() may return a different-cased
+        # label and saving must not rename the tile.
+        bi.display_label = bi.display_label.presence || label
+        bi.label = label
+        bi.save!
+      end
     end
 
     # True when the image has displayable artwork (at least one Doc). Cheap SQL,
     # no S3 — mirrors the `image.docs.any?` notion used elsewhere in the builder.
     def art?(image)
       image.present? && image.docs.exists?
+    end
+
+    # The best art-bearing image for `label`: the owner's own art first, then
+    # the curated public/admin "default" (most docs). Read-only — never creates.
+    # `label` may be in any casing; it is normalized here.
+    def best_arted_for(label, owner)
+      word = Boards::InterestWords.normalize_word(label)
+      best_arted(owner.images, word) || best_arted(default_public_scope, word)
+    end
+
+    # The art-bearing image for `word` in `relation` with the MOST docs (the
+    # "default"/canonical symbol), tie-broken by lowest id for determinism.
+    # Returns nil when no image for the label has art.
+    def best_arted(relation, word)
+      relation
+        .where(ci_label, word)
+        .left_joins(:docs)
+        .group("images.id")
+        .having("COUNT(docs.id) > 0")
+        .order(Arel.sql("COUNT(docs.id) DESC, images.id ASC"))
+        .first
+    end
+
+    # Curated, non-private images owned by the default admin (or unowned).
+    def default_public_scope
+      Image.public_img.where(user_id: [User::DEFAULT_ADMIN_ID, nil])
     end
 
     # Case-insensitive label match fragment for `where`.

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -119,9 +119,16 @@ module Boards
       source_boards.each_with_object({}) do |src, map|
         cloned =
           if adopted_root? && src.id == @source_root.id
+            # copy_tiles! already upgrades blank tiles to art for the root.
             clone_into_adopted_root(src)
           else
-            src.clone_with_images(@owner.id)
+            board = src.clone_with_images(@owner.id)
+            raise CloneError, "failed to clone source board #{src.id}" if board.nil?
+            # Board#clone_with_images has no art upgrade, so the seed's fringe
+            # sub-boards (and a dup-cloned root) would render their authored
+            # tiles blank wherever they point at an art-less library image.
+            Boards::ImageResolver.upgrade_board_tiles!(board, owner: @owner)
+            board
           end
         raise CloneError, "failed to clone source board #{src.id}" if cloned.nil?
 

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -188,6 +188,11 @@ class BuildBoardSetJob
     cloned = fringe_source.clone_with_images(owner.id)
     return false unless cloned
 
+    # Board#clone_with_images has no art upgrade, so prebuilt fringe tiles that
+    # point at an art-less library image would render blank. Upgrade them to the
+    # curated default image for the same label (matches the seed-set clone path).
+    Boards::ImageResolver.upgrade_board_tiles!(cloned, owner: owner)
+
     cloned.settings = (cloned.settings || {}).merge("builder_child" => true)
     cloned.save!
 

--- a/lib/tasks/board_builder.rake
+++ b/lib/tasks/board_builder.rake
@@ -1,0 +1,67 @@
+namespace :board_builder do
+  # Backfill for the Board Builder art-resolution fix: before this, only the
+  # root board of a built set ran the blank->art tile upgrade. The fringe/
+  # sub-boards (and standalone prebuilt fringe pages) were cloned through
+  # Board#clone_with_images, which has no upgrade, so their authored tiles
+  # rendered blank wherever they pointed at an art-less library image.
+  #
+  # This re-runs Boards::ImageResolver.upgrade_board_tiles! across every already-
+  # built set (root + children, marked settings["builder_root"]/["builder_child"])
+  # so existing sets pick up the curated "default" image (admin image with the
+  # most docs) for each label — exactly what new builds now do.
+  #
+  # Read-only by default (reports candidates). Apply with DRY_RUN=false.
+  # Optionally scope to one owner with USER_ID=N:
+  #   rake board_builder:upgrade_tile_images                      # preview all
+  #   DRY_RUN=false rake board_builder:upgrade_tile_images        # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_builder:upgrade_tile_images
+  desc "Upgrade blank Board Builder tiles to curated art (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task upgrade_tile_images: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    scope = Board.where("(settings ->> 'builder_root') = 'true' OR (settings ->> 'builder_child') = 'true'")
+    scope = scope.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    boards_touched = 0
+    tiles_upgraded = 0
+
+    scope.find_each do |board|
+      owner = board.user
+      next unless owner
+
+      candidates = blank_tile_candidates(board, owner)
+      next if candidates.zero?
+
+      boards_touched += 1
+      label = board.settings&.dig("builder_root") ? "root" : "child"
+      puts "#{dry_run ? '[DRY RUN] ' : ''}board ##{board.id} #{board.name.inspect} (#{label}, owner #{owner.id}): #{candidates} tile(s) to upgrade"
+
+      unless dry_run
+        Boards::ImageResolver.upgrade_board_tiles!(board, owner: owner)
+        tiles_upgraded += candidates
+      end
+    end
+
+    if dry_run
+      puts "Dry run only — #{boards_touched} board(s) with upgradeable tiles. Re-run with DRY_RUN=false to apply."
+    else
+      puts "Upgraded ~#{tiles_upgraded} tile(s) across #{boards_touched} board(s)."
+    end
+  end
+
+  # Count tiles on `board` that are currently blank (art-less) but for which a
+  # curated art-bearing image exists under the same label — i.e. the tiles
+  # upgrade_board_tiles! would actually re-point. Read-only.
+  def blank_tile_candidates(board, owner)
+    board.board_images.includes(:image).count do |bi|
+      image = bi.image
+      next false if Boards::ImageResolver.art?(image)
+
+      label = bi.label.presence || image&.label
+      next false if label.blank?
+
+      arted = Boards::ImageResolver.best_arted_for(label, owner)
+      !arted.nil? && arted.id != image&.id
+    end
+  end
+end

--- a/spec/services/boards/image_resolver_spec.rb
+++ b/spec/services/boards/image_resolver_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Boards::ImageResolver do
   let(:owner) { create(:user) }
   let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
 
-  def with_art(image)
-    create(:doc, documentable: image, user: image.user || admin)
+  def with_art(image, count: 1)
+    count.times { create(:doc, documentable: image, user: image.user || admin) }
     image
   end
 
@@ -44,6 +44,65 @@ RSpec.describe Boards::ImageResolver do
     it "normalizes the label before resolving" do
       arted = with_art(create(:image, label: "feelings", user_id: admin.id))
       expect(described_class.resolve("Feelings", owner: owner)).to eq(arted)
+    end
+
+    it "prefers the admin 'default' image with the MOST docs over a thinner one" do
+      few  = with_art(create(:image, label: "ball", user_id: admin.id), count: 1)
+      many = with_art(create(:image, label: "ball", user_id: admin.id), count: 3)
+
+      result = described_class.resolve("ball", owner: owner)
+
+      expect(result).to eq(many)
+      expect(result).not_to eq(few)
+    end
+  end
+
+  describe ".best_arted_for" do
+    it "returns nil and creates nothing when no art exists for the label" do
+      create(:image, label: "no_art_here", user_id: admin.id)
+
+      expect {
+        expect(described_class.best_arted_for("No_Art_Here", owner)).to be_nil
+      }.not_to change(Image, :count)
+    end
+  end
+
+  describe ".upgrade_board_tiles!" do
+    let(:board) { create(:board, user: owner) }
+
+    it "re-points a blank tile to the curated art image for its label, keeping the authored label" do
+      blank = create(:image, label: "animals", user_id: admin.id)
+      arted = with_art(create(:image, label: "animals", user_id: admin.id))
+      tile  = board.add_image(blank.id)
+      tile.update_columns(label: "Animals", display_label: "Animals")
+
+      described_class.upgrade_board_tiles!(board, owner: owner)
+
+      tile.reload
+      expect(tile.image_id).to eq(arted.id)
+      expect(tile.label).to eq("Animals")
+      expect(tile.display_label).to eq("Animals")
+    end
+
+    it "leaves a tile that already has art untouched" do
+      arted = with_art(create(:image, label: "dog", user_id: admin.id))
+      other = with_art(create(:image, label: "dog", user_id: admin.id), count: 5)
+      tile  = board.add_image(arted.id)
+
+      described_class.upgrade_board_tiles!(board, owner: owner)
+
+      expect(tile.reload.image_id).to eq(arted.id)
+      expect(tile.image_id).not_to eq(other.id)
+    end
+
+    it "leaves a blank tile blank when no art exists for the label" do
+      blank = create(:image, label: "niche_word", user_id: admin.id)
+      tile  = board.add_image(blank.id)
+
+      expect {
+        described_class.upgrade_board_tiles!(board, owner: owner)
+      }.not_to change(Image, :count)
+      expect(tile.reload.image_id).to eq(blank.id)
     end
   end
 

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe Boards::SeededSetCloner do
       expect(cloned_feelings.board_images.where(label: "happy").count).to eq(1)
     end
 
+    it "upgrades blank tiles on cloned FRINGE pages to curated art (not just the root)" do
+      # The seed's "apple" tile points at an art-less admin image. A curated
+      # art-bearing "apple" image exists in the public library (DEFAULT_ADMIN_ID)
+      # — the cloned Food page tile should be re-pointed to it, same as root
+      # tiles already were.
+      default_admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      arted_apple = create(:image, label: "apple", user_id: default_admin.id, is_private: false)
+      create(:doc, documentable: arted_apple, user: default_admin)
+
+      root = described_class.new(@source[:root], communicator: communicator).call
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      apple_tile  = cloned_food.board_images.find_by(label: "apple")
+
+      expect(apple_tile.image_id).to eq(arted_apple.id)
+      expect(Boards::ImageResolver.art?(apple_tile.image)).to be(true)
+    end
+
     it "adds a brand-new food interest to the cloned Food page" do
       root = described_class.new(
         @source[:root], communicator: communicator, interests: ["pizza"]


### PR DESCRIPTION
## Summary

Built board sets showed tile artwork on the **main board** but the **fringe/category pages** (Food, Feelings, Animals…) often rendered blank. Two coordinated fixes:

1. **Fringe pages now get the art upgrade too.** The blank→art tile upgrade only ran on the root board (`SeededSetCloner#copy_tiles!`). Fringe sub-boards and standalone prebuilt fringe pages clone through `Board#clone_with_images`, which has no upgrade — so they stayed blank wherever a tile pointed at an art-less library image. Extracted the upgrade into `Boards::ImageResolver.upgrade_board_tiles!` (blank→art only, authored tile label preserved, **never creates a stray image**) and run it on every cloned fringe board in `SeededSetCloner#clone_all` and `BuildBoardSetJob#clone_one_prebuilt_page!`.

2. **Resolution picks the curated "default" image.** When several `Image` rows share a label, `ImageResolver.resolve` now picks the one with the **most `Doc`s attached** (`COUNT(docs) DESC, id ASC`) — the admin's de-facto default symbol — preferring the owner's own art, then the `DEFAULT_ADMIN_ID`/unowned public library. Previously it grabbed the lowest-id image with any doc.

`Board#clone_with_images` itself is left untouched (used broadly outside the builder); the upgrade is confined to the builder call sites.

### Backfill
Existing already-built sets are unaffected by the forward fix. Backfill with the idempotent task:
```
rake board_builder:upgrade_tile_images            # dry-run preview
DRY_RUN=false rake board_builder:upgrade_tile_images
DRY_RUN=false USER_ID=N rake board_builder:upgrade_tile_images
```

### Docs
Updated `.claude-notes/board-builder.md`, `CLAUDE.md`, and `CHANGELOG.md`.

## Test plan
- New `image_resolver_spec` cases: most-docs default preference, `upgrade_board_tiles!` (re-points blank tile + keeps authored label; leaves already-arted tiles alone; leaves truly-blank labels blank), `best_arted_for` creates nothing.
- New `seeded_set_cloner_spec` case: cloned **fringe** page tiles get upgraded to curated art (not just the root).
- Full board-builder suite: **197 examples, 0 failures** (`spec/services/boards`, `spec/sidekiq/build_board_set_job_spec.rb`, `spec/requests/api/v1/board_builder_spec.rb`).
- Rake task smoke-tested (dry run, clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)