### PR TITLE
feat(analytics): fire server-side checkout_started from Stripe checkout (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — reliable server-side `checkout_started` analytics
+- Fire a server-side PostHog `checkout_started` when a Stripe Checkout Session
+  is created (subscription + top-up), keyed to the user's distinct_id
+  (itty_bitty_boards#452 / frontend #505). The browser event was routinely
+  dropped when the page unloads to Stripe before PostHog flushes, so the
+  `CTA → checkout_started → checkout_completed` funnel read zero; the reliable
+  capture is now on the backend. Carries `plan` / `billing_interval` / `source`
+  / `kind`, and threads `client_reference_id = user.id` + `source` into the
+  Checkout Session so Stripe-originated events attribute to the same person.
+  Instrumentation only — no user-facing behavior change.
+
 ### Added — new-subscriber onboarding email when a paid plan starts
 - New Mailchimp `subscription_started` Customer Journey fires when a user
   converts to an active paid plan (the non-active→active transition in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,8 +356,22 @@ PostHog events; the backend ensures the full funnel is always captured
 - **`user_signed_in`** `{ plan_type }` — on successful password login
   (`#create`). Same ad-blocker-resilience rationale.
 
-**Subscription lifecycle events** — fired from `API::WebhooksController`:
+**Subscription lifecycle events** — fired from `API::WebhooksController`
+(unless noted):
 
+- **`checkout_started`** `{ plan, billing_interval, kind, source }` (subscription)
+  / `{ plan, kind, pack_key, source }` (topup) — fired from
+  `API::Stripe::CheckoutSessionsController#create` / `#topup` when a Stripe
+  Checkout Session is **created** (itty_bitty_boards#452 / frontend #505). The
+  frontend fires this too, but it's routinely dropped when the page unloads to
+  Stripe before PostHog's batch flushes — so this server-side capture is the
+  reliable one; the client event stays a best-effort earlier signal. `plan` is
+  the base tier (`pro_yearly` → `pro`) with a separate `billing_interval` to
+  match the frontend + `subscription_started` shape; `kind` is `"subscription"`
+  or `"topup"` (mirroring `checkout_completed`); `source` is the CTA/page the
+  frontend threads through (`params[:source]`, default `"web_checkout"`). Both
+  checkout paths also set the Session's `client_reference_id = user.id` and add
+  `source` to metadata so Stripe-originated events attribute to the same person.
 - **`checkout_completed`** `{ plan, kind, amount_total, currency, source }` —
   on `checkout.session.completed`, the **authoritative** purchase-completion
   event (fires even if the user never returns to the success page; the frontend

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -47,6 +47,10 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     plan_key = params[:plan_key].to_s
     price_id = PLAN_PRICE_IDS[plan_key]
     promo_code = params[:promo_code].to_s.strip
+    # Which CTA/page initiated checkout (itty-bitty-frontend#505). Threaded
+    # from the frontend so the server-side `checkout_started` carries the same
+    # `source` the (best-effort) client event does; defaulted so it's never nil.
+    source = params[:source].to_s.strip.presence || "web_checkout"
 
     if plan_key == "free" || price_id.blank?
       current_user.update!(plan_type: "free", plan_status: "active")
@@ -100,10 +104,14 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     session_params = {
       mode: "subscription",
       customer: current_user.stripe_customer_id,
+      # PostHog distinct_id is String(user.id); threading it through Checkout
+      # lets Stripe-originated events attribute to the same person and helps
+      # close the identity-stitching gap (itty_bitty_boards#452).
+      client_reference_id: current_user.id.to_s,
       line_items: [{ price: price_id, quantity: 1 }],
       success_url: "#{frontend_base_url}/billing/success?session_id={CHECKOUT_SESSION_ID}",
       cancel_url: cancel_url,
-      metadata: { user_id: current_user.id, plan_key: plan_key },
+      metadata: { user_id: current_user.id, plan_key: plan_key, source: source },
       payment_method_collection: payment_method_collection,
     }
 
@@ -129,6 +137,22 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
 
     session = Stripe::Checkout::Session.create(session_params)
     current_user.update!(paid_plan_type: plan_key)
+    # Server-side `checkout_started` (itty_bitty_boards#452 / frontend #505).
+    # The frontend fires this too but it's routinely dropped when the page
+    # unloads to Stripe before PostHog's batch flushes, so the reliable capture
+    # is here at session-create. `plan`/`billing_interval` mirror the frontend +
+    # `subscription_started` shape so the CTA → checkout_started →
+    # checkout_completed funnel lines up.
+    PosthogService.capture_for_user(
+      current_user,
+      "checkout_started",
+      properties: {
+        plan: plan_base(plan_key),
+        billing_interval: billing_interval_for(plan_key),
+        kind: "subscription",
+        source: source,
+      },
+    )
     # Measure trial starts so trial→paid conversion is computable against the
     # later `subscription_started` event (issue #264 A/B instrumentation).
     AnalyticsEvent.track(
@@ -158,6 +182,7 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     env_key = TOPUP_PRICE_ENV_KEYS[pack_key]
     price_id = env_key.present? ? ENV[env_key].presence : nil
     quantity = [params[:quantity].to_i, 1].max
+    source = params[:source].to_s.strip.presence || "web_checkout"
 
     if price_id.blank?
       render json: { error: "Unknown or unconfigured pack_key" }, status: :bad_request
@@ -176,6 +201,8 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     session = Stripe::Checkout::Session.create(
       mode: "payment",
       customer: current_user.stripe_customer_id,
+      # Same distinct_id threading as subscription checkout (#452).
+      client_reference_id: current_user.id.to_s,
       line_items: [{ price: price_id, quantity: quantity }],
       # Match the frontend's existing /billing/success route, which reads
       # ?type=topup&credits=N to render the "credits added" screen
@@ -189,6 +216,20 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
         user_id: current_user.id,
         pack_key: pack_key,
         credit_amount: credit_amount * quantity,
+        source: source,
+      },
+    )
+    # Server-side `checkout_started` for top-ups, mirroring the subscription
+    # path and the `checkout_completed` topup event (kind: "topup"). `plan` is
+    # the user's current tier — a topup doesn't pick one.
+    PosthogService.capture_for_user(
+      current_user,
+      "checkout_started",
+      properties: {
+        plan: current_user.plan_type,
+        kind: "topup",
+        pack_key: pack_key,
+        source: source,
       },
     )
     render json: { url: session.url }
@@ -261,6 +302,20 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
 
   def ensure_customer!
     current_user.ensure_stripe_customer!
+  end
+
+  # Base plan tier without the billing-cadence suffix ("pro_yearly" → "pro"),
+  # so the `checkout_started` `plan` property matches the frontend + the
+  # webhook's `subscription_started` shape (plan + separate billing_interval).
+  def plan_base(plan_key)
+    plan_key.to_s.sub(/_yearly\z/, "")
+  end
+
+  # "yearly" for the `_yearly` price keys, "monthly" otherwise. Mirrors
+  # `billing_interval_from_price` in the webhook, but derived from the plan_key
+  # we already have at session-create time (no Stripe round-trip).
+  def billing_interval_for(plan_key)
+    plan_key.to_s.end_with?("_yearly") ? "yearly" : "monthly"
   end
 
   # Prefer the request's Origin (then Referer) when it points at a trusted

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -131,6 +131,58 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
     end
   end
 
+  describe "server-side checkout_started analytics (itty_bitty_boards#452 / frontend #505)" do
+    before do
+      user.update!(stripe_customer_id: "cus_existing")
+      allow(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://stripe.test/x"))
+    end
+
+    it "captures checkout_started with plan/billing_interval/source/kind, using the base plan for a yearly key" do
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "checkout_started",
+        properties: {
+          plan: "pro",              # base plan, _yearly suffix stripped
+          billing_interval: "yearly",
+          kind: "subscription",
+          source: "pricing_page",
+        },
+      )
+
+      do_post.call({ plan_key: "pro_yearly", source: "pricing_page" })
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "defaults billing_interval to monthly and source to web_checkout when not provided" do
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "checkout_started",
+        properties: hash_including(plan: "basic", billing_interval: "monthly", source: "web_checkout"),
+      )
+
+      do_post.call({ plan_key: "basic" })
+    end
+
+    it "threads source + distinct_id into the Checkout Session (metadata + client_reference_id)" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://stripe.test/x")
+      end
+
+      do_post.call({ plan_key: "basic", source: "onboarding" })
+
+      expect(captured[:client_reference_id]).to eq(user.id.to_s)
+      expect(captured[:metadata][:source]).to eq("onboarding")
+    end
+
+    it "does not fire checkout_started for the free-plan short-circuit" do
+      expect(PosthogService).not_to receive(:capture_for_user)
+      do_post.call({ plan_key: "free" })
+    end
+  end
+
   describe "payment_method_collection (no-card reverse trial / A-B arm)" do
     let(:captured) { {} }
 

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -180,6 +180,42 @@ RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
     end
   end
 
+  describe "server-side checkout_started analytics (itty_bitty_boards#452)" do
+    before do
+      user.update!(stripe_customer_id: "cus_topup_analytics", plan_type: "pro", plan_status: "active")
+      allow(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://example/cs"))
+    end
+
+    it "captures checkout_started with kind=topup, the current plan, pack_key, and source" do
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "checkout_started",
+        properties: { plan: "pro", kind: "topup", pack_key: "small", source: "billing_page" },
+      )
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small", source: "billing_page" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "threads distinct_id + source into the Checkout Session" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://example/cs")
+      end
+
+      post "/api/stripe/checkout_sessions/topup",
+           params: { pack_key: "small", source: "billing_page" },
+           headers: auth_headers(user)
+
+      expect(captured[:client_reference_id]).to eq(user.id.to_s)
+      expect(captured[:metadata][:source]).to eq("billing_page")
+    end
+  end
+
   describe "success_url query string" do
     before { user.update!(stripe_customer_id: "cus_qs") }
 


### PR DESCRIPTION
## What & why

Closes #452. Companion to itty-bitty-frontend#505.

The browser-side `checkout_started` (from frontend #307) fired **0 times in 14 days** in prod PostHog while real `checkout_completed` webhooks landed — because checkout redirects to Stripe, and PostHog's async batch transport hasn't flushed the event before the page unloads. This adds the **reliable** capture on the backend, where we already fire the other money-path events.

The backend already fires `checkout_completed`, `subscription_started`, `subscription_cancelled`, and `trial_started` server-side. The only missing money-path event was `checkout_started` — fired when the Stripe Checkout Session is **created**. That's what this adds.

## Changes

- **`API::Stripe::CheckoutSessionsController#create` / `#topup`** now fire `PosthogService.capture_for_user(user, "checkout_started", …)` after the Session is created, keyed to `user.id` (the same distinct_id the frontend identifies with).
  - Subscriptions: `{ plan (base tier), billing_interval, kind: "subscription", source }` — `plan`/`billing_interval` mirror the frontend + `subscription_started` shape so the funnel lines up.
  - Top-ups: `{ plan, kind: "topup", pack_key, source }` — mirrors the existing `checkout_completed` topup event.
- **Threads `source`** (`params[:source]`, default `"web_checkout"`) into the event and the Session metadata, and sets **`client_reference_id = user.id`** on both checkout paths so Stripe-originated events attribute to the same person (identity stitching, per #452).
- Docs: CLAUDE.md PostHog section + CHANGELOG entry.

## Acceptance criteria (#452)

- [x] Creating a Stripe Checkout Session emits a server-side `checkout_started` with the user's distinct_id
- [x] Subscription webhooks emit `subscription_started` / `subscription_cancelled` (already shipped; unchanged)
- [x] distinct_id threaded through checkout (`client_reference_id` + capture keyed to `user.id`)
- [x] Funnel `CTA → checkout_started → checkout_completed` buildable end-to-end

## Test plan

- `bundle exec rspec spec/requests/api/stripe/checkout_sessions_spec.rb spec/requests/api/stripe/checkout_sessions_topup_spec.rb` → **36 examples, 0 failures**.
- New specs assert: `checkout_started` props (base plan for a `_yearly` key, billing_interval, kind, source), `source`/`client_reference_id` threading into the Session, topup `kind:"topup"`, and no event on the free-plan short-circuit.
- Capture is prod-gated (`PosthogClient.enabled?`), so verifying in PostHog Live events needs a prod deploy (or `POSTHOG_CAPTURE_ENABLED=true` on staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)