### PR TITLE
fix(board-builder): stop Core 84 injecting an unrequested "Social" folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1263,6 +1263,20 @@ still works for backward compat.
   extended→core-84/10-15), `SEED_SET_PAGES`, `CATEGORY_SEED_ALIASES` (maps
   InterestCategories names like "Family & People" to seed set page names like
   "People").
+  - **No-interest defaults must be a subset of the level's seed pages.**
+    `STARTER_/STANDARD_/EXTENDED_DEFAULTS` are the categories seeded when the
+    child gives no interests. They **must** all be `SEED_SET_PAGES` of that
+    level's core template — a default that isn't a seed page resolves to
+    `:prebuilt`/`:ai_generated` and `add_fringe_pages!` adds it as an **extra
+    top-level folder**, which on the full authored Core 84 grid (84 tiles, no
+    open cells) spills onto a stray extra row. That was the "Core 84 builds an
+    unrequested `Social` folder + orphans a tile onto row 8" bug: `Social` sat
+    in `EXTENDED_DEFAULTS` but isn't a core-84 seed page, so a no-interest
+    Extended build injected it whenever the seed root reported a phantom open
+    cell (a latent tile overlap inflating `open_grid_cells`). Core 60 was
+    unaffected because its defaults are all seed pages. Invariant enforced by a
+    `structure_planner_spec` test; if you add a level or default, keep defaults
+    ⊆ seed pages.
 - **`Boards::FringeTemplates`** — module for standalone fringe page templates.
   Seeded from `db/seeds/board_builder_sets/fringe-pages/*.obf` via
   `bin/rails fringe_templates:seed` (also auto-runs after `vocab_sets:seed`).

--- a/app/services/boards/structure_planner.rb
+++ b/app/services/boards/structure_planner.rb
@@ -8,9 +8,15 @@ module Boards
 
     LEVEL_KEYS = LEVELS.keys.freeze
 
+    # Default categories seeded per level when the child gives no interests.
+    # These MUST stay a subset of the level's SEED_SET_PAGES so a no-interest
+    # build is exactly the authored core grid (a clean single page). A default
+    # that isn't a seed page resolves to :prebuilt/:ai_generated and gets added
+    # as an extra top-level folder — which, on the full authored Core 84 grid,
+    # spills onto a stray extra row (the "Social folder + orphaned tile" bug).
     STARTER_DEFAULTS  = %w[Food Feelings].freeze
     STANDARD_DEFAULTS = %w[Food Feelings Play People].freeze
