### PR TITLE
feat(board-builder): integrate gestalt Phrases layer into every built board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1064,15 +1064,32 @@ doesn't replace it; both can be set independently. Wiring:
   sentences at advanced). A glp-only profile is `present?`, so `.for` returns
   it. No `glp_stage` ⇒ no gestalt guidance (backward compatible).
 - **GLP board templates** (`Boards::GlpTemplates`): six predefined, admin-owned
-  whole-phrase template boards, identified by `category: "glp"` +
-  `is_template: true` (not starter blueprints or robust sets). `TEMPLATES` is the
-  single source of truth for both the idempotent seed (`bin/rails
+  whole-phrase function boards (Greetings/Requests/Protests/Comments/Feelings/
+  Transitions), identified by `category: "glp"` + `is_template: true`. `TEMPLATES`
+  is the single source of truth for the idempotent seed (`bin/rails
   glp_templates:seed`, via `.seed!`) and the stage-aware recommendation
   (`.recommended_for`). They surface in `GET /api/v1/board_builder/templates`
   (`kind: "glp"`, a `glp_templates` array, and a stage-driven
-  `recommended_template`); `?template_type=glp` returns only GLP templates. They
-  are **catalog/recommendation metadata** — the wizard `create` build path still
-  only builds starter/robust keys.
+  `recommended_template`) for **recommendation/badge display only** —
+  `?template_type=glp` still filters to them. **A GLP slug is NOT a build target**
+  (`POST /api/v1/board_builder` with `template=glp-*` → 422 `unknown_template`).
+- **Gestalts ride every build as an integrated Phrases layer** (the either/or
+  was retired). `Boards::StructurePlanner` adds a `phrases_page` to the plan
+  (folder-prominence by default; `:strip` for an early-stage `gestalt_early?`
+  communicator; `nil` only when `include_phrases: false` AND no `glp_stage`).
+  `BuildBoardSetJob#build_with_structure_planner` then builds it via
+  `Boards::PhrasesPageBuilder` (a "Phrases" board linking the six function pages,
+  cloned from `GlpTemplates.function_boards`), links it from the home board, and
+  for `gestalt_early?` surfaces a personalized quick-phrase strip on the home
+  board (capped to open grid cells — degrades to folder-only, never overflows).
+  The wizard sends an optional `include_phrases` boolean (default-on in the
+  planner). `build_glp` and the GLP-slug build branch were removed.
+- **Phrase-board wiring.** The new Phrases board doubles as the communicator's
+  **phrase board** (the sentence-builder save target + quick-phrase source,
+  `settings["phrase_board_id"]`). After a build, `wire_phrase_board!` sets it on
+  the communicator and backfills the owner **only when blank** — never clobbering
+  a phrase board the user already picked. Build-time only; existing sets aren't
+  retroactively given one.
 - **Whole-phrase tiles:** `part_of_speech: "phrase"` marks a gestalt script
   tile. `Image#ensure_defaults` preserves an explicit `"phrase"` POS instead of
   re-categorizing it as a single word (every other label is still categorized as

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -116,7 +116,8 @@ module API
           communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
         end
 
-        BuildBoardSetJob.perform_async(root.id, communicator.id, build_key, interests, categories)
+        BuildBoardSetJob.perform_async(root.id, communicator.id, build_key, interests, categories,
+                                       { "include_phrases" => include_phrases_param })
 
         render json: serialize_built_root(root), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e
@@ -150,11 +151,11 @@ module API
         elsif params[:template].present?
           template = params[:template].to_s
           robust_root  = Boards::RobustSets.find_root(template)
-          # GLP templates are seeded DB boards keyed by slug — the catalog
-          # advertises them, so the build path must accept them too.
-          glp_template = robust_root ? false : Boards::GlpTemplates.template_slug?(template)
-          starter_tree = robust_root || glp_template ? nil : Boards::StarterBlueprints.tree_for(template)
-          if robust_root.nil? && !glp_template && starter_tree.nil?
+          # GLP slugs are NO LONGER a build target — gestalts ride every build
+          # as the integrated Phrases layer (see build_with_structure_planner).
+          # GLP templates remain in the catalog for recommendation display only.
+          starter_tree = robust_root ? nil : Boards::StarterBlueprints.tree_for(template)
+          if robust_root.nil? && starter_tree.nil?
             raise Boards::BlueprintAssembler::UnknownTemplate,
                   "unknown template #{template.inspect}"
           end
@@ -163,6 +164,15 @@ module API
           raise Boards::BlueprintAssembler::UnknownTemplate,
                 "level or template is required"
         end
+      end
+
+      # Tri-state opt-in for the gestalt Phrases layer: nil (param absent) =>
+      # default-on in the planner; true/false honors the wizard toggle. A
+      # communicator with a glp_stage always gets the layer regardless.
+      def include_phrases_param
+        return nil unless params.key?(:include_phrases)
+
+        ActiveModel::Type::Boolean.new.cast(params[:include_phrases])
       end
 
       def resolve_root_name(build_key)

--- a/app/services/boards/glp_templates.rb
+++ b/app/services/boards/glp_templates.rb
@@ -92,6 +92,15 @@ module Boards
       boards.find_by(slug: slug)
     end
 
+    # The seeded function boards in TEMPLATES (communicative-function) order —
+    # the clone sources for the Board Builder's gestalt "Phrases" layer
+    # (Boards::PhrasesPageBuilder). Empty when the seed hasn't run.
+    def function_boards
+      slugs = TEMPLATES.map { |t| t[:slug] }
+      by_slug = boards.where(slug: slugs).index_by(&:slug)
+      slugs.filter_map { |slug| by_slug[slug] }
+    end
+
     # True when `slug` is a seeded GLP template board — used by the build path
     # to branch GLP templates away from robust sets / starter blueprints.
     def template_slug?(slug)

--- a/app/services/boards/phrases_page_builder.rb
+++ b/app/services/boards/phrases_page_builder.rb
@@ -1,0 +1,76 @@
+# app/services/boards/phrases_page_builder.rb
+#
+# Builds the gestalt "Phrases" layer for a Board Builder set: a "Phrases" board
+# whose tiles are folder links to per-function gestalt pages (Greetings,
+# Requests, Protests, Comments, Feelings, Transitions), each cloned from the
+# seeded Boards::GlpTemplates function boards. Whole-phrase tiles keep
+# part_of_speech: "phrase" (clone_with_images dups the BoardImage, and the
+# admin phrase Image carries the POS), so no art is generated for them.
+#
+# This service only constructs the Phrases sub-tree. The caller
+# (BuildBoardSetJob) links it from the home board and wires it as the
+# communicator's phrase_board_id.
+module Boards
+  class PhrasesPageBuilder
+    PHRASES_BOARD_NAME = "Phrases".freeze
+
+    def initialize(communicator:, owner:)
+      @communicator = communicator
+      @owner = owner
+    end
+
+    # Creates the Phrases board + its function sub-pages and returns the Phrases
+    # board (not yet linked to any home board). Returns nil when no GLP function
+    # boards are seeded (so the caller skips the layer cleanly).
+    def call
+      sources = Boards::GlpTemplates.function_boards
+      return nil if sources.empty?
+
+      phrases_board = build_board(PHRASES_BOARD_NAME)
+
+      sources.each do |source|
+        cloned = clone_function_page(source)
+        next unless cloned
+
+        add_folder_tile(phrases_board, source.name, cloned.id)
+      end
+
+      phrases_board
+    end
+
+    private
+
+    def build_board(name)
+      board = Board.new(name: name, user: @owner)
+      board.board_type = "static"
+      board.assign_parent
+      board.voice = VoiceService.normalize_voice(@communicator.voice)
+      board.generate_unique_slug
+      board.settings = (board.settings || {}).merge("builder_child" => true)
+      board.save!
+      board
+    end
+
+    # Clone a seeded GLP function board onto the owner. clone_with_images
+    # preserves tile order, part_of_speech ("phrase"), and resolves the admin
+    # phrase Images — phrase tiles render as colored script tiles, no art needed.
+    def clone_function_page(source)
+      cloned = source.clone_with_images(@owner.id)
+      return nil unless cloned
+
+      cloned.settings = (cloned.settings || {}).merge("builder_child" => true)
+      cloned.save!
+      cloned
+    end
+
+    # Mirrors BuildBoardSetJob#add_folder_tile! but scoped to the freshly-built,
+    # empty Phrases board (no grid-cap concerns here). Pins the tile label to the
+    # function name so a resolved art image can't rename it.
+    def add_folder_tile(board, name, predictive_board_id)
+      image = Boards::ImageResolver.resolve(name, owner: @owner)
+      tile = board.add_image(image.id)
+      tile&.update!(predictive_board_id: predictive_board_id, label: name, display_label: name)
+      tile
+    end
+  end
+end

--- a/app/services/boards/structure_planner.rb
+++ b/app/services/boards/structure_planner.rb
@@ -28,16 +28,17 @@ module Boards
 
     Result = Struct.new(
       :level, :core_template, :fringe_pages, :excluded_fringe_pages,
-      :catch_all_interests, :ai_credits_needed,
+      :catch_all_interests, :ai_credits_needed, :phrases_page,
       keyword_init: true,
     )
 
-    def initialize(level:, profile: nil, interests: [], explicit_categories: {}, user: nil)
+    def initialize(level:, profile: nil, interests: [], explicit_categories: {}, user: nil, include_phrases: nil)
       @level = normalize_level(level)
       @profile = profile
       @interests = interests
       @explicit_categories = explicit_categories || {}
       @user = user
+      @include_phrases = include_phrases
       @config = LEVELS.fetch(@level)
     end
 
@@ -64,10 +65,27 @@ module Boards
         excluded_fringe_pages: excluded,
         catch_all_interests: catch_all,
         ai_credits_needed: ai_credits,
+        phrases_page: plan_phrases_page,
       )
     end
 
     private
+
+    # The gestalt "Phrases" layer (Boards::PhrasesPageBuilder) is part of every
+    # built set — it doubles as the universal phrase board (sentence-builder
+    # save target + quick-phrase source). A communicator with a glp_stage always
+    # gets it; others get it unless the caller explicitly opts out
+    # (include_phrases: false). Prominence: an early-stage gestalt processor
+    # (stage 1–2) gets a quick-phrase :strip on the home board; everyone else
+    # gets the :folder.
+    def plan_phrases_page
+      stage = @profile&.glp_stage
+      include = stage.present? || @include_phrases != false
+      return nil unless include
+
+      prominence = @profile&.gestalt_early? ? :strip : :folder
+      { include: true, prominence: prominence, stage: stage }
+    end
 
     def normalize_level(level)
       key = level.to_s.downcase

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -25,7 +25,11 @@ class BuildBoardSetJob
   include Sidekiq::Job
   sidekiq_options retry: 1, queue: :default
 
-  def perform(root_board_id, communicator_id, level_or_template, interests = [], categories = {})
+  # Max gestalt phrases promoted to the home-board quick-phrase strip for an
+  # early-stage (NLA 1–2) communicator. Capped further by open grid cells.
+  PHRASES_STRIP_SIZE = 4
+
+  def perform(root_board_id, communicator_id, level_or_template, interests = [], categories = {}, options = {})
     root = Board.find_by(id: root_board_id)
     unless root
       Rails.logger.error "BuildBoardSetJob: Board with ID #{root_board_id} not found."
@@ -46,11 +50,11 @@ class BuildBoardSetJob
 
     begin
       explicit_categories = categories.is_a?(Hash) ? categories : {}
+      opts = options.is_a?(Hash) ? options : {}
+      include_phrases = opts["include_phrases"]
 
       if complexity_level?(level_or_template)
-        build_with_structure_planner(root, communicator, level_or_template, interests, explicit_categories)
-      elsif glp_template?(level_or_template)
-        build_glp(root, communicator, level_or_template, interests)
+        build_with_structure_planner(root, communicator, level_or_template, interests, explicit_categories, include_phrases)
       else
         build_legacy(root, communicator, level_or_template, interests, explicit_categories)
       end
@@ -70,27 +74,11 @@ class BuildBoardSetJob
     Boards::StructurePlanner::LEVELS.key?(value.to_s.downcase)
   end
 
-  def glp_template?(value)
-    Boards::GlpTemplates.template_slug?(value.to_s)
-  end
-
-  # GLP templates are flat, admin-owned whole-phrase boards (one communicative
-  # function each). Build = copy each phrase tile onto the pre-created root,
-  # preserving order and part_of_speech ("phrase"). Any interests the caregiver
-  # picked in the wizard fold into a "My Favorites" page so nothing is dropped.
-  def build_glp(root, communicator, slug, interests)
-    source = Boards::GlpTemplates.find_board(slug)
-    raise Boards::BlueprintAssembler::UnknownTemplate, "unknown glp template #{slug.inspect}" unless source
-
-    source.board_images.order(:position).each do |board_image|
-      root.add_image(board_image.image_id)
-    end
-
-    add_to_favorites!(root, communicator, interests) if interests.present?
-  end
-
-  # Phase 2: StructurePlanner-driven hybrid build.
-  def build_with_structure_planner(root, communicator, level, interests, explicit_categories)
+  # Phase 2: StructurePlanner-driven hybrid build. Gestalt phrases are no longer
+  # a separate build target — every set gets the full core+fringe vocabulary
+  # PLUS an integrated "Phrases" layer (Boards::PhrasesPageBuilder), with
+  # prominence tuned to the communicator's NLA stage.
+  def build_with_structure_planner(root, communicator, level, interests, explicit_categories, include_phrases = nil)
     owner = communicator.owner || communicator.user
     profile = CommunicatorProfile.for(communicator: communicator)
 
@@ -100,6 +88,7 @@ class BuildBoardSetJob
       interests: interests,
       explicit_categories: explicit_categories,
       user: owner,
+      include_phrases: include_phrases,
     ).call
 
     robust_root = Boards::RobustSets.find_root(plan.core_template)
