### PR TITLE
fix(partners): repair broken Mailchimp call + add stable journey trigger tag

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -530,9 +530,13 @@ class User < ApplicationRecord
     end
 
     begin
-      # MailchimpService.new.update_subscriber_tags(user.email, [partner_group], [])
-      Rails.logger.info "Recording new subscriber for Mailchimp: #{user.email} with tags: #{[partner_group]}"
-      MailchimpService.new.record_new_subscriber(user.email, [partner_group])
+      # "Partner Program" is the stable trigger tag the Partner Mailchimp
+      # Customer Journey fires on; the monthly PartnerPro_<Month> cohort tag
+      # stays for per-cohort reporting. Pass the User object + tags: keyword —
+      # record_new_subscriber reads user.email/first_name/etc, not a String.
+      partner_tags = ["Partner Program", partner_group]
+      Rails.logger.info "Recording new subscriber for Mailchimp: #{user.email} with tags: #{partner_tags}"
+      MailchimpService.new.record_new_subscriber(user, tags: partner_tags)
     rescue => e
       Rails.logger.error "Mailchimp tag update failed for pilot_partner: #{e.message}"
     end

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -82,4 +82,43 @@ namespace :partners do
     puts "\n#{dry_run ? 'Would grant' : 'Granted'} #{dry_run ? shorted.count : granted} user(s)."
     puts "Re-run with DRY_RUN=false to apply.\n\n" if dry_run
   end
+
+  # One-off: (re)record existing partners in Mailchimp with the stable
+  # "Partner Program" trigger tag plus their monthly PartnerPro_<Month> cohort
+  # tag. Needed because the signup-time tagging call was broken (passed a String
+  # where a User was expected), so partners created before that fix likely have
+  # no Mailchimp record — and thus can't enter the Partner Customer Journey.
+  # Dry-run by default (reports only); apply with DRY_RUN=false. Scope to one
+  # user with USER_ID=N.
+  #
+  # NOTE: if the journey is already live, backfilled partners enter at step 1 —
+  # fine for a relaunch, but they'll get the sequence fresh.
+  #
+  #   bin/rails partners:backfill_mailchimp_tags              # dry run
+  #   DRY_RUN=false bin/rails partners:backfill_mailchimp_tags
+  desc "Tag existing partners in Mailchimp with the stable 'Partner Program' trigger tag"
+  task backfill_mailchimp_tags: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    scope = User.where(role: "partner")
+    scope = scope.where(id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    puts "\n=== partners:backfill_mailchimp_tags (#{dry_run ? 'DRY RUN' : 'APPLYING'}) ==="
+    puts "Partners (role: partner): #{scope.count}\n\n"
+
+    tagged = 0
+    scope.find_each do |user|
+      tags = ["Partner Program", user.get_partner_group]
+      puts "  ##{user.id}  #{user.email.ljust(34)}  tags #{tags}"
+      next if dry_run
+
+      MailchimpService.new.record_new_subscriber(user, tags: tags)
+      tagged += 1
+    rescue => e
+      puts "    !! failed for ##{user.id}: #{e.message}"
+    end
+
+    puts "\n#{dry_run ? 'Would tag' : 'Tagged'} #{dry_run ? scope.count : tagged} partner(s)."
+    puts "Re-run with DRY_RUN=false to apply.\n\n" if dry_run
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,6 +85,29 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe ".handle_new_partner_pro_subscription" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "records the subscriber with the stable 'Partner Program' tag and the monthly cohort tag" do
+      mailchimp = instance_double(MailchimpService)
+      allow(MailchimpService).to receive(:new).and_return(mailchimp)
+
+      expect(mailchimp).to receive(:record_new_subscriber)
+        .with(user, tags: ["Partner Program", user.get_partner_group])
+
+      User.handle_new_partner_pro_subscription(user)
+    end
+
+    it "does not raise if the Mailchimp call fails (rescued)" do
+      mailchimp = instance_double(MailchimpService)
+      allow(MailchimpService).to receive(:new).and_return(mailchimp)
+      allow(mailchimp).to receive(:record_new_subscriber).and_raise(StandardError, "boom")
+
+      expect { User.handle_new_partner_pro_subscription(user) }.not_to raise_error
+      expect(user.reload.role).to eq("partner")
+    end
+  end
+
   after(:all) do
     Team.destroy_all
     User.destroy_all


### PR DESCRIPTION
## Summary

Fixes the broken Mailchimp tagging call on the Partner Pro provisioning path and adds the stable `Partner Program` trigger tag the Partner Customer Journey fires on.

The bug: `User.handle_new_partner_pro_subscription` called `record_new_subscriber(user.email, [partner_group])`, but the method signature is `record_new_subscriber(user, tags: [])` — a **String** where a **User** is expected, and a **positional** arg where `tags:` is **keyword-only**. That raised `ArgumentError` on every partner signup. The surrounding `begin/rescue` logged `"Mailchimp tag update failed for pilot_partner"` and swallowed it, so partners were **silently never recorded in Mailchimp** on the main path — and therefore couldn't enter the journey.

## Changes

- **`app/models/user.rb`** — pass the `user` object + `tags:` keyword, and include the stable `"Partner Program"` tag alongside the monthly `PartnerPro_<Month>` cohort tag (kept for per-cohort reporting). The `begin/rescue` is preserved so a Mailchimp hiccup still can't block partner creation.
- **`lib/tasks/partners.rake`** — new `partners:backfill_mailchimp_tags` task (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope) to (re)tag existing `role: "partner"` users so they enter the journey.
- **`spec/models/user_spec.rb`** — specs asserting the corrected `(user, tags: ["Partner Program", <cohort>])` call and that a Mailchimp failure is rescued (partner still provisioned).

Confirmed the only broken call site was `user.rb:535`; all other `record_new_subscriber` callers already use the `(user, tags:)` shape.

No migration, no new ENV var. Should land before the Partner Mailchimp journey goes live — the trigger depends on the tag existing.

## Test plan

- `bundle exec rspec spec/models/user_spec.rb` (new `.handle_new_partner_pro_subscription` block + existing partner block) — **6 examples, 0 failures**
- `bundle exec rspec spec/requests/api/auth_spec.rb -e partner` — **2 examples, 0 failures**
- `bundle exec rspec spec/models/mailchimp_service_spec.rb` — **18 examples, 0 failures**
- `bin/rails -T partners` shows the new `partners:backfill_mailchimp_tags` task registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)