### PR TITLE
fix(boards): let a deliberate "Use as thumbnail" pick outrank the auto preview

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -441,6 +441,14 @@ class API::BoardsController < API::ApplicationController
       new_board_settings = @board.settings.merge(settings)
       @board.settings = new_board_settings
 
+      # A deliberate tile pick ("Use as thumbnail") sets
+      # `display_image_is_custom` alongside the chosen `display_image_url`. It's
+      # mutually exclusive with "display follows preview": force the latter off
+      # so the column isn't nilled below and the pick can win in the getter.
+      if @board.display_image_is_custom?
+        @board.settings["display_follows_preview"] = false
+      end
+
       # When the user opts into "display follows preview" we nil out the
       # denormalized column so the override getter resolves to the live
       # preview URL. Any incoming `display_image_url` param is ignored in

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -241,17 +241,32 @@ class Board < ApplicationRecord
     ActiveModel::Type::Boolean.new.cast(settings["display_follows_preview"]) == true
   end
 
+  # When `settings["display_image_is_custom"]` is true the user has deliberately
+  # picked a specific tile's picture as the board thumbnail (the "Use as
+  # thumbnail" action, which writes the URL into the `display_image_url` column).
+  # That choice should outrank the auto preview, mirroring how an uploaded cover
+  # does — see the precedence note on #display_image_url.
+  def display_image_is_custom?
+    return false unless settings.is_a?(Hash)
+    ActiveModel::Type::Boolean.new.cast(settings["display_image_is_custom"]) == true
+  end
+
   # Override the AR-generated getter so reads (including serializers, grid
   # thumbnails) resolve the right image with this precedence:
   #
   #   1. An explicit custom cover the user uploaded (the `preset_display_image`
   #      attachment, set via API::BoardsController#update_preset_display_image)
   #      always wins — it's a deliberate choice, not an auto snapshot.
-  #   2. Otherwise the live, deterministically-keyed auto preview wins, so the
+  #   2. A deliberate tile pick (`display_image_is_custom` + the
+  #      `display_image_url` column) — the "Use as thumbnail" action. Also a
+  #      deliberate choice, so it outranks the auto preview; without this the
+  #      live preview (#3) silently swallows the user's pick on any board that
+  #      already has a generated preview.
+  #   3. Otherwise the live, deterministically-keyed auto preview wins, so the
   #      thumbnail tracks the board's *current* contents. The URL is stable
   #      (board_previews/<id>/preview.png) and self-cache-busts on regeneration
   #      via `?v=<blob.created_at>`, so an edited board never shows stale art.
-  #   3. The denormalized `display_image_url` column is only a seed thumbnail
+  #   4. The denormalized `display_image_url` column is only a seed thumbnail
   #      (e.g. the originating tile's image) used before the first preview
   #      exists; it's the last resort.
   #
@@ -259,6 +274,9 @@ class Board < ApplicationRecord
   def display_image_url
     if preset_display_image.attached? && (custom_cover = display_preset_image_url).present?
       return custom_cover
+    end
+    if display_image_is_custom? && (custom_pick = read_attribute(:display_image_url)).present?
+      return custom_pick
     end
     if preview_image.attached? && (live_preview = preview_image_url).present?
       return live_preview

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -547,6 +547,37 @@ RSpec.describe Board, type: :model do
         expect(board.display_image_url).not_to eq(board.preview_image_url)
       end
     end
+
+    context "with a deliberate tile pick (display_image_is_custom)" do
+      before do
+        attach_preview
+        board.update_column(:display_image_url, "https://example.com/picked-tile.png")
+        board.update!(settings: board.settings.merge("display_image_is_custom" => true))
+      end
+
+      it "the picked column value wins over the auto preview" do
+        freeze_time do
+          expect(board.display_image_url).to eq("https://example.com/picked-tile.png")
+          expect(board.display_image_url).not_to eq(board.preview_image_url)
+        end
+      end
+
+      it "an uploaded custom cover still outranks the tile pick" do
+        board.preset_display_image.attach(
+          io: StringIO.new("cover-bytes"),
+          filename: "preset_display_image.png",
+          content_type: "image/png",
+        )
+        expect(board.display_image_url).to eq(board.display_preset_image_url)
+      end
+
+      it "falls back to the preview when the flag is set but the column is blank" do
+        board.update_column(:display_image_url, nil)
+        freeze_time do
+          expect(board.display_image_url).to eq(board.preview_image_url)
+        end
+      end
+    end
   end
 
   describe "#preset_display_image_url" do

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -372,6 +372,46 @@ RSpec.describe "API::Boards", type: :request do
         expect(board.reload.read_attribute(:display_image_url))
           .to eq("https://example.com/user-cover.png")
       end
