### PR TITLE
feat(marketing): compact backpack safety + device tags for the AAC Classroom Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — compact backpack safety + device tags for the AAC Classroom Kit
+- New `GET /api/internal/marketing_artifacts/safety_tag.pdf` and
+  `.../device_tag.pdf` render generic, print-and-cut **backpack ID tags**
+  (`Marketing::SafetyTagSheet` / `Marketing::DeviceTagSheet`) — compact,
+  fixed physical size, laid 2-up on a single Letter page with cut lines, QR to
+  the `/classroom` funnel. These replace the kit's previous use of the app's
+  detailed Profile safety card, which is a full page and overflowed onto a
+  second page when exported (the card canvas is taller than A4). The kit's tags
+  no longer depend on a sample Profile. The app's Profile-driven safety card
+  (`Communicators::GenerateSafetyIdCard`) is unchanged.
+
 ### Added — host the AAC Classroom Kit (free marketing lead magnet)
 - New `MarketingAsset` model + `POST /api/internal/marketing_assets` and
   `GET /api/internal/marketing_assets/:slug` (behind `INTERNAL_API_KEY`) host a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1161,21 +1161,29 @@ which already depends on `pdf-lib`.
     → upsert + host → `{ slug, title, kind, url }` (`201`). The printables
     marketing-kit script POSTs the merged kit here to get the public URL.
   - `GET /api/internal/marketing_assets/:slug` → `{ ..., url }` or `404`.
