### PR TITLE
fix(mailchimp): make journey trigger resilient to gem accessor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Mailchimp journey triggers can't flood the Sidekiq dead set
+- `MailchimpService#trigger_journey` resolves the gem's Customer Journeys
+  accessor defensively (camelCase `customerJourneys`, falling back to snake_case
+  only if a future gem adds it) and now **catches/​logs/​swallows a
+  `NoMethodError`** instead of letting it crash `MailchimpEventJob`. Previously a
+  gem-shape mismatch raised on every trigger, exhausted the job's retries, and
+  piled hundreds of jobs into the Sidekiq dead set. `ApiError` 404-retry
+  behavior is unchanged.
+
 ### Fixed — User settings hardening & cleanup
 - The `PUT /api/users/:id/update_settings` endpoint now only persists a
   whitelist of real preference keys (voice, display toggles, board pointers,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,16 @@ GitHub build). Two distinct uses:
   events. Fired async via `MailchimpEventJob` (event types `sign_up` /
   `sign_in`) from `API::V1::AuthsController` and the Stripe checkout controller.
 - **Customer Journey triggers (email):** `MailchimpService#trigger_journey`
-  enrols a contact into a journey's **API-trigger step**
-  (`@client.customerJourneys.trigger` — the gem accessor is camelCase; there is
-  **no** snake_case `customer_journeys` alias, so it raises NoMethodError), so
-  Mailchimp sends the email designed in that journey. The contact is
-  upserted-and-retried-once if Mailchimp 404s.
+  enrols a contact into a journey's **API-trigger step** so Mailchimp sends the
+  email designed in that journey. The accessor is resolved via
+  `MailchimpService#customer_journeys_api`: the gem exposes it as camelCase
+  `customerJourneys` (there is **no** snake_case `customer_journeys` alias
+  today), so the helper prefers camelCase and falls back to snake_case only if a
+  future gem adds it — never calling a method the client lacks. A `NoMethodError`
+  from the trigger (the historical snake_case bug that flooded the Sidekiq dead
+  set) is **caught, logged, and swallowed** so `MailchimpEventJob` doesn't
+  exhaust its retries into Dead. The contact is upserted-and-retried-once if
+  Mailchimp 404s.
   Wired through the `MailchimpEventJob` `"journey"` event type, which takes a
   `journey_key`.
 

--- a/app/models/mailchimp_service.rb
+++ b/app/models/mailchimp_service.rb
@@ -105,12 +105,18 @@ class MailchimpService
   # already be an audience member; if Mailchimp 404s we upsert them and retry
   # once (guarded so a misconfigured journey_id can't loop forever).
   def trigger_journey(user, journey_id:, step_id:)
+    journeys = customer_journeys_api
+    if journeys.nil?
+      Rails.logger.error(
+        "[Mailchimp] Customer Journeys API unavailable on the client; " \
+        "skipping journey #{journey_id}/#{step_id} for #{user.email}"
+      )
+      return nil
+    end
+
     attempted_subscribe = false
     begin
