### PR TITLE
fix(board-builder): de-dupe re-seed tiles + mute folder tile names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Board Builder mutes folder/dynamic tile names
+- Tiles in a built board set that open another board (folder / dynamic tiles,
+  `predictive_board_id` set) now default to `mute_name: true`, so tapping a
+  folder navigates without speaking the folder's own label. Word tiles are
+  unchanged. Applied across the whole built set (root + sub-boards) by
+  `BuildBoardSetJob`.
+
+### Fixed — Board Builder "extra all done" duplicate tile
+- Built board sets (Core 60/84) no longer show a duplicate `all done` tile (and
+  any other duplicated word tile). Root cause: `Board.from_obf` keyed its tile
+  upsert on the resolved `image_id`, so a re-seed that resolved the same
+  authored button to a different `Image` appended a second tile instead of
+  updating the existing one; `SeededSetCloner` then copied it into every set
+  built since the bad re-seed. The upsert is now keyed on the stable OBF button
+  id, and the `vocab_sets:seed` sync pass collapses any duplicate it finds
+  (`Boards::TileDeduper`).
+- `rake board_builder:dedupe_seed_tiles` (dry-run by default; `DRY_RUN=false` to
+  apply, `USER_ID=N` to scope) removes the duplicate from the seed sources and
+  from already-built user sets.
+
 ### Added — AppSignal APM (per-request + host visibility)
 - Added the `appsignal` gem and `config/appsignal.yml` to capture per-request
   latency (p95/p99), slow queries/N+1, host CPU/memory/disk, and Sidekiq queue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1167,6 +1167,15 @@ still works for backward compat.
   during the clone. Still used by callers that want a trimmed clone; the hybrid
   build now passes `[]` (clone intact). `StructurePlanner#excluded_fringe_pages`
   is still computed on the plan but no longer consumed by the build.
