### PR TITLE
feat(boards): endpoint to remove a board's custom cover

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -4,7 +4,7 @@ class API::BoardsController < API::ApplicationController
   before_action :set_board, only: %i[ associate_image remove_image destroy associate_images print pdf assign_accounts show make_editable ]
   before_action :check_board_view_edit_permissions, only: %i[update destroy]
   before_action :check_board_create_permissions, only: %i[ create clone create_from_template import_obf ]
-  before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
+  before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image remove_preset_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
 
   def index
     limit_param = params[:limit].presence&.to_i
@@ -584,6 +584,14 @@ class API::BoardsController < API::ApplicationController
     file_extension = board_params[:preset_display_image]
     file_extension = file_extension.content_type.split("/").last if file_extension
     attach_image_to_board(image_data, file_extension)
+    render json: @board.api_view_with_images(current_user)
+  end
+
+  # Drop a user-uploaded custom cover so the board's cover falls back to the
+  # auto preview snapshot (or nothing). Mirror image of update_preset_display_image.
+  def remove_preset_display_image
+    set_board
+    @board.remove_preset_display_image!
     render json: @board.api_view_with_images(current_user)
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1644,6 +1644,18 @@ class Board < ApplicationRecord
     save
   end
 
+  # Reverse of attaching a custom cover (BoardsController#update_preset_display_image):
+  # purge the uploaded image, drop its legacy settings copy, and clear the
+  # denormalized `display_image_url` column so #display_image_url falls back to
+  # the live preview snapshot (or nil) instead of the now-removed cover URL.
+  def remove_preset_display_image!
+    preset_display_image.purge if preset_display_image.attached?
+    # Reassign (rather than mutate in place) so AR reliably tracks the change.
+    self.settings = (settings || {}).except("preset_display_image_url")
+    self.display_image_url = nil
+    save!
+  end
+
   def is_frozen?
     return false unless settings
     settings["freeze_board"] == true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,7 @@ Rails.application.routes.draw do
         get "get_description"
         get "download_obf"
         put "update_preset_display_image"
+        delete "remove_preset_display_image"
         put "recategorize_images"
         put "update_to_default_docs"
         put "set_colors"

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -549,6 +549,58 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "#remove_preset_display_image!" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+
+    def attach_preview(bytes = "png-bytes")
+      board.preview_image.attach(
+        io: StringIO.new(bytes),
+        filename: "preview.png",
+        content_type: "image/png",
+      )
+    end
+
+    def attach_cover
+      board.preset_display_image.attach(
+        io: StringIO.new("cover-bytes"),
+        filename: "preset_display_image.png",
+        content_type: "image/png",
+      )
+      board.update_preset_display_image_url(board.display_preset_image_url)
+      board.update_column(:display_image_url, board.display_preset_image_url)
+    end
+
+    it "purges the cover and clears its denormalized copies" do
+      attach_cover
+      expect(board.preset_display_image).to be_attached
+
+      board.remove_preset_display_image!
+
+      expect(board.reload.preset_display_image).not_to be_attached
+      expect(board.settings["preset_display_image_url"]).to be_nil
+      expect(board.read_attribute(:display_image_url)).to be_nil
+    end
+
+    it "falls back to the live preview after the custom cover is removed" do
+      attach_preview
+      attach_cover
+      # Custom cover wins while attached.
+      expect(board.display_image_url).to eq(board.display_preset_image_url)
+
+      board.remove_preset_display_image!
+
+      freeze_time do
+        expect(board.display_image_url).to eq(board.preview_image_url)
+      end
+    end
+
+    it "is a no-op-safe when no cover is attached" do
+      expect { board.remove_preset_display_image! }.not_to raise_error
+      expect(board.reload.preset_display_image).not_to be_attached
+    end
+  end
+
   describe "#preset_display_image_url" do
     let(:user) { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user) }

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -765,4 +765,43 @@ RSpec.describe "API::Boards", type: :request do
       expect(response).to have_http_status(:unprocessable_content)
     end
   end
+
+  describe "DELETE /api/boards/:id/remove_preset_display_image" do
+    let!(:cover_board) { create(:board, user: user, name: "Has Cover") }
+
+    before do
+      cover_board.preset_display_image.attach(
+        io: StringIO.new("cover-bytes"),
+        filename: "preset_display_image.png",
+        content_type: "image/png",
+      )
+      cover_board.update_preset_display_image_url(cover_board.display_preset_image_url)
+      cover_board.update_column(:display_image_url, cover_board.display_preset_image_url)
+    end
+
+    it "removes the custom cover and returns the updated board" do
+      delete "/api/boards/#{cover_board.id}/remove_preset_display_image",
+             headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(cover_board.reload.preset_display_image).not_to be_attached
+      expect(cover_board.settings["preset_display_image_url"]).to be_nil
+
+      body = JSON.parse(response.body)
+      expect(body["settings"]["preset_display_image_url"]).to be_nil
+    end
+
+    it "401s for an unauthenticated request" do
+      delete "/api/boards/#{cover_board.id}/remove_preset_display_image"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "does not let a non-owner remove another user's cover" do
+      delete "/api/boards/#{cover_board.id}/remove_preset_display_image",
+             headers: auth_headers(other_user)
+
+      expect(response).not_to have_http_status(:ok)
+      expect(cover_board.reload.preset_display_image).to be_attached
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backend follow-up to the board cover UX work in [itty-bitty-frontend#478](https://github.com/brittanyjohns/itty-bitty-frontend/pull/478). That PR reframed the board's "cover" (custom upload wins → else auto preview snapshot → else seed) but flagged a gap: **once a user uploads a custom cover there's no way to remove it** — `preset_display_image` always wins, so there's no path back to the auto snapshot.

This adds the missing endpoint.

### Changes
- **`DELETE /api/boards/:id/remove_preset_display_image`** — mirror image of `update_preset_display_image`, gated by the same `check_board_editable!` guard (owner/editor only). Returns the updated `api_view_with_images`.
- **`Board#remove_preset_display_image!`** — purges the `preset_display_image` attachment, drops the legacy `settings["preset_display_image_url"]` copy, and clears the denormalized `display_image_url` column so `#display_image_url` resolves back to the live preview snapshot (or nil if none).

### Why clear the column too
The upload path (`attach_image_to_board`) writes the preset URL into the `display_image_url` column. If we only purged the attachment, the resolver's last-resort branch would return that now-dead preset URL. Clearing it lets the preview snapshot take over cleanly.

## Test plan
Added specs (model + request):
- `Board#remove_preset_display_image!`: purges + clears both denormalized copies; falls back to the live preview after removal; no-op-safe when nothing is attached.
- `DELETE …/remove_preset_display_image`: success returns updated board with `preset_display_image_url` nil; 401 unauthenticated; non-owner blocked (cover stays attached).

⚠️ **Specs not run in-sandbox:** this fresh worktree off `origin/main` lacks the gitignored `config/master.key`, and the sandbox blocks reading it, so Rails can't boot here. Ruby syntax-checked all changed files (`ruby -c` → OK). Please run locally before merge:

```bash
bundle exec rspec spec/models/board_spec.rb -e "remove_preset_display_image" \
  spec/requests/api/boards_spec.rb -e "remove_preset_display_image"
```

## Follow-up (frontend)
The matching **"Remove custom cover"** button in the Board cover field isn't wired yet — it should land after this endpoint deploys (calling it before then would 404). Happy to add it to #478 or as a small separate PR once this is merged/deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)