-      # NOTE: the MailchimpMarketing gem exposes this API as `customerJourneys`
-      # (camelCase) — there is no snake_case `customer_journeys` accessor, so
-      # using it raises NoMethodError at runtime.
-      @client.customerJourneys.trigger(
+      journeys.trigger(
         journey_id,
         step_id,
         { email_address: user.email }
@@ -122,7 +128,27 @@ class MailchimpService
       end
       Rails.logger.error "[Mailchimp] Failed to trigger journey #{journey_id}/#{step_id}: #{e.message}"
       nil
+    rescue NoMethodError => e
+      # A NoMethodError here means the gem's journeys accessor/shape changed
+      # (the historical `customer_journeys` snake_case bug, which raised on
+      # every trigger and piled hundreds of jobs into the Sidekiq dead set).
+      # Retrying can't fix a missing method, so swallow it: log loudly and
+      # return nil so MailchimpEventJob succeeds instead of exhausting its
+      # retries into Dead.
+      Rails.logger.error "[Mailchimp] Customer Journeys accessor unavailable for journey #{journey_id}/#{step_id}: #{e.message}"
+      nil
     end
+  end
+
+  # Resolve the gem's Customer Journeys API regardless of accessor casing. The
+  # MailchimpMarketing gem exposes it as camelCase `customerJourneys` (no
+  # snake_case alias today); resolving defensively means a future casing change
+  # can't silently break, and we never call a method the client doesn't have.
+  def customer_journeys_api
+    return @client.customerJourneys if @client.respond_to?(:customerJourneys)
+    return @client.customer_journeys if @client.respond_to?(:customer_journeys)
+
+    nil
   end
 
   # Upsert merge fields on a contact (e.g. trial-wrap personalization:

--- a/spec/models/mailchimp_service_spec.rb
+++ b/spec/models/mailchimp_service_spec.rb
@@ -93,6 +93,39 @@ RSpec.describe MailchimpService do
       expect(bare_client).to respond_to(:customerJourneys)
       expect(bare_client).not_to respond_to(:customer_journeys)
     end
+
+    context "when the journeys accessor is missing or shape-changed" do
+      it "returns nil without raising when the client exposes no journeys accessor" do
+        allow(client).to receive(:respond_to?).with(:customerJourneys).and_return(false)
+        allow(client).to receive(:respond_to?).with(:customer_journeys).and_return(false)
+
+        service = described_class.new
+        expect(Rails.logger).to receive(:error).with(/Customer Journeys API unavailable/)
+        expect {
+          expect(service.trigger_journey(user, journey_id: 10, step_id: 20)).to be_nil
+        }.not_to raise_error
+      end
+
+      it "swallows a NoMethodError from the trigger call instead of crashing the job" do
+        allow(journeys).to receive(:trigger).and_raise(NoMethodError.new("undefined method `trigger'"))
+
+        service = described_class.new
+        expect(Rails.logger).to receive(:error).with(/Customer Journeys accessor unavailable/)
+        expect {
+          expect(service.trigger_journey(user, journey_id: 10, step_id: 20)).to be_nil
+        }.not_to raise_error
+      end
+
+      it "falls back to a snake_case accessor if a future gem only exposes that" do
+        snake_journeys = double("customer_journeys")
+        allow(client).to receive(:respond_to?).with(:customerJourneys).and_return(false)
+        allow(client).to receive(:respond_to?).with(:customer_journeys).and_return(true)
+        allow(client).to receive(:customer_journeys).and_return(snake_journeys)
+        expect(snake_journeys).to receive(:trigger).with(10, 20, { email_address: "parent@example.com" })
+
+        described_class.new.trigger_journey(user, journey_id: 10, step_id: 20)
+      end
+    end
   end
 
   describe "#archive_subscriber" do


### PR DESCRIPTION
## Summary

While triaging a Sidekiq dead set of ~1100 jobs, **79 dead `MailchimpEventJob`s** showed `undefined method 'customer_journeys' for an instance of MailchimpMarketing::Client`. The gem exposes the Customer Journeys API as **camelCase `customerJourneys`** with no snake_case alias, so calling the wrong name raises `NoMethodError`.

The current code already uses the camelCase name, so those dead jobs are historical — **but the failure mode is still live**: `trigger_journey` only rescued `MailchimpMarketing::ApiError`, so any `NoMethodError` (e.g. a future gem-shape change) would again crash `MailchimpEventJob`, exhaust its `retry: 3`, and flood the dead set.

## Fix

- **`customer_journeys_api`** resolves the accessor defensively: prefer `customerJourneys`, fall back to `customer_journeys` only if a future gem exposes it, and never call a method the client doesn't have (returns nil + logs instead).
- **`trigger_journey` now also rescues `NoMethodError`** — logs loudly and returns nil so the enqueuing job succeeds instead of retrying into Dead. `ApiError` 404-upsert-retry behavior is unchanged.

This makes the "known issue" permanently non-fatal: a gem accessor mismatch can no longer take down journey emails or pile jobs into Dead.

## Test plan

`bundle exec rspec spec/models/mailchimp_service_spec.rb spec/sidekiq/mailchimp_event_job_spec.rb` → **19 examples, 0 failures**.

New coverage: missing journeys accessor → nil + log (no raise); `NoMethodError` from `trigger` → swallowed; snake_case fallback path. Existing camelCase + `ApiError` 404/500 tests still pass.

## Note (separate, operational)

This stops *future* dead jobs. The existing ~1100 historical dead jobs (mostly `TranslateImageJob`, plus these Mailchimp ones) are harmless but can be cleared from the Sidekiq console — being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)