### PR TITLE
fix(profiles): harden public profile endpoints — strip email, rate limit, noindex

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,9 @@ gem "aws-sdk-s3", require: false
 # CORS
 gem "rack-cors"
 
+# Rate limiting
+gem "rack-attack"
+
 # Pagination
 gem "kaminari"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,6 +390,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.1.2)
@@ -615,6 +617,7 @@ DEPENDENCIES
   posthog-ruby (~> 2.0)
   puma (>= 5.0)
   pundit (~> 2.3)
+  rack-attack
   rack-cors
   rails (~> 7.1.2)
   rails_performance

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -1091,6 +1091,29 @@ class ChildAccount < ApplicationRecord
     }
   end
 
+  # Minimal public-safe view for unauthenticated profile endpoints.
+  # The full api_view leaks parent_email, supporter/supervisor emails,
+  # passcode, claim tokens, and internal settings. This view exposes
+  # only what the public page UI actually needs.
+  def public_api_view
+    cached_profile = profile
+    {
+      id: id,
+      name: name,
+      avatar_url: cached_profile&.avatar_url,
+      voice: voice,
+      boards: child_boards.includes(:board).where(favorite: true).map do |cb|
+        b = cb.board
+        {
+          id: cb.id,
+          name: b.name,
+          board_type: b.board_type,
+          display_image_url: b.display_image_url,
+        }
+      end,
+    }
+  end
+
   def index_api_view
     @boards = boards.all.alphabetical
     @child_boards = child_boards.includes(:board)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -296,7 +296,10 @@ class Profile < ApplicationRecord
       public_about_html: safe_html(public_about&.body&.to_s),
       public_intro_html: safe_html(public_intro&.body&.to_s),
       public_bio_html: safe_html(public_bio&.body&.to_s),
-      communicator_account: profileable_type == "ChildAccount" ? profileable.api_view : nil
+      # NOTE: communicator_account intentionally omitted — the full
+      # ChildAccount#api_view leaks parent email, supporter/supervisor
+      # emails, passcode, and claim tokens. The frontend PublicProfile
+      # component does not use this field.
     }
   end
 
@@ -324,11 +327,14 @@ class Profile < ApplicationRecord
       public_boards: public_boards.map(&:api_view),
       user_boards: user_boards.map(&:api_view),
       general_public_boards: Board.public_boards.map(&:api_view),
-      email: email,
+      # NOTE: email intentionally omitted — use settings["show_email"]
+      # on the frontend if the user opted in to displaying contact info.
       public_about_html: safe_html(public_about&.body&.to_s),
       public_intro_html: safe_html(public_intro&.body&.to_s),
       public_bio_html: safe_html(public_bio&.body&.to_s),
-      communicator_account: profileable_type == "ChildAccount" ? profileable.api_view : nil
+      # Use a minimal public-safe view instead of the full api_view which
+      # leaks parent email, supporter/supervisor emails, and passcode.
+      communicator_account: profileable_type == "ChildAccount" ? profileable.public_api_view : nil
     }
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Rate-limit public profile endpoints to prevent enumeration / scraping.
+# These endpoints skip authentication, so IP-based throttling is the
+# primary defence.
+#
+# Limits:
+#   /api/profiles/public/:slug  — 30 req/min per IP
+#   /api/profiles/check_slug    — 10 req/min per IP
+#
+# Blocked requests receive 429 Too Many Requests with a JSON body and a
+# Retry-After header.
+
+class Rack::Attack
+  ### Throttles ###
+
+  # Public profile lookup — generous enough for normal browsing but stops
+  # automated scraping.
+  throttle("public_profile/ip", limit: 30, period: 60) do |req|
+    if req.path.match?(%r{\A/api/profiles/public(/|\z)}) && req.get?
+      req.ip
+    end
+  end
+
+  # Slug availability check — tighter limit since it's only used during
+  # onboarding / profile editing, not normal page views.
+  throttle("check_slug/ip", limit: 10, period: 60) do |req|
+    if req.path.match?(%r{\A/api/profiles/check_slug(/|\z)}) && req.get?
+      req.ip
+    end
+  end
+
+  ### Custom response ###
+
+  self.throttled_responder = lambda do |req|
+    match_data = req.env["rack.attack.match_data"] || {}
+    retry_after = (match_data[:period] || 60) - (Time.now.to_i % (match_data[:period] || 60))
+
+    [
+      429,
+      {
+        "Content-Type" => "application/json; charset=utf-8",
+        "Retry-After" => retry_after.to_s,
+      },
+      [{ error: "rate_limited", retry_after: retry_after }.to_json],
+    ]
+  end
+end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,12 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: *
+Disallow: /api/
+
+# Public profile pages — these are intentionally unlisted.
+# They should only be accessed via direct link / QR code, not search engines.
+Disallow: /my/
+Disallow: /u/
+Disallow: /v/
+Disallow: /p/
+Disallow: /c/

--- a/spec/models/child_account_spec.rb
+++ b/spec/models/child_account_spec.rb
@@ -123,4 +123,35 @@ RSpec.describe ChildAccount, type: :model do
       expect(active.startup_url).to include("/accounts/sign-in?username=signme")
     end
   end
