### PR TITLE
feat(mailchimp): source-aware lead tags for classroom_kit leads

### DIFF
--- a/app/sidekiq/mailchimp_upsert_lead_job.rb
+++ b/app/sidekiq/mailchimp_upsert_lead_job.rb
@@ -7,7 +7,10 @@ class MailchimpUpsertLeadJob
   include Sidekiq::Job
   sidekiq_options queue: :default, retry: 3, backtrace: true
 
-  LEAD_TAG = "BoardDownloadLead".freeze
+  DEFAULT_LEAD_TAG = "BoardDownloadLead".freeze
+  # Source-specific Mailchimp tags so distinct lead funnels can be segmented.
+  # Anything not listed here falls back to DEFAULT_LEAD_TAG (existing behavior).
+  SOURCE_TAGS = { "classroom_kit" => "ClassroomKitLead" }.freeze
 
   def perform(download_lead_id)
     lead = DownloadLead.find_by(id: download_lead_id)
@@ -16,7 +19,7 @@ class MailchimpUpsertLeadJob
     MailchimpService.new.record_lead(
       email: lead.email,
       name: lead.name,
-      tags: [LEAD_TAG],
+      tags: [tag_for(lead)],
     )
 
     lead.update(mailchimp_status: "synced")
@@ -32,6 +35,12 @@ class MailchimpUpsertLeadJob
   end
 
   private
+
+  # Derive the Mailchimp tag from the lead's source so different capture funnels
+  # (e.g. the /classroom kit) land under their own segmentable tag.
+  def tag_for(lead)
+    SOURCE_TAGS.fetch(lead.source, DEFAULT_LEAD_TAG)
+  end
 
   # A nil status means we never got an HTTP response (network/timeout), which is
   # worth retrying. Otherwise only 429 (rate limited) and 5xx are transient.

--- a/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
+++ b/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe MailchimpUpsertLeadJob, type: :job do
       expect(lead.reload.mailchimp_status).to eq("synced")
     end
 
+    it "uses the ClassroomKitLead tag for a classroom_kit source lead" do
+      classroom_lead = create(:download_lead, email: "teacher@example.com", name: "Sam", source: "classroom_kit")
+
+      expect(mailchimp).to receive(:record_lead).with(
+        email: "teacher@example.com",
+        name: "Sam",
+        tags: ["ClassroomKitLead"],
+      )
+
+      job.perform(classroom_lead.id)
+
+      expect(classroom_lead.reload.mailchimp_status).to eq("synced")
+    end
+
     it "marks the lead failed and re-raises on a transient (5xx) Mailchimp API error" do
       allow(mailchimp).to receive(:record_lead)
         .and_raise(MailchimpMarketing::ApiError.new(status: 500, message: "boom"))


### PR DESCRIPTION
## Summary

Makes `MailchimpUpsertLeadJob`'s Mailchimp tag **source-aware** so leads captured through the new `/classroom` page (`POST /api/download_leads` with `source: "classroom_kit"`) sync under their own tag, `ClassroomKitLead`, instead of sharing `BoardDownloadLead` with free-board-download leads. That lets the classroom funnel be segmented and measured.

- Replaces the single `LEAD_TAG` constant with `DEFAULT_LEAD_TAG` + a `SOURCE_TAGS` lookup (`"classroom_kit" => "ClassroomKitLead"`).
- Any source not in the map falls back to `BoardDownloadLead`, so existing free-board leads are **unchanged**.
- Existing error handling (transient vs. permanent Mailchimp API errors) is untouched.

No migration, no new ENV vars — pure job logic + spec. Ships independently of the frontend `/classroom` PR (order doesn't matter). Mailchimp auto-creates the `ClassroomKitLead` tag on first use.

Implements `.claude-notes/classroom-lead-tag-handoff.md`.

## Test plan

`bundle exec rspec spec/sidekiq/mailchimp_upsert_lead_job_spec.rb spec/requests/api/download_leads_spec.rb`

- **10 examples, 0 failures.**
- New spec: a `source: "classroom_kit"` lead calls `record_lead` with `tags: ["ClassroomKitLead"]` and is marked synced.
- Existing default-source case still uses `tags: ["BoardDownloadLead"]`; error-handling cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)