### PR TITLE
fix(onboarding): assign random safety slug in MySpeak onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — New MySpeak communicators get an unguessable safety slug
+- MySpeak onboarding (`POST /api/v1/onboarding/myspeak`) no longer creates a
+  name-derived public slug. The safety profile now gets a random `s-xxxxxx`
+  slug (via `Profile#ensure_slug`), so a child's public emergency page can't be
+  found by guessing their name. The account's **username** stays readable. Any
+  client-supplied `slug` is ignored — random is enforced server-side. Completes
+  the random-slug work from the prior release for *new* signups (the "Pick your
+  link" wizard step is being removed in the frontend).
+
 ### Fixed — Mailchimp journey triggers can't flood the Sidekiq dead set
 - `MailchimpService#trigger_journey` resolves the gem's Customer Journeys
   accessor defensively (camelCase `customerJourneys`, falling back to snake_case

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,11 +569,17 @@ be found by guessing their name. Vendor/SLP/user pages keep readable slugs.
 - **When it's applied:** `Profile#ensure_slug` (a `before_validation … on:
   :create`) only fills a **blank** slug. For a safety profile it generates a
   random slug and sets `slug_type = "random"`; otherwise it falls back to
-  `username.parameterize` (`slug_type` stays `"legacy"`). Creation paths that
-  pass an explicit slug (the onboarding wizard's "Pick your link" step,
-  `ChildAccount#create_profile!`) are unchanged — they keep that slug. The
-  frontend dropping the explicit slug is what flips new communicators onto
-  random slugs (counterpart: `itty-bitty-frontend`).
+  `username.parameterize` (`slug_type` stays `"legacy"`).
+- **MySpeak onboarding always gets a random slug.**
+  `API::V1::Onboarding::MyspeakController#create` derives a readable, unique
+  **username** from the name (`unique_slug_for`) but leaves the profile **slug
+  blank** so `ensure_slug` assigns the random one — and **ignores any
+  client-supplied `slug`** (random is non-negotiable for safety pages; the
+  wizard no longer collects a link). The username stays human-readable because
+  it's the handle shown on the page a responder already scanned, not the public
+  URL. `ChildAccount#create_profile!` (programmatic communicator creation, not
+  the wizard) still passes a name-derived slug — its new profiles are caught by
+  the backfill task but it does **not** yet auto-randomize on create (follow-up).
 - **Not user-editable:** `Profile#slug_editable?` returns `false` when
   `slug_type == "random"`, regardless of the 7-day edit window. `slug_type` and
   `slug_editable` are exposed on `Profile#api_view`.

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -48,24 +48,18 @@ module API
           photo_data_url = params[:photo_data_url].to_s
           contacts       = Array(params[:contacts])
 
-          # Slug picking — the wizard's "Pick your link" step lets the user
-          # customize the slug before submit. If they accept the default we
-          # still derive from the name; if blank we fall back to a generated
-          # placeholder. User-supplied slugs go through the same format /
-          # reserved / availability checks the edit endpoint enforces.
-          requested_slug = params[:slug].to_s.strip.downcase.presence
-
-          if requested_slug
-            reason = Profile.slug_unavailable_reason(requested_slug)
-            if reason
-              render json: slug_error_payload(reason), status: :unprocessable_content
-              return
-            end
-            unique = requested_slug
-          else
-            base_slug = name.parameterize.presence || "communicator-#{SecureRandom.hex(3)}"
-            unique = unique_slug_for(base_slug)
-          end
+          # Safety profiles get an unguessable random slug, assigned by
+          # Profile#ensure_slug when the slug is left blank, so a child's public
+          # emergency page (`/my/<slug>`) can't be found by guessing their name.
+          # We deliberately ignore any client-supplied slug (the wizard no longer
+          # collects one) — random is non-negotiable for safety pages.
+          #
+          # We still derive a readable, unique *username* from the name: it's the
+          # account handle shown on the page a responder already scanned, not the
+          # public URL, so keeping it human-readable doesn't weaken discovery
+          # protection.
+          base_slug = name.parameterize.presence || "communicator-#{SecureRandom.hex(3)}"
+          unique = unique_slug_for(base_slug)
 
           profile = nil
           child = nil
@@ -86,11 +80,12 @@ module API
               status: status,
             )
 
+            # No `slug:` — left blank so Profile#ensure_slug assigns the random
+            # `s-xxxxxx` safety slug (slug_type "random", not user-editable).
             profile = Profile.new(
               profileable: child,
               profile_kind: "safety",
               username: unique,
-              slug: unique,
               bio: care_notes,
               settings: build_settings(pronouns: pronouns, contacts: contacts),
             )
@@ -124,22 +119,6 @@ module API
         end
 
         private
-
-        # Mirrors API::ProfilesController#slug_error_for. Kept inline to
-        # avoid a controller-to-controller call, but using the same error
-        # codes so the React SlugField only has to know one vocabulary.
-        def slug_error_payload(reason)
-          case reason
-          when :format
-            { error: "slug_invalid", message: "Links must be 3–40 characters: lowercase letters, numbers, and hyphens." }
-          when :reserved
-            { error: "slug_reserved", message: "That link is reserved. Please pick another." }
-          when :taken
-            { error: "slug_taken", message: "That link is already in use." }
-          else
-            { error: "slug_invalid", message: "That link can't be used." }
-          end
-        end
 
         def build_settings(pronouns:, contacts:)
           settings = {}

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -74,7 +74,10 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
 
         profile = child.profile
         expect(profile.profile_kind).to eq("safety")
-        expect(profile.slug).to eq("river-stone")
+        # Safety profiles get an unguessable random slug, not a name-derived one.
+        expect(profile.slug).to match(/\As-[a-z0-9]{6}\z/)
+        expect(profile.slug_type).to eq("random")
+        # ...but the username stays readable (it's the handle, not the public URL).
         expect(profile.username).to eq("river-stone")
         expect(profile.bio).to include("Loves big hugs")
         expect(profile.avatar).to be_attached
@@ -86,7 +89,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(profile.settings["ice_contact_3"]["name"]).to eq("Jo Stone")
 
         body = JSON.parse(response.body)
-        expect(body["slug"]).to eq("river-stone")
+        expect(body["slug"]).to match(/\As-[a-z0-9]{6}\z/)
         expect(body["profile_kind"]).to eq("safety")
         expect(body["settings"]["pronouns"]).to eq("they/them")
         expect(body["settings"]["ice_contact_1"]["phone"]).to eq("555-0101")
@@ -118,8 +121,8 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
       end
     end
 
-    context "slug collision" do
-      it "appends -2 to the slug" do
+    context "username collision" do
+      it "appends -2 to the username while the slug stays random" do
         Profile.create!(
           username: "river-stone",
           slug: "river-stone",
@@ -131,55 +134,40 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
 
         expect(response).to have_http_status(:created)
         new_profile = user.communicator_accounts.last.profile
-        expect(new_profile.slug).to eq("river-stone-2")
         expect(new_profile.username).to eq("river-stone-2")
+        expect(new_profile.slug).to match(/\As-[a-z0-9]{6}\z/)
       end
     end
 
-    context "user-picked slug from the 'Pick your link' wizard step" do
-      it "uses the picked slug when it's available and well-formed" do
+    context "random safety slug (the wizard no longer collects a link)" do
+      it "assigns a random slug and ignores any client-supplied slug" do
         post "/api/v1/onboarding/myspeak",
              params: base_payload.merge(slug: "my-custom-link").to_json, headers: headers
 
         expect(response).to have_http_status(:created)
         profile = user.communicator_accounts.last.profile
-        expect(profile.slug).to eq("my-custom-link")
-        expect(profile.username).to eq("my-custom-link")
+        expect(profile.slug).to match(/\As-[a-z0-9]{6}\z/)
+        expect(profile.slug).not_to eq("my-custom-link")
+        expect(profile.username).to eq("river-stone")
       end
 
-      it "rejects a picked slug with bad format (422 slug_invalid)" do
+      it "assigns a random slug even when no slug param is sent" do
         post "/api/v1/onboarding/myspeak",
-             params: base_payload.merge(slug: "Bad_Slug!").to_json, headers: headers
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(JSON.parse(response.body)["error"]).to eq("slug_invalid")
-      end
-
-      it "rejects a reserved slug (422 slug_reserved)" do
-        post "/api/v1/onboarding/myspeak",
-             params: base_payload.merge(slug: "admin").to_json, headers: headers
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(JSON.parse(response.body)["error"]).to eq("slug_reserved")
-      end
-
-      it "rejects a taken slug (422 slug_taken)" do
-        Profile.create!(username: "river-stone", slug: "river-stone", bio: "x", intro: "y")
-
-        post "/api/v1/onboarding/myspeak",
-             params: base_payload.merge(slug: "river-stone").to_json, headers: headers
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(JSON.parse(response.body)["error"]).to eq("slug_taken")
-      end
-
-      it "falls back to auto-generated slug when slug param is blank" do
-        post "/api/v1/onboarding/myspeak",
-             params: base_payload.merge(slug: "").to_json, headers: headers
+             params: base_payload.to_json, headers: headers
 
         expect(response).to have_http_status(:created)
         profile = user.communicator_accounts.last.profile
-        expect(profile.slug).to eq("river-stone")
+        expect(profile.slug).to match(/\As-[a-z0-9]{6}\z/)
+        expect(profile.slug_type).to eq("random")
+      end
+
+      it "does not 422 on a client slug that would otherwise be reserved/taken" do
+        # The slug is ignored entirely now, so a 'reserved' value can't error.
+        post "/api/v1/onboarding/myspeak",
+             params: base_payload.merge(slug: "admin").to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        expect(user.communicator_accounts.last.profile.slug).to match(/\As-[a-z0-9]{6}\z/)
       end
     end
 


### PR DESCRIPTION
## Summary

Follow-up to #387 (random slugs for safety profiles). That PR made `Profile#ensure_slug` generate a random `s-xxxxxx` slug **only when the slug is blank** — but **MySpeak onboarding never left it blank.** `API::V1::Onboarding::MyspeakController#create` derived a readable slug from the child's name and passed it explicitly to `Profile.new(slug: …)`, so **every new communicator was still getting a guessable `/my/<name>` URL.** The migration fixed existing profiles; new signups regressed straight back to name-based slugs.

## Change

- Leave the profile **slug blank** so `ensure_slug` assigns the random safety slug (`slug_type: "random"`, not user-editable).
- Keep deriving a readable, unique **username** from the name (`unique_slug_for`). The username is the account handle shown on the page a responder already scanned — not the public URL — so it doesn't weaken discovery protection.
- **Ignore any client-supplied `slug`.** Random is enforced server-side for safety pages, so a stale app or crafted request can't set a guessable slug. (Per decision: always-random.)
- Remove the now-dead `slug_error_payload` helper.

The companion frontend PR removes the wizard's "Pick your link" step and stops sending a slug.

## Test plan

`bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb` → **19 examples, 0 failures**.

Updated specs: happy path asserts a random `s-xxxxxx` slug + readable username; username-collision still appends `-2` while the slug stays random; a client-sent slug (incl. a reserved value like `admin`) is ignored rather than honored/422'd.

## Notes

- `ChildAccount#create_profile!` (programmatic communicator creation, not the wizard) still passes a name-derived slug — those profiles are caught by `rake profiles:migrate_to_random_slugs` but don't auto-randomize on create yet. Flagged as a follow-up in CLAUDE.md; happy to fold it in if you want new-create parity everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)