### PR TITLE
fix(screenshot-import): refund on failure, fix cell edits, guard commit, clean temp files, gate staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `spec/services/board_from_screenshot_spec.rb` and
   `spec/sidekiq/categorize_image_job_spec.rb`.
 
+### Fixed — "Make a Board From Screenshot" robustness
+- A failed screenshot import now **refunds** the 3 credits charged at upload —
+  previously a user whose AI analysis failed was out the credits with nothing to
+  show. The refund returns credits to the exact plan/topup split they came from
+  and is idempotent across Sidekiq retries.
+- Editing detected cells via `PATCH /api/board_screenshot_imports/:id` no longer
+  drops `row`/`col` changes (they weren't permitted) and no longer 500s when the
+  request omits the `board_screenshot` key.
+- Committing an import that isn't ready (still processing/failed) returns a clean
+  **422 `import_not_ready`** instead of a raw 500.
+- The preprocessed temp image is always cleaned up, even on failure (it was
+  leaking into `tmp/` on every import).
+- On **staging**, screenshot analysis now returns a deterministic placeholder
+  grid instead of calling paid OpenAI vision — mirroring the existing
+  image-generation placeholder, so QA doesn't incur API cost or burn credits.
+
 ### Fixed — Sandbox communicators no longer advertise a sign-in
 - A **sandbox** (no-login demo) communicator owned by a paid or free-trial user
   was returning `can_sign_in: true` and a real `startup_url`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -787,6 +787,40 @@ Tasks:
   finds over-entitled users. See
   `.claude-notes/beta-end-founding-rate-handoff.md`.
 
+## Make a Board From Screenshot
+
+Turns an uploaded screenshot of an existing AAC/communication board into a real
+SpeakAnyWay `Board` using OpenAI vision. Three-step flow, async in the middle:
+
+- **Upload** — `POST /api/board_screenshot_imports` (`name`, optional `columns`,
+  and either `cropped_image` base64 data URL or multipart `image`). Creates a
+  `BoardScreenshotImport` (`status: queued`), **spends 3 credits**
+  (`screenshot_import` feature key) via `check_credits!`, stashes the spend
+  transaction id on `import.metadata["credit_txn_id"]`, then enqueues
+  `BoardScreenshotImportJob`. `columns` is sanitized to a positive Integer or
+  `nil` (auto-detect) so a bad value can't fail the job after charging.
+- **Analyze (async)** — `BoardScreenshotImportJob` (queue `:ai_images`,
+  `retry: 1`): `ImagePreprocessor` resizes/deskews/contrast-boosts to a `tmp/`
+  file → `BoardScreenshotVisionService#parse_board` (OpenAI **Responses API**,
+  JSON mode, model `BOARD_SCREENSHOT_VISION_MODEL`, default `gpt-4.1-mini`)
+  returns a full `rows × cols` grid → one `BoardScreenshotCell` per cell →
+  `status: needs_review`. The preprocessed temp file is always unlinked in an
+  `ensure`. On any failure the import goes `status: failed` **and the 3 credits
+  are refunded** to their original plan/topup split (idempotent across the retry
+  via a `refund_for_txn` marker).
+- **Review + commit** — `PATCH /api/board_screenshot_imports/:id` lets the user
+  fix detected `label_norm`/`bg_color`/`row`/`col` per cell (and `cols`); then
+  `POST /api/board_screenshot_imports/:id/commit` runs `BoardFromScreenshot`,
+  which builds a static `Board` (col→`x`, row→`y` explicit grid layout),
+  resolves an `Image` per label, and links it back to the import. `commit`
+  returns **422 `import_not_ready`** unless the import is
+  `needs_review`/`committed`/`completed`.
+
+**Staging:** `BoardScreenshotVisionService#parse_board` returns a deterministic
+placeholder grid when `AppEnv.staging?` — no paid OpenAI call, no real credits
+burned — mirroring the image-generation placeholder short-circuit. (The vision
+call is **not** gated in real production.)
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -52,7 +52,9 @@ module API
       return true if current_user.admin?
 
       amount ||= CreditService.cost_for(feature_key)
-      CreditService.spend!(
+      # Expose the resulting transaction so callers that kick off async work can
+      # stash its id and refund the exact source split if that work later fails.
+      @credit_spend_transaction = CreditService.spend!(
         current_user,
         feature_key: feature_key,
         amount: amount,

--- a/app/controllers/api/board_screenshot_imports_controller.rb
+++ b/app/controllers/api/board_screenshot_imports_controller.rb
@@ -15,7 +15,7 @@ class API::BoardScreenshotImportsController < API::ApplicationController
 
   def create
     name = params[:name]
-    columns = params[:columns]
+    columns = sanitized_columns(params[:columns])
     cropped_image = params[:cropped_image]
     image = params[:image]
 
@@ -35,6 +35,13 @@ class API::BoardScreenshotImportsController < API::ApplicationController
     end
     import.save!
     return unless check_credits!(feature_key: "screenshot_import", feature_name: "AI Board Screenshot Imports")
+
+    # Record the spend transaction so the job can refund the exact source split
+    # if the AI analysis fails (the user is charged at upload, before the job runs).
+    if @credit_spend_transaction
+      import.update!(metadata: (import.metadata || {}).merge("credit_txn_id" => @credit_spend_transaction.id))
+    end
+
     BoardScreenshotImportJob.perform_async(import.id, columns)
     render json: { id: import.id, status: import.status }
   end
@@ -42,9 +49,9 @@ class API::BoardScreenshotImportsController < API::ApplicationController
   # Accept user-edited labels + (optional) rows/cols
   def update
     import = current_user.board_screenshot_imports.find(params[:id])
-    board_screenshot = params[:board_screenshot] || board_screenshot_import_update_params
+    board_screenshot = params[:board_screenshot].presence || board_screenshot_import_update_params
     cells_data = board_screenshot[:cells]
-    cols = params[:board_screenshot][:cols]
+    cols = board_screenshot[:cols]
     ActiveRecord::Base.transaction do
       import.guessed_cols = cols if cols.present?
       (cells_data || []).each do |c|
@@ -59,16 +66,21 @@ class API::BoardScreenshotImportsController < API::ApplicationController
         cand.col = col.to_i if col.present?
         cand.save!
       end
-      if import.update(status: "needs_review")
-        render json: { ok: true }
-      else
-        render json: { error: "Failed to update import" }, status: :unprocessable_content
-      end
+      import.update!(status: "needs_review")
     end
+    render json: { ok: true }
   end
+
+  COMMITTABLE_STATUSES = %w[needs_review committed completed].freeze
 
   def commit
     import = current_user.board_screenshot_imports.find(params[:id])
+    unless COMMITTABLE_STATUSES.include?(import.status)
+      render json: { error: "import_not_ready", message: "This screenshot import isn't ready to build a board yet." },
+             status: :unprocessable_content
+      return
+    end
+
     board_image_id = params[:board_image_id]
     @board = BoardFromScreenshot.commit!(import)
     board_image = BoardImage.find_by(id: board_image_id) if board_image_id.present?
@@ -89,7 +101,15 @@ class API::BoardScreenshotImportsController < API::ApplicationController
 
   private
 
+  # Coerce the client-supplied column count to a positive Integer, or nil
+  # (auto-detect). Avoids charging credits then failing the job on a bad value.
+  def sanitized_columns(value)
+    return nil if value.blank?
+    n = value.to_i
+    n.positive? ? n : nil
+  end
+
   def board_screenshot_import_update_params
-    params.permit(:guessed_rows, :guessed_cols, :name, :cols, cells: [:id, :label_norm, :bg_color])
+    params.permit(:guessed_rows, :guessed_cols, :name, :cols, cells: [:id, :label_norm, :bg_color, :row, :col])
   end
 end

--- a/app/services/board_screenshot_vision_service.rb
+++ b/app/services/board_screenshot_vision_service.rb
@@ -85,6 +85,11 @@ class BoardScreenshotVisionService
 
     @logger.debug "[BoardScreenshotVisionService] Parsing board from #{image_path} (forced_cols=#{forced_cols || "auto"})"
 
+    # Staging shares the prod box and uses real API keys, but we don't want to
+    # spend on paid OpenAI vision (or burn real credits) for QA. Mirror the
+    # image-generation placeholder short-circuit and return a deterministic grid.
+    return staged_stub(forced_cols) if AppEnv.staging?
+
     data_url = encode_image_as_data_url(image_path)
 
     user_prompt = if forced_cols
@@ -142,6 +147,32 @@ class BoardScreenshotVisionService
   end
 
   private
+
+  # Deterministic stand-in used on staging so the full import flow can be
+  # exercised without a paid OpenAI vision call. Returns a small filled grid.
+  STAGED_LABELS = %w[i want more help yes no stop go eat drink play].freeze
+
+  def staged_stub(forced_cols)
+    cols = forced_cols || 3
+    rows = 2
+    cells = []
+    rows.times do |r|
+      cols.times do |c|
+        label = STAGED_LABELS[(r * cols + c) % STAGED_LABELS.size]
+        cells << {
+          row: r,
+          col: c,
+          label_raw: label,
+          label_norm: label,
+          label: label,
+          confidence: 1.0,
+          bbox: [0.0, 0.0, 0.0, 0.0],
+          bg_color: "white",
+        }
+      end
+    end
+    { rows: rows, cols: cols, confidence_avg: 1.0, cells: cells }
+  end
 
   # Turn a local file into data:image/...;base64,....
   def encode_image_as_data_url(image_path)

--- a/app/sidekiq/board_screenshot_import_job.rb
+++ b/app/sidekiq/board_screenshot_import_job.rb
@@ -11,6 +11,8 @@ class BoardScreenshotImportJob
 
     Rails.logger.debug "[BoardScreenshotImportJob] Starting import #{import.id}"
 
+    processed_path = nil
+
     # 1) Get a local temp path for the uploaded screenshot (works with S3, etc.)
     import.image.open(tmpdir: Rails.root.join("tmp")) do |file|
       original_path = file.path
@@ -52,6 +54,47 @@ class BoardScreenshotImportJob
   rescue => e
     Rails.logger.error "[BoardScreenshotImportJob] Error: #{e.class}: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
-    import.update!(status: "failed", error_message: e.message) if import
+    if import
+      import.update!(status: "failed", error_message: e.message)
+      # The user was charged at upload; the analysis never produced a board, so
+      # make them whole. Idempotent across the one Sidekiq retry.
+      refund_credits!(import)
+    end
+  ensure
+    # ImagePreprocessor writes a standalone temp file that the image.open block
+    # does NOT clean up. Always unlink it so imports don't leak disk.
+    begin
+      File.delete(processed_path) if processed_path && File.exist?(processed_path)
+    rescue => e
+      Rails.logger.warn "[BoardScreenshotImportJob] temp cleanup failed: #{e.class}: #{e.message}"
+    end
+  end
+
+  private
+
+  # Refund the screenshot_import credits spent at upload time when the import
+  # fails. Refunds to the exact plan/topup split recorded on the spend txn, and
+  # guards against double-refund so the Sidekiq retry can't refund twice.
+  def refund_credits!(import)
+    txn_id = import.metadata&.dig("credit_txn_id")
+    return unless txn_id
+
+    spend = CreditTransaction.find_by(id: txn_id, kind: "spend")
+    return unless spend
+
+    already_refunded = CreditTransaction.where(kind: "refund")
+      .where("metadata ->> 'refund_for_txn' = ?", spend.id.to_s)
+      .exists?
+    return if already_refunded
+
+    user = import.user
+    from_plan = spend.metadata["from_plan"].to_i
+    from_topup = spend.metadata["from_topup"].to_i
+    meta = { import_id: import.id, refund_for_txn: spend.id }
+
+    CreditService.refund!(user, amount: from_plan, feature_key: "screenshot_import", source: "plan", metadata: meta) if from_plan.positive?
+    CreditService.refund!(user, amount: from_topup, feature_key: "screenshot_import", source: "topup", metadata: meta) if from_topup.positive?
+  rescue => e
+    Rails.logger.error "[BoardScreenshotImportJob] refund failed for import=#{import&.id}: #{e.class}: #{e.message}"
   end
 end

--- a/spec/requests/api/board_screenshot_imports_spec.rb
+++ b/spec/requests/api/board_screenshot_imports_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+# Covers the screenshot-import controller correctness fixes:
+# - create: image required, credit spend + txn stashed for refund, columns sanitized
+# - update: tolerant of a missing board_screenshot key, persists row/col edits
+# - commit: guarded against committing an import that isn't ready
+RSpec.describe "API::BoardScreenshotImports", type: :request do
+  let(:user)  { FactoryBot.create(:user) }
+  let(:other) { FactoryBot.create(:user) }
+
+  # 1x1 transparent PNG as a data URL (the controller only attaches it).
+  let(:data_url) do
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+  end
+
+  describe "POST /api/board_screenshot_imports (create)" do
+    it "rejects anonymous callers with 401" do
+      post "/api/board_screenshot_imports", params: { cropped_image: data_url }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 422 when no image is provided" do
+      post "/api/board_screenshot_imports", params: { name: "x" }, headers: auth_headers(user)
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to match(/no image/i)
+    end
+
+    it "creates the import, spends credits, stashes the txn id, and enqueues the job" do
+      expect(BoardScreenshotImportJob).to receive(:perform_async)
+
+      expect {
+        post "/api/board_screenshot_imports",
+             params: { name: "Kitchen", columns: "6", cropped_image: data_url },
+             headers: auth_headers(user)
+      }.to change { user.reload.plan_credits_balance }.by(-CreditService.cost_for("screenshot_import"))
+
+      expect(response).to have_http_status(:ok)
+      import = user.board_screenshot_imports.last
+      expect(import.metadata["credit_txn_id"]).to be_present
+      expect(CreditTransaction.find(import.metadata["credit_txn_id"]).kind).to eq("spend")
+    end
+
+    it "sanitizes a non-positive columns value to auto-detect (nil)" do
+      expect(BoardScreenshotImportJob).to receive(:perform_async) do |_id, columns|
+        expect(columns).to be_nil
+      end
+      post "/api/board_screenshot_imports",
+           params: { columns: "0", cropped_image: data_url },
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 402 and does not enqueue when the user is out of credits" do
+      user.update_columns(plan_credits_balance: 0, topup_credits_balance: 0)
+      expect(BoardScreenshotImportJob).not_to receive(:perform_async)
+
+      post "/api/board_screenshot_imports",
+           params: { cropped_image: data_url }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(402)
+      expect(JSON.parse(response.body)["error"]).to eq("insufficient_credits")
+    end
+  end
+
+  describe "PATCH /api/board_screenshot_imports/:id (update)" do
+    let(:import) { user.board_screenshot_imports.create!(status: "needs_review") }
+    let!(:cell)  { import.board_screenshot_cells.create!(row: 0, col: 0, label_norm: "old", bg_color: "white") }
+
+    it "persists label, color, row and col edits via the board_screenshot key" do
+      patch "/api/board_screenshot_imports/#{import.id}",
+            params: { board_screenshot: { cols: 4, cells: [{ id: cell.id, label_norm: "eat", bg_color: "#FF7070", row: 1, col: 2 }] } },
+            headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      cell.reload
+      expect(cell.label_norm).to eq("eat")
+      expect(cell.bg_color).to eq("#FF7070")
+      expect(cell.row).to eq(1)
+      expect(cell.col).to eq(2)
+      expect(import.reload.guessed_cols).to eq(4)
+    end
+
+    it "does not 500 when the board_screenshot key is absent" do
+      patch "/api/board_screenshot_imports/#{import.id}", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+      expect(import.reload.status).to eq("needs_review")
+    end
+  end
+
+  describe "POST /api/board_screenshot_imports/:id/commit" do
+    it "returns 422 when the import is not ready (still processing)" do
+      import = user.board_screenshot_imports.create!(status: "processing")
+      post "/api/board_screenshot_imports/#{import.id}/commit", headers: auth_headers(user)
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("import_not_ready")
+    end
+
+    it "builds a board when the import is ready" do
+      import = user.board_screenshot_imports.create!(status: "needs_review", guessed_cols: 2)
+      import.board_screenshot_cells.create!(row: 0, col: 0, label_norm: "hi", bg_color: "white")
+
+      expect {
+        post "/api/board_screenshot_imports/#{import.id}/commit", headers: auth_headers(user)
+      }.to change { user.boards.count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["ok"]).to be(true)
+      expect(body["board_id"]).to be_present
+    end
+  end
+end

--- a/spec/services/board_screenshot_vision_service_spec.rb
+++ b/spec/services/board_screenshot_vision_service_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe BoardScreenshotVisionService do
+  subject(:service) { described_class.new(openai_client: client) }
+  let(:responses) { double("responses") }
+  let(:client)    { double("openai_client", responses: responses) }
+
+  describe "#parse_board argument validation" do
+    it "raises when image_path is blank" do
+      expect { service.parse_board(image_path: "") }.to raise_error(ArgumentError)
+    end
+
+    it "raises when cols is not a positive integer" do
+      expect { service.parse_board(image_path: "/tmp/x.png", cols: 0) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "staging short-circuit" do
+    before { allow(AppEnv).to receive(:staging?).and_return(true) }
+
+    it "returns a deterministic grid without calling OpenAI" do
+      expect(responses).not_to receive(:create)
+
+      result = service.parse_board(image_path: "/tmp/whatever.png")
+
+      expect(result[:cells].size).to eq(result[:rows] * result[:cols])
+      expect(result[:cells]).to all(include(:row, :col, :label_norm, :bg_color))
+      expect(result[:confidence_avg]).to eq(1.0)
+    end
+
+    it "honors a forced column count" do
+      result = service.parse_board(image_path: "/tmp/whatever.png", cols: 5)
+      expect(result[:cols]).to eq(5)
+      expect(result[:cells].size).to eq(result[:rows] * 5)
+    end
+  end
+end

--- a/spec/sidekiq/board_screenshot_import_job_spec.rb
+++ b/spec/sidekiq/board_screenshot_import_job_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe BoardScreenshotImportJob, type: :job do
+  let(:user) { FactoryBot.create(:user) }
+  let(:import) do
+    imp = user.board_screenshot_imports.create!(status: "queued")
+    imp.image.attach(
+      io: File.open(Rails.root.join("spec/data/path_images/images/happy.png")),
+      filename: "screenshot.png",
+      content_type: "image/png",
+    )
+    imp
+  end
+
+  let(:vision_result) do
+    {
+      rows: 1, cols: 2, confidence_avg: 0.9,
+      cells: [
+        { row: 0, col: 0, label_raw: "Eat", label_norm: "eat", label: "eat", confidence: 0.9, bbox: [0, 0, 0, 0], bg_color: "white" },
+        { row: 0, col: 1, label_raw: nil, label_norm: nil, label: "", confidence: 0.5, bbox: [0, 0, 0, 0], bg_color: "white" },
+      ],
+    }
+  end
+
+  # Stub the service via `.new` (not allow_any_instance_of, which leaks its
+  # return/raise stub across examples under random ordering).
+  let(:vision) { instance_double(BoardScreenshotVisionService) }
+
+  # Stub preprocessing for every example so the job never shells out to
+  # ImageMagick (not installed on CI) — otherwise the job would die at the
+  # preprocess step before reaching the stubbed vision call. The temp path is a
+  # real file so the job's cleanup (and the success-path assertion) is exercised.
+  let(:preprocessed_temp) { Rails.root.join("tmp", "import_stub_#{SecureRandom.hex(4)}.jpg").to_s }
+  before do
+    allow(BoardScreenshotVisionService).to receive(:new).and_return(vision)
+    File.write(preprocessed_temp, "stub")
+    allow(ImagePreprocessor).to receive(:new).and_return(
+      instance_double(ImagePreprocessor, process!: { path: preprocessed_temp, rotation: 0, debug: {} }),
+    )
+  end
+
+  describe "success" do
+    before { allow(vision).to receive(:parse_board).and_return(vision_result) }
+
+    it "creates cells, marks the import needs_review, and deletes the preprocessed temp file" do
+      described_class.new.perform(import.id)
+
+      expect(import.reload.status).to eq("needs_review")
+      expect(import.board_screenshot_cells.count).to eq(2)
+      expect(import.guessed_cols).to eq(2)
+      expect(File.exist?(preprocessed_temp)).to be(false)
+    end
+  end
+
+  describe "failure refunds credits" do
+    before { allow(vision).to receive(:parse_board).and_raise(StandardError, "vision boom") }
+
+    it "marks the import failed and refunds the exact source split, idempotently" do
+      spend = CreditService.spend!(user, feature_key: "screenshot_import")
+      import.update!(metadata: { "credit_txn_id" => spend.id })
+      balance_after_spend = user.reload.plan_credits_balance
+
+      described_class.new.perform(import.id)
+
+      expect(import.reload.status).to eq("failed")
+      expect(import.error_message).to eq("vision boom")
+      expect(user.reload.plan_credits_balance).to eq(balance_after_spend + CreditService.cost_for("screenshot_import"))
+      expect(CreditTransaction.where(kind: "refund").count).to eq(1)
+
+      # A Sidekiq retry must not double-refund.
+      described_class.new.perform(import.id)
+      expect(CreditTransaction.where(kind: "refund").count).to eq(1)
+    end
+
+    it "does not refund when no credit txn was recorded" do
+      described_class.new.perform(import.id)
+      expect(import.reload.status).to eq("failed")
+      expect(CreditTransaction.where(kind: "refund").count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR **1 of 2** from a review of the **Make a Board From Screenshot** workflow ahead of the marketing push. This PR is the correctness/safety pass; PR 2 will cover optimizations (curated tile art via `ImageResolver`, batched cell creation, payload trim) plus deeper test coverage.

### What changed
- **Credit refund on failure.** The 3 `screenshot_import` credits are charged at upload, before the async job runs. If the AI analysis fails, the import now refunds those credits to the exact plan/topup split they came from. The spend transaction id is stashed on `import.metadata["credit_txn_id"]`; the refund is idempotent across the one Sidekiq retry (guarded by a `refund_for_txn` marker). Previously a failed import left the user out 3 credits with nothing to show.
- **`update` action fixes.** `row`/`col` cell edits were not in the permitted params and were silently dropped; added them. A request omitting the `board_screenshot` key would `500` (`params[:board_screenshot][:cols]` on nil) — now tolerant.
- **`commit` guard.** Committing an import that isn't ready (still `processing`/`failed`) returned a raw `500` (internal error leak). Now returns a clean **422 `import_not_ready`**.
- **Temp-file leak.** `ImagePreprocessor` writes a standalone `tmp/import_*.jpg` that the `image.open` block never cleaned up — it leaked on every import. Now always unlinked in an `ensure` (relevant given the prior disk-full outage).
- **`columns` sanitization.** Coerced to a positive Integer or `nil` (auto-detect) so a bad value can't fail the job *after* charging credits.
- **Staging gate (decision D).** `BoardScreenshotVisionService#parse_board` returns a deterministic placeholder grid when `AppEnv.staging?` — no paid OpenAI call, no real credits burned — mirroring the existing image-generation placeholder. Not gated in real production.

### Test plan
New specs (16 examples, all passing):
- `spec/requests/api/board_screenshot_imports_spec.rb` — create (auth, no-image 422, credit spend + txn stash, columns sanitize, 402), update (row/col edits, missing-key no-500), commit (422 not-ready, success builds board).
- `spec/sidekiq/board_screenshot_import_job_spec.rb` — success (cells created, no temp file left), failure (status failed + refund to correct split, idempotent retry, no-refund when no txn).
- `spec/services/board_screenshot_vision_service_spec.rb` — arg validation + staging short-circuit (no OpenAI call, honors forced cols).

```
bundle exec rspec spec/requests/api/board_screenshot_imports_spec.rb \
  spec/sidekiq/board_screenshot_import_job_spec.rb \
  spec/services/board_screenshot_vision_service_spec.rb
# 16 examples, 0 failures
```

Docs: CHANGELOG entry + new "Make a Board From Screenshot" section in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)