### PR TITLE
feat(board-groups): board set graph endpoint + tile focus support

### DIFF
--- a/app/controllers/api/board_groups_controller.rb
+++ b/app/controllers/api/board_groups_controller.rb
@@ -42,6 +42,20 @@ class API::BoardGroupsController < API::ApplicationController
     end
   end
 
+  # Bird's-eye map of a board set: every member board + tiles + folder→child
+  # edges, with depth / reachability / duplicate-word stats precomputed
+  # server-side (Boards::SetGraphBuilder). Owner-or-admin read.
+  def graph
+    board_group = BoardGroup.find_by(id: params[:id])
+    unless board_group
+      render json: { error: "Board Group not found" }, status: :not_found
+      return
+    end
+    return unless authorize_board_group_read!(board_group)
+
+    render json: Boards::SetGraphBuilder.new(board_group, viewing_user: current_user).call
+  end
+
   def create
     if current_user.at_board_group_limit?
       render json: {
@@ -237,6 +251,18 @@ class API::BoardGroupsController < API::ApplicationController
       return false
     end
     true
+  end
+
+  # Owner-or-admin gate for *reading* a set's graph. Unlike the public
+  # show/index reads, the map exposes the whole structure of a user's set, so
+  # it's restricted to the owner (and admins). Renders 403 and returns false
+  # when disallowed.
+  def authorize_board_group_read!(board_group)
+    return true if current_user&.admin?
+    return true if board_group.user_id == current_user&.id
+
+    render json: { error: "You don't have permission to view this board set." }, status: :forbidden
+    false
   end
 
   def board_group_params

--- a/app/services/boards/set_graph_builder.rb
+++ b/app/services/boards/set_graph_builder.rb
@@ -1,0 +1,173 @@
+require "set"
+
+module Boards
+  # Assembles a whole board set as a graph: every member board with its tiles,
+  # plus the folder→child edges, with depth / reachability / duplicate-word
+  # stats precomputed server-side. The frontend "bird's-eye map" renders this
+  # in one call — it never traverses the predictive links itself.
+  #
+  # v1 targets builder sets (the `predictive_board_id` tree keyed on a
+  # BoardGroup), but the shape generalizes to any BoardGroup.
+  class SetGraphBuilder
+    # Defensive hard cap on the root-BFS fallback so a cyclic/garbage set can't
+    # spin forever. Builder sets are tiny (root + ~a dozen pages).
+    MAX_BOARDS = 500
+
+    def initialize(board_group, viewing_user: nil)
+      @board_group = board_group
+      @viewing_user = viewing_user
+    end
+
+    def call
+      boards = resolve_boards
+      boards_by_id = boards.index_by(&:id)
+
+      edges = build_edges(boards, boards_by_id)
+      depth_by_id = compute_depths(edges)
+
+      board_payloads = boards.map do |board|
+        depth = depth_by_id[board.id]
+        {
+          id: board.id,
+          name: board.name,
+          depth: depth,
+          reachable: !depth.nil?,
+          tiles: board.board_images.map { |bi| tile_payload(bi) },
+        }
+      end
+
+      {
+        id: board_group.id,
+        name: board_group.name,
+        builder: board_group.builder?,
+        root_board_id: root_board_id,
+        stats: build_stats(board_payloads, depth_by_id),
+        boards: board_payloads,
+        edges: edges,
+      }
+    end
+
+    private
+
+    attr_reader :board_group, :viewing_user
+
+    def root_board_id
+      board_group.root_board_id
+    end
+
+    # Prefer post-#407 board_group membership. Fall back to a BFS from the root
+    # board over predictive links for sets that predate the backfill, so the
+    # endpoint still works on an unbackfilled set.
+    def resolve_boards
+      members = board_group.boards.includes(board_images: :image).to_a
+      return members if members.present?
+
+      bfs_boards_from_root
+    end
+
+    def bfs_boards_from_root
+      return [] if root_board_id.blank?
+
+      visited = {}
+      queue = [root_board_id]
+      until queue.empty? || visited.size >= MAX_BOARDS
+        board_id = queue.shift
+        next if visited.key?(board_id)
+
+        board = Board.includes(board_images: :image).find_by(id: board_id)
+        next unless board
+
+        visited[board_id] = board
+        board.board_images.each do |bi|
+          target = bi.predictive_board_id
+          queue << target if target.present? && target != bi.board_id && !visited.key?(target)
+        end
+      end
+      visited.values
+    end
+
+    # Every tile with a non-null predictive_board_id whose target board is in
+    # the set becomes a folder→child edge.
+    def build_edges(boards, boards_by_id)
+      edges = []
+      boards.each do |board|
+        board.board_images.each do |bi|
+          target_id = bi.predictive_board_id
+          next if target_id.blank?
+          next unless boards_by_id.key?(target_id)
+
+          edges << {
+            from: board.id,
+            to: target_id,
+            via_tile_id: bi.id,
+            via_label: tile_label(bi),
+          }
+        end
+      end
+      edges
+    end
+
+    # BFS from the root board over the edges. Boards in the set never reached
+    # get no depth entry → nil depth / reachable: false downstream.
+    def compute_depths(edges)
+      depths = {}
+      return depths if root_board_id.blank?
+
+      adjacency = Hash.new { |h, k| h[k] = [] }
+      edges.each { |e| adjacency[e[:from]] << e[:to] }
+
+      depths[root_board_id] = 0
+      queue = [root_board_id]
+      until queue.empty?
+        current = queue.shift
+        adjacency[current].each do |neighbor|
+          next if depths.key?(neighbor)
+
+          depths[neighbor] = depths[current] + 1
+          queue << neighbor
+        end
+      end
+      depths
+    end
+
+    def build_stats(board_payloads, depth_by_id)
+      word_tiles = board_payloads.flat_map { |b| b[:tiles] }.reject { |t| t[:is_folder] }
+
+      # Distinct word labels (case-insensitive) that land on 2+ distinct boards.
+      label_board_ids = Hash.new { |h, k| h[k] = Set.new }
+      board_payloads.each do |board|
+        board[:tiles].each do |tile|
+          next if tile[:is_folder]
+
+          label = tile[:label].to_s.downcase.strip
+          next if label.blank?
+
+          label_board_ids[label] << board[:id]
+        end
+      end
+      duplicate_words = label_board_ids.count { |_label, ids| ids.size >= 2 }
+
+      {
+        boards: board_payloads.size,
+        words: word_tiles.size,
+        max_depth: depth_by_id.values.max || 0,
+        duplicate_words: duplicate_words,
+        unreachable_boards: board_payloads.count { |b| !b[:reachable] },
+      }
+    end
+
+    def tile_payload(board_image)
+      {
+        id: board_image.id,
+        label: tile_label(board_image),
+        image_url: board_image.display_image_url,
+        links_to_board_id: board_image.predictive_board_id,
+        is_folder: board_image.predictive_board_id.present?,
+      }
+    end
+
+    def tile_label(board_image)
+      board_image.display_label.presence || board_image.label
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,7 @@ Rails.application.routes.draw do
         get "preset"
       end
       member do
+        get "graph"
         post "rearrange_boards"
         post "save_layout"
         post "add_board/:board_id", to: "board_groups#add_board"

--- a/spec/requests/api/board_groups_graph_spec.rb
+++ b/spec/requests/api/board_groups_graph_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+# Covers GET /api/board_groups/:id/graph — the bird's-eye map endpoint backed
+# by Boards::SetGraphBuilder — plus the deep-link affordance: GET /api/boards/:id
+# already returns each tile's BoardImage id for ?focus=<tileId>.
+RSpec.describe "API::BoardGroups graph", type: :request do
+  let(:user)  { FactoryBot.create(:user) }
+  let(:other) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:admin_user) }
+
+  def build_group_for(owner)
+    home  = FactoryBot.create(:board, user: owner, name: "Home")
+    food  = FactoryBot.create(:board, user: owner, name: "Food")
+    FactoryBot.create(:board_image, board: home, image: FactoryBot.create(:image, label: "Food"), predictive_board_id: food.id)
+    FactoryBot.create(:board_image, board: food, image: FactoryBot.create(:image, label: "apple"))
+
+    group = FactoryBot.create(:board_group, user: owner, builder: true, layout: {})
+    [home, food].each { |b| group.add_board(b) }
+    group.update!(root_board_id: home.id)
+    { group: group, home: home, food: food }
+  end
+
+  describe "authorization" do
+    it "rejects anonymous callers with 401" do
+      set = build_group_for(user)
+      get "/api/board_groups/#{set[:group].id}/graph"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "rejects a non-owner non-admin with 403" do
+      set = build_group_for(user)
+      get "/api/board_groups/#{set[:group].id}/graph", headers: auth_headers(other)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "allows the owner" do
+      set = build_group_for(user)
+      get "/api/board_groups/#{set[:group].id}/graph", headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "allows an admin who is not the owner" do
+      set = build_group_for(user)
+      get "/api/board_groups/#{set[:group].id}/graph", headers: auth_headers(admin)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "404s an unknown set" do
+      get "/api/board_groups/0/graph", headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "payload" do
+    it "returns boards, tiles, edges and stats" do
+      set = build_group_for(user)
+      get "/api/board_groups/#{set[:group].id}/graph", headers: auth_headers(user)
+
+      body = JSON.parse(response.body)
+      expect(body["root_board_id"]).to eq(set[:home].id)
+      expect(body["builder"]).to be(true)
+      expect(body["stats"]["boards"]).to eq(2)
+      expect(body["stats"]["max_depth"]).to eq(1)
+      expect(body["edges"]).to include(a_hash_including("from" => set[:home].id, "to" => set[:food].id))
+
+      home = body["boards"].find { |b| b["id"] == set[:home].id }
+      folder = home["tiles"].find { |t| t["label"] == "Food" }
+      expect(folder["is_folder"]).to be(true)
+      expect(folder["links_to_board_id"]).to eq(set[:food].id)
+    end
+  end
+
+  describe "GET /api/boards/:id tile ids (?focus deep-link support)" do
+    it "includes each tile's BoardImage id" do
+      home = FactoryBot.create(:board, user: user, name: "Home")
+      bi = FactoryBot.create(:board_image, board: home, image: FactoryBot.create(:image, label: "I"))
+
+      get "/api/boards/#{home.id}", headers: auth_headers(user)
+
+      body = JSON.parse(response.body)
+      tile = body["images"].find { |t| t["id"] == bi.id }
+      expect(tile).to be_present
+    end
+  end
+end

