### PR TITLE
fix(board-builder): finalize Core 60 seed to a true 60 tiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1302,7 +1302,9 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
   on its **root board** (`settings["board_builder_robust_slug"]`), queried via
   `Boards::RobustSets`. Idempotent (`Board.from_obf` upserts by
   `(user_id, obf_id)`). Format spec: `db/seeds/board_builder_sets/README.md`.
-  Slugs `core-60` (ships a placeholder), `core-84` (TBD).
+  Slugs `core-60` (authored as a full 60-tile home: 50 core words + 8 category
+  folders — People, Feelings, Food, Drinks, Play, Places, Body, More — wired in
+  the bottom row, flanked by `this`/`that`), `core-84` (TBD).
   - **Tile upserts are keyed on the authored OBF button id, not the resolved
     `image_id`.** `Board.upsert_board_image` matches an existing tile by the
     button id stamped on `board_image.data["obf_button_id"]` (falling back to

--- a/db/seeds/board_builder_sets/core-60/boards/core-60.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/core-60.obf
@@ -68,16 +68,16 @@
         53
       ],
       [
-        null,
+        62,
         54,
         55,
         56,
+        61,
         57,
         58,
         59,
         60,
-        null,
-        null
+        63
       ]
     ]
   },
@@ -387,6 +387,24 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 61,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 62,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 63,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -238,6 +238,32 @@ RSpec.describe VocabSets do
     end
   end
 
+  describe "finalized 60-tile root (Drinks wired, this/that added)" do
+    it "places exactly 60 tiles on the Core 60 home board" do
+      expect(@c60_root.board_images.count).to eq(60)
+    end
+
+    it "wires the Drinks folder tile to the seeded Drinks board" do
+      drinks_tile = @c60_root.board_images.find_by(label: "Drinks")
+      expect(drinks_tile).to be_present
+      expect(drinks_tile.predictive_board_id).to be_present
+      expect(Board.find(drinks_tile.predictive_board_id).name).to eq("Drinks")
+    end
+
+    it "adds the this/that core word tiles that fill the home grid to 60" do
+      expect(@c60_root.board_images.pluck(:label)).to include("this", "that")
+    end
+
+    it "links all eight category folders from the home board" do
+      folder_names = @c60_root.board_images.where.not(predictive_board_id: nil).map do |bi|
+        Board.find(bi.predictive_board_id).name
+      end
+      expect(folder_names).to contain_exactly(
+        "People", "Feelings", "Food", "Drinks", "Play", "Places", "Body", "More"
+      )
+    end
+  end
+
   def collect_set_board_ids(root)
     ids = [root.id]
     root.board_images.where.not(predictive_board_id: nil).each do |bi|


### PR DESCRIPTION
## Summary

A Core 60 build in prod came out **57 tiles** — 3 short of its name. This wasn't a build bug: the Core 60 robust seed **root board was authored with only 57 tiles** (50 core words + 7 category folders, with 3 empty cells in the bottom row), so the builder faithfully cloned 57. The seed also shipped an **orphaned `drinks.obf`** sub-board that no folder tile on the root linked to.

This finalizes the seed to a true 60:

- **Wire up Drinks** — add a `Drinks` folder tile linking the existing (previously orphaned) `drinks.obf`, placed right after `Food`.
- **Fill the last 2 cells** with `this` / `that` — high-frequency core determiners missing from the 50 words — flanking the folder group.

New bottom row: `[this, People, Feelings, Food, Drinks, Play, Places, Body, More, that]` → 50 words + 10 bottom-row tiles = **60**, all 8 category folders linked, no orphan board.

## Note on already-built sets

Re-seeding (`bin/rails vocab_sets:seed`) updates the **admin source only**. Sets already built by users are clones made before this change and **won't gain the 3 tiles** — they need a fresh build (delete + rebuild) to pick them up.

## Test plan

- Extended `spec/services/vocab_sets_spec.rb` with a "finalized 60-tile root" block: asserts the home board has exactly 60 tiles, the Drinks folder is wired to the seeded Drinks board, `this`/`that` are present, and all 8 category folders link.
- `bundle exec rspec spec/services/vocab_sets_spec.rb` → **27 examples, 0 failures**
- Ran the build path to confirm the now-full grid doesn't regress overflow handling: `seeded_set_cloner_spec`, `build_board_set_job_grid_spec`, `build_board_set_job_spec` → **58 examples, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)