### PR TITLE
fix(board-builder): never overflow the authored grid (86 → 84 tiles)

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -360,12 +360,28 @@ into the first open cell and only starts a **new row** once the grid is full
 fringe page overflowed onto a stray extra row — the "85th tile" bug.
 
 `add_fringe_pages_within_grid!` caps the top-level folder tiles it adds to the
-number of open cells (`root_open_cells`), reserving one cell for "My Favorites"
-whenever leftovers are expected. Interest-bearing pages are placed first, so a
+number of open cells (`root_open_cells`, which delegates to the shared
+`Board#open_grid_cells`), reserving one cell for "My Favorites" whenever
+leftovers are expected. Interest-bearing pages are placed first, so a
 nearly-full grid still gets the pages the child actually asked for; anything
 that doesn't fit folds into My Favorites — nothing typed is dropped. Net result:
 a built robust set never exceeds its authored grid and never leaves a dead
 (unlinked) folder tile behind.
+
+> **Hard cap (the "86 tiles instead of 84" fix).** The reservation alone wasn't
+> enough once the Phrases layer started riding every build: a fuller authored
+> grid (fewer reserved gaps than the repo's Core 84) left no cell for the
+> catch-all, yet the catch-all tile was added **unconditionally** — so it (and
+> a fringe page) spilled onto a stray 8th row → 86 tiles. The cap is now a hard
+> guarantee enforced by **every** top-level tile-adder via `open_grid_cells`:
+> the Phrases folder + quick-phrase strip (`build_phrases_layer!`/
+> `add_phrase_strip!`), `BuildBoardSetJob#add_to_favorites!`, **and**
+> `SeededSetCloner#create_favorites_board!`. When there's genuinely no open
+> cell the catch-all tile is skipped (logged), never spilled. Separately,
+> `SeededSetCloner#fringe_for_category` applies `CATEGORY_SEED_ALIASES`
+> ("Family & People" → People, "Health & Body" → Body) so those seed-set
+> interests reach the cloned page instead of spawning an extra "My Favorites"
+> folder — one of the original overflow triggers.
 
 > The old hybrid path *excluded* "unplanned" seed pages via
 > `StructurePlanner#excluded_fringe_pages` + `SeededSetCloner(exclude_fringe:)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `spec/services/board_from_screenshot_spec.rb` and
   `spec/sidekiq/categorize_image_job_spec.rb`.
 
+### Fixed — Board Builder "Extended" no longer produces an over-full board
+- An **Extended** Board Builder set built on a fuller Core 84 grid (e.g. one
+  carrying the new Phrases layer with fewer reserved empty cells) could exceed
+  the authored 7×12 (84-cell) grid, spilling tiles onto a stray extra row — the
+  reported **86 tiles instead of 84**. The grid cap is now a hard guarantee:
+  the grid math lives in one place (`Board#open_grid_cells`) and **every**
+  top-level tile-adder honors it — the "My Favorites" catch-all in both
+  `BuildBoardSetJob` and `SeededSetCloner`, plus the existing Phrases folder and
+  quick-phrase strip — so a built set never overflows regardless of how little
+  slack the seed leaves. Aliased interest categories ("Family & People",
+  "Health & Body") now route into the cloned People/Body pages instead of
+  spawning a spurious extra "My Favorites" folder. Regression coverage added in
+  `spec/sidekiq/build_board_set_job_grid_spec.rb`.
+
 ### Fixed — Sandbox communicators no longer advertise a sign-in
 - A **sandbox** (no-login demo) communicator owned by a paid or free-trial user
   was returning `can_sign_in: true` and a real `startup_url`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   quick-phrase strip — so a built set never overflows regardless of how little
   slack the seed leaves. Aliased interest categories ("Family & People",
   "Health & Body") now route into the cloned People/Body pages instead of
-  spawning a spurious extra "My Favorites" folder. Regression coverage added in
-  `spec/sidekiq/build_board_set_job_grid_spec.rb`.
-  
+  spawning a spurious extra "My Favorites" folder. The early-stage quick-phrase
+  strip also **dedupes against the home board** so it can't surface a phrase the
+  home board already carries — e.g. "all done" is both an authored core word and
+  a Transitions gestalt, which previously produced a duplicate "all done" tile.
+  Regression coverage added in `spec/sidekiq/build_board_set_job_grid_spec.rb`.
+
 ### Fixed — "Make a Board From Screenshot" robustness
 - A failed screenshot import now **refunds** the 3 credits charged at upload —
   previously a user whose AI analysis failed was out the credits with nothing to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1136,8 +1136,11 @@ doesn't replace it; both can be set independently. Wiring:
   cloned from `GlpTemplates.function_boards`), links it from the home board, and
   for `gestalt_early?` surfaces a personalized quick-phrase strip on the home
   board (capped to open grid cells — degrades to folder-only, never overflows).
