### PR TITLE
feat(board-builder): backfill builder BoardGroups for pre-#407 sets (#409)

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -191,6 +191,29 @@ Label-only picker catalog. No `Image` resolution.
   (limit 1) can build one tree, and the tree's own sub-boards never trip the
   read-only lock; a second build is blocked.
 
+**Counting now lives in a builder `BoardGroup` (#407).** New builds write a real
+`BoardGroup(builder: true, root_board_id: root)` whose members are the root +
+every predictive child (`board_group_boards`). The set then counts as **one
+Board Set** (`User#countable_board_group_count` / `board_group_limit`) and
+**zero board slots** (`User#countable_board_count` excludes
+`builder_grouped_board_ids`), and deleting the group cascade-deletes the whole
+tree. "Set-ness" lives in the BoardGroup, not the fragile `builder_child`
+JSONB marker. The `builder_root` marker on the root board is still the detection
+key for re-runs and the backfill.
+
+**Backfill for pre-#407 sets (#409):** existing builder sets predate the
+BoardGroup, so `rake board_groups:backfill_builder_sets`
+(`lib/tasks/board_groups.rake`) wraps each `builder_root` tree lacking a builder
+BoardGroup into one — root + predictive descendants (BFS to `MAX_DEPTH` 2,
+owner-scoped), mirroring the controller/job construction. Idempotent (a root
+already wrapped by `root_board_id` is skipped, so re-runs add no duplicate
+groups/join rows). **Applies by default; preview with `DRY_RUN=1`**, scope with
+`USER_ID=N`. Logs each user's board-set count before/after and prints a report
+of any user left over `board_group_limit` (e.g. a Free user with a hand-made set
++ a builder set reads 2/1) — those are left as-is per #409 since limits are
+enforced only on create, so existing sets stay accessible. Deploy order:
+deploy #407 → run `DRY_RUN=1` → review the over-limit report → run for real.
+
 ## Decisions & future work
 
 - **Interests persisted** to `child_account.details` (not a new column) so the

--- a/lib/tasks/board_groups.rake
+++ b/lib/tasks/board_groups.rake
@@ -1,0 +1,144 @@
+namespace :board_groups do
+  # Backfill for issue #409 (follow-up to #407). Before #407, a Board Builder
+  # run persisted a whole linked tree but NO BoardGroup — "set-ness" lived in
+  # the root board's settings["builder_root"] JSONB marker, the root counted as
+  # a board, and deleting the root orphaned its children. #407 made new builds
+  # write a real `builder: true` BoardGroup (root + every predictive child as
+  # board_group_boards) so the set counts as ONE Board Set (board_group_limit),
+  # zero board slots, and cascade-deletes as a unit.
+  #
+  # Existing builder sets in prod predate that and have no BoardGroup. This task
+  # wraps each `builder_root` tree that lacks a builder BoardGroup into one,
+  # exactly mirroring the controller/BuildBoardSetJob construction:
+  #   BoardGroup(builder: true, root_board_id: root, user: root.user, name: root.name)
+  #   + board_group_boards for the root and its predictive_board_id descendants
+  #     (BFS bounded to MAX_DEPTH = 2 — root + 2 levels — matching
+  #     Boards::BoardTreeBuilder / SeededSetCloner, scoped to the owner's boards
+  #     so a tile pointing at a shared board can't pull it into the sweep).
+  #
+  # Idempotent: a root that already has a builder BoardGroup (root_board_id
+  # match) is skipped, so re-runs create no duplicate groups or join rows.
+  #
+  # Logs each user's countable_board_group_count before/after and prints a
+  # report of any user left OVER their board_group_limit (e.g. a Free user with
+  # both a hand-made set and a builder set reads 2/1). Per issue #409 those
+  # users are left as-is — limits are enforced only on create, so no one loses
+  # access to existing sets; they just can't make new ones until under cap.
+  #
+  # APPLIES BY DEFAULT. Preview with DRY_RUN=1 (per the deploy ordering in #409:
+  # run --dry-run, review the over-limit report, then run for real). Scope to one
+  # owner with USER_ID=N:
+  #   DRY_RUN=1 rake board_groups:backfill_builder_sets        # preview all
+  #   rake board_groups:backfill_builder_sets                  # apply all
+  #   DRY_RUN=1 USER_ID=740 rake board_groups:backfill_builder_sets
+  desc "Wrap existing Board Builder trees into builder BoardGroups (DRY_RUN=1 to preview; USER_ID=N to scope)"
+  task backfill_builder_sets: :environment do
+    dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase.strip)
+
+    roots = Board.where("(boards.settings ->> 'builder_root') = 'true'")
+    roots = roots.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    # Only builder roots that don't already have a builder BoardGroup.
+    pending = roots.find_all do |root|
+      next false unless root.user_id
+      !BoardGroup.builder.exists?(root_board_id: root.id)
+    end
+
+    skipped = roots.count - pending.size
+    by_user = pending.group_by(&:user_id)
+
+    puts "#{dry_run ? '[DRY RUN] ' : ''}Backfilling builder BoardGroups for #{pending.size} root(s) " \
+         "across #{by_user.size} user(s). (#{skipped} root(s) already wrapped — skipped.)"
+
+    # Per-user board-set count BEFORE any of their roots are wrapped.
+    before_counts = by_user.keys.index_with do |uid|
+      BoardGroup.where(user_id: uid, predefined: [false, nil]).count
+    end
+
+    created_groups = 0
+    attached_boards = 0
+
+    by_user.each do |uid, user_roots|
+      user_roots.each do |root|
+        member_ids = builder_set_board_ids(root)
+
+        if dry_run
+          puts "  [DRY RUN] would wrap root ##{root.id} #{root.name.inspect} (owner #{uid}): " \
+               "new builder group + #{member_ids.size} board(s)."
+        else
+          ActiveRecord::Base.transaction do
+            owner = root.user
+            group = owner.board_groups.create!(name: root.name, builder: true)
+            # set_root_board nulls root_board_id on create (the group has no
+            # boards yet), so attach the root first, then pin it — mirrors the
+            # controller. Children follow at sequential positions.
+            group.board_group_boards.create!(board_id: root.id, position: 0)
+            group.update!(root_board_id: root.id)
+            (member_ids - [root.id]).each_with_index do |bid, i|
+              group.board_group_boards.create!(board_id: bid, position: i + 1)
+            end
+          end
+        end
+
+        created_groups += 1
+        attached_boards += member_ids.size
+      end
+    end
+
+    # Per-user before/after + over-limit report.
+    over_limit = []
+    puts "\nPer-user board-set counts (countable_board_group_count):"
+    by_user.each do |uid, user_roots|
+      user = User.find(uid)
+      before = before_counts[uid]
+      after = dry_run ? before + user_roots.size : user.countable_board_group_count
+      limit = user.board_group_limit
+      flag = (after > limit)
+      puts "  user ##{uid} (#{user.plan_type || 'free'}): #{before} -> #{after} (limit #{limit})" \
+           "#{flag ? '  *** OVER LIMIT' : ''}"
+      over_limit << { user: user, before: before, after: after, limit: limit } if flag
+    end
+
+    puts "\n#{dry_run ? '[DRY RUN] would create' : 'Created'} #{created_groups} builder " \
+         "BoardGroup(s); #{attached_boards} board(s) attached."
+
+    if over_limit.any?
+      puts "\n=== OVER board_group_limit after backfill (#{over_limit.size} user(s)) ==="
+      puts "Left as-is per #409 — limits enforced only on create, so existing sets stay accessible."
+      over_limit.each do |row|
+        admin = row[:user].admin? ? " [admin — exempt from gate]" : ""
+        puts "  user ##{row[:user].id} (#{row[:user].plan_type || 'free'}): " \
+             "#{row[:after]}/#{row[:limit]}#{admin}"
+      end
+    else
+      puts "\nNo users left over board_group_limit."
+    end
+
+    puts "\nDry run only — re-run without DRY_RUN to apply." if dry_run
+  end
+end
+
+# Every board in a builder set: BFS the predictive_board_id links from the root,
+# bounded to MAX_DEPTH levels and scoped to the owner's own boards. Mirrors
+# Boards::BoardTreeBuilder::MAX_DEPTH (2) and BuildBoardSetJob#set_board_ids so
+# the backfill attaches exactly the boards a fresh build would.
+def builder_set_board_ids(root, max_depth = 2)
+  owner_id = root.user_id
+  seen = [root.id]
+  frontier = [root.id]
+  depth = 0
+
+  while frontier.any? && depth < max_depth
+    child_ids = BoardImage.where(board_id: frontier)
+                          .where.not(predictive_board_id: nil)
+                          .pluck(:predictive_board_id).uniq
+    children = Board.where(id: child_ids, user_id: owner_id).where.not(id: seen).pluck(:id)
+    break if children.empty?
+
+    seen.concat(children)
+    frontier = children
+    depth += 1
+  end
+
+  seen
+end

