### PR TITLE
feat(handoff): preserve inherited boards as team boards + non-destructive removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `profile_views` for the audit trail; only the email is throttled. Parent-alert
   email copy updated from "safety page was viewed" to "emergency info was
   opened" (en + es). Issue #384 follow-up.
+### Fixed — Removing a hand-off board no longer deletes it
+- After a communicator is transferred, the new owner can clear/curate the
+  dashboard without losing boards. On hand-off, the communicator's boards are
+  registered as **team boards**, and "remove from dashboard" (`DELETE
+  /api/child_boards/:id`) now **detaches** the board instead of deleting it —
+  it stays available via the team to re-add. The board is only hard-deleted when
+  it's a throwaway template clone that nothing else references. Dashboard board
+  entries also expose a `can_remove` flag (keyed to communicator ownership) so
+  the new owner sees the remove control. `rake communicators:repair_handoff_teams`
+  backfills the team-board safety net for already-claimed communicators.
+
 ### Fixed — Communicator hand-off now updates the right team
 - When a family claimed a loaned communicator, the new owner was sometimes added
   to the wrong team (the communicator's *own* team was left with only the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -840,6 +840,35 @@ out of scope for #166.
 known backend-enforcement gaps — lives in
 `marketing/.claude-notes/handoff-workflow.md`. Keep that doc and this
 section in sync when the rules change.
+
+### Board removal after hand-off (non-destructive)
+
+Boards put on a communicator via `assign_boards` are **cloned** (a new
+`Board` marked `is_template: true`, owned by the user who added them — the
+SLP), referenced by a `ChildBoard` join. After a hand-off the new owner
+should be able to clear/curate the dashboard **without losing boards**.
+
+- **On claim, `claim_by!` registers the communicator's current dashboard
+  boards as team boards** (`register_dashboard_boards_on_team!`) on its own
+  team. While a board is on the dashboard it's excluded from
+  `available_teams_boards` (no duplicate); once removed it reappears there,
+  re-addable. The `repair_handoff_teams` rake task backfills this for
+  already-claimed communicators.
+- **Removal is non-destructive.** `DELETE /api/child_boards/:id`
+  (`ChildBoardsController#destroy`) always detaches the `ChildBoard`, and
+  only hard-deletes the underlying `Board` when it's an **orphan template**
+  (`is_template` AND no `team_boards` AND not on another communicator AND
+  owned by the remover — `orphan_template?`). So a hand-off owner removing
+  an inherited board (a team board / SLP-owned clone) detaches it but keeps
+  it; the old "delete the board whenever `is_template`" behavior only still
+  applies to a true throwaway clone on your own communicator.
+- **Detach stays owner-gated; the api_view exposes `can_remove`.** Detach
+  authorization is communicator-ownership (`editable_by?`), not board
+  ownership, so the new owner is allowed. The dashboard board entries now
+  carry **`can_remove`** (keyed to communicator ownership) alongside
+  `can_edit` (board ownership, gates clone-to-edit), so the frontend can
+  show the remove control to a hand-off owner who doesn't own the board.
+  (Frontend wiring to consume `can_remove` is a companion change.)
 ### Editing the communicator object itself
 
 `ChildAccount#editable_by?(user)` returns true iff the user is the

--- a/app/controllers/api/child_boards_controller.rb
+++ b/app/controllers/api/child_boards_controller.rb
@@ -50,20 +50,38 @@ class API::ChildBoardsController < API::ApplicationController
   def destroy
     Rails.logger.info "Deleting child board with ID: #{params[:id]}"
     @board = @child_board.board
+    @child_board.destroy
 
-    if @board.is_template
-      Rails.logger.info "Deleting associated board ID: #{@board.id}"
-      @child_board.destroy
+    # Removal is non-destructive by default: detach the board from this
+    # dashboard but keep the board record. We only delete the underlying
+    # board when it's a throwaway per-communicator template that nothing
+    # else references — never one that's a team board or still on another
+    # communicator. This lets a hand-off owner clear inherited boards
+    # without destroying content the team (or the original SLP) relies on,
+    # while preserving the old cleanup for a self-created template clone.
+    if @board && @board.is_template && orphan_template?(@board)
+      Rails.logger.info "Deleting orphaned template board ID: #{@board.id}"
       @board.destroy
     else
-      Rails.logger.info "Deleting child board ID: #{@child_board.id} without deleting associated board ID: #{@board.id}"
-      @child_board.destroy
+      Rails.logger.info "Detached child_board #{params[:id]}; preserved board ID: #{@board&.id}"
     end
 
     render json: { message: "child_board deleted" }
   end
 
   private
+
+  # A per-communicator template clone is safe to hard-delete only when
+  # nothing else references it: it's not shared as a team board, it's not on
+  # any other communicator's dashboard (the just-removed ChildBoard is
+  # already destroyed by the time we check), and the remover owns it. In any
+  # other case we detach only, so removing a board from one dashboard can
+  # never destroy content another surface still depends on.
+  def orphan_template?(board)
+    return false if board.team_boards.exists?
+    return false if board.child_boards.exists?
+    board.user_id == current_user&.id
+  end
 
   def load_child_board
     @child_board = ChildBoard.find(params[:id])

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -421,6 +421,9 @@ class ChildAccount < ApplicationRecord
         # rights — `created_by_id` drives `is_owner` / `can_invite` in the
         # team api_view, so without this the new owner couldn't manage it.
         team.update!(created_by: user) unless team.created_by_id == user.id
+        # Preserve the inherited dashboard boards as team boards so the new
+        # owner can clear/curate the dashboard without losing them.
+        register_dashboard_boards_on_team!(team)
       end
     end
 
@@ -535,6 +538,21 @@ class ChildAccount < ApplicationRecord
     return if settings["primary_team_id"] == team.id
     settings["primary_team_id"] = team.id
     save!
+  end
+
+  # Register the communicator's current dashboard boards as team boards on
+  # `team`. This is the safety net behind non-destructive board removal: once
+  # a board is also a team board, `ChildBoardsController#destroy` detaches it
+  # from the dashboard instead of deleting it, and it stays available via the
+  # team for re-adding. Idempotent — `Team#add_board!` skips boards already on
+  # the team. Attributed to each board's owner (the original sharer).
+  def register_dashboard_boards_on_team!(team)
+    return unless team
+    child_boards.includes(:board).find_each do |cb|
+      board = cb.board
+      next unless board
+      team.add_board!(board, board.user_id || cb.created_by_id)
+    end
   end
 
   # Ensure this communicator has a team. If it already does, return
@@ -726,6 +744,11 @@ class ChildAccount < ApplicationRecord
           board_owner_name: b.user&.display_name,
           most_used: cb.board_id == cached_most_used_board&.id,
           can_edit: viewing_user&.id == b.user_id,
+          # Removing a board from the dashboard is a curation action gated on
+          # *communicator* ownership, not board ownership — so a hand-off owner
+          # can clear inherited boards they don't own. (Removal is
+          # non-destructive: see ChildBoardsController#destroy.)
+          can_remove: viewing_user.present? && (viewing_user.id == owner_id || viewing_user.admin?),
         }
       end,
       can_sign_in: can_sign_in?,
