### PR TITLE
fix(handoff): update the communicator's own team on claim, enforce Pro lending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Communicator hand-off now updates the right team
+- When a family claimed a loaned communicator, the new owner was sometimes added
+  to the wrong team (the communicator's *own* team was left with only the
+  previous owner). `ChildAccount#claim_by!` now resolves the communicator's own
+  team deterministically instead of using `teams.first`, adds the new owner as
+  **admin**, keeps the previous owner as **supervisor**, and **transfers team
+  ownership** to the new owner so they can manage the team. Existing accounts can
+  be repaired with `rake communicators:repair_handoff_teams` (dry-run by
+  default).
+
+### Changed — Lending a communicator is enforced as Pro-only
+- The `lend` and `promote_to_loaner` endpoints now return **HTTP 403
+  `pro_required`** for non-Pro callers (admins bypass), matching the frontend's
+  existing Pro-only "Lend to a family" controls. Closes a gap where a Basic user
+  — or a direct API call — could lend a communicator.
+
 ### Changed — New MySpeak communicators get an unguessable safety slug
 - MySpeak onboarding (`POST /api/v1/onboarding/myspeak`) no longer creates a
   name-derived public slug. The safety profile now gets a random `s-xxxxxx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,7 +731,29 @@ post-claim, or the SLP pre-claim). That user is "**owner-pinned**" on the
 communicator's team: they cannot be removed or have their role changed by
 any non-owner. Full matrix in issue #166. Server-side rules:
 
-- `ChildAccount#claim_by!` auto-adds the new owner to the team.
+- `ChildAccount#claim_by!` (the SLP→family hand-off) updates the
+  communicator's **own** team: new owner → `admin`, previous owner →
+  `supervisor`, and **team ownership (`created_by_id`) transfers to the new
+  owner** so they get `is_owner` / `can_invite` (the "Manage team" controls).
+- **"Own team" is resolved deterministically, not `teams.first`.** A
+  communicator can belong to several teams (its own + shared/board teams it's
+  added to), so `ChildAccount#primary_team` resolves: (1) the team pinned in
+  `settings["primary_team_id"]`, (2) the namesake team
+  (`"<name>'s Communication Team"`, the creation convention), (3) the oldest
+  team as a legacy fallback. `ensure_team!` and `claim_by!` pin
+  `primary_team_id` so resolution stays stable across renames and join order.
+  Before this, `claim_by!` acted on `teams.first` and could update the wrong
+  team — leaving the communicator's own team without the new owner.
+  Existing stale data is repaired by `rake communicators:repair_handoff_teams`
+  (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope). It only
+  touches a communicator's identifiable own team — never a shared one.
+- **Lending / hand-off is Pro-only, enforced server-side.**
+  `API::ChildAccountsController#require_pro_for_lending!` gates `lend` and
+  `promote_to_loaner` (after the ownership check, so a non-owner still gets the
+  generic Unauthorized) and returns **HTTP 403 `pro_required`** for non-Pro
+  non-admin callers. Covers the `active→loaner` lend path too, which skips the
+  slot check. The frontend `LoanerControls` Pro gate is now defense-in-depth,
+  not the only guard.
 - `DELETE /api/teams/:id/remove_member` returns **HTTP 403
   `cannot_remove_owner`** if the target is owner-pinned and the caller is
   neither that user nor a system admin. The owner can remove themselves.
@@ -746,9 +768,11 @@ any non-owner. Full matrix in issue #166. Server-side rules:
   `account_owner_ids` and per-member `is_account_owner` so the frontend
   can hide destructive controls.
 
-A real **transfer ownership** flow doesn't exist yet — it's out of scope
-for #166 and will get its own endpoint (touches `child_account.owner_id`,
-not just team membership).
+The SLP→family **hand-off** (loaner → claim) is the supported ownership
+transfer: `claim_by!` moves both `child_account.owner_id` and the own team's
+`created_by_id` to the new owner. A standalone **transfer ownership** endpoint
+(active → another user directly, outside the loaner flow) still doesn't exist —
+out of scope for #166.
 
 **Full SLP→parent handoff contract** — including the permissions matrix
 (who can do what to a claimed communicator), the lifecycle states, and

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -45,6 +45,8 @@ class API::ChildAccountsController < API::ApplicationController
       return
     end
 
