### PR TITLE
fix(mailchimp): stop retrying/re-surfacing permanent lead-sync errors

### DIFF
--- a/app/models/mailchimp_service.rb
+++ b/app/models/mailchimp_service.rb
@@ -36,10 +36,10 @@ class MailchimpService
     if e.status == 404
       result = record_new_subscriber(user)
       if result
-        puts "Successfully added subscriber for email #{email}. Retrying sign-in event."
+        Rails.logger.info("[Mailchimp] Added subscriber for #{email}. Retrying sign-in event.")
         retry
       else
-        puts "Failed to add subscriber for email #{email}. Cannot record sign-in event."
+        Rails.logger.error("[Mailchimp] Failed to add subscriber for #{email}. Cannot record sign-in event.")
       end
     end
     nil
@@ -96,7 +96,12 @@ class MailchimpService
     end
     response
   rescue MailchimpMarketing::ApiError => e
-    puts "Error recording new subscriber: #{e.message}"
+    # Swallowed so a Mailchimp blip can't break signup, but logged at error
+    # level with status + detail so a *permanent* config problem (e.g. an
+    # audience "required merge field" like ADDRESS rejecting every new-contact
+    # upsert with a 400) is visible instead of silently failing every signup
+    # sync. Was a bare `puts` that never reached the structured log / tracker.
+    Rails.logger.error("[Mailchimp] record_new_subscriber failed for #{email}: #{e.status} #{e.detail || e.message}")
     nil
   end
 

--- a/app/sidekiq/mailchimp_upsert_lead_job.rb
+++ b/app/sidekiq/mailchimp_upsert_lead_job.rb
@@ -23,6 +23,22 @@ class MailchimpUpsertLeadJob
   rescue MailchimpMarketing::ApiError => e
     Rails.logger.error("[Mailchimp] lead upsert API error: #{e.status} #{e.detail || e.message}")
     lead&.update(mailchimp_status: "failed")
-    raise
+    # Only retry transient failures (rate limiting / 5xx). A permanent 4xx —
+    # e.g. an audience "required merge field" the config demands but a bare
+    # email lead can't supply (the ADDRESS 400 that flooded error tracking) —
+    # fails identically on every retry, so re-raising just burns the retry
+    # budget into the Dead set and re-surfaces the same untriaged exception.
+    raise if transient_error?(e)
+  end
+
+  private
+
+  # A nil status means we never got an HTTP response (network/timeout), which is
+  # worth retrying. Otherwise only 429 (rate limited) and 5xx are transient.
+  def transient_error?(error)
+    status = error.status
+    return true if status.nil?
+
+    status == 429 || status >= 500
   end
 end

--- a/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
+++ b/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
@@ -21,11 +21,30 @@ RSpec.describe MailchimpUpsertLeadJob, type: :job do
       expect(lead.reload.mailchimp_status).to eq("synced")
     end
 
-    it "marks the lead failed and re-raises on a Mailchimp API error" do
+    it "marks the lead failed and re-raises on a transient (5xx) Mailchimp API error" do
       allow(mailchimp).to receive(:record_lead)
         .and_raise(MailchimpMarketing::ApiError.new(status: 500, message: "boom"))
 
       expect { job.perform(lead.id) }.to raise_error(MailchimpMarketing::ApiError)
+      expect(lead.reload.mailchimp_status).to eq("failed")
+    end
+
+    it "re-raises on a rate-limit (429) so Sidekiq retries" do
+      allow(mailchimp).to receive(:record_lead)
+        .and_raise(MailchimpMarketing::ApiError.new(status: 429, message: "slow down"))
+
+      expect { job.perform(lead.id) }.to raise_error(MailchimpMarketing::ApiError)
+      expect(lead.reload.mailchimp_status).to eq("failed")
+    end
+
+    it "marks the lead failed but does NOT re-raise on a permanent 4xx (e.g. required merge field)" do
+      allow(mailchimp).to receive(:record_lead)
+        .and_raise(MailchimpMarketing::ApiError.new(
+          status: 400,
+          detail: "Your merge fields were invalid.",
+        ))
+
+      expect { job.perform(lead.id) }.not_to raise_error
       expect(lead.reload.mailchimp_status).to eq("failed")
     end
 


### PR DESCRIPTION
## Summary

Fixes the prod `MailchimpMarketing::ApiError` (Untriaged) firing from `MailchimpUpsertLeadJob#perform`.

**Root cause:** the Mailchimp audience has **ADDRESS marked as a required merge field**. `MailchimpService#record_lead` only sends `FNAME` (anonymous free-board-download leads have no address), so every new-contact upsert is rejected with a permanent `400 — "Your merge fields were invalid. ADDRESS: Please enter a complete address."` The job re-raised on **any** `ApiError`, so with `retry: 3` each lead failed identically 3× into the Dead set and re-surfaced to error tracking every time.

> ⚠️ **The real fix is a config change you need to make:** in the Mailchimp audience → *Settings → Audience fields and \*|MERGE|\* tags*, set **ADDRESS** back to **not required**. Nothing in the app sends an address, and it shouldn't for a lead-capture flow. This 400 also silently breaks normal signup CRM sync (see below) — it only stopped alerting because `record_new_subscriber` swallows the error.

## Changes (code hardening)

- **`MailchimpUpsertLeadJob`** — only re-raise (retry) on **transient** errors: `429` (rate limit), `5xx`, or a nil status (no HTTP response). A permanent `4xx` marks the lead `failed` and stops — no wasted retries, no error-tracker spam.
- **Sibling audit / silent-failure fix** — `MailchimpService#record_new_subscriber` and `#record_signin_event` were swallowing API errors via bare `puts` (stdout only, no status/detail), which is why the same required-ADDRESS 400 on *signups* never surfaced. They now log at `Rails.logger.error` with `status` + `detail`, so a permanent config problem is visible while still not breaking the signup flow.

## Test plan

- `bundle exec rspec spec/sidekiq/mailchimp_upsert_lead_job_spec.rb spec/models/mailchimp_service_spec.rb` → **23 examples, 0 failures**
- New job specs: 5xx re-raises, 429 re-raises, permanent 400 marks `failed` **and does not re-raise**.
- `ruby -c` clean on both changed app files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)