@@ -1104,6 +1127,11 @@ class ChildAccount < ApplicationRecord
           board_owner_name: b.user&.display_name,
           most_used: cb.board_id == cached_most_used_board&.id,
           can_edit: viewing_user&.id == b.user_id,
+          # Removing a board from the dashboard is a curation action gated on
+          # *communicator* ownership, not board ownership — so a hand-off owner
+          # can clear inherited boards they don't own. (Removal is
+          # non-destructive: see ChildBoardsController#destroy.)
+          can_remove: viewing_user.present? && (viewing_user.id == owner_id || viewing_user.admin?),
         }
       end,
       can_sign_in: can_sign_in?,

--- a/lib/tasks/communicators.rake
+++ b/lib/tasks/communicators.rake
@@ -166,6 +166,13 @@ namespace :communicators do
         actions << "prev owner #{demote_id} #{demote_tu&.role || 'none'}->supervisor" if demote_tu&.role != "supervisor"
       end
 
+      # Preserve inherited dashboard boards as team boards (the safety net for
+      # non-destructive removal) — same as claim_by! now does on transfer.
+      on_team_ids = team.board_ids
+      dashboard_ids = ca.child_boards.includes(:board).filter_map { |cb| cb.board&.id }.uniq
+      to_register = (dashboard_ids - on_team_ids).size
+      actions << "register #{to_register} dashboard board(s) on team" if to_register > 0
+
       if actions.empty?
         puts "#{dry_run ? '[DRY RUN] ' : ''}communicator ##{ca.id} #{ca.name.inspect} (team ##{team.id}) — already correct"
         next
