### PR TITLE
feat(staging): decouple staging from the prod box (#393)

### DIFF
--- a/.github/workflows/staging-sync-env.yml
+++ b/.github/workflows/staging-sync-env.yml
@@ -24,7 +24,15 @@ jobs:
           HATCHBOX_STAGING_APP_ID: ${{ secrets.HATCHBOX_STAGING_APP_ID }}
 
           # ---- Literals (staging-specific or shared with prod) ----
+          # CUTOVER (issue #393): when the new staging box's Hatchbox app is
+          # created, it gets a NEW <subdomain>.hatchboxapp.com. Update the host
+          # in STAGING_HOST + the 5 URL literals below to that subdomain, set the
+          # HATCHBOX_STAGING_APP_ID secret to the new app id, then re-run this
+          # workflow. STAGING_HOST is what the Rails app reads (config/environments/
+          # production.rb + cors.rb); leaving it at the legacy value is safe until
+          # cutover.
           STAGING: "true"
+          STAGING_HOST: ypk9e.hatchboxapp.com
           API_URL: https://ypk9e.hatchboxapp.com
           DOMAIN: https://ypk9e.hatchboxapp.com
           FRONT_END_URL: https://ypk9e.hatchboxapp.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Serializers:** jsonapi-serializer gem
 - **Hosting:** Hatchbox / EC2
   - Production: `main` branch → `speakanyway.com` (Hatchbox app `670kd.hatchboxapp.com`)
-  - Staging: `staging` branch → `https://ypk9e.hatchboxapp.com`. **Deploy branch, not a development branch** — it mirrors `main`. Promote by force-pushing `origin/main` onto `staging` and then running the `Deploy staging (manual)` workflow via `workflow_dispatch` (see `.github/workflows/staging-deploy.yml`) — pushing to `staging` alone does NOT trigger a deploy; the workflow is what fires the Hatchbox deploy. (Brittany's `deploy-staging` skill does both steps.) Any commits on `staging` that aren't on `main` are treated as drift and will be wiped by the next promotion's force-push — don't push experimental work there expecting it to survive. Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`. Use the `AppEnv.staging?` helper (`app/models/app_env.rb`) for this check in app code.
+  - Staging: `staging` branch → its own Hatchbox app on a **separate, dedicated EC2 instance** (issue #393 — staging no longer shares the production box, so a staging test can't starve prod of CPU/RAM). **Deploy branch, not a development branch** — it mirrors `main`. Promote by force-pushing `origin/main` onto `staging` and then running the `Deploy staging (manual)` workflow via `workflow_dispatch` (see `.github/workflows/staging-deploy.yml`) — pushing to `staging` alone does NOT trigger a deploy; the workflow is what fires the Hatchbox deploy (via the Hatchbox API + `HATCHBOX_STAGING_APP_ID`/deploy-hook secrets — **box-independent**, so moving staging to a new server only requires updating those secrets, not the workflow). (Brittany's `deploy-staging` skill does both steps.) Any commits on `staging` that aren't on `main` are treated as drift and will be wiped by the next promotion's force-push — don't push experimental work there expecting it to survive. Staging-specific behavior is gated on `ENV["STAGING"] == "true"` — both envs run with `RAILS_ENV=production`. Use the `AppEnv.staging?` helper (`app/models/app_env.rb`) for this check in app code. The staging **host** is ENV-driven via `STAGING_HOST` (defaults to the legacy `ypk9e.hatchboxapp.com`; read by `config/environments/production.rb` + `config/initializers/cors.rb`), so a new Hatchbox app/subdomain needs only an env-var change (set `STAGING_HOST` + the URL literals in `.github/workflows/staging-sync-env.yml` and re-run the env sync), not a code change.
   - **Staging skips paid OpenAI image calls.** When `AppEnv.staging?`, `OpenAiClient#create_image` / `#create_image_variation`, `ImageVariationService`, and `ImageEditService` return the bundled `public/placeholder.jpeg` instead of calling OpenAI. The rest of the image pipeline runs normally.
 
 ## Frontend
@@ -83,7 +83,10 @@ backlog size (default 200).
 - `DiskSpaceAlertJob` (`app/sidekiq/`) runs hourly via sidekiq-cron and
   emails an admin (`ADMIN_EMAIL`) when the root disk crosses 80% (warn) or
   90% (critical). Alerts are debounced in Redis to once per severity per 6h.
-  Skipped on staging, since staging shares the production EC2 box. Added
+  Runs on **both** prod and staging — since #393 staging is its own EC2 box,
+  so it monitors its own disk (its debounce keys live in its own Redis, no
+  cross-env collision). It was skipped on staging before, when staging shared
+  the prod box and the job would have duplicated every prod alert. Added
   after a disk-full outage wedged the box during a deploy.
 - **External `/up` monitor (BetterStack):** HTTP monitor hits
   `https://670kd.hatchboxapp.com/up` (prod) every 3 min. Pages on failure
@@ -92,9 +95,12 @@ backlog size (default 200).
   `config/routes.rb`. Catches failure modes the in-app jobs can't: wedged
   puma (the 2026-05-30 outage), nginx/DNS/network, full-box down.
   Configured in BetterStack's UI; nothing in this repo to change when
-  tuning the monitor. Staging is intentionally not monitored — it shares
-  the prod box, so a prod alert covers both. Added after the 2026-05-30
-  outage where puma was alive per systemd but all threads were wedged.
+  tuning the monitor. Staging is **not** currently externally monitored. This
+  was fine when staging shared the prod box (a prod page covered both), but
+  since #393 staging is its own box — adding a separate BetterStack monitor
+  on the staging `/up` is a reasonable follow-up (external UI config, no repo
+  change). Added after the 2026-05-30 outage where puma was alive per systemd
+  but all threads were wedged.
 
 ## Safety-profile view alerts (issue #384)
 

--- a/app/services/board_screenshot_vision_service.rb
+++ b/app/services/board_screenshot_vision_service.rb
@@ -85,9 +85,9 @@ class BoardScreenshotVisionService
 
     @logger.debug "[BoardScreenshotVisionService] Parsing board from #{image_path} (forced_cols=#{forced_cols || "auto"})"
 
-    # Staging shares the prod box and uses real API keys, but we don't want to
-    # spend on paid OpenAI vision (or burn real credits) for QA. Mirror the
-    # image-generation placeholder short-circuit and return a deterministic grid.
+    # Staging uses real API keys, but we don't want to spend on paid OpenAI
+    # vision (or burn real credits) for QA. Mirror the image-generation
+    # placeholder short-circuit and return a deterministic grid.
     return staged_stub(forced_cols) if AppEnv.staging?
 
     data_url = encode_image_as_data_url(image_path)

--- a/app/sidekiq/disk_space_alert_job.rb
+++ b/app/sidekiq/disk_space_alert_job.rb
@@ -5,8 +5,9 @@
 # where the production disk filled silently and wedged the box during a deploy.
 #
 # Alerts are debounced through Redis so a sustained high-disk condition emails
-# at most once per severity per DEBOUNCE_WINDOW. Staging is skipped — it shares
-# the same EC2 box as production and would otherwise duplicate every alert.
+# at most once per severity per DEBOUNCE_WINDOW. Runs on both production and
+# staging — since #393 staging is its own EC2 box (no longer the prod box), so
+# it monitors its own disk and its debounce keys live in its own Redis.
 class DiskSpaceAlertJob
   include Sidekiq::Job
   sidekiq_options queue: :default, retry: 2
@@ -16,8 +17,6 @@ class DiskSpaceAlertJob
   DEBOUNCE_WINDOW = 6.hours.to_i
 
   def perform
-    return if AppEnv.staging?
-
     usage = root_disk_usage_percent
     return if usage.nil?
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,11 @@
 require "active_support/core_ext/integer/time"
 
+# Staging runs with RAILS_ENV=production + STAGING=true on its own EC2 box
+# (issue #393). The staging host is ENV-driven so a future Hatchbox app/subdomain
+# change needs no code change; defaults to the legacy subdomain for safety.
 staging = ENV["STAGING"] == "true"
-primary_host = staging ? "ypk9e.hatchboxapp.com" : "speakanyway.com"
+staging_host = ENV.fetch("STAGING_HOST", "ypk9e.hatchboxapp.com")
+primary_host = staging ? staging_host : "speakanyway.com"
 
 Rails.application.routes.default_url_options[:host] = primary_host
 Rails.application.routes.default_url_options[:protocol] = "https"
@@ -60,12 +64,12 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
-  config.action_cable.url = staging ? "wss://ypk9e.hatchboxapp.com/cable" : "wss://670kd.hatchboxapp.com/cable"
+  config.action_cable.url = staging ? "wss://#{staging_host}/cable" : "wss://670kd.hatchboxapp.com/cable"
   config.action_cable.allowed_request_origins = [
     "https://app.speakanyway.com",  # SPA/PWA
     "https://www.speakanyway.com",
     "https://speakanyway.com",
-    "https://ypk9e.hatchboxapp.com", # staging
+    "https://#{staging_host}", # staging
     /https:\/\/.*\.speakanyway\.com/,
     "capacitor://localhost",         # Capacitor iOS/Android WebView
     %r{\Ahttps://([a-z0-9-]+--)?speakanyway\.netlify\.app\z}, # Netlify previews + branch deploys
@@ -105,7 +109,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.default_url_options = {
-    host: staging ? "ypk9e.hatchboxapp.com" : "670kd.hatchboxapp.com",
+    host: staging ? staging_host : "670kd.hatchboxapp.com",
     protocol: "https",
   }
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,6 +5,10 @@
 
 # # Read more: https://github.com/cyu/rack-cors
 
+# Staging host is ENV-driven (issue #393) so a Hatchbox app/subdomain change
+# needs no code change; defaults to the legacy subdomain for safety.
+staging_host = ENV.fetch("STAGING_HOST", "ypk9e.hatchboxapp.com")
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins("http://localhost:8100",
@@ -12,7 +16,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
             "https://www.speakanyway.com",
             "https://app.speakanyway.com",
             "http://app.speakanyway.com",
-            "https://ypk9e.hatchboxapp.com",
+            "https://#{staging_host}",
             "capacitor://localhost",
             "https://localhost",
             "http://localhost",

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -28,9 +28,9 @@ module MailchimpClient
   end
 
   # Journeys send real email to real contacts, so they only fire where intended.
-  # Production fires automatically; staging (shares the prod box) and dev/test
-  # stay off unless MAILCHIMP_JOURNEYS_ENABLED is explicitly set (used for
-  # end-to-end verification against the test audience).
+  # Production fires automatically; staging (a separate non-prod environment) and
+  # dev/test stay off unless MAILCHIMP_JOURNEYS_ENABLED is explicitly set (used
+  # for end-to-end verification against the test audience).
   def self.journeys_enabled?
     return true if ENV["MAILCHIMP_JOURNEYS_ENABLED"] == "true"
 

--- a/config/initializers/posthog.rb
+++ b/config/initializers/posthog.rb
@@ -31,8 +31,9 @@ module PosthogClient
   end
 
   # Server-side capture only fires where intended. Production fires
-  # automatically; staging (shares the prod box) and dev/test stay off unless
-  # POSTHOG_CAPTURE_ENABLED is explicitly set (used for end-to-end verification).
+  # automatically; staging (a separate non-prod environment) and dev/test stay
+  # off unless POSTHOG_CAPTURE_ENABLED is explicitly set (used for end-to-end
+  # verification).
   # Also requires an API key to be present.
   def self.enabled?
     return false if ENV["POSTHOG_API_KEY"].blank?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -34,7 +34,7 @@ Sidekiq.configure_server do |config|
       "cron" => "0 * * * *",
       "class" => "DiskSpaceAlertJob",
       "queue" => "default",
-      "description" => "Hourly root-disk check; emails an admin at 80% (warn) / 90% (critical). Skipped on staging.",
+      "description" => "Hourly root-disk check; emails an admin at 80% (warn) / 90% (critical). Runs on prod and staging (since #393 staging is its own box).",
     },
     "loaner_reclaim" => {
       "cron" => "30 2 * * *",

--- a/script/hatchbox/staging_env_vars.yml
+++ b/script/hatchbox/staging_env_vars.yml
@@ -24,6 +24,7 @@ vars:
   - WEB_CONCURRENCY
 
   # ---- App URLs ----
+  - STAGING_HOST               # ypk9e.hatchboxapp.com (host only; read by production.rb + cors.rb)
   - API_URL                    # https://ypk9e.hatchboxapp.com
   - DOMAIN                     # https://ypk9e.hatchboxapp.com
   - FRONT_END_URL              # https://ypk9e.hatchboxapp.com

--- a/spec/sidekiq/disk_space_alert_job_spec.rb
+++ b/spec/sidekiq/disk_space_alert_job_spec.rb
@@ -40,9 +40,12 @@ RSpec.describe DiskSpaceAlertJob, type: :sidekiq do
     end
 
     context "on staging" do
-      it "sends no email even when the disk is critical" do
+      # Since #393 staging is its own EC2 box, so it monitors its own disk
+      # (no longer skipped — it shared the prod box before).
+      it "still alerts when the disk is critical" do
         allow(AppEnv).to receive(:staging?).and_return(true)
-        expect { perform_with_usage(95) }.not_to change { ActionMailer::Base.deliveries.size }
+        allow(job).to receive(:claim_alert_slot).and_return(true)
+        expect { perform_with_usage(95) }.to change { ActionMailer::Base.deliveries.size }.by(1)
       end
     end
 


### PR DESCRIPTION
Closes #393 (Phase 2b of scaling roadmap #390).

## Why
Staging currently shares the prod `t3.medium`, so a staging test can starve prod web/DB of CPU/RAM. Goal: staging on its own small instance, where a staging action can never degrade production.

## Key finding: the deploy path is already box-independent
The `Deploy staging (manual)` workflow fires Hatchbox via its API (`HATCHBOX_STAGING_APP_ID` / `HATCHBOX_STAGING_DEPLOY_HOOK` secrets), and Hatchbox owns server placement. So "point the deploy at the new box" is a **Hatchbox-side + secrets** action, not a workflow change. The code touch-points are just the hardcoded staging host and the "shares the prod box" rationale baked into a few gates/comments.

## What this PR changes (code/config — small)
- **Staging host is now ENV-driven (`STAGING_HOST`)**, defaulting to the legacy `ypk9e.hatchboxapp.com`, in `config/environments/production.rb` (primary host, Action Cable URL + origin, mailer host) and `config/initializers/cors.rb`. A new Hatchbox app/subdomain now needs only an env-var change. Wired `STAGING_HOST` into `script/hatchbox/staging_env_vars.yml` + `staging-sync-env.yml` with an explicit **cutover checklist** comment.
- **`DiskSpaceAlertJob` now runs on staging** (removed the `AppEnv.staging?` skip). It was only skipped to avoid duplicate alerts on the shared prod box; staging now has its own box + Redis, so it monitors its own disk.
- **Corrected stale "shares the prod box" comments** in the Mailchimp-journeys gate, PostHog gate, and board-screenshot vision stub. **Gating logic is unchanged** — staging must still not email real users, pollute analytics, or spend on paid OpenAI; only the *rationale* text changed.
- **CLAUDE.md** hosting + monitoring sections updated to describe the separate box, the box-independent deploy, `STAGING_HOST`, and staging disk monitoring.

## Cutover steps for the operator (provisioning side — not in this PR)
1. Provision the small staging instance + create its Hatchbox app (DB/Redis on the new box).
2. Set the `HATCHBOX_STAGING_APP_ID` (and/or `HATCHBOX_STAGING_DEPLOY_HOOK`) GitHub secret to the new app.
3. In `staging-sync-env.yml`, set `STAGING_HOST` + the 5 URL literals to the new `<subdomain>.hatchboxapp.com`; run **Sync staging env vars to Hatchbox**.
4. Run **Deploy staging (manual)** → verifies the end-to-end `deploy-staging` flow against the new box.
5. Confirm the prod box no longer runs `itty-bitty-boards-*` staging units.
6. (Optional follow-up) Add a BetterStack `/up` monitor for the staging box.

## Test plan / relevance
- Updated `spec/sidekiq/disk_space_alert_job_spec.rb` — the "on staging" case now asserts staging **alerts** (was: skipped). `bundle exec rspec spec/sidekiq/disk_space_alert_job_spec.rb` → **6 examples, 0 failures**.
- The host changes only take effect under `RAILS_ENV=production` (not bootable locally without prod secrets), so they're verified by `ruby -c` syntax checks + YAML load checks; they're config wiring, not unit-testable logic.
- Comment-only changes (Mailchimp/PostHog gates, vision stub) are behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)