### PR TITLE
feat(marketing): host + render AAC Classroom Kit artifacts (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — host the AAC Classroom Kit (free marketing lead magnet)
+- New `MarketingAsset` model + `POST /api/internal/marketing_assets` and
+  `GET /api/internal/marketing_assets/:slug` (behind `INTERNAL_API_KEY`) host a
+  print-ready marketing PDF (the assembled AAC Classroom Kit) at a stable public
+  slug. The file is attached at a deterministic S3 key
+  (`marketing_assets/<slug>.pdf`) with purge-then-reupload, so the public CDN
+  URL never changes across regenerations — the kit build is idempotent and the
+  URL is safe to drop into the `/classroom` page's `KIT_DOWNLOAD_URL`. Not a
+  sellable product; never published to any marketplace.
+- New `GET /api/internal/marketing_artifacts/name_tag.pdf` renders a generic,
+  fillable classroom name-tag sheet (variant A — no per-child data) N-up on a
+  Letter page via Grover, with a shared QR pointed at `qr_target_url`.
+- The per-communicator asset generators (`Communicators::GenerateSafetyIdCard` /
+  `GenerateDeviceTag`) now accept an optional `qr_target_url:` so the kit's
+  sample safety + device tags point their QR at the `/classroom` funnel instead
+  of the sample MySpeak page. Default behavior (QR → the profile's public page)
+  is unchanged. The internal profiles `PATCH` accepts a `qr_target_url` to drive
+  this regeneration.
+- New `bin/rails marketing:seed_kit_sample_profile` seeds one admin-owned,
+  clearly-generic sample safety profile so the kit renders realistic sample tags
+  without touching any real child's data (idempotent).
+
 ### Added — internal API endpoint to create a board from a curated vocab set
 - New `POST /api/internal/boards/from_vocab_set` (behind `INTERNAL_API_KEY`)
   clones the ROOT grid of a curated Board Builder vocab set (`core-60` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1138,6 +1138,51 @@ placeholder grid when `AppEnv.staging?` — no paid OpenAI call, no real credits
 burned — mirroring the image-generation placeholder short-circuit. (The vision
 call is **not** gated in real production.)
 
+## Marketing assets — AAC Classroom Kit hosting
+
+The AAC Classroom Kit is a **free marketing lead magnet** (a bundled print-ready
+PDF for the `/classroom` landing page) — **not** a sellable product and never
+published to any marketplace. The backend's job is to *host* the assembled kit
+PDF at a stable public URL and to render/source the individual artifacts;
+assembly (merging the per-artifact PDFs) happens in the **printables** repo,
+which already depends on `pdf-lib`.
+
+- **`MarketingAsset` (`app/models/marketing_asset.rb`) hosts a PDF at a stable
+  slug.** `has_one_attached :file` written at a **deterministic** S3 key
+  (`marketing_assets/<slug>.pdf`) via purge-then-reupload — the same
+  stable-key pattern as `Boards::GeneratePreviewAssets#stable_preview_key`.
+  Production S3 is `public: true`, so `#file_url` (CDN_HOST + key, `file.url`
+  fallback) is a permanent, unsigned CDN URL that **never changes across
+  regenerations**. `MarketingAsset.upsert_pdf!(slug:, bytes:, title:, kind:)` is
+  idempotent — re-running the kit build overwrites in place, so the
+  `KIT_DOWNLOAD_URL` is safe to hardcode on the frontend.
+- **Endpoints (behind `INTERNAL_API_KEY`, `namespace :internal`):**
+  - `POST /api/internal/marketing_assets` `{ slug, file(multipart PDF), title?, kind? }`
+    → upsert + host → `{ slug, title, kind, url }` (`201`). The printables
+    marketing-kit script POSTs the merged kit here to get the public URL.
+  - `GET /api/internal/marketing_assets/:slug` → `{ ..., url }` or `404`.
+  - `GET /api/internal/marketing_artifacts/name_tag.pdf?qr_target_url=&per_page=`
+    → streams the generic classroom name-tag sheet (`Marketing::NameTagSheet`,
+    Grover HTML→PDF, template `app/views/marketing/name_tag_sheet.html.erb`).
+    Variant A from `.claude-notes/name-tag-asset-sketch.md` — fillable, no
+    per-child data, N-up on Letter.
+- **Generic safety/device tags reuse a dedicated sample Profile.**
+  `bin/rails marketing:seed_kit_sample_profile` seeds one admin-owned,
+  clearly-generic safety `Profile` ("SpeakAnyWay Sample"). The kit renders its
+  tags through the existing `Communicators::GenerateSafetyIdCard` /
+  `GenerateDeviceTag`, which now take an optional **`qr_target_url:`** (threaded
+  through `BaseAssetGenerator`, folded into the freshness signature) so the kit
+  tags' QR points at the `/classroom` funnel instead of the sample MySpeak page.
+  The default (QR → `profile.public_url`) is unchanged for every real
+  communicator. The internal profiles `PATCH` forwards a `qr_target_url` to drive
+  this regeneration.
+- **Every kit QR** points at
+  `speakanyway.com/classroom?utm_source=aac_kit&utm_medium=print&utm_campaign=classroom_kit&utm_content=<artifact>`
+  (bare `speakanyway.com`, per brand rules).
+- Reference: `.claude-notes/artifact-generation-services.md` (the reusable
+  engines) and `.claude-notes/classroom-kit-hosting-handoff.md` (end-to-end
+  pipeline + the printables side + the `KIT_DOWNLOAD_URL` swap).
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/app/controllers/api/internal/marketing_artifacts_controller.rb
+++ b/app/controllers/api/internal/marketing_artifacts_controller.rb
@@ -1,0 +1,20 @@
+# Renders generic (data-less) marketing printables on demand and streams the
+# PDF, mirroring the board export endpoint's send_data shape. Currently serves
+# the generic AAC Classroom name-tag sheet (variant A). The printables
+# marketing-kit script fetches this, then merges it into the combined kit.
+class API::Internal::MarketingArtifactsController < API::Internal::ApplicationController
+  # GET /api/internal/marketing_artifacts/name_tag.pdf?qr_target_url=...&per_page=8
+  def name_tag
+    per_page = params[:per_page].presence
+    pdf = Marketing::NameTagSheet.new(
+      qr_target_url: params[:qr_target_url],
+      per_page: per_page ? per_page.to_i : Marketing::NameTagSheet::DEFAULT_PER_PAGE,
+    ).to_pdf
+
+    response.headers["Cache-Control"] = "no-store"
+    send_data pdf,
+      filename: "aac-classroom-name-tags.pdf",
+      type: "application/pdf",
+      disposition: "attachment"
+  end
+end

--- a/app/controllers/api/internal/marketing_assets_controller.rb
+++ b/app/controllers/api/internal/marketing_assets_controller.rb
@@ -1,0 +1,72 @@
+# Hosts the assembled AAC Classroom Kit PDF (and its individual artifacts) at a
+# stable public slug. The printables marketing-kit script merges the per-artifact
+# PDFs with pdf-lib, then POSTs the combined file here to obtain the permanent
+# CDN URL used as the /classroom page's KIT_DOWNLOAD_URL.
+#
+# Additive, behind INTERNAL_API_KEY. Never publishes to any marketplace.
+class API::Internal::MarketingAssetsController < API::Internal::ApplicationController
+  # POST /api/internal/marketing_assets
+  # Params: slug (required), file (required, multipart PDF), title, kind.
+  def create
+    slug = params[:slug].to_s.strip
+
+    if slug.blank?
+      render json: { error: "slug_required" }, status: :unprocessable_content
+      return
+    end
+
+    bytes = pdf_bytes
+    if bytes.blank?
+      render json: { error: "file_required" }, status: :unprocessable_content
+      return
+    end
+
+    asset = MarketingAsset.upsert_pdf!(
+      slug: slug,
+      bytes: bytes,
+      title: params[:title],
+      kind: params[:kind].presence || "kit",
+    )
+
+    render json: asset_json(asset), status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: "invalid_asset", details: e.record.errors.full_messages }, status: :unprocessable_content
+  rescue => e
+    Rails.logger.error("[Internal::MarketingAssets#create] #{e.class}: #{e.message}")
+    render json: { error: "upload_failed" }, status: :unprocessable_content
+  end
+
+  # GET /api/internal/marketing_assets/:slug
+  def show
+    asset = MarketingAsset.find_by(slug: params[:slug])
+
+    if asset.nil?
+      render json: { error: "marketing_asset_not_found", slug: params[:slug] }, status: :not_found
+      return
+    end
+
+    render json: asset_json(asset)
+  end
+
+  private
+
+  def pdf_bytes
+    file = params[:file]
+    return nil if file.blank?
+
+    if file.respond_to?(:read)
+      file.read
+    else
+      file.to_s
+    end
+  end
+
+  def asset_json(asset)
+    {
+      slug: asset.slug,
+      title: asset.title,
+      kind: asset.kind,
+      url: asset.file_url,
+    }
+  end
+end

--- a/app/controllers/api/internal/profiles_controller.rb
+++ b/app/controllers/api/internal/profiles_controller.rb
@@ -10,7 +10,7 @@ class API::Internal::ProfilesController < API::Internal::ApplicationController
 
     if @profile.update(profile_params)
       @profile.enqueue_audio_job_if_needed
-      @profile.generate_attachments! if @profile.safety?
+      regenerate_safety_assets! if @profile.safety?
       render json: response_payload
     else
       Rails.logger.debug("[Internal::Profiles#update] errors=#{@profile.errors.full_messages}")
@@ -28,6 +28,21 @@ class API::Internal::ProfilesController < API::Internal::ApplicationController
     @profile ||= Profile.find_by(slug: params[:id])
 
     render json: { error: "Profile not found" }, status: :not_found unless @profile
+  end
+
+  # Regenerate the safety/device assets. When the caller passes qr_target_url
+  # (the AAC Classroom Kit points the sample tags at /classroom), render both
+  # assets with that QR override and force a re-render; otherwise keep the
+  # default per-communicator behavior (QR -> the profile's public page).
+  def regenerate_safety_assets!
+    qr_target_url = params.dig(:profile, :qr_target_url).presence || params[:qr_target_url].presence
+
+    if qr_target_url
+      Communicators::GenerateSafetyIdCard.call(@profile, regenerate: true, qr_target_url: qr_target_url)
+      Communicators::GenerateDeviceTag.call(@profile, regenerate: true, qr_target_url: qr_target_url)
+    else
+      @profile.generate_attachments!
+    end
   end
 
   def apply_rich_text_fields

--- a/app/models/marketing_asset.rb
+++ b/app/models/marketing_asset.rb
@@ -1,0 +1,69 @@
+# A hosted, print-ready marketing PDF (e.g. the assembled AAC Classroom Kit)
+# addressed by a stable public slug. There is no natural parent record for the
+# combined kit PDF — it is not a Board or a Profile — so this small model owns
+# the attachment.
+#
+# The file is attached at a DETERMINISTIC S3 key (`marketing_assets/<slug>.pdf`)
+# with purge-then-reupload on every regeneration, mirroring
+# Boards::GeneratePreviewAssets#stable_preview_key. Production S3 is
+# `public: true`, so the resulting URL is a permanent, unsigned, CDN-stable
+# link that never changes across re-runs — exactly what the /classroom page's
+# KIT_DOWNLOAD_URL needs. Re-running the kit build is therefore idempotent:
+# same slug -> same URL, new bytes.
+class MarketingAsset < ApplicationRecord
+  has_one_attached :file
+
+  SLUG_FORMAT = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/
+
+  validates :slug, presence: true, uniqueness: true, format: { with: SLUG_FORMAT }
+  validates :kind, presence: true
+
+  # Upsert an asset by slug and (re)attach the given PDF bytes at the stable key.
+  def self.upsert_pdf!(slug:, bytes:, title: nil, kind: "kit")
+    asset = find_or_initialize_by(slug: slug)
+    asset.title = title if title.present?
+    asset.kind = kind.presence || asset.kind.presence || "kit"
+    asset.save!
+    asset.attach_pdf!(bytes)
+    asset
+  end
+
+  # Deterministic key so the public CDN URL is stable across regenerations.
+  def storage_key
+    "marketing_assets/#{slug}.pdf"
+  end
+
+  def attach_pdf!(bytes)
+    # Purge the existing object at the deterministic key first, or
+    # create_and_upload! would collide on the unique active_storage_blobs.key
+    # index (same pattern as Boards::GeneratePreviewAssets#attach_png).
+    file.purge if file.attached?
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(bytes),
+      filename: "#{slug}.pdf",
+      content_type: "application/pdf",
+      key: storage_key,
+    )
+    file.attach(blob)
+    self
+  end
+
+  # Permanent public URL for the hosted PDF. Prefers the CloudFront CDN host
+  # (like Board#pdf_url / Profile#url_for_attachment) and falls back to the
+  # direct Active Storage URL. Never raises — a hosting URL must not break the
+  # caller.
+  def file_url
+    return nil unless file.attached?
+
+    cdn_host = ENV["CDN_HOST"]
+    if cdn_host.present?
+      "#{cdn_host}/#{file.key}"
+    else
+      file.url
+    end
+  rescue => e
+    Rails.logger.warn("MarketingAsset#file_url failed for #{slug}: #{e.class}: #{e.message}")
+    nil
+  end
+end

--- a/app/services/communicators/base_asset_generator.rb
+++ b/app/services/communicators/base_asset_generator.rb
@@ -6,13 +6,30 @@ require "rqrcode"
 
 module Communicators
   class BaseAssetGenerator
-    attr_reader :profile
+    attr_reader :profile, :qr_target_url
 
-    def initialize(profile)
+    # qr_target_url overrides where the asset's QR code points. Default (nil)
+    # keeps the per-communicator behavior (QR -> profile.public_url). The AAC
+    # Classroom Kit passes the /classroom marketing URL so its sample tags drive
+    # leads instead of linking the sample MySpeak page.
+    def initialize(profile, qr_target_url: nil)
       @profile = profile
+      @qr_target_url = qr_target_url.presence
     end
 
     private
+
+    # Where the QR should point: the override when given, else the supplied
+    # fallback (normally profile.public_url).
+    def effective_qr_url(fallback)
+      qr_target_url || fallback
+    end
+
+    # Fold the QR override into the freshness signature so a differing QR target
+    # busts the attached-and-fresh cache and forces a re-render.
+    def asset_signature(base)
+      qr_target_url.present? ? "#{base}::qr=#{qr_target_url}" : base
+    end
 
     def rendered_html(template:, locals: {})
       ApplicationController.render(

--- a/app/services/communicators/generate_device_tag.rb
+++ b/app/services/communicators/generate_device_tag.rb
@@ -4,12 +4,12 @@ module Communicators
     PNG_WIDTH = 1200
     PNG_HEIGHT = 700
 
-    def self.call(profile, regenerate: false)
-      new(profile).call(regenerate: regenerate)
+    def self.call(profile, regenerate: false, qr_target_url: nil)
+      new(profile, qr_target_url: qr_target_url).call(regenerate: regenerate)
     end
 
     def call(regenerate: false)
-      signature = profile.safety_info_signature
+      signature = asset_signature(profile.safety_info_signature)
 
       unless regenerate
         if attached_and_fresh?(:device_tag_png, signature: signature) &&
@@ -57,7 +57,7 @@ module Communicators
         profile: profile,
         avatar_data_url: avatar_data_url,
         logo: logo_base64,
-        qr_data_url: qr_data_url_for(profile.public_url),
+        qr_data_url: qr_data_url_for(effective_qr_url(profile.public_url)),
         display_name: profile.device_tag_display_name,
         device_notes: settings["device_notes"].presence || "This device is my voice. Please use it to help me communicate and access important information in any situation.",
         primary_contact_name: primary_contact["name"].presence || "Emergency Contact",

--- a/app/services/communicators/generate_safety_id_card.rb
+++ b/app/services/communicators/generate_safety_id_card.rb
@@ -4,12 +4,12 @@ module Communicators
     PNG_WIDTH = 1200
     PNG_HEIGHT = 1800
 
-    def self.call(profile, regenerate: false)
-      new(profile).call(regenerate: regenerate)
+    def self.call(profile, regenerate: false, qr_target_url: nil)
+      new(profile, qr_target_url: qr_target_url).call(regenerate: regenerate)
     end
 
     def call(regenerate: false)
-      signature = profile.safety_info_signature
+      signature = asset_signature(profile.safety_info_signature)
 
       unless regenerate
         if attached_and_fresh?(:safety_id_png, signature: signature) &&
@@ -54,7 +54,7 @@ module Communicators
       {
         profile: profile,
         avatar_data_url: avatar_data_url,
-        qr_data_url: qr_data_url_for(profile.public_url),
+        qr_data_url: qr_data_url_for(effective_qr_url(profile.public_url)),
         logo: logo_base64,
         display_name: profile.safety_display_name,
         emergency_notes: settings["emergency_notes"].presence || "Please call my emergency contacts.",

--- a/app/services/marketing/name_tag_sheet.rb
+++ b/app/services/marketing/name_tag_sheet.rb
@@ -1,0 +1,70 @@
+require "rqrcode"
+require "base64"
+
+module Marketing
+  # Renders the generic AAC Classroom name-tag sheet (variant A from
+  # .claude-notes/name-tag-asset-sketch.md): a fillable "Hi! My name is ___"
+  # card, N-up on a Letter page, with a shared QR pointing at the marketing
+  # funnel. No Profile / no per-child data — it is a blank classroom printable.
+  #
+  # HTML -> PDF via Grover, same engine as the board and communicator-asset
+  # generators. Returns PDF bytes; the caller streams or hosts them.
+  class NameTagSheet
+    DEFAULT_PER_PAGE = 8 # 2 columns x 4 rows on Letter portrait
+
+    def initialize(qr_target_url: nil, per_page: DEFAULT_PER_PAGE)
+      @qr_target_url = qr_target_url.presence
+      @per_page = per_page.to_i.positive? ? per_page.to_i : DEFAULT_PER_PAGE
+    end
+
+    def to_pdf
+      Grover.new(html, **grover_options).to_pdf
+    end
+
+    private
+
+    attr_reader :qr_target_url, :per_page
+
+    def html
+      ApplicationController.render(
+        template: "marketing/name_tag_sheet",
+        layout: false,
+        assigns: {
+          card_count: per_page,
+          logo: logo_base64,
+          qr_data_url: qr_data_url,
+        },
+        formats: [:html],
+      )
+    end
+
+    def grover_options
+      {
+        format: "Letter",
+        landscape: false,
+        viewport: { width: 612, height: 792 },
+        full_page: false,
+        prefer_css_page_size: true,
+        print_background: true,
+      }
+    end
+
+    def qr_data_url
+      return nil if qr_target_url.blank?
+
+      png = RQRCode::QRCode.new(qr_target_url).as_png(
+        size: 300,
+        border_modules: 4,
+        module_px_size: 6,
+      )
+      "data:image/png;base64,#{Base64.strict_encode64(png.to_s)}"
+    end
+
+    def logo_base64
+      path = Rails.root.join("public/logo_bubble.png")
+      return nil unless File.exist?(path)
+
+      Base64.strict_encode64(File.binread(path))
+    end
+  end
+end

--- a/app/views/marketing/name_tag_sheet.html.erb
+++ b/app/views/marketing/name_tag_sheet.html.erb
@@ -1,0 +1,137 @@
+<%# Generic AAC Classroom name-tag sheet — variant A (fillable, no per-child data).
+    N cards laid out 2-up across a Letter page. Mirrors the card in
+    .claude-notes/name-tag-asset-sketch.md. QR (shared) points at the /classroom
+    funnel; @qr_data_url is nil-safe (blank slot when no QR requested). %>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+        margin: 0;
+        padding: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: #1e293b;
+      }
+      @page { margin: 0; size: letter; }
+
+      .sheet {
+        box-sizing: border-box;
+        width: 100vw;
+        min-height: 100vh;
+        padding: 10mm;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-auto-rows: 1fr;
+        gap: 6mm;
+      }
+
+      .card {
+        box-sizing: border-box;
+        border: 1.5px solid #e2e8f0;
+        border-radius: 14px;
+        background: #fff;
+        padding: 5mm 6mm;
+        display: flex;
+        flex-direction: column;
+        min-height: 40mm;
+      }
+
+      .brand-rule {
+        height: 6px;
+        border-radius: 6px;
+        background: linear-gradient(90deg, #8b5cf6, #6366f1, #3b82f6);
+        margin: -1mm -1mm 3mm;
+      }
+
+      .top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .logo img { height: 8mm; display: block; }
+      .eyebrow {
+        font-weight: 800;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+        color: #7c3aed;
+        font-size: 10pt;
+      }
+
+      .body {
+        flex: 1;
+        display: grid;
+        grid-template-columns: minmax(0, 1.7fr) auto;
+        gap: 5mm;
+        align-items: center;
+      }
+      .name-line {
+        border-bottom: 2px solid #cbd5e1;
+        height: 12mm;
+      }
+      .tagline {
+        font-size: 10pt;
+        color: #475569;
+        margin-top: 3mm;
+      }
+      .qr { text-align: center; }
+      .qr img { width: 20mm; height: 20mm; display: block; }
+      .qr-blank {
+        width: 20mm; height: 20mm;
+        border: 1.5px dashed #cbd5e1; border-radius: 6px;
+      }
+      .qr-caption {
+        font-size: 8pt; font-weight: 800; color: #64748b;
+        text-transform: uppercase; letter-spacing: .06em; margin-top: 1.5mm;
+      }
+
+      .footer {
+        display: flex;
+        justify-content: space-between;
+        font-size: 8pt;
+        color: #94a3b8;
+        font-weight: 700;
+        margin-top: 3mm;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <% @card_count.times do %>
+        <div class="card">
+          <div class="brand-rule"></div>
+          <div class="top">
+            <span class="logo">
+              <% if @logo.present? %>
+                <img src="data:image/png;base64,<%= @logo %>" alt="SpeakAnyWay" />
+              <% end %>
+            </span>
+            <span class="eyebrow">Hi! My name is</span>
+          </div>
+
+          <div class="body">
+            <div>
+              <div class="name-line"></div>
+              <div class="tagline">Here's how I communicate.</div>
+            </div>
+            <div class="qr">
+              <% if @qr_data_url.present? %>
+                <img src="<%= @qr_data_url %>" alt="Scan to learn more" />
+              <% else %>
+                <div class="qr-blank"></div>
+              <% end %>
+              <div class="qr-caption">Scan to meet me</div>
+            </div>
+          </div>
+
+          <div class="footer">
+            <span>Powered by SpeakAnyWay</span>
+            <span>speakanyway.com</span>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -413,6 +413,14 @@ Rails.application.routes.draw do
         end
       end
       resources :profiles, only: [:show, :update]
+
+      # Hosted marketing PDFs (AAC Classroom Kit) addressed by a stable slug.
+      resources :marketing_assets, only: [:create, :show], param: :slug
+
+      # Generic (data-less) marketing printables rendered on demand.
+      get "marketing_artifacts/name_tag",
+          to: "marketing_artifacts#name_tag",
+          defaults: { format: :pdf }
     end
 
     namespace :v1 do

--- a/db/migrate/20260706120000_create_marketing_assets.rb
+++ b/db/migrate/20260706120000_create_marketing_assets.rb
@@ -1,0 +1,13 @@
+class CreateMarketingAssets < ActiveRecord::Migration[7.1]
+  def change
+    create_table :marketing_assets do |t|
+      t.string :slug, null: false
+      t.string :title
+      t.string :kind, null: false, default: "kit"
+
+      t.timestamps
+    end
+
+    add_index :marketing_assets, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_25_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
@@ -500,6 +500,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_25_120000) do
     t.index ["obf_id"], name: "index_images_on_obf_id"
     t.index ["use_custom_audio"], name: "index_images_on_use_custom_audio"
     t.index ["voice"], name: "index_images_on_voice"
+  end
+
+  create_table "marketing_assets", force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "title"
+    t.string "kind", default: "kit", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slug"], name: "index_marketing_assets_on_slug", unique: true
   end
 
   create_table "menus", force: :cascade do |t|

--- a/lib/tasks/marketing.rake
+++ b/lib/tasks/marketing.rake
@@ -1,0 +1,46 @@
+namespace :marketing do
+  # The AAC Classroom Kit's safety + device tags reuse the existing
+  # Profile-driven generators (Communicators::GenerateSafetyIdCard /
+  # GenerateDeviceTag), which need a real safety Profile. This seeds ONE
+  # admin-owned, clearly-generic sample communicator + safety profile so the kit
+  # renders realistic (filled) sample tags without touching any real child's
+  # data. Idempotent — safe to re-run.
+  #
+  #   bin/rails marketing:seed_kit_sample_profile
+  #
+  # Prints the profile id + slug for the printables marketing-kit script to
+  # fetch tags from (GET /api/internal/profiles/:id with a qr_target_url).
+  desc "Seed the generic AAC Classroom Kit sample safety profile (idempotent)"
+  task seed_kit_sample_profile: :environment do
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+
+    child = ChildAccount.find_or_initialize_by(username: "speakanyway-sample")
+    child.user = admin
+    child.name = "SpeakAnyWay Sample" if child.name.blank?
+    child.status = ChildAccount::ACTIVE if child.status.blank?
+    child.save!
+
+    profile = child.profile || child.create_profile!
+
+    sample_settings = {
+      "device_notes" => "This device is my voice. Please use it to help me communicate and access important information in any situation.",
+      "emergency_notes" => "Please stay calm, speak to me directly, and let me use my device to respond.",
+      "allergies" => "Sample: none listed",
+      "medical_conditions" => "Sample: none listed",
+      "medications" => "Sample: none listed",
+      "ice_contact_1" => {
+        "name" => "Sample Caregiver",
+        "phone" => "(555) 123-4567",
+        "relationship" => "Parent / Guardian",
+      },
+    }
+
+    profile.settings = (profile.settings || {}).merge(sample_settings)
+    profile.save!
+
+    puts "AAC Classroom Kit sample profile ready:"
+    puts "  child_account_id: #{child.id}"
+    puts "  profile_id:       #{profile.id}"
+    puts "  profile_slug:     #{profile.slug}"
+  end
+end

--- a/spec/models/marketing_asset_spec.rb
+++ b/spec/models/marketing_asset_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe MarketingAsset, type: :model do
+  let(:pdf_bytes) { "%PDF-1.4 fake pdf bytes" }
+
+  describe "validations" do
+    it "requires a slug" do
+      expect(described_class.new(slug: nil)).not_to be_valid
+    end
+
+    it "rejects an invalid slug format" do
+      expect(described_class.new(slug: "Not A Slug")).not_to be_valid
+      expect(described_class.new(slug: "classroom-kit")).to be_valid
+    end
+
+    it "enforces slug uniqueness" do
+      described_class.create!(slug: "classroom-kit")
+      dup = described_class.new(slug: "classroom-kit")
+      expect(dup).not_to be_valid
+    end
+  end
+
+  describe ".upsert_pdf!" do
+    it "creates the asset and attaches the PDF at the deterministic key" do
+      asset = described_class.upsert_pdf!(slug: "classroom-kit", bytes: pdf_bytes, title: "Kit")
+
+      expect(asset).to be_persisted
+      expect(asset.title).to eq("Kit")
+      expect(asset.file).to be_attached
+      expect(asset.file.key).to eq("marketing_assets/classroom-kit.pdf")
+    end
+
+    it "is idempotent: re-running replaces bytes but keeps the slug and stable key" do
+      described_class.upsert_pdf!(slug: "classroom-kit", bytes: pdf_bytes, title: "Kit")
+
+      expect {
+        described_class.upsert_pdf!(slug: "classroom-kit", bytes: "%PDF new bytes", title: "Kit v2")
+      }.not_to change(described_class, :count)
+
+      asset = described_class.find_by(slug: "classroom-kit")
+      expect(asset.title).to eq("Kit v2")
+      expect(asset.file.key).to eq("marketing_assets/classroom-kit.pdf")
+    end
+  end
+
+  describe "#file_url" do
+    it "returns nil when no file is attached" do
+      expect(described_class.new(slug: "x").file_url).to be_nil
+    end
+
+    it "builds a CDN URL from the stable key when CDN_HOST is set" do
+      asset = described_class.upsert_pdf!(slug: "classroom-kit", bytes: pdf_bytes)
+
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("CDN_HOST").and_return("https://cdn.example.com")
+
+      expect(asset.file_url).to eq("https://cdn.example.com/marketing_assets/classroom-kit.pdf")
+    end
+  end
+end

--- a/spec/requests/api/internal/marketing_artifacts_spec.rb
+++ b/spec/requests/api/internal/marketing_artifacts_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::MarketingArtifacts", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+
+    # Bypass actual Chromium / Grover rendering.
+    fake_grover = instance_double(Grover, to_pdf: "%PDF-fake-name-tags")
+    allow(Grover).to receive(:new).and_return(fake_grover)
+  end
+
+  describe "GET /api/internal/marketing_artifacts/name_tag.pdf" do
+    it "returns 401 without a valid bearer token" do
+      get "/api/internal/marketing_artifacts/name_tag.pdf"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "streams a generic name-tag sheet PDF pointing the QR at the given target" do
+      expect(Marketing::NameTagSheet).to receive(:new).with(
+        hash_including(qr_target_url: "https://speakanyway.com/classroom?utm_content=name_tag"),
+      ).and_call_original
+
+      get "/api/internal/marketing_artifacts/name_tag.pdf",
+          params: { qr_target_url: "https://speakanyway.com/classroom?utm_content=name_tag" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+      expect(response.headers["Content-Disposition"]).to include("attachment")
+      expect(response.body).to start_with("%PDF")
+    end
+  end
+end

--- a/spec/requests/api/internal/marketing_assets_spec.rb
+++ b/spec/requests/api/internal/marketing_assets_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe "API::Internal::MarketingAssets", type: :request do
 
   describe "GET /api/internal/marketing_assets/:slug" do
     it "returns the hosted asset URL" do
+      allow(ENV).to receive(:[]).with("CDN_HOST").and_return("https://cdn.example.com")
       MarketingAsset.upsert_pdf!(slug: "classroom-kit", bytes: "%PDF x", title: "Kit")
 
       get "/api/internal/marketing_assets/classroom-kit", headers: auth_headers
@@ -77,7 +78,7 @@ RSpec.describe "API::Internal::MarketingAssets", type: :request do
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
       expect(body["slug"]).to eq("classroom-kit")
-      expect(body["url"]).to be_present
+      expect(body["url"]).to eq("https://cdn.example.com/marketing_assets/classroom-kit.pdf")
     end
 
     it "404s for an unknown slug" do

--- a/spec/requests/api/internal/marketing_assets_spec.rb
+++ b/spec/requests/api/internal/marketing_assets_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "API::Internal::MarketingAssets", type: :request do
+  let(:internal_key) { "test-internal-key" }
+  let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
+  let!(:admin_user) { create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  def pdf_upload
+    Rack::Test::UploadedFile.new(
+      StringIO.new("%PDF-1.4 fake kit"),
+      "application/pdf",
+      original_filename: "kit.pdf",
+    )
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+  end
+
+  describe "POST /api/internal/marketing_assets" do
+    it "returns 401 without a valid bearer token" do
+      post "/api/internal/marketing_assets", params: { slug: "classroom-kit", file: pdf_upload }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "hosts the uploaded PDF at a stable slug and returns the public URL" do
+      allow(ENV).to receive(:[]).with("CDN_HOST").and_return("https://cdn.example.com")
+
+      expect {
+        post "/api/internal/marketing_assets",
+             params: { slug: "classroom-kit", title: "AAC Classroom Kit", file: pdf_upload },
+             headers: auth_headers
+      }.to change(MarketingAsset, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body["slug"]).to eq("classroom-kit")
+      expect(body["title"]).to eq("AAC Classroom Kit")
+      expect(body["url"]).to eq("https://cdn.example.com/marketing_assets/classroom-kit.pdf")
+    end
+
+    it "is idempotent on re-upload (same slug -> same record and URL)" do
+      post "/api/internal/marketing_assets",
+           params: { slug: "classroom-kit", file: pdf_upload }, headers: auth_headers
+
+      expect {
+        post "/api/internal/marketing_assets",
+             params: { slug: "classroom-kit", title: "v2", file: pdf_upload }, headers: auth_headers
+      }.not_to change(MarketingAsset, :count)
+
+      expect(response).to have_http_status(:created)
+      asset = MarketingAsset.find_by(slug: "classroom-kit")
+      expect(asset.title).to eq("v2")
+      expect(asset.file.key).to eq("marketing_assets/classroom-kit.pdf")
+    end
+
+    it "422s when slug is missing" do
+      post "/api/internal/marketing_assets", params: { file: pdf_upload }, headers: auth_headers
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("slug_required")
+    end
+
+    it "422s when file is missing" do
+      post "/api/internal/marketing_assets", params: { slug: "classroom-kit" }, headers: auth_headers
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("file_required")
+    end
+  end
+
+  describe "GET /api/internal/marketing_assets/:slug" do
+    it "returns the hosted asset URL" do
+      MarketingAsset.upsert_pdf!(slug: "classroom-kit", bytes: "%PDF x", title: "Kit")
+
+      get "/api/internal/marketing_assets/classroom-kit", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["slug"]).to eq("classroom-kit")
+      expect(body["url"]).to be_present
+    end
+
+    it "404s for an unknown slug" do
+      get "/api/internal/marketing_assets/nope", headers: auth_headers
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)["error"]).to eq("marketing_asset_not_found")
+    end
+  end
+end

--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -91,6 +91,20 @@ RSpec.describe "API::Internal::Profiles", type: :request do
       expect(Communicators::GenerateDeviceTag).to have_received(:call).with(profile)
     end
 
+    it "regenerates the tags pointed at qr_target_url when provided (AAC Classroom Kit)" do
+      kit_url = "https://speakanyway.com/classroom?utm_content=safety_tag"
+
+      patch "/api/internal/profiles/#{profile.id}",
+            params: { qr_target_url: kit_url, profile: {} }.to_json,
+            headers: json_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(Communicators::GenerateSafetyIdCard)
+        .to have_received(:call).with(profile, regenerate: true, qr_target_url: kit_url)
+      expect(Communicators::GenerateDeviceTag)
+        .to have_received(:call).with(profile, regenerate: true, qr_target_url: kit_url)
+    end
+
     it "accepts an empty profile patch and regenerates safety attachments" do
       patch "/api/internal/profiles/#{profile.id}",
             params: { profile: {} }.to_json,

--- a/spec/services/communicators/asset_generator_qr_override_spec.rb
+++ b/spec/services/communicators/asset_generator_qr_override_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# The AAC Classroom Kit reuses the per-communicator asset generators but points
+# their QR at the /classroom funnel instead of the sample profile's public page.
+RSpec.describe "Communicator asset generators — qr_target_url override" do
+  let(:child) { create(:child_account) }
+  let(:profile) { child.create_profile! }
+  let(:kit_url) { "https://speakanyway.com/classroom?utm_content=safety_tag" }
+
+  before do
+    # Avoid real headless-Chrome renders.
+    allow_any_instance_of(Communicators::BaseAssetGenerator)
+      .to receive(:generate_png_from_html).and_return("png-bytes")
+    allow_any_instance_of(Communicators::BaseAssetGenerator)
+      .to receive(:generate_pdf_from_html).and_return("pdf-bytes")
+  end
+
+  describe Communicators::GenerateDeviceTag do
+    it "points the QR at the override when given" do
+      expect_any_instance_of(described_class)
+        .to receive(:qr_data_url_for).with(kit_url).and_return("data:image/png;base64,x")
+
+      described_class.call(profile, qr_target_url: kit_url)
+    end
+
+    it "defaults the QR to the profile's public page when no override is given" do
+      expect_any_instance_of(described_class)
+        .to receive(:qr_data_url_for).with(profile.public_url).and_return("data:image/png;base64,x")
+
+      described_class.call(profile)
+    end
+  end
+
+  describe Communicators::GenerateSafetyIdCard do
+    it "points the QR at the override when given" do
+      expect_any_instance_of(described_class)
+        .to receive(:qr_data_url_for).with(kit_url).and_return("data:image/png;base64,x")
+
+      described_class.call(profile, qr_target_url: kit_url)
+    end
+  end
+
+  it "folds the override into the freshness signature so tags re-render for a new QR target" do
+    generator = Communicators::GenerateDeviceTag.new(profile, qr_target_url: kit_url)
+    base = profile.safety_info_signature
+
+    expect(generator.send(:asset_signature, base)).to include(base)
+    expect(generator.send(:asset_signature, base)).to include("qr=#{kit_url}")
+
+    plain = Communicators::GenerateDeviceTag.new(profile)
+    expect(plain.send(:asset_signature, base)).to eq(base)
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the **AAC Classroom Kit** — a **free `/classroom` lead magnet**, never a sellable/marketplace product. This PR provides the two things the backend owns: **hosting** the assembled kit PDF at a stable public URL, and **rendering** the individual artifacts. Assembling the artifacts into one kit PDF (pdf-lib merge) happens in the `speakanyway-printables` repo as a follow-up PR.

Phase 1 explore + the two design decisions (hosting mechanism; how the generic tags are produced) were approved before building — see `.claude-notes/classroom-kit-hosting-handoff.md`.

### What's here
- **`MarketingAsset` model + `POST`/`GET /api/internal/marketing_assets(/:slug)`** (behind `INTERNAL_API_KEY`). Hosts a PDF at a **deterministic S3 key** (`marketing_assets/<slug>.pdf`) with purge-then-reupload — the same stable-key pattern as `Boards::GeneratePreviewAssets#stable_preview_key`. Prod S3 is `public: true`, so `#file_url` (CDN_HOST + key, `file.url` fallback) is a **permanent, unsigned CDN URL that never changes across regenerations**. `upsert_pdf!` makes re-running the kit build idempotent → the URL is safe to hardcode as the frontend's `KIT_DOWNLOAD_URL`.
- **`GET /api/internal/marketing_artifacts/name_tag.pdf`** — generic, fillable classroom name-tag sheet (variant A from the name-tag sketch; no per-child data), `Marketing::NameTagSheet` + ERB, N-up on Letter via Grover, QR from `qr_target_url`.
- **`qr_target_url:` override** on `Communicators::GenerateSafetyIdCard` / `GenerateDeviceTag` (threaded through `BaseAssetGenerator`, folded into the freshness signature) and the internal profiles `PATCH`, so the kit's **sample** safety + device tags point their QR at the `/classroom` funnel. **Default behavior (QR → `profile.public_url`) is unchanged** for every real communicator.
- **`bin/rails marketing:seed_kit_sample_profile`** — seeds one admin-owned, clearly-generic sample safety profile so the tags render realistic sample data without any real child (idempotent).

Every kit QR targets bare `speakanyway.com/classroom?utm_source=aac_kit&utm_medium=print&utm_campaign=classroom_kit&utm_content=<artifact>`.

### Design decisions (approved)
- **Hosting:** a small `MarketingAsset` model (vs. reusing `Board#pdf_file` or a dangling S3 blob) — the combined kit PDF has no natural parent record, and the deterministic key gives a stable URL + idempotent re-runs.
- **Generic tags:** a dedicated **sample Profile** + a `qr_target_url` override (vs. static duplicate templates) — reuses the existing generators wholesale and produces a realistic filled sample.
- **Assembly** lives in printables (it already depends on `pdf-lib` + has a merge step); Rails only renders + hosts. Documented for the follow-up PR.

### Not in scope (follow-up printables PR)
The `npm run marketing-kit` orchestration (build boards via `from_vocab_set` + scenario, export PDFs, merge with pdf-lib, upload the combined PDF here, print the `KIT_DOWNLOAD_URL`). Fully specced in `.claude-notes/classroom-kit-hosting-handoff.md`. Actually running it to mint the live URL spends OpenAI credits (StoryTime) and writes a prod-hosted asset, so it's gated on an explicit go-ahead.

## Test plan
- `bundle exec rspec spec/models/marketing_asset_spec.rb spec/requests/api/internal/marketing_assets_spec.rb spec/requests/api/internal/marketing_artifacts_spec.rb spec/services/communicators/asset_generator_qr_override_spec.rb` — **20 examples, 0 failures**.
- `bundle exec rspec spec/requests/api/internal/` — **64 examples, 0 failures** (incl. the new internal-profiles `qr_target_url` case).
- Regression sweep of every spec referencing the changed generators / `url_for_attachment` (`regenerate_safety_cards_job`, `profiles`, `profiles_owner_protection`, `myspeak`) — **67 examples, 0 failures**.
- Migration applied cleanly; `db/schema.rb` updated.

No new gems. Additive endpoints behind `INTERNAL_API_KEY`; no migration risk beyond the new `marketing_assets` table. `CDN_HOST` optional (raw S3 public URL as fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)