### PR TITLE
feat(board-builder): write a real BoardGroup; builder set counts as 1 board set (#407)

### DIFF
--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -71,8 +71,13 @@ module API
           return
         end
 
-        if current_user.at_board_limit?
-          render json: { error: "Maximum number of boards reached (#{current_user.countable_board_count}/#{current_user.board_limit}). Please upgrade to add more." },
+        # A builder set is a Board Set (BoardGroup), so it counts against the
+        # board-SET cap, not the per-board cap. Exactly one group slot, zero
+        # board slots (see User#countable_board_count / #countable_board_group_count).
+        if current_user.at_board_group_limit?
+          render json: { error: "You've reached your plan's board set limit (#{current_user.countable_board_group_count}/#{current_user.board_group_limit}). Upgrade to add more.",
+                         limit: current_user.board_group_limit,
+                         count: current_user.countable_board_group_count },
                  status: :unprocessable_content
           return
         end
@@ -100,6 +105,7 @@ module API
         categories = Boards::InterestWords.extract_categories(raw_interests)
 
         root = nil
+        board_group = nil
         ActiveRecord::Base.transaction do
           root = Board.new(name: root_name, user: owner)
           root.board_type = "dynamic"
@@ -113,11 +119,22 @@ module API
           child_board = communicator.child_boards.create!(board: root, created_by_id: owner.id)
           child_board.update!(favorite: true)
 
+          # The builder set's canonical container. Member boards (root + every
+          # child the job builds) attach here; this is what the user's board-set
+          # limit counts and what cascade-deletes the whole tree. Add the root
+          # now; the job attaches the rest. (BoardGroup#set_root_board nulls
+          # root_board_id on create when the group has no boards yet, so pin it
+          # after the join exists.)
+          board_group = owner.board_groups.create!(name: root_name, builder: true)
+          board_group.board_group_boards.create!(board: root, position: 0)
+          board_group.update!(root_board_id: root.id)
+
           communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
         end
 
         BuildBoardSetJob.perform_async(root.id, communicator.id, build_key, interests, categories,
-                                       { "include_phrases" => include_phrases_param })
+                                       { "include_phrases" => include_phrases_param,
+                                         "board_group_id" => board_group.id })
 
         render json: serialize_built_root(root), status: :created
       rescue Boards::BlueprintAssembler::UnknownTemplate => e

--- a/app/models/board_group.rb
+++ b/app/models/board_group.rb
@@ -23,6 +23,7 @@
 #  margin_settings       :jsonb            not null
 #  settings              :jsonb            not null
 #  description           :text
+#  builder               :boolean          default(FALSE), not null
 #
 class BoardGroup < ApplicationRecord
   # has_many :board_group_boards, dependent: :destroy
@@ -34,6 +35,7 @@ class BoardGroup < ApplicationRecord
   belongs_to :root_board, class_name: "Board", optional: true
 
   scope :predefined, -> { where(predefined: true) }
+  scope :builder, -> { where(builder: true) }
   scope :alphabetical, -> { order(Arel.sql("LOWER(name) ASC")) }
   scope :featured, -> { where(predefined: true, featured: true) }
   scope :by_name, ->(name) { where("name ILIKE ?", "%#{name}%") }
@@ -59,7 +61,32 @@ class BoardGroup < ApplicationRecord
   # after_initialize :set_initial_layout, if: :layout_empty?
   # after_save :set_layouts_for_screen_sizes
   before_create :set_root_board
+  # prepend: true so this runs BEFORE the has_many :board_group_boards
+  # dependent: :destroy callback (declared earlier) wipes the join rows we read
+  # to find the member boards.
+  before_destroy :destroy_member_boards_if_builder, prepend: true
   after_initialize :set_number_of_columns, if: :no_colmns_set
