### PR TITLE
test(internal-api): fix flaky profiles spec (users PK sequence collision)

### DIFF
--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -4,7 +4,15 @@ RSpec.describe "API::Internal::Profiles", type: :request do
   let(:internal_key) { "test-internal-key" }
   let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
   let(:json_headers) { auth_headers.merge("Content-Type" => "application/json") }
-  let!(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let!(:admin_user) do
+    user = User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+    # Inserting a row with an explicit primary key does not advance the
+    # `users` sequence, so the next factory-built user (e.g. via
+    # `create(:child_account)`'s `association :user`) would otherwise collide
+    # on id=1. Reset the sequence to MAX(id)+1.
+    ActiveRecord::Base.connection.reset_pk_sequence!("users")
+    user
+  end
   let(:profile_owner) { create(:child_account) }
   let!(:profile) do
     create(:profile,


### PR DESCRIPTION
## What changed

Reset the \`users\` primary-key sequence after creating \`admin_user\` at an explicit id in \`spec/requests/api/internal/profiles_spec.rb\`.

## Why

CI failed with:

\`\`\`
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "users_pkey"
DETAIL: Key (id)=(1) already exists.
# ./app/models/user.rb:627:in `set_default_settings'
\`\`\`

The spec creates \`admin_user\` with an explicit \`id: User::DEFAULT_ADMIN_ID\` (= 1 in test). Inserting a row with an explicit primary key **does not advance** the Postgres \`users_id_seq\`. The next factory-built user — \`create(:child_account)\`'s \`association :user\` — then drew \`id=1\` from the still-at-1 sequence and collided.

It only fails on a fresh CI database where the sequence sits at 1; locally the sequence was already advanced, so it passed. \`profiles_spec.rb\` is the only internal spec that creates fresh factory users after the explicit-id admin, so it's the only one affected.

## Test plan

- Reproduced locally by forcing \`SELECT setval('users_id_seq', 1, false)\` → spec failed with the same \`users_pkey\` violation.
- Applied the fix, forced the sequence back to 1, re-ran: **12 examples, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)