### PR TITLE
feat(communicators): raise the free demo board cap from 1 to 3

### DIFF
--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -46,9 +46,10 @@ class ChildAccount < ApplicationRecord
 
   DEMO_ACCOUNT_BOARD_LIMIT = 3
   # Board cap for the MySpeak demo communicator a Free user gets. Stored per
-  # account in settings["demo_board_limit"]; Pro demo accounts keep the
-  # DEMO_ACCOUNT_BOARD_LIMIT default.
-  FREE_DEMO_BOARD_LIMIT = 1
+  # account in settings["demo_board_limit"]. Held at the same floor as
+  # DEMO_ACCOUNT_BOARD_LIMIT so Free families get a usable starter set (3
+  # boards) on their demo communicator, not just one.
+  FREE_DEMO_BOARD_LIMIT = 3
   belongs_to :user, optional: true
   belongs_to :vendor, optional: true
   belongs_to :owner, class_name: "User", optional: true

--- a/db/migrate/20260623120000_raise_free_demo_board_limit_to_three.rb
+++ b/db/migrate/20260623120000_raise_free_demo_board_limit_to_three.rb
@@ -1,0 +1,25 @@
+# Free users' demo/sandbox communicators were seeded with
+# settings["demo_board_limit"] = 1. We've raised FREE_DEMO_BOARD_LIMIT to 3 to
+# match DEMO_ACCOUNT_BOARD_LIMIT, so existing Free accounts that were capped
+# below 3 should be lifted to 3 too — otherwise current Free families stay
+# stuck at one board while new ones get three.
+class RaiseFreeDemoBoardLimitToThree < ActiveRecord::Migration[7.1]
+  FLOOR = 3
+
+  def up
+    # jsonb lets us target only the rows that carry a sub-floor cap.
+    ChildAccount
+      .where("(settings ->> 'demo_board_limit') IS NOT NULL")
+      .where("(settings ->> 'demo_board_limit')::int < ?", FLOOR)
+      .find_each do |account|
+        account.settings["demo_board_limit"] = FLOOR
+        account.save!(validate: false)
+      end
+  end
+
+  def down
+    # Not reversible: prior per-account caps (all 1 for Free) aren't recoverable
+    # and lowering them again would just re-impose the limit we removed.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_08_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"

--- a/spec/requests/api/child_accounts_demo_limit_spec.rb
+++ b/spec/requests/api/child_accounts_demo_limit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
         u
       end
 
-      it "creates the sandbox capped at one board" do
+      it "creates the sandbox capped at the free demo board limit (3)" do
         post "/api/child_accounts",
           params: { name: "My Kid", username: "my-kid-#{SecureRandom.hex(3)}", status: "sandbox", password: "abcdef", password_confirmation: "abcdef" },
           headers: auth_headers(user)
@@ -19,7 +19,7 @@ RSpec.describe "API::ChildAccounts sandbox + slot limits", type: :request do
         account = ChildAccount.find_by(owner_id: user.id, status: "sandbox")
         expect(account).to be_present
         expect(account.settings["demo_board_limit"]).to eq(ChildAccount::FREE_DEMO_BOARD_LIMIT)
-        expect(account.settings["demo_board_limit"]).to eq(1)
+        expect(account.settings["demo_board_limit"]).to eq(3)
       end
 
       it "blocks a second sandbox once the slot is used" do


### PR DESCRIPTION
## Summary

Free users' MySpeak demo/sandbox communicators were capped at **1 board** (`settings["demo_board_limit"] = 1`), while Pro sandboxes and the default allow **3** (`DEMO_ACCOUNT_BOARD_LIMIT`). This raises the free cap to 3 so Free families get a usable starter set on their demo communicator — even existing accounts.

## Changes
- **`child_account.rb`**: `FREE_DEMO_BOARD_LIMIT` `1 → 3` (now equals `DEMO_ACCOUNT_BOARD_LIMIT`). The two seed sites — `User#handle_myspeak_setup` and `Api::ChildAccountsController#create` — read the constant, so new free sandboxes now seed with 3 automatically.
- **Migration** `RaiseFreeDemoBoardLimitToThree`: lifts any existing account whose stored `demo_board_limit` is `< 3` up to 3, so current Free families benefit, not just new signups. Data-only (jsonb update); irreversible `down`.
- **Spec**: `child_accounts_demo_limit_spec` now asserts the seeded free demo cap is 3.

The enforcement path (`ChildAccountsController#assign_boards`, `BoardsController`) is unchanged — it already reads `settings["demo_board_limit"] || DEMO_ACCOUNT_BOARD_LIMIT`.

## Frontend
No change needed — [frontend #436](https://github.com/brittanyjohns/itty-bitty-frontend/pull/436) reads `settings.demo_board_limit ?? 3`, which is now accurate for free communicators too.

## Test plan
⚠️ **Specs not run locally** — `bundle`/`rails db:migrate`/`rspec` were blocked in this environment, so I couldn't execute the suite or the migration. Please run before merging:
```
RAILS_ENV=test bundle exec rspec spec/requests/api/child_accounts_demo_limit_spec.rb \
  spec/requests/api/child_accounts_owner_protection_spec.rb \
  spec/models/communicator_sandbox_promotion_spec.rb \
  spec/models/child_account_promote_to_loaner_spec.rb
```
`schema.rb` version was bumped manually to match the migration (data-only, no structural change); `rails db:migrate` will reconcile it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)