### PR TITLE
fix(board-builder): don't make a whole board for a single interest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable user-facing changes to this project will be documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed — Board Builder no longer makes a whole board for a single interest
+- A lone interest word (e.g. "backpack") whose category isn't a seed or prebuilt
+  page for the chosen level used to spin up an entire AI-generated board named
+  after that one word. Now an AI page is only created when its category has at
+  least `BOARD_BUILDER_MIN_AI_PAGE_INTERESTS` interests (default 2). A sparse
+  interest is placed on an existing matching board in the set when one exists
+  (e.g. a category folder already present), and otherwise lands in My Favorites
+  — never its own board. Cuts spurious single-word boards and saves AI credits.
+
 ## [1.2.1] — 2026-06-23
 
 ### Changed — Board Builder mutes folder/dynamic tile names

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1156,11 +1156,22 @@ still works for backward compat.
   Profile-aware prompts. Credit-gated: costs 2 credits (`ai_board_page` feature
   key). Falls back to "My Favorites" catch-all when user lacks credits or
   generation fails.
+- **AI pages need ≥ `MIN_AI_PAGE_INTERESTS` interests
+  (`BOARD_BUILDER_MIN_AI_PAGE_INTERESTS`, default 2).** `StructurePlanner#drop_sparse_ai_pages`
+  removes any `:ai_generated` page whose category has fewer interests, so a lone
+  interest (e.g. "backpack" → School, which is neither a seed nor prebuilt page in
+  core-60) doesn't spawn — and pay for — a whole AI board named after that one
+  word. Its words fall to `catch_all_interests` instead. **Seed/prebuilt pages are
+  not gated** (they're curated/default content; gating them would drop a
+  zero-interest default like the prebuilt "Social" in Extended).
 - **`BuildBoardSetJob`** routes between the hybrid path (when `level` is a
   `StructurePlanner::LEVELS` key) and the legacy path (direct template keys like
   `core-60`, `home`). The hybrid path: plan → clone seed set **intact** →
-  add prebuilt/AI fringe pages **within the authored grid** → route catch-all to
-  "My Favorites".
+  add prebuilt/AI fringe pages **within the authored grid** →
+  `route_catch_all_to_existing_boards!` (place each leftover interest on an
+  **existing matching board** in the set — e.g. a capped seed page, since the seed
+  set always clones intact — matched by category with the seed aliases) → route the
+  rest to **"My Favorites"**.
 - **Grid cap (no overflow / no dead tiles).** The authored core board fills its
   grid with a few intentional empty cells (Core 84 = 7×12 = 84 cells, 81 tiles,
   3 gaps). `Board#add_image` fills the next open cell and only starts a new row

--- a/app/services/boards/structure_planner.rb
+++ b/app/services/boards/structure_planner.rb
@@ -26,6 +26,13 @@ module Boards
 
     AI_CREDITS_PER_PAGE = CreditService.cost_for("ai_board_page")
 
