### PR TITLE
feat(users): expose board_group_limit + board_group_count in api_view

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1612,6 +1612,11 @@ class User < ApplicationRecord
       board_count: board_count,
       has_boards: board_count > 0,
       board_limit_reached: board_count >= board_limit,
+      # Board Set (BoardGroup) usage — mirrors the board_limit/board_count
+      # pair so a future "Board Sets: X of Y" surface can read it off the
+      # current-user payload (the model methods already exist).
+      board_group_limit: board_group_limit,
+      board_group_count: countable_board_group_count,
       can_create_boards: can_create_boards,
       editable_board_id: effective_editable_board_id,
       editable_board_switch_available_at: editable_board_switch_available_at,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -317,6 +317,30 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#api_view board set (BoardGroup) usage" do
+    it "exposes board_group_limit and board_group_count" do
+      user = FactoryBot.create(:free_user)
+      view = user.api_view
+      expect(view).to have_key(:board_group_limit)
+      expect(view).to have_key(:board_group_count)
+      expect(view[:board_group_limit]).to eq(user.board_group_limit)
+      expect(view[:board_group_count]).to eq(0)
+    end
+
+    it "counts a builder board set as one group" do
+      user = FactoryBot.create(:free_user)
+      BoardGroup.create!(name: "Built set", user: user, builder: true)
+      expect(user.api_view[:board_group_count]).to eq(1)
+    end
+
+    it "excludes predefined (admin-curated) sets from the count" do
+      user = FactoryBot.create(:free_user)
+      BoardGroup.create!(name: "Mine", user: user)
+      BoardGroup.create!(name: "Curated", user: user, predefined: true)
+      expect(user.api_view[:board_group_count]).to eq(1)
+    end
+  end
+
   describe "#ensure_minimum_communicator_slot!" do
     it "bumps a 0 limit up to the free-plan default" do
       user = FactoryBot.create(:free_user)


### PR DESCRIPTION
## Summary

Follow-up to #407 / PR #412. `User#api_view` exposed `board_limit` / `board_count` / `board_limit_reached` but not the Board Set (BoardGroup) equivalents. This adds:

```ruby
board_group_limit: board_group_limit,
board_group_count: countable_board_group_count,
```

The model methods already existed and are unchanged — this just serializes them into the current-user payload so a future "Board Sets: X of Y" surface can read set-usage off the user object.

## Test plan

Added a `#api_view board set (BoardGroup) usage` describe block in `spec/models/user_spec.rb`:
- exposes both keys with correct values
- a `builder: true` set counts as one group
- `predefined` (admin-curated) sets are excluded from the count

`bundle exec rspec spec/models/user_spec.rb -e "board set" -e "api_view"` → **8 examples, 0 failures**.

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)