### PR TITLE
feat(profiles): alert parents when a child's safety page is viewed (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   safety ID card + device tag (new QR code) and email the parent that fresh
   cards are ready to download. Random slugs are not user-editable.
 
+### Added — Parents are alerted when their child's safety page is viewed (#384)
+- When someone opens a public safety (MySpeak) profile page
+  (`GET /api/profiles/public/:slug`), the parent now gets an email letting them
+  know their child's emergency info was accessed, with the timestamp and an
+  approximate (city-level) location of the viewer. Zero friction for the
+  viewer — no login, no gate.
+- Every public safety-page view is logged to a new `profile_views` table
+  (IP + user agent + timestamp) so unexpected access patterns are visible.
+- Alerts are **on by default** and throttled to **at most one per profile per
+  hour** so a parent checking their own page isn't spammed. A parent can turn
+  them off per-profile via `settings["view_alerts_enabled"] = false`
+  (surfaced as `view_alerts_enabled` on the profile `api_view`), and the global
+  `settings["disable_notifications"]` flag is also respected.
+- Backend-only; no frontend changes required. All work (geolocation, throttle,
+  email) runs in `RecordProfileViewJob` so the public emergency page is never
+  slowed or broken by it. Email is the v1 channel; a push channel is stubbed in
+  `Notifications::SafetyViewNotifier` for when device-token infra lands.
+- Coarse IP→location uses the new `geocoder` gem (provider/key ENV-tunable:
+  `GEOCODER_IP_LOOKUP`, `IPINFO_API_KEY`); location is simply omitted if the
+  lookup is unconfigured or fails.
+
 ### Changed — Screenshot board import commits faster (deferred AAC categorization)
 - Committing a board imported from a screenshot
   (`POST /api/board_screenshot_imports/:id/commit`) created a new `Image` for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,53 @@ backlog size (default 200).
   the prod box, so a prod alert covers both. Added after the 2026-05-30
   outage where puma was alive per systemd but all threads were wedged.
 