+
+  # A builder group OWNS its member boards (the whole built tree), so destroying
+  # it destroys every member board — fixing the orphan-on-delete bug where
+  # deleting a builder root leaked its predictive_board_id children as invisible,
+  # uncounted boards (issue #407). Hand-made groups are pure collections:
+  # destroying them drops only the join rows (board_group_boards dependent:
+  # :destroy), leaving the member boards intact — that behavior is unchanged.
+  #
+  # We destroy the actual Board records (NOT `boards.destroy_all`, which on a
+  # has_many :through only deletes the join rows). Each Board's own
+  # `dependent: :destroy` cleans up its board_group_boards + child_boards rows.
+  # root_board_id is a FK back into one of these boards with no ON DELETE, and
+  # the group row still exists during before_destroy, so null it first or
+  # destroying the root trips the constraint.
+  def destroy_member_boards_if_builder
+    return unless builder?
+
+    update_columns(root_board_id: nil) if root_board_id.present?
+    member_board_ids = board_group_boards.pluck(:board_id).uniq
+    Board.where(id: member_board_ids).destroy_all
+  end
 
   def set_slug
     return unless name.present? && slug.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1356,12 +1356,29 @@ class User < ApplicationRecord
   end
 
   # Single source of truth for "how many boards count against the limit."
-  # Excludes predefined boards and Board Builder sub-boards — a builder wizard
-  # run persists a whole linked tree, but the user only chose one thing, so the
-  # tree counts as ONE (its root). Memoized because board list serialization
-  # calls board_editable? once per board.
+  # Excludes predefined boards and every board that belongs to one of the user's
+  # Board Builder groups — a builder wizard run persists a whole linked tree but
+  # the user only chose one thing, so it costs exactly ONE board-set slot
+  # (countable_board_group_count) and ZERO board slots. Memoized because board
+  # list serialization calls board_editable? once per board.
+  #
+  # This replaced the older settings["builder_child"] flag exclusion: "set-ness"
+  # now lives in the builder BoardGroup, not a fragile JSONB marker (issue #407).
   def countable_board_count
-    @countable_board_count ||= boards.where(predefined: false).not_builder_child.count
+    @countable_board_count ||=
+      boards.where(predefined: false)
+            .where.not(id: builder_grouped_board_ids)
+            .count
+  end
+
+  # Board ids that belong to one of THIS user's builder board groups. A builder
+  # set's boards (root + every child) are members of a `builder: true` BoardGroup,
+  # so they're excluded from the board-limit count.
+  def builder_grouped_board_ids
+    BoardGroupBoard
+      .joins(:board_group)
+      .where(board_groups: { user_id: id, builder: true })
+      .select(:board_id)
   end
 
   # The one gate every board-creation path checks. Admins are never limited.

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -36,7 +36,14 @@ class BuildBoardSetJob
       return
     end
 
+    opts = options.is_a?(Hash) ? options : {}
+    board_group_id = opts["board_group_id"]
+
     if root.status == "complete" || root.board_images.exists?
+      # Already built (a retry after a partial run, or a stale duplicate enqueue).
+      # Still backfill the group membership so a set built before the attach ran
+      # — or one whose attach was interrupted — ends up fully grouped. Idempotent.
+      attach_set_to_group!(root, board_group_id)
       root.update_column(:status, "complete")
       return
     end
@@ -50,7 +57,6 @@ class BuildBoardSetJob
 
     begin
       explicit_categories = categories.is_a?(Hash) ? categories : {}
-      opts = options.is_a?(Hash) ? options : {}
       include_phrases = opts["include_phrases"]
 
       if complexity_level?(level_or_template)
@@ -59,6 +65,11 @@ class BuildBoardSetJob
         build_legacy(root, communicator, level_or_template, interests, explicit_categories)
       end
 
+      # Attach the whole built set (root + every child the build produced —
+      # fringe/phrases/favorites/AI pages included) to its builder BoardGroup.
+      # This is the single chokepoint after the full set exists, so it catches
+      # boards the build services add outside SeededSetCloner/BoardTreeBuilder.
+      attach_set_to_group!(root, board_group_id)
       mute_dynamic_tile_names!(root)
       generate_preview!(root)
       root.update_column(:status, "complete")
@@ -173,6 +184,24 @@ class BuildBoardSetJob
 
         bi.update_column(:data, data.merge("mute_name" => true))
       end
+  end
+
+  # Attach every board in the built set to its builder BoardGroup, so the set is
+  # counted as one Board Set (0 board slots) and cascade-deletes as a unit. The
+  # controller already added the root at position 0; this adds the children. The
+  # board_group_boards rows are created only when missing, so re-running the job
+  # never duplicates them.
+  def attach_set_to_group!(root, board_group_id)
+    return unless board_group_id
+
+    group = BoardGroup.find_by(id: board_group_id)
+    return unless group
+
+    ids = set_board_ids(root)
+    existing = group.board_group_boards.where(board_id: ids).pluck(:board_id).to_set
+    (ids - existing.to_a).each do |bid|
+      group.board_group_boards.create!(board_id: bid)
+    end
   end
 
   # Every board in the just-built set: BFS the predictive_board_id links from the