+    return unless require_pro_for_lending!
+
     unless @child_account.sandbox?
       render json: account_error_payload("Only sandbox communicators can be promoted to loaner"), status: :unprocessable_content
       return
@@ -91,6 +93,8 @@ class API::ChildAccountsController < API::ApplicationController
       end
       return
     end
+
+    return unless require_pro_for_lending!
 
     # Slot check — only meaningful when the account isn't already in
     # the slot pool (sandbox). Loaners already count; active → loaner
@@ -533,6 +537,27 @@ class API::ChildAccountsController < API::ApplicationController
     render json: account_error_payload("not_owner").merge(
       message: "Only the owner can edit this communicator.",
     ), status: :forbidden
+  end
+
+  # Lending / hand-off is a Pro-only feature. The frontend already hides
+  # the LoanerControls for non-Pro users, but the gate must also hold on
+  # the server: without it a Basic user (or any direct API caller) could
+  # promote a sandbox to a loaner, or lend a self-created active — the
+  # active→loaner path in `lend` skips the slot check, so nothing else
+  # would stop them. System admins bypass for support.
+  #
+  # Called *after* the per-action ownership check so a non-owner still
+  # gets the generic Unauthorized response and we don't leak the gate.
+  # Returns true when allowed; otherwise renders 403 and returns false so
+  # the caller can `return unless require_pro_for_lending!`.
+  def require_pro_for_lending!
+    return true if current_user.admin? || current_user.pro?
+
+    render json: account_error_payload("pro_required").merge(
+      message: "Lending a communicator to a family is a Pro feature.",
+      upgrade_url: "/account/billing/upgrade",
+    ), status: :forbidden
+    false
   end
 
   # Mutation endpoints (lend, end_loan, etc.) return the current account

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -411,9 +411,16 @@ class ChildAccount < ApplicationRecord
       save!
 
       if previous_owner && previous_owner != user
+        # Act on the communicator's OWN team, not whichever team happens
+        # to sort first — a communicator may be on several teams.
         team = primary_team || ensure_team!(creator: user)
+        pin_primary_team!(team)
         team.upsert_member!(previous_owner, "supervisor")
         team.upsert_member!(user, "admin")
+        # Hand the team over to the new owner so they get full management
+        # rights — `created_by_id` drives `is_owner` / `can_invite` in the
+        # team api_view, so without this the new owner couldn't manage it.
+        team.update!(created_by: user) unless team.created_by_id == user.id
       end
     end
 
@@ -492,9 +499,42 @@ class ChildAccount < ApplicationRecord
     anchor + LoanerReclaimJob::RECLAIM_AFTER
   end
 
+  # The communicator's "own" team — the one created *for* it, whose
+  # membership the handoff and owner checks act on. A communicator can
+  # belong to multiple teams (its own, plus shared/board teams it's been
+  # added to), so `teams.first` is unreliable (issue: handoff updated
+  # the wrong team). Resolve deterministically:
+  #   1. the team id pinned in settings (set by `ensure_team!` / claim),
+  #   2. the namesake team auto-created at creation ("<name>'s Communication Team"),
+  #   3. fall back to the oldest team (legacy single-team accounts).
   def primary_team
-    # For now, assume 1 team per communicator
-    teams.first
+    pinned_id = settings&.dig("primary_team_id")
+    if pinned_id
+      pinned = teams.find_by(id: pinned_id)
+      return pinned if pinned
+    end
+    namesake_team || teams.order(:id).first
+  end
+
+  # The team auto-created for this communicator, matched by the naming
+  # convention used on creation (`child_accounts_controller#create` and
+  # the MySpeak onboarding controller both use "<name>'s Communication
+  # Team"). Best-effort: a renamed communicator won't match, which is why
+  # `ensure_team!`/`claim_by!` pin the id in settings going forward.
+  def namesake_team
+    return nil if name.blank?
+    teams.find_by(name: "#{name}'s Communication Team")
+  end
+
+  # Record which team is this communicator's primary/own team so
+  # `primary_team` resolves it unambiguously regardless of join order or
+  # later renames. Idempotent.
+  def pin_primary_team!(team)
+    return if team.nil?
+    self.settings ||= {}
+    return if settings["primary_team_id"] == team.id
+    settings["primary_team_id"] = team.id
+    save!
   end
 
   # Ensure this communicator has a team. If it already does, return
