### PR TITLE
feat(internal-api): create board from curated vocab set (from_vocab_set) (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — internal API endpoint to create a board from a curated vocab set
+- New `POST /api/internal/boards/from_vocab_set` (behind `INTERNAL_API_KEY`)
+  clones the ROOT grid of a curated Board Builder vocab set (`core-60` /
+  `core-84`) into a fresh admin-owned board and returns it as JSON (`201`), so an
+  internal caller (the printables marketing generator) can source a poster from
+  vetted core vocabulary and immediately export it to PDF. v1 clones only the
+  root grid, not the linked fringe tree. Returns `404 vocab_set_not_seeded` when
+  the requested set isn't seeded in the environment (no `500`). Additive — no
+  migration, no new ENV var, and `create`/`update`/`show`/`export` are unchanged.
+
 ### Added — new-subscriber onboarding email when a paid plan starts
 - New Mailchimp `subscription_started` Customer Journey fires when a user
   converts to an active paid plan (the non-active→active transition in the

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -40,6 +40,32 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     end
   end
 
+  # POST /api/internal/boards/from_vocab_set
+  #
+  # Clone the ROOT board of a curated Board Builder vocab set (core-60 /
+  # core-84) into a fresh admin-owned board the caller can immediately export
+  # to PDF. v1 clones only the root grid (the poster surface), not the linked
+  # fringe tree. 404s (not 500s) when the requested set isn't seeded here.
+  def from_vocab_set
+    root = Boards::RobustSets.find_root(params[:slug])
+
+    if root.nil?
+      render json: { error: "vocab_set_not_seeded", slug: params[:slug] }, status: :not_found
+      return
+    end
+
+    board = root.clone_with_images(current_user.id, params[:name].presence || root.name)
+
+    unless board&.persisted?
+      render json: { error: "clone_failed", slug: params[:slug] }, status: :unprocessable_content
+      return
+    end
+
+    finalize_cloned_vocab_board!(board)
+
+    render json: board.api_view_with_images(current_user), status: :created
+  end
+
   def show
     @board = Board.find(params[:id])
     render json: @board.api_view_with_images(current_user)
@@ -114,6 +140,25 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
   end
 
   private
+
+  # The clone inherits the seed root's settings via `dup`, which would carry
+  # the robust-set markers and make it look like a *second* seeded root for the
+  # slug (polluting Boards::RobustSets.find_root / the wizard catalog). Strip
+  # them, then apply any caller-supplied tags/settings. Always saves — removing
+  # the markers is itself a change.
+  def finalize_cloned_vocab_board!(board)
+    settings = board.settings || {}
+    settings.delete(Boards::RobustSets::ROOT_MARKER)
+    settings.delete(Boards::RobustSets::SLUG_MARKER)
+    settings = settings.merge(params[:settings].to_unsafe_h) if params[:settings].present?
+    board.settings = settings
+
+    if params[:tags].present?
+      board.tags = Array(params[:tags]).select { |t| t.is_a?(String) && t.present? }
+    end
+
+    board.save
+  end
 
   def enqueue_generation_job!(creation_type)
     word_count = (params[:wordCount].presence || params[:word_count].presence || 12).to_i

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,6 +394,9 @@ Rails.application.routes.draw do
 
     namespace :internal do
       resources :boards, only: [:create, :update, :show] do
+        collection do
+          post :from_vocab_set
+        end
         member do
           get :export, action: :export_pdf, defaults: { format: :pdf }
         end

--- a/spec/requests/api/internal/boards_from_vocab_set_spec.rb
+++ b/spec/requests/api/internal/boards_from_vocab_set_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::Boards from_vocab_set", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let(:json_headers) { auth_headers.merge("Content-Type" => "application/json") }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  # A seeded robust-set ROOT board (Core 84) owned by the internal admin, with a
+  # couple of tiles, stamped so Boards::RobustSets.find_root("core-84") resolves it.
+  let!(:root) do
+    board = create(:board, name: "Core 84", user: admin_user)
+    2.times { create(:board_image, board: board, image: create(:image)) }
+    Boards::RobustSets.mark_root!(board, "core-84")
+    board
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/boards/from_vocab_set" do
+    context "without a valid bearer token" do
+      it "returns 401" do
+        post "/api/internal/boards/from_vocab_set", params: { slug: "core-84" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "with a valid bearer token" do
+      it "clones the seeded root into a new admin-owned board and returns 201" do
+        expect {
+          post "/api/internal/boards/from_vocab_set",
+               params: { slug: "core-84" }.to_json,
+               headers: json_headers
+        }.to change(Board, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        body = JSON.parse(response.body)
+        clone = Board.find(body["id"])
+
+        expect(clone.id).not_to eq(root.id)
+        expect(clone.user_id).to eq(User::DEFAULT_ADMIN_ID)
+        expect(clone.name).to eq("Core 84")
+        # Tiles copied from the source grid.
+        expect(clone.board_images.count).to eq(root.board_images.count)
+      end
+
+      it "does not turn the clone into a second seeded robust-set root" do
+        post "/api/internal/boards/from_vocab_set",
+             params: { slug: "core-84" }.to_json,
+             headers: json_headers
+
+        clone = Board.find(JSON.parse(response.body)["id"])
+
+        # The robust-set markers are stripped from the clone, so the lookup
+        # still resolves the original seed root — not the fresh clone.
+        expect(Boards::RobustSets.find_root("core-84")).to eq(root)
+        expect(clone.settings["board_builder_robust"]).to be_nil
+        expect(clone.settings["board_builder_robust_slug"]).to be_nil
+      end
+
+      it "honors an override name and applies tags" do
+        post "/api/internal/boards/from_vocab_set",
+             params: { slug: "core-84", name: "Core Words Poster", tags: ["marketing", "aac-kit"] }.to_json,
+             headers: json_headers
+
+        expect(response).to have_http_status(:created)
+        clone = Board.find(JSON.parse(response.body)["id"])
+        expect(clone.name).to eq("Core Words Poster")
+        expect(clone.tags).to match_array(["marketing", "aac-kit"])
+      end
+
+      it "returns 404 with an error body when the set is not seeded" do
+        expect {
+          post "/api/internal/boards/from_vocab_set",
+               params: { slug: "core-999" }.to_json,
+               headers: json_headers
+        }.not_to change(Board, :count)
+
+        expect(response).to have_http_status(:not_found)
+        body = JSON.parse(response.body)
+        expect(body["error"]).to eq("vocab_set_not_seeded")
+        expect(body["slug"]).to eq("core-999")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `POST /api/internal/boards/from_vocab_set` (behind `INTERNAL_API_KEY`) so an internal-API caller — the printables marketing generator — can spin up a board from a curated Board Builder vocab set (`core-60` / `core-84`) in one call, then export it to PDF. Previously the internal API could only create from a raw `word_list` or a `scenario` topic; there was no way to say "give me the vetted core-84 grid."

Closes #455.

### What it does
- **Route:** `post :from_vocab_set` on the internal `boards` collection.
- **Action:** looks up the seeded root via `Boards::RobustSets.find_root(slug)`, clones it with `Board#clone_with_images` (owned by the internal admin, `DEFAULT_ADMIN_ID`), and renders `board.api_view_with_images` (`201`) — the same shape `create`/`show` return, so the caller can immediately hit `GET /boards/:id/export.pdf`.
- **v1 scope:** clones only the set's ROOT grid (the poster surface), not the linked fringe tree.
- **Params:** `slug` (required), optional `name`, `tags`, `settings`.
- **Marker strip:** the clone inherits the seed root's settings via `dup`, so it would carry the `board_builder_robust` / `_slug` markers and masquerade as a *second* seeded root (polluting `find_root` / the wizard catalog). The action strips those before saving.
- **Clear failure:** unknown/unseeded slug → `404 vocab_set_not_seeded` (never `500`).
- **Additive:** `create` / `update` / `show` / `export` are unchanged. No migration, no new ENV var.

### Notes
- The curated sets must be seeded in the target environment (`bin/rails vocab_sets:seed`) or the endpoint 404s — the intended, clear failure.
- Because the clone reuses already-rendered images, it's exportable immediately (no image-render lag).

## Test plan
- New request spec `spec/requests/api/internal/boards_from_vocab_set_spec.rb`:
  - `201` — clones the seeded root into a distinct admin-owned board; tiles copied.
  - clone does **not** become a second seeded robust-set root (markers stripped; `find_root` still resolves the original).
  - honors override `name` and applies `tags`.
  - unknown slug → `404` with `{ error: "vocab_set_not_seeded", slug }`.
  - missing/blank `Authorization` → `401` (inherited behavior).
- `bundle exec rspec spec/requests/api/internal/boards_from_vocab_set_spec.rb` → **5 examples, 0 failures**.
- `bundle exec rspec spec/requests/api/internal/boards_spec.rb` (regression) → **15 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)