### PR TITLE
refactor(board-builder): silence batch-order warning in upgrade_board_tiles!

### DIFF
--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -49,7 +49,10 @@ module Boards
     # is preserved: a curated art image may be stored under different casing
     # ("animals"), and we must not rename folder tiles ("Animals").
     def upgrade_board_tiles!(board, owner:)
-      board.board_images.includes(:image).find_each do |bi|
+      # `.each` (not find_each): a board has at most ~84 tiles, so batching buys
+      # nothing — and find_each would override board_images' position ordering,
+      # logging a noisy "Scoped order is ignored" warning on every build.
+      board.board_images.includes(:image).each do |bi|
         image = bi.image
         next if art?(image)
 


### PR DESCRIPTION
## Summary

Follow-up to #366. `Boards::ImageResolver.upgrade_board_tiles!` iterated tiles with `find_each`, which overrides `board_images`' default `position` ordering and logs:

```
Scoped order is ignored, it's forced to be batch order.
```

once per board. That fired across all 48 boards during the prod backfill (`rake board_builder:upgrade_tile_images`) and would also fire in Sidekiq logs on **every** new build, since the method runs during the cloner/job clone paths.

A board has at most ~84 tiles, so batching buys nothing — switched to plain `.each`. Behavior is identical (each tile is upgraded independently; order never mattered), just quiet.

## Test plan
- `spec/services/boards/image_resolver_spec.rb` — **12 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)