### PR TITLE
docs(board-sets): boards vs. Board Sets counting (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Board Builder output counts as one Board Set, not a dozen boards
+- A Board Builder run now counts as **one Board Set** (`board_group_limit`)
+  instead of one board against your board limit. The whole linked tree it builds
+  costs a single set slot and zero board slots, so "build a full communicator in
+  one tap" no longer eats your board allowance. Standalone boards you make
+  outside the builder still count individually. Per-plan set caps: Free 1,
+  Basic 25, Pro 50 (ENV-overridable via `FREE/BASIC/PRO_BOARD_GROUP_LIMIT`). At
+  the cap, the builder returns a "board set limit" message (422), matching the
+  Board Sets API.
+
 ### Fixed — board preview thumbnails (wrong/stale + missing)
 - Board grid thumbnails now reliably reflect the board's **current** contents.
   `Board#display_image_url` (what the grid reads first) resolves with a clear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -678,13 +678,15 @@ When a paid user (Basic/Pro) cancels, `apply_free_plan` resets `plan_type` to
   (`app/models/board.rb`). The board's `api_view` exposes `can_edit`,
   `locked`, and `lock_reason` for the frontend.
 - "Over their board limit" is computed by `User#countable_board_count` (own,
-  non-predefined, non-`builder_child` boards) vs `User#board_limit`. This is the
-  **single source of truth** for board counting — `User#at_board_limit?` wraps
-  it (admins never limited), and every creation gate (create, clone,
-  `create_from_template`, `import_obf`, menus, generated-board claim,
-  Board Builder) plus the `can_create_boards` api_view flag and this read-only
-  rule all route through it. Board Builder sub-boards are excluded so a built
-  tree counts as one (see the Board Builder section).
+  non-predefined boards that **don't belong to a `builder: true` BoardGroup**)
+  vs `User#board_limit`. This is the **single source of truth** for board
+  counting — `User#at_board_limit?` wraps it (admins never limited), and every
+  creation gate (create, clone, `create_from_template`, `import_obf`, menus,
+  generated-board claim) plus the `can_create_boards` api_view flag and this
+  read-only rule all route through it. A Board Builder run's boards are members
+  of a builder BoardGroup, so they're excluded here and the whole built tree
+  costs **zero** board slots — it counts as **one Board Set** against
+  `board_group_limit` instead (see the Board Sets and Board Builder sections).
 - The user picks which single board keeps full edit access via
   `PATCH /api/boards/:id/make_editable`. The selection is persisted on
   `users.editable_board_id`. If none is set, `effective_editable_board_id`
@@ -1268,24 +1270,29 @@ Endpoints (`API::V1::BoardBuilderController`, all auth-gated):
   favorited root board's `api_view` (**201**). **422 `unknown_template`** /
   **422 `build_failed`** (the build is transactional — failure rolls back, no
   orphans). The frontend page ships separately in `itty-bitty-frontend`.
-  - **Board-limit gated, but a tree counts as ONE board.** `create` returns
-    **422 "Maximum number of boards reached"** when `current_user.at_board_limit?`
-    (see the board-limit section below). Because one wizard run persists a whole
-    linked tree, `BoardTreeBuilder` marks every sub-board (depth > 0)
-    `settings["builder_child"] = true`, and `User#countable_board_count` excludes
-    them — so the tree counts as its single root, not ~5. This also keeps the
-    whole built set editable (the read-only lock keys off the same count).
+  - **A built set is a Board Set, counted via `board_group_limit` (issue #407).**
+    A wizard run persists a whole linked tree *and* a `builder: true` BoardGroup
+    wrapping it, so it costs exactly **one Board Set slot and zero board slots**.
+    `create` gates on **`current_user.at_board_group_limit?`** (not the per-board
+    limit) and returns **422** with the same "board set limit" copy as
+    `BoardGroupsController` (`"You've reached your plan's board set limit
+    (N/M). Upgrade to add more."`). `User#countable_board_count` excludes every
+    board that belongs to a builder BoardGroup (`builder_grouped_board_ids`), so
+    the tree never counts against `board_limit` and the whole set stays editable
+    (the read-only lock keys off the same count). `BoardTreeBuilder` /
+    `SeededSetCloner` still stamp `settings["builder_root"]` /
+    `["builder_child"]` on the boards, but those JSONB flags are **no longer the
+    counting mechanism** — `builder_root` now only marks the root for re-run
+    detection; the BoardGroup is what makes a set a set.
   - **Re-run guard (issue #269): detect + warn, never silently dupe.** If the
     communicator already has a builder set, `create` returns **409
     `board_builder_set_exists`** (`{ existing_root_id, existing_root_name,
     built_at }`) instead of stacking a second favorited root; the client
     re-sends with **`confirm=true`** to build another. Detection is
     `ChildAccount#board_builder_root` — each root is marked
-    `settings["builder_root"] = true` by `BoardTreeBuilder` (counterpart to
-    `builder_child`; does **not** affect the board-limit count). It's
-    deletion-safe: delete the set and a re-run is a fresh build. The 409 check
-    runs *after* the board-limit gate, so a Free user at their limit gets the
-    422 first.
+    `settings["builder_root"] = true` by `BoardTreeBuilder`. It's deletion-safe:
+    delete the set and a re-run is a fresh build. The 409 check runs *after* the
+    board-set-limit gate, so a user at their set limit gets the 422 first.
 
 ### Robust vocabulary sets (Core 60 / Core 84)
 

--- a/README.md
+++ b/README.md
@@ -797,6 +797,39 @@ curl -X GET https://<host>/api/boards/<board_id>/download_obf \
 - Specs: `spec/requests/api/boards/import_export_spec.rb`,
   `spec/models/obz_importer_spec.rb`
 
+## Plans & limits: boards vs. Board Sets
+
+The app counts two different things against two separate per-plan caps:
+
+- **Boards** — individual standalone boards a user creates/clones/imports.
+  Counted by `User#countable_board_count` (own, non-predefined boards) against
+  `User#board_limit`.
+- **Board Sets** (`BoardGroup`, user-facing name "Board Sets") — collections of
+  boards, including the linked tree a **Board Builder** run produces. Counted by
+  `User#countable_board_group_count` (own, non-predefined sets) against
+  `User#board_group_limit`.
+
+A **Board Builder** run persists a whole linked tree wrapped in a `builder: true`
+BoardGroup. It costs **one Board Set slot and zero board slots** — the tree's
+boards are excluded from the board count — so "build a full communicator in one
+tap" counts as a single set, not a dozen boards. Standalone boards you create
+outside the builder still count individually against `board_limit`.
+
+Both caps are plan-derived and ENV-overridable (a per-user
+`settings["board_limit"]` / `settings["board_group_limit"]` override wins over
+the plan default; admins are never limited):
+
+| Plan  | Boards (`board_limit`)    | Board Sets (`board_group_limit`) |
+| ----- | ------------------------- | -------------------------------- |
+| Free  | `FREE_BOARD_LIMIT` (1)    | `FREE_BOARD_GROUP_LIMIT` (1)     |
+| Basic | `BASIC_BOARD_LIMIT` (100) | `BASIC_BOARD_GROUP_LIMIT` (25)   |
+| Pro   | `PRO_BOARD_LIMIT` (300)   | `PRO_BOARD_GROUP_LIMIT` (50)     |
+
+When a user is at either cap, the relevant creation path returns **422** with a
+limit message (e.g. Board Builder and `BoardGroupsController` both render
+"You've reached your plan's board set limit…"). **422 is the limit signal; 402
+is reserved for AI-credit exhaustion.**
+
 ## Board Builder wizard
 
 Builds a real, linked board set for a communicator from two wizard inputs — a


### PR DESCRIPTION
## Summary

Follow-up to #407. Brings backend docs + copy in line with the new counting model: a Board Builder run is a **Board Set** (a `builder: true` BoardGroup) counting **1 against `board_group_limit`** and **0 against `board_limit`** — not 1 board against the board limit.

Backend work items from #410:

- ✅ **README** — new "Plans & limits: boards vs. Board Sets" section explaining the two caps, with a `FREE/BASIC/PRO_BOARD_GROUP_LIMIT` (+ `board_limit`) table.
- ✅ **CLAUDE.md** — replaced the stale `settings["builder_child"]` flag-counting description and the wrong "422 Maximum number of boards reached / `at_board_limit?`" gating with the real model: a builder BoardGroup, gated on `at_board_group_limit?`, "board set limit" copy. Clarified the JSONB `builder_root`/`builder_child` flags are still written but are no longer the counting mechanism.
- ✅ **CHANGELOG** — user-facing entry.
- ✅ **Builder limit-hit error copy** — already reads "You've reached your plan's board set limit…" in `board_builder_controller.rb`, matching `BoardGroupsController`. Confirmed; no code change needed.

## Out of scope (separate repo)

- ⬜ Help-center `plans-and-slot-limits` article — lives in the frontend/marketing repo, handled as a separate change.

## Test plan

Doc-only change (README / CLAUDE.md / CHANGELOG) — no code touched, no tests to run. All claims were verified against the current code (`User#countable_board_count`, `#countable_board_group_count`, `#at_board_group_limit?`, `BoardBuilderController#create`, `BoardGroupsController`).

Refs #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)