--- a/db/migrate/20260624130000_add_builder_to_board_groups.rb
+++ b/db/migrate/20260624130000_add_builder_to_board_groups.rb
@@ -1,0 +1,11 @@
+class AddBuilderToBoardGroups < ActiveRecord::Migration[7.1]
+  # Marks a BoardGroup as Board Builder output (the canonical container for a
+  # built set). Gates the builder-only counting + cascade-delete behavior so
+  # hand-made groups are unchanged. Consistent with the existing
+  # predefined/featured boolean flags; a real column over a settings JSONB key
+  # because the JSONB-flag fragility is exactly what this work removes.
+  def change
+    add_column :board_groups, :builder, :boolean, default: false, null: false
+    add_index  :board_groups, :builder
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_24_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_24_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -142,6 +142,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_24_120000) do
     t.jsonb "margin_settings", default: {}, null: false
     t.jsonb "settings", default: {}, null: false
     t.text "description"
+    t.boolean "builder", default: false, null: false
+    t.index ["builder"], name: "index_board_groups_on_builder"
     t.index ["description"], name: "index_board_groups_on_description"
     t.index ["featured"], name: "index_board_groups_on_featured"
     t.index ["original_obf_root_id"], name: "index_board_groups_on_original_obf_root_id"

--- a/spec/models/board_group_spec.rb
+++ b/spec/models/board_group_spec.rb
@@ -23,6 +23,7 @@
 #  margin_settings       :jsonb            not null
 #  settings              :jsonb            not null
 #  description           :text
+#  builder               :boolean          default(FALSE), not null
 #
 require "rails_helper"
 
@@ -63,6 +64,60 @@ RSpec.describe BoardGroup, type: :model do
       expect(board_group.boards).to include(board_1, board_2)
       expect(board_1.board_groups).to include(board_group)
       expect(board_2.board_groups).to include(board_group)
+    end
+  end
+
+  # Issue #407: a builder group OWNS its member boards, so destroying it
+  # destroys every member board (fixing the orphan-on-delete bug). Hand-made
+  # groups are pure collections — destroying them keeps the member boards.
+  describe "cascade delete (builder vs hand-made)" do
+    def builder_group_with_members(owner)
+      root  = Board.create!(name: "Built Root", user: owner, parent: owner, slug: "root-#{SecureRandom.hex(4)}")
+      child = Board.create!(name: "Built Child", user: owner, parent: owner, slug: "child-#{SecureRandom.hex(4)}")
+      group = owner.board_groups.create!(name: "Built Set", builder: true)
+      group.board_group_boards.create!(board: root)
+      group.board_group_boards.create!(board: child)
+      group.update!(root_board_id: root.id)
+      [group, root, child]
+    end
+
+    it "destroys all member boards and join rows when a builder group is destroyed" do
+      group, root, child = builder_group_with_members(user)
+
+      expect { group.destroy! }
+        .to change { Board.where(id: [root.id, child.id]).count }.from(2).to(0)
+        .and change { BoardGroupBoard.where(board_group_id: group.id).count }.to(0)
+
+      expect(BoardGroup.exists?(group.id)).to be(false)
+    end
+
+    it "destroys the builder root even though root_board_id FKs back to it" do
+      group, root, _child = builder_group_with_members(user)
+      # root_board_id is a no-ON-DELETE FK into a member board; the cascade must
+      # null it before destroying the board or the delete would raise.
+      expect(group.root_board_id).to eq(root.id)
+      expect { group.destroy! }.not_to raise_error
+      expect(Board.exists?(root.id)).to be(false)
+    end
+
+    it "also destroys the root's communicator ChildBoard join" do
+      communicator = create(:child_account, user: user)
+      group, root, _child = builder_group_with_members(user)
+      cb = communicator.child_boards.create!(board: root, created_by_id: user.id)
+
+      group.destroy!
+
+      expect(ChildBoard.exists?(cb.id)).to be(false)
+    end
+
+    it "leaves member boards intact when a hand-made (non-builder) group is destroyed" do
+      board = Board.create!(name: "Kept", user: user, parent: user, slug: "kept-#{SecureRandom.hex(4)}")
+      group = user.board_groups.create!(name: "Manual Set") # builder defaults to false
+      group.board_group_boards.create!(board: board)
+
+      expect { group.destroy! }.not_to change { Board.exists?(board.id) }
+      expect(Board.exists?(board.id)).to be(true)
+      expect(BoardGroupBoard.where(board_group_id: group.id).count).to eq(0)
     end
   end
 

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -57,14 +57,6 @@ RSpec.describe User, "plan limits", type: :model do
       expect(user.at_board_limit?).to be(false)
     end
 
