### PR TITLE
feat(partners): Partner Pro pilot expiry reminders + admin surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Partner Pro pilot expiry reminders (no auto-downgrade)
+- The 3-month Partner Pro pilot's end date (`plan_expires_at`) was previously
+  set but never acted on, so partners kept Pro-level access indefinitely with no
+  reminder. New `PartnerPilotEndingJob` (daily) now emails partners a friendly
+  "your pilot is wrapping up" heads-up ~14 days before their end date and emails
+  the SpeakAnyWay admin a digest of partners ending soon / newly ended.
+- **Nothing is auto-downgraded** — partners keep their boards and access; the
+  digest is a prompt to convert, extend, or downgrade each partner by hand.
+  `rake partners:pilot_status` lists pilots by status on demand. Lead time is
+  tunable via `PARTNER_PILOT_REMINDER_LEAD_DAYS` (default 14).
+
 ### Added — owner picks which communicators stay signable on downgrade (#439)
 - When a user is over their plan's communicator slot limit after a downgrade,
   the over-limit accounts enter fallback mode (private sign-in paused; public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,6 +505,48 @@ the non-active→active transition in the upsert; guarded so renewals don't
 double-count). Primary A/B metric is **net paid users per 100 signups**, not
 trial→paid rate.
 
+### Partner Program (`partner_pro`)
+
+The `/sign-up/partner` flow (frontend `viewType="partner"`) posts to the normal
+`POST /api/v1/users` with `plan_type=partner_pro`. `API::V1::AuthsController#sign_up`
+then sets `plan_type=partner_pro`, `plan_status=active`, `role=partner`, and calls
+`User.handle_new_partner_pro_subscription`, which sets
+`plan_expires_at = Time.now + 3.months` (only if nil), tags Mailchimp, and sends
+`PartnerMailer.welcome_email` (the free welcome + welcome journey are skipped).
+Entitlements equal Pro (`setup_partner_pro_plan` → 300 boards / 5 communicators /
+1500 credits). **No Stripe subscription, no card, no promo code** — the grant is
+local DB fields, which is why partners get Pro free for the pilot. `partner_pro`
+is in `RefreshFreeTierCreditsJob`'s refreshable set, so credits re-grant monthly.
+
+**The 3-month window is surfaced but NOT enforced (Phase 1, deliberate).**
+`plan_expires_at` was previously set and never read — partners kept Pro forever
+with no signal. `PartnerPilotEndingJob` (daily 5:30am UTC, sidekiq-cron) closes
+that without auto-downgrading (partners are high-value B2B leads managed by hand):
+
+- **Reminder pass** — partners within `PARTNER_PILOT_REMINDER_LEAD_DAYS` (default
+  14) of `plan_expires_at`, not yet reminded, get `PartnerMailer.pilot_ending_email`
+  (a heads-up, not a shutoff — copy in `partner_mailer.pilot_ending_email`,
+  en + es). Flags `settings["partner_pilot_ending_notified"]` so it fires once.
+- **Expired pass** — partners past `plan_expires_at`, still `partner_pro`, get
+  flagged `settings["partner_pilot_expired"]` + `partner_pilot_expired_at`. **No
+  plan change.** Once-only via the flag.
+- Both feed a single `AdminMailer.partner_pilot_review` digest to `ADMIN_EMAIL`
+  (only sent when there's something) so Brittany can convert/extend/downgrade.
+- `rake partners:pilot_status` — read-only list of pilots by status (ended /
+  ending-soon / active / no-date), respects the lead-days ENV.
+- **Admin dashboard surface.** `Admin::MissionControlHelper#partner_pilot_status`
+  computes the same status (never mutates). The server-rendered admin
+  (`/admin/users`) has a **Partner** filter and chips non-active pilots
+  (`Pilot ended` / `Ending soon`) on the row; the user detail page
+  (`/admin/users/:id`) shows a **Partner Pilot** card (end date, days left,
+  reminder-sent, expired-flagged) so you can action a partner in one place —
+  extend by bumping `plan_expires_at`, or adjust plan by hand.
+
+**Phase 2 (not built):** if partner volume outgrows hand-management, move the
+pilot onto a real Stripe no-card trial (reuses the reverse-trial machinery
+above — auto-expiry, `trial_will_end` reminder, clean cancel→Free, one-click
+conversion) and retire this job + the bespoke `partner_pro` grant.
+
 ### Email-only (passwordless) signup — paid-intent path
 
 `POST /api/v1/users/email_signup` (itty-bitty-frontend#367): a paid-intent

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -63,8 +63,9 @@ module Admin
 
     def apply_filter(scope)
       case @filter
-      when "admin"  then scope.where(role: "admin")
-      when "pro"    then scope.where(plan_type: "pro")
+      when "admin"   then scope.where(role: "admin")
+      when "pro"     then scope.where(plan_type: "pro")
+      when "partner" then scope.where(plan_type: "partner_pro")
       when "basic"  then scope.where(plan_type: "basic")
       when "free"   then scope.where(plan_type: "free")
       when "trial"  then scope.where(plan_type: "basic_trial")

--- a/app/helpers/admin/mission_control_helper.rb
+++ b/app/helpers/admin/mission_control_helper.rb
@@ -26,5 +26,46 @@ module Admin
     def plan_badge_class(user)
       PLAN_BADGE_CLASSES.fetch(user.plan_type.to_s, "bg-gray-800 text-gray-400")
     end
+
+    PARTNER_PILOT_STATE_META = {
+      ended:        { label: "Pilot ended",  badge: "bg-red-900/60 text-red-300" },
+      ending_soon:  { label: "Ending soon",  badge: "bg-yellow-900/60 text-yellow-300" },
+      active:       { label: "Pilot active", badge: "bg-green-900/60 text-green-300" },
+      no_end_date:  { label: "No end date",  badge: "bg-gray-800 text-gray-400" },
+    }.freeze
+
+    def partner_pilot?(user)
+      user.plan_type.to_s == "partner_pro"
+    end
+
+    # Snapshot of where a Partner Pro pilot sits in its 3-month window, for the
+    # admin dashboard. Mirrors the categories PartnerPilotEndingJob acts on.
+    # Returns nil for non-partners. Never mutates anything.
+    def partner_pilot_status(user)
+      return nil unless partner_pilot?(user)
+
+      ends_at = user.plan_expires_at
+      settings = user.settings.is_a?(Hash) ? user.settings : {}
+      lead_days = (ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"] || 14).to_i
+
+      state =
+        if ends_at.nil?               then :no_end_date
+        elsif ends_at <= Time.current then :ended
+        elsif ends_at <= Time.current + lead_days.days then :ending_soon
+        else :active
+        end
+
+      meta = PARTNER_PILOT_STATE_META.fetch(state)
+      {
+        state: state,
+        label: meta[:label],
+        badge_class: meta[:badge],
+        end_date: ends_at,
+        days_left: ends_at ? ((ends_at - Time.current) / 1.day).ceil : nil,
+        reminded: settings["partner_pilot_ending_notified"] == true,
+        expired_flagged: settings["partner_pilot_expired"] == true,
+        expired_at: settings["partner_pilot_expired_at"],
+      }
+    end
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -25,6 +25,18 @@ class AdminMailer < BaseMailer
     mail(to: to_email, subject: subject, from: "noreply@speakanyway.com")
   end
 
+  # Partner-pilot review digest, sent by PartnerPilotEndingJob when there are
+  # partners ending soon and/or newly past their 3-month window. Gives Brittany
+  # a single actionable list — nobody is auto-downgraded, so this is the signal
+  # to convert / extend / downgrade each partner by hand.
+  def partner_pilot_review(expiring:, expired:)
+    to_email = ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"
+    @expiring = expiring || []
+    @expired = expired || []
+    subject = "Partner pilots: #{@expired.size} ended, #{@expiring.size} ending soon"
+    mail(to: to_email, subject: subject, from: "noreply@speakanyway.com")
+  end
+
   # Server disk-space alert, sent by DiskSpaceAlertJob.
   def disk_space_alert(usage:, severity:)
     to_email = ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -11,4 +11,23 @@ class PartnerMailer < BaseMailer
       mail(to: @user.email, subject: I18n.t("partner_mailer.welcome_email.subject"))
     end
   end
+
+  # "Your 3-month pilot is wrapping up" nudge, sent by PartnerPilotEndingJob
+  # when a Partner Pro account is within the reminder lead window of its
+  # plan_expires_at. Points the partner at their account and an easy way to
+  # continue on a paid plan; the pilot does NOT auto-cancel, so the tone is a
+  # heads-up, not a shutoff notice.
+  def pilot_ending_email(user)
+    @user = user
+    @end_date = user.plan_expires_at
+    @days_left = @end_date ? [((@end_date - Time.current) / 1.day).ceil, 0].max : nil
+    @front_end_url = ENV["FRONT_END_URL"] || "http://localhost:8100"
+    @sign_in_url = "#{@front_end_url}/users/sign-in?email=#{CGI.escape(@user.email)}"
+    @plans_url = "#{@front_end_url}/plans"
+    @partner_portal_url = ENV["PARTNER_PORTAL_URL"] || "https://www.speakanyway.com/partner-portal"
+
+    with_user_locale(@user) do
+      mail(to: @user.email, subject: I18n.t("partner_mailer.pilot_ending_email.subject"))
+    end
+  end
 end

--- a/app/sidekiq/partner_pilot_ending_job.rb
+++ b/app/sidekiq/partner_pilot_ending_job.rb
@@ -1,0 +1,100 @@
+# Daily Sidekiq-cron sweep over Partner Pro pilots that keeps the 3-month
+# pilot window meaningful WITHOUT auto-downgrading anyone.
+#
+# Background: a `partner_pro` signup grants Pro-level access with
+# `plan_expires_at = now + 3.months`, but nothing ever reads that date — so
+# partners silently keep Pro forever and Brittany gets no signal to have the
+# convert/extend/downgrade conversation. Partners are high-value B2B leads
+# (SLP champions, schools), so a hard auto-drop is the wrong tool. Instead this
+# job:
+#
+#   1. REMINDER pass — partners whose `plan_expires_at` is within the lead
+#      window (PARTNER_PILOT_REMINDER_LEAD_DAYS, default 14) and not yet
+#      reminded get a "your pilot is wrapping up" email. Flags
+#      settings["partner_pilot_ending_notified"] so it fires once per pilot.
+#   2. EXPIRED pass — partners whose `plan_expires_at` has passed and who are
+#      still `partner_pro` get flagged settings["partner_pilot_expired"] (with
+#      partner_pilot_expired_at) so they're findable and counted once. NO plan
+#      change — expiry handling stays a human decision (see rake
+#      partners:pilot_status and the admin digest below).
+#
+# Both passes feed a single AdminMailer digest to Brittany so she can act. The
+# flags make the job idempotent: a partner is reminded once and included in the
+# digest once, no matter how many days the cron runs before she deals with them.
+#
+# Deliberately NOT enforcing a downgrade here is Phase 1 of the partner-expiry
+# work (see backend CLAUDE.md "Partner Program"). If partner volume ever
+# outgrows hand-management, Phase 2 moves the pilot onto a real Stripe no-card
+# trial and this job is retired.
+class PartnerPilotEndingJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :default, retry: 3
+
+  REMINDER_FLAG = "partner_pilot_ending_notified".freeze
+  EXPIRED_FLAG = "partner_pilot_expired".freeze
+
+  def perform
+    expiring = []
+    expired = []
+
+    partner_pilots.find_each do |user|
+      ends_at = user.plan_expires_at
+      next if ends_at.nil?
+
+      if ends_at <= Time.current
+        # Pilot window has ended. Flag for review (once) — never downgrade.
+        next if flagged?(user, EXPIRED_FLAG)
+
+        flag_expired!(user)
+        expired << user
+      elsif ends_at <= reminder_cutoff
+        # Ending soon and not yet reminded.
+        next if flagged?(user, REMINDER_FLAG)
+
+        PartnerMailer.pilot_ending_email(user).deliver_now
+        flag!(user, REMINDER_FLAG)
+        expiring << user
+      end
+    rescue => e
+      Rails.logger.error "PartnerPilotEndingJob: failed for user #{user&.id} - #{e.message}"
+    end
+
+    if expiring.any? || expired.any?
+      AdminMailer.partner_pilot_review(expiring: expiring, expired: expired).deliver_now
+    end
+
+    Rails.logger.info "PartnerPilotEndingJob: completed — #{expiring.size} ending soon, #{expired.size} newly expired"
+  end
+
+  private
+
+  def lead_days
+    (ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"] || 14).to_i.days
+  end
+
+  def reminder_cutoff
+    Time.current + lead_days
+  end
+
+  def partner_pilots
+    User.where(plan_type: "partner_pro").where.not(plan_expires_at: nil)
+  end
+
+  def flagged?(user, key)
+    user.settings.is_a?(Hash) && user.settings[key] == true
+  end
+
+  def flag!(user, key)
+    user.settings = (user.settings || {}).merge(key => true)
+    user.save!
+  end
+
+  def flag_expired!(user)
+    user.settings = (user.settings || {}).merge(
+      EXPIRED_FLAG => true,
+      "partner_pilot_expired_at" => Time.current.iso8601,
+    )
+    user.save!
+  end
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,6 +18,7 @@
       <option value="" <%= "selected" if @filter.blank? %>>All users</option>
       <option value="admin" <%= "selected" if @filter == "admin" %>>Admins</option>
       <option value="pro" <%= "selected" if @filter == "pro" %>>Pro</option>
+      <option value="partner" <%= "selected" if @filter == "partner" %>>Partner Pro</option>
       <option value="basic" <%= "selected" if @filter == "basic" %>>Basic</option>
       <option value="free" <%= "selected" if @filter == "free" %>>Free</option>
       <option value="trial" <%= "selected" if @filter == "trial" %>>Trial</option>
@@ -84,6 +85,11 @@
             <% end %>
             <% if user.locked? %>
               <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5 ml-1">locked</span>
+            <% end %>
+            <% if (pilot = partner_pilot_status(user)) && pilot[:state] != :active %>
+              <span class="<%= pilot[:badge_class] %> inline-block text-xs rounded px-2 py-0.5 ml-1" title="Pilot ends <%= pilot[:end_date]&.strftime('%b %-d, %Y') || '—' %>">
+                <%= pilot[:label] %>
+              </span>
             <% end %>
           </td>
           <td class="px-5 py-3 text-xs text-t2 text-center">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -51,6 +51,42 @@
   </div>
 </div>
 
+<%# ─── Partner pilot (partner_pro only) ───────────────────── %>
+<% if (pilot = partner_pilot_status(@user)) %>
+  <div class="admin-card border rounded-xl p-6 mb-8">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-xs font-semibold uppercase tracking-widest text-t2">Partner Pilot</h2>
+      <span class="<%= pilot[:badge_class] %> inline-block text-xs rounded px-2.5 py-1"><%= pilot[:label] %></span>
+    </div>
+    <dl class="space-y-2.5 text-xs">
+      <div class="flex justify-between">
+        <dt class="text-t2">Pilot ends</dt>
+        <dd class="text-t1 font-mono text-right"><%= pilot[:end_date]&.strftime("%b %-d, %Y") || "— (no end date set)" %></dd>
+      </div>
+      <% if pilot[:days_left] %>
+        <div class="flex justify-between">
+          <dt class="text-t2">Days left</dt>
+          <dd class="text-t1 font-mono text-right"><%= pilot[:days_left] %></dd>
+        </div>
+      <% end %>
+      <div class="flex justify-between">
+        <dt class="text-t2">Ending-soon reminder sent</dt>
+        <dd class="text-t1 font-mono text-right"><%= pilot[:reminded] ? "Yes" : "No" %></dd>
+      </div>
+      <div class="flex justify-between">
+        <dt class="text-t2">Flagged expired (for review)</dt>
+        <dd class="text-t1 font-mono text-right">
+          <%= pilot[:expired_flagged] ? "Yes" : "No" %><%= " · #{pilot[:expired_at]}" if pilot[:expired_at].present? %>
+        </dd>
+      </div>
+    </dl>
+    <p class="text-[10px] text-t3 mt-3">
+      Partners are never auto-downgraded. Convert, extend (bump <span class="font-mono">plan_expires_at</span>), or downgrade by hand.
+      <span class="font-mono">rake partners:pilot_status</span> lists all pilots.
+    </p>
+  </div>
+<% end %>
+
 <%# ─── Credit adjustment ──────────────────────────────────── %>
 <div class="admin-card border rounded-xl p-6 mb-8">
   <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Adjust Credits</h2>

--- a/app/views/admin_mailer/partner_pilot_review.html.erb
+++ b/app/views/admin_mailer/partner_pilot_review.html.erb
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Partner pilots need review</title>
+  </head>
+  <body style="margin:0; padding:0; background-color:#f7f7fb; font-family: Arial, Helvetica, sans-serif;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f7f7fb; padding:20px;">
+      <tr>
+        <td align="center">
+          <table width="640" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
+            <tr>
+              <td style="color:#333333; font-size:15px; line-height:1.5;">
+                <h2 style="margin-top:0;">Partner pilot review</h2>
+                <p>These Partner Pro pilots need a decision — convert, extend, or downgrade. Nobody was auto-downgraded.</p>
+
+                <h3 style="margin-bottom:6px;">⏳ Ending soon (<%= @expiring.size %>)</h3>
+                <% if @expiring.any? %>
+                  <table width="100%" cellpadding="6" cellspacing="0" style="border-collapse:collapse; font-size:14px;">
+                    <tr style="background:#f4f2ff; text-align:left;">
+                      <th style="padding:6px;">Name</th>
+                      <th style="padding:6px;">Email</th>
+                      <th style="padding:6px;">Ends</th>
+                    </tr>
+                    <% @expiring.each do |user| %>
+                      <tr style="border-bottom:1px solid #eeeeee;">
+                        <td style="padding:6px;"><%= user.name.presence || "—" %></td>
+                        <td style="padding:6px;"><%= user.email %></td>
+                        <td style="padding:6px;"><%= user.plan_expires_at&.strftime("%b %d, %Y") %></td>
+                      </tr>
+                    <% end %>
+                  </table>
+                <% else %>
+                  <p style="color:#666666;">None.</p>
+                <% end %>
+
+                <h3 style="margin-bottom:6px;">🔔 Newly ended (<%= @expired.size %>)</h3>
+                <% if @expired.any? %>
+                  <table width="100%" cellpadding="6" cellspacing="0" style="border-collapse:collapse; font-size:14px;">
+                    <tr style="background:#fff3f0; text-align:left;">
+                      <th style="padding:6px;">Name</th>
+                      <th style="padding:6px;">Email</th>
+                      <th style="padding:6px;">Ended</th>
+                    </tr>
+                    <% @expired.each do |user| %>
+                      <tr style="border-bottom:1px solid #eeeeee;">
+                        <td style="padding:6px;"><%= user.name.presence || "—" %></td>
+                        <td style="padding:6px;"><%= user.email %></td>
+                        <td style="padding:6px;"><%= user.plan_expires_at&.strftime("%b %d, %Y") %></td>
+                      </tr>
+                    <% end %>
+                  </table>
+                <% else %>
+                  <p style="color:#666666;">None.</p>
+                <% end %>
+
+                <hr style="border:none; border-top:1px solid #eeeeee; margin:24px 0;" />
+                <p style="color:#666666; font-size:13px;">Run <code>rake partners:pilot_status</code> any time for the full list. Ending-soon partners also got a heads-up email; they still keep Pro access until you act.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/partner_mailer/pilot_ending_email.html.erb
+++ b/app/views/partner_mailer/pilot_ending_email.html.erb
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title><%= t("partner_mailer.pilot_ending_email.title") %></title>
+  </head>
+  <body style="margin:0; padding:0; background-color:#f7f7fb; font-family: Arial, Helvetica, sans-serif;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f7f7fb; padding:20px;">
+      <tr>
+        <td align="center">
+          <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
+            <tr>
+              <td style="color:#333333; font-size:16px; line-height:1.5;">
+                <p><%= t("partner_mailer.pilot_ending_email.greeting_html", name: @user.name).html_safe %></p>
+
+                <p><%= t("partner_mailer.pilot_ending_email.intro") %></p>
+
+                <% if @end_date %>
+                  <p style="background:#f4f2ff; border-radius:8px; padding:12px 16px; margin:16px 0;">
+                    <strong><%= t("partner_mailer.pilot_ending_email.end_date_label") %></strong>
+                    <%= @end_date.strftime("%B %d, %Y") %>
+                    <% if @days_left %>
+                      <span style="color:#666666;">(<%= t("partner_mailer.pilot_ending_email.days_left", count: @days_left) %>)</span>
+                    <% end %>
+                  </p>
+                <% end %>
+
+                <p><%= t("partner_mailer.pilot_ending_email.keep_going") %></p>
+
+                <p style="margin:20px 0;">
+                  <a href="<%= @plans_url %>" style="display:inline-block; background:#6c63ff; color:#ffffff; text-decoration:none; padding:12px 20px; border-radius:8px; font-weight:bold;"><%= t("partner_mailer.pilot_ending_email.cta") %></a>
+                </p>
+
+                <p><%= t("partner_mailer.pilot_ending_email.no_pressure") %></p>
+
+                <p>
+                  <a href="<%= @sign_in_url %>" style="color:#6c63ff; text-decoration:none;"><%= t("partner_mailer.pilot_ending_email.signin_link") %></a>
+                </p>
+
+                <hr style="border:none; border-top:1px solid #eeeeee; margin:24px 0;" />
+
+                <p style="color:#666666; font-size:14px;"><%= t("partner_mailer.pilot_ending_email.feedback_note_html", url: @partner_portal_url).html_safe %></p>
+
+                <p style="color:#666666; font-size:14px;"><%= t("partner_mailer.pilot_ending_email.signoff") %></p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -66,5 +66,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Daily (5am UTC) trial-ending reminder for RevenueCat (iOS/Apple) trialists ~REVENUECAT_TRIAL_REMINDER_LEAD_DAYS (default 3) before settings[\"trial_ends_at\"]. Apple/RevenueCat send no trial_will_end webhook (unlike Stripe), so this computes it and enqueues the shared MailchimpTrialWrapJob. Flags user.settings[\"rc_trial_wrap_sent\"] so each trial is nudged once.",
     },
+    "partner_pilot_ending" => {
+      "cron" => "30 5 * * *",
+      "class" => "PartnerPilotEndingJob",
+      "queue" => "default",
+      "description" => "Daily (5:30am UTC) Partner Pro pilot sweep. Emails partners a heads-up ~PARTNER_PILOT_REMINDER_LEAD_DAYS (default 14) before plan_expires_at (flags settings[\"partner_pilot_ending_notified\"]), and flags partners past plan_expires_at with settings[\"partner_pilot_expired\"] — NO auto-downgrade. Sends Brittany an AdminMailer digest of both so she can convert/extend/downgrade by hand.",
+    },
   })
 end

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -415,6 +415,21 @@ en:
       voice_html: "Your voice will directly shape the future of the <strong>SpeakAnyWay Partner Program</strong>. 💜"
       thanks: "Thank you for joining the journey!"
       signature: "Brittany"
+    pilot_ending_email:
+      subject: "Your SpeakAnyWay Partner pilot is wrapping up soon"
+      title: "Your Partner pilot is wrapping up"
+      greeting_html: "Hi <strong>%{name}</strong>,"
+      intro: "Your 3-month SpeakAnyWay Partner Pilot is coming to an end soon. We've loved having you build, test, and share boards with real students during the pilot."
+      end_date_label: "Your pilot runs through:"
+      days_left:
+        one: "1 day left"
+        other: "%{count} days left"
+      keep_going: "Want to keep your Pro-level access — all your boards, communicators, MySpeak IDs, and AI credits — without interruption? You can continue on a paid plan anytime."
+      cta: "See plans & continue"
+      no_pressure: "No pressure, and nothing disappears the moment the pilot ends — your boards stay put. This is just a heads-up so you can decide what's next for you and your students."
+      signin_link: "Sign in to your account"
+      feedback_note_html: "Have thoughts on the pilot? We'd love to hear them in the <a href=\"%{url}\">Partner Portal</a> — your feedback shapes what we build next. 💜"
+      signoff: "Thank you for being part of the journey, — Brittany"
 
   base_mailer:
     team_invitation_email:

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -403,6 +403,21 @@ es:
       voice_html: "Tu voz dará forma directa al futuro del <strong>Programa de Socios de SpeakAnyWay</strong>. 💜"
       thanks: "¡Gracias por unirte al camino!"
       signature: "Brittany"
+    pilot_ending_email:
+      subject: "Tu piloto de Socio de SpeakAnyWay está por terminar"
+      title: "Tu piloto de Socio está por terminar"
+      greeting_html: "Hola <strong>%{name}</strong>,"
+      intro: "Tu Piloto de Socio de SpeakAnyWay de 3 meses está por terminar pronto. Nos ha encantado tenerte creando, probando y compartiendo tableros con estudiantes reales durante el piloto."
+      end_date_label: "Tu piloto está disponible hasta:"
+      days_left:
+        one: "Queda 1 día"
+        other: "Quedan %{count} días"
+      keep_going: "¿Quieres mantener tu acceso de nivel Pro — todos tus tableros, comunicadores, IDs de MySpeak y créditos de IA — sin interrupción? Puedes continuar con un plan de pago en cualquier momento."
+      cta: "Ver planes y continuar"
+      no_pressure: "Sin presión, y nada desaparece en el momento en que termina el piloto — tus tableros se quedan. Esto es solo un aviso para que decidas qué sigue para ti y tus estudiantes."
+      signin_link: "Inicia sesión en tu cuenta"
+      feedback_note_html: "¿Tienes ideas sobre el piloto? Nos encantaría escucharlas en el <a href=\"%{url}\">Portal de Socios</a> — tus comentarios dan forma a lo que construimos. 💜"
+      signoff: "Gracias por ser parte del camino, — Brittany"
 
   base_mailer:
     team_invitation_email:

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -1,0 +1,44 @@
+namespace :partners do
+  # Read-only snapshot of where every Partner Pro pilot sits relative to its
+  # 3-month window. Mirrors the categories PartnerPilotEndingJob acts on so you
+  # can see who's ending soon / already ended without waiting for the daily
+  # digest. Changes nothing — safe to run any time.
+  #
+  #   bin/rails partners:pilot_status
+  #   PARTNER_PILOT_REMINDER_LEAD_DAYS=21 bin/rails partners:pilot_status
+  desc "List Partner Pro pilots by expiry status (read-only)"
+  task pilot_status: :environment do
+    lead_days = (ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"] || 14).to_i
+    now = Time.current
+    cutoff = now + lead_days.days
+
+    partners = User.where(plan_type: "partner_pro")
+    with_date = partners.where.not(plan_expires_at: nil)
+
+    expired = with_date.where("plan_expires_at <= ?", now).order(:plan_expires_at)
+    ending_soon = with_date.where("plan_expires_at > ? AND plan_expires_at <= ?", now, cutoff).order(:plan_expires_at)
+    active = with_date.where("plan_expires_at > ?", cutoff).order(:plan_expires_at)
+    no_date = partners.where(plan_expires_at: nil).order(:created_at)
+
+    print_group = lambda do |label, scope|
+      puts "\n#{label} (#{scope.size})"
+      puts("-" * 60)
+      scope.each do |u|
+        ends = u.plan_expires_at&.strftime("%Y-%m-%d") || "—"
+        flags = []
+        flags << "reminded" if u.settings.is_a?(Hash) && u.settings["partner_pilot_ending_notified"]
+        flags << "expired-flagged" if u.settings.is_a?(Hash) && u.settings["partner_pilot_expired"]
+        suffix = flags.any? ? "  [#{flags.join(', ')}]" : ""
+        puts "  ##{u.id}  #{u.email.ljust(34)}  ends #{ends}#{suffix}"
+      end
+    end
+
+    puts "\n=== Partner Pro pilot status (lead window: #{lead_days} days) ==="
+    puts "Total partner_pro: #{partners.size}"
+    print_group.call("🔔 ENDED (needs review — not downgraded)", expired)
+    print_group.call("⏳ ENDING SOON (within #{lead_days} days)", ending_soon)
+    print_group.call("✅ ACTIVE (beyond lead window)", active)
+    print_group.call("❔ NO plan_expires_at set", no_date)
+    puts
+  end
+end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -18,4 +18,27 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.html_part.body.decoded).to include("CRITICAL")
     end
   end
+
+  describe "#partner_pilot_review" do
+    it "addresses the admin, summarizes counts, and lists both groups" do
+      expiring = FactoryBot.create(:user, name: "Soon", email: "soon@example.com", plan_type: "partner_pro")
+      expiring.update_columns(plan_expires_at: 5.days.from_now)
+      expired = FactoryBot.create(:user, name: "Past", email: "past@example.com", plan_type: "partner_pro")
+      expired.update_columns(plan_expires_at: 3.days.ago)
+
+      mail = described_class.partner_pilot_review(expiring: [expiring], expired: [expired]).deliver_now
+
+      expect(mail.to).to eq([ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"])
+      expect(mail.subject).to eq("Partner pilots: 1 ended, 1 ending soon")
+      body = mail.html_part.body.decoded
+      expect(body).to include("soon@example.com")
+      expect(body).to include("past@example.com")
+    end
+
+    it "renders cleanly when a group is empty" do
+      mail = described_class.partner_pilot_review(expiring: [], expired: []).deliver_now
+      expect(mail.subject).to eq("Partner pilots: 0 ended, 0 ending soon")
+      expect(mail.html_part.body.decoded).to include("None.")
+    end
+  end
 end

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe PartnerMailer, type: :mailer do
       expect(mail.subject).to eq("Welcome to the SpeakAnyWay Partner Program!")
     end
   end
+
+  describe "#pilot_ending_email" do
+    let(:user) { FactoryBot.create(:user, name: "Pat", plan_type: "partner_pro") }
+
+    before { user.update_columns(plan_expires_at: 10.days.from_now) }
+
+    it "renders the English subject and body with the CTA" do
+      use_locale(user, "en-US")
+      mail = described_class.pilot_ending_email(user).deliver_now
+      expect(mail.subject).to eq("Your SpeakAnyWay Partner pilot is wrapping up soon")
+      expect(mail.html_part.body.decoded).to include("Hi <strong>Pat</strong>")
+      expect(mail.html_part.body.decoded).to include("See plans &amp; continue")
+    end
+
+    it "renders the Spanish subject and body" do
+      use_locale(user, "es-US")
+      mail = described_class.pilot_ending_email(user).deliver_now
+      expect(mail.subject).to eq("Tu piloto de Socio de SpeakAnyWay está por terminar")
+      expect(mail.html_part.body.decoded).to include("Hola <strong>Pat</strong>")
+    end
+  end
 end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response.body).not_to include("alice@example.com")
     end
 
+    it "filters Partner Pro accounts and chips their pilot status" do
+      partner = create(:user, email: "slp@example.com", plan_type: "partner_pro")
+      partner.update_columns(plan_expires_at: 2.days.ago)
+
+      get admin_dashboard_users_path(filter: "partner")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("slp@example.com")
+      expect(response.body).not_to include("alice@example.com")
+      expect(response.body).to include("Pilot ended")
+    end
+
     context "when not signed in" do
       before { sign_out admin }
 
@@ -97,6 +109,21 @@ RSpec.describe "Admin::Users", type: :request do
       user1.update(settings: { "board_limit" => 10 })
       get admin_dashboard_user_path(user1)
       expect(response.body).to include("board_limit")
+    end
+
+    it "shows a Partner Pilot card for partner_pro users" do
+      partner = create(:user, email: "pilot@example.com", plan_type: "partner_pro")
+      partner.update_columns(plan_expires_at: 10.days.from_now)
+
+      get admin_dashboard_user_path(partner)
+
+      expect(response.body).to include("Partner Pilot")
+      expect(response.body).to include("Pilot ends")
+    end
+
+    it "does not show the Partner Pilot card for non-partner users" do
+      get admin_dashboard_user_path(user2) # pro
+      expect(response.body).not_to include("Partner Pilot")
     end
   end
 

--- a/spec/sidekiq/partner_pilot_ending_job_spec.rb
+++ b/spec/sidekiq/partner_pilot_ending_job_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe PartnerPilotEndingJob, type: :job do
+  subject(:job) { described_class.new }
+
+  def create_partner(plan_expires_at:, settings: nil)
+    user = FactoryBot.create(:user, plan_type: "partner_pro", role: "partner")
+    user.update_columns(plan_expires_at: plan_expires_at)
+    user.update!(settings: settings) if settings
+    user.reload
+  end
+
+  def partner_reminder_mails
+    ActionMailer::Base.deliveries.select { |m| m.subject.match?(/pilot is wrapping up/i) }
+  end
+
+  def admin_digest
+    ActionMailer::Base.deliveries.find { |m| m.subject.include?("Partner pilots") }
+  end
+
+  before { ActionMailer::Base.deliveries.clear }
+
+  describe "#perform" do
+    context "a partner ending within the lead window" do
+      it "emails the partner and flags them reminded" do
+        user = create_partner(plan_expires_at: 5.days.from_now)
+
+        expect { job.perform }
+          .to change { user.reload.settings["partner_pilot_ending_notified"] }.to(true)
+        expect(partner_reminder_mails).not_to be_empty
+      end
+
+      it "does not re-email an already-reminded partner" do
+        create_partner(plan_expires_at: 5.days.from_now,
+                       settings: { "partner_pilot_ending_notified" => true })
+
+        job.perform
+
+        expect(partner_reminder_mails).to be_empty
+      end
+
+      it "does not change plan_type (no downgrade)" do
+        user = create_partner(plan_expires_at: 5.days.from_now)
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+      end
+    end
+
+    context "a partner past expiry" do
+      it "flags the pilot expired without downgrading" do
+        user = create_partner(plan_expires_at: 2.days.ago)
+
+        expect { job.perform }
+          .to change { user.reload.settings["partner_pilot_expired"] }.to(true)
+        expect(user.reload.plan_type).to eq("partner_pro")
+        expect(user.settings["partner_pilot_expired_at"]).to be_present
+      end
+
+      it "does not send the ending-soon email to an expired partner" do
+        create_partner(plan_expires_at: 2.days.ago)
+
+        job.perform
+
+        expect(partner_reminder_mails).to be_empty
+      end
+
+      it "does not re-flag an already-flagged partner" do
+        user = create_partner(
+          plan_expires_at: 2.days.ago,
+          settings: { "partner_pilot_expired" => true, "partner_pilot_expired_at" => 10.days.ago.iso8601 },
+        )
+        original = user.settings["partner_pilot_expired_at"]
+
+        job.perform
+
+        expect(user.reload.settings["partner_pilot_expired_at"]).to eq(original)
+      end
+    end
+
+    context "the admin digest" do
+      it "is sent once with a summary count when there are candidates" do
+        create_partner(plan_expires_at: 3.days.from_now)
+        create_partner(plan_expires_at: 1.day.ago)
+
+        job.perform
+
+        expect(admin_digest).to be_present
+        expect(admin_digest.subject).to eq("Partner pilots: 1 ended, 1 ending soon")
+      end
+
+      it "is not sent when nothing is ending or expired" do
+        create_partner(plan_expires_at: 60.days.from_now)
+
+        job.perform
+
+        expect(admin_digest).to be_nil
+      end
+    end
+
+    context "partners outside the window" do
+      it "ignores a partner with no plan_expires_at" do
+        user = create_partner(plan_expires_at: nil)
+
+        job.perform
+
+        expect(user.reload.settings["partner_pilot_ending_notified"]).to be_nil
+        expect(user.settings["partner_pilot_expired"]).to be_nil
+      end
+
+      it "ignores a partner expiring beyond the lead window" do
+        user = create_partner(plan_expires_at: 45.days.from_now)
+
+        job.perform
+
+        expect(user.reload.settings["partner_pilot_ending_notified"]).to be_nil
+        expect(partner_reminder_mails).to be_empty
+      end
+    end
+
+    context "with a custom PARTNER_PILOT_REMINDER_LEAD_DAYS" do
+      it "reminds partners inside the widened window" do
+        user = create_partner(plan_expires_at: 20.days.from_now)
+
+        climate = ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"]
+        ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"] = "30"
+        begin
+          job.perform
+        ensure
+          ENV["PARTNER_PILOT_REMINDER_LEAD_DAYS"] = climate
+        end
+
+        expect(user.reload.settings["partner_pilot_ending_notified"]).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The 3-month Partner Pro pilot (`/sign-up/partner`) granted Pro-level access with `plan_expires_at = now + 3.months`, but **nothing ever read that date** — partners kept Pro indefinitely and there was no signal to convert/extend/downgrade them.

This is **Phase 1**: keep the window meaningful **without auto-downgrading anyone** (partners are high-value B2B leads managed by hand). No Stripe changes.

### What it does
- **`PartnerPilotEndingJob`** (daily, 5:30am UTC via sidekiq-cron), one sweep over `partner_pro` users:
  - **Reminder pass** — partners within `PARTNER_PILOT_REMINDER_LEAD_DAYS` (default 14) of `plan_expires_at`, not yet reminded, get `PartnerMailer.pilot_ending_email` (a heads-up, not a shutoff; en + es). Flags `settings["partner_pilot_ending_notified"]` so it fires once.
  - **Expired pass** — partners past `plan_expires_at`, still `partner_pro`, get flagged `settings["partner_pilot_expired"]` (+ `partner_pilot_expired_at`). **No plan change.** Once-only.
  - Both feed a single **`AdminMailer.partner_pilot_review`** digest to `ADMIN_EMAIL` (only when there's something) so it's actionable by hand.
- **`rake partners:pilot_status`** — read-only list of pilots by status.
- **Admin dashboard** (server-rendered `/admin/*`):
  - Users list: new **Partner Pro** filter + status chips (`Ending soon` / `Pilot ended`) on partner rows.
  - User detail: a **Partner Pilot** card (status, end date, days left, reminder-sent, expired-flagged).
  - New read-only `Admin::MissionControlHelper#partner_pilot_status`.
- Docs: new "Partner Program (`partner_pro`)" section in `CLAUDE.md` + `CHANGELOG.md` entry.

**Phase 2 (not built):** if partner volume outgrows hand-management, move the pilot onto a real Stripe no-card trial (reuses the reverse-trial machinery — auto-expiry, `trial_will_end` reminder, clean cancel→Free, one-click conversion) and retire this job.

## Test plan
- `bundle exec rspec spec/sidekiq/partner_pilot_ending_job_spec.rb spec/mailers/partner_mailer_spec.rb spec/mailers/admin_mailer_spec.rb spec/requests/admin/users_spec.rb` → **40 examples, 0 failures**.
  - Job: reminder fires once in-window; expired flagged without downgrade; admin digest sent only when candidates exist; nil/out-of-window ignored; custom lead-days.
  - Mailers: en + es partner ending email; admin digest counts + empty-state.
  - Admin: Partner filter + chip on list; Partner Pilot card shows for partners / hidden for non-partners.
- `bundle exec rails zeitwerk:check` → all files load cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)