### PR TITLE
fix(board-groups): alias /api/v1/board_groups/:id/graph to graph action

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,6 +216,11 @@ Rails.application.routes.draw do
         post "remove_board/:board_id", to: "board_groups#remove_board"
       end
     end
+    # Back-compat alias: the board-set map handoff documented the graph endpoint
+    # under /api/v1/, but board_groups lives in the plain /api namespace like
+    # every other board_group route. This alias keeps the /api/v1/ path working
+    # so callers that followed the doc don't 404; both paths hit the same action.
+    get "v1/board_groups/:id/graph", to: "board_groups#graph"
     get "sample_voices", to: "images#sample_voices"
 
     resources :generated_boards, param: :token, only: %i[create show] do

--- a/spec/requests/api/board_groups_graph_spec.rb
+++ b/spec/requests/api/board_groups_graph_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe "API::BoardGroups graph", type: :request do
       expect(folder["is_folder"]).to be(true)
       expect(folder["links_to_board_id"]).to eq(set[:food].id)
     end
+
+    it "is also reachable via the /api/v1/ back-compat alias" do
+      set = build_group_for(user)
+      get "/api/v1/board_groups/#{set[:group].id}/graph", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["root_board_id"]).to eq(set[:home].id)
+      expect(body["stats"]["boards"]).to eq(2)
+    end
   end
 
   describe "GET /api/boards/:id tile ids (?focus deep-link support)" do


### PR DESCRIPTION
## Why

The board-set map handoff doc told the frontend to call `GET /api/v1/board_groups/:id/graph`, but `board_groups` lives in the plain `/api` namespace (like every other board_group route), so the `v1` path returns a routing **404**. Verified live on staging:

- `GET /api/v1/board_groups/6/graph` → **404**
- `GET /api/board_groups/6/graph` → **200** (correct route, shipped in #413)

## Fix

Add a back-compat alias route so `/api/v1/board_groups/:id/graph` resolves to the same `API::BoardGroupsController#graph` action. The canonical `/api/board_groups/:id/graph` is unchanged — **both** paths now work, so callers that followed the doc stop 404ing without any client change.

```ruby
# config/routes.rb (inside namespace :api)
get "v1/board_groups/:id/graph", to: "board_groups#graph"
```

## Test plan

```
bundle exec rspec spec/requests/api/board_groups_graph_spec.rb
# 8 examples, 0 failures
```

Added a request spec asserting the `/api/v1/` alias returns 200 with the same payload as the canonical route. Auth, payload, and the existing graph behavior are unchanged.

Ships after a deploy to take effect on staging/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)