### PR TITLE
feat(board-builder): use folder-tile image as sub-board thumbnail

### DIFF
--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -72,6 +72,7 @@ class BuildBoardSetJob
       attach_set_to_group!(root, board_group_id)
       mute_dynamic_tile_names!(root)
       finalize_sub_boards!(root)
+      set_sub_board_previews_from_tiles!(root)
       generate_preview!(root)
       root.update_column(:status, "complete")
     rescue => e
@@ -208,6 +209,39 @@ class BuildBoardSetJob
 
       board.settings = settings.merge("freeze_board" => true)
       board.save! # save recomputes check_is_sub_board => sub_board: true
+    end
+  end
+
+  # Sub-boards aren't rendered to a PNG preview (GenerateBoardPreviewJob skips
+  # builder_child boards). Instead each sub-board's thumbnail is the folder tile
+  # that opens it — "whatever board image represents it" wherever that tile lives
+  # in the set (the root for top-level fringe pages, the Phrases board for the
+  # function pages, etc.). We resolve that tile's image and write it onto the
+  # sub-board's denormalized display_image_url COLUMN (the tier-3 seed thumbnail
+  # in Board#display_image_url), then purge any stray preview_image so the column
+  # wins. update_column skips callbacks so this never re-enqueues a preview.
+  def set_sub_board_previews_from_tiles!(root)
+    owner = root.user
+    ids = set_board_ids(root)
+    child_ids = ids - [root.id]
+    return if child_ids.empty?
+
+    # The folder tiles (anywhere in the set) that open each child board. If a
+    # child is reachable from more than one tile, any one is a fine thumbnail.
+    tiles_by_child = BoardImage
+      .where(board_id: ids, predictive_board_id: child_ids)
+      .includes(:image)
+      .index_by(&:predictive_board_id)
+
+    Board.where(id: child_ids).find_each do |child|
+      tile = tiles_by_child[child.id]
+      next unless tile
+
+      url = tile.tile_image_url(owner)
+      next if url.blank?
+
+      child.update_column(:display_image_url, url) unless child.read_attribute(:display_image_url) == url
+      child.preview_image.purge if child.preview_image.attached?
     end
   end
 

--- a/app/sidekiq/generate_board_preview_job.rb
+++ b/app/sidekiq/generate_board_preview_job.rb
@@ -11,6 +11,16 @@ class GenerateBoardPreviewJob
 
     board = Board.find(board_id)
 
+    # Board Builder sub-boards (builder_child pages — fringe/Phrases/function/
+    # My Favorites/AI pages) are deliberately NOT rendered to a PNG/PDF: they're
+    # represented by the folder tile that opens them, and BuildBoardSetJob writes
+    # that tile's image onto the sub-board's display_image_url column. Skipping
+    # the Grover render here is the single chokepoint that covers every enqueue
+    # source (clone_with_images, grid/layout saves, blueprint add_image) — by the
+    # time this async job runs, the builder_child flag is committed. The root
+    # (builder_root) and all non-builder boards still render normally.
+    return if board.settings.is_a?(Hash) && board.settings["builder_child"]
+
     # GeneratePreviewAssets attaches the PNG and refreshes the preset display
     # image URL atomically, so there's no post-attach reload/write race here.
     # Any Grover/upload failure propagates and the job retries (retry: 3).

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -94,6 +94,48 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
+  describe "#perform sub-board previews from folder tiles" do
+    it "uses the linking folder tile's image as each sub-board's thumbnail instead of a generated preview" do
+      root = precreate_root!(name: "Home")
+
+      # Give the home template's folder labels art-bearing owner images so their
+      # folder tiles resolve to a real URL (the resolver prefers art-bearing
+      # images), exercising the positive path rather than vacuously skipping.
+      ["Food", "Play", "Feelings", "My Favorites"].each do |label|
+        img = create(:image, label: label, user_id: user.id, src_url: "https://example.com/#{label.parameterize}.png")
+        create(:doc, documentable: img, user: user)
+      end
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"])
+
+      children = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").to_a
+      expect(children).to be_present
+
+      set_ids = (children.map(&:id) + [root.id])
+
+      matched = 0
+      children.each do |child|
+        # No PNG preview is rendered for a sub-board.
+        expect(child.preview_image).not_to be_attached,
+          "expected child ##{child.id} #{child.name.inspect} to have no generated preview"
+
+        tile = BoardImage.where(board_id: set_ids, predictive_board_id: child.id).first
+        next unless tile
+
+        expected = tile.tile_image_url(user)
+        next if expected.blank?
+
+        expect(child.read_attribute(:display_image_url)).to eq(expected),
+          "expected child ##{child.id} #{child.name.inspect} thumbnail to match its folder tile"
+        matched += 1
+      end
+
+      # The home template's folder tiles resolve to real art, so at least one
+      # sub-board thumbnail is sourced from its tile (not vacuously skipped).
+      expect(matched).to be > 0
+    end
+  end
+
   describe "#perform scope classification + sub-board freeze" do
     it "registers the root as in_use and a main board, not a sub-board" do
       root = precreate_root!(name: "Home")