@@ -506,12 +546,17 @@ class ChildAccount < ApplicationRecord
   # (e.g. the API controllers use "<communicator>'s Communication
   # Team"). Passing nil falls back to the default.
   def ensure_team!(creator:, name: nil)
-    return primary_team if primary_team.present?
+    existing = primary_team
+    if existing.present?
+      pin_primary_team!(existing)
+      return existing
+    end
 
     team_name = name.presence || "#{self.name || "Communicator"}'s Team"
     team = Team.create!(name: team_name, created_by: creator)
     TeamAccount.create!(team: team, account: self)
     team.upsert_member!(creator, "admin") if creator
+    pin_primary_team!(team)
     team
   end
 

--- a/lib/tasks/communicators.rake
+++ b/lib/tasks/communicators.rake
@@ -100,4 +100,110 @@ namespace :communicators do
       puts "Promoted #{promoted} communicator(s) across #{affected_users} user(s)."
     end
   end
+
+  # Repair for the handoff team-membership bug: `ChildAccount#claim_by!`
+  # used to act on `teams.first`, which is unreliable when a communicator
+  # belongs to more than one team. The hand-off could update the wrong
+  # team, leaving the communicator's OWN team (the "<name>'s Communication
+  # Team" auto-created at creation) with stale membership — the new owner
+  # missing, the previous owner still admin, and team ownership unchanged.
+  #
+  # For each already-claimed (active) communicator this:
+  #   - pins settings["primary_team_id"] to the own team,
+  #   - adds the current owner as `admin`,
+  #   - transfers team ownership (created_by) to the current owner so they
+  #     get is_owner / can_invite,
+  #   - demotes the team's previous creator (the lending SLP) to
+  #     `supervisor` — matching what claim_by! now does going forward.
+  #
+  # Conservative: only acts when the communicator's OWN team is
+  # identifiable (pinned id, namesake name, or the team where this
+  # communicator is the only account). A communicator that only appears on
+  # a shared team is skipped and logged, so we never hijack someone else's
+  # team. Idempotent.
+  #
+  # Dry-run by default. Apply with DRY_RUN=false. Optionally scope to one
+  # owner with USER_ID=N:
+  #   rake communicators:repair_handoff_teams                    # preview all
+  #   DRY_RUN=false rake communicators:repair_handoff_teams      # apply all
+  #   DRY_RUN=false USER_ID=740 rake communicators:repair_handoff_teams
+  desc "Repair stale handoff team membership/ownership on claimed communicators (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task repair_handoff_teams: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    scope = ChildAccount
+      .where(status: ChildAccount::ACTIVE)
+      .where.not(claimed_at: nil)
+      .where.not(owner_id: nil)
+    scope = scope.where(owner_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    repaired = 0
+    skipped = 0
+
+    scope.find_each do |ca|
+      owner = ca.owner
+      next if owner.nil?
+
+      team = handoff_repair_own_team(ca)
+      if team.nil?
+        skipped += 1
+        puts "#{dry_run ? '[DRY RUN] ' : ''}communicator ##{ca.id} #{ca.name.inspect} (owner #{owner.id}) — SKIP: no own team identifiable"
+        next
+      end
+
+      previous_creator_id = team.created_by_id
+      actions = []
+      actions << "pin primary_team=#{team.id}" if ca.settings&.dig("primary_team_id") != team.id
+
+      owner_tu = team.team_users.find_by(user_id: owner.id)
+      actions << (owner_tu ? "owner #{owner.id} #{owner_tu.role}->admin" : "add owner #{owner.id} as admin") if owner_tu&.role != "admin"
+
+      actions << "transfer team owner #{previous_creator_id}->#{owner.id}" if previous_creator_id != owner.id
+
+      demote_id = (previous_creator_id != owner.id) ? previous_creator_id : nil
+      if demote_id
+        demote_tu = team.team_users.find_by(user_id: demote_id)
+        actions << "prev owner #{demote_id} #{demote_tu&.role || 'none'}->supervisor" if demote_tu&.role != "supervisor"
+      end
+
+      if actions.empty?
+        puts "#{dry_run ? '[DRY RUN] ' : ''}communicator ##{ca.id} #{ca.name.inspect} (team ##{team.id}) — already correct"
+        next
+      end
+
+      puts "#{dry_run ? '[DRY RUN] ' : ''}communicator ##{ca.id} #{ca.name.inspect} (team ##{team.id} #{team.name.inspect}): #{actions.join('; ')}"
+
+      unless dry_run
+        ActiveRecord::Base.transaction do
+          ca.pin_primary_team!(team)
+          team.upsert_member!(owner, "admin")
+          team.upsert_member!(User.find_by(id: demote_id), "supervisor") if demote_id
+          team.update!(created_by_id: owner.id) if previous_creator_id != owner.id
+        end
+        repaired += 1
+      end
+    end
+
+    if dry_run
+      puts "Dry run only (#{skipped} skipped) — re-run with DRY_RUN=false to apply."
+    else
+      puts "Repaired #{repaired} communicator(s); skipped #{skipped}."
+    end
+  end
+end
+
+# Resolve a communicator's OWN team for the handoff repair, conservatively.
+# Returns the pinned team, else the namesake team, else the single team
+# where this communicator is the only account, else nil (do not guess).
+def handoff_repair_own_team(child_account)
+  pinned_id = child_account.settings&.dig("primary_team_id")
+  if pinned_id
+    pinned = child_account.teams.find_by(id: pinned_id)
+    return pinned if pinned
+  end
+
+  namesake = child_account.namesake_team
+  return namesake if namesake
+
+  child_account.teams.find { |team| team.account_ids == [child_account.id] }
 end

--- a/spec/lib/tasks/repair_handoff_teams_rake_spec.rb
+++ b/spec/lib/tasks/repair_handoff_teams_rake_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# Repair task for the hand-off team-membership bug. Reconstructs a stale
+# post-claim state (new owner missing from the communicator's own team) and
+# verifies the task heals it without touching unrelated shared teams.
+RSpec.describe "communicators:repair_handoff_teams", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["communicators:repair_handoff_teams"] }
+  let(:old_owner) { create(:user, plan_type: "pro", created_at: 3.months.ago) }
+  let(:new_owner) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  after do
+    task.reenable
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+  end
+
+  # An active communicator whose OWN (namesake) team was never updated at
+  # claim time: it still has only the previous owner as admin.
+  def broken_handoff(name: "Newton")
+    ca = create(:child_account, user: new_owner, owner: new_owner, status: "active",
+                                passcode: "x", name: name, claimed_at: 1.day.ago)
+    namesake = Team.create!(name: "#{name}'s Communication Team", created_by: old_owner)
+    TeamAccount.create!(team: namesake, account: ca)
+    namesake.upsert_member!(old_owner, "admin")
+    [ca.reload, namesake]
+  end
+
+  def silent
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  it "dry-run reports but does not mutate" do
+    ca, namesake = broken_handoff
+
+    silent { task.invoke }
+
+    expect(namesake.team_users.find_by(user_id: new_owner.id)).to be_nil
+    expect(namesake.reload.created_by_id).to eq(old_owner.id)
+    expect(ca.reload.settings["primary_team_id"]).to be_nil
+  end
+
+  it "repairs the own team: new owner admin, prev owner supervisor, ownership transferred" do
+    ca, namesake = broken_handoff
+    ENV["DRY_RUN"] = "false"
+
+    silent { task.invoke }
+
+    expect(namesake.team_users.find_by(user_id: new_owner.id)&.role).to eq("admin")
+    expect(namesake.team_users.find_by(user_id: old_owner.id)&.role).to eq("supervisor")
+    expect(namesake.reload.created_by_id).to eq(new_owner.id)
+    expect(ca.reload.settings["primary_team_id"]).to eq(namesake.id)
+  end
+
+  it "leaves an unrelated shared team alone" do
+    ca, _namesake = broken_handoff
+    shared = Team.create!(name: "Shared Crew", created_by: old_owner)
+    TeamAccount.create!(team: shared, account: ca)
+    # Make it genuinely shared (a second account), so it can't be mistaken
+    # for this communicator's own team.
+    other = create(:child_account, user: old_owner, owner: old_owner, status: "active",
+                                   passcode: "y", username: "other-#{SecureRandom.hex(2)}")
+    TeamAccount.create!(team: shared, account: other)
+    shared.upsert_member!(old_owner, "admin")
+    ENV["DRY_RUN"] = "false"
+
+    silent { task.invoke }
+
+    expect(shared.team_users.find_by(user_id: new_owner.id)).to be_nil
+    expect(shared.reload.created_by_id).to eq(old_owner.id)
+  end
+
+  it "skips a communicator with no identifiable own team" do
+    # Active claimed communicator that only lives on a shared team.
+    ca = create(:child_account, user: new_owner, owner: new_owner, status: "active",
+                                passcode: "x", claimed_at: 1.day.ago, name: "Lonely")
+    shared = Team.create!(name: "Shared Crew", created_by: old_owner)
+    TeamAccount.create!(team: shared, account: ca)
+    other = create(:child_account, user: old_owner, owner: old_owner, status: "active",
+                                   passcode: "y", username: "o-#{SecureRandom.hex(2)}")
+    TeamAccount.create!(team: shared, account: other)
+    shared.upsert_member!(old_owner, "admin")
+    ENV["DRY_RUN"] = "false"
+
+    silent { task.invoke }
+
+    expect(shared.team_users.find_by(user_id: new_owner.id)).to be_nil
+    expect(ca.reload.settings["primary_team_id"]).to be_nil
+  end
+
+  it "is idempotent — a second run makes no further changes" do
+    ca, namesake = broken_handoff
+    ENV["DRY_RUN"] = "false"
+
+    silent { task.invoke }
+    task.reenable
+    expect { silent { task.invoke } }.not_to(change { namesake.reload.updated_at })
+    expect(namesake.reload.created_by_id).to eq(new_owner.id)
+    expect(ca.reload.settings["primary_team_id"]).to eq(namesake.id)
+  end
+end