-  The wizard sends an optional `include_phrases` boolean (default-on in the
-  planner). `build_glp` and the GLP-slug build branch were removed.
+  The strip **dedupes against the home board's existing labels**, so a phrase
+  that's already an authored core word (e.g. "all done", which is also a
+  Transitions gestalt) isn't added a second time. The wizard sends an optional
+  `include_phrases` boolean (default-on in the planner). `build_glp` and the
+  GLP-slug build branch were removed.
 - **Phrase-board wiring.** The new Phrases board doubles as the communicator's
   **phrase board** (the sentence-builder save target + quick-phrase source,
   `settings["phrase_board_id"]`). After a build, `wire_phrase_board!` sets it on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -921,6 +921,26 @@ still works for backward compat.
   **intact** (`exclude_fringe: []`) so every authored folder — People…Describe,
   **including More** — stays linked to a real board; the prior exclusion path left
   stripped pages as dead, unlinked folder tiles.
+  - **The cap is a hard guarantee, not just a reservation (the "86 tiles"
+    fix).** The grid math is shared: `Board#open_grid_cells` is the single
+    source of truth (the job's `root_open_cells` delegates to it). **Every**
+    top-level tile-adder now checks it before placing — the Phrases folder +
+    quick-phrase strip (`build_phrases_layer!`/`add_phrase_strip!`), the job's
+    catch-all (`add_to_favorites!`), **and** `SeededSetCloner#create_favorites_board!`
+    — so the built set can never exceed the authored grid no matter how little
+    slack the seed leaves. If a grid genuinely has no open cell, the catch-all
+    tile is skipped with a `Rails.logger.warn` rather than spilled (only
+    possible on an under-slack seed; the authored Core 84's 3 gaps never trip
+    it). The earlier code only reserved a cell and called `add_to_favorites!`
+    unconditionally, so a fuller-than-repo production grid (e.g. a Core 84 with
+    a Phrases layer and fewer gaps) spilled My Favorites + a fringe page onto a
+    stray 8th row → 86 tiles.
+  - **Alias-aware interest routing in the cloner.** `SeededSetCloner` matches an
+    interest's category to a cloned fringe board via `fringe_for_category`,
+    applying `StructurePlanner::CATEGORY_SEED_ALIASES` ("Family & People" →
+    People, "Health & Body" → Body). Without it those (planner-classified
+    seed-set) interests missed the cloned People/Body page and fell through to a
+    spurious extra "My Favorites" folder tile — one of the overflow triggers.
 - **`SeededSetCloner`** accepts `exclude_fringe:` — a list of page names to skip
   during the clone. Still used by callers that want a trimmed clone; the hybrid
   build now passes `[]` (clone intact). `StructurePlanner#excluded_fringe_pages`

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1254,6 +1254,31 @@ class Board < ApplicationRecord
     self.board_images.reset
   end
 
+  # Open cells in the authored grid before a new tile would spill onto a fresh
+  # row — mirrors BoardsHelper#next_available_cell's placement rule (fill the
+  # gaps in the existing rows first, only start a new row once the grid is full).
+  # Board Builder uses this to cap how many top-level folder/strip tiles it adds
+  # so a built set never overflows the authored grid onto a stray extra row.
+  def open_grid_cells(screen_size = "lg")
+    update_board_layout(screen_size)
+    grid = layout[screen_size] || {}
+    return 0 if grid.empty?
+
+    columns = get_number_of_columns(screen_size)
+    occupied = []
+    max_row = 0
+    grid.each_value do |cell|
+      x = cell["x"] || 0
+      y = cell["y"] || 0
+      w = cell["w"] || 1
+      h = cell["h"] || 1
+      h.times { |dy| w.times { |dx| occupied << [x + dx, y + dy] } }
+      max_row = [max_row, y + h - 1].max
+    end
+
+    [(columns * (max_row + 1)) - occupied.uniq.size, 0].max
+  end
+
   def reset_layouts
     self.layout = {}
     self.set_layouts_for_screen_sizes

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -258,14 +258,29 @@ module Boards
 
       @interests.each do |word|
         category = @explicit_categories[word] || Boards::InterestCategories.category_for(word)
-        fringe   = category && fringe_by_name[category.to_s.downcase]
+        fringe   = category && fringe_for_category(category, fringe_by_name)
         fringe ? add_interest_to_board(fringe, word) : unrouted << word
       end
 
       return if unrouted.empty?
 
       favorites = fringe_by_name[FAVORITES_NAME.downcase] || create_favorites_board!(root)
+      # create_favorites_board! returns nil when the grid has no open cell for a
+      # folder tile — never overflow the authored grid. Leftovers stay unrouted.
+      return unless favorites
+
       unrouted.each { |word| add_interest_to_board(favorites, word) }
+    end
+
+    # Match an interest's category to a cloned fringe board. Some
+    # InterestCategories names differ from the seed page they belong to
+    # ("Family & People" -> "People", "Health & Body" -> "Body"); the
+    # StructurePlanner counts those as seed-set interests, so without the alias
+    # they'd miss the cloned People/Body board and fall through to My Favorites
+    # — spawning an extra top-level folder tile the home grid didn't budget for.
+    def fringe_for_category(category, fringe_by_name)
+      fringe_by_name[category.to_s.downcase] ||
+        fringe_by_name[Boards::StructurePlanner::CATEGORY_SEED_ALIASES[category].to_s.downcase]
     end
 
     # Cloned non-root boards keyed by normalized name, freshly reloaded so their
@@ -308,6 +323,14 @@ module Boards
     # it doesn't count against the limit, and link it from the root via a folder
     # tile + predictive_board_id (mirrors the assembler/tree-builder pattern).
     def create_favorites_board!(root)
+      # Needs an open cell for its folder tile; on a grid with no slack left,
+      # adding one would spill onto a stray extra row. Skip rather than overflow
+      # (BuildBoardSetJob's catch-all still surfaces leftovers when there's room).
+      if root.open_grid_cells < 1
+        Rails.logger.warn "[SeededSetCloner] root #{root.id}: no grid space for My Favorites; leftover interests not surfaced on the home board"
+        return nil
+      end
+
       favorites = Board.new(name: FAVORITES_NAME, user: @owner)
       favorites.board_type = "static"
       favorites.assign_parent

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -146,9 +146,14 @@ class BuildBoardSetJob
     source = slug && Boards::GlpTemplates.find_board(slug)
     return unless source
 
-    image_ids = source.board_images.order(:position)
-      .limit([PHRASES_STRIP_SIZE, open].min).map(&:image_id)
-    image_ids.each { |image_id| root.add_image(image_id) }
+    # Skip any phrase the home board already carries — e.g. "all done" is both an
+    # authored core word AND a Transitions gestalt, so an undeduped strip would
+    # add a second "all done" tile. Dedupe by label, then cap to the open cells.
+    existing = root.board_images.map { |bi| bi.label.to_s.downcase }
+    candidates = source.board_images.order(:position)
+      .reject { |bi| existing.include?(bi.label.to_s.downcase) }
+      .first([PHRASES_STRIP_SIZE, open].min)
+    candidates.each { |bi| root.add_image(bi.image_id) }
   end
 
   # The new Phrases board doubles as the communicator's phrase board (the

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -267,26 +267,9 @@ class BuildBoardSetJob
   end
 
   # Open cells on the authored core grid before a new tile would spill onto a
-  # fresh row — mirrors BoardsHelper#next_available_cell's placement rule
-  # (fill gaps in the existing rows first, only then start a new row).
+  # fresh row. Delegates to Board#open_grid_cells (shared with SeededSetCloner).
   def root_open_cells(board, screen_size = "lg")
-    board.update_board_layout(screen_size)
-    grid = board.layout[screen_size] || {}
-    return 0 if grid.empty?
-
-    columns = board.get_number_of_columns(screen_size)
-    occupied = []
-    max_row = 0
-    grid.each_value do |cell|
-      x = cell["x"] || 0
-      y = cell["y"] || 0
-      w = cell["w"] || 1
-      h = cell["h"] || 1
-      h.times { |dy| w.times { |dx| occupied << [x + dx, y + dy] } }
-      max_row = [max_row, y + h - 1].max
-    end
-
-    [(columns * (max_row + 1)) - occupied.uniq.size, 0].max
+    board.open_grid_cells(screen_size)
   end
 
   def build_fringe_from_blueprint!(root, owner, communicator, blueprint)
@@ -321,6 +304,17 @@ class BuildBoardSetJob
       .first&.then { |bi| Board.find_by(id: bi.predictive_board_id) }
 
     unless favorites
+      # A new My Favorites needs an open cell for its folder tile. If the
+      # authored grid has no slack left, adding it would spill onto a stray
+      # extra row (the 85th/86th tile). Skip rather than overflow — log so an
+      # under-slack seed is visible. (With the authored Core 84's reserved gaps
+      # this never trips; the reservation in add_fringe_pages_within_grid! keeps
+      # a cell free whenever leftovers are expected.)
+      if root.open_grid_cells < 1
+        Rails.logger.warn "[BuildBoardSetJob] root #{root.id}: no grid space for My Favorites; #{words.size} interest(s) not surfaced on the home board"
+        return
+      end
+
       favorites = Board.new(name: "My Favorites", user: owner)
       favorites.board_type = "static"
       favorites.assign_parent

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -157,6 +157,21 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     end
   end
 
+  # The early-stage quick-phrase strip must not surface a phrase the home board
+  # already carries. "all done" is both an authored core word and a Transitions
+  # gestalt, so an undeduped strip would add a second "all done" tile.
+  it "does not duplicate an authored core word onto the home board via the phrase strip" do
+    communicator.update!(details: (communicator.details || {}).merge("glp_stage" => 1))
+    # Force the strip to pull the Transitions board (which contains "all done").
+    allow(Boards::GlpTemplates).to receive(:recommended_for).and_return("glp-transitions-routines")
+
+    root = build!([])
+
+    all_done = root.board_images.select { |bi| bi.label.to_s.downcase == "all done" }
+    expect(all_done.size).to eq(1)
+    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
+  end
+
   it "gives category folder tiles a curated image instead of a blank one" do
     admin = User.find_by(id: User::DEFAULT_ADMIN_ID)
     # Curated, art-bearing admin images for an authored folder (People, cloned)

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
 
   before do
     allow_any_instance_of(Grover).to receive(:to_png).and_return(ChunkyPNG::Image.new(1, 1).to_blob)
-    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+    admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
     VocabSets.seed_slug!("core-84")
     Dir.glob(Boards::FringeTemplates::SEED_DIR.join("*.obf")).sort.each do |p|
       Boards::FringeTemplates.seed_obf!(p)
     end
+    # The Phrases layer rides every build now; seed the GLP function boards so
+    # the integration test exercises the real (Phrases-inclusive) build path.
+    Boards::GlpTemplates.seed!(admin: admin)
   end
 
   let(:user) { create(:user, id: 9001) }
@@ -43,6 +46,18 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     cats = Boards::InterestWords.extract_categories(interests)
     described_class.new.perform(root.id, communicator.id, "extended", norm, cats)
     root.reload
+  end
+
+  # Pad the admin-owned seed root so the per-user clone starts with `remaining`
+  # open cells — simulates a fuller authored grid (fewer reserved gaps) than the
+  # repo's. Exposes whether the build's tile-adders honor the grid or spill.
+  def shrink_seed_grid!(remaining: 0)
+    admin = User.find_by(id: User::DEFAULT_ADMIN_ID)
+    seed_root = Boards::RobustSets.find_root("core-84")
+    (seed_root.open_grid_cells - remaining).times do |i|
+      seed_root.add_image(Image.create!(label: "pad#{i}", user_id: admin.id).id)
+    end
+    seed_root.reload
   end
 
   # Every capitalized, multi-letter tile (a folder label like "Animals") must
@@ -99,6 +114,47 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(root.status).to eq("complete")
     expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
     expect(dead_folder_tiles(root)).to be_empty
+  end
+
+  # Regression for the "86 tiles instead of 84" report: when the authored grid
+  # has no slack left (a fuller Core 84 than the repo seed), the catch-all
+  # "My Favorites" tile and an early-stage quick-phrase strip used to spill onto
+  # a stray extra row. The build must stay within the grid regardless of slack.
+  it "never overflows the grid even when the seed has no open cells" do
+    shrink_seed_grid!(remaining: 0)
+    # Early-stage gestalt -> quick-phrase strip, the most aggressive cell user.
+    communicator.update!(details: (communicator.details || {}).merge("glp_stage" => 1))
+
+    root = build!([
+      { "word" => "grandma", "category" => "Family & People" },
+      { "word" => "toilet", "category" => "Bathroom" },
+      { "word" => "dog", "category" => "Animals" },
+    ])
+
+    expect(root.status).to eq("complete")
+    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
+    expect(dead_folder_tiles(root)).to be_empty
+  end
+
+  # Aliased InterestCategories ("Family & People" -> People, "Health & Body" ->
+  # Body) are seed-set interests; they must land in the cloned seed pages, not
+  # spawn a spurious extra "My Favorites" folder tile on the home grid.
+  it "routes aliased seed-set interests into the cloned People/Body pages" do
+    root = build!([
+      { "word" => "grandma", "category" => "Family & People" },
+      { "word" => "tummy", "category" => "Health & Body" },
+    ])
+
+    people = Board.find(root.board_images.find { |bi| bi.label == "People" }.predictive_board_id)
+    body   = Board.find(root.board_images.find { |bi| bi.label == "Body" }.predictive_board_id)
+    expect(people.board_images.map { |bi| bi.label.to_s.downcase }).to include("grandma")
+    expect(body.board_images.map { |bi| bi.label.to_s.downcase }).to include("tummy")
+
+    favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+    if favorites_tile
+      fav = Board.find(favorites_tile.predictive_board_id)
+      expect(fav.board_images.map { |bi| bi.label.to_s.downcase }).not_to include("grandma", "tummy")
+    end
   end
 
   it "gives category folder tiles a curated image instead of a blank one" do


### PR DESCRIPTION
## Summary

Two related Board Builder home-grid integrity fixes.

### 1. Never overflow the authored grid (the reported 86 → 84)

The authored Core 84 grid is 7×12 = 84 cells (81 tiles + 3 reserved empty cells). The build adds top-level folder tiles — fringe-page folders, the **Phrases** layer (folder + early-stage quick-phrase strip), and a **"My Favorites"** catch-all. On a fuller grid (e.g. with the Phrases layer eating the reserved slack), two tile-adders weren't bounded by the grid and spilled onto a stray 8th row:

- `BuildBoardSetJob#add_to_favorites!` added the catch-all folder tile **unconditionally**.
- `SeededSetCloner#create_favorites_board!` added its catch-all tile with **no grid check**.

A secondary trigger: aliased interest categories (**"Family & People"**, **"Health & Body"**) are counted as seed-set by the planner, but the cloner matched category→fringe by exact name, so they fell through to a *spurious* extra "My Favorites" folder instead of the cloned People/Body pages.

**Fix:**
- **Single source of grid truth** — extracted `Board#open_grid_cells`; the job's `root_open_cells` delegates to it.
- **Hard grid cap** — *every* top-level tile-adder honors it. The "My Favorites" catch-all in both `BuildBoardSetJob` and `SeededSetCloner` is skipped (with a `Rails.logger.warn`) rather than spilled when the grid has no open cell.
- **Alias-aware routing** — `SeededSetCloner#fringe_for_category` applies `CATEGORY_SEED_ALIASES` so those interests land in the cloned People/Body pages, not a spurious folder.

### 2. No duplicate core-word tiles from the phrase strip

The early-stage quick-phrase strip surfaced the top phrases from the stage-recommended GLP function board onto the home board **without deduping**. "all done" is both an authored core word *and* a Transitions gestalt, so the strip could add a second "all done" tile (reported on Core 60). The strip now **dedupes against the home board's existing labels** before placing — keeping the single authored tile, introducing no filler word.

## Test plan

Confirmed the overflow empirically (a 0-slack grid produced 85; with the fix it stays at 84). Added regressions to `spec/sidekiq/build_board_set_job_grid_spec.rb`:
- no-overflow at zero slack (worst-case early-gestalt strip path)
- alias routing into People/Body
- phrase strip does not duplicate an authored core word ("all done")

Ran green: grid spec (6 examples), plus `seeded_set_cloner_spec`, `build_board_set_job_spec`, `phrases_page_builder_spec`, `board_builder_spec` (pre-rebase). 0 failures.

## Note / follow-up

The grid cap guarantees **no overflow**. On a grid with genuinely zero open cells, catch-all interests are skipped (logged) rather than surfaced. The repo's Core 84/60 keep reserved gaps so nothing is dropped there — if the production seed is fuller, reconciling it to always reserve slack is a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)