-  - `GET /api/internal/marketing_artifacts/name_tag.pdf?qr_target_url=&per_page=`
-    → streams the generic classroom name-tag sheet (`Marketing::NameTagSheet`,
-    Grover HTML→PDF, template `app/views/marketing/name_tag_sheet.html.erb`).
-    Variant A from `.claude-notes/name-tag-asset-sketch.md` — fillable, no
-    per-child data, N-up on Letter.
-- **Generic safety/device tags reuse a dedicated sample Profile.**
-  `bin/rails marketing:seed_kit_sample_profile` seeds one admin-owned,
-  clearly-generic safety `Profile` ("SpeakAnyWay Sample"). The kit renders its
-  tags through the existing `Communicators::GenerateSafetyIdCard` /
-  `GenerateDeviceTag`, which now take an optional **`qr_target_url:`** (threaded
-  through `BaseAssetGenerator`, folded into the freshness signature) so the kit
-  tags' QR points at the `/classroom` funnel instead of the sample MySpeak page.
-  The default (QR → `profile.public_url`) is unchanged for every real
-  communicator. The internal profiles `PATCH` forwards a `qr_target_url` to drive
-  this regeneration.
+  - `GET /api/internal/marketing_artifacts/{name_tag,safety_tag,device_tag}.pdf?qr_target_url=&per_page=`
+    → stream the generic classroom sheets (`Marketing::NameTagSheet` /
+    `SafetyTagSheet` / `DeviceTagSheet`, Grover HTML→PDF, templates under
+    `app/views/marketing/`, shared helpers in `Marketing::SheetRendering`). All
+    are fillable, no per-child data, laid N-up on a single **Letter** page with
+    cut lines.
+- **The kit's safety + device tags are compact, print-and-cut backpack tags.**
+  `SafetyTagSheet` (a "Communication ID" tag: photo circle, fillable name,
+  "I use a device to communicate", QR) and `DeviceTagSheet` ("This device is my
+  voice", QR) render generic, fixed-physical-size tags **2-up on Letter** — not
+  the app's detailed Profile safety card. This was a deliberate change: the app's
+  `Communicators::GenerateSafetyIdCard` renders a full-page 1200×1800 card that
+  **overflowed onto a 2nd page** when exported (taller than A4) and is too big
+  for a backpack tag. The kit tags no longer depend on a sample Profile.
+  - **The app's Profile-driven safety/device cards are unchanged**, including the
+    optional `qr_target_url:` override on `GenerateSafetyIdCard`/`GenerateDeviceTag`
+    (still available; just no longer used by the kit). The
+    `marketing:seed_kit_sample_profile` rake also remains but is no longer needed
+    for the kit.
+  - **Known follow-up:** `Communicators::BaseAssetGenerator#generate_pdf_from_html`
+    still uses `format: "A4"`, so a real user's downloaded safety-card PDF can
+    overflow to 2 pages. Not fixed here (out of scope for the kit change) — a
+    separate fix would size the page to the card.
 - **Every kit QR** points at
   `speakanyway.com/classroom?utm_source=aac_kit&utm_medium=print&utm_campaign=classroom_kit&utm_content=<artifact>`
   (bare `speakanyway.com`, per brand rules).

--- a/app/controllers/api/internal/marketing_artifacts_controller.rb
+++ b/app/controllers/api/internal/marketing_artifacts_controller.rb
@@ -1,19 +1,36 @@
 # Renders generic (data-less) marketing printables on demand and streams the
-# PDF, mirroring the board export endpoint's send_data shape. Currently serves
-# the generic AAC Classroom name-tag sheet (variant A). The printables
-# marketing-kit script fetches this, then merges it into the combined kit.
+# PDF, mirroring the board export endpoint's send_data shape. Serves the AAC
+# Classroom Kit's generic sheets — name tags, and the compact print-and-cut
+# backpack safety + device tags. The printables marketing-kit script fetches
+# these, then merges them into the combined kit.
 class API::Internal::MarketingArtifactsController < API::Internal::ApplicationController
   # GET /api/internal/marketing_artifacts/name_tag.pdf?qr_target_url=...&per_page=8
   def name_tag
+    stream_sheet(Marketing::NameTagSheet, "aac-classroom-name-tags.pdf")
+  end
+
+  # GET /api/internal/marketing_artifacts/safety_tag.pdf?qr_target_url=...&per_page=2
+  def safety_tag
+    stream_sheet(Marketing::SafetyTagSheet, "aac-classroom-safety-tags.pdf")
+  end
+
+  # GET /api/internal/marketing_artifacts/device_tag.pdf?qr_target_url=...&per_page=2
+  def device_tag
+    stream_sheet(Marketing::DeviceTagSheet, "aac-classroom-device-tags.pdf")
+  end
+
+  private
+
+  def stream_sheet(sheet_class, filename)
     per_page = params[:per_page].presence
-    pdf = Marketing::NameTagSheet.new(
+    pdf = sheet_class.new(
       qr_target_url: params[:qr_target_url],
-      per_page: per_page ? per_page.to_i : Marketing::NameTagSheet::DEFAULT_PER_PAGE,
+      per_page: per_page ? per_page.to_i : sheet_class::DEFAULT_PER_PAGE,
     ).to_pdf
 
     response.headers["Cache-Control"] = "no-store"
     send_data pdf,
-      filename: "aac-classroom-name-tags.pdf",
+      filename: filename,
       type: "application/pdf",
       disposition: "attachment"
   end

--- a/app/services/marketing/device_tag_sheet.rb
+++ b/app/services/marketing/device_tag_sheet.rb
@@ -1,0 +1,27 @@
+module Marketing
+  # Generic AAC device tag ("This device is my voice"), compact and
+  # print-and-cut, laid N-up on a Letter page. No per-child data; the QR points
+  # at the /classroom funnel. The compact kit counterpart to the app's
+  # Profile-driven Communicators::GenerateDeviceTag.
+  class DeviceTagSheet
+    include SheetRendering
+
+    DEFAULT_PER_PAGE = 2 # two landscape tags stacked on Letter
+
+    def initialize(qr_target_url: nil, per_page: DEFAULT_PER_PAGE)
+      @qr_target_url = qr_target_url.presence
+      @per_page = per_page.to_i.positive? ? per_page.to_i : DEFAULT_PER_PAGE
+    end
+
+    def to_pdf
+      render_letter_pdf(
+        template: "marketing/device_tag_sheet",
+        assigns: {
+          card_count: @per_page,
+          logo: logo_base64,
+          qr_data_url: qr_data_url(@qr_target_url),
+        },
+      )
+    end
+  end
+end

--- a/app/services/marketing/safety_tag_sheet.rb
+++ b/app/services/marketing/safety_tag_sheet.rb
@@ -1,0 +1,27 @@
+module Marketing
+  # Generic AAC "communication ID" backpack tag, compact and print-and-cut,
+  # laid N-up on a Letter page. Fillable (no per-child data); the QR points at
+  # the /classroom funnel. Distinct from the app's detailed Profile safety card
+  # (Communicators::GenerateSafetyIdCard) — this is a small clip-on tag.
+  class SafetyTagSheet
+    include SheetRendering
+
+    DEFAULT_PER_PAGE = 2 # two portrait tags side-by-side on Letter
+
+    def initialize(qr_target_url: nil, per_page: DEFAULT_PER_PAGE)
+      @qr_target_url = qr_target_url.presence
+      @per_page = per_page.to_i.positive? ? per_page.to_i : DEFAULT_PER_PAGE
+    end
+
+    def to_pdf
+      render_letter_pdf(
+        template: "marketing/safety_tag_sheet",
+        assigns: {
+          card_count: @per_page,
+          logo: logo_base64,
+          qr_data_url: qr_data_url(@qr_target_url),
+        },
+      )
+    end
+  end
+end

--- a/app/services/marketing/sheet_rendering.rb
+++ b/app/services/marketing/sheet_rendering.rb
@@ -1,0 +1,49 @@
+require "rqrcode"
+require "base64"
+
+module Marketing
+  # Shared helpers for the generic (data-less) marketing tag sheets — the
+  # compact, print-and-cut backpack tags in the AAC Classroom Kit. Each sheet
+  # renders a fixed-physical-size card N-up on a Letter page via Grover, with a
+  # shared QR pointing at the marketing funnel. No Profile / no per-child data.
+  module SheetRendering
+    LETTER_GROVER_OPTIONS = {
+      format: "Letter",
+      landscape: false,
+      viewport: { width: 612, height: 792 },
+      full_page: false,
+      prefer_css_page_size: true,
+      print_background: true,
+    }.freeze
+
+    private
+
+    def render_letter_pdf(template:, assigns:)
+      html = ApplicationController.render(
+        template: template,
+        layout: false,
+        assigns: assigns,
+        formats: [:html],
+      )
+      Grover.new(html, **LETTER_GROVER_OPTIONS).to_pdf
+    end
+
+    def qr_data_url(url, size: 300)
+      return nil if url.blank?
+
+      png = RQRCode::QRCode.new(url).as_png(
+        size: size,
+        border_modules: 4,
+        module_px_size: 6,
+      )
+      "data:image/png;base64,#{Base64.strict_encode64(png.to_s)}"
+    end
+
+    def logo_base64
+      path = Rails.root.join("public/logo_bubble.png")
+      return nil unless File.exist?(path)
+
+      Base64.strict_encode64(File.binread(path))
+    end
+  end
+end

--- a/app/views/marketing/device_tag_sheet.html.erb
+++ b/app/views/marketing/device_tag_sheet.html.erb
@@ -1,0 +1,82 @@
+<%# Compact AAC device tags ("This device is my voice") — generic, print-and-cut.
+    N landscape tags (4.6in x 2.5in) stacked on a Letter page with dashed cut
+    lines. QR (@qr_data_url, nil-safe) points at the /classroom funnel. %>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        -webkit-print-color-adjust: exact; print-color-adjust: exact;
+        margin: 0; padding: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: #1e293b;
+      }
+      @page { margin: 0; size: letter; }
+
+      .sheet {
+        box-sizing: border-box;
+        width: 8.5in; min-height: 11in;
+        padding: 0.7in 0.4in;
+        display: flex; flex-direction: column; align-items: center;
+        gap: 0.35in;
+      }
+
+      .tag {
+        box-sizing: border-box;
+        width: 4.6in; height: 2.5in;
+        border: 1.5px dashed #cbd5e1;      /* cut line */
+        border-radius: 0.16in;
+        background: #fff; padding: 0.12in;
+        display: flex;
+      }
+      .inner {
+        flex: 1; border-radius: 0.12in; border: 1px solid #e8eef6; overflow: hidden;
+        display: flex; flex-direction: column;
+      }
+      .rule { height: 0.09in; background: linear-gradient(90deg, #7c3aed, #6366f1, #3b82f6); }
+      .body { flex: 1; padding: 0.14in 0.16in; display: flex; align-items: center; gap: 0.16in; }
+      .copy { flex: 1; }
+      .eyebrow { font-size: 7.5pt; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; color: #7c3aed; }
+      .headline { font-size: 15pt; font-weight: 900; color: #0f172a; line-height: 1.05; margin: 0.03in 0; }
+      .sub { font-size: 9pt; color: #475569; line-height: 1.25; }
+      .qr { text-align: center; }
+      .qr img { width: 1.15in; height: 1.15in; display: block; }
+      .qr-blank { width: 1.15in; height: 1.15in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
+      .qr .cap { font-size: 6.5pt; font-weight: 800; color: #64748b; text-transform: uppercase; letter-spacing: .05em; margin-top: 0.02in; }
+      .footer { display: flex; align-items: center; justify-content: space-between; padding: 0.05in 0.16in; background: #f8fafc; border-top: 1px solid #e8eef6; font-size: 7pt; font-weight: 700; color: #94a3b8; }
+      .footer .logo img { height: 0.16in; display: block; }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <% @card_count.times do %>
+        <div class="tag">
+          <div class="inner">
+            <div class="rule"></div>
+            <div class="body">
+              <div class="copy">
+                <div class="eyebrow">SpeakAnyWay AAC</div>
+                <div class="headline">This device is my voice.</div>
+                <div class="sub">Please help me use it to communicate. It speaks for me.</div>
+              </div>
+              <div class="qr">
+                <% if @qr_data_url.present? %>
+                  <img src="<%= @qr_data_url %>" alt="Scan to learn more" />
+                <% else %>
+                  <div class="qr-blank"></div>
+                <% end %>
+                <div class="cap">Scan me</div>
+              </div>
+            </div>
+            <div class="footer">
+              <span>Powered by SpeakAnyWay</span>
+              <span class="logo"><% if @logo.present? %><img src="data:image/png;base64,<%= @logo %>" alt="SpeakAnyWay" /><% end %></span>
+              <span>speakanyway.com</span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </body>
+</html>

--- a/app/views/marketing/safety_tag_sheet.html.erb
+++ b/app/views/marketing/safety_tag_sheet.html.erb
@@ -1,0 +1,102 @@
+<%# Compact AAC communication-ID backpack tags — generic/fillable, print-and-cut.
+    N portrait tags (3.4in x 4.9in) laid 2-up on a Letter page with dashed cut
+    lines. QR (@qr_data_url, nil-safe) points at the /classroom funnel. %>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html, body {
+        -webkit-print-color-adjust: exact; print-color-adjust: exact;
+        margin: 0; padding: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: #1e293b;
+      }
+      @page { margin: 0; size: letter; }
+
+      .sheet {
+        box-sizing: border-box;
+        width: 8.5in; min-height: 11in;
+        padding: 0.55in 0.4in;
+        display: flex; flex-wrap: wrap; align-content: flex-start;
+        gap: 0.3in; justify-content: center;
+      }
+
+      .tag {
+        box-sizing: border-box;
+        width: 3.4in; height: 4.9in;
+        border: 1.5px dashed #cbd5e1;      /* cut line */
+        border-radius: 0.16in;
+        background: #fff;
+        padding: 0.14in;
+        display: flex; flex-direction: column;
+        overflow: hidden;
+      }
+      .inner {
+        flex: 1; border-radius: 0.12in;
+        border: 1px solid #e8eef6; overflow: hidden;
+        display: flex; flex-direction: column;
+      }
+      .band {
+        background: linear-gradient(90deg, #7c3aed, #6366f1, #3b82f6);
+        color: #fff; padding: 0.1in 0.14in;
+        display: flex; align-items: center; justify-content: space-between;
+      }
+      .band .logo img { height: 0.22in; display: block; filter: brightness(0) invert(1); }
+      .band .eyebrow {
+        font-size: 8.5pt; font-weight: 800; letter-spacing: .06em; text-transform: uppercase;
+      }
+      .body { flex: 1; padding: 0.14in; display: flex; flex-direction: column; align-items: center; text-align: center; }
+      .photo {
+        width: 1.05in; height: 1.05in; border-radius: 999px;
+        border: 2px dashed #c7d2fe; margin-top: 0.04in;
+        display: flex; align-items: center; justify-content: center;
+        color: #a5b4fc; font-size: 7.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: .05em;
+      }
+      .name-label { font-size: 8pt; color: #64748b; font-weight: 700; margin: 0.14in 0 0.02in; align-self: stretch; text-align: left; }
+      .name-line { border-bottom: 1.5px solid #94a3b8; height: 0.28in; align-self: stretch; }
+      .msg { font-size: 9pt; line-height: 1.3; color: #334155; margin-top: 0.12in; }
+      .qr-row { margin-top: auto; display: flex; align-items: center; gap: 0.12in; width: 100%; }
+      .qr img { width: 0.92in; height: 0.92in; display: block; }
+      .qr-blank { width: 0.92in; height: 0.92in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
+      .qr-copy { text-align: left; }
+      .qr-copy .lead { font-size: 8.5pt; font-weight: 800; color: #7c3aed; }
+      .qr-copy .sub { font-size: 7.5pt; color: #64748b; }
+      .footer { background: #f8fafc; border-top: 1px solid #e8eef6; padding: 0.06in 0.14in; display: flex; justify-content: space-between; font-size: 7pt; color: #94a3b8; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <% @card_count.times do %>
+        <div class="tag">
+          <div class="inner">
+            <div class="band">
+              <span class="eyebrow">Communication ID</span>
+              <span class="logo">
+                <% if @logo.present? %><img src="data:image/png;base64,<%= @logo %>" alt="SpeakAnyWay" /><% end %>
+              </span>
+            </div>
+            <div class="body">
+              <div class="photo">Photo</div>
+              <div class="name-label">MY NAME</div>
+              <div class="name-line"></div>
+              <div class="msg">I use a device to communicate. Please be patient and let me use my voice.</div>
+              <div class="qr-row">
+                <% if @qr_data_url.present? %>
+                  <div class="qr"><img src="<%= @qr_data_url %>" alt="Scan for info" /></div>
+                <% else %>
+                  <div class="qr-blank"></div>
+                <% end %>
+                <div class="qr-copy">
+                  <div class="lead">Scan me</div>
+                  <div class="sub">Emergency &amp; communication info</div>
+                </div>
+              </div>
+            </div>
+            <div class="footer"><span>Powered by SpeakAnyWay</span><span>speakanyway.com</span></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -421,6 +421,12 @@ Rails.application.routes.draw do
       get "marketing_artifacts/name_tag",
           to: "marketing_artifacts#name_tag",
           defaults: { format: :pdf }
+      get "marketing_artifacts/safety_tag",
+          to: "marketing_artifacts#safety_tag",
+          defaults: { format: :pdf }
+      get "marketing_artifacts/device_tag",
+          to: "marketing_artifacts#device_tag",
+          defaults: { format: :pdf }
     end
 
     namespace :v1 do

--- a/spec/requests/api/internal/marketing_artifacts_spec.rb
+++ b/spec/requests/api/internal/marketing_artifacts_spec.rb
@@ -35,4 +35,47 @@ RSpec.describe "API::Internal::MarketingArtifacts", type: :request do
       expect(response.body).to start_with("%PDF")
     end
   end
+
+  describe "GET /api/internal/marketing_artifacts/safety_tag.pdf" do
+    it "returns 401 without a valid bearer token" do
+      get "/api/internal/marketing_artifacts/safety_tag.pdf"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "streams a compact safety-tag sheet PDF pointing the QR at the given target" do
+      expect(Marketing::SafetyTagSheet).to receive(:new).with(
+        hash_including(qr_target_url: "https://speakanyway.com/classroom?utm_content=safety_tag"),
+      ).and_call_original
+
+      get "/api/internal/marketing_artifacts/safety_tag.pdf",
+          params: { qr_target_url: "https://speakanyway.com/classroom?utm_content=safety_tag" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+      expect(response.headers["Content-Disposition"]).to include("attachment")
+      expect(response.body).to start_with("%PDF")
+    end
+  end
+
+  describe "GET /api/internal/marketing_artifacts/device_tag.pdf" do
+    it "returns 401 without a valid bearer token" do
+      get "/api/internal/marketing_artifacts/device_tag.pdf"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "streams a compact device-tag sheet PDF pointing the QR at the given target" do
+      expect(Marketing::DeviceTagSheet).to receive(:new).with(
+        hash_including(qr_target_url: "https://speakanyway.com/classroom?utm_content=device_tag"),
+      ).and_call_original
+
+      get "/api/internal/marketing_artifacts/device_tag.pdf",
+          params: { qr_target_url: "https://speakanyway.com/classroom?utm_content=device_tag" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("application/pdf")
+      expect(response.body).to start_with("%PDF")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the kit's **safety tag being too big and spilling onto a second page**. The kit was reusing the app's detailed Profile safety card (`Communicators::GenerateSafetyIdCard`) — a full-page 1200×1800 card that **overflows A4 onto a 2nd page** on export and is far too large for a backpack ID tag.

Replaces the kit's safety + device tags with **compact, print-and-cut backpack tags**, 2-up on a single Letter page.

- **`Marketing::SafetyTagSheet`** — a "Communication ID" backpack tag: photo circle, fillable name line, "I use a device to communicate", QR → `/classroom`.
- **`Marketing::DeviceTagSheet`** — "This device is my voice" tag, QR → `/classroom`.
- Shared helpers in **`Marketing::SheetRendering`** (QR, logo, Letter render); templates under `app/views/marketing/`.
- New endpoints **`GET /api/internal/marketing_artifacts/{safety_tag,device_tag}.pdf`** (mirror `name_tag`).
- The kit's tags **no longer depend on a sample Profile**.

Verified with a real Grover render: each sheet is **exactly one Letter page** (612×792pt), 2 tags each with dashed cut lines.

### Preview
Safety tags (2-up): "Communication ID" — photo / MY NAME line / message / QR "Scan me · Emergency & communication info".
Device tags (2-up): "This device is my voice" / QR "Scan me".

### Not changed / follow-up
- The app's Profile-driven safety/device cards (`GenerateSafetyIdCard`/`GenerateDeviceTag`) and their `qr_target_url:` override are **unchanged**; `marketing:seed_kit_sample_profile` remains but is no longer needed for the kit.
- **Known follow-up (noted in CLAUDE.md, out of scope here):** the app's own downloaded safety-card PDF can also overflow to 2 pages because `BaseAssetGenerator#generate_pdf_from_html` uses `format: "A4"`. A separate fix would size the page to the card.

## Test plan
- `bundle exec rspec spec/requests/api/internal/marketing_artifacts_spec.rb` — new `safety_tag`/`device_tag` cases (401 + happy path), **6 examples, 0 failures**.
- `bundle exec rspec spec/requests/api/internal/marketing_{artifacts,assets}_spec.rb spec/models/marketing_asset_spec.rb spec/services/communicators/asset_generator_qr_override_spec.rb` — **24 examples, 0 failures**.
- Real render check: both sheets = 1 Letter page.

Pairs with a printables PR that switches the `marketing-kit` script to these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)