### PR TITLE
fix(communicators): stop sandbox accounts advertising a sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Sandbox communicators no longer advertise a sign-in
+- A **sandbox** (no-login demo) communicator owned by a paid or free-trial user
+  was returning `can_sign_in: true` and a real `startup_url`
+  (`/accounts/sign-in?username=…`) in its API payload — even though a sandbox
+  has no passcode and cannot be signed into. `ChildAccount#can_sign_in?` now
+  short-circuits to `false` for any sandbox (before the admin/plan checks), and
+  `ChildAccount#startup_url` returns `nil` for a sandbox, so the contradiction
+  no longer reaches the frontend. Active and loaner communicators are
+  unchanged. Specs added in `spec/models/child_account_spec.rb`.
+
 ### Fixed — Board Builder fringe pages now show tile artwork
 - A built board set's **main board** showed pictures on its tiles, but the
   **fringe/category pages** (Food, Feelings, Animals…) often rendered blank. The

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -769,6 +769,12 @@ class ChildAccount < ApplicationRecord
   end
 
   def can_sign_in?(user_context = nil)
+    # Sandboxes are no-login demo accounts — they never have a passcode, so
+    # nobody (not even an admin) can sign into one. Guard first so a sandbox
+    # owned by a paid/trial user can't fall through to the plan check below and
+    # wrongly report can_sign_in: true.
+    return false if sandbox?
+
     if user_context && user_context.admin?
       return true
     end
@@ -859,6 +865,9 @@ class ChildAccount < ApplicationRecord
   end
 
   def startup_url
+    # A sandbox has no private sign-in, so don't advertise a sign-in URL for it.
+    return nil if sandbox?
+
     base_url = ENV["FRONT_END_URL"] || "http://localhost:8100"
     "#{base_url}/accounts/sign-in?username=#{username}"
   end

--- a/spec/models/child_account_spec.rb
+++ b/spec/models/child_account_spec.rb
@@ -87,4 +87,40 @@ RSpec.describe ChildAccount, type: :model do
       expect(account.authentication_token).not_to eq(old_token)
     end
   end
+
+  # A sandbox is a no-login demo account. It must never advertise a private
+  # sign-in — neither via can_sign_in? nor a startup_url — even though its
+  # owner may be on a paid plan or in their free trial. Regression guard for
+  # the contradiction where a sandbox shipped can_sign_in: true + a real URL.
+  describe "sandbox sign-in gating" do
+    let(:paid_user) { FactoryBot.create(:user, plan_type: "pro") }
+
+    it "denies can_sign_in? for a sandbox owned by a paid user" do
+      sandbox = FactoryBot.create(:child_account, user: paid_user,
+                                                   status: ChildAccount::SANDBOX)
+      expect(paid_user.paid_plan?).to be(true)
+      expect(sandbox.can_sign_in?).to be(false)
+    end
+
+    it "returns a nil startup_url for a sandbox" do
+      sandbox = FactoryBot.create(:child_account, user: paid_user,
+                                                   status: ChildAccount::SANDBOX)
+      expect(sandbox.startup_url).to be_nil
+    end
+
+    it "denies can_sign_in? for a sandbox even when the owner is an admin" do
+      admin   = FactoryBot.create(:admin_user)
+      sandbox = FactoryBot.create(:child_account, user: admin,
+                                                  status: ChildAccount::SANDBOX)
+      expect(sandbox.can_sign_in?).to be(false)
+    end
+
+    it "still allows sign-in and a startup_url for an active communicator" do
+      active = FactoryBot.create(:child_account, user: paid_user,
+                                                 username: "signme",
+                                                 status: ChildAccount::ACTIVE)
+      expect(active.can_sign_in?).to be(true)
+      expect(active.startup_url).to include("/accounts/sign-in?username=signme")
+    end
+  end
 end


### PR DESCRIPTION
## What & why

A **sandbox** (no-login demo) communicator was shipping a contradictory API payload: `status: "sandbox"` / `is_demo: true` **and** `can_sign_in: true` with a real `startup_url` (`/accounts/sign-in?username=…`). A sandbox has no passcode and can never be signed into, so the frontend was advertising a sign-in link that goes nowhere. (Spotted on a real sandbox account: `is_demo: true`, `passcode: null`, `sign_in_count: 0`, yet `can_sign_in: true` + a `startup_url`.)

### Root cause — `app/models/child_account.rb`
- `can_sign_in?` only checked the **owner's** plan (`paid_plan?` / `vendor?` / `free_trial?`) and `fallback_mode?`, never the account's own sandbox status. A sandbox owned by a paid (or trialing) user fell through to `return true`.
- `startup_url` built a sign-in URL **unconditionally** for every account.

### Fix
- `can_sign_in?` now returns `false` for any sandbox, guarded **first** (before the admin and plan checks) — a sandbox has no passcode for anyone, including an admin, to use.
- `startup_url` returns `nil` for a sandbox. This propagates correctly to `api_view` / `vendor_api_view` and the profile serializer; the setup-email path was already meaningless for a passcode-less sandbox.

Active and loaner communicators are unaffected.

## Reviewer notes
- No DB/migration changes; pure model logic.
- The frontend already treats sandboxes as no-login, so this only removes the false signal — no frontend change is required for correctness. (Companion frontend PR brittanyjohns/itty-bitty-frontend#425 adds a sandbox⇄full toggle + passcode reveal, which is what surfaced this.)

## Test plan
- `bundle exec rspec spec/models/child_account_spec.rb` — **12 examples, 0 failures**, including 4 new specs:
  - sandbox + paid owner → `can_sign_in?` false
  - sandbox → `startup_url` nil
  - sandbox + admin owner → `can_sign_in?` false
  - active + paid owner → still `true` and a real `startup_url` (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