+    # A category needs at least this many interest words to justify its own
+    # AI-generated page. Below it, a lone stray interest (e.g. "backpack") would
+    # otherwise spawn — and pay for — a whole page named after that one word;
+    # instead the words fall through to catch_all and get placed on an existing
+    # matching board or My Favorites at build time. ENV-tunable.
+    MIN_AI_PAGE_INTERESTS = Integer(ENV.fetch("BOARD_BUILDER_MIN_AI_PAGE_INTERESTS", "2"))
+
     Result = Struct.new(
       :level, :core_template, :fringe_pages, :excluded_fringe_pages,
       :catch_all_interests, :ai_credits_needed, :phrases_page,
@@ -47,6 +54,7 @@ module Boards
       needed_categories = collect_needed_categories(categorized)
       fringe_pages = plan_fringe_pages(needed_categories, categorized)
       fringe_pages = cap_pages(fringe_pages)
+      fringe_pages = drop_sparse_ai_pages(fringe_pages)
 
       excluded = compute_excluded(fringe_pages)
       catch_all = collect_catch_all(categorized, fringe_pages)
@@ -151,6 +159,19 @@ module Boards
       remaining_slots = max - kept.size
       kept += without.first(remaining_slots) if remaining_slots > 0
       kept
+    end
+
+    # Drop AI pages that don't clear MIN_AI_PAGE_INTERESTS. Their category is no
+    # longer planned, so collect_catch_all folds the words into catch_all (then
+    # routed to an existing board or My Favorites at build time). Seed/prebuilt
+    # pages are intentionally left alone — they're curated/default content, and
+    # gating them would drop legitimate zero-interest defaults (e.g. prebuilt
+    # "Social" in Extended).
+    def drop_sparse_ai_pages(fringe_pages)
+      fringe_pages.reject do |page|
+        page[:source] == :ai_generated &&
+          Array(page[:interests]).size < MIN_AI_PAGE_INTERESTS
+      end
     end
 
     def compute_excluded(planned_fringe)

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -111,7 +111,7 @@ class BuildBoardSetJob
     # open cells; fringe pages then adapt to whatever's left.
     phrases_board = build_phrases_layer!(root, communicator, owner, plan) if plan.phrases_page&.dig(:include)
 
-    add_fringe_pages_within_grid!(root, communicator, owner, profile, plan)
+    add_fringe_pages_within_grid!(root, communicator, owner, profile, plan, explicit_categories)
 
     wire_phrase_board!(communicator, owner, phrases_board) if phrases_board
   end
@@ -227,7 +227,7 @@ class BuildBoardSetJob
   # can't fit fold their interests into the single "My Favorites" catch-all
   # (one tile, deduped) so nothing the child asked for is dropped — it just
   # lands in Favorites instead of its own page.
-  def add_fringe_pages_within_grid!(root, communicator, owner, profile, plan)
+  def add_fringe_pages_within_grid!(root, communicator, owner, profile, plan, explicit_categories = {})
     root.reload
     open_cells = root_open_cells(root)
 
@@ -258,7 +258,55 @@ class BuildBoardSetJob
       end
     end
 
+    # Place leftover interests on an existing matching board where one exists,
+    # then drop the rest into My Favorites.
+    catch_all = route_catch_all_to_existing_boards!(root, owner, catch_all, explicit_categories)
     add_to_favorites!(root, communicator, catch_all) if catch_all.any?
+  end
+
+  # Before dumping leftover interests into My Favorites, drop each word onto an
+  # existing board in the set whose category matches — e.g. a capped seed page
+  # (the seed set always clones intact, so the board exists even when the planner
+  # didn't budget the word into it) or a sparse AI category whose words were
+  # demoted to catch_all. Returns the still-unrouted words.
+  def route_catch_all_to_existing_boards!(root, owner, words, explicit_categories)
+    return words if words.blank?
+
+    root.reload
+    boards_by_name = set_top_level_boards_by_name(root)
+    explicit = explicit_categories || {}
+    unrouted = []
+
+    words.each do |word|
+      category = explicit[word].presence || Boards::InterestCategories.category_for(word)
+      board = category && existing_board_for_category(category, boards_by_name)
+      if board
+        add_interest_to_board(owner, board, word)
+      else
+        unrouted << word
+      end
+    end
+
+    unrouted
+  end
+
+  # name(downcased) => Board for every board the root's folder tiles open.
+  def set_top_level_boards_by_name(root)
+    ids = root.board_images.where.not(predictive_board_id: nil).pluck(:predictive_board_id).uniq
+    Board.where(id: ids).each_with_object({}) do |board, map|
+      map[board.name.to_s.strip.downcase] = board
+    end
+  end
+
+  # Resolve an InterestCategories name to an existing set board, honoring the
+  # seed-page aliases ("Family & People" -> People). Never returns My Favorites —
+  # that's the explicit fallback, not a category home.
+  def existing_board_for_category(category, boards_by_name)
+    name = Boards::StructurePlanner::CATEGORY_SEED_ALIASES[category] || category
+    board = boards_by_name[name.to_s.strip.downcase]
+    return nil if board.nil? || board.name.to_s.strip.casecmp?("my favorites")
+
+    board
   end
 
   # Adds one fringe page as a top-level folder tile. Returns true only when a

--- a/spec/services/boards/structure_planner_spec.rb
+++ b/spec/services/boards/structure_planner_spec.rb
@@ -78,6 +78,31 @@ RSpec.describe Boards::StructurePlanner do
     end
   end
 
+  describe "sparse AI page gating" do
+    # "backpack" -> School (InterestCategories). In a core-60 build School is
+    # neither a seed page nor a prebuilt fringe template, so the category would
+    # otherwise become an :ai_generated page named after the one word.
+    it "does NOT spawn an AI page for a single niche interest; routes it to catch_all" do
+      plan = described_class.new(level: "standard", interests: ["backpack"]).call
+
+      school = plan.fringe_pages.find { |p| p[:name] == "School" }
+      expect(school).to be_nil
+      expect(plan.fringe_pages.select { |p| p[:source] == :ai_generated }).to be_empty
+      expect(plan.catch_all_interests).to include("backpack")
+      expect(plan.ai_credits_needed).to eq(0)
+    end
+
+    it "DOES spawn an AI page once the niche category clears the threshold" do
+      plan = described_class.new(level: "standard", interests: %w[backpack homework]).call
+
+      school = plan.fringe_pages.find { |p| p[:name] == "School" }
+      expect(school).to be_present
+      expect(school[:source]).to eq(:ai_generated)
+      expect(school[:interests]).to contain_exactly("backpack", "homework")
+      expect(plan.catch_all_interests).not_to include("backpack", "homework")
+    end
+  end
+
   describe "page count capping" do
     it "caps starter at 6 pages" do
       many_interests = %w[dog pizza happy toilet shirt bed sing tree hi run tablet car]

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -240,6 +240,28 @@ RSpec.describe BuildBoardSetJob do
       expect(root.status).to eq("complete")
     end
 
+    # "backpack" -> School, which is not a seed page or prebuilt template in
+    # core-60, so it used to spawn a whole AI-generated board named after the one
+    # word. It should not: no AI call, and the word lands in My Favorites.
+    it "does not spawn a dedicated AI board for a lone niche interest" do
+      root = precreate_root!(name: "Core 60")
+
+      expect(Boards::AiPageGenerator).not_to receive(:new)
+      described_class.new.perform(root.id, communicator.id, "standard", ["backpack"])
+
+      root.reload
+      expect(root.status).to eq("complete")
+
+      folder_names = root.board_images.select(&:is_dynamic?).map do |bi|
+        Board.find(bi.predictive_board_id).name.to_s.downcase
+      end
+      expect(folder_names).not_to include("backpack")
+
+      favorites = user.boards.find_by(name: "My Favorites")
+      expect(favorites).to be_present
+      expect(favorites.board_images.map { |bi| bi.label.to_s.downcase }).to include("backpack")
+    end
+
     it "normalizes legacy template keys — core-60 routes to standard path" do
       root = precreate_root!(name: "Core 60")
 
@@ -368,6 +390,63 @@ RSpec.describe BuildBoardSetJob do
       expect {
         described_class.new.perform(-1, communicator.id, "home", [])
       }.not_to raise_error
+    end
+  end
+
+  # Part 2: a leftover interest goes onto an existing matching board where one
+  # exists in the set, and only falls through to My Favorites when none does.
+  describe "#route_catch_all_to_existing_boards!" do
+    let(:job) { described_class.new }
+
+    def link_board!(root, target, label)
+      root.board_images.create!(
+        image: create(:image, label: label, user_id: root.user_id),
+        predictive_board_id: target.id,
+      )
+    end
+
+    it "drops a leftover word onto the existing board for its category" do
+      root = create(:board, user: user, name: "Root")
+      food = create(:board, user: user, name: "Food")
+      link_board!(root, food, "Food")
+
+      leftover = job.send(:route_catch_all_to_existing_boards!, root, user, ["pizza"], {})
+
+      expect(leftover).to eq([])
+      expect(food.reload.board_images.map { |bi| bi.label.to_s.downcase }).to include("pizza")
+    end
+
+    it "honors a seed-page alias (Health & Body -> Body)" do
+      root = create(:board, user: user, name: "Root")
+      body = create(:board, user: user, name: "Body")
+      link_board!(root, body, "Body")
+
+      leftover = job.send(:route_catch_all_to_existing_boards!, root, user, ["wibble"],
+                          { "wibble" => "Health & Body" })
+
+      expect(leftover).to eq([])
+      expect(body.reload.board_images.map { |bi| bi.label.to_s.downcase }).to include("wibble")
+    end
+
+    it "returns words with no matching board for the My Favorites fallback" do
+      root = create(:board, user: user, name: "Root")
+      link_board!(root, create(:board, user: user, name: "Food"), "Food")
+
+      # backpack -> School; no School board in the set
+      leftover = job.send(:route_catch_all_to_existing_boards!, root, user, ["backpack"], {})
+
+      expect(leftover).to eq(["backpack"])
+    end
+
+    it "never routes into My Favorites (that is the explicit fallback)" do
+      root = create(:board, user: user, name: "Root")
+      favorites = create(:board, user: user, name: "My Favorites")
+      link_board!(root, favorites, "My Favorites")
+
+      leftover = job.send(:route_catch_all_to_existing_boards!, root, user, ["backpack"], {})
+
+      expect(leftover).to eq(["backpack"])
+      expect(favorites.reload.board_images.map { |bi| bi.label.to_s.downcase }).not_to include("backpack")
     end
   end
 end


### PR DESCRIPTION
## Summary

A lone interest word in the Board Builder could spin up an entire **AI-generated board named after that one word**. Reported case: picking "backpack" produced a folder/board called "Backpack" in the corner.

**Root cause:** `InterestCategories.category_for("backpack")` → **"School"**. In a **core-60** build, "School" is neither a seed page nor a prebuilt `FringeTemplates` page, so `StructurePlanner#source_for_category` returns `:ai_generated` — and the planner created a dedicated page for it with **no minimum-interest threshold**, so one word became a ~10-tile AI board (and burned an `ai_board_page` credit). (In a core-84 build "School" *is* a seed page, so "backpack" already routed correctly as a single tile — the bug only hits levels whose core lacks the category.)

## Changes

**Part 1 — gate AI pages by interest count** (`StructurePlanner`)
- `drop_sparse_ai_pages` removes any `:ai_generated` page whose category has fewer than `MIN_AI_PAGE_INTERESTS` interests (`BOARD_BUILDER_MIN_AI_PAGE_INTERESTS`, default **2**). Sparse interests fall through to `catch_all`.
- **Seed/prebuilt pages are not gated** — they're curated/default content, and gating them would drop a legitimate zero-interest default like the prebuilt "Social" page in Extended.

**Part 2 — place leftovers on an existing board first** (`BuildBoardSetJob`)
- `route_catch_all_to_existing_boards!` matches each catch-all word's category (explicit or dictionary, honoring the seed aliases) to a board **already in the set** and drops it there; only unmatched words go to **My Favorites**. This is what lets a capped seed-category word land on its existing seed board (the seed set always clones intact) instead of Favorites. Never routes into "My Favorites" itself (that's the explicit fallback).

**Net effect:** a lone niche interest makes **no AI call** and lands on an existing matching board or My Favorites — never its own board. Cuts spurious single-word boards and saves AI credits.

## Test plan

- `spec/services/boards/structure_planner_spec.rb` — single niche interest (backpack→School) produces **no** AI page and lands in `catch_all`; 2+ interests in that category **do** get an AI page. (28 examples)
- `spec/sidekiq/build_board_set_job_spec.rb` — integration: a lone "backpack" core-60 build asserts `Boards::AiPageGenerator` is **never instantiated** and the word ends up in My Favorites; plus 4 unit cases for `route_catch_all_to_existing_boards!` (category match, seed alias, no-match fallback, never-into-Favorites). (26 examples)
- Regression: build grid (17), `SeededSetCloner` (22), board_builder request (48) — all green.

Docs: CLAUDE.md Board Builder section + CHANGELOG (Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)