### PR TITLE
test(preview-job): decouple preset URL assertion from storage backend

### DIFF
--- a/spec/sidekiq/generate_board_preview_job_spec.rb
+++ b/spec/sidekiq/generate_board_preview_job_spec.rb
@@ -20,12 +20,16 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
     board.reload
     expect(board.preview_image).to be_attached
     expect(board.preview_image.key).to eq("board_previews/#{board.id}/preview.png")
-    # In production the URL is the stable CDN form; in test we go through the
-    # Disk service, which signs each URL with a fresh timestamp so two calls
-    # don't return string-equal results. Asserting the preset was written and
-    # points at the Active Storage disk route is enough to prove intent.
+    # The preset must point at the generated preview blob, but the exact URL
+    # form depends on the configured storage backend: the Disk service yields a
+    # signed /rails/active_storage/ route (CI default), while an S3/CDN-backed
+    # environment (ACTIVE_STORAGE_SERVICE=amazon + CDN_HOST, as some local
+    # setups use) yields a CloudFront URL built from the blob key. Accept either
+    # so the test isn't coupled to a developer's local storage config.
     expect(board.settings["preset_display_image_url"]).to be_present
-    expect(board.settings["preset_display_image_url"]).to match(%r{/rails/active_storage/})
+    expect(board.settings["preset_display_image_url"]).to match(
+      %r{/rails/active_storage/|board_previews/#{board.id}/preview\.png},
+    )
   end
 
   it "does not modify the board's display_image_url" do


### PR DESCRIPTION
## Summary

`spec/sidekiq/generate_board_preview_job_spec.rb` failed locally for any developer whose Active Storage points at S3/CDN (`ACTIVE_STORAGE_SERVICE=amazon` + `CDN_HOST`). The test asserted `preset_display_image_url` matches the Disk-service route `/rails/active_storage/`, but with an S3/CDN backend the URL is the CloudFront form built from the blob key (`https://…cloudfront.net/board_previews/<id>/preview.png?v=…`), so it didn't match.

CI (Disk service) always passed; this only bit local runs with a prod-like storage config. Loosen the assertion to accept **either** form so it proves intent (the preset points at the generated preview blob) without coupling to the storage backend.

## Test plan
- `bundle exec rspec spec/sidekiq/generate_board_preview_job_spec.rb` → green under a local S3/CDN config (was failing there) and under Disk (CI).
- `bundle exec rspec spec/sidekiq/generate_board_preview_job_spec.rb spec/models/user_plan_limits_spec.rb` → 15 examples, 0 failures.

## Note (not in this PR)
The other locally-failing spec — `user_plan_limits_spec` expecting Pro `paid_communicator_limit` = 5 — is **not** a code/test bug. The constant defaults to 5 (the 2026-05-31 pricing bump) and CI passes. It only failed on a local checkout whose gitignored `config/application.yml` still had the pre-bump `PRO_PAID_COMMUNICATOR_LIMIT: "3"`. That's stale local config, fixed locally (not committable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)