-    it "counts a Board Builder tree as ONE (excludes builder_child sub-boards)" do
-      create(:board, user: user, name: "root")
-      create(:board, user: user, name: "Food",  settings: { "builder_child" => true })
-      create(:board, user: user, name: "Play",  settings: { "builder_child" => true })
-      expect(user.countable_board_count).to eq(1)
-      expect(user.at_board_limit?).to be(true)
-    end
-
     it "never limits admins" do
       admin = create(:admin_user)
       create(:board, user: admin)
@@ -76,6 +68,74 @@ RSpec.describe User, "plan limits", type: :model do
       create(:board, user: user)
       # Fresh instance — countable_board_count memoizes, matching the controller.
       expect(User.find(user.id).can_create_boards).to be(false)
+    end
+  end
+
+  # Issue #407: a Board Builder set is a real `builder: true` BoardGroup. It
+  # costs EXACTLY one board-set slot and ZERO board slots — its member boards
+  # (root + children) are excluded from countable_board_count, and the group
+  # itself counts as one in countable_board_group_count. Hand-made groups are
+  # unchanged in this phase: their member boards still count against board_limit.
+  describe "builder-set vs standalone vs hand-made counting matrix" do
+    let(:user) { create(:free_user) }
+
+    # A builder set: root + N children, all members of a `builder: true` group.
+    def make_builder_set(owner, children: 3, name: "Built Set")
+      root  = create(:board, user: owner, name: "#{name} Root")
+      group = owner.board_groups.create!(name: name, builder: true)
+      group.board_group_boards.create!(board: root)
+      group.update!(root_board_id: root.id)
+      children.times do |i|
+        child = create(:board, user: owner, name: "#{name} Child #{i}")
+        group.board_group_boards.create!(board: child)
+      end
+      group
+    end
+
+    # A hand-made set: a non-builder group whose member boards still count.
+    def make_manual_group(owner, boards: 2, name: "Manual Set")
+      group = owner.board_groups.create!(name: name) # builder defaults to false
+      boards.times { |i| group.board_group_boards.create!(board: create(:board, user: owner, name: "#{name} #{i}")) }
+      group
+    end
+
+    it "new user, nothing => 0 boards / 0 sets" do
+      expect(user.countable_board_count).to eq(0)
+      expect(user.countable_board_group_count).to eq(0)
+    end
+
+    it "1 standalone board => 1 board / 0 sets" do
+      create(:board, user: user)
+      expect(user.countable_board_count).to eq(1)
+      expect(user.countable_board_group_count).to eq(0)
+    end
+
+    it "1 builder set (root + 3 children) => 0 boards / 1 set" do
+      make_builder_set(user, children: 3)
+      expect(user.countable_board_count).to eq(0)
+      expect(user.countable_board_group_count).to eq(1)
+    end
+
+    it "1 builder set + 2 standalone boards => 2 boards / 1 set" do
+      make_builder_set(user, children: 3)
+      2.times { |i| create(:board, user: user, name: "Standalone #{i}") }
+      expect(user.countable_board_count).to eq(2)
+      expect(user.countable_board_group_count).to eq(1)
+    end
+
+    it "1 builder set + 1 hand-made group (2 boards) => 2 boards / 2 sets" do
+      make_builder_set(user, children: 3)
+      make_manual_group(user, boards: 2)
+      # Hand-made members still count against board_limit in this phase.
+      expect(user.countable_board_count).to eq(2)
+      expect(user.countable_board_group_count).to eq(2)
+    end
+
+    it "2 builder sets => 0 boards / 2 sets" do
+      make_builder_set(user, children: 3, name: "Set A")
+      make_builder_set(user, children: 2, name: "Set B")
+      expect(user.countable_board_count).to eq(0)
+      expect(user.countable_board_group_count).to eq(2)
     end
   end
 

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -306,8 +306,13 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         # Interests are normalized + persisted in-request for re-run prefill.
         expect(communicator.reload.details["interests"]).to eq(["dinosaurs", "grandma"])
 