@@ -116,7 +105,63 @@ class BuildBoardSetJob
       ).call
     end
 
+    # Build the Phrases layer BEFORE fringe pages so its folder tile (and an
+    # early-stage quick-phrase strip) get first claim on the authored grid's
+    # open cells; fringe pages then adapt to whatever's left.
+    phrases_board = build_phrases_layer!(root, communicator, owner, plan) if plan.phrases_page&.dig(:include)
+
     add_fringe_pages_within_grid!(root, communicator, owner, profile, plan)
+
+    wire_phrase_board!(communicator, owner, phrases_board) if phrases_board
+  end
+
+  # Builds the gestalt Phrases sub-tree (Boards::PhrasesPageBuilder), links it
+  # from the home board, and — for an early-stage gestalt processor — surfaces a
+  # personalized quick-phrase strip on the home board. Returns the Phrases board
+  # (for phrase_board wiring), or nil when there's no room / no seeded templates.
+  def build_phrases_layer!(root, communicator, owner, plan)
+    root.reload
+    return nil if root_open_cells(root) < 1
+
+    phrases_board = Boards::PhrasesPageBuilder.new(communicator: communicator, owner: owner).call
+    return nil unless phrases_board
+
+    add_folder_tile!(root, owner, Boards::PhrasesPageBuilder::PHRASES_BOARD_NAME, phrases_board.id)
+
+    add_phrase_strip!(root, plan.phrases_page[:stage]) if plan.phrases_page[:prominence] == :strip
+
+    phrases_board
+  end
+
+  # Early-stage (gestalt_early?) prominence: surface the top phrases from the
+  # stage-recommended function directly on the home board, capped to the open
+  # cells left after the Phrases folder + core vocab. Degrades to folder-only
+  # when the authored grid has no room — never overflows onto a stray row.
+  def add_phrase_strip!(root, stage)
+    root.reload
+    open = root_open_cells(root)
+    return if open < 1
+
+    slug = Boards::GlpTemplates.recommended_for(stage)
+    source = slug && Boards::GlpTemplates.find_board(slug)
+    return unless source
+
+    image_ids = source.board_images.order(:position)
+      .limit([PHRASES_STRIP_SIZE, open].min).map(&:image_id)
+    image_ids.each { |image_id| root.add_image(image_id) }
+  end
+
+  # The new Phrases board doubles as the communicator's phrase board (the
+  # sentence-builder save target + quick-phrase source). Wire it on the
+  # communicator and backfill the owner — but only when blank, never clobbering
+  # a phrase board the user already picked.
+  def wire_phrase_board!(communicator, owner, phrases_board)
+    if communicator.settings["phrase_board_id"].blank?
+      communicator.update!(settings: (communicator.settings || {}).merge("phrase_board_id" => phrases_board.id))
+    end
+    if owner.settings["phrase_board_id"].blank?
+      owner.update!(settings: (owner.settings || {}).merge("phrase_board_id" => phrases_board.id))
+    end
   end
 
   def collect_seed_set_interests(plan)

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "grandma"])
 
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"], {}])
+          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"], {}, { "include_phrases" => nil }])
       end
 
       it "builds a linked set, routes interests into category vs favorites folders, and completes (job drained)" do
