### PR TITLE
fix(billing): actionable plan-change errors when no payment method on file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — clearer plan-change errors when there's no payment method
+- `POST /api/subscriptions/change_plan` now returns a distinct, actionable
+  **402 `payment_method_required`** (with a message pointing to the billing
+  portal) when a switch fails because the customer has no payment method on
+  file — instead of the generic `400 "Failed to change plan"` that gave the
+  frontend nothing to act on. Card declines still return `402 payment_failed`;
+  other Stripe errors still return the generic 400.
+- `POST /api/subscriptions/preview_plan_change` now returns a
+  `payment_method_required` boolean — true only when the switch bills the
+  customer today (`amount_due > 0`) **and** there's no payment method on file —
+  so the confirm modal can prompt for a card up front instead of letting the
+  user hit a Confirm that can only fail. Credit-only downgrades aren't flagged.
+
 ### Added — boards now lay out well on phones and tablets, not just large screens
 - Medium/small column counts are now **derived proportionally** from a board's
   authored large-screen count (`Boards::ScreenColumns`: md ≈ ⅔ of lg, sm ≈ ⅓ of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -571,6 +571,20 @@ demo/myspeak signups keep using `sign_up`. Key invariants:
   The Stripe portal config must permit subscription updates for the relevant
   products for the flow to render. Frontend CTA wiring is a separate PR
   (itty-bitty-frontend#369 keeps the portal fallback until it lands).
+- **In-app plan switch error contract (`change_plan` / `preview_plan_change`):**
+  the direct in-app switch (`Stripe::Subscription.update`, no portal redirect)
+  maps Stripe failures to actionable codes so the modal can respond, not just
+  show a dead end. `change_plan` returns **402 `payment_failed`** on a
+  `Stripe::CardError` (declined card), **402 `payment_method_required`** on a
+  `Stripe::InvalidRequestError` whose message indicates the customer has **no
+  payment method on file** (detected via `missing_payment_method_error?` — Stripe
+  exposes no stable code, so we match the message), and the generic **400
+  "Failed to change plan"** for any other Stripe error. `preview_plan_change`
+  returns a **`payment_method_required`** boolean — true only when the switch
+  bills today (`upcoming.amount_due > 0`) **and** `customer_has_payment_method?`
+  is false — so the frontend can prompt for a card before the user confirms.
+  Credit-only downgrades (nothing due today) are never flagged. A no-payment-
+  method user is steered to the billing portal (`billing_portal`).
 
 ### `paid_plan?` semantics
 

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -146,6 +146,13 @@ class API::SubscriptionsController < API::ApplicationController
     upcoming = Stripe::Invoice.upcoming(invoice_params)
     new_price = Stripe::Price.retrieve(price_id)
 
+    # Warn up-front when this switch bills the customer today but they have no
+    # payment method on file — so the modal prompts them to the billing portal
+    # before they hit a Confirm that would only fail. Credit-only downgrades
+    # (amount_due <= 0) don't need a card, so they aren't flagged.
+    payment_method_required =
+      upcoming.amount_due.to_i > 0 && !customer_has_payment_method?(customer_id, subscription)
+
     render json: {
       current_plan: current_user.plan_type,
       new_plan: new_price.metadata["plan_type"] || plan_key.sub(/_yearly$/, ""),
@@ -155,6 +162,7 @@ class API::SubscriptionsController < API::ApplicationController
       next_billing_date: Time.at(subscription.current_period_end).iso8601,
       discount: promo.present? ? { code: params[:promo_code].to_s.strip, percent_off: promo.coupon&.percent_off, amount_off: promo.coupon&.amount_off } : nil,
       currency: upcoming.currency,
+      payment_method_required: payment_method_required,
     }, status: :ok
   rescue Stripe::StripeError => e
     Rails.logger.error "preview_plan_change: #{e.class} - #{e.message} (user #{current_user.id})"
@@ -217,6 +225,18 @@ class API::SubscriptionsController < API::ApplicationController
   rescue Stripe::CardError => e
     Rails.logger.error "change_plan card error: #{e.class} - #{e.message} (user #{current_user.id})"
     render json: { error: "payment_failed", message: "Your payment method was declined. Please update it and try again." }, status: :payment_required
+  rescue Stripe::InvalidRequestError => e
+    # An upgrade (or interval switch) that bills immediately fails when the
+    # customer has no payment method on file — a common case for no-card
+    # reverse-trial users. Surface a distinct, actionable code so the frontend
+    # can route them to the billing portal instead of showing a dead-end error.
+    if missing_payment_method_error?(e)
+      Rails.logger.warn "change_plan no payment method: #{e.message} (user #{current_user.id})"
+      render json: { error: "payment_method_required", message: "You don't have a payment method on file. Add one in the billing portal, then try changing your plan again." }, status: :payment_required
+    else
+      Rails.logger.error "change_plan: #{e.class} - #{e.message} (user #{current_user.id})"
+      render json: { error: "Failed to change plan" }, status: :bad_request
+    end
   rescue Stripe::StripeError => e
     Rails.logger.error "change_plan: #{e.class} - #{e.message} (user #{current_user.id})"
     render json: { error: "Failed to change plan" }, status: :bad_request
@@ -301,5 +321,32 @@ class API::SubscriptionsController < API::ApplicationController
     return nil if code.blank?
 
     Stripe::PromotionCode.list(code: code, active: true, limit: 1).data.first
+  end
+
+  # Does the customer have a usable payment method for an immediate charge?
+  # Checks the subscription's own default first, then the customer's default
+  # payment method / legacy default source. On any Stripe error we assume "yes"
+  # so we never block a plan change on an inconclusive lookup — the actual
+  # change attempt surfaces the real error reactively.
+  def customer_has_payment_method?(customer_id, subscription = nil)
+    return true if subscription.respond_to?(:default_payment_method) && subscription.default_payment_method.present?
+
+    customer = Stripe::Customer.retrieve(customer_id)
+    customer.invoice_settings&.default_payment_method.present? || customer.default_source.present?
+  rescue Stripe::StripeError => e
+    Rails.logger.warn "customer_has_payment_method? lookup failed: #{e.message} (user #{current_user.id})"
+    true
+  end
+
+  # A Stripe::InvalidRequestError raised because the customer has no payment
+  # method on file (e.g. updating a no-card subscription to a plan that bills
+  # immediately). Stripe doesn't expose a stable code for this, so match the
+  # message — the only signal it gives.
+  def missing_payment_method_error?(error)
+    message = error.message.to_s.downcase
+    message.include?("no attached payment") ||
+      message.include?("payment source") ||
+      message.include?("default payment method") ||
+      message.include?("no payment method")
   end
 end

--- a/spec/requests/api/subscriptions_change_plan_spec.rb
+++ b/spec/requests/api/subscriptions_change_plan_spec.rb
@@ -229,6 +229,25 @@ RSpec.describe "POST /api/subscriptions/change_plan", type: :request do
     end
   end
 
+  context "when the customer has no payment method" do
+    before do
+      stub_subscription_list([active_sub])
+      allow(Stripe::Subscription).to receive(:update)
+        .and_raise(Stripe::InvalidRequestError.new(
+          "This customer has no attached payment source or default payment method.", nil,
+        ))
+    end
+
+    it "returns 402 with payment_method_required so the frontend can prompt the billing portal" do
+      do_post
+
+      expect(response).to have_http_status(:payment_required)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("payment_method_required")
+      expect(body["message"]).to include("billing portal")
+    end
+  end
+
   context "when Stripe raises a generic error" do
     before do
       stub_subscription_list([active_sub])

--- a/spec/requests/api/subscriptions_preview_plan_change_spec.rb
+++ b/spec/requests/api/subscriptions_preview_plan_change_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     OpenStruct.new(amount_due: 500, currency: "usd")
   end
 
+  let(:customer_with_pm) do
+    OpenStruct.new(invoice_settings: OpenStruct.new(default_payment_method: "pm_123"), default_source: nil)
+  end
+  let(:customer_without_pm) do
+    OpenStruct.new(invoice_settings: OpenStruct.new(default_payment_method: nil), default_source: nil)
+  end
+
   def stub_price_ids
     stub_const(
       "API::Stripe::CheckoutSessionsController::PLAN_PRICE_IDS",
@@ -39,7 +46,12 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
     post "/api/subscriptions/preview_plan_change", params: params, headers: auth_headers(user)
   end
 
-  before { stub_price_ids }
+  before do
+    stub_price_ids
+    # Default: the customer has a payment method on file. The no-payment-method
+    # contexts below override this.
+    allow(Stripe::Customer).to receive(:retrieve).and_return(customer_with_pm)
+  end
 
   context "with a valid plan switch" do
     before do
@@ -60,6 +72,7 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
       expect(body["billing_interval"]).to eq("monthly")
       expect(body["currency"]).to eq("usd")
       expect(body["discount"]).to be_nil
+      expect(body["payment_method_required"]).to eq(false)
     end
 
     it "calls Invoice.upcoming with subscription_details params" do
@@ -192,6 +205,40 @@ RSpec.describe "POST /api/subscriptions/preview_plan_change", type: :request do
       do_post
 
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "customer has no payment method and a charge is due" do
+    before do
+      stub_subscription_list([active_sub])
+      allow(Stripe::Invoice).to receive(:upcoming).and_return(upcoming_invoice)
+      allow(Stripe::Price).to receive(:retrieve).with("price_pro").and_return(new_price)
+      allow(Stripe::Customer).to receive(:retrieve).and_return(customer_without_pm)
+    end
+
+    it "flags payment_method_required" do
+      do_post
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["payment_method_required"]).to eq(true)
+    end
+  end
+
+  context "credit-only downgrade (nothing due today) with no payment method" do
+    let(:no_charge_invoice) { OpenStruct.new(amount_due: 0, currency: "usd") }
+
+    before do
+      stub_subscription_list([active_sub])
+      allow(Stripe::Invoice).to receive(:upcoming).and_return(no_charge_invoice)
+      allow(Stripe::Price).to receive(:retrieve).with("price_pro").and_return(new_price)
+      allow(Stripe::Customer).to receive(:retrieve).and_return(customer_without_pm)
+    end
+
+    it "does not require a payment method (no immediate charge)" do
+      do_post
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["payment_method_required"]).to eq(false)
     end
   end
 


### PR DESCRIPTION
## Summary

When a subscriber tries to change plans but has **no payment method on file** (common for no-card reverse-trial users), `change_plan` failed with a generic `400 "Failed to change plan"` — leaving the frontend nothing to act on and the user staring at "Something went wrong changing your plan."

This makes the backend distinguish that case and hand the frontend something actionable:

- **`change_plan`** now maps a no-payment-method `Stripe::InvalidRequestError` to **`402 payment_method_required`** with a billing-portal message (`missing_payment_method_error?` matches the message — Stripe exposes no stable code). Card declines still return `402 payment_failed`; any other Stripe error still returns the generic `400`.
- **`preview_plan_change`** now returns a **`payment_method_required`** boolean — true only when the switch bills today (`amount_due > 0`) **and** `customer_has_payment_method?` is false — so the confirm modal can prompt for a card up front instead of letting the user hit a Confirm that can only fail. Credit-only downgrades are never flagged.

Companion frontend PR wires the modal to these (prompt + "Add a payment method" → billing portal).

## Test plan

- `bundle exec rspec spec/requests/api/subscriptions_change_plan_spec.rb spec/requests/api/subscriptions_preview_plan_change_spec.rb` → **27 examples, 0 failures**
  - new: no-PM error → `402 payment_method_required`; generic Stripe error still `400`; preview flag true when charge due + no PM, false for credit-only downgrade and when a PM is on file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)