+        # The set's builder BoardGroup is created in-request and its id rides the
+        # job options so the job can attach the children it builds.
+        group = user.board_groups.find_by(builder: true, root_board_id: root.id)
+        expect(group).to be_present
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"], {}, { "include_phrases" => nil }])
+          .to eq([root.id, communicator.id, "home", ["dinosaurs", "grandma"], {},
+                  { "include_phrases" => nil, "board_group_id" => group.id }])
       end
 
       it "builds a linked set, routes interests into category vs favorites folders, and completes (job drained)" do
@@ -418,7 +423,8 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(response).to have_http_status(:created)
         opts = BuildBoardSetJob.jobs.last["args"][5]
-        expect(opts).to eq({ "include_phrases" => false })
+        expect(opts["include_phrases"]).to eq(false)
+        expect(opts["board_group_id"]).to be_present
       end
 
       it "still 422s unknown_template for a bogus glp-looking slug" do
@@ -476,9 +482,12 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
-    context "board-limit gate (a built tree counts as ONE board)" do
-      it "returns 422, builds nothing, and enqueues no job when the user is already at their limit" do
-        create(:board, user: user) # user is Free (limit 1) → now at limit
+    context "board-set-limit gate (a built tree counts as ONE Board Set, zero boards)" do
+      it "returns 422, builds nothing, and enqueues no job when the user is already at their board-set limit" do
+        # A builder set is a Board Set, so the gate is the board_group limit
+        # (Free = 1). A standalone board no longer blocks a build — an existing
+        # builder/hand-made group does.
+        user.board_groups.create!(name: "Existing Set", builder: true) # Free group_limit 1 → at limit
         jobs_before = BuildBoardSetJob.jobs.size
 
         expect {
@@ -489,10 +498,27 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(BuildBoardSetJob.jobs.size).to eq(jobs_before)
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to match(/board set limit/)
+        expect(body["limit"]).to eq(1)
+        expect(body["count"]).to eq(1)
       end
 
-      it "counts the whole built tree as one, so a second build is blocked" do
+      it "leaves the standalone board limit untouched — a Free user with a builder set can still make a standalone board" do
+        # Build a set (consumes the 1 board-set slot, 0 board slots).
+        post "/api/v1/board_builder",
+             params: { communicator_id: communicator.id, template: "home" }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+        BuildBoardSetJob.drain
+
+        fresh = User.find(user.id)
+        expect(fresh.countable_board_group_count).to eq(1)
+        expect(fresh.countable_board_count).to eq(0)   # board slot still free
+        expect(fresh.at_board_limit?).to be(false)     # standalone create still allowed
+      end
+
+      it "counts the whole built tree as one Board Set (0 boards), so a second builder run is blocked" do
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "home",
                        interests: ["dinosaurs"] }.to_json,
@@ -501,9 +527,11 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         BuildBoardSetJob.drain
 
         fresh = User.find(user.id)
-        # The tree persisted multiple boards, but it counts as one.
+        # The tree persisted multiple boards, but they're all group members, so
+        # the set costs zero board slots and exactly one board-set slot.
         expect(fresh.boards.where(predefined: false).count).to be > 1
-        expect(fresh.countable_board_count).to eq(1)
+        expect(fresh.countable_board_count).to eq(0)
+        expect(fresh.countable_board_group_count).to eq(1)
 
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "home" }.to_json,
@@ -528,9 +556,10 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
     end
 
     context "re-run guard (issue #269)" do
-      # Raise the board limit so the #270 limit gate doesn't pre-empt the re-run
-      # guard — that gate only blocks Free users; the dup problem is paid users.
-      before { user.update!(settings: user.settings.to_h.merge("board_limit" => 10)) }
+      # Raise the board-SET limit so the limit gate doesn't pre-empt the re-run
+      # guard — the gate only blocks users at their board_group cap; the dup
+      # problem is paid users (issue #407 flipped this gate from board_limit).
+      before { user.update!(settings: user.settings.to_h.merge("board_group_limit" => 10)) }
 
       it "warns with 409 board_builder_set_exists on a re-run and builds nothing" do
         post "/api/v1/board_builder",