@@ -396,7 +396,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         Boards::GlpTemplates.seed!(admin: create(:admin_user))
       end
 
-      it "accepts a GLP template slug (regression: used to 422 unknown_template)" do
+      it "no longer accepts a GLP slug as a build target (gestalts ride every build)" do
         seed_glp_templates!
 
         expect {
@@ -404,29 +404,21 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
                params: { communicator_id: communicator.id,
                          template: "glp-greetings-social" }.to_json,
                headers: headers
-        }.to change { BuildBoardSetJob.jobs.size }.by(1)
+        }.not_to change { BuildBoardSetJob.jobs.size }
 
-        expect(response).to have_http_status(:created)
-        root = Board.find(JSON.parse(response.body)["id"])
-        # Root takes the GLP template's name, and the slug rides through to the job.
-        expect(root.name).to eq("Greetings & Social")
-        expect(BuildBoardSetJob.jobs.last["args"][2]).to eq("glp-greetings-social")
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("unknown_template")
       end
 
-      it "builds the whole-phrase tiles onto the root and completes (job drained)" do
-        seed_glp_templates!
+      it "passes include_phrases through to the build job" do
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id,
-                       template: "glp-greetings-social" }.to_json,
+                       level: "standard", include_phrases: false }.to_json,
              headers: headers
