### PR TITLE
fix(jobs): no-op UpdateUserBoardsJob when a board was deleted before run

### DIFF
--- a/app/sidekiq/update_user_boards_job.rb
+++ b/app/sidekiq/update_user_boards_job.rb
@@ -3,8 +3,12 @@ class UpdateUserBoardsJob
   sidekiq_options queue: :critical, retry: 2
 
   def perform(cloned_board_id, source_board_id)
-    cloned_board = Board.find(cloned_board_id)
-    source_board = Board.find(source_board_id)
+    # Best-effort post-clone fixup. Either board can be deleted between
+    # enqueue and run (e.g. the user discards a just-cloned board), so a
+    # missing record is a no-op, not a failure worth retrying/alerting on.
+    cloned_board = Board.find_by(id: cloned_board_id)
+    source_board = Board.find_by(id: source_board_id)
+    return unless cloned_board && source_board
 
     cloned_board.update_user_boards_after_cloning(source_board, cloned_board.user_id)
   end

--- a/spec/sidekiq/update_user_boards_job_spec.rb
+++ b/spec/sidekiq/update_user_boards_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe UpdateUserBoardsJob, type: :job do
+  describe "#perform" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:cloned_board) { FactoryBot.create(:board, user: user) }
+    let(:source_board) { FactoryBot.create(:board, user: user) }
+
+    it "repoints the user's board images at the cloned board" do
+      expect(Board).to receive(:find_by).with(id: cloned_board.id).and_return(cloned_board)
+      expect(Board).to receive(:find_by).with(id: source_board.id).and_return(source_board)
+      expect(cloned_board).to receive(:update_user_boards_after_cloning).with(source_board, cloned_board.user_id)
+
+      described_class.new.perform(cloned_board.id, source_board.id)
+    end
+
+    it "no-ops when the cloned board was deleted between enqueue and run" do
+      expect {
+        described_class.new.perform(-1, source_board.id)
+      }.not_to raise_error
+    end
+
+    it "no-ops when the source board was deleted between enqueue and run" do
+      expect {
+        described_class.new.perform(cloned_board.id, -1)
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What & why

Production alert: `UpdateUserBoardsJob#perform` raised `ActiveRecord::RecordNotFound` (`Couldn't find Board with 'id'=5419`).

This is an enqueue-vs-run race. After a board clone, `board.rb:1135` fires `UpdateUserBoardsJob.perform_async(cloned_board.id, source.id)` to repoint `predictive_board_id` pointers at the new clone. If the cloned (or source) board is deleted before the Sidekiq worker runs — e.g. a user discards a just-cloned board, or an aborted build tears it down — the hard `Board.find` raises, retries twice (`retry: 2`), then surfaces as an alert.

The job is a **best-effort post-clone fixup**: if the board no longer exists, there's nothing to repoint. It should no-op, not fail.

## Change

- Swap both `Board.find` calls for `Board.find_by(id:)` and return early when either board is missing. Mirrors the defensive `Board.find_by(id:)` already used a few lines away in `clone_and_update_predictive_board` (`board.rb:1145`).

## Tests

Added `spec/sidekiq/update_user_boards_job_spec.rb`: happy path + both race cases (cloned board missing, source board missing).

```
3 examples, 0 failures
```