--- a/spec/services/boards/set_graph_builder_spec.rb
+++ b/spec/services/boards/set_graph_builder_spec.rb
@@ -1,0 +1,171 @@
+require "rails_helper"
+
+RSpec.describe Boards::SetGraphBuilder do
+  let(:user) { FactoryBot.create(:user) }
+
+  # Build a tile on `board`. A folder tile links to `links_to` (a Board);
+  # a word tile passes links_to: nil. The label drives duplicate-word stats.
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(
+      :board_image,
+      board: board,
+      image: image,
+      predictive_board_id: links_to&.id,
+    )
+  end
+
+  # A builder set:
+  #   Home (root, depth 0)
+  #     ├─ Food (depth 1) ── Fruit (depth 2)
+  #     └─ Play (depth 1)
+  #   Orphan (in set, nothing links to it → unreachable)
+  #
+  # Duplicate words: "more" (Home + Food), "apple" (Food + Fruit).
+  def build_set!
+    home   = FactoryBot.create(:board, user: user, name: "Home")
+    food   = FactoryBot.create(:board, user: user, name: "Food")
+    play   = FactoryBot.create(:board, user: user, name: "Play")
+    fruit  = FactoryBot.create(:board, user: user, name: "Fruit")
+    orphan = FactoryBot.create(:board, user: user, name: "Orphan")
+
+    add_tile(home, label: "Food", links_to: food)
+    add_tile(home, label: "Play", links_to: play)
+    add_tile(home, label: "I")
+    add_tile(home, label: "more")
+
+    add_tile(food, label: "Fruit", links_to: fruit)
+    add_tile(food, label: "apple")
+    add_tile(food, label: "more")
+
+    add_tile(play, label: "go")
+
+    add_tile(fruit, label: "apple")
+
+    add_tile(orphan, label: "lonely")
+
+    group = FactoryBot.create(:board_group, user: user, builder: true, layout: {})
+    [home, food, play, fruit, orphan].each { |b| group.add_board(b) }
+    group.update!(root_board_id: home.id)
+    { group: group, home: home, food: food, play: play, fruit: fruit, orphan: orphan }
+  end
+
+  subject(:graph) { described_class.new(set[:group]).call }
+
+  let(:set) { build_set! }
+
+  it "returns top-level set metadata" do
+    expect(graph[:id]).to eq(set[:group].id)
+    expect(graph[:name]).to eq(set[:group].name)
+    expect(graph[:builder]).to be(true)
+    expect(graph[:root_board_id]).to eq(set[:home].id)
+  end
+
+  it "computes depth and reachability per board via BFS from the root" do
+    by_id = graph[:boards].index_by { |b| b[:id] }
+
+    expect(by_id[set[:home].id][:depth]).to eq(0)
+    expect(by_id[set[:food].id][:depth]).to eq(1)
+    expect(by_id[set[:play].id][:depth]).to eq(1)
+    expect(by_id[set[:fruit].id][:depth]).to eq(2)
+
+    expect(by_id[set[:home].id][:reachable]).to be(true)
+    expect(by_id[set[:fruit].id][:reachable]).to be(true)
+  end
+
+  it "marks a board nothing links to as unreachable with null depth" do
+    orphan = graph[:boards].find { |b| b[:id] == set[:orphan].id }
+    expect(orphan[:reachable]).to be(false)
+    expect(orphan[:depth]).to be_nil
+  end
+
+  it "distinguishes folder tiles from word tiles" do
+    home = graph[:boards].find { |b| b[:id] == set[:home].id }
+
+    folder = home[:tiles].find { |t| t[:label] == "Food" }
+    expect(folder[:is_folder]).to be(true)
+    expect(folder[:links_to_board_id]).to eq(set[:food].id)
+
+    word = home[:tiles].find { |t| t[:label] == "I" }
+    expect(word[:is_folder]).to be(false)
+    expect(word[:links_to_board_id]).to be_nil
+  end
+
+  it "exposes each tile's BoardImage id and image_url" do
+    home = graph[:boards].find { |b| b[:id] == set[:home].id }
+    bi = set[:home].board_images.find_by(label: "I")
+    tile = home[:tiles].find { |t| t[:label] == "I" }
+    expect(tile[:id]).to eq(bi.id)
+    expect(tile).to have_key(:image_url)
+  end
+
+  it "builds edges only for links whose target board is in the set" do
+    expect(graph[:edges]).to contain_exactly(
+      a_hash_including(from: set[:home].id, to: set[:food].id, via_label: "Food"),
+      a_hash_including(from: set[:home].id, to: set[:play].id, via_label: "Play"),
+      a_hash_including(from: set[:food].id, to: set[:fruit].id, via_label: "Fruit"),
+    )
+  end
+
+  it "computes set-wide stats" do
+    stats = graph[:stats]
+    expect(stats[:boards]).to eq(5)
+    expect(stats[:words]).to eq(7) # I, more, apple, more, go, apple, lonely
+    expect(stats[:max_depth]).to eq(2)
+    expect(stats[:duplicate_words]).to eq(2) # "more" and "apple"
+    expect(stats[:unreachable_boards]).to eq(1)
+  end
+
+  it "counts a duplicate label once even when it appears on more than two boards" do
+    # add "more" to a third board (play) — still a single duplicate label
+    add_tile(set[:play], label: "more")
+    expect(described_class.new(set[:group]).call[:stats][:duplicate_words]).to eq(2)
+  end
+
+  describe "N+1 safety" do
+    def count_queries
+      count = 0
+      counter = lambda do |_name, _start, _finish, _id, payload|
+        next if payload[:name].to_s =~ /SCHEMA|TRANSACTION/
+        next if payload[:sql] =~ /\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i
+
+        count += 1
+      end
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { yield }
+      count
+    end
+
+    it "does not scale query count with the number of boards/tiles" do
+      small = build_set!
+      large = build_set!
+      # double the size of the large set
+      4.times do |i|
+        extra = FactoryBot.create(:board, user: user, name: "Extra #{i}")
+        add_tile(extra, label: "x#{i}")
+        large[:group].add_board(extra)
+      end
+
+      small_count = count_queries { described_class.new(small[:group]).call }
+      large_count = count_queries { described_class.new(large[:group]).call }
+
+      expect(large_count).to eq(small_count)
+    end
+  end
+
+  describe "root-BFS fallback for an unbackfilled set" do
+    it "resolves boards from root_board_id when membership is empty" do
+      home = FactoryBot.create(:board, user: user, name: "Home")
+      child = FactoryBot.create(:board, user: user, name: "Child")
+      add_tile(home, label: "Child", links_to: child)
+      add_tile(child, label: "word")
+
+      group = FactoryBot.create(:board_group, user: user, builder: true, layout: {})
+      group.update!(root_board_id: home.id) # no board_group_boards added
+
+      result = described_class.new(group).call
+      ids = result[:boards].map { |b| b[:id] }
+      expect(ids).to contain_exactly(home.id, child.id)
+      expect(result[:stats][:boards]).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements `.claude-notes/board-set-map-handoff.md` — the backend that powers the frontend "bird's-eye map" of a board set.