@@ -636,9 +665,9 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       # retry idempotency) lives in spec/sidekiq/build_board_set_job_spec.rb;
       # this covers the user-visible request-level artifact.
       it "leaves the root as the failed artifact and the next run 409s until confirmed" do
-        # Lift the Free board limit so the second POST reaches the 409 guard
-        # (the limit gate runs first and the failed root still counts as one).
-        user.update!(settings: user.settings.to_h.merge("board_limit" => 10))
+        # Lift the Free board-set limit so the second POST reaches the 409 guard
+        # (the limit gate runs first and the failed set still holds one group slot).
+        user.update!(settings: user.settings.to_h.merge("board_group_limit" => 10))
         allow_any_instance_of(Boards::BoardTreeBuilder)
           .to receive(:call).and_raise(Boards::BoardTreeBuilder::BuildError, "boom")
 
@@ -682,15 +711,19 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(child_board.favorite).to eq(true)
 
         expect(communicator.reload.details["interests"]).to eq(["pizza"])
+        group = user.board_groups.find_by(builder: true, root_board_id: root.id)
+        expect(group).to be_present
         expect(BuildBoardSetJob.jobs.last["args"])
-          .to eq([root.id, communicator.id, "core-60", ["pizza"], {}, { "include_phrases" => nil }])
+          .to eq([root.id, communicator.id, "core-60", ["pizza"], {},
+                  { "include_phrases" => nil, "board_group_id" => group.id }])
 
         BuildBoardSetJob.drain
         root.reload
         expect(root.status).to eq("complete")
 
-        # The whole cloned set counts as ONE board.
-        expect(User.find(user.id).countable_board_count).to eq(1)
+        # The whole cloned set is one Board Set: 0 board slots, 1 board-set slot.
+        expect(User.find(user.id).countable_board_count).to eq(0)
+        expect(User.find(user.id).countable_board_group_count).to eq(1)
 
         # Cloned core tiles landed on the SAME root the 201 returned.
         expect(root.board_images.map(&:label)).to include("I", "Food")
@@ -701,13 +734,17 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         food_tile = root.board_images.find { |bi| bi.label == "Food" }
         expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
+        # The cloned fringe page is also a group member (not just the root), so
+        # it doesn't leak as a standalone uncounted board.
+        expect(group.reload.boards).to include(root, cloned_food)
+
         # The user's copy must never surface as a pickable robust template.
         expect(Boards::RobustSets.all_roots.pluck(:id)).not_to include(root.id)
       end
 
-      it "is blocked by the board limit (422) — a cloned set still counts as one" do
+      it "is blocked by the board-set limit (422) — a cloned set is one Board Set" do
         seed_robust_set!
-        create(:board, user: user) # Free (limit 1) → at limit
+        user.board_groups.create!(name: "Existing Set", builder: true) # Free group_limit 1 → at limit
 
         expect {
           post "/api/v1/board_builder",
@@ -716,12 +753,12 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         }.not_to change { communicator.child_boards.count }
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(JSON.parse(response.body)["error"]).to match(/Maximum number of boards/)
+        expect(JSON.parse(response.body)["error"]).to match(/board set limit/)
       end
 
       it "warns with 409 on a re-run unless confirm=true" do
         seed_robust_set!
-        user.update!(settings: user.settings.to_h.merge("board_limit" => 10))
+        user.update!(settings: user.settings.to_h.merge("board_group_limit" => 10))
 
         post "/api/v1/board_builder",
              params: { communicator_id: communicator.id, template: "core-60" }.to_json,

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe Boards::SeededSetCloner do
   end
 
   describe "#call" do
-    it "clones the linked set for the owner and counts the whole set as ONE board" do
-      expect {
-        @root = described_class.new(@source[:root], communicator: communicator).call
-      }.to change { User.find(owner.id).countable_board_count }.from(0).to(1)
+    it "clones the linked set for the owner and marks builder metadata (root + fringe)" do
+      # The cloner builds + marks the set; the "counts as one Board Set" property
+      # now lives in the builder BoardGroup the controller/job attaches (#407),
+      # so this asserts the clone structure + markers, not countable_board_count.
+      @root = described_class.new(@source[:root], communicator: communicator).call
 
       expect(@root.user_id).to eq(owner.id)
       expect(@root.predefined).to be(false)
