### PR TITLE
fix(child-auth): serialize admin bypass sign-in through api_view

### DIFF
--- a/app/controllers/api/v1/child_auths_controller.rb
+++ b/app/controllers/api/v1/child_auths_controller.rb
@@ -27,7 +27,7 @@ class API::V1::ChildAuthsController < API::ApplicationController
       unless child.can_sign_in?(user_context)
         if user_context&.admin?
           child.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip, sign_in_count: child.sign_in_count + 1)
-          return render json: { token: auth_token, account: child }
+          return render json: { token: auth_token, account: child.api_view(user_context) }
         end
         # Temporarily disable this check
         # return render json: { error: "Account not active. Please upgrade to a pro account to continue.", token: "" }, status: :unauthorized

--- a/spec/requests/api/v1/child_auths_spec.rb
+++ b/spec/requests/api/v1/child_auths_spec.rb
@@ -58,5 +58,26 @@ RSpec.describe "API::V1::ChildAuths", type: :request do
       post login_path, params: { username: "nope", password: "wrong" }
       expect(response).to have_http_status(:unauthorized)
     end
+
+    # Regression: the admin bypass path (reached when can_sign_in? is false but
+    # the owner is an admin — e.g. a passcode-bearing sandbox, whose sandbox
+    # guard short-circuits can_sign_in? before the admin check) must serialize
+    # the communicator through api_view, like every other success path, rather
+    # than dumping the raw ActiveRecord model (wrong shape for the frontend +
+    # leaks internal columns).
+    it "renders the api_view shape (not the raw model) on the admin bypass path" do
+      admin = FactoryBot.create(:admin_user)
+      account = FactoryBot.create(:child_account, user: admin, status: ChildAccount::SANDBOX,
+                                                  passcode: "secret123")
+
+      body = login(account)
+
+      expect(response).to have_http_status(:ok)
+      expect(body["token"]).to be_present
+      # parent_name is an api_view-only key (computed, not a column); updated_at
+      # is a raw column api_view never emits.
+      expect(body["account"]).to include("parent_name")
+      expect(body["account"]).not_to have_key("updated_at")
+    end
   end
 end


### PR DESCRIPTION
## Summary

In `API::V1::ChildAuthsController#create`, the **admin bypass** path rendered the raw ActiveRecord model instead of `api_view`:

```ruby
return render json: { token: auth_token, account: child }      # before
return render json: { token: auth_token, account: child.api_view(user_context) }  # after
```

Every other success path returns `child.api_view`. The raw model has the wrong shape for the frontend (missing computed keys the dashboard expects — `parent_name`, `can_edit_communicator`, `boards`, `most_used_board`, …) and dumps internal columns.

### When the branch is reached

It fires when `can_sign_in?` returns `false` **but** the owner is an admin. The clearest case: a **passcode-bearing sandbox** owned by an admin — `can_sign_in?`'s `return false if sandbox?` guard runs *before* the admin check, so it falls through to the controller's `if user_context&.admin?` bypass. (A fallback-mode account owned by an admin returns `can_sign_in? == true` via the admin short-circuit and never hits this branch.) Edge case, but real — and an admin signing into a communicator for support is exactly when a correct payload matters.

## Test plan

- Added a regression request spec: admin signs into a passcode-bearing sandbox → 200 + token, and `account` is the `api_view` shape (`parent_name` present, raw column `updated_at` absent).
- Verified the new spec **fails** on the pre-fix line and **passes** with the fix.
- `bundle exec rspec spec/requests/api/v1/child_auths_spec.rb` → **5 examples, 0 failures**.

## Notes / out of scope

This came out of a review of the free-user passcode/communicator sign-in flow. A separate, riskier finding — `User#free_trial?` conflating account age with trial status — is filed as #433 rather than changed here (it touches trial UI the frontend consumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)