--- a/spec/models/child_account_handoff_team_spec.rb
+++ b/spec/models/child_account_handoff_team_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for the hand-off team-membership bug: claim_by! used
+# `teams.first`, which is unreliable when a communicator belongs to more than
+# one team — the hand-off updated the wrong team and left the communicator's
+# OWN team with the new owner missing. See ChildAccount#primary_team and the
+# `communicators:repair_handoff_teams` rake task.
+RSpec.describe ChildAccount, "hand-off team membership", type: :model do
+  let(:slp) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  def make_parent(plan)
+    u = create(:user, plan_type: plan, created_at: 2.months.ago)
+    case plan
+    when "free"  then u.setup_free_limits
+    when "basic" then u.setup_basic_limits
+    when "pro"   then u.setup_pro_limits
+    end
+    u.save!
+    u
+  end
+
+  # A loaner that belongs to TWO teams, mimicking production: an unrelated
+  # shared team created first (so it sorts first by id), plus the
+  # communicator's own namesake team. No primary_team_id is pinned, so this
+  # exercises the namesake-name fallback (the legacy-data path).
+  def loaner_on_two_teams(name: "Newton")
+    loaner = create(:child_account, user: slp, owner: slp, status: "loaner",
+                                    passcode: "loaner01", name: name)
+    shared = Team.create!(name: "Shared Crew", created_by: slp)
+    TeamAccount.create!(team: shared, account: loaner)
+    shared.upsert_member!(slp, "admin")
+
+    namesake = Team.create!(name: "#{name}'s Communication Team", created_by: slp)
+    TeamAccount.create!(team: namesake, account: loaner)
+    namesake.upsert_member!(slp, "admin")
+
+    [loaner.reload, shared, namesake]
+  end
+
+  describe "#primary_team resolution" do
+    it "prefers the namesake team over an earlier-created shared team" do
+      loaner, shared, namesake = loaner_on_two_teams
+
+      # `teams.first` (the old behavior) would return the shared team.
+      expect(loaner.teams.order(:id).first).to eq(shared)
+      expect(loaner.primary_team).to eq(namesake)
+    end
+
+    it "prefers a pinned primary_team_id over the namesake name" do
+      loaner, shared, _namesake = loaner_on_two_teams
+      loaner.pin_primary_team!(shared)
+
+      expect(loaner.reload.primary_team).to eq(shared)
+    end
+  end
+
+  describe "#ensure_team! pins the created team" do
+    it "records primary_team_id so resolution is unambiguous" do
+      loaner = create(:child_account, user: slp, owner: slp, status: "loaner", passcode: "x")
+      team = loaner.ensure_team!(creator: slp)
+
+      expect(loaner.reload.settings["primary_team_id"]).to eq(team.id)
+      expect(loaner.primary_team).to eq(team)
+    end
+  end
+
+  describe "#claim_by! across plan tiers" do
+    %w[free basic pro].each do |plan|
+      context "Pro SLP -> #{plan} family" do
+        it "updates the communicator's OWN team and leaves shared teams alone" do
+          loaner, shared, namesake = loaner_on_two_teams
+          parent = make_parent(plan)
+
+          loaner.claim_by!(user: parent)
+
+          # Ownership transferred on the account itself.
+          expect(loaner.reload.owner_id).to eq(parent.id)
+          expect(loaner.status).to eq("active")
+
+          # Own (namesake) team: new owner admin, old owner supervisor.
+          expect(namesake.team_users.find_by(user_id: parent.id)&.role).to eq("admin")
+          expect(namesake.team_users.find_by(user_id: slp.id)&.role).to eq("supervisor")
+
+          # Team management transferred to the new owner.
+          expect(namesake.reload.created_by_id).to eq(parent.id)
+
+          # primary_team pinned to the namesake team.
+          expect(loaner.reload.settings["primary_team_id"]).to eq(namesake.id)
+
+          # The unrelated shared team is untouched.
+          expect(shared.team_users.find_by(user_id: parent.id)).to be_nil
+          expect(shared.reload.created_by_id).to eq(slp.id)
+          expect(shared.team_users.find_by(user_id: slp.id).role).to eq("admin")
+        end
+      end
+    end
+
+    it "creates and uses an own team when the communicator has none" do
+      loaner = create(:child_account, user: slp, owner: slp, status: "loaner", passcode: "x")
+      parent = make_parent("pro")
+
+      loaner.claim_by!(user: parent)
+
+      team = loaner.reload.primary_team
+      expect(team).to be_present
+      expect(team.team_users.find_by(user_id: parent.id)&.role).to eq("admin")
+      expect(team.team_users.find_by(user_id: slp.id)&.role).to eq("supervisor")
+      expect(team.created_by_id).to eq(parent.id)
+      expect(loaner.settings["primary_team_id"]).to eq(team.id)
+    end
+  end
+end

