### PR TITLE
test(mission_control): fix midnight-boundary flake in overview metrics spec

### DIFF
--- a/spec/services/mission_control/overview_metrics_spec.rb
+++ b/spec/services/mission_control/overview_metrics_spec.rb
@@ -2,6 +2,13 @@ require "rails_helper"
 
 RSpec.describe MissionControl::OverviewMetrics do
   describe ".call" do
+    # Freeze to midday UTC so "today" rows seeded with `1.hour.ago` can't slip
+    # into yesterday's calendar-day bucket when the suite happens to run in the
+    # hour after midnight — the daily breakdown and the day-window counts both
+    # bucket by Time.zone calendar day. DB-only spec, so the Redis/`travel_to`
+    # TTL caveat doesn't apply.
+    around { |example| travel_to(Time.utc(2026, 6, 23, 12, 0, 0)) { example.run } }
+
     let!(:admin) { create(:user, role: "admin", created_at: 1.hour.ago) }
     let!(:user_today) { create(:user, created_at: 1.hour.ago, last_sign_in_at: 1.hour.ago) }
     let!(:user_3d) { create(:user, created_at: 3.days.ago, last_sign_in_at: 3.days.ago) }


### PR DESCRIPTION
## Summary

`spec/services/mission_control/overview_metrics_spec.rb` fails intermittently — but only when the suite runs in the ~1 hour after **UTC midnight**.

`MissionControl::OverviewMetrics` buckets signups by `Time.zone` **calendar day** (`signups_today` uses `beginning_of_day..end_of_day`; `signups_daily_7d` uses `group_by_day`). The spec seeds its "today" user with `created_at: 1.hour.ago`. Just after midnight, `1.hour.ago` lands in *yesterday's* date bucket while the assertion looks at `Time.zone.today`, so `signups_daily_7d[today]` comes back `0` instead of `1`:

```
expected: 1
     got: 0
# overview_metrics_spec.rb:37
```

## Fix

Freeze the clock to midday UTC for the example group:

```ruby
around { |example| travel_to(Time.utc(2026, 6, 23, 12, 0, 0)) { example.run } }
```

Every timestamp in the spec is relative (`1.hour.ago`, `3.days.ago`, …), so they shift with the frozen clock and all existing assertions still hold — the freeze only removes the dependency on real wall-clock time. It's a DB-only spec, so the Redis/`travel_to` TTL caveat in CLAUDE.md doesn't apply.

## Test plan

`bundle exec rspec spec/services/mission_control/overview_metrics_spec.rb` → **7 examples, 0 failures**, verified while running inside the post-midnight UTC window that previously triggered the failure.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)