-    EXTENDED_DEFAULTS = %w[Food Feelings Play People Places Body Social].freeze
+    EXTENDED_DEFAULTS = %w[Food Feelings Play People Places Body].freeze
 
     # Fringe pages that ship with each seed set (authored content, stable).
     SEED_SET_PAGES = {
@@ -164,9 +170,9 @@ module Boards
     # Drop AI pages that don't clear MIN_AI_PAGE_INTERESTS. Their category is no
     # longer planned, so collect_catch_all folds the words into catch_all (then
     # routed to an existing board or My Favorites at build time). Seed/prebuilt
-    # pages are intentionally left alone — they're curated/default content, and
-    # gating them would drop legitimate zero-interest defaults (e.g. prebuilt
-    # "Social" in Extended).
+    # pages are intentionally left alone — they're curated content and can carry
+    # interest words routed in later; only AI pages (paid, generated per word)
+    # are gated here.
     def drop_sparse_ai_pages(fringe_pages)
       fringe_pages.reject do |page|
         page[:source] == :ai_generated &&

--- a/spec/services/boards/structure_planner_spec.rb
+++ b/spec/services/boards/structure_planner_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe Boards::StructurePlanner do
       expect(names).to include("Food", "Feelings")
     end
 
+    # Invariant: a no-interest build must be exactly the authored core grid (a
+    # clean single page). That only holds if every default category is already a
+    # seed page of the level's core template — a non-seed default resolves to
+    # :prebuilt/:ai_generated and gets added as an extra folder that spills the
+    # grid (the Core 84 "Social folder + orphaned tile" regression).
+    it "keeps every level's no-interest defaults inside the core template's seed pages" do
+      {
+        "starter"  => "core-60",
+        "standard" => "core-60",
+        "extended" => "core-84",
+      }.each do |level, template|
+        plan = described_class.new(level: level, interests: [], include_phrases: false).call
+        expect(plan.fringe_pages).to all(satisfy { |p| p[:source] == :seed_set }),
+          "#{level}: no-interest defaults must all be seed pages, got " \
+          "#{plan.fringe_pages.reject { |p| p[:source] == :seed_set }.map { |p| [p[:name], p[:source]] }.inspect}"
+
+        seed_pages = described_class::SEED_SET_PAGES[template].map(&:downcase)
+        default_consts = described_class.const_get("#{level.upcase}_DEFAULTS")
+        expect(default_consts.map(&:downcase)).to all(be_in(seed_pages)),
+          "#{level}_DEFAULTS must be a subset of #{template} seed pages"
+      end
+    end
+
     it "includes categories from interests" do
       plan = described_class.new(level: "starter", interests: ["dog", "cat"]).call
       names = plan.fringe_pages.map { |p| p[:name] }

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -40,12 +40,26 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     root
   end
 
-  def build!(interests)
+  def build!(interests, include_phrases: nil)
     root = precreate_root!
     norm = Boards::InterestWords.normalize_list(interests)
     cats = Boards::InterestWords.extract_categories(interests)
-    described_class.new.perform(root.id, communicator.id, "extended", norm, cats)
+    opts = include_phrases.nil? ? {} : { "include_phrases" => include_phrases }
+    described_class.new.perform(root.id, communicator.id, "extended", norm, cats, opts)
     root.reload
+  end
+
+  # Force a latent overlap in the admin-owned seed root so two authored tiles
+  # share one cell — open_grid_cells then reports a phantom free cell (84 tiles
+  # occupying 83 unique cells). This is the real prod condition that let a
+  # no-interest default "Social" folder slip onto the full Core 84 grid.
+  def overlap_seed_grid!
+    seed_root = Boards::RobustSets.find_root("core-84")
+    bi = seed_root.board_images.order(:position).last
+    bi.layout["lg"] = { "x" => 0, "y" => 0, "w" => 1, "h" => 1, "i" => bi.id.to_s }
+    bi.save!
+    seed_root.update_board_layout("lg")
+    seed_root.reload
   end
 
   # Pad the admin-owned seed root so the per-user clone starts with `remaining`
@@ -119,6 +133,30 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(root.status).to eq("complete")
     expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
     expect(dead_folder_tiles(root)).to be_empty
+  end
+
+  # Regression: Core 84, GLP unchecked (include_phrases: false) + no interests
+  # must be exactly the authored 84 — no injected "Social" folder, no orphaned
+  # 8th-row tile. Reproduces the reported bug both on a clean seed AND when the
+  # seed carries a latent overlap (the prod condition that inflated
+  # open_grid_cells and let a no-interest default folder slip in).
+  [false, true].each do |with_overlap|
+    it "stays a clean 84 with no GLP and no interests#{' even when the seed has an overlap' if with_overlap}" do
+      overlap_seed_grid! if with_overlap
+
+      root = build!([], include_phrases: false)
+
+      expect(root.status).to eq("complete")
+      expect(root.board_images.count).to eq(CORE_84_GRID_CELLS)
+      # No non-authored default folder was injected.
+      expect(root.board_images.map(&:label)).not_to include("Social")
+      # The authored question word stays in-grid (row index 4), never orphaned
+      # onto a stray 8th row.
+      who = root.board_images.find { |bi| bi.label == "who" }
+      expect(who).to be_present
+      expect(root.large_screen_rows).to eq(7)
+      expect(dead_folder_tiles(root)).to be_empty
+    end
   end
 
   it "mutes the name on dynamic folder tiles, leaving word tiles unmuted" do


### PR DESCRIPTION
## What & why

Extended (Core 84) builds with **no interests and no GLP** rendered **85 tiles** — an unauthored **"Social" folder** plus an orphaned tile (`who`) on a stray 8th row. Core 60 built fine.

**Root cause (two things combined):**
1. `EXTENDED_DEFAULTS` listed `"Social"`, which is **not** a core-84 seed page, so it resolved to a `:prebuilt` fringe page the build tries to add — even with zero interests. Core 60's defaults are all seed pages, so nothing is ever added (hence the divergence).
2. The full-grid guard that should skip a no-interest default was defeated by a **latent tile overlap in the seed root** (two tiles on one cell → `open_grid_cells` reports a phantom free cell), letting `Social` slip in and displace the authored `who` tile onto a new row.

The core-84 seed *file* is a clean 84; this was purely a build-path bug. I reproduced the exact break (85 tiles + Social) by simulating the seed overlap.

## The fix

Drop `"Social"` from `EXTENDED_DEFAULTS` so the defaults are a subset of the core-84 seed pages (mirrors Starter/Standard). A no-interest Extended build is now a clean **84 regardless of the overlap**. `Social` still appears when the child actually has a Social-category interest (that comes from interests, not defaults).

One functional line changed; the rest is comments, tests, and a CLAUDE.md note documenting the **"no-interest defaults must be a subset of the level's seed pages"** invariant.

## Test plan

`bundle exec rspec spec/services/boards/structure_planner_spec.rb spec/sidekiq/build_board_set_job_grid_spec.rb` → **38 examples, 0 failures.**

New coverage:
- **Planner invariant** — every level's no-interest defaults are all `:seed_set` / a subset of `SEED_SET_PAGES` (fast guard against this regression class).
- **Core 84 integration** — no-GLP/no-interest builds to exactly 84 tiles, no `Social`, `who` stays in-grid (7 rows), tested on **both a clean seed and an overlapped seed** (the reproduced prod condition).
- Existing with-interest growth + GLP cases unchanged.

## Note (optional follow-up, not blocking)

The build is now robust to a seed overlap, but the overlap in the **prod seed root itself** is a separate latent issue (the seed renders with a hidden tile — "84 looks like 82"). To clean that on staging/prod: `bin/rails vocab_sets:seed` then `DRY_RUN=false bin/rails board_builder:repair_grid`. Not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)