--- a/spec/requests/api/child_accounts_lend_pro_gate_spec.rb
+++ b/spec/requests/api/child_accounts_lend_pro_gate_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Lending / hand-off is a Pro-only feature. The gate must hold server-side,
+# not only in the frontend LoanerControls. See
+# API::ChildAccountsController#require_pro_for_lending!.
+RSpec.describe "API::ChildAccounts lending Pro gate", type: :request do
+  def sandbox_owned_by(owner)
+    create(:child_account, user: owner, owner: owner, status: "sandbox", passcode: nil)
+  end
+
+  describe "POST /lend" do
+    it "rejects a Basic owner with 403 pro_required and leaves the status unchanged" do
+      owner = create(:user, plan_type: "basic", created_at: 2.months.ago)
+      sandbox = sandbox_owned_by(owner)
+
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("pro_required")
+      expect(sandbox.reload.status).to eq("sandbox")
+    end
+
+    it "rejects a Free owner with 403" do
+      owner = create(:user, plan_type: "free", created_at: 2.months.ago)
+      sandbox = sandbox_owned_by(owner)
+
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "allows a Pro owner to lend (sandbox -> loaner)" do
+      owner = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      owner.setup_pro_limits
+      owner.save!
+      sandbox = sandbox_owned_by(owner)
+
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(sandbox.reload.status).to eq("loaner")
+    end
+
+    it "blocks a Basic owner from lending a self-created active (active -> loaner path)" do
+      owner = create(:user, plan_type: "basic", created_at: 2.months.ago)
+      active = create(:child_account, user: owner, owner: owner, status: "active",
+                                      passcode: "x", username: "act-#{SecureRandom.hex(2)}")
+
+      post "/api/child_accounts/#{active.id}/lend", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(active.reload.status).to eq("active")
+    end
+
+    it "returns Unauthorized (not the Pro gate) for a non-owner, so the gate isn't leaked" do
+      owner = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      sandbox = sandbox_owned_by(owner)
+      other = create(:user, plan_type: "basic")
+
+      post "/api/child_accounts/#{sandbox.id}/lend", headers: auth_headers(other)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "POST /promote_to_loaner" do
+    it "rejects a Basic owner with 403 pro_required" do
+      owner = create(:user, plan_type: "basic", created_at: 2.months.ago)
+      sandbox = sandbox_owned_by(owner)
+
+      post "/api/child_accounts/#{sandbox.id}/promote_to_loaner", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("pro_required")
+      expect(sandbox.reload.status).to eq("sandbox")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the SLP→family communicator hand-off so the new owner lands on the **right** team, and enforces "only Pro can lend" on the backend.

