### PR TITLE
feat(myspeak): surface recommended Core Words starter first via durable tag

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -200,6 +200,14 @@ class API::BoardsController < API::ApplicationController
 
     @public_boards = scope.to_a
 
+    if params["myspeak"] == "true"
+      # Surface the recommended starter board(s) first, then keep the
+      # alphabetical order for the rest. api_view already exposes tags.
+      @public_boards.sort_by! do |board|
+        [board.tags.include?("myspeak-recommended") ? 0 : 1, board.name.to_s.downcase]
+      end
+    end
+
     render json: { public_boards: @public_boards.map { |board| board.api_view(current_user) } }
   end
 

--- a/lib/tasks/myspeak.rake
+++ b/lib/tasks/myspeak.rake
@@ -1,0 +1,27 @@
+# MySpeak starter-board maintenance tasks.
+#
+# The "Core Words" starter board lives as a production row (it is not in
+# db/seeds/myspeak_starter_boards.rb), so its recommendation has to be made
+# durable by tagging the existing row rather than re-seeding it.
+namespace :myspeak do
+  RECOMMENDED_TAG = "myspeak-recommended".freeze
+
+  desc "Tag the MySpeak 'Core Words' starter board as recommended (idempotent)"
+  task tag_recommended: :environment do
+    board = Board.myspeak_public_boards.find_by("LOWER(name) = ?", "core words")
+
+    if board.nil?
+      puts "[myspeak:tag_recommended] No public MySpeak board named 'Core Words' found — nothing to do."
+      next
+    end
+
+    new_tags = board.tags | [RECOMMENDED_TAG]
+
+    if new_tags == board.tags
+      puts "[myspeak:tag_recommended] Board ##{board.id} (#{board.name}) already tagged '#{RECOMMENDED_TAG}'. tags=#{board.tags.inspect}"
+    else
+      board.update!(tags: new_tags)
+      puts "[myspeak:tag_recommended] Tagged board ##{board.id} (#{board.name}). tags=#{board.tags.inspect}"
+    end
+  end
+end

--- a/spec/lib/tasks/myspeak_rake_spec.rb
+++ b/spec/lib/tasks/myspeak_rake_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "myspeak rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["myspeak:tag_recommended"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  let!(:admin) do
+    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+  end
+
+  def myspeak_board(name, tags)
+    create(:board, user: admin, name: name, predefined: true, published: true, tags: tags)
+  end
+
+  describe "myspeak:tag_recommended" do
+    it "adds myspeak-recommended to the Core Words board, keeping myspeak" do
+      board = myspeak_board("Core Words", ["myspeak"])
+
+      run_task
+
+      expect(board.reload.tags).to include("myspeak", "myspeak-recommended")
+    end
+
+    it "is idempotent — re-running adds no duplicate tag" do
+      board = myspeak_board("Core Words", ["myspeak", "myspeak-recommended"])
+
+      run_task
+
+      expect(board.reload.tags.count("myspeak-recommended")).to eq(1)
+    end
+
+    it "matches the board name case-insensitively" do
+      board = myspeak_board("core words", ["myspeak"])
+
+      run_task
+
+      expect(board.reload.tags).to include("myspeak-recommended")
+    end
+
+    it "no-ops when no public MySpeak Core Words board exists" do
+      other = myspeak_board("Animals", ["myspeak"])
+
+      expect { run_task }.not_to raise_error
+      expect(other.reload.tags).not_to include("myspeak-recommended")
+    end
+  end
+end

--- a/spec/requests/api/public_boards_myspeak_spec.rb
+++ b/spec/requests/api/public_boards_myspeak_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+# GET /api/public_boards?myspeak=true feeds the MySpeak onboarding board
+# picker. The board tagged "myspeak-recommended" (the "Core Words" starter)
+# must surface first, ahead of the otherwise-alphabetical list.
+RSpec.describe "API public_boards myspeak ordering", type: :request do
+  # public_boards scopes to User::DEFAULT_ADMIN_ID, so the admin must own that id.
+  let!(:admin) do
+    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+  end
+
+  def myspeak_board(name, tags)
+    create(:board, user: admin, name: name, predefined: true, published: true, tags: tags)
+  end
+
+  # Alphabetically these sort Animals, Basics, Core Words. The recommended tag
+  # must pull Core Words to the front despite the alphabetical names ahead of it.
+  # Three boards keeps the scope above the < 3 public_boards fallback.
+  let!(:animals)    { myspeak_board("Animals", ["myspeak"]) }
+  let!(:basics)     { myspeak_board("Basics", ["myspeak"]) }
+  let!(:core_words) { myspeak_board("Core Words", ["myspeak", "myspeak-recommended"]) }
+
+  it "returns the recommended Core Words board first for ?myspeak=true" do
+    get "/api/public_boards", params: { myspeak: "true" }
+
+    expect(response).to have_http_status(:ok)
+    names = JSON.parse(response.body)["public_boards"].map { |b| b["name"] }
+
+    expect(names.first).to eq("Core Words")
+    expect(names).to eq(["Core Words", "Animals", "Basics"])
+  end
+end


### PR DESCRIPTION
## Summary

Makes the MySpeak onboarding starter-board recommendation **durable** by tagging the recommended board rather than depending on incidental ordering.

1. **Tag at the source of truth + rake task.** The "Core Words" starter board exists only as a production DB row (it is *not* in `db/seeds/myspeak_starter_boards.rb`), so its source of truth is that row. New idempotent task `lib/tasks/myspeak.rake` → `myspeak:tag_recommended` finds `Board.myspeak_public_boards.find_by("LOWER(name) = ?", "core words")` and merges `myspeak-recommended` into its `tags` (keeping the existing `myspeak` tag). Safe to re-run; no-ops cleanly when the board isn't present.
2. **Order recommended-first in the API.** `API::BoardsController#public_boards` now sorts the `?myspeak=true` result so any board tagged `myspeak-recommended` comes first, with the rest staying alphabetical. `api_view` already exposes `tags`, so no serializer change. The existing `< 3 → public_boards` fallback and the ETag/`stale?` handling are untouched.

### Rollout
After merge/deploy, run once to tag the existing production row:
```
bin/rails myspeak:tag_recommended
```

## Test plan

- `spec/requests/api/public_boards_myspeak_spec.rb` — asserts Core Words (tagged `myspeak-recommended`) is returned first for `?myspeak=true`, ahead of alphabetically-earlier boards (Animals, Basics).
- `spec/lib/tasks/myspeak_rake_spec.rb` — adds the tag while keeping `myspeak`; idempotent on re-run (no duplicate); case-insensitive name match; no-ops when no Core Words board exists.

Ran locally — all pass:
- new specs: 5 examples, 0 failures
- related `myspeak` specs (onboarding + starter-board seed): 24 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)