+
         expect(response).to have_http_status(:created)
-
-        BuildBoardSetJob.drain
-
-        root = Board.find(JSON.parse(response.body)["id"])
-        expect(root.status).to eq("complete")
-        expect(root.board_images.map(&:label)).to include("hi there!", "see you later")
-        expect(root.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
+        opts = BuildBoardSetJob.jobs.last["args"][5]
+        expect(opts).to eq({ "include_phrases" => false })
       end
 
       it "still 422s unknown_template for a bogus glp-looking slug" do
@@ -691,7 +683,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(communicator.reload.details["interests"]).to eq(["pizza"])
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "core-60", ["pizza"], {}])
+          .to eq([root.id, communicator.id, "core-60", ["pizza"], {}, { "include_phrases" => nil }])
 
         BuildBoardSetJob.drain
         root.reload

--- a/spec/services/boards/phrases_page_builder_spec.rb
+++ b/spec/services/boards/phrases_page_builder_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Boards::PhrasesPageBuilder do
+  let(:user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user) }
+
+  describe "#call" do
+    it "returns nil when no GLP function boards are seeded" do
+      expect(described_class.new(communicator: communicator, owner: user).call).to be_nil
+    end
+
+    context "with seeded GLP templates" do
+      before { Boards::GlpTemplates.seed!(admin: create(:admin_user)) }
+
+      it "builds a Phrases board linking the six function sub-pages" do
+        phrases_board = described_class.new(communicator: communicator, owner: user).call
+
+        expect(phrases_board).to be_present
+        expect(phrases_board.name).to eq("Phrases")
+        expect(phrases_board.settings["builder_child"]).to be(true)
+
+        function_tiles = phrases_board.board_images.select { |bi| bi.predictive_board_id.present? }
+        expect(function_tiles.map(&:label)).to match_array(
+          ["Greetings & Social", "Requests & Wants", "Protests & Boundaries",
+           "Comments & Observations", "Feelings & Emotions", "Transitions & Routines"],
+        )
+      end
+
+      it "clones the function pages with whole-phrase tiles preserved" do
+        phrases_board = described_class.new(communicator: communicator, owner: user).call
+
+        greetings_tile = phrases_board.board_images.find { |bi| bi.label == "Greetings & Social" }
+        greetings = Board.find(greetings_tile.predictive_board_id)
+
+        expect(greetings.settings["builder_child"]).to be(true)
+        expect(greetings.board_images.map(&:label)).to include("hi there!", "good morning")
+        expect(greetings.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
+        # Cloned onto the owner, not left admin-owned.
+        expect(greetings.user_id).to eq(user.id)
+      end
+    end
+  end
+end

--- a/spec/services/boards/structure_planner_spec.rb
+++ b/spec/services/boards/structure_planner_spec.rb
@@ -174,4 +174,37 @@ RSpec.describe Boards::StructurePlanner do
       expect(food_page&.dig(:interests)).not_to include("pizza") if food_page
     end
   end
+
+  describe "phrases_page planning" do
+    def profile(glp_stage: nil)
+      early = glp_stage.present? && glp_stage <= 2
+      instance_double(CommunicatorProfile, glp_stage: glp_stage, gestalt_early?: early)
+    end
+
+    it "includes a folder-prominence Phrases page by default (no stage, no opt-out)" do
+      plan = described_class.new(level: "standard", interests: []).call
+      expect(plan.phrases_page).to include(include: true, prominence: :folder)
+    end
+
+    it "promotes a strip for an early-stage gestalt processor" do
+      plan = described_class.new(level: "standard", profile: profile(glp_stage: 1), interests: []).call
+      expect(plan.phrases_page).to include(include: true, prominence: :strip, stage: 1)
+    end
+
+    it "uses the folder for a later-stage processor" do
+      plan = described_class.new(level: "standard", profile: profile(glp_stage: 5), interests: []).call
+      expect(plan.phrases_page).to include(prominence: :folder, stage: 5)
+    end
+
+    it "omits the Phrases page when explicitly opted out and no stage is set" do
+      plan = described_class.new(level: "standard", interests: [], include_phrases: false).call
+      expect(plan.phrases_page).to be_nil
+    end
+
+    it "still includes the Phrases page for a glp-stage communicator even when opted out" do
+      plan = described_class.new(level: "standard", profile: profile(glp_stage: 1),
+                                 interests: [], include_phrases: false).call
+      expect(plan.phrases_page).to include(include: true, prominence: :strip)
+    end
+  end
 end

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -131,38 +131,66 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
-  describe "#perform with a GLP template" do
+  describe "#perform Phrases layer (gestalt integration)" do
     def seed_glp_templates!
       Boards::GlpTemplates.seed!(admin: create(:admin_user))
     end
 
-    it "copies the whole-phrase tiles onto the pre-created root and completes" do
+    before do
+      seed_robust_set!
       seed_glp_templates!
-      root = precreate_root!(name: "Greetings & Social")
+    end
 
-      described_class.new.perform(root.id, communicator.id, "glp-greetings-social", [])
+    it "links an integrated Phrases page with the six function sub-pages" do
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "standard", [])
 
       root.reload
       expect(root.status).to eq("complete")
