### PR TITLE
feat(admin): show board IDs in the user detail boards table

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -230,6 +230,7 @@
       <table class="w-full text-sm">
         <thead>
           <tr style="border-bottom: 1px solid var(--border);">
+            <th class="text-left text-xs font-medium text-t2 px-5 py-3">ID</th>
             <th class="text-left text-xs font-medium text-t2 px-5 py-3">Name</th>
             <th class="text-left text-xs font-medium text-t2 px-5 py-3">Images</th>
             <th class="text-left text-xs font-medium text-t2 px-5 py-3">Updated</th>
@@ -238,6 +239,7 @@
         <tbody>
           <% @boards.each do |board| %>
             <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+              <td class="px-5 py-2.5 text-xs text-t3 font-mono"><%= board.id %></td>
               <td class="px-5 py-2.5 text-xs text-t1"><%= board.name %></td>
               <td class="px-5 py-2.5 text-xs text-t3"><%= board.board_images.size %></td>
               <td class="px-5 py-2.5 text-xs text-t3 whitespace-nowrap"><%= board.updated_at.strftime("%b %-d, %Y") %></td>


### PR DESCRIPTION
## What

Adds a **Board ID** column as the first column of the Boards table on the admin user detail page (`/admin/users/:id`).

The table now reads: **ID · Name · Images · Updated**, with the ID rendered in a monospace/muted style to match the existing admin styling.

## Why

Admins couldn't identify a specific board by its ID from the portal — only the name was shown, which isn't unique. Surfacing the ID makes it easy to cross-reference a board in the console, logs, or other tools.

## Notes

Template-only, presentational change in `app/views/admin/users/show.html.erb`. It surfaces `board.id`, an attribute already loaded on `@boards` — no controller, model, query, or authorization changes. No test impact (view-only, no logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)