+- **Folder/dynamic tiles default to muted names.**
+  `BuildBoardSetJob#mute_dynamic_tile_names!` runs at the end of every build
+  (the single chokepoint before `generate_preview!`) and sets
+  `board_image.data["mute_name"] = true` on every dynamic tile
+  (`is_dynamic?` → `predictive_board_id` present and not a self-link) across the
+  whole set — root + linked sub-boards, walked via `set_board_ids` (BFS over
+  predictive links, scoped to the owner's boards). So tapping a folder navigates
+  without speaking the folder's own label; word tiles are untouched.
+  `update_column` skips the audio hook/validations. Idempotent.
 - **Tile images prefer the curated "default" image (`Boards::ImageResolver`).**
   All three build paths (cloner, `BlueprintAssembler`, `BuildBoardSetJob`)
   resolve a tile label via `Boards::ImageResolver.resolve(label, owner:)`. When
@@ -1254,6 +1263,28 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
   `Boards::RobustSets`. Idempotent (`Board.from_obf` upserts by
   `(user_id, obf_id)`). Format spec: `db/seeds/board_builder_sets/README.md`.
   Slugs `core-60` (ships a placeholder), `core-84` (TBD).
+  - **Tile upserts are keyed on the authored OBF button id, not the resolved
+    `image_id`.** `Board.upsert_board_image` matches an existing tile by the
+    button id stamped on `board_image.data["obf_button_id"]` (falling back to
+    `image_id` for tiles seeded before stamping existed). Before this, the upsert
+    keyed on `image_id` alone, so when `find_or_create_image_for_button` resolved
+    the **same** authored button to a **different** `Image` across re-seeds (the
+    OBF button's `image_id` drifted, so the `obf_id` branch missed and the
+    label-only fallback picked a different match), it **appended a duplicate
+    tile** instead of updating the existing one. That's how the Core 60 source
+    grew a second `all done` word tile (2026-06-17 re-seed), which
+    `SeededSetCloner` then copied into every built set (the "extra all done"
+    bug). As a backstop, `VocabSets#dedupe_tiles!` (via
+    `Boards::TileDeduper.collapse_duplicates!`) runs in the seed sync pass and
+    collapses any surviving same-label/same-kind duplicate on each seeded board
+    — a word tile and its same-named category folder (`play` vs `Play`) are
+    **not** merged. Re-seeding is now self-healing for this case.
+  - **Remediation:** `rake board_builder:dedupe_seed_tiles` (dry-run by default,
+    `DRY_RUN=false` to apply, `USER_ID=N` to scope) collapses the duplicate on
+    the robust seed sources **and** every already-built user set
+    (`settings["builder_root"]/["builder_child"]`) — re-seeding only heals the
+    admin sources, not the user clones, so run this for the live sets built
+    between the bad re-seed and the fix.
 - **Build:** `#create` branches on `Boards::RobustSets.find_root(template)`.
   A match runs `Boards::SeededSetCloner` (walks the linked set to depth 2,
   clones each board, **rewires** `predictive_board_id` to the clones, marks

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2662,11 +2662,21 @@ class Board < ApplicationRecord
   private_class_method :attach_image_doc
 
   def self.upsert_board_image(board, image, item, coords, display_url, apply_button_attributes: false)
-    board_image = board.board_images.find_by(image_id: image.id)
+    obf_button_id = item["id"].presence&.to_s
+
+    # Idempotency key is the AUTHORED OBF button id, NOT the resolved image_id.
+    # find_or_create_image_for_button can resolve the same button to a DIFFERENT
+    # Image across re-imports/re-seeds (label+obf_id drift), so keying the upsert
+    # on image_id appended a brand-new tile every time resolution drifted — that's
+    # how a re-seed grew a second "all done" tile on the Core 60 builder source.
+    # Match the button first so a re-import updates the same tile; fall back to
+    # image_id for tiles seeded before button ids were stamped.
+    board_image = find_board_image_for_button(board, image, obf_button_id)
     unless board_image
       board_image = board.board_images.new(image_id: image.id, voice: board.voice,
                                            position: board.board_images_count,
                                            display_image_url: display_url)
+      stamp_obf_button_id(board_image, obf_button_id)
       # Let BoardImage's after_create :create_voice_audio_after_create
       # fire — that's the canonical hook for enqueuing SaveAudioJob, and
       # an existing pre-rendered Polly file (same image+voice+language)
@@ -2675,6 +2685,12 @@ class Board < ApplicationRecord
       # at all because nothing else compensated.
       board_image.save!
     end
+
+    # Heal resolution drift on an existing tile: re-point it at the freshly
+    # resolved image and (back)stamp the button id so future re-imports converge
+    # onto this same tile instead of forking a duplicate.
+    board_image.image_id = image.id if board_image.image_id != image.id
+    stamp_obf_button_id(board_image, obf_button_id)
 
     apply_obf_part_of_speech(board_image, image, item) if apply_button_attributes
 
@@ -2700,6 +2716,28 @@ class Board < ApplicationRecord
     board_image
   end
   private_class_method :upsert_board_image
+
+  # Resolve the existing tile for an authored OBF button. Prefer the stable
+  # button id (stamped on board_image.data); fall back to image_id for tiles
+  # seeded before stamping existed. nil → caller creates a fresh tile.
+  def self.find_board_image_for_button(board, image, obf_button_id)
+    if obf_button_id.present?
+      existing = board.board_images.where("data ->> 'obf_button_id' = ?", obf_button_id).first
+      return existing if existing
+    end
+    board.board_images.find_by(image_id: image.id)
+  end
+  private_class_method :find_board_image_for_button
+
+  # Persist the authored OBF button id on the tile so a later re-import matches
+  # this same tile even if button→image resolution drifts. Only writes when the
+  # value actually changes, to avoid marking the record dirty needlessly.
+  def self.stamp_obf_button_id(board_image, obf_button_id)
+    return if obf_button_id.blank?
+    board_image.data ||= {}
+    board_image.data["obf_button_id"] = obf_button_id if board_image.data["obf_button_id"] != obf_button_id
+  end
+  private_class_method :stamp_obf_button_id
 
   # #279: honor the OBF button's authored part_of_speech so the tile gets its
   # Fitzgerald-key color (ColorHelper::PRESET_DATA) instead of inheriting

--- a/app/services/boards/tile_deduper.rb
+++ b/app/services/boards/tile_deduper.rb
@@ -1,0 +1,51 @@
+module Boards
+  # Collapses duplicate tiles a buggy re-import/re-seed appended to a board.
+  #
+  # Background: Board.upsert_board_image used to key on the resolved image_id, so
+  # when find_or_create_image_for_button resolved the SAME authored button to a
+  # different Image across runs (label+obf_id drift in the source OBF), the
+  # upsert forked a brand-new tile instead of updating the existing one. That's
+  # how the Core 60 builder source grew a second "all done" word tile, which then
+  # cloned into every built set (the "extra all done" bug). The structural fix
+  # lives in Board.upsert_board_image (now keyed on the stable OBF button id);
+  # this collapses the duplicates that already landed.
+  #
+  # Safe to run on any board: it only ever removes EXTRA tiles that share a label
+  # AND a kind (word vs folder), keeping the authored-position one.
+  module TileDeduper
+    module_function
+
+    # Returns the number of duplicate tiles removed (0 when the board is clean).
+    # dry_run: report-only — counts what WOULD be removed without destroying.
+    def collapse_duplicates!(board, dry_run: false)
+      removed = 0
+
+      duplicate_groups(board).each do |_key, tiles|
+        # Keep the authored-position tile (lowest position, oldest id as a
+        # tiebreak); the rest are appended duplicates.
+        tiles.drop(1).each do |tile|
+          tile.destroy unless dry_run
+          removed += 1
+        end
+      end
+
+      removed
+    end
+
+    # Groups of >1 tiles sharing a normalized label AND kind, each sorted so the
+    # tile to KEEP is first. Grouping on (label, folder?) keeps a word tile
+    # ("play") distinct from its same-named category folder ("Play") — those are
+    # intentionally separate tiles, not duplicates.
+    def duplicate_groups(board)
+      board.board_images.includes(:image).group_by { |bi| group_key(bi) }
+           .reject { |(label, _folder), tiles| label.blank? || tiles.size < 2 }
+           .transform_values { |tiles| tiles.sort_by { |bi| [bi.position || Float::INFINITY, bi.id] } }
+    end
+
+    def group_key(board_image)
+      label = (board_image.label.presence || board_image.image&.label).to_s.strip.downcase
+      [label, board_image.predictive_board_id.present?]
+    end
+    private_class_method :group_key
+  end
+end

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -103,8 +103,19 @@ module VocabSets
 
     prune_removed_tiles!(slug, boards_by_obf_id)
     prune_removed_boards!(slug, boards_by_obf_id)
+    dedupe_tiles!(boards_by_obf_id)
 
     root
+  end
+
+  # Collapse duplicate tiles a prior buggy re-seed may have appended. The label
+  # is still authored, so prune_removed_tiles! keeps BOTH copies — this removes
+  # the extra. Admin-owned set boards only; user clones are separate rows healed
+  # by rake board_builder:dedupe_seed_tiles. Idempotent: a no-op once clean.
+  def dedupe_tiles!(boards_by_obf_id)
+    boards_by_obf_id.each_value do |board|
+      Boards::TileDeduper.collapse_duplicates!(board)
+    end
   end
 
   # Map of obf_id => [button labels] parsed straight from the authored source

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -59,6 +59,7 @@ class BuildBoardSetJob
         build_legacy(root, communicator, level_or_template, interests, explicit_categories)
       end
 
+      mute_dynamic_tile_names!(root)
       generate_preview!(root)
       root.update_column(:status, "complete")
     rescue => e
@@ -154,6 +155,47 @@ class BuildBoardSetJob
       .reject { |bi| existing.include?(bi.label.to_s.downcase) }
       .first([PHRASES_STRIP_SIZE, open].min)
     candidates.each { |bi| root.add_image(bi.image_id) }
+  end
+
+  # Folder / dynamic tiles (those that open another board when tapped) shouldn't
+  # speak their own label — only word tiles should. Default the BoardImage
+  # "mute_name" flag to true on every dynamic tile across the freshly built set
+  # (root + linked sub-boards). Display-only flag; update_column skips the audio
+  # hook + validations. Idempotent — a no-op once already muted.
+  def mute_dynamic_tile_names!(root)
+    BoardImage
+      .where(board_id: set_board_ids(root))
+      .where.not(predictive_board_id: nil)
+      .where("predictive_board_id <> board_id")
+      .find_each do |bi|
+        data = bi.data || {}
+        next if data["mute_name"] == true
+
+        bi.update_column(:data, data.merge("mute_name" => true))
+      end
+  end
+
+  # Every board in the just-built set: BFS the predictive_board_id links from the
+  # root, bounded in depth and scoped to the owner's boards so a tile pointing at
+  # a shared/admin board can't pull it into the sweep.
+  def set_board_ids(root, max_depth = 3)
+    owner_id = root.user_id
+    seen = [root.id]
+    frontier = [root.id]
+    depth = 0
+
+    while frontier.any? && depth < max_depth
+      child_ids = BoardImage.where(board_id: frontier).where.not(predictive_board_id: nil)
+        .pluck(:predictive_board_id).uniq
+      children = Board.where(id: child_ids, user_id: owner_id).where.not(id: seen).pluck(:id)
+      break if children.empty?
+
+      seen.concat(children)
+      frontier = children
+      depth += 1
+    end
+
+    seen
   end
 
   # The new Phrases board doubles as the communicator's phrase board (the

--- a/lib/tasks/board_builder.rake
+++ b/lib/tasks/board_builder.rake
@@ -49,6 +49,80 @@ namespace :board_builder do
     end
   end
 
+  # Remediation for the "extra all done" duplicate-tile bug. A re-seed of the
+  # Core 60/84 builder source appended a second word tile for a label whose
+  # button->image resolution drifted (see Boards::TileDeduper / Board
+  # .upsert_board_image), and SeededSetCloner copied it into every set built
+  # since. This collapses those duplicates on:
+  #   - the robust seed SOURCE boards (root + descendants), and
+  #   - every already-built user set (settings builder_root / builder_child).
+  # Keeps the authored-position tile; removes the appended copy. A word tile and
+  # its same-named category folder ("play" vs "Play") are NOT merged.
+  #
+  # Read-only by default. Apply with DRY_RUN=false; scope with USER_ID=N:
+  #   rake board_builder:dedupe_seed_tiles                  # preview all
+  #   DRY_RUN=false rake board_builder:dedupe_seed_tiles    # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_builder:dedupe_seed_tiles
+  desc "Collapse duplicate Board Builder tiles on seeds + built sets (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task dedupe_seed_tiles: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    boards = dedupe_target_boards(ENV["USER_ID"])
+    boards_touched = 0
+    tiles_removed = 0
+
+    boards.each do |board|
+      groups = Boards::TileDeduper.duplicate_groups(board)
+      next if groups.empty?
+
+      boards_touched += 1
+      removed_here = groups.sum { |_key, tiles| tiles.size - 1 }
+      tiles_removed += removed_here
+
+      detail = groups.map { |(label, _folder), tiles| "#{label.inspect} x#{tiles.size} (keep pos #{tiles.first.position})" }.join(", ")
+      kind = board.settings&.dig("board_builder_robust_slug") ? "seed" : (board.settings&.dig("builder_root") ? "root" : "child")
+      puts "#{dry_run ? '[DRY RUN] ' : ''}board ##{board.id} #{board.name.inspect} (#{kind}, owner #{board.user_id}): #{detail}"
+
+      Boards::TileDeduper.collapse_duplicates!(board) unless dry_run
+    end
+
+    if dry_run
+      puts "Dry run only — #{boards_touched} board(s), #{tiles_removed} duplicate tile(s) to remove. Re-run with DRY_RUN=false to apply."
+    else
+      puts "Removed #{tiles_removed} duplicate tile(s) across #{boards_touched} board(s)."
+    end
+  end
+
+  # Boards to scan: robust seed SOURCE boards (root + linked descendants, the
+  # template clones copy from) plus every built user set. USER_ID scopes to one
+  # owner (seed sources are admin-owned, so a non-admin USER_ID yields built
+  # sets only).
+  def dedupe_target_boards(user_id = nil)
+    seed_roots = Board.where("(settings ->> 'board_builder_robust_slug') IS NOT NULL")
+    ids = seed_roots.pluck(:id).to_set
+    seed_roots.find_each { |root| collect_set_descendant_ids(root, ids) }
+
+    built = Board.where("(settings ->> 'builder_root') = 'true' OR (settings ->> 'builder_child') = 'true'")
+    ids.merge(built.pluck(:id))
+
+    scope = Board.where(id: ids.to_a)
+    scope = scope.where(user_id: user_id) if user_id.present?
+    scope
+  end
+
+  # Walk predictive_board_id links from a seed root, bounded to the cloner's
+  # MAX_DEPTH (root + 2 levels), accumulating board ids.
+  def collect_set_descendant_ids(board, acc, depth = 2)
+    return if depth.negative? || board.nil?
+
+    board.board_images.where.not(predictive_board_id: nil).pluck(:predictive_board_id).uniq.each do |child_id|
+      next if acc.include?(child_id)
+
+      acc << child_id
+      collect_set_descendant_ids(Board.find_by(id: child_id), acc, depth - 1)
+    end
+  end
+
   # Count tiles on `board` that are currently blank (art-less) but for which a
   # curated art-bearing image exists under the same label — i.e. the tiles
   # upgrade_board_tiles! would actually re-point. Read-only.

--- a/spec/models/board_from_obf_idempotency_spec.rb
+++ b/spec/models/board_from_obf_idempotency_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Regression: Board.upsert_board_image keyed the tile "upsert" on the resolved
+# image_id, but find_or_create_image_for_button can resolve the SAME authored
+# button to a different Image across re-imports (the OBF button's image_id
+# changed, so the obf_id branch misses and the fallback picks a different
+# label match). That forked a duplicate tile every time resolution drifted —
+# how the Core 60 builder source grew a second "all done" word tile. The upsert
+# is now keyed on the stable authored button id instead.
+RSpec.describe "Board.from_obf re-import idempotency", type: :model do
+  let(:user) { create(:user) }
+
+  # Two same-label images. The OLDER one (lower id) is the fallback target when
+  # the button's image_id no longer matches an obf_id — i.e. resolution drift.
+  let!(:old_image) { create(:image, label: "all done", user_id: user.id, obf_id: "obf-old") }
+  let!(:img_a)     { create(:image, label: "all done", user_id: user.id, obf_id: "img-a") }
+
+  def obf(image_id:)
+    {
+      "id" => "core",
+      "name" => "Core",
+      "buttons" => [{ "id" => "b1", "label" => "all done", "image_id" => image_id }],
+      "grid" => { "rows" => 1, "columns" => 1, "order" => [["b1"]] },
+      "images" => [],
+    }
+  end
+
+  it "resolves the button to its obf_id match on first import and stamps the button id" do
+    board, = Board.from_obf(obf(image_id: "img-a"), user)
+
+    expect(board.board_images.count).to eq(1)
+    tile = board.board_images.first
+    expect(tile.image_id).to eq(img_a.id)
+    expect(tile.data["obf_button_id"]).to eq("b1")
+  end
+
+  it "updates the same tile instead of forking a duplicate when resolution drifts" do
+    board, = Board.from_obf(obf(image_id: "img-a"), user)
+    first_tile = board.board_images.first
+
+    # The button's image_id changed: the obf_id branch misses and resolution
+    # falls back to the oldest same-label image (old_image).
+    board2, = Board.from_obf(obf(image_id: "changed"), user)
+
+    expect(board2.id).to eq(board.id)
+    expect(board2.board_images.count).to eq(1), "expected the drifted re-import to update the tile, not append a second 'all done'"
+
+    tile = board2.board_images.first
+    expect(tile.id).to eq(first_tile.id)
+    expect(tile.image_id).to eq(old_image.id)
+    expect(tile.data["obf_button_id"]).to eq("b1")
+  end
+end

--- a/spec/services/boards/tile_deduper_spec.rb
+++ b/spec/services/boards/tile_deduper_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Boards::TileDeduper do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  # Each tile gets its OWN Image row that happens to share the label — the real
+  # "all done" duplicate pointed at two distinct same-label images. BoardImage's
+  # set_defaults derives the tile label from its image, so the image label is
+  # what makes two tiles count as duplicates.
+  def tile(label, position:, predictive_board_id: nil)
+    create(:board_image, board: board, position: position,
+                         predictive_board_id: predictive_board_id,
+                         image: create(:image, label: label, user_id: user.id))
+  end
+
+  describe ".collapse_duplicates!" do
+    it "removes the appended duplicate word tile, keeping the authored-position one" do
+      keep = tile("all done", position: 5)
+      drop = tile("all done", position: 40)
+
+      expect { described_class.collapse_duplicates!(board) }
+        .to change { board.board_images.count }.by(-1)
+
+      expect(board.board_images.exists?(keep.id)).to be(true)
+      expect(board.board_images.exists?(drop.id)).to be(false)
+    end
+
+    it "keeps the lowest-position copy regardless of insertion order" do
+      late = tile("all done", position: 57)
+      early = tile("all done", position: 39)
+
+      described_class.collapse_duplicates!(board)
+
+      expect(board.board_images.exists?(early.id)).to be(true)
+      expect(board.board_images.exists?(late.id)).to be(false)
+    end
+
+    it "does not merge a word tile with its same-named category folder" do
+      folder_target = create(:board, user: user)
+      tile("play", position: 3)
+      tile("Play", position: 50, predictive_board_id: folder_target.id)
+
+      expect { described_class.collapse_duplicates!(board) }
+        .not_to change { board.board_images.count }
+    end
+
+    it "collapses three copies down to one" do
+      tile("all done", position: 1)
+      tile("all done", position: 2)
+      tile("all done", position: 3)
+
+      expect { described_class.collapse_duplicates!(board) }
+        .to change { board.board_images.count }.by(-2)
+    end
+
+    it "is a no-op on a clean board and returns 0" do
+      tile("want", position: 1)
+      tile("more", position: 2)
+
+      expect(described_class.collapse_duplicates!(board)).to eq(0)
+      expect(board.board_images.count).to eq(2)
+    end
+
+    it "dry_run reports the removable count without destroying" do
+      tile("all done", position: 1)
+      tile("all done", position: 2)
+
+      expect(described_class.collapse_duplicates!(board, dry_run: true)).to eq(1)
+      expect(board.board_images.count).to eq(2)
+    end
+  end
+end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -133,6 +133,24 @@ RSpec.describe VocabSets do
       VocabSets.seed_slug!("core-60")
       expect(Board.exists?(theirs.id)).to be(true)
     end
+
+    # The "extra all done" bug: a prior buggy re-seed appended a second tile for
+    # a still-authored label (prune_removed_tiles! keeps both). A re-seed now
+    # collapses the duplicate, keeping the authored tile.
+    it "collapses a duplicate authored tile appended by a prior buggy re-seed" do
+      authored = @c60_root.board_images.find_by(label: "all done")
+      expect(authored).to be_present
+
+      dup = create(:board_image, board: @c60_root, label: "all done", position: 999,
+                                 image: create(:image, label: "all done", user_id: @admin.id))
+      expect(@c60_root.board_images.where(label: "all done").count).to eq(2)
+
+      VocabSets.seed_slug!("core-60")
+
+      expect(@c60_root.reload.board_images.where(label: "all done").count).to eq(1)
+      expect(@c60_root.board_images.exists?(authored.id)).to be(true)
+      expect(@c60_root.board_images.exists?(dup.id)).to be(false)
+    end
   end
 
   describe "tile colors from authored part_of_speech (#279)" do

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -116,6 +116,23 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(dead_folder_tiles(root)).to be_empty
   end
 
+  it "mutes the name on dynamic folder tiles, leaving word tiles unmuted" do
+    root = build!([{ "word" => "dog", "category" => "Animals" }])
+
+    folder_tiles = root.board_images.select(&:is_dynamic?)
+    word_tiles = root.board_images.reject(&:is_dynamic?)
+
+    expect(folder_tiles).not_to be_empty
+    expect(folder_tiles).to all(satisfy { |bi| bi.data["mute_name"] == true })
+    expect(word_tiles).to all(satisfy { |bi| bi.data.to_h["mute_name"] != true })
+
+    # The default applies across the whole built set, not just the home board.
+    animals = Board.find(root.board_images.find { |bi| bi.label == "Animals" }.predictive_board_id)
+    animals.board_images.select(&:is_dynamic?).each do |bi|
+      expect(bi.data["mute_name"]).to be(true)
+    end
+  end
+
   # Regression for the "86 tiles instead of 84" report: when the authored grid
   # has no slack left (a fuller Core 84 than the repo seed), the catch-all
   # "My Favorites" tile and an early-stage quick-phrase strip used to spill onto


### PR DESCRIPTION
## Summary

Two Board Builder fixes, found while investigating a duplicate "all done" tile in a freshly built set on prod.

### 1. "Extra all done" duplicate tile (root cause + fix)

`Board.upsert_board_image` keyed its tile upsert on the resolved **`image_id`**. `find_or_create_image_for_button` can resolve the *same* authored OBF button to a *different* `Image` across re-seeds (the button's `image_id` drifts → the `obf_id` branch misses → the label-only fallback picks a different match). When that happened, the upsert **appended a brand-new tile** instead of updating the existing one.

That's exactly what bit us: the **Core 60 builder source** grew a second `all done` word tile on the **2026-06-17 re-seed** (image `15969` alongside the original `16584`), and `SeededSetCloner` faithfully copied both into **every set built since** — 10 of 17 live builder roots on prod.

Fixes:
- **`Board.upsert_board_image`** now keys on the stable authored OBF **button id** (`data["obf_button_id"]`), falling back to `image_id` for tiles seeded before stamping existed. Prevents the duplicate from ever forming and heals resolution drift in place.
- **`Boards::TileDeduper`** (new) collapses same-label/same-kind duplicate tiles, keeping the authored-position one. A word tile and its same-named category folder (`play` vs `Play`) are **not** merged.
- **`VocabSets`** runs the deduper in its seed sync pass → `vocab_sets:seed` is now self-healing for this case.
- **`rake board_builder:dedupe_seed_tiles`** (dry-run default; `DRY_RUN=false`, `USER_ID=N`) heals the seed sources **and** the already-built user sets.

### 2. Folder/dynamic tiles default to muted names

Tiles that open another board (`is_dynamic?` → `predictive_board_id` set, not a self-link) now default to `data["mute_name"] = true`, so tapping a folder navigates without speaking the folder's own label. `BuildBoardSetJob#mute_dynamic_tile_names!` applies it across the whole built set (root + linked sub-boards) at the single build chokepoint; word tiles are untouched.

## Why

The build itself never touched the gestalt/strip dedup path (`stage=nil`, no Phrases tile) — the duplicate came straight out of the clone because the **seed source** carried it. The real bug was seeding idempotency at the tile level, so the fix targets `upsert_board_image` (prevention) + a deduper (remediation).

## Test plan

- `spec/services/boards/tile_deduper_spec.rb` — 6 examples (collapse, keep-lowest-position, word-vs-folder not merged, 3→1, no-op, dry-run)
- `spec/models/board_from_obf_idempotency_spec.rb` — 2 examples (re-import with drifted resolution updates the same tile, no duplicate; stamps button id)
- `spec/services/vocab_sets_spec.rb` — added a re-seed dedupe case (23 total, green)
- `spec/sidekiq/build_board_set_job_grid_spec.rb` — added a mute case (7 total, green)
- Regression: `obz_importer_spec`, `import_export_spec`, `seeded_set_cloner_spec`, `build_board_set_job_spec`, `board_spec` — **102 examples, 0 failures**

## Prod remediation (run after deploy)

```bash
bin/rails board_builder:dedupe_seed_tiles            # preview
DRY_RUN=false bin/rails board_builder:dedupe_seed_tiles   # apply (seeds + 10 built sets, incl. board 5213)
bin/rails vocab_sets:seed SLUGS=core-60,core-84      # optional: keep sources clean going forward
```

Note: the mute default applies to **new builds**; existing sets aren't retroactively muted (can add a backfill rake if wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)