-      labels = root.board_images.map(&:label)
-      expect(labels).to include("hi there!", "see you later", "good morning")
-      # part_of_speech carries over so tiles render as gestalt scripts, not words.
-      expect(root.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
-      # Flat board — no sub-board folder tiles.
-      expect(root.board_images.map(&:predictive_board_id).compact).to be_empty
+
+      phrases_tile = root.board_images.find { |bi| bi.label == "Phrases" }
+      expect(phrases_tile&.predictive_board_id).to be_present
+
+      phrases_board = Board.find(phrases_tile.predictive_board_id)
+      function_tiles = phrases_board.board_images.select { |bi| bi.predictive_board_id.present? }
+      expect(function_tiles.size).to eq(6)
+
+      greetings = Board.find(function_tiles.find { |bi| bi.label == "Greetings & Social" }.predictive_board_id)
+      expect(greetings.board_images.map(&:label)).to include("hi there!", "good morning")
+      expect(greetings.board_images.map { |bi| bi.image.part_of_speech }.uniq).to eq(["phrase"])
     end
 
-    it "folds picked interests into a My Favorites page (nothing dropped)" do
-      seed_glp_templates!
-      root = precreate_root!(name: "Greetings & Social")
+    it "wires the new Phrases board as the communicator's and owner's phrase board" do
+      root = precreate_root!(name: "Core 60")
 
-      described_class.new.perform(root.id, communicator.id, "glp-greetings-social", ["grandma"])
+      described_class.new.perform(root.id, communicator.id, "standard", [])
+
+      phrases_tile = root.reload.board_images.find { |bi| bi.label == "Phrases" }
+      phrases_board_id = phrases_tile.predictive_board_id
+
+      expect(communicator.reload.settings["phrase_board_id"]).to eq(phrases_board_id)
+      expect(user.reload.settings["phrase_board_id"]).to eq(phrases_board_id)
+    end
+
+    it "never clobbers a phrase board the user already picked" do
+      communicator.update!(settings: (communicator.settings || {}).merge("phrase_board_id" => 4242))
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "standard", [])
+
+      expect(communicator.reload.settings["phrase_board_id"]).to eq(4242)
+    end
+
+    it "surfaces a quick-phrase strip on the home board for an early-stage processor" do
+      communicator.update!(details: (communicator.details || {}).merge("glp_stage" => 1))
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "standard", [])
 
       root.reload
