### PR TITLE
fix(partners): grant Pro credits at signup + treat Partner Pro as Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Partner Pro accounts now get full Pro credits + permissions immediately
+- Partner Pro signups were landing with the Free credit allowance (e.g. 25 AI
+  credits) instead of the Pro allowance (1,500), because credits were granted
+  while the account was still Free (before it was flipped to `partner_pro`) and
+  never re-granted. Partner signups now receive the Pro credit allowance
+  **immediately at signup** — no waiting on a background job.
+- Partner Pro is now treated as a Pro-equivalent tier everywhere: `pro?` returns
+  true for it, so partners get Pro permissions (paid-plan gates, 5 supporter
+  seats, communicator lending/hand-off, unlimited MySpeak IDs) to match their
+  already-Pro board/communicator limits. Previously partners were silently
+  treated as Free on those permission checks.
+- Backfill for existing partners stuck on the Free allowance:
+  `rake partners:grant_pro_credits` (dry-run by default; `DRY_RUN=false` to apply).
+
 ### Added — Partner Pro pilot expiry reminders (no auto-downgrade)
 - The 3-month Partner Pro pilot's end date (`plan_expires_at`) was previously
   set but never acted on, so partners kept Pro-level access indefinitely with no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,6 +518,26 @@ Entitlements equal Pro (`setup_partner_pro_plan` → 300 boards / 5 communicator
 local DB fields, which is why partners get Pro free for the pilot. `partner_pro`
 is in `RefreshFreeTierCreditsJob`'s refreshable set, so credits re-grant monthly.
 
+**Partner Pro is Pro-equivalent everywhere — `User#pro?` returns true for it.**
+`pro?` is `%w[pro pro_yearly partner_pro].include?(plan_type)`, so a partner is
+treated as Pro by `paid_plan?`, `partner_pro?` (`pro? && role == "partner"`),
+`supporter_limit` (5), the lending gate (`require_pro_for_lending!`), and the
+api_view `pro` flag. Before this, `pro?` was the exact string `"pro"`, so
+partners silently fell through to Free-level treatment on those checks (and
+`partner_pro?` was always false). Limits already came from `setup_partner_pro_plan`
+/ `board_group_limit` (both mirror `PRO_PLAN_LIMITS`); this fixes the boolean
+permission gates to match.
+
+**Credits are granted at signup, synchronously — not by cron.** The
+`after_create :grant_initial_plan_credits` hook runs while the account is still
+`free` (it's created before the controller flips it to `partner_pro`), granting
+the *free* allowance; `ensure_initial_grant!` then no-ops because a `plan_grant`
+already exists. So `handle_new_partner_pro_subscription` calls
+`CreditService.grant_plan!` with the `partner_pro` amount (1500) right after
+`user.save`, resetting the balance immediately. Backfill the pre-fix cohort
+(partners stuck on the free allowance) with `rake partners:grant_pro_credits`
+(dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope).
+
 **The 3-month window is surfaced but NOT enforced (Phase 1, deliberate).**
 `plan_expires_at` was previously set and never read — partners kept Pro forever
 with no signal. `PartnerPilotEndingJob` (daily 5:30am UTC, sidekiq-cron) closes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -286,7 +286,7 @@ class User < ApplicationRecord
   end
 
   def supporter_limit
-    plan_type == "pro" ? 5 : 2
+    pro? ? 5 : 2
   end
 
   # Communicator slot math:
@@ -511,6 +511,24 @@ class User < ApplicationRecord
     partner_group = user.get_partner_group
     user.settings["partner_group"] = partner_group
     user.save
+
+    # Grant the Partner Pro (Pro-equivalent) credit allowance IMMEDIATELY.
+    # The after_create :grant_initial_plan_credits hook already ran while the
+    # account was still `free` (granting the free allowance), and
+    # ensure_initial_grant! is a no-op once any plan_grant exists — so without
+    # this a partner would sit on the free allowance until a cron re-grant.
+    # grant_plan! resets the plan balance to the partner_pro monthly amount now.
+    begin
+      CreditService.grant_plan!(
+        user,
+        amount: CreditService.monthly_credits_for("partner_pro"),
+        period_end: CreditService.initial_period_end_for("partner_pro"),
+        metadata: { source: "partner_pro_signup", plan_type: "partner_pro" },
+      )
+    rescue => e
+      Rails.logger.error "Partner Pro credit grant failed for #{user&.email}: #{e.message}"
+    end
+
     begin
       # MailchimpService.new.update_subscriber_tags(user.email, [partner_group], [])
       Rails.logger.info "Recording new subscriber for Mailchimp: #{user.email} with tags: #{[partner_group]}"
@@ -1059,8 +1077,14 @@ class User < ApplicationRecord
     "User"
   end
 
+  # Partner Pro is a Pro-equivalent tier: partners get the same permissions and
+  # limits as paying Pro users (setup_partner_pro_plan mirrors PRO_PLAN_LIMITS),
+  # so pro? must treat it as Pro. This single predicate feeds paid_plan?,
+  # partner_pro?, supporter_limit, the lending gate, and the api_view `pro`
+  # flag — so a partner is Pro everywhere those are checked. pro_yearly is
+  # included for parity with the setup_limits / board_group_limit case bodies.
   def pro?
-    plan_type == "pro"
+    %w[pro pro_yearly partner_pro].include?(plan_type)
   end
 
   def pro_vendor?

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -41,4 +41,45 @@ namespace :partners do
     print_group.call("❔ NO plan_expires_at set", no_date)
     puts
   end
+
+  # Backfill: grant the Partner Pro (Pro-equivalent) credit allowance to any
+  # partner_pro user still sitting below it — the cohort created before the
+  # signup-time grant fix, who got the free allowance instead of 1500.
+  # Dry-run by default (reports only); apply with DRY_RUN=false. Scope to one
+  # user with USER_ID=N.
+  #
+  #   bin/rails partners:grant_pro_credits              # dry run
+  #   DRY_RUN=false bin/rails partners:grant_pro_credits
+  desc "Grant the Pro-equivalent credit allowance to under-granted Partner Pro users"
+  task grant_pro_credits: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    allowance = CreditService.monthly_credits_for("partner_pro")
+
+    scope = User.where(plan_type: "partner_pro")
+    scope = scope.where(id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+    shorted = scope.where("plan_credits_balance < ?", allowance)
+
+    puts "\n=== partners:grant_pro_credits (#{dry_run ? 'DRY RUN' : 'APPLYING'}) ==="
+    puts "Partner Pro allowance: #{allowance}"
+    puts "Under-granted partner_pro users: #{shorted.count}\n\n"
+
+    granted = 0
+    shorted.find_each do |user|
+      puts "  ##{user.id}  #{user.email.ljust(34)}  #{user.plan_credits_balance.to_i} -> #{allowance}"
+      next if dry_run
+
+      CreditService.grant_plan!(
+        user,
+        amount: allowance,
+        period_end: CreditService.initial_period_end_for("partner_pro"),
+        metadata: { source: "partner_pro_backfill", plan_type: "partner_pro" },
+      )
+      granted += 1
+    rescue => e
+      puts "    !! failed for ##{user.id}: #{e.message}"
+    end
+
+    puts "\n#{dry_run ? 'Would grant' : 'Granted'} #{dry_run ? shorted.count : granted} user(s)."
+    puts "Re-run with DRY_RUN=false to apply.\n\n" if dry_run
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,6 +62,29 @@ require "rails_helper"
 RSpec.describe User, type: :model do
   include ActiveJob::TestHelper
 
+  describe "Partner Pro is Pro-equivalent" do
+    let(:partner) { FactoryBot.create(:user, plan_type: "partner_pro", role: "partner") }
+
+    it "counts as pro? and paid_plan?" do
+      expect(partner.pro?).to be(true)
+      expect(partner.paid_plan?).to be(true)
+    end
+
+    it "reports partner_pro? true (pro? && role partner)" do
+      expect(partner.partner_pro?).to be(true)
+    end
+
+    it "gets the Pro supporter limit (5, not 2)" do
+      expect(partner.supporter_limit).to eq(5)
+    end
+
+    it "gets Pro board/communicator/board-set limits" do
+      expect(partner.board_limit).to eq(User::PRO_PLAN_LIMITS["board_limit"])
+      expect(partner.board_group_limit).to eq(User::PRO_PLAN_LIMITS["board_group_limit"])
+      expect(partner.settings["paid_communicator_limit"]).to eq(User::PRO_PLAN_LIMITS["paid_communicator_limit"])
+    end
+  end
+
   after(:all) do
     Team.destroy_all
     User.destroy_all

--- a/spec/requests/api/auth_spec.rb
+++ b/spec/requests/api/auth_spec.rb
@@ -172,6 +172,22 @@ RSpec.describe "API::V1::Auth", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "grants partner_pro signups the Pro credit allowance immediately" do
+      allow(MailchimpService).to receive(:new).and_return(instance_double(MailchimpService, record_new_subscriber: true))
+      allow_any_instance_of(User).to receive(:send_partner_welcome_email)
+
+      post "/api/v1/users", params: valid_params.merge(plan_type: "partner_pro")
+
+      expect(response).to have_http_status(:ok)
+      user = User.find_by(email: "new-free@example.com")
+      expect(user.plan_type).to eq("partner_pro")
+      # Not the free-tier allowance the after_create hook granted first.
+      expect(user.plan_credits_balance).to eq(CreditService.monthly_credits_for("partner_pro"))
+      expect(user.pro?).to be(true)
+      expect(user.paid_plan?).to be(true)
+      expect(user.supporter_limit).to eq(5)
+    end
+
     it "skips the welcome email when should_send_welcome_email? is false" do
       allow_any_instance_of(User).to receive(:should_send_welcome_email?).and_return(false)
       expect_any_instance_of(User).not_to receive(:send_welcome_email)


### PR DESCRIPTION
## Summary

Follow-up to #441. A `partner_pro` signup wasn't actually landing on Pro — two bugs:

### 1. Only got the Free credit allowance (the reported "25 AI tokens")
`after_create :grant_initial_plan_credits` runs while the account is still `free` (the controller flips it to `partner_pro` **after** save), so the partner got the Free allowance, and `ensure_initial_grant!` no-ops once a `plan_grant` row exists. `handle_new_partner_pro_subscription` now calls `CreditService.grant_plan!` with the `partner_pro` amount (1,500) right after save — **granted immediately at signup, no cron wait.**

### 2. Not treated as Pro for permissions
`User#pro?` was the exact string `"pro"`, so `partner_pro` fell through to Free-level treatment on `paid_plan?`, `supporter_limit` (2 vs 5), the communicator lending gate, and the api_view `pro` flag — and `partner_pro?` (`pro? && role`) was **always false**. `pro?` is now `%w[pro pro_yearly partner_pro].include?(plan_type)`, so partners are Pro-equivalent everywhere. Board/communicator/board-set **limits already** mirrored `PRO_PLAN_LIMITS`; this fixes the boolean permission gates to match.

### Backfill for the existing cohort
Partners who already signed up before this fix are stuck on the Free allowance. Grant them the Pro allowance:

```
DRY_RUN=false bin/rails partners:grant_pro_credits
```
(dry-run by default; `USER_ID=N` to scope to one account.)

## Test plan
- `bundle exec rspec spec/requests/api/auth_spec.rb spec/models/user_spec.rb` → **73 examples, 0 failures**.
  - Partner signup grants 1,500 credits immediately + is `pro?` / `paid_plan?` / `supporter_limit == 5`.
  - User model Pro-parity specs (`pro?`, `partner_pro?`, `paid_plan?`, supporter/board/board-set limits).
  - Existing auth + user suites unaffected by the `pro?` change.
- `rake partners:grant_pro_credits` loads and dry-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)