### PR TITLE
refactor(boards): one display_image_source switch for board covers

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -4,7 +4,7 @@ class API::BoardsController < API::ApplicationController
   before_action :set_board, only: %i[ associate_image remove_image destroy associate_images print pdf assign_accounts show make_editable ]
   before_action :check_board_view_edit_permissions, only: %i[update destroy]
   before_action :check_board_create_permissions, only: %i[ create clone create_from_template import_obf ]
-  before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
+  before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image set_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
 
   def index
     limit_param = params[:limit].presence&.to_i
@@ -436,9 +436,10 @@ class API::BoardsController < API::ApplicationController
       @board.voice = voice
       @board.name = board_params["name"] unless board_params["name"].blank?
       @board.description = board_params["description"]
-      @board.display_image_url = board_params["display_image_url"]
+      # The board cover (display image) is deliberately NOT set here. It's owned
+      # by the dedicated endpoints (#set_display_image / #update_preset_display_image),
+      # so a generic save (name/colors/tiles) can never clobber the chosen cover.
       @board.bg_color = board_params["bg_color"] if board_params["bg_color"].present?
-      # @board.update_preset_display_image_url(board_params["display_image_url"]) if board_params["display_image_url"].present?
       @board.predefined = board_params["predefined"]
       @board.category = board_params["category"]
       @board.tags = board_params["tags"] if board_params["tags"].present?
@@ -461,21 +462,6 @@ class API::BoardsController < API::ApplicationController
       new_board_settings = @board.settings.merge(settings)
       @board.settings = new_board_settings
 
-      # A deliberate tile pick ("Use as thumbnail") sets
-      # `display_image_is_custom` alongside the chosen `display_image_url`. It's
-      # mutually exclusive with "display follows preview": force the latter off
-      # so the column isn't nilled below and the pick can win in the getter.
-      if @board.display_image_is_custom?
-        @board.settings["display_follows_preview"] = false
-      end
-
-      # When the user opts into "display follows preview" we nil out the
-      # denormalized column so the override getter resolves to the live
-      # preview URL. Any incoming `display_image_url` param is ignored in
-      # this mode — the form may echo back the previous resolved value.
-      if @board.display_follows_preview?
-        @board.display_image_url = nil
-      end
       @board.set_text_color(board_params["text_color"]) if board_params["text_color"].present?
 
       word_list = params["word_list"] || []
@@ -599,6 +585,37 @@ class API::BoardsController < API::ApplicationController
       Rails.logger.error "Setting colors failed for some images: #{results.inspect}"
       render json: { error: "Setting colors failed for some images" }, status: :unprocessable_content
     end
+  end
+
+  # Switch which image represents the board (its cover / thumbnail):
+  #   source=preview                        → the auto-generated grid snapshot
+  #   source=custom, display_image_url=<url> → a specific tile's picture
+  # A custom cover the user *uploads* goes through #update_preset_display_image
+  # instead (also source=custom). This is the ONLY place a generic caller flips
+  # the switch, so a normal board save can't disturb the cover.
+  def set_display_image
+    set_board
+    source = params[:source].to_s
+
+    case source
+    when "preview"
+      @board.settings = (@board.settings || {}).merge("display_image_source" => "preview")
+      @board.save!
+    when "custom"
+      src = params[:display_image_url].presence
+      if src.blank?
+        render json: { error: "display_image_url is required when source is custom" }, status: :unprocessable_content
+        return
+      end
+      @board.write_attribute(:display_image_url, src)
+      @board.settings = (@board.settings || {}).merge("display_image_source" => "custom")
+      @board.save!
+    else
+      render json: { error: "source must be 'preview' or 'custom'" }, status: :unprocessable_content
+      return
+    end
+
+    render json: @board.api_view_with_images(current_user)
   end
 
   def update_preset_display_image
@@ -1400,7 +1417,10 @@ class API::BoardsController < API::ApplicationController
 
     preset_display_image_url = @board.display_preset_image_url
     @board.update_preset_display_image_url(preset_display_image_url)
