### PR TITLE
chore(mailchimp): recover failed DownloadLead syncs

### DIFF
--- a/lib/tasks/mailchimp.rake
+++ b/lib/tasks/mailchimp.rake
@@ -35,4 +35,32 @@ namespace :mailchimp do
     MailchimpUpsertSubscriberJob.perform_async(user.id)
     puts "Enqueued MailchimpUpsertSubscriberJob for user #{user.id} (#{user.email})"
   end
+
+  # Re-enqueue DownloadLeads whose Mailchimp sync failed (mailchimp_status
+  # "failed") — e.g. after fixing the contact data / audience config that
+  # rejected them (the required-merge-field 400). Dry-run by default; set
+  # DRY_RUN=false to actually reset status to "pending" and enqueue the job.
+  # Scope to one address with EMAIL=someone@example.com.
+  desc "Re-enqueue failed DownloadLead Mailchimp syncs (DRY_RUN=false to apply, EMAIL= to scope)"
+  task :retry_failed_leads => :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    scope = DownloadLead.mailchimp_failed
+    scope = scope.where(email: ENV["EMAIL"]) if ENV["EMAIL"].present?
+
+    total = scope.count
+    puts "Found #{total} failed lead(s)#{ENV["EMAIL"].present? ? " for #{ENV["EMAIL"]}" : ""}."
+    if dry_run
+      scope.find_each { |lead| puts "[dry-run] would re-enqueue lead #{lead.id} (#{lead.email})" }
+      puts "Dry run — nothing enqueued. Re-run with DRY_RUN=false to apply."
+    else
+      count = 0
+      scope.find_each do |lead|
+        lead.update(mailchimp_status: DownloadLead::MAILCHIMP_PENDING)
+        MailchimpUpsertLeadJob.perform_async(lead.id)
+        count += 1
+        puts "Re-enqueued lead #{lead.id} (#{lead.email})"
+      end
+      puts "Re-enqueued #{count} lead(s)."
+    end
+  end
 end

--- a/spec/lib/tasks/mailchimp_retry_failed_leads_rake_spec.rb
+++ b/spec/lib/tasks/mailchimp_retry_failed_leads_rake_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "mailchimp:retry_failed_leads", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["mailchimp:retry_failed_leads"] }
+
+  after do
+    task.reenable
+    ENV.delete("DRY_RUN")
+    ENV.delete("EMAIL")
+  end
+
+  def invoke_task
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    task.invoke
+    output.string
+  ensure
+    $stdout = original_stdout
+  end
+
+  let!(:failed_lead) do
+    FactoryBot.create(:download_lead, email: "fail@example.com",
+                                      mailchimp_status: DownloadLead::MAILCHIMP_FAILED)
+  end
+  let!(:synced_lead) do
+    FactoryBot.create(:download_lead, email: "ok@example.com",
+                                      mailchimp_status: DownloadLead::MAILCHIMP_SYNCED)
+  end
+
+  it "dry-runs by default: lists failed leads, enqueues nothing, no writes" do
+    expect(MailchimpUpsertLeadJob).not_to receive(:perform_async)
+
+    output = invoke_task
+
+    expect(output).to include("Found 1 failed lead")
+    expect(output).to include(failed_lead.email)
+    expect(output).to include("Dry run")
+    expect(failed_lead.reload.mailchimp_status).to eq(DownloadLead::MAILCHIMP_FAILED)
+  end
+
+  it "with DRY_RUN=false resets status to pending and enqueues the job for failed leads only" do
+    ENV["DRY_RUN"] = "false"
+    expect(MailchimpUpsertLeadJob).to receive(:perform_async).with(failed_lead.id).once
+    expect(MailchimpUpsertLeadJob).not_to receive(:perform_async).with(synced_lead.id)
+
+    invoke_task
+
+    expect(failed_lead.reload.mailchimp_status).to eq(DownloadLead::MAILCHIMP_PENDING)
+    expect(synced_lead.reload.mailchimp_status).to eq(DownloadLead::MAILCHIMP_SYNCED)
+  end
+
+  it "scopes to a single address with EMAIL" do
+    other_failed = FactoryBot.create(:download_lead, email: "other@example.com",
+                                                     mailchimp_status: DownloadLead::MAILCHIMP_FAILED)
+    ENV["DRY_RUN"] = "false"
+    ENV["EMAIL"] = failed_lead.email
+    expect(MailchimpUpsertLeadJob).to receive(:perform_async).with(failed_lead.id).once
+    expect(MailchimpUpsertLeadJob).not_to receive(:perform_async).with(other_failed.id)
+
+    invoke_task
+
+    expect(other_failed.reload.mailchimp_status).to eq(DownloadLead::MAILCHIMP_FAILED)
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #443. Adds a rake task to re-run `DownloadLead`s stuck in `mailchimp_status: "failed"` once the underlying cause is cleared.

**Context / corrected diagnosis:** the original ADDRESS 400 was **not** an audience-config problem — ADDRESS is not marked required. Production has only **3 failed lead rows across 2 emails** (`audrey.king@sunshine.org`, `ebarnabee@coveschool.org`), which points to a **per-contact** cause: those emails already exist in the audience with a **partial ADDRESS**, and Mailchimp re-validates the whole record on `set_list_member` (upsert), rejecting an incomplete address even though our request never sends one. Fix the contact data in Mailchimp (complete or clear the address), then re-run these leads.

## Change

- **`rake mailchimp:retry_failed_leads`** — re-enqueues `MailchimpUpsertLeadJob` for every `DownloadLead` with `mailchimp_status: "failed"`.
  - **Dry-run by default** (repo convention) — lists what it would do, enqueues nothing. `DRY_RUN=false` to apply.
  - `EMAIL=someone@example.com` scopes to a single address.
  - On apply: resets status to `"pending"` and enqueues the job.

## Recovery runbook

1. In Mailchimp, fix the ADDRESS on `audrey.king@sunshine.org` and `ebarnabee@coveschool.org` (complete or clear it).
2. `bin/rails mailchimp:retry_failed_leads` (dry-run — confirm the list).
3. `DRY_RUN=false bin/rails mailchimp:retry_failed_leads` to re-sync.

## Test plan

- `bundle exec rspec spec/lib/tasks/mailchimp_retry_failed_leads_rake_spec.rb` → **3 examples, 0 failures** (dry-run makes no writes/enqueues; apply resets status + enqueues failed leads only; EMAIL scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)