+
+      it "persists a deliberate tile pick (display_image_is_custom) and resolves to it" do
+        patch "/api/boards/#{board.id}",
+              params: {
+                board: {
+                  display_image_url: "https://example.com/picked-tile.png",
+                  settings: { display_image_is_custom: true },
+                },
+              },
+              headers: auth_headers(user),
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        board.reload
+        expect(board.read_attribute(:display_image_url))
+          .to eq("https://example.com/picked-tile.png")
+        expect(board.settings["display_image_is_custom"]).to be true
+        expect(JSON.parse(response.body)["display_image_url"])
+          .to eq("https://example.com/picked-tile.png")
+      end
+
+      it "forces display_follows_preview off when a tile is picked, so the pick isn't nilled" do
+        board.update!(settings: board.settings.merge("display_follows_preview" => true))
+
+        patch "/api/boards/#{board.id}",
+              params: {
+                board: {
+                  display_image_url: "https://example.com/picked-tile.png",
+                  settings: { display_image_is_custom: true },
+                },
+              },
+              headers: auth_headers(user),
+              as: :json
+
+        expect(response).to have_http_status(:ok)
+        board.reload
+        expect(board.settings["display_follows_preview"]).to be false
+        expect(board.read_attribute(:display_image_url))
+          .to eq("https://example.com/picked-tile.png")
+      end
     end
 
     # Manually adding words must let the user put a word that's already on the


### PR DESCRIPTION
## Summary

The board header thumbnail (and grid thumbnails) inconsistently failed to update when a user clicked **"Use as board thumbnail"** in a board-image modal. It worked on some boards and silently no-op'd on others.

**Root cause:** the "Use as thumbnail" action writes the picked tile's URL into the `display_image_url` **column**, but the column is precedence **#3** in the `Board#display_image_url` getter — below the auto-generated **live preview (#2)**:

```
1. uploaded custom cover (preset_display_image)   ← wins
2. live auto preview                              ← swallows the pick
3. display_image_url column                       ← what the button writes
```

Any board whose layout has ever been edited has a `preview_image` attached (`save_layout!` enqueues `GenerateBoardPreviewJob`), so the getter returned the preview and ignored the picked tile. The save succeeded and the toast said "updated," but the header thumbnail never changed. Un-edited boards (no preview yet) showed the pick — hence the inconsistency.

## Fix

A deliberate tile pick should outrank the auto preview, the same way an uploaded cover already does. Add a new precedence tier gated on a `settings["display_image_is_custom"]` flag:

```
1. uploaded custom cover
2. deliberate tile pick  (display_image_is_custom + column)   ← NEW
3. live auto preview
4. display_image_url column (seed fallback)
```

- **`Board#display_image_is_custom?`** — boolean helper, mirrors `display_follows_preview?`.
- **`Board#display_image_url` getter** — returns the column over the live preview when the flag is set and the column is present.
- **`BoardsController#update`** — when the pick flag is present, forces `display_follows_preview` off (mutually exclusive) so the column isn't nilled and the pick survives.

Boards **without** the flag are completely unaffected — the live preview still wins — so existing behavior is unchanged. The frontend companion (sends the flag from `handleSetDisplayImage`) ships in a separate `itty-bitty-frontend` PR.

## Test plan

`bundle exec rspec spec/models/board_spec.rb -e "display_image_url precedence" spec/requests/api/boards_spec.rb -e "PATCH /api/boards/:id"` → **21 examples, 0 failures.**

- Model: pick beats the auto preview; an uploaded cover still beats the pick; flag-set-but-blank-column falls back to the preview.
- Request: the pick flag persists and the api_view resolves to the picked URL; `display_follows_preview` is forced off so the pick isn't nilled.

## Reviewer note — coordinate with #435

[#435](https://github.com/brittanyjohns/itty_bitty_boards/pull/435) (remove custom cover) is complementary, not conflicting — different regions of `board.rb` / `boards_controller.rb`. Its `remove_preset_display_image!` already nils the `display_image_url` column; once both land it should **also** clear `settings["display_image_is_custom"]` so a "reset to auto preview" leaves no dangling flag. Happy to fold that one-liner in here if #435 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)