-    @board.display_image_url = preset_display_image_url
+    @board.write_attribute(:display_image_url, preset_display_image_url)
+    # An uploaded cover is a deliberate pick — flip the switch to custom so the
+    # getter serves it instead of the auto preview.
+    @board.settings = (@board.settings || {}).merge("display_image_source" => "custom")
     @board.save!
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -232,51 +232,59 @@ class Board < ApplicationRecord
     # generate_preview(generate_pdf: true) # PDF with header for sharing
   end
 
-  # When `settings["display_follows_preview"]` is true, the board's
-  # display image should track the live preview rather than a frozen
-  # snapshot URL. Persisting *intent* sidesteps the stale `?v=` problem
-  # that arises when callers store a previous `preview_image_url` string.
-  def display_follows_preview?
-    return false unless settings.is_a?(Hash)
-    ActiveModel::Type::Boolean.new.cast(settings["display_follows_preview"]) == true
+  # The board's display image (thumbnail) has ONE switch:
+  # `settings["display_image_source"]`, either "preview" (default) or "custom".
+  #
+  #   - "preview" → the auto-generated grid snapshot (the `preview_image`
+  #     attachment). Tracks the board's *current* contents; the
+  #     `display_image_url` column is ignored (kept only as a pre-preview seed).
+  #     Storing intent — rather than a frozen `preview_image_url` string —
+  #     sidesteps the stale `?v=` cache-bust problem.
+  #   - "custom" → a deliberate pick: an uploaded cover (`preset_display_image`
+  #     attachment) if present, else the URL the user chose in the
+  #     `display_image_url` column (the "Use as thumbnail" action).
+  #
+  # The switch is only ever flipped through the dedicated endpoints
+  # (BoardsController#set_display_image / #update_preset_display_image), never as
+  # a side effect of a generic board save — so editing name/colors/tiles can't
+  # clobber the cover.
+  DISPLAY_IMAGE_SOURCES = %w[preview custom].freeze
+
+  def display_image_source
+    stored = settings.is_a?(Hash) ? settings["display_image_source"] : nil
+    return stored if DISPLAY_IMAGE_SOURCES.include?(stored)
+    # Backward-compat inference for boards saved before this field existed,
+    # so they resolve correctly until `board_covers:backfill_source` runs.
+    return "custom" if preset_display_image.attached?
+    return "custom" if legacy_display_image_is_custom?
+    "preview"
   end
 
-  # When `settings["display_image_is_custom"]` is true the user has deliberately
-  # picked a specific tile's picture as the board thumbnail (the "Use as
-  # thumbnail" action, which writes the URL into the `display_image_url` column).
-  # That choice should outrank the auto preview, mirroring how an uploaded cover
-  # does — see the precedence note on #display_image_url.
-  def display_image_is_custom?
+  def display_image_custom?
+    display_image_source == "custom"
+  end
+
+  # Legacy flag reader, kept ONLY so pre-existing boards infer the right source
+  # above. Nothing writes `display_image_is_custom` anymore.
+  def legacy_display_image_is_custom?
     return false unless settings.is_a?(Hash)
     ActiveModel::Type::Boolean.new.cast(settings["display_image_is_custom"]) == true
   end
 
-  # Override the AR-generated getter so reads (including serializers, grid
-  # thumbnails) resolve the right image with this precedence:
+  # Override the AR-generated getter so reads (serializers, grid thumbnails)
+  # resolve the cover from the single `display_image_source` switch:
   #
-  #   1. An explicit custom cover the user uploaded (the `preset_display_image`
-  #      attachment, set via API::BoardsController#update_preset_display_image)
-  #      always wins — it's a deliberate choice, not an auto snapshot.
-  #   2. A deliberate tile pick (`display_image_is_custom` + the
-  #      `display_image_url` column) — the "Use as thumbnail" action. Also a
-  #      deliberate choice, so it outranks the auto preview; without this the
-  #      live preview (#3) silently swallows the user's pick on any board that
-  #      already has a generated preview.
-  #   3. Otherwise the live, deterministically-keyed auto preview wins, so the
-  #      thumbnail tracks the board's *current* contents. The URL is stable
-  #      (board_previews/<id>/preview.png) and self-cache-busts on regeneration
-  #      via `?v=<blob.created_at>`, so an edited board never shows stale art.
-  #   4. The denormalized `display_image_url` column is only a seed thumbnail
-  #      (e.g. the originating tile's image) used before the first preview
-  #      exists; it's the last resort.
+  #   custom  → uploaded cover, else the chosen `display_image_url` column value
+  #   preview → live auto preview, else the seed column as a last resort
   #
   # The setter is untouched — writes still go straight to the column.
   def display_image_url
