### PR TITLE
fix(board-builder): classify built sets correctly (in_use, sub-boards, frozen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `rake board_builder:repair_grid` (dry-run by default; `DRY_RUN=false` to apply)
   to clean existing seed sources and built sets.
 
+### Fixed — Board Builder sets now classify correctly on the boards list
+- A built board set's **home board** now shows up under **"In use"** and
+  **"Main boards"** like any other assigned board. Previously the builder
+  attached the home board to the communicator in a way nothing else did, so it
+  never registered as "in use" and got lost on the boards list.
+- The set's **sub-pages** (Food, Feelings, category folders, etc.) are now
+  correctly classified as **sub-boards** instead of leaking into the main
+  boards list, so the list shows the set's home board rather than every page.
+- Built sub-pages are now **frozen** by default: tapping a word on a sub-page no
+  longer auto-returns to the home board, so a child can keep making selections
+  on the page. (Still adjustable per board in the editor.)
+- Existing built sets can be brought in line with
+  `rake board_builder:reclassify_builder_sets` (dry-run by default).
+
 ### Fixed — board preview thumbnails (wrong/stale + missing)
 - Board grid thumbnails now reliably reflect the board's **current** contents.
   `Board#display_image_url` (what the grid reads first) resolves with a clear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1216,6 +1216,34 @@ still works for backward compat.
   predictive links, scoped to the owner's boards). So tapping a folder navigates
   without speaking the folder's own label; word tiles are untouched.
   `update_column` skips the audio hook/validations. Idempotent.
+- **Scope classification + sub-board freeze.**
+  `BuildBoardSetJob#finalize_sub_boards!` runs at the same end-of-build chokepoint
+  (beside `mute_dynamic_tile_names!`) and, for every `builder_child` board in the
+  set (everything but the root, walked via `set_board_ids`): sets
+  `settings["freeze_board"] = true` and re-saves it so `Board#check_is_sub_board`
+  recomputes against the now-wired `predictive_board_id` links and sets the
+  `sub_board` column **true**. Two problems this fixes: (1) child pages used to
+  leak into the **`main_boards`** scope (`sub_board: [false, nil]`) because their
+  last save happened before the parent linked them, so `sub_board` stayed false;
+  (2) navigating into a child page auto-returned home on the next tap. Freezing is
+  the lever — there is **no separate `return_home` setting**; `freeze_board: true`
+  is what stops auto-return, and the `frozen`/`freeze_parent_board`/`board_frozen`
+  flags the api_view exposes are what the frontend's return-home affordance keys
+  off. The **root is intentionally left unfrozen and `sub_board: false`** so it
+  stays a main board. Default-on but user-overridable in the editor. Idempotent.
+- **Built roots register as `in_use`.** The set's root lives **directly** on the
+  communicator (the `ChildBoard` has `board_id = root.id`, `original_board_id =
+  nil` — unlike the clone-source `assign_boards`/`assign_accounts` path). So
+  `Board#check_in_use` was broadened to mark a board `in_use` when **either** a
+  `ChildBoard` points at it via `original_board_id` (clone source) **or** via
+  `board_id` (direct attach) — i.e. "the board is on a communicator." Without
+  this the builder root never surfaced under the `in_use` scope even though it's
+  literally assigned. The clone-source path is unaffected (clones are
+  `is_template: true`, excluded from the index anyway).
+- **Backfill for pre-fix sets:** `rake board_builder:reclassify_builder_sets`
+  (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope) re-saves
+  each existing built set so the root recomputes `in_use` and every child page
+  gets `freeze_board` + `sub_board`.
 - **Tile images prefer the curated "default" image (`Boards::ImageResolver`).**
   All three build paths (cloner, `BlueprintAssembler`, `BuildBoardSetJob`)
   resolve a tile label via `Boards::ImageResolver.resolve(label, owner:)`. When

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -613,13 +613,16 @@ class Board < ApplicationRecord
     self.tags = tags.reject { |t| t == normalized_tag }
   end
 
+  # A board is "in use" when it's on a communicator. Two ways that happens:
+  #   1. It's the SOURCE of a clone put on a communicator (assign_boards /
+  #      assign_accounts), recorded as ChildBoard#original_board_id.
+  #   2. It's attached DIRECTLY (no clone) via ChildBoard#board_id — the Board
+  #      Builder path, where the built root lives straight on the communicator.
+  # Without case 2, builder roots stayed in_use=false and never surfaced under
+  # the "in use" scope even though they're literally assigned to a communicator.
   def check_in_use
-    child_board_templates = ChildBoard.where(original_board_id: id)
-    if child_board_templates.any?
-      self.in_use = true
-    elsif !child_board_templates.any?
-      self.in_use = false
-    end
+    self.in_use = ChildBoard.where(original_board_id: id).exists? ||
+      ChildBoard.where(board_id: id).exists?
   end
 
   IS_SUB_BOARD_TAG = "sub-board".freeze

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -71,6 +71,7 @@ class BuildBoardSetJob
       # boards the build services add outside SeededSetCloner/BoardTreeBuilder.
       attach_set_to_group!(root, board_group_id)
       mute_dynamic_tile_names!(root)
+      finalize_sub_boards!(root)
       generate_preview!(root)
       root.update_column(:status, "complete")
     rescue => e
@@ -184,6 +185,30 @@ class BuildBoardSetJob
 
         bi.update_column(:data, data.merge("mute_name" => true))
       end
+  end
+
+  # Every sub-board of a builder set (the builder_child pages — everything in
+  # the set EXCEPT the root) is finalized as a real "page":
+  #
+  #   - settings["freeze_board"] = true so navigating into it doesn't auto-return
+  #     to home on the next tap; the frontend's return-home affordance keys off
+  #     the freeze_parent_board/board_frozen flags the api_view then exposes.
+  #   - re-saved so Board#check_is_sub_board recomputes against the now-wired
+  #     predictive_board_id links and sets the sub_board column true. Without this
+  #     the children leaked into the `main_boards` scope (their last save happened
+  #     before the parent linked them, so sub_board stayed false).
+  #
+  # The root is intentionally left unfrozen and sub_board=false so it stays a
+  # main board. A no-op once already frozen + classified (idempotent on retry).
+  def finalize_sub_boards!(root)
+    child_ids = set_board_ids(root) - [root.id]
+    Board.where(id: child_ids).find_each do |board|
+      settings = board.settings || {}
+      next if settings["freeze_board"] == true && board.sub_board == true
+
+      board.settings = settings.merge("freeze_board" => true)
+      board.save! # save recomputes check_is_sub_board => sub_board: true
+    end
   end
 
   # Attach every board in the built set to its builder BoardGroup, so the set is

--- a/lib/tasks/board_builder.rake
+++ b/lib/tasks/board_builder.rake
@@ -139,6 +139,65 @@ namespace :board_builder do
     end
   end
 
+  # Backfill for the Board Builder scope/classification fix. Sets built before
+  # that change have:
+  #   - roots that never registered as in_use (the ChildBoard attaches the root
+  #     directly, and the old Board#check_in_use only counted clone sources), so
+  #     they never surfaced under the "in use" scope, AND
+  #   - sub-boards (builder_child) that leaked into the `main_boards` scope
+  #     (their sub_board column was never set true) and weren't frozen.
+  #
+  # This re-saves each built set so Board#check_in_use / #check_is_sub_board
+  # recompute against the now-complete relations, and freezes every child page
+  # (settings["freeze_board"] = true) so navigating in doesn't auto-return home —
+  # exactly what BuildBoardSetJob#finalize_sub_boards! now does at build time.
+  #
+  # Read-only by default. Apply with DRY_RUN=false; scope with USER_ID=N:
+  #   rake board_builder:reclassify_builder_sets               # preview all
+  #   DRY_RUN=false rake board_builder:reclassify_builder_sets  # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_builder:reclassify_builder_sets
+  desc "Reclassify built Board Builder sets: root in_use, children sub_board+frozen (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task reclassify_builder_sets: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    roots = Board.where("(settings ->> 'builder_root') = 'true'")
+    roots = roots.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    sets_touched = 0
+    children_frozen = 0
+
+    roots.find_each do |root|
+      child_ids = builder_set_child_ids(root)
+      sets_touched += 1
+      puts "#{dry_run ? '[DRY RUN] ' : ''}set ##{root.id} #{root.name.inspect} (owner #{root.user_id}): root in_use, #{child_ids.size} child page(s) frozen + sub_board"
+
+      next if dry_run
+
+      # Re-save the root so check_in_use picks up its direct ChildBoard.
+      root.save!
+      Board.where(id: child_ids).find_each do |child|
+        child.settings = (child.settings || {}).merge("freeze_board" => true)
+        child.save! # recomputes check_is_sub_board => sub_board: true
+        children_frozen += 1
+      end
+    end
+
+    if dry_run
+      puts "Dry run only — #{sets_touched} built set(s) to reclassify. Re-run with DRY_RUN=false to apply."
+    else
+      puts "Reclassified #{sets_touched} set(s); froze #{children_frozen} child page(s)."
+    end
+  end
+
+  # The builder_child boards under a built root: BFS predictive_board_id links
+  # (bounded to the cloner's MAX_DEPTH), scoped to the owner so a tile pointing at
+  # a shared/admin board can't pull it in. Excludes the root itself.
+  def builder_set_child_ids(root)
+    acc = Set.new
+    collect_set_descendant_ids(root, acc)
+    Board.where(id: acc.to_a, user_id: root.user_id).pluck(:id)
+  end
+
   # Boards to scan: robust seed SOURCE boards (root + linked descendants, the
   # template clones copy from) plus every built user set. USER_ID scopes to one
   # owner (seed sources are admin-owned, so a non-admin USER_ID yields built

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -125,6 +125,33 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "#check_in_use (before_save)" do
+    let(:user)  { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user, name: "Home") }
+
+    it "is not in_use with no ChildBoard" do
+      board.save!
+      expect(board.reload.in_use).to be(false)
+    end
+
+    it "is in_use when directly attached to a communicator (Board Builder path)" do
+      communicator = FactoryBot.create(:child_account, user: user)
+      communicator.child_boards.create!(board: board, created_by_id: user.id)
+
+      board.save!
+      expect(board.reload.in_use).to be(true)
+    end
+
+    it "is in_use when it is the source of a clone on a communicator (assign path)" do
+      communicator = FactoryBot.create(:child_account, user: user)
+      clone = FactoryBot.create(:board, user: user, name: "Home copy", is_template: true)
+      communicator.child_boards.create!(board: clone, original_board: board, created_by_id: user.id)
+
+      board.save!
+      expect(board.reload.in_use).to be(true)
+    end
+  end
+
   describe "#update_grid_layout" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user, layout: { "lg" => [] }) }

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -94,6 +94,47 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
+  describe "#perform scope classification + sub-board freeze" do
+    it "registers the root as in_use and a main board, not a sub-board" do
+      root = precreate_root!(name: "Home")
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs"])
+
+      root.reload
+      expect(root.in_use).to be(true)
+      expect(root.sub_board).to be_falsey
+      expect(Board.main_boards).to include(root)
+      expect(Board.in_use).to include(root)
+      expect(Board.sub_boards).not_to include(root)
+    end
+
+    it "marks every child page as a sub-board and freezes it (kept out of main_boards)" do
+      root = precreate_root!(name: "Home")
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"])
+
+      children = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+      expect(children).to be_present
+
+      children.each do |child|
+        expect(child.sub_board).to be(true), "expected child ##{child.id} #{child.name.inspect} to be a sub_board"
+        expect(child.settings["freeze_board"]).to be(true), "expected child ##{child.id} #{child.name.inspect} to be frozen"
+        expect(child.is_frozen?).to be(true)
+      end
+
+      expect(Board.main_boards).not_to include(*children)
+      expect(Board.sub_boards).to include(*children)
+    end
+
+    it "exposes the freeze on the api_view so the frontend can drop auto-return" do
+      root = precreate_root!(name: "Home")
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs"])
+
+      child = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").first
+      expect(child.user_api_view[:frozen]).to be(true)
+    end
+  end
+
   describe "#perform with a robust seeded set" do
     it "clones the set into the pre-created root, rewires links, routes interests, and completes" do
       source_root = seed_robust_set!