@@ -136,8 +137,6 @@ RSpec.describe Boards::SeededSetCloner do
 
       fav_tile = root.board_images.find_by(label: "My Favorites")
       expect(fav_tile.predictive_board_id).to eq(favorites.id)
-
-      expect(User.find(owner.id).countable_board_count).to eq(1)
     end
 
     it "queues AI art for a novel interest word with no existing symbol" do
@@ -235,7 +234,6 @@ RSpec.describe Boards::SeededSetCloner do
         expect(cloned_feelings.board_images.find_by(label: "home").predictive_board_id).to eq(root.id)
 
         expect(owner.boards.count).to eq(3)
-        expect(User.find(owner.id).countable_board_count).to eq(1)
       end
 
       it "preserves the adopted root's identity, does not re-attach, and never inherits the robust catalog markers" do

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -75,8 +75,10 @@ RSpec.describe BuildBoardSetJob do
       expect(communicator.child_boards.where(board_id: root.id).count).to eq(1)
       expect(communicator.child_boards.count).to eq(1)
 
-      # The whole tree counts as ONE board.
-      expect(User.find(user.id).countable_board_count).to eq(1)
+      # Builder markers persist as transition metadata; the "counts as one"
+      # property now lives in the builder BoardGroup (see the #407 attachment
+      # specs) — this job invocation passes no group, so it asserts the markers.
+      expect(children.pluck("settings").map { |s| s["builder_child"] }).to all(be(true))
     end
 
     it "preserves the root identity the 201 payload exposed (name, slug, user)" do
@@ -117,7 +119,8 @@ RSpec.describe BuildBoardSetJob do
       expect(Boards::RobustSets.all_roots.pluck(:id)).to contain_exactly(source_root.id)
 
       expect(communicator.child_boards.count).to eq(1)
-      expect(User.find(user.id).countable_board_count).to eq(1)
+      # Builder markers persist; "counts as one" lives in the group (#407).
+      expect(cloned_food.reload.settings["builder_child"]).to be(true)
     end
 
     it "queues AI art for a novel interest word with no existing symbol" do
@@ -360,6 +363,64 @@ RSpec.describe BuildBoardSetJob do
 
       expect(Board.count).to eq(boards_before)
       expect(root.reload.status).to eq("complete")
+    end
+  end
+
+  # Issue #407: the builder set's boards (root + everything the job builds)
+  # become members of a `builder: true` BoardGroup so the set counts as one
+  # Board Set (0 board slots) and cascade-deletes as a unit.
+  describe "board group attachment (#407)" do
+    # Mirrors the controller: pre-create the root, its builder group, add the
+    # root at position 0, and hand the group id to the job via options.
+    def precreate_root_and_group!(name:)
+      root  = precreate_root!(name: name)
+      group = user.board_groups.create!(name: name, builder: true)
+      group.board_group_boards.create!(board: root, position: 0)
+      group.update!(root_board_id: root.id)
+      [root, group]
+    end
+
+    it "attaches every built board (root + children) to the builder group" do
+      root, group = precreate_root_and_group!(name: "Home")
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"],
+                                  {}, { "board_group_id" => group.id })
+
+      group.reload
+      member_ids = group.boards.pluck(:id)
+      built_ids  = user.boards.where(predefined: false).pluck(:id)
+      # Root + every sub-board the build produced are all group members.
+      expect(member_ids).to match_array(built_ids)
+      expect(member_ids).to include(root.id)
+      expect(built_ids.size).to be > 1
+
+      # The whole set costs zero board slots and one board-set slot.
+      fresh = User.find(user.id)
+      expect(fresh.countable_board_count).to eq(0)
+      expect(fresh.countable_board_group_count).to eq(1)
+    end
+
+    it "is idempotent — a retry does not duplicate board_group_boards rows" do
+      root, group = precreate_root_and_group!(name: "Home")
+      described_class.new.perform(root.id, communicator.id, "home", [], {}, { "board_group_id" => group.id })
+      members_after_first = group.reload.board_group_boards.count
+
+      described_class.new.perform(root.id, communicator.id, "home", [], {}, { "board_group_id" => group.id })
+
+      expect(group.reload.board_group_boards.count).to eq(members_after_first)
+    end
+
+    it "backfills membership when an already-built set is re-run with the group id" do
+      root, group = precreate_root_and_group!(name: "Home")
+      # Build with NO group id (simulates a set built before the attach existed).
+      described_class.new.perform(root.id, communicator.id, "home", [])
+      expect(group.reload.board_group_boards.count).to eq(1) # only the controller's root
+
+      # Re-run (root is complete) WITH the group id — the early-return path still
+      # attaches the rest.
+      described_class.new.perform(root.id, communicator.id, "home", [], {}, { "board_group_id" => group.id })
+
+      expect(group.reload.boards.pluck(:id)).to match_array(user.boards.where(predefined: false).pluck(:id))
     end
   end
 