+## Safety-profile view alerts (issue #384)
+
+Public safety (MySpeak) pages (`GET /api/profiles/public/:slug`) are designed to
+be opened with zero friction in an emergency. This subsystem gives parents
+visibility into when that happens.
+
+- **Capture is fire-and-forget.** `API::ProfilesController#public` enqueues
+  `RecordProfileViewJob.perform_async(profile.id, request.remote_ip,
+  request.user_agent)` **only for safety profiles** (`profile.safety?` — not
+  pro `public_page` profiles, not unclaimed placeholders), wrapped in a rescue
+  so a Redis/enqueue hiccup can never slow or 500 the emergency page. It's placed
+  before the `stale?`/ETag block so a 304 still counts as a view.
+- **`RecordProfileViewJob`** (`app/sidekiq/`) does all the heavy/failable work
+  off-request:
+  1. Always logs the raw view (IP + user agent + timestamp) to the
+     **`profile_views`** table (`ProfileView` model) — the audit history that
+     makes unexpected access patterns visible.
+  2. Sends the parent alert only when: the communicator has an owner
+     (`Profile#alert_recipient` → `child_account.owner`), the per-profile
+     opt-out is off (`Profile#view_alerts_enabled?`, default **true**), the
+     owner hasn't set the global `settings["disable_notifications"]`, and the
+     **per-profile hourly throttle** is claimed (atomic Redis `SET NX EX`, key
+     `safety_view_notify:<profile_id>`, mirroring `DiskSpaceAlertJob`). Window is
+     ENV-tunable via `SAFETY_VIEW_THROTTLE_SECONDS` (default 3600).
+  3. **Geolocation runs only after the throttle is claimed** — so the external
+     IP lookup happens at most once per profile per hour, not on every bot/scan.
+     Only the notified view row gets `approx_location`/`geo`; throttled views are
+     logged without location.
+- **Channels:** `Notifications::SafetyViewNotifier` is the channel-dispatch
+  seam. v1 = email (`SafetyProfileMailer#viewed_alert`, i18n under
+  `safety_profile_mailer.viewed_alert` in `config/locales/mailer.{en,es}.yml`).
+  A **push channel is stubbed** (`deliver_push` / `push_enabled? == false`) so it
+  drops in once device-token registration + FCM/APNS exist — there is **no push
+  infrastructure today**.
+- **Coarse IP→location** is `IpGeolocation.coarse(ip)` (`app/services/`), a total
+  wrapper over the **`geocoder`** gem that returns a city-level
+  `{ city, region, country, label }` or **nil** on any error / private IP /
+  missing result (the email just omits location). Provider is ENV-tunable in
+  `config/initializers/geocoder.rb`: `GEOCODER_IP_LOOKUP` (default `ipinfo_io`),
+  `IPINFO_API_KEY`, `GEOCODER_TIMEOUT`.
+- **Opt-out is frontend-free:** `view_alerts_enabled` rides the existing
+  `settings: {}` param on `PATCH /api/profiles/:id` and is exposed on the
+  authenticated `Profile#api_view`, so a toggle needs no new endpoint.
+- **Note on `should_receive_notifications?`:** intentionally **not** reused here
+  — it bundles an unrelated cross-feature 2-hour throttle that would wrongly
+  swallow a safety alert. The per-profile hourly throttle is the only timing gate.
+
 ## Mailchimp integration
 
 We use the Mailchimp **Marketing API** (`MailchimpMarketing` gem, official

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,7 @@ gem "matrix", "~> 0.4.2"
 
 gem "http"
 gem "browser", "~> 5.3"
+gem "geocoder", "~> 1.8" # Coarse IP→location lookup for safety-profile view alerts
 gem "annotate", "~> 3.2"
 
 gem "grover"     # HTML → PDF via headless Chrome

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
       unicode (>= 0.4.4.5)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -234,6 +235,9 @@ GEM
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
+    geocoder (1.8.6)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     groupdate (6.5.1)
@@ -597,6 +601,7 @@ DEPENDENCIES
   figaro
   font-awesome-sass (~> 6.4.0)
   foreman
+  geocoder (~> 1.8)
   groupdate (~> 6.5)
   grover
   http

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -52,6 +52,12 @@ class API::ProfilesController < API::ApplicationController
       return
     end
 
+    # Log the view + (throttled) alert the parent (issue #384). Safety profiles
+    # only, and enqueued *before* the stale?/render below so it still counts on
+    # a 304. Fully fire-and-forget: a Redis/enqueue hiccup must never slow or
+    # break this public emergency page.
+    log_safety_profile_view(@profile)
+
     response.headers["Cache-Control"] = "no-cache, private, must-revalidate"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
@@ -317,6 +323,18 @@ class API::ProfilesController < API::ApplicationController
     else
       { error: "slug_invalid", message: "That link can't be used." }
     end
+  end
+
+  # Enqueue async view-logging + parent alert for a safety profile. All heavy
+  # lifting (geolocation, throttle, email) happens in RecordProfileViewJob; here
+  # we only capture the request IP + user agent and hand off. Rescues broadly so
+  # a Redis outage can't 500 the public page.
+  def log_safety_profile_view(profile)
+    return unless profile.safety?
+
+    RecordProfileViewJob.perform_async(profile.id, request.remote_ip, request.user_agent)
+  rescue => e
+    Rails.logger.warn("[Profiles#public] failed to enqueue view log: #{e.class}: #{e.message}")
   end
 
   def set_placeholders

--- a/app/mailers/safety_profile_mailer.rb
+++ b/app/mailers/safety_profile_mailer.rb
@@ -1,0 +1,27 @@
+class SafetyProfileMailer < BaseMailer
+  # Alerts a parent that their child's public safety page was viewed (issue
+  # #384). Sent from Notifications::SafetyViewNotifier, which has already
+  # applied the per-profile hourly throttle and the parent's opt-out.
+  def viewed_alert(profile, profile_view)
+    @profile = profile
+    @owner = profile.alert_recipient
+    return if @owner&.email.blank?
+
+    @child_name = profile.safety_display_name
+    # Unambiguous UTC stamp — the app stores timestamps in UTC and the parent's
+    # timezone isn't known here.
+    @viewed_at_display = profile_view.viewed_at.utc.strftime("%B %-d, %Y at %-l:%M %p UTC")
+    @approx_location = profile_view.approx_location.presence
+    @manage_url = "#{frontend_url}/dashboard/myspeak"
+
+    with_user_locale(@owner) do
+      mail(
+        to: @owner.email,
+        subject: I18n.t(
+          "safety_profile_mailer.viewed_alert.subject",
+          child_name: @child_name,
+        ),
+      )
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -26,6 +26,8 @@ class Profile < ApplicationRecord
   has_many :page_follows, foreign_key: :followed_page_id, dependent: :destroy
   has_many :followers, through: :page_follows, source: :follower_user
 
+  has_many :profile_views, dependent: :destroy
+
   has_one_attached :avatar
   has_one_attached :intro_audio
   has_one_attached :bio_audio
@@ -136,6 +138,26 @@ class Profile < ApplicationRecord
     elsif profileable.respond_to?(:user_id)
       profileable&.user_id
     end
+  end
+
+  # The User who should receive safety-page view alerts (issue #384): the
+  # communicator's owner (family/parent post-claim). Nil for non-communicator
+  # profiles or unclaimed accounts.
+  def alert_recipient
+    return nil unless profileable_type == "ChildAccount"
+
+    profileable&.owner
+  end
+
+  # Parents are notified by default when their child's safety page is viewed.
+  # They can opt out per-profile by setting settings["view_alerts_enabled"]
+  # to false (the existing settings: {} param on the profile-update endpoint
+  # already accepts this). Stored as a string or boolean by the frontend.
+  def view_alerts_enabled?
+    raw = (settings || {})["view_alerts_enabled"]
+    return true if raw.nil? # default ON (opt-out)
+
+    ![false, "false", "0", 0].include?(raw)
   end
 
   def email
@@ -260,6 +282,7 @@ class Profile < ApplicationRecord
       public_url: public_url,
       startup_url: startup_url,
       allow_discovery: allow_discovery,
+      view_alerts_enabled: view_alerts_enabled?,
       name: name,
 
       # Keep full settings ONLY for authenticated/edit contexts

--- a/app/models/profile_view.rb
+++ b/app/models/profile_view.rb
@@ -1,0 +1,43 @@
+# app/models/profile_view.rb
+# == Schema Information
+#
+# Table name: profile_views
+#
+#  id              :bigint           not null, primary key
+#  profile_id      :bigint           not null
+#  ip_address      :string
+#  user_agent      :string
+#  approx_location :string
+#  geo             :jsonb            not null
+#  notified        :boolean          default(FALSE), not null
+#  viewed_at       :datetime         not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# An audit record of a single public view of a safety (communicator) profile
+# page. Written by RecordProfileViewJob after a request to
+# API::ProfilesController#public. Two purposes:
+#
+#   1. Drives the parent "someone viewed your child's safety page" alert.
+#   2. Builds a history so unexpected access patterns become visible (the abuse-
+#      detection value in issue #384).
+#
+# `notified: true` marks the views that actually triggered a parent email (at
+# most one per profile per hour — see RecordProfileViewJob throttling).
+class ProfileView < ApplicationRecord
+  belongs_to :profile
+
+  validates :viewed_at, presence: true
+
+  before_validation :set_viewed_at, on: :create
+
+  scope :recent, -> { order(viewed_at: :desc) }
+  scope :notified, -> { where(notified: true) }
+  scope :since, ->(time) { where("viewed_at >= ?", time) }
+
+  private
+
+  def set_viewed_at
+    self.viewed_at ||= Time.current
+  end
+end

--- a/app/services/ip_geolocation.rb
+++ b/app/services/ip_geolocation.rb
@@ -1,0 +1,43 @@
+# Coarse, city-level IP geolocation for safety-profile view alerts (issue #384).
+#
+# Wraps Geocoder so the rest of the app gets a tiny, safe surface: pass an IP,
+# get back a plain hash (or nil). It NEVER raises — any provider error, timeout,
+# private/loopback IP, or missing result yields nil, in which case the alert
+# email simply omits the location. This must stay total: it runs off the public
+# emergency page (via RecordProfileViewJob) and can never be allowed to break a
+# notification.
+module IpGeolocation
+  module_function
+
+  # Returns { city:, region:, country:, label: } or nil.
+  # `label` is a human string like "Austin, Texas, US" suitable for an email.
+  def coarse(ip)
+    ip = ip.to_s.strip
+    return nil if ip.blank? || private_or_local?(ip)
+
+    result = Geocoder.search(ip).first
+    return nil if result.nil?
+
+    city    = presence(result.city)
+    region  = presence(result.respond_to?(:state) ? result.state : nil)
+    country = presence(result.country)
+    label   = [city, region, country].compact.join(", ").presence
+    return nil if label.nil?
+
+    { city: city, region: region, country: country, label: label }
+  rescue => e
+    Rails.logger.warn("[IpGeolocation] lookup failed for #{ip}: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def private_or_local?(ip)
+    addr = IPAddr.new(ip)
+    addr.loopback? || addr.private? || addr.link_local?
+  rescue IPAddr::Error
+    true # unparseable → treat as unusable
+  end
+
+  def presence(value)
+    value.to_s.strip.presence
+  end
+end

--- a/app/services/notifications/safety_view_notifier.rb
+++ b/app/services/notifications/safety_view_notifier.rb
@@ -1,0 +1,57 @@
+# Delivers the "someone viewed your child's safety page" alert to a parent
+# (issue #384).
+#
+# This is the channel-dispatch seam. v1 sends **email** via SafetyProfileMailer.
+# A **push** channel is stubbed (`deliver_push`) so that when device-token
+# registration + FCM/APNS land, push slots in here without touching the job,
+# throttle, or opt-out logic. Until then it is a no-op log line.
+#
+# The caller (RecordProfileViewJob) owns throttling, opt-out, and the
+# ProfileView audit record; this class only fans a single, already-vetted alert
+# out to the enabled channels.
+module Notifications
+  class SafetyViewNotifier
+    def self.deliver(profile:, profile_view:, owner:)
+      new(profile: profile, profile_view: profile_view, owner: owner).deliver
+    end
+
+    def initialize(profile:, profile_view:, owner:)
+      @profile = profile
+      @profile_view = profile_view
+      @owner = owner
+    end
+
+    def deliver
+      deliver_email
+      deliver_push # stub for now
+      true
+    end
+
+    private
+
+    attr_reader :profile, :profile_view, :owner
+
+    def deliver_email
+      return if owner&.email.blank?
+
+      SafetyProfileMailer.viewed_alert(profile, profile_view).deliver_now
+    end
+
+    # Push notifications are not wired up yet — there is no device-token
+    # infrastructure in the app. When that exists, dispatch here. Kept as a
+    # named seam so the channel fan-out is obvious and testable.
+    def deliver_push
+      return unless push_enabled?
+
+      Rails.logger.info(
+        "[SafetyViewNotifier] push channel not yet implemented " \
+        "(profile=#{profile.id}, owner=#{owner&.id})"
+      )
+    end
+
+    def push_enabled?
+      # Future: owner.has_registered_devices? — false today, so this never fires.
+      false
+    end
+  end
+end

--- a/app/services/notifications/safety_view_notifier.rb
+++ b/app/services/notifications/safety_view_notifier.rb
@@ -34,7 +34,10 @@ module Notifications
     def deliver_email
       return if owner&.email.blank?
 
-      SafetyProfileMailer.viewed_alert(profile, profile_view).deliver_now
+      # deliver_later (not deliver_now) so a stalled SMTP session can't wedge the
+      # worker thread — the app standardized on this after the #207 outage, and
+      # the no-inline-mailer guard spec enforces it outside app/sidekiq/.
+      SafetyProfileMailer.viewed_alert(profile, profile_view).deliver_later
     end
 
     # Push notifications are not wired up yet — there is no device-token

--- a/app/sidekiq/record_profile_view_job.rb
+++ b/app/sidekiq/record_profile_view_job.rb
@@ -1,0 +1,84 @@
+# Records a single public view of a safety (communicator) profile page and,
+# when appropriate, alerts the parent (issue #384).
+#
+# Enqueued (fire-and-forget) from API::ProfilesController#public for safety
+# profiles only. All the work that could be slow or fail — geolocation, email —
+# happens here, off the request, so the public emergency page always loads fast
+# and is never broken by this feature.
+#
+# Flow:
+#   1. Bail unless this is a safety profile with an owner to notify.
+#   2. Coarse IP→location lookup (best-effort; nil on any failure).
+#   3. Always persist a ProfileView (the audit log for abuse-pattern detection).
+#   4. Throttle: at most ONE alert per profile per hour (atomic Redis claim).
+#   5. Skip the alert (but keep the log) if the parent opted out or has
+#      notifications globally disabled.
+#   6. Otherwise deliver via Notifications::SafetyViewNotifier and mark the
+#      ProfileView notified.
+class RecordProfileViewJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 1
+
+  NOTIFY_THROTTLE_WINDOW = (ENV["SAFETY_VIEW_THROTTLE_SECONDS"] || 1.hour.to_i).to_i
+
+  def perform(profile_id, ip_address = nil, user_agent = nil)
+    profile = Profile.find_by(id: profile_id)
+    return if profile.nil? || !profile.safety?
+
+    owner = profile.alert_recipient
+
+    # Always log the raw view (IP + timestamp) for the abuse-pattern history.
+    profile_view = profile.profile_views.create!(
+      ip_address: ip_address,
+      user_agent: user_agent,
+      viewed_at: Time.current,
+      notified: false,
+    )
+
+    return if owner.nil?
+    return unless profile.view_alerts_enabled?
+    return if owner_disabled_all_notifications?(owner)
+    return unless claim_notify_slot(profile.id)
+
+    # Geolocation runs only once we're actually going to notify — so the
+    # external lookup happens at most once per profile per hour, not on every
+    # bot/scan that hits the public page.
+    geo = IpGeolocation.coarse(ip_address)
+    profile_view.update!(
+      approx_location: geo&.dig(:label),
+      geo: geo ? geo.except(:label) : {},
+      notified: true,
+    )
+
+    Notifications::SafetyViewNotifier.deliver(
+      profile: profile,
+      profile_view: profile_view,
+      owner: owner,
+    )
+  end
+
+  private
+
+  # Respect the user's global notification kill-switch (the same
+  # settings["disable_notifications"] flag User#should_receive_notifications?
+  # reads). We deliberately do NOT reuse that helper here: it also enforces an
+  # unrelated cross-feature 2-hour throttle that could silently swallow a safety
+  # alert because the parent happened to get some other email recently. The
+  # per-profile hourly throttle below is the only timing gate that should apply.
+  def owner_disabled_all_notifications?(owner)
+    settings = owner.settings || {}
+    [true, "true", "1", 1].include?(settings["disable_notifications"])
+  end
+
+  # Atomic per-profile debounce so concurrent views can't each fire an email.
+  # Mirrors DiskSpaceAlertJob's Redis SET NX EX pattern.
+  def claim_notify_slot(profile_id)
+    result = Sidekiq.redis do |conn|
+      conn.call(
+        "SET", "safety_view_notify:#{profile_id}", Time.current.to_i,
+        "NX", "EX", NOTIFY_THROTTLE_WINDOW
+      )
+    end
+    result == "OK"
+  end
+end

--- a/app/views/safety_profile_mailer/viewed_alert.html.erb
+++ b/app/views/safety_profile_mailer/viewed_alert.html.erb
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title><%= t("safety_profile_mailer.viewed_alert.title") %></title>
+  <style>
+    body { background-color: #f0f0f0; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .container { background-color: #ffffff; margin: auto; max-width: 600px; padding: 24px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .header { font-size: 22px; margin-bottom: 16px; color: #153a62; }
+    .content { font-size: 16px; color: #444444; line-height: 1.6; }
+    .detail { margin: 6px 0; }
+    .label { font-weight: bold; color: #153a62; }
+    .button { display: inline-block; margin-top: 16px; padding: 10px 20px; background-color: #153a62; text-decoration: none; border-radius: 5px; color: #ffffff; }
+    .footer { margin-top: 24px; font-size: 13px; color: #888888; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <%= t("safety_profile_mailer.viewed_alert.heading", child_name: @child_name) %>
+    </div>
+    <div class="content">
+      <p><%= t("safety_profile_mailer.viewed_alert.intro", child_name: @child_name) %></p>
+
+      <p class="detail">
+        <span class="label"><%= t("safety_profile_mailer.viewed_alert.when_label") %></span>
+        <%= @viewed_at_display %>
+      </p>
+
+      <% if @approx_location %>
+        <p class="detail">
+          <span class="label"><%= t("safety_profile_mailer.viewed_alert.location_label") %></span>
+          <%= @approx_location %>
+          <br>
+          <em style="font-size: 13px; color: #888;"><%= t("safety_profile_mailer.viewed_alert.location_note") %></em>
+        </p>
+      <% end %>
+
+      <p><%= t("safety_profile_mailer.viewed_alert.reassurance") %></p>
+
+      <p style="text-align: center;">
+        <a href="<%= @manage_url %>" class="button"><%= t("safety_profile_mailer.viewed_alert.cta") %></a>
+      </p>
+    </div>
+
+    <div class="footer">
+      <p><%= t("safety_profile_mailer.viewed_alert.optout_note") %></p>
+      <p><%= t("safety_profile_mailer.viewed_alert.signature") %></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/views/safety_profile_mailer/viewed_alert.text.erb
+++ b/app/views/safety_profile_mailer/viewed_alert.text.erb
@@ -1,0 +1,17 @@
+<%= t("safety_profile_mailer.viewed_alert.heading", child_name: @child_name) %>
+
+<%= t("safety_profile_mailer.viewed_alert.intro", child_name: @child_name) %>
+
+<%= t("safety_profile_mailer.viewed_alert.when_label") %> <%= @viewed_at_display %>
+<% if @approx_location -%>
+<%= t("safety_profile_mailer.viewed_alert.location_label") %> <%= @approx_location %>
+<%= t("safety_profile_mailer.viewed_alert.location_note") %>
+<% end -%>
+
+<%= t("safety_profile_mailer.viewed_alert.reassurance") %>
+
+<%= t("safety_profile_mailer.viewed_alert.cta") %>: <%= @manage_url %>
+
+--
+<%= t("safety_profile_mailer.viewed_alert.optout_note") %>
+<%= t("safety_profile_mailer.viewed_alert.signature") %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,18 @@
+# Geocoder is used only for **coarse, city-level** IP geolocation on safety-
+# profile view alerts (see IpGeolocation + RecordProfileViewJob). It is never
+# used for street-level lookups.
+#
+# The lookup runs inside a Sidekiq job, so a slow or failing provider can never
+# block or break the public emergency page — IpGeolocation rescues everything
+# and returns nil, in which case the alert email simply omits the location.
+#
+# Provider is ENV-tunable so production can point at a keyed service
+# (e.g. ipinfo.io) without a code change. Defaults to the free, no-key
+# `ipinfo_io` lookup for development.
+Geocoder.configure(
+  ip_lookup: (ENV["GEOCODER_IP_LOOKUP"] || "ipinfo_io").to_sym,
+  timeout: (ENV["GEOCODER_TIMEOUT"] || 3).to_i,
+  units: :km,
+  # An API token for the configured IP provider, when one is required.
+  ipinfo_io: { api_key: ENV["IPINFO_API_KEY"] },
+)

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -468,3 +468,16 @@ en:
       fallback_link: "If the button doesn't work, paste this link into your browser:"
       signoff: "Happy Communicating,"
       signature: "The SpeakAnyWay Team"
+  safety_profile_mailer:
+    viewed_alert:
+      subject: "%{child_name}'s safety page was just viewed"
+      title: "Safety page viewed"
+      heading: "Someone viewed %{child_name}'s safety page"
+      intro: "We're letting you know that %{child_name}'s public safety profile was opened. If this was you or someone you trust, no action is needed."
+      when_label: "When:"
+      location_label: "Approximate location:"
+      location_note: "Based on the viewer's network location — approximate and may not be exact."
+      reassurance: "This page is meant to be opened in an emergency by someone helping your child. These alerts simply give you visibility into when that happens."
+      cta: "Manage your safety pages"
+      optout_note: "You're receiving this because safety-view alerts are on for this profile. You can turn them off anytime from your MySpeak settings."
+      signature: "The SpeakAnyWay Team"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -456,3 +456,16 @@ es:
       fallback_link: "Si el botón no funciona, pega este enlace en tu navegador:"
       signoff: "Feliz comunicación,"
       signature: "El equipo de SpeakAnyWay"
+  safety_profile_mailer:
+    viewed_alert:
+      subject: "Se acaba de ver la página de seguridad de %{child_name}"
+      title: "Página de seguridad vista"
+      heading: "Alguien vio la página de seguridad de %{child_name}"
+      intro: "Te avisamos que se abrió el perfil de seguridad público de %{child_name}. Si fuiste tú o alguien de tu confianza, no necesitas hacer nada."
+      when_label: "Cuándo:"
+      location_label: "Ubicación aproximada:"
+      location_note: "Basada en la ubicación de red del visitante — aproximada y puede no ser exacta."
+      reassurance: "Esta página está pensada para abrirse en una emergencia por alguien que ayuda a tu hijo/a. Estas alertas solo te dan visibilidad de cuándo ocurre."
+      cta: "Administrar tus páginas de seguridad"
+      optout_note: "Recibes esto porque las alertas de visualización están activadas para este perfil. Puedes desactivarlas cuando quieras desde la configuración de MySpeak."
+      signature: "El equipo de SpeakAnyWay"

--- a/db/migrate/20260624120000_create_profile_views.rb
+++ b/db/migrate/20260624120000_create_profile_views.rb
@@ -1,0 +1,17 @@
+class CreateProfileViews < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profile_views do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.string :ip_address
+      t.string :user_agent
+      t.string :approx_location # coarse, e.g. "Austin, Texas, US"
+      t.jsonb :geo, default: {}, null: false # raw coarse geo: city/region/country
+      t.boolean :notified, default: false, null: false
+      t.datetime :viewed_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :profile_views, [:profile_id, :viewed_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_23_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_24_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -481,6 +481,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_23_130000) do
     t.jsonb "language_settings", default: {}
     t.string "language", default: "en"
     t.index ["category"], name: "index_images_on_category"
+    t.index ["language_settings"], name: "index_images_on_language_settings_gin", using: :gin
     t.index ["obf_id"], name: "index_images_on_obf_id"
     t.index ["use_custom_audio"], name: "index_images_on_use_custom_audio"
     t.index ["voice"], name: "index_images_on_voice"
@@ -756,6 +757,20 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_23_130000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_category_id"], name: "index_products_on_product_category_id"
+  end
+
+  create_table "profile_views", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.string "approx_location"
+    t.jsonb "geo", default: {}, null: false
+    t.boolean "notified", default: false, null: false
+    t.datetime "viewed_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id", "viewed_at"], name: "index_profile_views_on_profile_id_and_viewed_at"
+    t.index ["profile_id"], name: "index_profile_views_on_profile_id"
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -1044,6 +1059,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_23_130000) do
   add_foreign_key "pay_payment_methods", "pay_customers", column: "customer_id"
   add_foreign_key "pay_subscriptions", "pay_customers", column: "customer_id"
   add_foreign_key "products", "product_categories"
+  add_foreign_key "profile_views", "profiles"
   add_foreign_key "scenarios", "users"
   add_foreign_key "subscriptions", "users"
   add_foreign_key "team_accounts", "child_accounts"

--- a/spec/mailers/safety_profile_mailer_spec.rb
+++ b/spec/mailers/safety_profile_mailer_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe SafetyProfileMailer, type: :mailer do
+  let(:owner) { FactoryBot.create(:user, email: "parent@example.com") }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+  let(:profile) { Profile.create!(profileable: child, username: "sky-mail", slug: "sky-mail") }
+
+  describe "#viewed_alert" do
+    it "addresses the parent and names the child in the subject" do
+      view = profile.profile_views.create!(viewed_at: Time.utc(2026, 6, 24, 15, 5))
+      mail = described_class.viewed_alert(profile, view)
+
+      expect(mail.to).to eq([owner.email])
+      expect(mail.subject).to include("Sky")
+    end
+
+    it "includes the timestamp and renders without a location when none was captured" do
+      view = profile.profile_views.create!(viewed_at: Time.utc(2026, 6, 24, 15, 5))
+      mail = described_class.viewed_alert(profile, view)
+      body = mail.body.encoded
+
+      expect(body).to include("June 24, 2026")
+      expect(body).not_to include("Approximate location")
+    end
+
+    it "includes the approximate location when present" do
+      view = profile.profile_views.create!(
+        viewed_at: Time.utc(2026, 6, 24, 15, 5),
+        approx_location: "Austin, Texas, US",
+      )
+      body = described_class.viewed_alert(profile, view).body.encoded
+
+      expect(body).to include("Austin, Texas, US")
+    end
+
+    it "does not deliver when the profile has no owner" do
+      orphan = Profile.create!(username: "orphan-1", slug: "orphan-1")
+      view = ProfileView.create!(profile: orphan)
+      mail = described_class.viewed_alert(orphan, view)
+      expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+    end
+  end
+end

--- a/spec/models/profile_view_spec.rb
+++ b/spec/models/profile_view_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ProfileView, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child_account, user: user, owner: user) }
+  let(:profile) { Profile.create!(profileable: child, username: "view-spec", slug: "view-spec") }
+
+  it "belongs to a profile" do
+    view = described_class.new
+    expect(view).not_to be_valid
+    expect(view.errors[:profile]).to be_present
+  end
+
+  it "defaults viewed_at on create" do
+    view = profile.profile_views.create!
+    expect(view.viewed_at).to be_present
+  end
+
+  it "defaults geo to an empty hash and notified to false" do
+    view = profile.profile_views.create!
+    expect(view.geo).to eq({})
+    expect(view.notified).to eq(false)
+  end
+
+  describe "scopes" do
+    it "recent orders newest first" do
+      old = profile.profile_views.create!(viewed_at: 2.hours.ago)
+      fresh = profile.profile_views.create!(viewed_at: 1.minute.ago)
+      expect(described_class.recent.to_a).to eq([fresh, old])
+    end
+
+    it "notified returns only notified rows" do
+      yes = profile.profile_views.create!(notified: true)
+      profile.profile_views.create!(notified: false)
+      expect(described_class.notified.to_a).to eq([yes])
+    end
+  end
+end

--- a/spec/requests/api/profiles_view_alerts_spec.rb
+++ b/spec/requests/api/profiles_view_alerts_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #384 — viewing a public safety page enqueues a view-log / parent-alert
+# job. The job itself is unit-tested in spec/sidekiq; here we only assert the
+# controller wiring: safety pages enqueue, others don't, and an enqueue failure
+# never breaks the public page.
+RSpec.describe "GET /api/profiles/public/:slug view logging", type: :request do
+  let(:owner) { FactoryBot.create(:user, email: "parent-view@example.com") }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+
+  def safety_profile
+    Profile.create!(profileable: child, username: "sky-safety", slug: "sky-safety")
+  end
+
+  before { RecordProfileViewJob.jobs.clear }
+
+  it "enqueues a view-log job for a safety profile" do
+    profile = safety_profile
+
+    expect {
+      get "/api/profiles/public/#{profile.slug}"
+    }.to change { RecordProfileViewJob.jobs.size }.by(1)
+
+    expect(response).to have_http_status(:ok)
+    args = RecordProfileViewJob.jobs.last["args"]
+    expect(args.first).to eq(profile.id)
+  end
+
+  it "does not enqueue for a pro public_page profile" do
+    profile = Profile.new(profileable: child, username: "sky-pro", slug: "sky-pro")
+    profile.profile_kind = "public_page"
+    profile.save!
+
+    expect {
+      get "/api/profiles/public/#{profile.slug}"
+    }.not_to change { RecordProfileViewJob.jobs.size }
+  end
+
+  it "does not enqueue for an unclaimed placeholder" do
+    placeholder = Profile.create!(
+      username: "ph-1", slug: "ph-1", placeholder: true,
+      claim_token: SecureRandom.hex(8), claimed_at: nil,
+    )
+
+    expect {
+      get "/api/profiles/public/#{placeholder.slug}"
+    }.not_to change { RecordProfileViewJob.jobs.size }
+  end
+
+  it "still serves the page when enqueue raises" do
+    profile = safety_profile
+    allow(RecordProfileViewJob).to receive(:perform_async).and_raise(StandardError, "redis down")
+
+    get "/api/profiles/public/#{profile.slug}"
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/ip_geolocation_spec.rb
+++ b/spec/services/ip_geolocation_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe IpGeolocation do
+  describe ".coarse" do
+    it "returns nil for blank / private / loopback IPs without calling the provider" do
+      expect(Geocoder).not_to receive(:search)
+      expect(described_class.coarse(nil)).to be_nil
+      expect(described_class.coarse("127.0.0.1")).to be_nil
+      expect(described_class.coarse("10.0.0.5")).to be_nil
+      expect(described_class.coarse("192.168.1.10")).to be_nil
+    end
+
+    it "returns a coarse hash with a human label for a resolvable IP" do
+      result = double("geo", city: "Austin", state: "Texas", country: "US")
+      allow(Geocoder).to receive(:search).and_return([result])
+
+      out = described_class.coarse("8.8.8.8")
+      expect(out).to eq(
+        city: "Austin", region: "Texas", country: "US", label: "Austin, Texas, US"
+      )
+    end
+
+    it "returns nil when the provider yields no result" do
+      allow(Geocoder).to receive(:search).and_return([])
+      expect(described_class.coarse("8.8.8.8")).to be_nil
+    end
+
+    it "never raises — provider errors become nil" do
+      allow(Geocoder).to receive(:search).and_raise(StandardError, "boom")
+      expect(described_class.coarse("8.8.8.8")).to be_nil
+    end
+
+    it "builds a partial label when some fields are missing" do
+      result = double("geo", city: "Berlin", state: nil, country: "DE")
+      allow(Geocoder).to receive(:search).and_return([result])
+      expect(described_class.coarse("8.8.8.8")[:label]).to eq("Berlin, DE")
+    end
+  end
+end

--- a/spec/services/notifications/safety_view_notifier_spec.rb
+++ b/spec/services/notifications/safety_view_notifier_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Notifications::SafetyViewNotifier do
+  include ActiveJob::TestHelper
+
   let(:owner) { FactoryBot.create(:user, email: "parent@example.com") }
   let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
   let(:profile) { Profile.create!(profileable: child, username: "sky-notify", slug: "sky-notify") }
@@ -8,9 +10,11 @@ RSpec.describe Notifications::SafetyViewNotifier do
 
   describe ".deliver" do
     it "sends the parent the viewed-alert email" do
-      expect {
-        described_class.deliver(profile: profile, profile_view: profile_view, owner: owner)
-      }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      perform_enqueued_jobs do
+        expect {
+          described_class.deliver(profile: profile, profile_view: profile_view, owner: owner)
+        }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      end
 
       expect(ActionMailer::Base.deliveries.last.to).to eq([owner.email])
     end
@@ -19,7 +23,7 @@ RSpec.describe Notifications::SafetyViewNotifier do
       allow(owner).to receive(:email).and_return(nil)
       expect {
         described_class.deliver(profile: profile, profile_view: profile_view, owner: owner)
-      }.not_to change { ActionMailer::Base.deliveries.size }
+      }.not_to have_enqueued_mail(SafetyProfileMailer, :viewed_alert)
     end
 
     it "the push channel is a no-op stub today" do

--- a/spec/services/notifications/safety_view_notifier_spec.rb
+++ b/spec/services/notifications/safety_view_notifier_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Notifications::SafetyViewNotifier do
+  let(:owner) { FactoryBot.create(:user, email: "parent@example.com") }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+  let(:profile) { Profile.create!(profileable: child, username: "sky-notify", slug: "sky-notify") }
+  let(:profile_view) { profile.profile_views.create!(approx_location: "Austin, Texas, US") }
+
+  describe ".deliver" do
+    it "sends the parent the viewed-alert email" do
+      expect {
+        described_class.deliver(profile: profile, profile_view: profile_view, owner: owner)
+      }.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+      expect(ActionMailer::Base.deliveries.last.to).to eq([owner.email])
+    end
+
+    it "does not send email when the owner has no email" do
+      allow(owner).to receive(:email).and_return(nil)
+      expect {
+        described_class.deliver(profile: profile, profile_view: profile_view, owner: owner)
+      }.not_to change { ActionMailer::Base.deliveries.size }
+    end
+
+    it "the push channel is a no-op stub today" do
+      notifier = described_class.new(profile: profile, profile_view: profile_view, owner: owner)
+      expect(notifier.send(:push_enabled?)).to eq(false)
+      # deliver_push must not raise and must not deliver anything
+      expect { notifier.send(:deliver_push) }.not_to change { ActionMailer::Base.deliveries.size }
+    end
+  end
+end

--- a/spec/sidekiq/record_profile_view_job_spec.rb
+++ b/spec/sidekiq/record_profile_view_job_spec.rb
@@ -1,0 +1,102 @@
+require "rails_helper"
+
+RSpec.describe RecordProfileViewJob, type: :sidekiq do
+  let(:job) { described_class.new }
+  let(:owner) { FactoryBot.create(:user, email: "parent@example.com") }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+  let(:profile) { Profile.create!(profileable: child, username: "sky-job", slug: "sky-job") }
+
+  before do
+    # Coarse geo is mocked so the suite never makes a network call.
+    allow(IpGeolocation).to receive(:coarse).and_return(
+      city: "Austin", region: "Texas", country: "US", label: "Austin, Texas, US"
+    )
+    # Clear the per-profile throttle key so each example starts fresh.
+    Sidekiq.redis { |c| c.call("DEL", "safety_view_notify:#{profile.id}") }
+  end
+
+  def deliveries = ActionMailer::Base.deliveries.size
+
+  describe "#perform" do
+    it "logs a ProfileView and emails the parent" do
+      expect {
+        job.perform(profile.id, "8.8.8.8", "Mozilla/5.0")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(1)
+
+      view = ProfileView.last
+      expect(view.profile).to eq(profile)
+      expect(view.ip_address).to eq("8.8.8.8")
+      expect(view.user_agent).to eq("Mozilla/5.0")
+      expect(view.approx_location).to eq("Austin, Texas, US")
+      expect(view.geo).to include("city" => "Austin", "country" => "US")
+      expect(view.notified).to eq(true)
+    end
+
+    it "still logs and emails when geolocation yields nothing (no location in the email)" do
+      allow(IpGeolocation).to receive(:coarse).and_return(nil)
+
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(1)
+
+      view = ProfileView.last
+      expect(view.approx_location).to be_nil
+      expect(view.geo).to eq({})
+    end
+
+    it "does nothing for a non-safety profile" do
+      pro = Profile.new(profileable: child, username: "sky-pro", slug: "sky-pro")
+      pro.profile_kind = "public_page"
+      pro.save!
+
+      expect {
+        job.perform(pro.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(0).and change { deliveries }.by(0)
+    end
+
+    it "no-ops when the profile is missing" do
+      expect {
+        job.perform(-1, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(0).and change { deliveries }.by(0)
+    end
+
+    it "logs the view but sends no email when the parent opted out of view alerts" do
+      profile.update!(settings: { "view_alerts_enabled" => false })
+
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(0)
+
+      expect(ProfileView.last.notified).to eq(false)
+    end
+
+    it "logs the view but sends no email when the parent disabled all notifications" do
+      owner.update!(settings: (owner.settings || {}).merge("disable_notifications" => true))
+
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(0)
+    end
+
+    it "logs the view but sends no email when the communicator has no owner" do
+      # A ChildAccount re-derives owner from user on save, so a truly ownerless
+      # communicator also has no user.
+      ownerless = FactoryBot.create(:child_account, user: nil, owner: nil)
+      orphan = Profile.create!(profileable: ownerless, username: "no-owner", slug: "no-owner")
+
+      expect {
+        job.perform(orphan.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(0)
+    end
+
+    it "throttles to one email per profile per hour" do
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA")
+        described_class.new.perform(profile.id, "9.9.9.9", "UA")
+      }.to change { ProfileView.count }.by(2).and change { deliveries }.by(1)
+
+      # Both views are logged; only the first is marked notified.
+      expect(ProfileView.where(profile: profile, notified: true).count).to eq(1)
+    end
+  end
+end

--- a/spec/sidekiq/record_profile_view_job_spec.rb
+++ b/spec/sidekiq/record_profile_view_job_spec.rb
@@ -1,10 +1,16 @@
 require "rails_helper"
 
 RSpec.describe RecordProfileViewJob, type: :sidekiq do
+  include ActiveJob::TestHelper
+
   let(:job) { described_class.new }
   let(:owner) { FactoryBot.create(:user, email: "parent@example.com") }
   let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
   let(:profile) { Profile.create!(profileable: child, username: "sky-job", slug: "sky-job") }
+
+  # The notifier uses deliver_later; perform enqueued mailer jobs inline so the
+  # ActionMailer::Base.deliveries assertions below reflect actual sends.
+  around { |example| perform_enqueued_jobs { example.run } }
 
   before do
     # Coarse geo is mocked so the suite never makes a network call.


### PR DESCRIPTION
Closes #384.

## Summary

Public safety (MySpeak) pages (`GET /api/profiles/public/:slug`) are designed to be opened with zero friction in an emergency — someone finds a lost child, scans the QR code, no login. This adds parent **visibility** into when that happens.

When a safety page is viewed, the parent gets an **email** with the timestamp and an **approximate (city-level) location** of the viewer. Every view is also logged for abuse-pattern detection. Backend-only — **no frontend changes required**.

### How it works
- `ProfilesController#public` enqueues `RecordProfileViewJob` **for safety profiles only** (not pro `public_page`, not unclaimed placeholders). Fire-and-forget + rescued, and placed *before* the `stale?`/ETag block so a 304 still counts. The public emergency page is never slowed or broken by this.
- `RecordProfileViewJob` (`app/sidekiq/`):
  1. Always logs the raw view (IP + UA + timestamp) to the new **`profile_views`** table.
  2. Alerts the parent only when: the communicator has an owner, the per-profile opt-out is off, the global `disable_notifications` flag is off, and the **atomic per-profile hourly Redis throttle** is claimed (`SET NX EX`, mirrors `DiskSpaceAlertJob`; window ENV-tunable via `SAFETY_VIEW_THROTTLE_SECONDS`, default 3600).
  3. **Geo lookup runs only after the throttle is claimed** — so the external IP lookup happens at most once per profile per hour, not on every bot/scan.
- `Notifications::SafetyViewNotifier` is the channel-dispatch seam. **v1 = email** (`SafetyProfileMailer#viewed_alert`, en/es i18n). A **push channel is stubbed** (`deliver_push` / `push_enabled? == false`) for when device-token infra lands — there is no push infrastructure in the app today.
- `IpGeolocation.coarse` wraps the new **`geocoder`** gem; returns a city-level label or **nil** on any error / private IP (email just omits location). Provider is ENV-tunable (`GEOCODER_IP_LOOKUP`, `IPINFO_API_KEY`, `GEOCODER_TIMEOUT`).

### Decisions (confirmed with @brittanyjohns)
- **Channel:** email now + push stub.
- **Location:** coarse server-side IP (geocoder gem).
- **Default:** on by default (opt-out). Per-profile via `settings["view_alerts_enabled"]` (exposed as `view_alerts_enabled` on `Profile#api_view`); rides the existing `settings: {}` param, so no new endpoint/UI is needed. Global `settings["disable_notifications"]` is also respected.
- **Storage:** dedicated `profile_views` table for the abuse-pattern history.

## Test plan
Ran the relevant + regression specs — **88 examples, 0 failures**:
- `spec/models/profile_view_spec.rb`
- `spec/sidekiq/record_profile_view_job_spec.rb` (logs, throttles, opt-out, disabled, no-owner, non-safety skip, missing profile, geo-nil)
- `spec/mailers/safety_profile_mailer_spec.rb`
- `spec/services/notifications/safety_view_notifier_spec.rb` (email sent, push stub no-ops)
- `spec/services/ip_geolocation_spec.rb` (private/loopback skip, partial label, never raises)
- `spec/requests/api/profiles_view_alerts_spec.rb` (enqueues for safety only, never raises on enqueue failure)
- Regression: `spec/models/profile_spec.rb`, `spec/requests/api/profiles_spec.rb`

Also verified `Rails.application.eager_load!` is clean and both locale files parse.

## Notes
- New gem: **`geocoder`** (approved) — coarse IP geolocation only.
- One migration (`profile_views`), no destructive changes.
- The random-slug migration (`feat/random-slugs`) also touches `ProfilesController#public`; this change is one additive line there, so whichever merges second needs only a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)