-    if preset_display_image.attached? && (custom_cover = display_preset_image_url).present?
-      return custom_cover
-    end
-    if display_image_is_custom? && (custom_pick = read_attribute(:display_image_url)).present?
-      return custom_pick
+    if display_image_custom?
+      if preset_display_image.attached? && (custom_cover = display_preset_image_url).present?
+        return custom_cover
+      end
+      picked = read_attribute(:display_image_url)
+      return picked if picked.present?
     end
     if preview_image.attached? && (live_preview = preview_image_url).present?
       return live_preview
@@ -1057,13 +1065,13 @@ class Board < ApplicationRecord
     @cloned_board = @source.dup
     # A clone gets its own freshly-generated preview (enqueued below via
     # run_generate_preview_job). `dup` copies the source's
-    # display_image_url column verbatim — for boards that follow their
-    # preview that string points at the *source's* image, so the clone
-    # would render the wrong board. Default every clone to "follow my
-    # own preview" and drop the inherited snapshot.
+    # display_image_url column verbatim — for a "preview" board that string
+    # points at the *source's* image, so the clone would render the wrong
+    # board. Default every clone to its own auto preview and drop the
+    # inherited snapshot.
     @cloned_board.write_attribute(:display_image_url, nil)
     @cloned_board.settings = (@cloned_board.settings || {}).merge(
-      "display_follows_preview" => true,
+      "display_image_source" => "preview",
     )
     @cloned_board.user_id = cloned_user_id
     @cloned_board.name = new_name
@@ -1933,6 +1941,7 @@ class Board < ApplicationRecord
       cost: cost,
       audio_url: audio_url,
       display_image_url: display_image_url || preview_image_url,
+      display_image_source: display_image_source,
       # floating_words: words,
       common_words: Board.common_words,
       user_id: user_id,
@@ -2263,6 +2272,7 @@ class Board < ApplicationRecord
       cost: cost,
       display_image_url: @display_image_url || @preview_image_url,
       preview_image_url: @preview_image_url,
+      display_image_source: display_image_source,
       board_type: board_type,
       user_id: user_id,
       voice: voice,
@@ -2297,6 +2307,7 @@ class Board < ApplicationRecord
       lock_reason: locked_for?(viewing_user) ? "free_plan_board_limit" : nil,
       display_image_url: display_image_url,
       preview_image_url: preview_image_url,
+      display_image_source: display_image_source,
       word_sample: word_sample,
       frozen: is_frozen?,
       word_list: data["current_word_list"],

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -155,11 +155,12 @@ module Boards
       # Source settings minus the robust-set catalog markers — a user's copy
       # must never surface as a pickable template (the dup-based clone path
       # predates this concern). The controller's own settings (builder_root)
-      # win on conflict; display_follows_preview mirrors clone_with_images.
+      # win on conflict; display_image_source mirrors clone_with_images so the
+      # adopted root tracks its own freshly-generated preview.
       root.settings = (src.settings || {})
         .except(Boards::RobustSets::ROOT_MARKER, Boards::RobustSets::SLUG_MARKER)
         .merge(root.settings || {})
-        .merge("display_follows_preview" => true)
+        .merge("display_image_source" => "preview")
       root.save!
 
       copy_tiles!(src, root)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Rails.application.routes.draw do
         get "get_description"
         get "download_obf"
         put "update_preset_display_image"
+        put "set_display_image"
         put "recategorize_images"
         put "update_to_default_docs"
         put "set_colors"