@@ -179,6 +186,7 @@ namespace :communicators do
           team.upsert_member!(owner, "admin")
           team.upsert_member!(User.find_by(id: demote_id), "supervisor") if demote_id
           team.update!(created_by_id: owner.id) if previous_creator_id != owner.id
+          ca.register_dashboard_boards_on_team!(team)
         end
         repaired += 1
       end

--- a/spec/lib/tasks/repair_handoff_teams_rake_spec.rb
+++ b/spec/lib/tasks/repair_handoff_teams_rake_spec.rb
@@ -98,6 +98,17 @@ RSpec.describe "communicators:repair_handoff_teams", type: :task do
     expect(ca.reload.settings["primary_team_id"]).to be_nil
   end
 
+  it "registers the communicator's dashboard boards as team boards" do
+    ca, namesake = broken_handoff
+    board = create(:board, user: old_owner, name: "Inherited")
+    create(:child_board, board: board, child_account: ca)
+    ENV["DRY_RUN"] = "false"
+
+    silent { task.invoke }
+
+    expect(namesake.reload.boards).to include(board)
+  end
+
   it "is idempotent — a second run makes no further changes" do
     ca, namesake = broken_handoff
     ENV["DRY_RUN"] = "false"

--- a/spec/models/child_account_handoff_team_spec.rb
+++ b/spec/models/child_account_handoff_team_spec.rb
@@ -97,6 +97,19 @@ RSpec.describe ChildAccount, "hand-off team membership", type: :model do
       end
     end
 
+    it "registers the communicator's dashboard boards as team boards (preservation safety net)" do
+      loaner, _shared, namesake = loaner_on_two_teams
+      parent = make_parent("pro")
+      b1 = create(:board, user: slp, name: "Board One")
+      b2 = create(:board, user: slp, name: "Board Two")
+      create(:child_board, board: b1, child_account: loaner)
+      create(:child_board, board: b2, child_account: loaner)
+
+      loaner.claim_by!(user: parent)
+
+      expect(namesake.reload.boards).to include(b1, b2)
+    end
+
     it "creates and uses an own team when the communicator has none" do
       loaner = create(:child_account, user: slp, owner: slp, status: "loaner", passcode: "x")
       parent = make_parent("pro")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,5 +45,19 @@ RSpec.configure do |config|
   # never run a real request cycle so we set it once globally.
   config.before(:each) do
     ActiveStorage::Current.url_options = { host: "localhost", port: 4000, protocol: "http" }
