### PR TITLE
feat(communicator): owner picks which communicators stay signable on downgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — owner picks which communicators stay signable on downgrade (#439)
+- When a user is over their plan's communicator slot limit after a downgrade,
+  the over-limit accounts enter fallback mode (private sign-in paused; public
+  MySpeak page + boards stay open). Previously the system auto-kept whichever
+  communicators signed in most recently. Now the **owner chooses** which ones
+  stay full, mirroring the board "make this one editable" pick.
+- New `POST /api/child_accounts/keep_signable` `{ communicator_ids: [...] }`
+  persists the owner's pick (owner-owned ids only, capped at the slot limit) and
+  re-reconciles immediately; the chosen ids keep private sign-in, the rest fall
+  back. `User#reconcile_communicator_fallback!` now orders **owner-pinned first,
+  then most-recently-active**. `communicator_slot_limit` and
+  `kept_communicator_ids` are exposed on the user `api_view` for the picker UI.
+  No access or boards are ever removed — only which accounts can sign in
+  privately changes.
+
 ### Added — free board PDF downloads for anonymous visitors (lead capture)
 - `GET /api/free_download_boards` (public, no auth) lists the curated public
   board gallery (`Board.public_boards` — admin-owned, predefined + published)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -746,11 +746,23 @@ nonspeaking child is never stranded mid-use.
   Free signup (capped at 1) is never flagged — fallback is *only ever a
   consequence of downgrade*. Use `enter_fallback!` / `exit_fallback!`.
 - **One reconciler, both directions.** `User#reconcile_communicator_fallback!`
-  orders slotted (loaner+active) communicators **most-recently-active first**
-  (`last_sign_in_at` desc, nulls last), keeps the top `slot_limit` signable,
-  and flags the overflow. A downgrade flags the overflow; a re-upgrade restores
-  them as slots free up (no manual re-claim); any still over the new limit stay
-  in fallback. Idempotent; admins are never limited.
+  orders slotted (loaner+active) communicators **owner-pinned first, then
+  most-recently-active** (`last_sign_in_at` desc, nulls last), keeps the top
+  `slot_limit` signable, and flags the overflow. A downgrade flags the overflow;
+  a re-upgrade restores them as slots free up (no manual re-claim); any still
+  over the new limit stay in fallback. Idempotent; admins are never limited.
+- **Owner picks which stay signable (#439).** The mirror of the board
+  `make_editable` pick. `User#kept_communicator_ids` (stored on
+  `settings["kept_communicator_ids"]`) is the owner's explicit "keep these
+  signable" set; reconcile moves those to the front (in the order chosen) before
+  the recency rule, so the owner — not just last-sign-in — decides which N stay
+  full when over the limit. Empty ⇒ recency only (unchanged behavior).
+  `User#set_kept_communicator_ids!(ids)` persists the set (owner-owned ids only,
+  capped at `slot_limit`) and re-runs reconcile immediately. Endpoint:
+  **`POST /api/child_accounts/keep_signable`** `{ communicator_ids: [...] }` →
+  `{ kept_communicator_ids, communicator_slot_limit, communicators: [...] }`.
+  `communicator_slot_limit` + `kept_communicator_ids` are also on the user
+  `api_view` so the over-limit picker can pre-check the right toggles.
 - **Trigger:** `after_save :reconcile_communicator_fallback!, if:
   :saved_change_to_plan_type?` on `User`. Every plan transition (Stripe
   cancel/pause via `apply_free_plan`, `DowngradeSoftTrialJob`, and upgrades via

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -19,6 +19,23 @@ class API::ChildAccountsController < API::ApplicationController
     render json: @child_accounts.map(&:index_api_view)
   end
 
+  # POST /child_accounts/keep_signable
+  #
+  # Owner picks which communicators stay signable when over the plan's slot
+  # limit (issue #439) — the mirror of the board "make_editable" pick. The
+  # chosen ids keep private sign-in; the rest enter fallback mode (public
+  # MySpeak page stays open and read-only). Owner-scoped: ids the caller
+  # doesn't own are ignored, and the set is capped at the plan slot limit.
+  def keep_signable
+    kept = current_user.set_kept_communicator_ids!(params[:communicator_ids])
+    accounts = current_user.slotted_communicator_accounts.order(name: :asc)
+    render json: {
+      kept_communicator_ids: kept,
+      communicator_slot_limit: Permissions::CommunicatorLimits.slot_limit_for(current_user.settings || {}),
+      communicators: accounts.map(&:index_api_view),
+    }
+  end
+
   # GET /child_accounts/1
   # GET /child_accounts/1.json
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1460,6 +1460,18 @@ class User < ApplicationRecord
                  .order(Arel.sql("last_sign_in_at DESC NULLS LAST, updated_at DESC, id DESC"))
                  .to_a
 
+    # Owner-chosen priority (issue #439): communicators the owner explicitly
+    # pinned to keep signable move to the front, in the order they picked them;
+    # everything unpinned keeps the most-recently-active ordering. So which
+    # communicators stay full vs. fall back is the owner's call, not just
+    # whichever signed in last. No pick ⇒ the historical recency rule.
+    kept = kept_communicator_ids
+    unless kept.empty?
+      pinned, rest = accounts.partition { |account| kept.include?(account.id) }
+      pinned.sort_by! { |account| kept.index(account.id) }
+      accounts = pinned + rest
+    end
+
     accounts.each_with_index do |account, index|
       keep = limit.nil? || index < limit
       if keep
@@ -1468,6 +1480,32 @@ class User < ApplicationRecord
         account.enter_fallback! unless account.fallback_mode?
       end
     end
+  end
+
+  # The communicators the owner has explicitly pinned to keep signable when over
+  # the slot limit (issue #439). Stored on settings as an array of ids; read back
+  # sanitized to integers. Empty ⇒ no explicit pick, so reconcile falls back to
+  # the most-recently-active rule.
+  KEPT_COMMUNICATOR_IDS_KEY = "kept_communicator_ids".freeze
+
+  def kept_communicator_ids
+    Array(settings && settings[KEPT_COMMUNICATOR_IDS_KEY]).map(&:to_i)
+  end
+
+  # Persist the owner's pinned set and re-run reconcile so the choice takes
+  # effect immediately. Only ids the user actually owns as slotted (loaner/active)
+  # communicators are honored; the set is capped at the current slot limit (extra
+  # pins are dropped, keeping the order the owner sent). Returns the stored ids.
+  def set_kept_communicator_ids!(ids)
+    owned = slotted_communicator_accounts.pluck(:id)
+    requested = Array(ids).map(&:to_i).uniq.select { |id| owned.include?(id) }
+    limit = Permissions::CommunicatorLimits.slot_limit_for(settings || {})
+    requested = requested.first(limit) if limit
+    self.settings ||= {}
+    self.settings[KEPT_COMMUNICATOR_IDS_KEY] = requested
+    save!
+    reconcile_communicator_fallback!
+    requested
   end
 
   # Promote sandbox communicators to full (active) accounts up to the number of
@@ -1656,6 +1694,11 @@ class User < ApplicationRecord
       comm_account_limit: paid_comm_limit_total,
       paid_communicator_count: paid_comm_count,
       paid_comm_account_limit_reached: paid_comm_account_limit_reached,
+
+      # Owner's pinned "keep signable" set + the plan slot limit, so the
+      # over-limit picker (issue #439) can pre-check the right toggles.
+      communicator_slot_limit: Permissions::CommunicatorLimits.slot_limit_for(settings || {}),
+      kept_communicator_ids: kept_communicator_ids,
 
       # Communicators (DEMO)
       demo_comm_account_limit: demo_limit,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,11 @@ Rails.application.routes.draw do
     end
 
     resources :child_accounts do
+      collection do
+        # #439: owner picks which communicators stay signable when over the
+        # plan's slot limit (the rest fall back to the public MySpeak page).
+        post "keep_signable"
+      end
       member do
         post "assign_boards"
         post "send_setup_email"

--- a/spec/models/communicator_fallback_spec.rb
+++ b/spec/models/communicator_fallback_spec.rb
@@ -110,6 +110,64 @@ RSpec.describe "Communicator fallback mode (#255)", type: :model do
     end
   end
 
+  describe "owner-chosen keep set (#439)" do
+    it "keeps the owner's pinned communicator signable over a more-recently-active one" do
+      owner, (a0, a1, a2) = pro_owner_with_active(3)
+      owner.update!(plan_type: "basic") # limit 2: default keeps a0, a1; a2 falls back
+      expect(a2.reload.fallback_mode?).to be(true)
+
+      # Owner overrides: keep a2 (and a0). a1 now falls back instead.
+      owner.set_kept_communicator_ids!([a2.id, a0.id])
+
+      expect(a2.reload.fallback_mode?).to be(false)
+      expect(a0.reload.fallback_mode?).to be(false)
+      expect(a1.reload.fallback_mode?).to be(true)
+    end
+
+    it "caps the pinned set at the plan slot limit, keeping the order sent" do
+      owner, (a0, a1, a2) = pro_owner_with_active(3)
+      owner.update!(plan_type: "basic") # limit 2
+
+      kept = owner.set_kept_communicator_ids!([a2.id, a1.id, a0.id])
+
+      expect(kept).to eq([a2.id, a1.id])      # third pick dropped (over limit)
+      expect(a0.reload.fallback_mode?).to be(true)
+    end
+
+    it "ignores ids the caller does not own" do
+      owner, (a0, _a1, _a2) = pro_owner_with_active(3)
+      owner.update!(plan_type: "basic")
+      stranger = FactoryBot.create(:child_account, status: ChildAccount::ACTIVE)
+
+      kept = owner.set_kept_communicator_ids!([a0.id, stranger.id])
+
+      expect(kept).to eq([a0.id])
+    end
+
+    it "reverts to the most-recently-active rule when the pick is cleared" do
+      owner, (a0, a1, a2) = pro_owner_with_active(3)
+      owner.update!(plan_type: "basic")
+      owner.set_kept_communicator_ids!([a2.id])   # pin the least-recent
+      expect(a2.reload.fallback_mode?).to be(false)
+
+      owner.set_kept_communicator_ids!([])         # clear the pick
+
+      expect(a0.reload.fallback_mode?).to be(false) # recency again
+      expect(a1.reload.fallback_mode?).to be(false)
+      expect(a2.reload.fallback_mode?).to be(true)
+    end
+
+    it "surfaces the slot limit and kept ids on the user api_view" do
+      owner, (a0, _a1, _a2) = pro_owner_with_active(3)
+      owner.update!(plan_type: "basic")
+      owner.set_kept_communicator_ids!([a0.id])
+
+      view = owner.api_view
+      expect(view[:communicator_slot_limit]).to eq(2)
+      expect(view[:kept_communicator_ids]).to eq([a0.id])
+    end
+  end
+
   describe "new Free signup" do
     it "is capped at 1 communicator and is never flagged into fallback" do
       free_user = FactoryBot.create(:free_user)

--- a/spec/requests/api/child_accounts_keep_signable_spec.rb
+++ b/spec/requests/api/child_accounts_keep_signable_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Issue #439 — owner picks which communicators stay signable when over the
+# plan's slot limit (the mirror of the board "make_editable" pick). The chosen
+# ids keep private sign-in; the rest enter fallback mode (public MySpeak page
+# stays open). Endpoint: POST /api/child_accounts/keep_signable.
+RSpec.describe "API::ChildAccounts keep_signable (#439)", type: :request do
+  let(:owner) { create(:user, plan_type: "pro") }
+
+  # Three active communicators, most-recently-active first (a0, a1, a2).
+  let!(:accounts) do
+    Array.new(3) do |i|
+      acct = create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE,
+                                    username: "comm_#{owner.id}_#{i}", passcode: "pass#{i}0")
+      acct.update_column(:last_sign_in_at, (i + 1).hours.ago)
+      acct
+    end
+  end
+
+  before { owner.update!(plan_type: "basic") } # Basic slot limit = 2
+
+  it "pins the owner's chosen communicators and falls back the rest" do
+    a0, a1, a2 = accounts
+
+    post "/api/child_accounts/keep_signable",
+      params: { communicator_ids: [a2.id, a0.id] },
+      headers: auth_headers(owner)
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["kept_communicator_ids"]).to eq([a2.id, a0.id])
+    expect(body["communicator_slot_limit"]).to eq(2)
+
+    expect(a2.reload.fallback_mode?).to be(false)
+    expect(a0.reload.fallback_mode?).to be(false)
+    expect(a1.reload.fallback_mode?).to be(true)
+  end
+
+  it "ignores communicators owned by someone else" do
+    a0 = accounts.first
+    stranger = create(:child_account, status: ChildAccount::ACTIVE)
+
+    post "/api/child_accounts/keep_signable",
+      params: { communicator_ids: [a0.id, stranger.id] },
+      headers: auth_headers(owner)
+
+    expect(JSON.parse(response.body)["kept_communicator_ids"]).to eq([a0.id])
+  end
+
+  it "requires authentication" do
+    post "/api/child_accounts/keep_signable", params: { communicator_ids: [] }
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the "owner controls the downgrade" work (companion frontend PR adds the picker UI).

When a user is over their plan's communicator slot limit after a downgrade, the over-limit accounts enter **fallback mode** — private passcode sign-in is paused, but the communicator, its boards, and the public MySpeak page are all retained and stay open (read-only). Nothing is deleted; only private sign-in is gated. This mirrors the board read-only rule.

**The problem:** the system auto-kept whichever communicators signed in *most recently* and paused the rest — the owner had no say in which ones stayed full. After a Pro→Basic downgrade (Basic = 2 slots), a user with 3+ communicators could find the "wrong" one paused.

**This PR** lets the owner choose. Reconcile now orders **owner-pinned first, then most-recently-active**, so the owner — not last-sign-in — decides which N stay signable.

### Changes
- `User#kept_communicator_ids` — owner's explicit keep set, stored on `settings["kept_communicator_ids"]`. Empty ⇒ recency rule (unchanged behavior).
- `User#set_kept_communicator_ids!(ids)` — persists the pick (owner-owned slotted ids only, capped at `slot_limit`) and re-runs reconcile immediately.
- `User#reconcile_communicator_fallback!` — pinned-first ordering.
- `POST /api/child_accounts/keep_signable` `{ communicator_ids: [...] }` → `{ kept_communicator_ids, communicator_slot_limit, communicators: [...] }`. Owner-scoped; foreign ids ignored.
- `communicator_slot_limit` + `kept_communicator_ids` on the user `api_view` so the picker can pre-check the right toggles.
- Updated the CLAUDE.md "Communicator sign-in on downgrade" section + CHANGELOG.

### Not in this PR
- The picker UI (banner on the communicators list) ships in the companion `itty-bitty-frontend` PR, which consumes `keep_signable` + the new api_view fields.

## Test plan
- `bundle exec rspec spec/models/communicator_fallback_spec.rb spec/requests/api/child_accounts_keep_signable_spec.rb` → **21 examples, 0 failures**.
- New coverage: owner pin overrides recency, pick capped at slot limit (order preserved), foreign ids ignored, clearing the pick reverts to recency, api_view exposes slot limit + kept ids, endpoint owner-scoping + auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)