+
+  # public_api_view backs unauthenticated public profile pages. Unlike the full
+  # api_view, it must never leak parent email, passcode, claim tokens, or other
+  # internal fields — only safe display data.
+  describe "#public_api_view" do
+    let(:account) { FactoryBot.create(:child_account, user: user, name: "Sunny") }
+
+    it "exposes only the safe display keys" do
+      expect(account.public_api_view.keys).to contain_exactly(:id, :name, :avatar_url, :voice, :boards)
+    end
+
+    it "does not leak any sensitive or internal fields" do
+      view = account.public_api_view
+      %i[parent_email passcode claim_token claim_url supporters supervisors
+         settings details user_id authentication_token].each do |leaked|
+        expect(view).not_to have_key(leaked)
+      end
+    end
+
+    it "includes only favorited boards, with display-safe attributes" do
+      fav_board = FactoryBot.create(:board, user: user, name: "Faves")
+      favorited = FactoryBot.create(:child_board, child_account: account, board: fav_board, favorite: true)
+      FactoryBot.create(:child_board, child_account: account,
+                                      board: FactoryBot.create(:board, user: user),
+                                      favorite: false)
+
+      boards = account.public_api_view[:boards]
+      expect(boards.map { |b| b[:id] }).to contain_exactly(favorited.id)
+      expect(boards.first.keys).to contain_exactly(:id, :name, :board_type, :display_image_url)
+    end
+  end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -205,4 +205,42 @@ RSpec.describe Profile, type: :model do
       expect(Profile.slug_unavailable_reason("river-stone")).to be_nil
     end
   end
+
+  # The public views back unauthenticated profile pages. They must not leak
+  # the communicator's full api_view (parent email, passcode, claim tokens)
+  # nor a raw email field.
+  describe "#safety_view" do
+    let(:profile) { build_profile(slug: "safe-page").tap(&:save!) }
+
+    it "omits communicator_account and email" do
+      view = profile.safety_view
+      expect(view).not_to have_key(:communicator_account)
+      expect(view).not_to have_key(:email)
+    end
+  end
+
+  describe "#public_page_view" do
+    let(:profile) do
+      build_profile(slug: "pro-page").tap do |p|
+        p.profile_kind = "public_page"
+        p.save!
+      end
+    end
+
+    it "omits the raw email field" do
+      expect(profile.public_page_view).not_to have_key(:email)
+    end
+
+    it "exposes a ChildAccount communicator_account via the sanitized public_api_view" do
+      view = profile.public_page_view
+      expect(view[:communicator_account]).to eq(child.public_api_view)
+      expect(view[:communicator_account].keys).to contain_exactly(:id, :name, :avatar_url, :voice, :boards)
+    end
+
+    it "does not leak the communicator's parent email or passcode" do
+      account = profile.public_page_view[:communicator_account]
+      expect(account).not_to have_key(:parent_email)
+      expect(account).not_to have_key(:passcode)
+    end
+  end
 end

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -198,4 +198,38 @@ RSpec.describe "API::Profiles", type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "GET /api/profiles/public/:slug (no leak of sensitive fields)" do
+    let(:owner) { FactoryBot.create(:user, email: "parent-leak@example.com") }
+    let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+
+    it "returns a public_page communicator_account without parent email, passcode, or claim tokens" do
+      profile = Profile.new(profileable: child, username: "sky-page", slug: "sky-page")
+      profile.profile_kind = "public_page"
+      profile.save!
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      account = body["communicator_account"]
+      expect(account.keys).to contain_exactly("id", "name", "avatar_url", "voice", "boards")
+      expect(response.body).not_to include(owner.email)
+      expect(response.body).not_to include(child.passcode.to_s) if child.passcode.present?
+      expect(account).not_to have_key("parent_email")
+    end
+
+    it "returns a safety_view without communicator_account or email for a safety profile" do
+      profile = Profile.new(profileable: child, username: "sky-safe", slug: "sky-safe")
+      profile.save! # default profile_kind is "safety"
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body).not_to have_key("communicator_account")
+      expect(body).not_to have_key("email")
+      expect(response.body).not_to include(owner.email)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Hardens the unauthenticated public profile endpoints so they can't leak PII or be scraped. Implements `.claude-notes/public-profile-security-handoff.md`.

- **Strip PII from public views.** `Profile#safety_view` drops `communicator_account` (the full `ChildAccount#api_view` leaks parent email, supporter/supervisor emails, passcode, claim tokens). `Profile#public_page_view` drops the raw `email` field and routes the communicator through a new sanitized view.
- **New `ChildAccount#public_api_view`** (the critical missing piece — the pushed `profile.rb` already called it). Exposes only `id`, `name`, `avatar_url`, `voice`, and favorited boards (id/name/board_type/display_image_url). Everything else from `api_view` is stripped.
- **Rate limiting via rack-attack** (new gem, 6.8.0): `GET /api/profiles/public/*` at 30/min/IP, `GET /api/profiles/check_slug*` at 10/min/IP, with a JSON 429 + `Retry-After` responder.
- **robots.txt** disallows `/api/` and the unlisted profile path prefixes (`/my/`, `/u/`, `/v/`, `/p/`, `/c/`).
- Authenticated `user_api_view` / `api_view` are unchanged.

## Notes

- Production `config.cache_store` is unset → Rails default (file store), **not** `null_store`, so the rack-attack throttle is live in prod. Confirmed `Rack::Attack` is in the middleware stack. No migration, no ENV, no seeds.
- The 429 throttle isn't unit-tested because the test env uses `null_store` (rack-attack no-ops there); the throttle config is verified by inspection + the route-pattern match.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/models/child_account_spec.rb spec/requests/api/profiles_spec.rb`

→ **74 examples, 0 failures.** New focused specs:
- `ChildAccount#public_api_view` exposes only safe keys, leaks nothing, favorited boards only.
- `Profile#safety_view` / `#public_page_view` omit `communicator_account` / `email`.
- `GET /api/profiles/public/:slug` returns no parent email or passcode (both public_page and safety variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)