--- a/lib/tasks/board_covers.rake
+++ b/lib/tasks/board_covers.rake
@@ -1,0 +1,54 @@
+namespace :board_covers do
+  # Backfill the single display-image switch (settings["display_image_source"])
+  # for boards created before it existed, then drop the retired flags
+  # (display_image_is_custom / display_follows_preview). Resolution already
+  # infers the right source at read time (Board#display_image_source), so this
+  # task is a cleanup — correctness does not depend on running it.
+  #
+  # A board is "custom" when it has an uploaded cover (preset_display_image
+  # attached) or the legacy display_image_is_custom flag; everything else is
+  # "preview".
+  #
+  # Read-only by default (reports what would change). Apply with DRY_RUN=false.
+  # Scope to one owner with USER_ID=N.
+  #
+  #   rake board_covers:backfill_source                       # dry run, all
+  #   DRY_RUN=false rake board_covers:backfill_source         # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_covers:backfill_source
+  desc "Backfill settings.display_image_source + drop legacy flags (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task backfill_source: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    scope = Board.all
+    scope = scope.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    to_custom = 0
+    to_preview = 0
+    flags_cleared = 0
+
+    scope.find_each do |board|
+      settings = board.settings.is_a?(Hash) ? board.settings.dup : {}
+      had_legacy_flags = settings.key?("display_image_is_custom") || settings.key?("display_follows_preview")
+      already_set = Board::DISPLAY_IMAGE_SOURCES.include?(settings["display_image_source"])
+
+      # Compute the source before stripping the legacy flags (inference reads them).
+      resolved = board.display_image_source
+
+      next unless had_legacy_flags || !already_set
+
+      settings.delete("display_image_is_custom")
+      settings.delete("display_follows_preview")
+      settings["display_image_source"] = resolved
+
+      resolved == "custom" ? (to_custom += 1) : (to_preview += 1)
+      flags_cleared += 1 if had_legacy_flags
+
+      unless dry_run
+        board.update_columns(settings: settings) # skip validations/callbacks — data cleanup only
+      end
+    end
+
+    verb = dry_run ? "would set" : "set"
+    puts "board_covers:backfill_source — #{verb}: #{to_custom} custom, #{to_preview} preview; legacy flags cleared on #{flags_cleared} board(s)."
+    puts "(dry run — re-run with DRY_RUN=false to apply)" if dry_run
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -94,9 +94,10 @@ RSpec.describe Board, type: :model do
       expect(cloned.read_attribute(:display_image_url)).to be_nil
     end
 
-    it "defaults the clone to follow its own preview" do
+    it "defaults the clone to its own auto preview" do
       cloned = board.clone_with_images(user.id)
-      expect(cloned.settings["display_follows_preview"]).to be true
+      expect(cloned.settings["display_image_source"]).to eq("preview")
+      expect(cloned.display_image_source).to eq("preview")
     end
 
     context "tile display_image_url fallback on clone" do
@@ -548,7 +549,7 @@ RSpec.describe Board, type: :model do
       end
     end
 
-    context "with a deliberate tile pick (display_image_is_custom)" do
+    context "with a legacy tile pick (display_image_is_custom flag, backward compat)" do
       before do
         attach_preview
         board.update_column(:display_image_url, "https://example.com/picked-tile.png")
@@ -576,6 +577,53 @@ RSpec.describe Board, type: :model do
         freeze_time do
           expect(board.display_image_url).to eq(board.preview_image_url)
         end