**Root cause:** `ChildAccount#claim_by!` updated `teams.first`, which is unreliable when a communicator belongs to more than one team (its own namesake team + any shared/board team it's been added to). The hand-off updated the wrong team, leaving the communicator's own team with only the previous owner — the new owner was missing.

### Changes
- **Deterministic own-team resolution** (`child_account.rb`): `primary_team` now resolves pinned `settings["primary_team_id"]` → namesake team (`"<name>'s Communication Team"`) → oldest team (legacy fallback). `ensure_team!` and `claim_by!` pin the id so it stays stable across renames/join order.
- **`claim_by!`**: acts on the own team — new owner → `admin`, previous owner → `supervisor`, and **team ownership (`created_by_id`) transfers to the new owner** so they get `is_owner`/`can_invite` (the "Manage team" controls).
- **Pro gate** (`child_accounts_controller.rb`): `lend` and `promote_to_loaner` return **403 `pro_required`** for non-Pro non-admin callers — checked *after* the ownership check so the gate isn't leaked to non-owners. Covers the `active→loaner` lend path that skipped the slot check. Frontend Pro gate is now defense-in-depth.
- **Repair task** (`communicators.rake`): `rake communicators:repair_handoff_teams` (dry-run by default; `DRY_RUN=false`, `USER_ID=N`) heals already-claimed communicators. Conservatively **skips** any communicator with no positively-identifiable own team, so shared teams are never touched.
- Docs: backend `CLAUDE.md` "Team permissions" section + `CHANGELOG.md`.

### Post-deploy
Run `DRY_RUN=false rake communicators:repair_handoff_teams` to fix existing claimed accounts (preview without the flag first).

## Test plan
New specs + regression sweep of existing claim/team/promote/onboarding suites — **123 examples, 0 failures**:
- `spec/models/child_account_handoff_team_spec.rb` — Pro→Free / Pro→Basic / Pro→Pro hand-off, own-team-vs-shared-team regression, `primary_team` resolution, `ensure_team!` pinning.
- `spec/requests/api/child_accounts_lend_pro_gate_spec.rb` — Basic/Free → 403, Pro → 200, active→loaner blocked for Basic, non-owner still 401.
- `spec/lib/tasks/repair_handoff_teams_rake_spec.rb` — dry-run no-op, repair, shared-team untouched, skip-when-no-own-team, idempotency.
- Existing: `child_account_claim_spec`, `child_account_ensure_team_spec`, `child_account_promote_to_loaner_spec`, `child_accounts_claim_spec`, `child_accounts_promote_spec`, `team_permissions_spec`, `child_accounts_owner_protection_spec`, `team_upsert_member_spec`, `team_user_spec`, `v1/onboarding/myspeak_spec`.

## Follow-ups (not in this PR)
- `marketing/.claude-notes/handoff-workflow.md` (separate repo) should be synced with the new multi-team + Pro-gate behavior.
- Investigate *why* a communicator ended up on a second/shared team in the first place (creation-path question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)