--- a/spec/sidekiq/generate_board_preview_job_spec.rb
+++ b/spec/sidekiq/generate_board_preview_job_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
     expect(other_board.reload.read_attribute(:display_image_url)).to eq(shared_url)
   end
 
+  context "with a Board Builder sub-board" do
+    it "skips PNG generation for a builder_child board" do
+      board.update_column(:settings, board.settings.merge("builder_child" => true))
+
+      described_class.new.perform(board.id, "generate_png" => true)
+
+      board.reload
+      expect(board.preview_image).not_to be_attached
+      expect(board.settings).not_to have_key("preset_display_image_url")
+    end
+
+    it "still generates for the builder_root board" do
+      board.update_column(:settings, board.settings.merge("builder_root" => true))
+
+      described_class.new.perform(board.id, "generate_png" => true)
+
+      expect(board.reload.preview_image).to be_attached
+    end
+  end
+
   describe "sidekiq options" do
     it "retries on failure" do
       expect(described_class.sidekiq_options["retry"]).to eq(3)


### PR DESCRIPTION
## What

Board Builder sub-boards (`builder_child` pages — fringe pages, Phrases, function pages, My Favorites, AI pages) no longer render a PDF/PNG preview. Instead each sub-board's thumbnail is **whatever board image represents it** — the folder tile that opens it, wherever that tile lives in the set (the root for top-level fringe pages, the Phrases board for the function pages, etc.).

## Why

Generating a Grover/headless-Chrome PNG + S3 upload for every sub-board in a set is wasteful when the set already has a perfectly good representation of each page: the folder tile a user taps to open it. Sourcing the thumbnail from that tile is cheaper and visually consistent with how the page appears in its parent.

## How

- **`GenerateBoardPreviewJob`** early-returns for `builder_child` boards. This is the single chokepoint that covers every enqueue source (`clone_with_images`, grid/layout saves, blueprint `add_image`); by the time the async job runs, the `builder_child` flag is committed. The root (`builder_root`) and all non-builder boards still render normally — the root's own preview is unaffected.
- **`BuildBoardSetJob#set_sub_board_previews_from_tiles!`** (new finalize step, run right after `finalize_sub_boards!`) finds the `BoardImage` anywhere in the set whose `predictive_board_id` points at each sub-board, resolves that tile's image via `tile_image_url`, and writes it to the sub-board's `display_image_url` column (the tier-3 seed thumbnail in `Board#display_image_url`). It then purges any stray `preview_image` so the column wins. `update_column` skips callbacks, so it never re-enqueues a preview.

## Notes for reviewers

- **Scope:** new builds only — existing built sets are untouched (per request).
- **Behavior change:** because the gate lives on the shared `GenerateBoardPreviewJob`, an *explicit* "regenerate preview" request on a builder sub-board also no-ops — those pages are permanently represented by their folder tile. This matches the intent ("instead of generating the PNG"); easy to relax later if we want edited sub-boards to render a real preview.
- Thumbnail resolution precedence is unchanged: `preset_display_image` attachment → `preview_image` attachment → `display_image_url` column. Sub-boards now resolve to the column (tier 3) since no preview is attached.

## Test plan

- `spec/sidekiq/generate_board_preview_job_spec.rb` — job skips PNG for a `builder_child` board; still generates for `builder_root`.
- `spec/sidekiq/build_board_set_job_spec.rb` — after a build, each sub-board has no `preview_image` attached and its `display_image_url` column equals its linking folder tile's image URL.
- Ran: `build_board_set_job_spec`, `generate_board_preview_job_spec`, `build_board_set_job_grid_spec`, `seeded_set_cloner_spec`, `board_tree_builder_spec`, `board_builder_spec` (request) — **127 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)