### PR TITLE
ci: skip RSpec & security checks on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,61 @@ on:
     branches: [main]
 
 jobs:
+  # Detect whether the change touches anything other than docs. Markdown,
+  # docs/, and LICENSE are docs-only; everything else is "code". The expensive
+  # RSpec matrix is skipped on docs-only changes, but the required `rspec`
+  # gate job still runs and reports success, so branch protection isn't
+  # deadlocked (a workflow that never runs leaves a required check pending
+  # forever). Fail-safe: if we can't determine the changed files, run full CI.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE='${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}'
+          else
+            BASE='${{ github.event.before }}'
+            if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+              echo "No usable base commit; running full CI."
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            RANGE="${BASE}...${{ github.sha }}"
+          fi
+
+          FILES=$(git diff --name-only "$RANGE" 2>/dev/null)
+          if [ $? -ne 0 ] || [ -z "$FILES" ]; then
+            echo "Could not determine changed files; running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          CODE=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|docs/*|LICENSE) ;;   # docs-only — ignore
+              *) CODE=true ;;
+            esac
+          done <<< "$FILES"
+
+          echo "Non-docs (code) changes present: $CODE"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+
   rspec-shard:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -105,13 +159,19 @@ jobs:
           echo "Running $(echo "$FILES" | wc -l | tr -d ' ') spec files (shard ${{ matrix.ci_node_index }})"
           bundle exec rspec $FAIL_FAST $FILES
 
+  # Required status check. Always runs so branch protection gets a reported
+  # result. On docs-only changes the shards are skipped and this passes.
   rspec:
-    needs: rspec-shard
+    needs: [changes, rspec-shard]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check shard results
         run: |
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Docs-only change — RSpec shards skipped, passing."
+            exit 0
+          fi
           if [ "${{ needs.rspec-shard.result }}" != "success" ]; then
             echo "One or more RSpec shards failed"
             exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,22 +6,77 @@ on:
   pull_request:
 
 jobs:
+  # Detect whether the change touches anything other than docs (see ci.yml for
+  # the full rationale). The security jobs below always run so their required
+  # status checks are reported, but their expensive steps are skipped on
+  # docs-only changes. Fail-safe: run full checks if detection is uncertain.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE='${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}'
+          else
+            BASE='${{ github.event.before }}'
+            if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+              echo "No usable base commit; running full checks."
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            RANGE="${BASE}...${{ github.sha }}"
+          fi
+
+          FILES=$(git diff --name-only "$RANGE" 2>/dev/null)
+          if [ $? -ne 0 ] || [ -z "$FILES" ]; then
+            echo "Could not determine changed files; running full checks."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$FILES"
+
+          CODE=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md|docs/*|LICENSE) ;;   # docs-only — ignore
+              *) CODE=true ;;
+            esac
+          done <<< "$FILES"
+
+          echo "Non-docs (code) changes present: $CODE"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+
   brakeman:
     name: Brakeman static analysis
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - if: needs.changes.outputs.code == 'true'
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle exec brakeman --no-pager --ignore-config config/brakeman.ignore
+      - if: needs.changes.outputs.code == 'true'
+        run: bundle exec brakeman --no-pager --ignore-config config/brakeman.ignore
 
   bundler-audit:
     name: Bundler audit (known CVEs)
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - if: needs.changes.outputs.code == 'true'
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       # All ignored CVEs require Rails >= 7.2.3.1 / 8.0.4.1 / 8.1.2.1; no 7.1.x patch
@@ -52,7 +107,8 @@ jobs:
       # calls (no user-controlled redirects). Remove once MailchimpMarketing
       # supports excon >= 1.x.
       #   CVE-2026-54171  excon header leak on redirect
-      - run: |
+      - if: needs.changes.outputs.code == 'true'
+        run: |
           bundle exec bundler-audit check --update \
             --ignore CVE-2026-33168 CVE-2026-33169 CVE-2026-33170 \
                      CVE-2026-33173 CVE-2026-33174 CVE-2026-33176 \


### PR DESCRIPTION
## What

Stops CI from re-running the full RSpec suite (and Brakeman / bundler-audit) when a PR or push only touches documentation — markdown files, `docs/`, or `LICENSE`.

A new lightweight `changes` job diffs the PR/push and sets `code=true` when anything other than docs changed. The expensive work is gated behind it:

- **`ci.yml`** — the 3-node `rspec-shard` matrix runs only when code changed. The required `rspec` gate job **always** runs and reports a real result, passing immediately on docs-only changes.
- **`security.yml`** — Brakeman and bundler-audit jobs always run (so their required status checks report) but their heavy bundle/scan steps are skipped on docs-only changes.

"Docs" = `**/*.md` (CHANGELOG.md, CLAUDE.md, READMEs, `.claude-notes/*.md`), anything under `docs/`, and `LICENSE`.

## Why not `paths-ignore`?

This repo's branch protection requires three checks: `rspec`, `Brakeman static analysis`, and `Bundler audit (known CVEs)`. The two obvious approaches both break:

- **`paths-ignore:` on the trigger** — a skipped workflow never reports its required checks, so the PR sits forever at "waiting for status to be reported" and can't merge.
- **Stub companion workflow** — double-reports the `rspec` context on PRs that mix code + docs, which could let a failing run be masked by the passing stub.

The in-workflow `changes`-gate pattern avoids both: each required context is reported exactly once, with a genuine pass/fail.

## Safety properties

- A PR mixing docs **and** code runs everything.
- If change detection fails or there's no usable base commit, it **defaults to running full CI** — never silently skips tests.
- Required status checks always report, so no merge deadlock.

## Test plan

- Validated both workflow files parse as valid YAML.
- Unit-tested the docs/code classification shell logic locally: docs-only → skip, mixed → run, code-only → run.
- CI-config only; no application code changed. The live verification: this PR touches only `.github/` (non-docs), so it should exercise the full path and stay green; a follow-up docs-only PR should show the RSpec shards skipped while the required gates report success.