### 1. Graph endpoint
`GET /api/board_groups/:id/graph` returns a whole set in one call, backed by a new `Boards::SetGraphBuilder` PORO (`app/services/boards/set_graph_builder.rb`):

- **boards + tiles + edges** — each board with its tiles (`id`, `label`, `image_url`, `links_to_board_id`, `is_folder`) plus folder→child `edges` built from every tile whose `predictive_board_id` targets a board in the set.
- **`depth` / `reachable`** — BFS from `root_board_id` over the predictive links (root = 0). A board in the set that nothing links to → `reachable: false`, `depth: null`.
- **stats** — `boards`, `words` (word-tile count), `max_depth`, `duplicate_words` (distinct case-insensitive word labels on 2+ boards), `unreachable_boards`.
- **Auth** — owner-or-admin read gate (`authorize_board_group_read!`): non-owner non-admin → 403, unknown set → 404, anonymous → 401.
- **N+1** — eager-loads `boards → board_images → image`; query count is constant regardless of set size (asserted in spec).
- **Membership resolution** — prefers post-#407 `board_group.boards`; falls back to a root-BFS for unbackfilled sets, with a defensive `MAX_BOARDS` cap against cycles.

Route added as a `member` action under the existing `namespace :api` board_groups resource (matching how the controller is mounted).

### 2. `?focus=<tileId>` deep-link support
`GET /api/boards/:id` (`Board#api_view_with_predictive_images`) **already** serializes each tile's `BoardImage#id` as `id`, so the frontend can match `?focus=<tileId>` with **no backend change**. Locked in with a regression test.

## Test plan

New specs, both green:
- `spec/services/boards/set_graph_builder_spec.rb` — depth/reachability, unreachable board, folder vs word tiles, edges scoped to in-set targets, stats (incl. duplicate label counted once across 3 boards), N+1 constant-query check, root-BFS fallback.
- `spec/requests/api/board_groups_graph_spec.rb` — auth matrix (401/403/owner/admin/404), payload shape, and the `GET /api/boards/:id` tile-id regression.

```
bundle exec rspec spec/services/boards/set_graph_builder_spec.rb spec/requests/api/board_groups_graph_spec.rb
# 17 examples, 0 failures
bundle exec rspec spec/requests/api/board_groups_spec.rb
# 27 examples, 0 failures (no regression from controller changes)
```

Read-only, additive, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)