-      favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
-      expect(favorites_tile&.predictive_board_id).to be_present
-      favorites = Board.find(favorites_tile.predictive_board_id)
-      expect(favorites.board_images.map(&:label)).to include("grandma")
+      phrase_tiles = root.board_images.select { |bi| bi.image.part_of_speech == "phrase" }
+      expect(phrase_tiles).not_to be_empty
     end
   end
 


### PR DESCRIPTION
Closes #368.

## Summary

Retires the dead-end GLP build path (a flat phrase-only board with no core vocabulary — a clinical dead end for the NLA journey). Every Board Builder build now produces the full robust core+fringe vocabulary **plus** an integrated gestalt **Phrases** layer, with prominence tuned to the communicator's NLA stage, and the new Phrases board auto-wired as the communicator's phrase board.

**Scope:** this only affects the Board Builder path (`BuildBoardSetJob#build_with_structure_planner`). Regular board create / clone / AI-generate / manual boards are untouched.

## What changed

- **`Boards::StructurePlanner`** — plans a `phrases_page` (folder by default; `:strip` for an early-stage `gestalt_early?` communicator; omitted only when `include_phrases: false` **and** no `glp_stage`). New `include_phrases` option.
- **`Boards::PhrasesPageBuilder`** (new) — builds a "Phrases" board linking the six function pages (Greetings / Requests / Protests / Comments / Feelings / Transitions) cloned from `GlpTemplates.function_boards`, whole-phrase `part_of_speech: "phrase"` preserved.
- **`BuildBoardSetJob`** — builds + links the Phrases layer **before** fringe pages (first claim on open grid cells); for early stages surfaces a personalized quick-phrase strip on the home board (capped to open cells, degrades to folder-only — never overflows the authored grid); wires the new Phrases board as the communicator's/owner's `phrase_board_id` **only when blank** (never clobbering an existing pick). `build_glp` and the GLP-slug branch removed.
- **Controller** — accepts `include_phrases`; GLP slugs are **no longer a build target** (kept in the catalog for recommendation display only) → 422 `unknown_template`.
- **CLAUDE.md** — documents the unified path + phrase-board wiring; corrects the stale "GLP = catalog metadata only" claim.