+      end
+    end
+
+    context "with the explicit switch settings[display_image_source]" do
+      before { attach_preview }
+
+      it "source=custom serves the picked column value over the auto preview" do
+        board.update_column(:display_image_url, "https://example.com/picked-tile.png")
+        board.update!(settings: board.settings.merge("display_image_source" => "custom"))
+        freeze_time do
+          expect(board.display_image_url).to eq("https://example.com/picked-tile.png")
+          expect(board.display_image_url).not_to eq(board.preview_image_url)
+        end
+      end
+
+      # The switch-back path, and the reason the echo-back clobber is harmless:
+      # in preview mode the column is ignored, so a stale URL stamped into it by
+      # a generic save can never freeze the thumbnail.
+      it "source=preview serves the live auto preview, ignoring a stale column value" do
+        board.update_column(:display_image_url, "https://example.com/old-pick.png")
+        board.update!(settings: board.settings.merge("display_image_source" => "preview"))
+        freeze_time do
+          expect(board.display_image_url).to eq(board.preview_image_url)
+          expect(board.display_image_url).not_to eq("https://example.com/old-pick.png")
+        end
+      end
+    end
+
+    describe "#display_image_source" do
+      it "defaults to preview" do
+        expect(board.display_image_source).to eq("preview")
+      end
+
+      it "infers custom when a cover is uploaded (backward compat)" do
+        board.preset_display_image.attach(io: StringIO.new("c"), filename: "c.png", content_type: "image/png")
+        expect(board.display_image_source).to eq("custom")
+      end
+
+      it "infers custom from the legacy display_image_is_custom flag (backward compat)" do
+        board.update!(settings: board.settings.merge("display_image_is_custom" => true))
+        expect(board.display_image_source).to eq("custom")
+      end
+
+      it "an explicit stored source always wins over inference" do
+        board.preset_display_image.attach(io: StringIO.new("c"), filename: "c.png", content_type: "image/png")
+        board.update!(settings: board.settings.merge("display_image_source" => "preview"))
+        expect(board.display_image_source).to eq("preview")
       end
     end
   end

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -340,14 +340,17 @@ RSpec.describe "API::Boards", type: :request do
         expect(board.margin_settings["lg"]).to eq("x" => 10, "y" => 10)
       end
 
-      it "clears the display_image_url column when settings.display_follows_preview is true" do
-        board.update_column(:display_image_url, "https://example.com/old-preview.png")
+      it "does not touch the board cover on a generic save (name/colors)" do
+        board.update_column(:display_image_url, "https://example.com/picked-tile.png")
+        board.update!(settings: board.settings.merge("display_image_source" => "custom"))
 
+        # A form save echoes the whole board back, including the resolved cover
+        # URL — it must never clobber the chosen cover.
         patch "/api/boards/#{board.id}",
               params: {
                 board: {
-                  display_image_url: "https://example.com/old-preview.png",
-                  settings: { display_follows_preview: true },
+                  name: "Renamed board",
+                  display_image_url: "https://example.com/echoed-resolved.png",
                 },
               },
               headers: auth_headers(user),
@@ -355,62 +358,59 @@ RSpec.describe "API::Boards", type: :request do
 
         expect(response).to have_http_status(:ok)
         board.reload
-        expect(board.read_attribute(:display_image_url)).to be_nil
-        expect(board.settings["display_follows_preview"]).to be true
+        expect(board.name).to eq("Renamed board")
+        expect(board.read_attribute(:display_image_url))
+          .to eq("https://example.com/picked-tile.png")
+        expect(board.display_image_source).to eq("custom")
       end
+    end
 
-      it "keeps the display_image_url column when the flag is not set" do
-        patch "/api/boards/#{board.id}",
-              params: {
-                board: {
-                  display_image_url: "https://example.com/user-cover.png",
-                },
-              },
-              headers: auth_headers(user)
-
-        expect(response).to have_http_status(:ok)
-        expect(board.reload.read_attribute(:display_image_url))
-          .to eq("https://example.com/user-cover.png")
-      end
-
-      it "persists a deliberate tile pick (display_image_is_custom) and resolves to it" do
-        patch "/api/boards/#{board.id}",
-              params: {
-                board: {
-                  display_image_url: "https://example.com/picked-tile.png",
-                  settings: { display_image_is_custom: true },
-                },
-              },
-              headers: auth_headers(user),
-              as: :json
+    describe "PUT /api/boards/:id/set_display_image" do
+      it "source=custom persists the tile pick and resolves to it" do
+        put "/api/boards/#{board.id}/set_display_image",
+            params: { source: "custom", display_image_url: "https://example.com/picked-tile.png" },
+            headers: auth_headers(user),
+            as: :json
 
         expect(response).to have_http_status(:ok)
         board.reload
         expect(board.read_attribute(:display_image_url))
           .to eq("https://example.com/picked-tile.png")