+
+    # Keep the users id sequence above User::DEFAULT_ADMIN_ID. Several specs
+    # insert the admin with an explicit id (== DEFAULT_ADMIN_ID); an explicit
+    # id doesn't advance the Postgres sequence, and sequences aren't rolled back
+    # between examples — so depending on shard/run order, a later create(:user)
+    # could grab that same id and raise PG::UniqueViolation on users_pkey. This
+    # makes the next sequence id deterministically clear of the fixed admin id.
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      SELECT setval(
+        pg_get_serial_sequence('users', 'id'),
+        GREATEST(COALESCE((SELECT MAX(id) FROM users), 0), #{User::DEFAULT_ADMIN_ID}),
+        true
+      )
+    SQL
   end
 end

--- a/spec/requests/api/child_boards_handoff_removal_spec.rb
+++ b/spec/requests/api/child_boards_handoff_removal_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Non-destructive board removal after a hand-off. Removing a board from the
+# communicator dashboard must never destroy a board the team (or another
+# communicator) still relies on — see ChildBoardsController#destroy and
+# ChildAccount#register_dashboard_boards_on_team!.
+RSpec.describe "API::ChildBoards non-destructive removal", type: :request do
+  let(:parent) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:slp)    { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  # Post-claim shape: parent owns the active communicator; SLP is a supervisor.
+  let!(:child_account) do
+    create(:child_account, user: parent, owner: parent,
+                           status: ChildAccount::ACTIVE, passcode: "ownerpw1")
+  end
+  let!(:team) do
+    t = child_account.ensure_team!(creator: parent)
+    t.upsert_member!(slp, "supervisor")
+    t
+  end
+
+  it "detaches but preserves a template board that is also a team board" do
+    board = create(:board, user: slp, name: "Inherited", is_template: true)
+    cb = create(:child_board, board: board, child_account: child_account)
+    team.add_board!(board, slp.id) # the transfer safety net
+
+    expect {
+      delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+    }.to change { ChildBoard.where(id: cb.id).count }.from(1).to(0)
+
+    expect(response).to have_http_status(:ok)
+    expect(Board.exists?(board.id)).to be(true)
+    # And it's now available to re-add from the team pool.
+    expect(child_account.reload.available_teams_boards.map(&:board_id)).to include(board.id)
+  end
+
+  it "preserves a template board still on another communicator's dashboard" do
+    board = create(:board, user: slp, name: "Shared template", is_template: true)
+    cb = create(:child_board, board: board, child_account: child_account)
+    other = create(:child_account, user: slp, owner: slp, status: ChildAccount::ACTIVE,
+                                   passcode: "x", username: "other-#{SecureRandom.hex(2)}")
+    create(:child_board, board: board, child_account: other)
+
+    delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+
+    expect(response).to have_http_status(:ok)
+    expect(Board.exists?(board.id)).to be(true)
+  end
+
+  it "detaches a non-template board without deleting it" do
+    board = create(:board, user: slp, name: "Library board") # is_template defaults false
+    cb = create(:child_board, board: board, child_account: child_account)
+
+    delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+
+    expect(response).to have_http_status(:ok)
+    expect(Board.exists?(board.id)).to be(true)
+  end
+
+  it "still deletes a throwaway template clone nothing else references (cleanup preserved)" do
+    board = create(:board, user: parent, name: "Throwaway", is_template: true)
+    cb = create(:child_board, board: board, child_account: child_account)
+
+    expect {
+      delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+    }.to change { Board.where(id: board.id).count }.from(1).to(0)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "exposes can_remove on the dashboard boards for the communicator owner" do
+    board = create(:board, user: slp, name: "Inherited", is_template: true)
+    create(:child_board, board: board, child_account: child_account)
+
+    view = child_account.api_view(parent)
+    entry = view[:boards].find { |b| b[:board_id] == board.id }
+
+    expect(entry[:can_remove]).to be(true)   # owns the communicator
+    expect(entry[:can_edit]).to be(false)    # but not the board itself
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to the hand-off team fix (#399). After a communicator is transferred, the new owner can now **clear/curate the dashboard without losing boards**, and removal is never destructive.

**The problem:** boards on a communicator are SLP-owned `is_template` clones. After hand-off:
- "Remove from dashboard" (`DELETE /api/child_boards/:id`) **deleted** the board whenever `is_template` — silent data loss.
- The dashboard `can_edit` flag was keyed to board ownership, so the new owner saw `can_edit: false` on inherited boards and the remove control was hidden.

**Decisions (from discussion):** curate + clone-to-edit (no ownership/permission-model changes), and non-destructive removal with *all* dashboard boards preserved as team boards on transfer.

### Changes
- **`claim_by!`** registers the communicator's current dashboard boards as **team boards** on its own team (`register_dashboard_boards_on_team!`). While on the dashboard they're excluded from `available_teams_boards` (no dupes); once removed they reappear there to re-add.
- **`ChildBoardsController#destroy`** is now non-destructive: always detaches the `ChildBoard`, and only hard-deletes the board when it's an **orphan template** (`is_template` AND no `team_boards` AND not on another communicator AND owned by the remover — `orphan_template?`). Preserves the old cleanup for a throwaway self-created clone; never destroys shared/inherited content.
- **`api_view` / `vendor_api_view`** expose **`can_remove`** on dashboard boards (keyed to communicator ownership) so the new owner sees the remove control. `can_edit` stays board-owner keyed (gates clone-to-edit).
- **`repair_handoff_teams`** also backfills the team-board safety net for already-claimed communicators.

### Test plan
55 examples, 0 failures across new + existing suites:
- `child_account_handoff_team_spec` — claim_by! registers dashboard boards as team boards.
- `child_boards_handoff_removal_spec` — template+team-board preserved; template on another communicator preserved; non-template detach-only; orphan clone still deleted; `can_remove` flag exposed.
- `repair_handoff_teams_rake_spec` — repair registers dashboard boards on the team.
- Regression: `child_boards_owner_protection_spec`, `child_account_claim_spec`, `child_accounts_claim_spec`, `child_accounts_lend_pro_gate_spec`.

### Follow-up (separate repo)
- **Frontend (`itty-bitty-frontend`):** consume the new `can_remove` flag to show the "remove from dashboard" control to a hand-off owner who doesn't own the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)