### PR TITLE
fix(board-builder): repair off-grid tiles so Speak matches the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — builder boards rendered differently in Speak vs. the editor
+- Board Builder sets (e.g. Core 84) could carry duplicate tiles and folder tiles
+  pushed **past** the grid edge (x=13 on a 12-column board). The editor clamped
+  to the configured columns, but the Speak/dynamic view widened the grid to fit
+  them — so the same board looked different in Speak. `Boards::TileDeduper` now
+  keeps the **in-grid** copy of a duplicate, and a new `Boards::LayoutRepacker`
+  pulls any remaining out-of-grid tiles back inside the grid. Run
+  `rake board_builder:repair_grid` (dry-run by default; `DRY_RUN=false` to apply)
+  to clean existing seed sources and built sets.
+
 ### Fixed — board preview thumbnails (wrong/stale + missing)
 - Board grid thumbnails now reliably reflect the board's **current** contents.
   `Board#display_image_url` (what the grid reads first) resolves with a clear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1327,6 +1327,25 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
     (`settings["builder_root"]/["builder_child"]`) — re-seeding only heals the
     admin sources, not the user clones, so run this for the live sets built
     between the bad re-seed and the fix.
+  - **Off-grid tiles + the Speak-view divergence — `rake board_builder:repair_grid`.**
+    A duplicate folder tile could be parked PAST the grid edge (e.g. a Core 84
+    `More` folder at `x=13` on a 12-column board). The editor renders through
+    react-grid-layout, which clamps to the configured `cols`, but the native
+    **Speak** view sized the grid by the tile extent and silently widened to 14
+    columns — so the same board looked different in Speak than in every editor
+    view. Two layers fix it: **(1)** `Boards::TileDeduper` now keeps the
+    **in-grid** copy of a duplicate (not blindly the lowest-position one), so it
+    no longer preserves the off-grid twin and delete the authored in-grid tile;
+    **(2)** `Boards::LayoutRepacker` is the safety net for a genuine
+    *non-duplicate* overflow tile — it moves only the overflowing tiles into the
+    first empty rows below the fitting tiles (per screen size, then resyncs
+    `board.layout`), a Ruby port of the frontend `repackLayout`. The combined
+    `rake board_builder:repair_grid` (dry-run by default; `DRY_RUN=false`,
+    `USER_ID=N`) runs dedupe + repack across the seed sources and every built
+    set and regenerates the preview for any board it changes. The companion
+    frontend fix (itty-bitty-frontend `NativeLayoutGrid` repacks to the
+    configured columns) means Speak matches the editor even before this data
+    cleanup runs.
 - **Build:** `#create` branches on `Boards::RobustSets.find_root(template)`.
   A match runs `Boards::SeededSetCloner` (walks the linked set to depth 2,
   clones each board, **rewires** `predictive_board_id` to the clones, marks

--- a/app/services/boards/layout_repacker.rb
+++ b/app/services/boards/layout_repacker.rb
@@ -1,0 +1,118 @@
+module Boards
+  # Pulls tiles that are stored PAST the configured column count back inside the
+  # grid, for each screen size. Mirrors the frontend `repackLayout`
+  # (itty-bitty-frontend src/components/images/native/nativeLayoutMath.ts): only
+  # the overflowing tiles move — authored in-grid tiles keep their exact x/y —
+  # and the overflow is shelf-packed into the first empty rows below them.
+  #
+  # Why this exists: a builder/seed bug can leave a tile at e.g. x=13 on a
+  # 12-column board. The editor renders through react-grid-layout, which keeps
+  # the grid at the configured `cols`, but the native Speak view sized the grid
+  # by the tile extent and so silently widened to 14 columns — making Speak look
+  # different from every other view. TileDeduper removes off-grid DUPLICATES;
+  # this is the safety net for a genuine non-duplicate overflow tile.
+  module LayoutRepacker
+    module_function
+
+    SCREENS = %w[lg md sm].freeze
+
+    # Repacks every screen size and resyncs the board's denormalized layout.
+    # Returns the number of tiles moved across all screens (0 when clean).
+    # dry_run: report-only — counts what WOULD move without persisting.
+    # ignore_ids: board_image ids to skip — used by a dry-run preview to exclude
+    # tiles that the dedupe pass will remove first, so an off-grid duplicate is
+    # not double-counted as an overflow tile.
+    def repack!(board, dry_run: false, ignore_ids: [])
+      ignore = ignore_ids.to_a.map(&:to_i).to_set
+      moved = SCREENS.sum { |screen| repack_screen!(board, screen, dry_run: dry_run, ignore: ignore) }
+      resync_board_layout!(board) if moved.positive? && !dry_run
+      moved
+    end
+
+    # Returns the number of overflow tiles moved for one screen size.
+    def repack_screen!(board, screen, dry_run: false, ignore: Set.new)
+      columns = column_count(board, screen)
+      return 0 if columns < 1
+
+      items = board.board_images.to_a.filter_map do |bi|
+        next if ignore.include?(bi.id)
+
+        cell = bi.layout.is_a?(Hash) ? bi.layout[screen] : nil
+        cell.nil? ? nil : [bi, cell]
+      end
+
+      overflow = items.select { |_bi, c| (c["x"].to_i + tile_w(c)) > columns }
+      return overflow.size if overflow.empty? || dry_run
+
+      fits = items - overflow
+      base_y = fits.map { |_bi, c| c["y"].to_i + tile_h(c) }.max || 0
+
+      cx = 0
+      cy = base_y
+      row_h = 0
+      # Shelf-pack overflow tiles in reading order, just like the frontend.
+      overflow.sort_by { |_bi, c| [c["y"].to_i, c["x"].to_i] }.each do |bi, cell|
+        w = [tile_w(cell), columns].min
+        h = tile_h(cell)
+        if cx + w > columns
+          cx = 0
+          cy += row_h
+          row_h = 0
+        end
+        bi.layout[screen] = cell.merge("i" => bi.id.to_s, "x" => cx, "y" => cy, "w" => w, "h" => h)
+        bi.save!
+        cx += w
+        row_h = [row_h, h].max
+      end
+
+      overflow.size
+    end
+
+    # Rebuild board.layout from the (now corrected) per-tile layouts, for every
+    # screen, keyed by board_image id — matching Board#update_board_layout's
+    # shape but without wiping the other screen sizes.
+    def resync_board_layout!(board)
+      new_layout = {}
+      ordered = board.board_images.order(:position)
+      SCREENS.each do |screen|
+        screen_layout = {}
+        ordered.each do |bi|
+          cell = bi.layout.is_a?(Hash) ? bi.layout[screen] : nil
+          next if cell.nil?
+
+          screen_layout[bi.id.to_s] = cell.merge("i" => bi.id.to_s)
+        end
+        new_layout[screen] = screen_layout unless screen_layout.empty?
+      end
+      board.update_column(:layout, new_layout)
+    end
+
+    def column_count(board, screen)
+      explicit =
+        case screen
+        when "sm" then board.small_screen_columns
+        when "md" then board.medium_screen_columns
+        else board.large_screen_columns
+        end
+      cols = explicit.to_i
+      cols = board.number_of_columns.to_i if cols < 1
+      cols < 1 ? default_columns(screen) : cols
+    end
+    private_class_method :column_count
+
+    def default_columns(screen)
+      { "sm" => 4, "md" => 8, "lg" => 12 }.fetch(screen, 12)
+    end
+    private_class_method :default_columns
+
+    def tile_w(cell)
+      [cell["w"].to_i, 1].max
+    end
+    private_class_method :tile_w
+
+    def tile_h(cell)
+      [cell["h"].to_i, 1].max
+    end
+    private_class_method :tile_h
+  end
+end

--- a/app/services/boards/tile_deduper.rb
+++ b/app/services/boards/tile_deduper.rb
@@ -15,6 +15,8 @@ module Boards
   module TileDeduper
     module_function
 
+    SCREEN = "lg".freeze
+
     # Returns the number of duplicate tiles removed (0 when the board is clean).
     # dry_run: report-only — counts what WOULD be removed without destroying.
     def collapse_duplicates!(board, dry_run: false)
@@ -32,15 +34,55 @@ module Boards
       removed
     end
 
+    # The ids collapse_duplicates! would destroy (every tile after the kept one
+    # in each duplicate group). Lets a dry-run preview sequence dedupe→repack
+    # without mutating: the repacker can ignore these so it doesn't count an
+    # off-grid duplicate as a genuine overflow tile.
+    def removable_tile_ids(board)
+      duplicate_groups(board).flat_map { |_key, tiles| tiles.drop(1).map(&:id) }
+    end
+
     # Groups of >1 tiles sharing a normalized label AND kind, each sorted so the
     # tile to KEEP is first. Grouping on (label, folder?) keeps a word tile
     # ("play") distinct from its same-named category folder ("Play") — those are
     # intentionally separate tiles, not duplicates.
+    #
+    # Keep-order: an IN-GRID tile (its lg cell fits the board's column count)
+    # always wins over an out-of-grid one, THEN lowest position, THEN oldest id.
+    # The in-grid rule matters because a builder bug can leave the lower-position
+    # copy of a duplicate folder tile parked PAST the grid edge (e.g. a Core 84
+    # "More" folder at x=13 on a 12-column board); blindly keeping the
+    # lowest-position tile would preserve the broken off-grid copy and delete the
+    # authored in-grid one — leaving the Speak view rendering wider than the grid.
     def duplicate_groups(board)
+      columns = board_columns(board)
       board.board_images.includes(:image).group_by { |bi| group_key(bi) }
            .reject { |(label, _folder), tiles| label.blank? || tiles.size < 2 }
-           .transform_values { |tiles| tiles.sort_by { |bi| [bi.position || Float::INFINITY, bi.id] } }
+           .transform_values { |tiles| tiles.sort_by { |bi| keep_order(bi, columns) } }
     end
+
+    def keep_order(board_image, columns)
+      [in_grid?(board_image, columns) ? 0 : 1, board_image.position || Float::INFINITY, board_image.id]
+    end
+    private_class_method :keep_order
+
+    # True when the tile's lg cell sits fully within the configured columns.
+    def in_grid?(board_image, columns)
+      cell = board_image.layout.is_a?(Hash) ? board_image.layout[SCREEN] : nil
+      return true if cell.nil? # no lg layout → not the off-grid culprit; don't penalize
+
+      x = cell["x"].to_i
+      w = [cell["w"].to_i, 1].max
+      (x + w) <= columns
+    end
+    private_class_method :in_grid?
+
+    def board_columns(board)
+      cols = board.large_screen_columns.to_i
+      cols = board.number_of_columns.to_i if cols < 1
+      cols < 1 ? 12 : cols
+    end
+    private_class_method :board_columns
 
     def group_key(board_image)
       label = (board_image.label.presence || board_image.image&.label).to_s.strip.downcase

--- a/lib/tasks/board_builder.rake
+++ b/lib/tasks/board_builder.rake
@@ -93,6 +93,52 @@ namespace :board_builder do
     end
   end
 
+  # Full grid repair for the "Speak view looks different" bug: collapse duplicate
+  # tiles (keeping the IN-GRID copy) AND repack any remaining out-of-grid tiles
+  # back inside the configured columns, across the robust seed sources and every
+  # built user set. This is the complete fix — dedupe_seed_tiles alone leaves the
+  # off-grid folder duplicates in place when their lower-position copy is the
+  # off-grid one. Regenerates the board preview for any board it changes.
+  #
+  # Read-only by default. Apply with DRY_RUN=false; scope with USER_ID=N:
+  #   rake board_builder:repair_grid                  # preview all
+  #   DRY_RUN=false rake board_builder:repair_grid    # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_builder:repair_grid
+  desc "Dedupe + repack out-of-grid Board Builder tiles (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task repair_grid: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    boards = dedupe_target_boards(ENV["USER_ID"])
+    boards_touched = 0
+    tiles_removed = 0
+    tiles_moved = 0
+
+    boards.each do |board|
+      # In a dry run nothing is destroyed, so tell the repacker which off-grid
+      # duplicates the dedupe pass WOULD remove first — otherwise they'd be
+      # double-counted as overflow tiles needing a repack.
+      removable = dry_run ? Boards::TileDeduper.removable_tile_ids(board) : []
+      removed = Boards::TileDeduper.collapse_duplicates!(board, dry_run: dry_run)
+      board.board_images.reset unless dry_run
+      moved = Boards::LayoutRepacker.repack!(board, dry_run: dry_run, ignore_ids: removable)
+      next if removed.zero? && moved.zero?
+
+      boards_touched += 1
+      tiles_removed += removed
+      tiles_moved += moved
+      kind = board.settings&.dig("board_builder_robust_slug") ? "seed" : (board.settings&.dig("builder_root") ? "root" : "child")
+      puts "#{dry_run ? '[DRY RUN] ' : ''}board ##{board.id} #{board.name.inspect} (#{kind}, owner #{board.user_id}): #{removed} duplicate(s) removed, #{moved} tile(s) repacked"
+
+      board.run_generate_preview_job unless dry_run
+    end
+
+    if dry_run
+      puts "Dry run only — #{boards_touched} board(s): #{tiles_removed} duplicate(s) to remove, #{tiles_moved} tile(s) to repack. Re-run with DRY_RUN=false to apply."
+    else
+      puts "Repaired #{boards_touched} board(s): removed #{tiles_removed} duplicate(s), repacked #{tiles_moved} tile(s)."
+    end
+  end
+
   # Boards to scan: robust seed SOURCE boards (root + linked descendants, the
   # template clones copy from) plus every built user set. USER_ID scopes to one
   # owner (seed sources are admin-owned, so a non-admin USER_ID yields built

--- a/spec/services/boards/layout_repacker_spec.rb
+++ b/spec/services/boards/layout_repacker_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe Boards::LayoutRepacker do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  before { board.update_column(:large_screen_columns, 12) }
+
+  # Create a tile with an explicit lg layout (bypassing callbacks so the stored
+  # x/y is exactly what we set — including deliberately out-of-grid positions).
+  def tile(label, x:, y:, position:, w: 1, h: 1)
+    bi = create(:board_image, board: board, position: position,
+                              image: create(:image, label: label, user_id: user.id))
+    bi.update_column(:layout, { "lg" => { "i" => bi.id.to_s, "x" => x, "y" => y, "w" => w, "h" => h } })
+    bi
+  end
+
+  def lg(bi)
+    bi.reload.layout["lg"]
+  end
+
+  describe ".repack!" do
+    it "moves an out-of-grid tile inside the configured columns" do
+      tile("I", x: 0, y: 0, position: 0)
+      over = tile("More", x: 13, y: 1, position: 1) # past the 12-col grid
+
+      moved = described_class.repack!(board)
+
+      expect(moved).to eq(1)
+      cell = lg(over)
+      expect(cell["x"] + cell["w"]).to be <= 12
+    end
+
+    it "leaves authored in-grid tiles exactly where they are" do
+      keep = tile("I", x: 0, y: 0, position: 0)
+      tile("More", x: 13, y: 1, position: 1)
+
+      described_class.repack!(board)
+
+      expect(lg(keep)).to include("x" => 0, "y" => 0)
+    end
+
+    it "drops the overflow tile to a new row below the fitting tiles" do
+      tile("I", x: 0, y: 0, position: 0)
+      over = tile("More", x: 13, y: 0, position: 1) # same stored row, but off-grid
+
+      described_class.repack!(board)
+
+      expect(lg(over)["y"]).to be > 0
+    end
+
+    it "is a no-op on a board whose tiles already fit, returning 0" do
+      a = tile("I", x: 0, y: 0, position: 0)
+      b = tile("you", x: 11, y: 0, position: 1)
+
+      expect(described_class.repack!(board)).to eq(0)
+      expect(lg(a)).to include("x" => 0, "y" => 0)
+      expect(lg(b)).to include("x" => 11, "y" => 0)
+    end
+
+    it "clamps a tile wider than the grid down to the column count" do
+      board.update_column(:large_screen_columns, 4)
+      wide = tile("banner", x: 2, y: 0, position: 0, w: 6) # spans to 8 on a 4-col grid
+
+      described_class.repack!(board)
+
+      cell = lg(wide)
+      expect(cell["w"]).to be <= 4
+      expect(cell["x"] + cell["w"]).to be <= 4
+    end
+
+    it "dry_run reports the move count without persisting" do
+      tile("I", x: 0, y: 0, position: 0)
+      over = tile("More", x: 13, y: 1, position: 1)
+
+      expect(described_class.repack!(board, dry_run: true)).to eq(1)
+      expect(lg(over)).to include("x" => 13) # untouched
+    end
+
+    it "resyncs the board's denormalized layout after repacking" do
+      tile("I", x: 0, y: 0, position: 0)
+      over = tile("More", x: 13, y: 1, position: 1)
+
+      described_class.repack!(board)
+
+      board.reload
+      stored = board.layout["lg"][over.id.to_s]
+      expect(stored["x"] + stored["w"]).to be <= 12
+    end
+  end
+end

--- a/spec/services/boards/tile_deduper_spec.rb
+++ b/spec/services/boards/tile_deduper_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe Boards::TileDeduper do
         .to change { board.board_images.count }.by(-2)
     end
 
+    it "keeps the IN-GRID copy even when the off-grid duplicate has a lower position" do
+      board.update_column(:large_screen_columns, 12)
+      folder_target = create(:board, user: user)
+      # The off-grid copy (x=13 on a 12-col board) was inserted first (low
+      # position) — the exact Core 84 builder bug. The authored in-grid copy
+      # (bottom row) came later. We must keep the in-grid one.
+      off_grid = tile("More", position: 5, predictive_board_id: folder_target.id)
+      off_grid.update_column(:layout, { "lg" => { "i" => off_grid.id.to_s, "x" => 13, "y" => 1, "w" => 1, "h" => 1 } })
+      in_grid = tile("More", position: 40, predictive_board_id: folder_target.id)
+      in_grid.update_column(:layout, { "lg" => { "i" => in_grid.id.to_s, "x" => 7, "y" => 6, "w" => 1, "h" => 1 } })
+
+      expect { described_class.collapse_duplicates!(board) }
+        .to change { board.board_images.count }.by(-1)
+
+      expect(board.board_images.exists?(in_grid.id)).to be(true)
+      expect(board.board_images.exists?(off_grid.id)).to be(false)
+    end
+
     it "is a no-op on a clean board and returns 0" do
       tile("want", position: 1)
       tile("more", position: 2)


### PR DESCRIPTION
## Summary

The backend root-cause companion to [itty-bitty-frontend#466](https://github.com/brittanyjohns/itty-bitty-frontend/pull/466). A builder-made **Core 84** rendered differently in the **Speak/dynamic view** than in the editor. Investigation of the seed source (board 6751 locally) found **102 tiles on an 84-cell grid**: 21 duplicate tiles, including 4 folder tiles (`Play`/`Places`/`Body`/`More`) stored **past** the 12-column grid at x=12–13. The Speak renderer sized the grid by the tile extent and silently widened to 14 columns; the editor (react-grid-layout) clamped to 12. The frontend PR makes Speak render correctly; **this PR fixes the data at the source.**

### The wrinkle this fixes

The existing `rake board_builder:dedupe_seed_tiles` keeps the **lowest-position** duplicate — but for those 4 folders the off-grid copy has the *lower* position, so it would keep the broken off-grid tile and delete the authored in-grid one. This PR corrects that and adds a repack safety net.

## Changes

- **`Boards::TileDeduper`** — keep-order now prefers the **in-grid** tile (its lg cell fits the column count), then lowest position, then oldest id. Backward compatible: tiles with no/equal layout fall back to the old position/id ordering. Adds `removable_tile_ids` for accurate dry-run previews.
- **`Boards::LayoutRepacker`** (new) — moves only out-of-grid tiles into the first empty rows below the fitting tiles, per screen size (lg/md/sm), then resyncs the denormalized `board.layout`. Ruby port of the frontend `repackLayout`; authored in-grid tiles never move.
- **`rake board_builder:repair_grid`** (new) — dry-run by default (`DRY_RUN=false` to apply, `USER_ID=N` to scope). Runs dedupe + repack across robust seed sources and every built set, regenerating the preview for any board it changes. Dry-run sequences dedupe→repack so off-grid duplicates aren't double-counted as overflow.
- Docs: backlog `CLAUDE.md` (Robust vocab sets remediation) + `CHANGELOG.md`.

## Verification

- **Specs:** `tile_deduper_spec` (new in-grid keep-choice case) + `layout_repacker_spec` (repack, clamp-wide-tile, no-op, dry-run, `board.layout` resync) — **14 examples, 0 failures.**
- **Dry-run against local Core 84 (board 6751):** `21 duplicate(s) removed, 0 tile(s) repacked` → returns the board to the authored **81 tiles**, all in-grid. Across all 28 builder boards locally: 183 duplicates to remove, 0 genuine overflow.

## Rollout

After merge + deploy, run on the environment hosting the affected boards (staging/prod):

```
DRY_RUN=false rake board_builder:repair_grid
```

(Preview first with the bare `rake board_builder:repair_grid`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)