### PR DESCRIPTION
## Summary

Board Builder sets weren't being scoped/categorized correctly on the boards list: the built home board never appeared under **In use** or **Main boards**, and its sub-pages leaked into the main list. Root cause was that the builder attaches boards to a communicator differently than every other flow, so the `in_use` / `sub_board` scope columns never got set.

### What was wrong
- **`in_use`** — the builder attaches the root **directly** to the communicator (`ChildBoard.board_id = root.id`, `original_board_id = nil`), but `Board#check_in_use` only counted boards that were the *source of a clone* (the `assign_boards`/`assign_accounts` pattern). So the built root was forced `in_use: false`.
- **`sub_board`** — child pages got `settings["builder_child"]` but their `sub_board` column was never reliably set (the `predictive_board_id` link is wired *after* their last save, so `check_is_sub_board` ran too early), letting them leak into the `main_boards` scope.
- **No freeze** — tapping a word on a sub-page auto-returned to home. There is no separate `return_home` setting; `settings["freeze_board"] = true` is the lever, and the frontend's return-home button keys off the `frozen` / `freeze_parent_board` / `board_frozen` flags the api_view exposes.

## Changes
- **`app/models/board.rb`** — broaden `check_in_use` to mark a board in use when a `ChildBoard` references it via `original_board_id` **or** `board_id` ("the board is on a communicator"). Clone-source path unaffected (clones are `is_template: true`, excluded from the index anyway).
- **`app/sidekiq/build_board_set_job.rb`** — add `finalize_sub_boards!(root)` at the existing end-of-build chokepoint (beside `mute_dynamic_tile_names!`): freeze every `builder_child` page and re-save so `check_is_sub_board` recomputes `sub_board: true`. Root left unfrozen / `sub_board: false` so it stays a main board. Idempotent.
- **`lib/tasks/board_builder.rake`** — `rake board_builder:reclassify_builder_sets` backfill for pre-fix sets (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope).
- **Docs** — CLAUDE.md (Board Builder section) + CHANGELOG.

## Result
- Built set's **home board** → appears under **In use** and **Main boards**.
- Built **sub-pages** → classified as **sub-boards** (out of the main list), and **frozen** so navigation doesn't auto-return home (still adjustable per board in the editor).

## Test plan
- New specs (6/6 pass): `check_in_use` direct-attach (model) + builder classification/freeze (job).
- Full builder suites pass (88/88): `spec/sidekiq/build_board_set_job_spec.rb`, `build_board_set_job_grid_spec.rb`, `spec/requests/api/v1/board_builder_spec.rb`.
- Board + ChildBoard + ChildAccount model specs pass (covers the global `check_in_use` change): 77 examples, 0 failures, 1 pending.
- Rake task syntax-checks and registers.

## Note for frontend
The backend now serializes `frozen` / `freeze_parent_board` / `board_frozen` for built sub-pages — wiring the return-home button to consume those flags is a companion frontend change if it isn't already.