--- a/spec/lib/tasks/board_groups_backfill_builder_sets_spec.rb
+++ b/spec/lib/tasks/board_groups_backfill_builder_sets_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# Backfill task for issue #409 — wrap existing Board Builder trees (a
+# `builder_root` board + its predictive children) into a real `builder: true`
+# BoardGroup so the set counts as one Board Set, mirroring what #407 made new
+# builds do.
+RSpec.describe "board_groups:backfill_builder_sets rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["board_groups:backfill_builder_sets"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    original = ENV.to_hash.slice("DRY_RUN", "USER_ID")
+    example.run
+    ENV["DRY_RUN"] = original["DRY_RUN"]
+    ENV["USER_ID"] = original["USER_ID"]
+  end
+
+  before do
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+  end
+
+  # Build a builder tree exactly like a pre-#407 set: a root marked
+  # builder_root, a child board linked via a folder tile's predictive_board_id,
+  # and a grandchild one level deeper. No BoardGroup yet.
+  def build_builder_tree!(owner, root_name: "My Built Set")
+    root = create(:board, user: owner, name: root_name,
+                          settings: { "builder_root" => true })
+    child = create(:board, user: owner, name: "Food",
+                           settings: { "builder_child" => true })
+    grandchild = create(:board, user: owner, name: "Fruit",
+                                settings: { "builder_child" => true })
+
+    folder = create(:board_image, board: root, image: create(:image, label: "Food", user_id: owner.id))
+    folder.update!(predictive_board_id: child.id)
+
+    deep_folder = create(:board_image, board: child, image: create(:image, label: "Fruit", user_id: owner.id))
+    deep_folder.update!(predictive_board_id: grandchild.id)
+
+    { root: root, child: child, grandchild: grandchild }
+  end
+
+  describe "a fresh builder tree" do
+    let(:owner) { create(:user, plan_type: "basic") }
+    let!(:tree) { build_builder_tree!(owner) }
+
+    it "creates a builder BoardGroup wrapping the root + all predictive descendants" do
+      expect { run_task }.to change { BoardGroup.builder.count }.by(1)
+
+      group = BoardGroup.builder.find_by(root_board_id: tree[:root].id)
+      expect(group).to be_present
+      expect(group.user_id).to eq(owner.id)
+      expect(group.name).to eq(tree[:root].name)
+      expect(group.builder).to be(true)
+      expect(group.board_ids).to match_array([tree[:root].id, tree[:child].id, tree[:grandchild].id])
+    end
+
+    it "makes the whole tree count as ONE board set (zero extra board slots)" do
+      run_task
+      expect(owner.reload.countable_board_group_count).to eq(1)
+      # Every board in the set is now a builder-group member, so it costs no
+      # board slots.
+      expect(owner.countable_board_count).to eq(0)
+    end
+
+    it "previews without writing anything in DRY_RUN=1" do
+      ENV["DRY_RUN"] = "1"
+      expect { run_task }.not_to change { BoardGroup.count }
+      expect(BoardGroupBoard.count).to eq(0)
+    end
+  end
+
+  describe "idempotency" do
+    let(:owner) { create(:user, plan_type: "basic") }
+    let!(:tree) { build_builder_tree!(owner) }
+
+    it "re-running creates no duplicate groups or join rows" do
+      run_task
+      group = BoardGroup.builder.find_by(root_board_id: tree[:root].id)
+      bgb_count = group.board_group_boards.count
+
+      expect { run_task }.not_to change { BoardGroup.count }
+      expect { run_task }.not_to change { BoardGroupBoard.count }
+      expect(group.reload.board_group_boards.count).to eq(bgb_count)
+    end
+
+    it "skips roots that already have a builder BoardGroup" do
+      run_task
+      # A root post-#407 already wrapped — a second run leaves it alone.
+      expect { run_task }.not_to change { BoardGroup.builder.count }
+    end
+  end
+
+  describe "over-limit report" do
+    # A Free user (board_group_limit 1) who already has a hand-made set AND a
+    # builder set ends up at 2/1 after backfill — kept, but flagged.
+    let(:free_user) { create(:user, plan_type: "free") }
+    let!(:handmade_set) { create(:board_group, user: free_user, predefined: false) }
+    let!(:tree) { build_builder_tree!(free_user) }
+
+    it "reports the user as over board_group_limit and still backfills (kept, not blocked)" do
+      expect(free_user.board_group_limit).to eq(1)
+
+      expect { run_task }.to output(/OVER board_group_limit/).to_stdout
+
+      free_user.reload
+      expect(free_user.countable_board_group_count).to eq(2)
+      expect(free_user.countable_board_group_count).to be > free_user.board_group_limit
+      # The builder set was still created — no one loses access to existing sets.
+      expect(BoardGroup.builder.find_by(root_board_id: tree[:root].id)).to be_present
+    end
+
+    it "does not flag a user who stays within their limit" do
+      basic_user = create(:user, plan_type: "basic")
+      build_builder_tree!(basic_user, root_name: "Within Limit Set")
+
+      ENV["USER_ID"] = basic_user.id.to_s
+      expect { run_task }.to output(/No users left over board_group_limit/).to_stdout
+    end
+  end
+
+  describe "USER_ID scoping" do
+    let(:owner_a) { create(:user, plan_type: "basic") }
+    let(:owner_b) { create(:user, plan_type: "basic") }
+    let!(:tree_a) { build_builder_tree!(owner_a, root_name: "A Set") }
+    let!(:tree_b) { build_builder_tree!(owner_b, root_name: "B Set") }
+
+    it "only backfills the scoped user" do
+      ENV["USER_ID"] = owner_a.id.to_s
+      run_task
+
+      expect(BoardGroup.builder.find_by(root_board_id: tree_a[:root].id)).to be_present
+      expect(BoardGroup.builder.find_by(root_board_id: tree_b[:root].id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the idempotent backfill from #409 (follow-up to #407). Before #407, a Board Builder run persisted a whole linked tree but **no `BoardGroup`** — "set-ness" lived in the root's `settings["builder_root"]` JSONB marker, the root counted as a board, and deleting it orphaned its children. #407 made new builds write a real `builder: true` BoardGroup so a set counts as **one Board Set** (zero board slots) and cascade-deletes as a unit. Existing sets in prod predate that and have no group.

New rake task `board_groups:backfill_builder_sets` (`lib/tasks/board_groups.rake`) wraps each `builder_root` tree lacking a builder BoardGroup into one, mirroring the controller/`BuildBoardSetJob` construction:

- Creates `BoardGroup(builder: true, root_board_id: root, user: root.user, name: root.name)`.
- Attaches the root (position 0) + its `predictive_board_id` descendants via `board_group_boards` (BFS to `MAX_DEPTH` 2, owner-scoped so a tile pointing at a shared board can't be pulled in) — matching `Boards::BoardTreeBuilder` / `BuildBoardSetJob#set_board_ids`.
- **Idempotent:** a root already wrapped (by `root_board_id` match) is skipped, so re-runs create no duplicate groups or join rows.
- Logs each user's `countable_board_group_count` before/after and prints a report of any user left **over** `board_group_limit` (e.g. a Free user with a hand-made set + a builder set reads 2/1). Per #409 these are left as-is — limits are enforced only on create, so existing sets stay accessible.

**Usage** — applies by default, preview with `DRY_RUN=1`, scope with `USER_ID=N`:

```
DRY_RUN=1 rake board_groups:backfill_builder_sets        # preview all
rake board_groups:backfill_builder_sets                  # apply all
DRY_RUN=1 USER_ID=740 rake board_groups:backfill_builder_sets
```

**Deploy order (from #409):** deploy #407 → run `DRY_RUN=1` → review the over-limit report → run for real.

### Grandfathering

Took option (a) from the issue: over-limit users are left as-is (not bumped). The report surfaces them so Brittany can review.

## Test plan

- New spec `spec/lib/tasks/board_groups_backfill_builder_sets_spec.rb` covers:
  - a fresh tree gets backfilled (group wraps root + all predictive descendants; counts as one set, zero board slots),
  - `DRY_RUN=1` writes nothing,
  - re-running is a no-op (no duplicate groups/join rows; already-wrapped roots skipped),
  - the over-limit report flags a Free 2/1 user and still backfills (kept, not blocked); within-limit users aren't flagged,
  - `USER_ID` scoping.
- `bundle exec rspec spec/lib/tasks/board_groups_backfill_builder_sets_spec.rb` → **8 examples, 0 failures**.

Closes #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)