## Phrase-board wiring (the sleeper win)

`phrase_board_id` is the board the sentence builder saves built sentences onto and pulls quick phrases from — a manual picker most users never set, so it shipped inert. The Board Builder now points it at the new Phrases page when it was unset, so the save/quick-phrase loop works for Board Builder users out of the box. Build-time only; existing sets aren't retroactively wired.

## Test plan

Targeted specs (`bundle exec rspec`), **111 examples, 0 failures**:
- `spec/services/boards/structure_planner_spec.rb` — `phrases_page` planning (folder default, `:strip` early stage, omitted on opt-out + no stage, always-on for glp_stage)
- `spec/services/boards/phrases_page_builder_spec.rb` — Phrases board + 6 function pages, whole-phrase POS preserved, cloned onto owner
- `spec/sidekiq/build_board_set_job_spec.rb` — integrated Phrases page linked, phrase_board set-when-blank / preserved-when-set, early-stage strip
- `spec/requests/api/v1/board_builder_spec.rb` — GLP slug → 422, `include_phrases` passthrough, job-args
- `spec/services/boards/glp_templates_spec.rb`, `spec/sidekiq/build_board_set_job_grid_spec.rb` — regression

No migrations, no new ENV vars. Deploy note: `glp_templates:seed` must have run in prod (the six function boards are the clone sources).

## Follow-up

Frontend counterpart: brittanyjohns/itty-bitty-frontend#424 (blocked on this PR's `include_phrases` contract + GLP-slug-now-422 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