### PR DESCRIPTION
Closes #407.

## Summary

Board Builder output is now a real `builder: true` **BoardGroup** (the canonical "Board Set" container) and counts as **1 against `board_group_limit`** (Free 1 / Basic 25 / Pro 50), **0 against `board_limit`** — no double counting. This replaces the fragile `settings["builder_child"]` JSONB flag trick that `User#countable_board_count` used, and fixes a live orphan-delete bug.

### What changed

- **Migration** — `board_groups.builder` boolean (default `false`, `null: false`) + index. Additive, reuses existing `*_BOARD_GROUP_LIMIT` env (no new required env).
- **`BoardBuilderController#create`** — gate flips from `at_board_limit?` to `at_board_group_limit?` (new "board set limit" 422 with `limit`/`count`); creates the builder `BoardGroup`, adds the root, and passes `board_group_id` to the job. (Group create pins `root_board_id` after the join since `BoardGroup#set_root_board` nulls it on create when the group has no boards yet.)
- **`BuildBoardSetJob`** — attaches the **whole** built set (root + every child the build produces — fringe/phrases/favorites/AI pages) to the group, as the single chokepoint after the set exists. Idempotent; also backfills on a re-run / early-return path. *(This is deliberately broader than the handoff's per-service `@map.values` approach, which would miss boards the job adds outside `SeededSetCloner`/`BoardTreeBuilder` — those would then leak into `board_limit` once flag-based counting is removed.)*
- **`User#countable_board_count`** — excludes boards that are members of one of the user's **builder** groups (`builder_grouped_board_ids`), replacing the `not_builder_child` flag exclusion. `builder_root`/`builder_child` markers are kept as transition metadata but counting no longer depends on them.
- **`BoardGroup` cascade** — a **builder** group now destroys its member boards on `destroy`, fixing the orphan-on-delete bug (deleting a builder root left its `predictive_board_id` children dangling as invisible, uncounted boards). Hand-made groups are unchanged (join rows only). Two correctness details: `prepend: true` so it runs before the `board_group_boards` `dependent: :destroy` wipes the rows we read; and we destroy the actual `Board` records (not `boards.destroy_all`, which on a `has_many :through` only removes join rows) after nulling `root_board_id` (a no-`ON DELETE` FK back into a member board). Each `Board`'s own `dependent: :destroy` cleans its join + `ChildBoard` rows.

### Scope / sequencing

- Scoped to **builder** groups only — hand-made `BoardGroup`s are untouched (their members still count against `board_limit`; deliberate, deferred follow-up).
- **Backfill is a separate follow-up** (idempotent `--dry-run` rake task to wrap pre-existing `builder_root` trees into builder groups + report anyone over `board_group_limit`). Per the handoff, do **not** flip counting on prod with pre-existing builder sets until backfill has run.

## Test plan

`bundle exec rspec` on the affected specs — **134 examples, 0 failures**:

- `spec/models/user_plan_limits_spec.rb` — full counting matrix (new user / standalone / builder set / builder+standalone / builder+hand-made / 2 builder sets), exact `countable_board_count` + `countable_board_group_count`.
- `spec/requests/api/v1/board_builder_spec.rb` — board-set-limit gate (422 + standalone limit untouched), job-args incl. `board_group_id`, group membership of cloned fringe, re-run guard, robust clone path.
- `spec/models/board_group_spec.rb` — cascade-delete: builder destroys members + join rows + root (FK) + ChildBoard; hand-made keeps members.
- `spec/sidekiq/build_board_set_job_spec.rb` — attaches full set, idempotent on retry, backfills on re-run.
- `spec/services/boards/seeded_set_cloner_spec.rb`, `spec/services/boards/board_tree_builder_spec.rb`, `spec/requests/api/boards/create_from_template_limit_spec.rb` — green (regular board-limit gate + markers unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)