### PR TITLE
chore(deps): bump concurrent-ruby to 1.3.7 (clear CVEs)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       xpath (~> 3.2)
     cgi (0.5.1)
     chunky_png (1.4.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal


### PR DESCRIPTION
## Summary

`bundler-audit` started failing on **every** PR and `main` after three `concurrent-ruby` advisories landed in ruby-advisory-db on 2026-06-23:

| CVE | Issue |
|---|---|
| CVE-2026-54904 | `AtomicReference#update` livelocks on `Float::NAN` |
| CVE-2026-54905 | `ReentrantReadWriteLock` read-count overflow grants write lock |
| CVE-2026-54906 | `ReadWriteLock` wrong-thread release / counter corruption |

All three are fixed in **1.3.7**. Since a patched version exists, this bumps the gem rather than adding to the `--ignore` list (which is reserved for CVEs with no available patch — see the comments in `security.yml`).

Conservative update: only `concurrent-ruby` moves in `Gemfile.lock` (1.3.6 → 1.3.7).

## Test plan

- `bundle exec bundler-audit check --update` with the existing ignore list → **No vulnerabilities found** ✅
- Diff is a single line in `Gemfile.lock`; no other gems touched.
- Doc-only/dependency change — no app code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)