### PR TITLE
fix(board-builder): keep built root a main board + self-heal core seed tile overlaps

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -254,6 +254,17 @@ lose.
   `Boards::RobustSets` (`find_root` / `all_roots` / `slug_for` / `mark_root!`)
   is the single place that query lives. Idempotent: `Board.from_obf` upserts by
   `(user_id, obf_id)`.
+- **Layout self-heal on re-seed (`VocabSets#repair_layout!`).** A clean
+  first-time import is always correct (84/60 tiles, no overlaps). But the
+  historical duplicate-tile bug could leave the surviving tile on the wrong cell
+  — two tiles stacked on one cell (e.g. `wait` on `again` at `[10,5]`) while
+  another sat empty, so the home board rendered with a tile hidden ("84 looks
+  like 82"). `repair_layout!` runs LAST in `seed_slug!` and re-pins every tile to
+  its authored `[x,y]` from the source OBF grid (matched by `obf_button_id`), so
+  a single `bin/rails vocab_sets:seed` converges a corrupted source to clean.
+  Existing **user clones** of a corrupted source are healed by
+  `rake board_builder:repair_grid` — `Boards::LayoutRepacker` now un-stacks
+  in-grid **overlapping** tiles in addition to off-grid ones.
 
 **Per-user build (reuses `clone_with_images`):**
 - `Boards::StarterBlueprints.catalog` merges the static trees (`kind:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   on the page. (Still adjustable per board in the editor.)
 - Existing built sets can be brought in line with
   `rake board_builder:reclassify_builder_sets` (dry-run by default).
+- The home board now **stays** a main board even though its sub-pages each carry
+  a "Home" tile that links back to it. Previously those back-links re-classified
+  the home board as a sub-board on a later save, dropping it off the boards list
+  again; `Board#check_is_sub_board` now pins any builder home board as a main
+  board regardless.
+
+### Fixed — Core 84 / Core 60 missing tiles ("84 only shows 82")
+- A built core set could render with fewer tiles than authored because two tiles
+  ended up stacked on the **same grid cell** (one hidden behind the other) while
+  another cell sat empty — a leftover from an earlier seeding bug. A clean
+  first-time seed was always correct; this only affected sources mangled by past
+  re-seeds.
+- `bin/rails vocab_sets:seed` is now **self-healing**: it re-pins every tile to
+  its authored grid position from the source, so one re-seed restores a clean
+  84/60 with no overlapping tiles.
+- For sets already built from a corrupted source, `Boards::LayoutRepacker` (and
+  thus `rake board_builder:repair_grid`) now also un-stacks **overlapping**
+  tiles, not just off-grid ones — no tile is lost; the displaced one moves to a
+  free cell.
 
 ### Fixed — board preview thumbnails (wrong/stale + missing)
 - Board grid thumbnails now reliably reflect the board's **current** contents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1265,6 +1265,16 @@ still works for backward compat.
   flags the api_view exposes are what the frontend's return-home affordance keys
   off. The **root is intentionally left unfrozen and `sub_board: false`** so it
   stays a main board. Default-on but user-overridable in the editor. Idempotent.
+  - **The root is pinned as a main board in the model, not just by being skipped
+    here.** The seed's child pages each carry an authored **"Home" tile** whose
+    `predictive_board_id` points back at the root, so once those links are wired
+    the root *has* parent boards — and any later `root.save!` (e.g.
+    `allow_scroll_if_grown!`) would flip it to `sub_board: true` and drop it out
+    of the `main_boards` scope / the communicator dashboard. `Board#check_is_sub_board`
+    now **short-circuits to `sub_board: false` for any `settings["builder_root"]`
+    board**, regardless of inbound links, so the Home tiles keep working as
+    navigation while the root stays a main board. `rake board_builder:reclassify_builder_sets`
+    re-saves existing roots, so the guard heals already-built sets too.
 - **Built roots register as `in_use`.** The set's root lives **directly** on the
   communicator (the `ChildBoard` has `board_id = root.id`, `original_board_id =
   nil` — unlike the clone-source `assign_boards`/`assign_accounts` path). So
@@ -1385,6 +1395,20 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
     collapses any surviving same-label/same-kind duplicate on each seeded board
     — a word tile and its same-named category folder (`play` vs `Play`) are
     **not** merged. Re-seeding is now self-healing for this case.
+  - **Layout self-heal on re-seed (`VocabSets#repair_layout!`).** The same
+    duplicate bug could also leave the surviving tile on the **wrong cell**: the
+    upsert set the matched tile's coords but a leftover copy kept stale ones, and
+    dedupe could keep the wrong copy — so two tiles ended up on **one cell** (e.g.
+    Core 84 `wait` parked on `again` at `[10,5]`) while another cell sat empty,
+    rendering one tile hidden behind another ("84 looks like 82"). Neither dedupe
+    (different labels, not duplicates) nor `LayoutRepacker` (the cell is in-grid,
+    not off-grid) catches that. `repair_layout!` runs **last** in `seed_slug!`
+    and re-pins every surviving tile to its **authored** `[x,y]` read straight
+    from the source OBF grid (matched by `data["obf_button_id"]`), so a single
+    `bin/rails vocab_sets:seed` now converges a corrupted source back to a clean
+    84/60 with zero overlaps. A clean re-seed is a no-op. A clean **first-time**
+    import was always correct; this only heals sources mangled by the historical
+    re-seed bug.
   - **Remediation:** `rake board_builder:dedupe_seed_tiles` (dry-run by default,
     `DRY_RUN=false` to apply, `USER_ID=N` to scope) collapses the duplicate on
     the robust seed sources **and** every already-built user set
@@ -1401,9 +1425,13 @@ layout + `part_of_speech` colors survive). Reuses `ObzImporter` (seed) and
     **in-grid** copy of a duplicate (not blindly the lowest-position one), so it
     no longer preserves the off-grid twin and delete the authored in-grid tile;
     **(2)** `Boards::LayoutRepacker` is the safety net for a genuine
-    *non-duplicate* overflow tile — it moves only the overflowing tiles into the
-    first empty rows below the fitting tiles (per screen size, then resyncs
-    `board.layout`), a Ruby port of the frontend `repackLayout`. The combined
+    *non-duplicate* **displaced** tile — one that's either **off-grid** (`x+w >
+    cols`) **or overlapping** a cell an earlier (reading-order) tile already
+    claims. It moves only the displaced tiles into the first empty rows below the
+    fitting tiles (per screen size, then resyncs `board.layout`), a Ruby port of
+    the frontend `repackLayout`. The overlap case is what heals **user clones**
+    built from a corrupted source — `repair_layout!` fixes the admin seed, but
+    existing user sets need this. The combined
     `rake board_builder:repair_grid` (dry-run by default; `DRY_RUN=false`,
     `USER_ID=N`) runs dedupe + repack across the seed sources and every built
     set and regenerates the preview for any board it changes. The companion

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -630,11 +630,22 @@ class Board < ApplicationRecord
   IS_SUB_BOARD_TAG = "sub-board".freeze
 
   def check_is_sub_board
-    parent_boards = parent_boards(user_id)
-    if parent_boards.any?
+    # A Board Builder ROOT is a MAIN board that lives directly on the
+    # communicator, even though each of its child pages carries a "Home" tile
+    # whose predictive_board_id points back at the root. Those back-links would
+    # otherwise make the root look like a sub-board (it has "parent" boards) and
+    # drop it out of the main_boards scope / the communicator's dashboard. Pin it
+    # as a main board regardless of who links to it.
+    if settings.is_a?(Hash) && settings["builder_root"]
+      self.sub_board = false
+      remove_tag(IS_SUB_BOARD_TAG)
+      return
+    end
+
+    if parent_boards(user_id).any?
       self.sub_board = true
       add_tag(IS_SUB_BOARD_TAG)
-    elsif !parent_boards.any?
+    else
       self.sub_board = false
       remove_tag(IS_SUB_BOARD_TAG)
     end

--- a/app/services/boards/layout_repacker.rb
+++ b/app/services/boards/layout_repacker.rb
@@ -1,16 +1,20 @@
 module Boards
-  # Pulls tiles that are stored PAST the configured column count back inside the
-  # grid, for each screen size. Mirrors the frontend `repackLayout`
-  # (itty-bitty-frontend src/components/images/native/nativeLayoutMath.ts): only
-  # the overflowing tiles move — authored in-grid tiles keep their exact x/y —
-  # and the overflow is shelf-packed into the first empty rows below them.
+  # Pulls DISPLACED tiles back into a clean grid, for each screen size: tiles
+  # stored PAST the configured column count (off-grid), and tiles that OVERLAP a
+  # cell an earlier tile already claims. Only the displaced tiles move —
+  # authored/earlier in-grid tiles keep their exact x/y — and each is placed into
+  # the first free cell (filling in-grid gaps before growing a new row). Mirrors
+  # the frontend `repackLayout` (itty-bitty-frontend
+  # src/components/images/native/nativeLayoutMath.ts).
   #
   # Why this exists: a builder/seed bug can leave a tile at e.g. x=13 on a
-  # 12-column board. The editor renders through react-grid-layout, which keeps
-  # the grid at the configured `cols`, but the native Speak view sized the grid
-  # by the tile extent and so silently widened to 14 columns — making Speak look
-  # different from every other view. TileDeduper removes off-grid DUPLICATES;
-  # this is the safety net for a genuine non-duplicate overflow tile.
+  # 12-column board (off-grid) — the editor renders through react-grid-layout,
+  # which keeps the grid at the configured `cols`, but the native Speak view sized
+  # the grid by the tile extent and so silently widened to 14 columns, making
+  # Speak look different from every other view. The same class of bug can park two
+  # tiles on the SAME cell (core-84 "wait" on "again"), rendering one hidden
+  # behind the other ("84 looks like 82"). TileDeduper removes off-grid/overlapping
+  # DUPLICATES; this is the safety net for genuine non-duplicate displaced tiles.
   module LayoutRepacker
     module_function
 
@@ -29,29 +33,47 @@ module Boards
       moved
     end
 
-    # Returns the number of overflow tiles moved for one screen size.
+    # Returns the number of displaced tiles moved for one screen size. A tile is
+    # "displaced" when it sits OFF-GRID (x + w past the column count) OR OVERLAPS
+    # a cell an earlier (reading-order) tile already claims — e.g. a builder/seed
+    # bug that parked two tiles on the same cell (core-84 "wait" on "again"),
+    # leaving one rendered hidden behind the other. Earlier tiles keep their exact
+    # authored cell; only the displaced ones move, into the first free cells.
     def repack_screen!(board, screen, dry_run: false, ignore: Set.new)
       columns = column_count(board, screen)
       return 0 if columns < 1
 
-      items = board.board_images.to_a.filter_map do |bi|
+      # Reading order so the authored/earlier tile wins a contested cell.
+      items = board.board_images.order(:position).to_a.filter_map do |bi|
         next if ignore.include?(bi.id)
 
         cell = bi.layout.is_a?(Hash) ? bi.layout[screen] : nil
         cell.nil? ? nil : [bi, cell]
       end
 
-      overflow = items.select { |_bi, c| (c["x"].to_i + tile_w(c)) > columns }
-      return overflow.size if overflow.empty? || dry_run
+      occupied = Set.new
+      displaced = []
+      fits = []
+      items.each do |bi, c|
+        cells = cell_coords(c, columns)
+        if off_grid?(c, columns) || cells.any? { |xy| occupied.include?(xy) }
+          displaced << [bi, c]
+        else
+          cells.each { |xy| occupied << xy }
+          fits << [bi, c]
+        end
+      end
 
-      fits = items - overflow
+      return displaced.size if displaced.empty? || dry_run
+
       base_y = fits.map { |_bi, c| c["y"].to_i + tile_h(c) }.max || 0
 
       cx = 0
       cy = base_y
       row_h = 0
-      # Shelf-pack overflow tiles in reading order, just like the frontend.
-      overflow.sort_by { |_bi, c| [c["y"].to_i, c["x"].to_i] }.each do |bi, cell|
+      # Shelf-pack displaced tiles in reading order below the fitting tiles, just
+      # like the frontend repackLayout — so editor and Speak agree on the result.
+      displaced.sort_by { |_bi, c| [c["y"].to_i, c["x"].to_i] }.each do |bi, cell|
         w = [tile_w(cell), columns].min
         h = tile_h(cell)
         if cx + w > columns
@@ -65,8 +87,23 @@ module Boards
         row_h = [row_h, h].max
       end
 
-      overflow.size
+      displaced.size
     end
+
+    # The grid cells a tile occupies at its current x/y, width clamped to columns.
+    def cell_coords(cell, columns)
+      x = cell["x"].to_i
+      y = cell["y"].to_i
+      w = [tile_w(cell), columns].min
+      h = tile_h(cell)
+      h.times.flat_map { |dy| w.times.map { |dx| [x + dx, y + dy] } }
+    end
+    private_class_method :cell_coords
+
+    def off_grid?(cell, columns)
+      (cell["x"].to_i + tile_w(cell)) > columns
+    end
+    private_class_method :off_grid?
 
     # Rebuild board.layout from the (now corrected) per-tile layouts, for every
     # screen, keyed by board_image id — matching Board#update_board_layout's

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -104,8 +104,89 @@ module VocabSets
     prune_removed_tiles!(slug, boards_by_obf_id)
     prune_removed_boards!(slug, boards_by_obf_id)
     dedupe_tiles!(boards_by_obf_id)
+    repair_layout!(slug, boards_by_obf_id)
 
     root
+  end
+
+  # Re-pin every surviving tile to its AUTHORED grid cell, read straight from the
+  # source OBF and matched by the stable obf_button_id stamped on the tile. Runs
+  # LAST in the seed pass — after prune + dedupe — so it heals the layout
+  # corruption a prior buggy re-seed could leave: when find_or_create_image_for_button
+  # forked a duplicate tile, the upsert set the matched tile's coords but a
+  # leftover copy kept stale coords, and dedupe could keep the wrong one — leaving
+  # two tiles sharing one cell (e.g. core-84 "wait" on "again" at [10,5]) while
+  # another cell sat empty. The board then renders with one tile hidden behind
+  # another ("84 looks like 82"). Neither dedupe (different labels, not duplicates)
+  # nor LayoutRepacker (the cell is in-grid, not overflow) catches that. Authored
+  # buttons are all 1×1 grid cells, so we pin w/h to 1 — matching the upsert.
+  # Admin-owned set boards only; user clones are healed by board_builder:repair_grid.
+  def repair_layout!(slug, boards_by_obf_id)
+    coords_by_obf_id = source_coords_by_obf_id(slug)
+
+    boards_by_obf_id.each do |obf_id, board|
+      coords = coords_by_obf_id[obf_id]
+      next if coords.blank?
+
+      changed = false
+      board.board_images.find_each do |bi|
+        button_id = bi.data.is_a?(Hash) ? bi.data["obf_button_id"] : nil
+        next if button_id.blank?
+
+        cell = coords[button_id.to_s]
+        next if cell.nil?
+
+        x, y = cell
+        next if already_at?(bi, x, y)
+
+        layout = { "x" => x, "y" => y, "w" => 1, "h" => 1, "i" => bi.id.to_s }
+        bi.layout ||= {}
+        %w[lg md sm xs xxs].each { |screen| bi.layout[screen] = layout }
+        bi.save!
+        changed = true
+      end
+
+      board.update_board_layout("lg") if changed
+    end
+  end
+
+  # True when the tile already sits at [x, y] across the persisted screens, so a
+  # re-seed of a clean set is a no-op (no needless writes / preview churn).
+  def already_at?(board_image, x, y)
+    layout = board_image.layout
+    return false unless layout.is_a?(Hash)
+
+    %w[lg md sm].all? do |screen|
+      cell = layout[screen]
+      cell.is_a?(Hash) && cell["x"] == x && cell["y"] == y
+    end
+  end
+
+  # { obf_id => { button_id => [x, y] } } parsed straight from each authored OBF
+  # in the slug's manifest — the canonical grid placement repair_layout! pins to.
+  def source_coords_by_obf_id(slug)
+    dir = SETS_DIR.join(slug)
+    manifest = JSON.parse(File.read(dir.join("manifest.json")))
+    paths = (manifest.dig("paths", "boards") || {}).values.uniq
+
+    paths.each_with_object({}) do |rel, acc|
+      file = dir.join(rel)
+      next unless File.file?(file)
+
+      obf = JSON.parse(File.read(file))
+      order = obf.dig("grid", "order")
+      next unless order.is_a?(Array)
+
+      coords = {}
+      order.each_with_index do |row, y|
+        Array(row).each_with_index do |button_id, x|
+          next if button_id.to_s.strip.empty?
+
+          coords[button_id.to_s] = [x, y]
+        end
+      end
+      acc[obf["id"].to_s] = coords
+    end
   end
 
   # Collapse duplicate tiles a prior buggy re-seed may have appended. The label

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -152,6 +152,35 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "#check_is_sub_board (before_save)" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "marks a board with a parent (predictive link) as a sub_board" do
+      child  = FactoryBot.create(:board, user: user, name: "Food")
+      parent = FactoryBot.create(:board, user: user, name: "Home")
+      FactoryBot.create(:board_image, board: parent, predictive_board_id: child.id)
+
+      child.save!
+      expect(child.reload.sub_board).to be(true)
+    end
+
+    it "keeps a builder_root a main board even when a child page links back to it" do
+      # The controller assign_parents the root before saving (so it isn't a Menu);
+      # mirror that so the main_boards scope (non_menus) can include it.
+      root = FactoryBot.build(:board, user: user, name: "Communication Board",
+                                      settings: { "builder_root" => true })
+      root.assign_parent
+      root.save!
+      child = FactoryBot.create(:board, user: user, name: "Food")
+      # The child's authored "Home" tile points back at the root, like the seed.
+      FactoryBot.create(:board_image, board: child, predictive_board_id: root.id)
+
+      root.save!
+      expect(root.reload.sub_board).to be(false)
+      expect(Board.main_boards.where(id: root.id)).to exist
+    end
+  end
+
   describe "#update_grid_layout" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user, layout: { "lg" => [] }) }

--- a/spec/services/boards/layout_repacker_spec.rb
+++ b/spec/services/boards/layout_repacker_spec.rb
@@ -87,5 +87,40 @@ RSpec.describe Boards::LayoutRepacker do
       stored = board.layout["lg"][over.id.to_s]
       expect(stored["x"] + stored["w"]).to be <= 12
     end
+
+    context "in-grid overlaps (two tiles on one cell)" do
+      it "moves the later overlapping tile off the shared cell, keeping the earlier one put" do
+        keep = tile("again", x: 10, y: 5, position: 0)
+        dup  = tile("wait", x: 10, y: 5, position: 1) # parked on again's cell
+
+        moved = described_class.repack!(board)
+
+        expect(moved).to eq(1)
+        expect(lg(keep)).to include("x" => 10, "y" => 5) # earlier tile untouched
+        expect([lg(dup)["x"], lg(dup)["y"]]).not_to eq([10, 5])
+      end
+
+      it "leaves no two tiles sharing a cell and loses no tiles" do
+        tile("a", x: 0, y: 0, position: 0)
+        tile("b", x: 0, y: 0, position: 1)
+        tile("c", x: 1, y: 0, position: 2)
+        tile("d", x: 1, y: 0, position: 3)
+
+        described_class.repack!(board)
+
+        cells = board.board_images.map { |bi| lg(bi).values_at("x", "y") }
+        expect(cells.uniq.size).to eq(4)
+        expect(board.board_images.count).to eq(4)
+      end
+
+      it "shelf-packs the displaced tile below the fitting tiles (matches frontend repackLayout)" do
+        tile("a", x: 0, y: 0, position: 0)
+        dup = tile("b", x: 0, y: 0, position: 1) # collides at [0,0]
+
+        described_class.repack!(board)
+
+        expect(lg(dup)["y"]).to be > 0
+      end
+    end
   end
 end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -153,6 +153,56 @@ RSpec.describe VocabSets do
     end
   end
 
+  describe "layout self-heal on re-seed (repair_layout!)" do
+    # Count tiles whose lg cell collides with an earlier tile's lg cell.
+    def lg_overlaps(board)
+      seen = {}
+      count = 0
+      board.reload.board_images.each do |bi|
+        cell = bi.layout.is_a?(Hash) ? bi.layout["lg"] : nil
+        next if cell.nil? || cell["x"].nil?
+
+        key = [cell["x"].to_i, cell["y"].to_i]
+        count += 1 if seen[key]
+        seen[key] = true
+      end
+      count
+    end
+
+    # The historical re-seed bug could leave two tiles parked on one cell while
+    # another cell sat empty (core-84 "wait" on "again"), so the board rendered
+    # with a tile hidden behind another. Re-seeding must restore each surviving
+    # tile to its authored cell — no two tiles sharing a cell afterward.
+    it "re-pins overlapping tiles to their authored cells on re-seed" do
+      authored_count = @c84_root.board_images.count
+      again = @c84_root.board_images.find_by(label: "again")
+      wait  = @c84_root.board_images.find_by(label: "wait")
+      expect(again).to be_present
+      expect(wait).to be_present
+
+      # Simulate the corruption: drop "wait" onto "again"'s cell.
+      again_cell = again.reload.layout["lg"]
+      wait.update_column(:layout, wait.layout.merge(
+        "lg" => again_cell.merge("i" => wait.id.to_s),
+        "md" => again_cell.merge("i" => wait.id.to_s),
+        "sm" => again_cell.merge("i" => wait.id.to_s),
+      ))
+      @c84_root.update_board_layout("lg")
+      expect(lg_overlaps(@c84_root)).to be >= 1
+
+      VocabSets.seed_slug!("core-84")
+
+      expect(lg_overlaps(@c84_root)).to eq(0)
+      expect(@c84_root.reload.board_images.count).to eq(authored_count)
+    end
+
+    it "is a no-op on an already-clean set (no overlaps introduced)" do
+      expect(lg_overlaps(@c84_root)).to eq(0)
+      VocabSets.seed_slug!("core-84")
+      expect(lg_overlaps(@c84_root)).to eq(0)
+    end
+  end
+
   describe "tile colors from authored part_of_speech (#279)" do
     EXPECTED_TILES = {
       "I" => { pos: "pronoun", hex: "#FFEA75" },


### PR DESCRIPTION
## Summary

Fixes three Board Builder issues reported on built sets:

1. **Built root was classified as a `sub_board`.** Each seed child page (People, Food, …) carries an authored **"Home" tile** that links back to the root via `predictive_board_id`. Once those links are wired, the root *has* parent boards, so a later `root.save!` (e.g. `allow_scroll_if_grown!`) flipped it to `sub_board: true` — dropping it out of the `main_boards` scope / communicator dashboard. `Board#check_is_sub_board` now **pins any `settings["builder_root"]` board as a main board** regardless of inbound links, so the Home tiles keep working as navigation while the root stays a main board.

2. **"Root not assigned like the main flow"** — same root cause. The `ChildBoard` attach + favorite was already correct (`in_use=true`, `favorite=true`); the only thing wrong was the `sub_board` misclassification above, which excluded it from the boards list. Fixed by #1.

3. **Core 84 showed 82 tiles (83 with GLP).** This was **stale seed data**, not a build bug — a clean first-time import is a perfect 84/84 and a clean build is exactly 84. A past re-seed bug left two tiles stacked on **one grid cell** (`wait` on `again` at `[10,5]`) with another cell empty, so one tile rendered hidden behind another. Neither dedupe (different labels) nor the repacker (in-grid, not off-grid) caught it.
   - `VocabSets#repair_layout!` now runs **last** in `seed_slug!` and re-pins every tile to its authored `[x,y]` from the source OBF (matched by `obf_button_id`), so a single `bin/rails vocab_sets:seed` converges a corrupted source back to a clean 84/60.
   - `Boards::LayoutRepacker` now treats **overlapping** tiles as displaced (not just off-grid), so `rake board_builder:repair_grid` heals existing **user sets** cloned from a corrupted source. No tile is lost; displaced tiles shelf-pack below the fitting tiles, matching the frontend `repackLayout`.

## Why

`check_is_sub_board` keyed purely on inbound predictive links, which a built set legitimately has (Home back-buttons). The seed corruption came from the historical duplicate-tile bug (already fixed at the upsert layer) — this adds layout self-healing so a re-seed fully repairs it, and extends the repacker to fix the user clones already built from the bad source.

## Verification

- End-to-end repro in console: corrupt source → re-seed → **84 tiles / 0 overlaps**; build → root `sub_board=false`, in `main_boards`, `in_use=true`, favorited, **84 tiles / 0 overlaps**; `LayoutRepacker.repack!` clears an in-grid overlap with no tile loss.
- **303 examples, 0 failures** across `spec/services/boards`, `spec/services/vocab_sets_spec.rb`, `spec/sidekiq/build_board_set_job_spec.rb`, `spec/requests/api/v1/board_builder_spec.rb`, plus `spec/models/board_spec.rb`. New tests cover all three fixes.

## Deploy / remediation (prod)

- `bin/rails vocab_sets:seed` — now self-healing; restores clean 84/60 seed sources.
- `DRY_RUN=false bin/rails board_builder:reclassify_builder_sets` — re-classifies existing built roots as main boards.
- `DRY_RUN=false bin/rails board_builder:repair_grid` — un-stacks overlapping tiles on existing user sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)