### PR TITLE
fix(mailer): point safety alert CTA to /dashboard

### DIFF
--- a/app/mailers/safety_profile_mailer.rb
+++ b/app/mailers/safety_profile_mailer.rb
@@ -12,7 +12,7 @@ class SafetyProfileMailer < BaseMailer
     # timezone isn't known here.
     @viewed_at_display = profile_view.viewed_at.utc.strftime("%B %-d, %Y at %-l:%M %p UTC")
     @approx_location = profile_view.approx_location.presence
-    @manage_url = "#{frontend_url}/dashboard/myspeak"
+    @manage_url = "#{frontend_url}/dashboard"
 
     with_user_locale(@owner) do
       mail(

--- a/spec/mailers/safety_profile_mailer_spec.rb
+++ b/spec/mailers/safety_profile_mailer_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe SafetyProfileMailer, type: :mailer do
       expect(body).to include("Austin, Texas, US")
     end
 
+    it "links the CTA to the dashboard, not a nonexistent myspeak route" do
+      view = profile.profile_views.create!(viewed_at: Time.utc(2026, 6, 24, 15, 5))
+      body = described_class.viewed_alert(profile, view).body.encoded
+
+      expect(body).to include("/dashboard")
+      expect(body).not_to include("/dashboard/myspeak")
+    end
+
     it "does not deliver when the profile has no owner" do
       orphan = Profile.create!(username: "orphan-1", slug: "orphan-1")
       view = ProfileView.create!(profile: orphan)


### PR DESCRIPTION
## What

The safety-view notification email (`SafetyProfileMailer#viewed_alert`, issue #384) had its "Manage" CTA pointing at `/dashboard/myspeak` — a frontend route that doesn't exist. Parents who clicked it landed on a dead link. Changed `@manage_url` to `#{frontend_url}/dashboard`.

## Why

`/dashboard/myspeak` is not a real route in the React frontend, so the alert's primary action went nowhere. `/dashboard` is the valid landing spot.

## Changes

- `app/mailers/safety_profile_mailer.rb` — `@manage_url` now builds `#{frontend_url}/dashboard`. Both the HTML and text views read from `@manage_url`, so both are fixed.
- Added a spec asserting the CTA links to `/dashboard` and not `/dashboard/myspeak`.

## Test plan

- `bundle exec rspec spec/mailers/safety_profile_mailer_spec.rb` — 5 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)