-        expect(board.settings["display_image_is_custom"]).to be true
-        expect(JSON.parse(response.body)["display_image_url"])
-          .to eq("https://example.com/picked-tile.png")
+        expect(board.display_image_source).to eq("custom")
+        body = JSON.parse(response.body)
+        expect(body["display_image_url"]).to eq("https://example.com/picked-tile.png")
+        expect(body["display_image_source"]).to eq("custom")
       end
 
-      it "forces display_follows_preview off when a tile is picked, so the pick isn't nilled" do
-        board.update!(settings: board.settings.merge("display_follows_preview" => true))
+      it "source=preview switches back to the auto preview" do
+        board.update_column(:display_image_url, "https://example.com/picked-tile.png")
+        board.update!(settings: board.settings.merge("display_image_source" => "custom"))
 
-        patch "/api/boards/#{board.id}",
-              params: {
-                board: {
-                  display_image_url: "https://example.com/picked-tile.png",
-                  settings: { display_image_is_custom: true },
-                },
-              },
-              headers: auth_headers(user),
-              as: :json
+        put "/api/boards/#{board.id}/set_display_image",
+            params: { source: "preview" },
+            headers: auth_headers(user),
+            as: :json
 
         expect(response).to have_http_status(:ok)
-        board.reload
-        expect(board.settings["display_follows_preview"]).to be false
-        expect(board.read_attribute(:display_image_url))
-          .to eq("https://example.com/picked-tile.png")
+        expect(board.reload.display_image_source).to eq("preview")
+      end
+
+      it "returns 422 when source=custom without a url" do
+        put "/api/boards/#{board.id}/set_display_image",
+            params: { source: "custom" },
+            headers: auth_headers(user),
+            as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it "returns 422 for an unknown source" do
+        put "/api/boards/#{board.id}/set_display_image",
+            params: { source: "bogus" },
+            headers: auth_headers(user),
+            as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 


### PR DESCRIPTION
## Summary

Simplifies the board cover (preview vs. display image) so switching actually works. Five overlapping mechanisms are collapsed to **one switch**: `settings["display_image_source"]` = `"preview"` | `"custom"`.

- **`preview`** (default) → the live auto grid snapshot. The `display_image_url` column is ignored in this mode, so a generic board save echoing back a resolved URL can no longer freeze the cover.
- **`custom`** → the uploaded cover, else the picked tile URL.

Retires `display_image_is_custom` and `display_follows_preview`.

### Changes
- `Board#display_image_url` getter rewritten around the single switch; `display_image_source` helper with **read-time inference** so existing boards resolve correctly with no migration.
- New dedicated `PUT /api/boards/:id/set_display_image` (`source=preview` or `source=custom`+`display_image_url`). **Generic `#update` no longer touches the cover** — editing name/colors/tiles can't clobber it.
- Uploads (`update_preset_display_image`) and clones (`clone_with_images`, `SeededSetCloner`) now set the switch.
- `display_image_source` added to the board serializers.
- `rake board_covers:backfill_source` (dry-run default) persists the field and drops the legacy flags. Correctness does not depend on running it.

Pairs with itty-bitty-frontend#`claude/display-image-simplify` (frontend calls the new endpoint) — **ship together**.

## Test plan
- `bundle exec rspec spec/models/board_spec.rb` — display_image_url precedence + `#display_image_source` + clone (27 examples, 0 failures)
- `bundle exec rspec spec/requests/api/boards_spec.rb` — new `set_display_image` action + "generic save doesn't clobber cover" (0 failures)
- `bundle exec rspec spec/services/boards/generate_preview_assets_spec.rb spec/sidekiq/generate_board_preview_job_spec.rb spec/services/boards/seeded_set_cloner_spec.rb` — 0 failures
- `rake -T board_covers` registers the backfill task

🤖 Generated with [Claude Code](https://claude.com/claude-code)