### PR TITLE
feat(marketing): stable kit board slugs + opt-in marketing print style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — stable slugs + marketing print style for the AAC Classroom Kit
+- The internal boards API (`POST /api/internal/boards` and
+  `POST /api/internal/boards/from_vocab_set`) gains opt-in
+  **`replace_existing_slug`** semantics: when set, a previous board holding the
+  requested slug is destroyed and the new board takes the exact slug — but only
+  when the previous board is owned by the internal admin **and** tagged
+  `marketing`. Anything else is left alone (the new board gets a suffixed slug
+  instead). `from_vocab_set` accepts the new-board slug as **`board_slug`**
+  (`slug` there is the vocab-set key). This keeps the printed kit's QR targets
+  (`/pb/<slug>`) stable across kit regenerations and stops `MKT —` scratch
+  boards accumulating.
+- The internal board PDF export (`GET /api/internal/boards/:id/export.pdf`)
+  gains an opt-in **`style=marketing`** param that renders a marketing-branded
+  template/layout pair (`api/boards/print_marketing` + `pdf_marketing`):
+  gradient header band, white QR chip, footer CTA. **The default (no param) is
+  byte-identical to before** — the shared `print`/`pdf` pair used for real
+  users' board exports is untouched (spec-guarded).
+- The marketing tag/name-tag sheets get a slim "print at 100% · cut along the
+  dashed lines" hint strip and a unified brand gradient.
+
 ### Added — compact backpack safety + device tags for the AAC Classroom Kit
 - New `GET /api/internal/marketing_artifacts/safety_tag.pdf` and
   `.../device_tag.pdf` render generic, print-and-cut **backpack ID tags**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - The marketing tag/name-tag sheets get a slim "print at 100% · cut along the
   dashed lines" hint strip and a unified brand gradient.
 
+### Fixed — kit tag QR codes were too dense to scan
+- The Communication ID (safety), device, and name-tag sheet QRs **didn't
+  register as QR codes on phones at all**: rqrcode's default ECC level (`:h`)
+  turned the ~119-char `/classroom` UTM URL into a 57-module QR, which at the
+  tags' printed sizes was ~0.31–0.45mm per module — below the ~0.5mm
+  phone-camera detection floor. (The board poster QR scanned fine because its
+  `/pb/<slug>` payload is much shorter.) Fixed by encoding at ECC `:l`
+  (41 modules — a clean printed lead magnet doesn't need 30% damage
+  redundancy), rendering a 480px print-resolution source PNG, and enlarging
+  the printed QR boxes (safety 0.92→1.15in, device 1.15→1.3in, name tag
+  20→26mm), putting every tag at ~0.53–0.67mm per module. Verified by
+  rasterizing the rendered sheets and machine-decoding: before, no QR decoded
+  below 150dpi; after, all three decode at 72dpi. Regression spec pins the
+  ECC level + source size.
+
 ### Added — compact backpack safety + device tags for the AAC Classroom Kit
 - New `GET /api/internal/marketing_artifacts/safety_tag.pdf` and
   `.../device_tag.pdf` render generic, print-and-cut **backpack ID tags**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1156,6 +1156,28 @@ which already depends on `pdf-lib`.
   regenerations**. `MarketingAsset.upsert_pdf!(slug:, bytes:, title:, kind:)` is
   idempotent — re-running the kit build overwrites in place, so the
   `KIT_DOWNLOAD_URL` is safe to hardcode on the frontend.
+- **Stable slugs for kit boards (`replace_existing_slug`).** The internal
+  boards endpoints (`POST /api/internal/boards`, `POST /api/internal/boards/
+  from_vocab_set`) accept an opt-in `replace_existing_slug` boolean: the
+  controller destroys the previous board holding the requested slug and gives
+  the new board the **exact** slug — scoped so only a board owned by the
+  internal admin AND tagged `marketing` is ever destroyed (anything else is
+  left alone and the new board gets a suffixed slug, logged). On
+  `from_vocab_set` the new-board slug rides **`board_slug`** (`slug` is the
+  vocab-set key), claimed only after the clone persists so a failed clone
+  never destroys the live QR target. This keeps the printed kit's
+  `/pb/<slug>` QR targets stable across regenerations and stops `MKT —`
+  scratch boards accumulating. Brief 404 window on the slug while a
+  regeneration is in flight — acceptable for a lead magnet.
+- **Marketing print style (`style=marketing`) on board PDF export.**
+  `GET /api/internal/boards/:id/export.pdf?style=marketing` renders the
+  marketing-branded pair `app/views/api/boards/print_marketing.html.erb` +
+  `app/views/layouts/pdf_marketing.html.erb` (gradient header band, white QR
+  chip, footer CTA; tile rendering identical since AAC colors are meaningful).
+  The pair is a deliberate **copy**, not a refactor — the shared
+  `print`/`pdf` pair backs real users' exports and stays byte-identical when
+  the param is absent (spec-guarded in `board_pdf_export_spec.rb`). Any
+  unknown `style` value falls back to the shared pair.
 - **Endpoints (behind `INTERNAL_API_KEY`, `namespace :internal`):**
   - `POST /api/internal/marketing_assets` `{ slug, file(multipart PDF), title?, kind? }`
     → upsert + host → `{ slug, title, kind, url }` (`201`). The printables

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -1,5 +1,16 @@
 class API::Internal::BoardsController < API::Internal::ApplicationController
+  # Tag that marks a board as an internal marketing artifact (set by the
+  # printables marketing-kit script). Only boards carrying it are eligible
+  # for replace-by-slug below.
+  MARKETING_TAG = "marketing".freeze
+
   def create
+    # Opt-in stable-slug semantics for marketing artifacts: free up the exact
+    # requested slug by destroying the previous kit board that held it, so the
+    # printed QR target (/pb/<slug>) survives kit regenerations and scratch
+    # boards don't accumulate.
+    claim_marketing_slug!(board_params[:slug]) if replace_existing_slug?
+
     @board = Board.new(board_params)
     @board.user = current_user
 
@@ -61,6 +72,11 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       return
     end
 
+    # `params[:slug]` is the VOCAB SET slug; the new board's slug rides
+    # `params[:board_slug]`. Claim it only after the clone persisted, so a
+    # failed clone never destroys the live QR target.
+    claim_marketing_slug!(params[:board_slug]) if replace_existing_slug? && params[:board_slug].present?
+
     finalize_cloned_vocab_board!(board)
 
     render json: board.api_view_with_images(current_user), status: :created
@@ -90,9 +106,15 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
 
     render_data.each { |k, v| instance_variable_set("@#{k}", v) }
 
+    # Opt-in marketing skin for the AAC Classroom Kit. The default template +
+    # layout are shared with real users' board exports and must stay
+    # byte-identical when the param is absent — the marketing variant is a
+    # separate template/layout pair, never a conditional inside the shared one.
+    marketing_style = params[:style] == "marketing"
+
     html = render_to_string(
-      template: "api/boards/print",
-      layout: "pdf",
+      template: marketing_style ? "api/boards/print_marketing" : "api/boards/print",
+      layout: marketing_style ? "pdf_marketing" : "pdf",
       formats: [:html],
     )
 
@@ -157,7 +179,33 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       board.tags = Array(params[:tags]).select { |t| t.is_a?(String) && t.present? }
     end
 
+    if params[:board_slug].present?
+      board.slug = board.generate_unique_slug(params[:board_slug])
+    end
+
     board.save
+  end
+
+  def replace_existing_slug?
+    ActiveModel::Type::Boolean.new.cast(params[:replace_existing_slug])
+  end
+
+  # Destroy the previous board occupying `slug` so the fresh build can take the
+  # exact same one. Tightly scoped: only a board owned by the internal-API
+  # admin AND tagged "marketing" is eligible. Anything else stays untouched —
+  # generate_unique_slug then suffixes the new board's slug instead of
+  # clobbering, and we log so the kit script's slug mismatch is explainable.
+  def claim_marketing_slug!(requested_slug)
+    slug = Board.create_slug(requested_slug.to_s)
+    return if slug.blank?
+
+    existing = Board.where(user_id: current_user.id, slug: slug).with_all_tags([MARKETING_TAG]).first
+    if existing
+      Rails.logger.info "[internal boards] replace_existing_slug: destroying marketing board #{existing.id} (#{existing.slug})"
+      existing.destroy
+    elsif Board.exists?(slug: slug)
+      Rails.logger.warn "[internal boards] replace_existing_slug: slug #{slug.inspect} is held by a non-marketing board — leaving it; the new board will get a suffixed slug"
+    end
   end
 
   def enqueue_generation_job!(creation_type)

--- a/app/services/marketing/name_tag_sheet.rb
+++ b/app/services/marketing/name_tag_sheet.rb
@@ -49,11 +49,14 @@ module Marketing
       }
     end
 
+    # Keep in lockstep with Marketing::SheetRendering#qr_data_url — same
+    # deliberate ECC :l (rqrcode's default :h makes the long UTM URL too
+    # dense to phone-scan at the small printed size; see the note there).
     def qr_data_url
       return nil if qr_target_url.blank?
 
-      png = RQRCode::QRCode.new(qr_target_url).as_png(
-        size: 300,
+      png = RQRCode::QRCode.new(qr_target_url, level: :l).as_png(
+        size: 480,
         border_modules: 4,
         module_px_size: 6,
       )

--- a/app/services/marketing/sheet_rendering.rb
+++ b/app/services/marketing/sheet_rendering.rb
@@ -28,10 +28,16 @@ module Marketing
       Grover.new(html, **LETTER_GROVER_OPTIONS).to_pdf
     end
 
-    def qr_data_url(url, size: 300)
+    # ECC level :l is deliberate. rqrcode defaults to :h, which turns the
+    # ~119-char /classroom UTM URL into a 57-module QR — at the tags' small
+    # printed size that's ~0.35mm per module, below what phone cameras detect
+    # (the "QR won't even scan" kit bug). :l needs only 41 modules, and a
+    # clean high-contrast print doesn't need :h's 30% damage redundancy.
+    # size: 480 keeps the source ≥300dpi at the printed sizes below.
+    def qr_data_url(url, size: 480)
       return nil if url.blank?
 
-      png = RQRCode::QRCode.new(url).as_png(
+      png = RQRCode::QRCode.new(url, level: :l).as_png(
         size: size,
         border_modules: 4,
         module_px_size: 6,

--- a/app/views/api/boards/print_marketing.html.erb
+++ b/app/views/api/boards/print_marketing.html.erb
@@ -1,0 +1,113 @@
+<%# Marketing-only variant of api/boards/print.html.erb, rendered inside the
+    pdf_marketing layout when the internal export_pdf endpoint gets
+    `style=marketing` (AAC Classroom Kit posters). Deliberately a COPY of the
+    shared template — see the note in layouts/pdf_marketing.html.erb. Tile
+    rendering is identical (AAC colors are meaningful); the skin is the page
+    furniture: gradient header band, white QR chip, footer CTA strip. %>
+<% unless @hide_header %>
+  <div class="header">
+    <div class="header-inner">
+      <div class="logo">
+        <% if @logo.present? %>
+          <img alt="SpeakAnyWay Logo" src="data:image/png;base64,<%= @logo %>">
+        <% end %>
+      </div>
+
+      <div class="header-copy">
+        <p class="board-title">
+          <strong><%= @board_title %></strong>
+        </p>
+
+        <p class="board-subtitle">
+          Free AAC resource &middot; SpeakAnyWay
+        </p>
+
+        <% if @qr_data_url.present? %>
+          <div class="board-link">
+            Scan the code or visit
+            <a href="<%= @qr_target_url %>" target="_blank" rel="noopener noreferrer"><%= @qr_target_url %></a>
+            — every word is free to tap in the app.
+          </div>
+        <% end %>
+      </div>
+
+      <% if @qr_data_url.present? %>
+        <div class="qr-chip">
+          <img src="<%= @qr_data_url %>" alt="QR code">
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<div class="board-wrap">
+  <div
+    class="board-sizer"
+    style="width:<%= @board_render_width_mm %>mm; height:<%= @board_render_height_mm %>mm;"
+  >
+    <div
+      class="board-grid"
+      style="
+        grid-template-columns: repeat(<%= @columns %>, 1fr);
+        grid-template-rows: repeat(<%= @rows %>, 1fr);
+      "
+    >
+      <% @tiles.each do |t| %>
+        <% bg_color = @hide_colors ? "" : (t["bg_color"] || "black") %>
+        <% border_color = @hide_colors ? "" : (t["border_color"] || "black") %>
+        <% border_width = t["border_width"] || 0 %>
+        <% border_radius = t["border_radius"] || 0 %>
+        <% if t["hide_label"] %>
+          <% label_hidden = true %>
+        <% else %>
+          <% label_hidden = false %>
+        <% end %>
+        <% col_start = t["x"].to_i + 1 %>
+        <% row_start = t["y"].to_i + 1 %>
+        <% col_span = t["w"].to_i %>
+        <% row_span = t["h"].to_i %>
+
+        <div
+          class="tile"
+          style="
+            background-color:<%= bg_color.presence || "#ffffff" %>;
+            grid-column:<%= col_start %> / span <%= col_span %>;
+            grid-row:<%= row_start %> / span <%= row_span %>;
+            border-color:<%= border_color.presence || "#e2e8f0" %>;
+            border-width:<%= border_width %>px;
+            border-radius:<%= border_radius %>px;
+          "
+
+        >
+          <div class="tile-media">
+            <% if t["image_url"].present? %>
+              <img src="<%= t["image_url"] %>" alt="<%= t["label"] %>">
+            <% else %>
+              <img
+                src="<%= generate_placeholder_image(t["label"]) %>"
+                alt="<%= t["label"] %>"
+                class="tile-placeholder-image"
+              >
+            <% end %>
+          </div>
+
+          <% unless label_hidden %>
+            <div
+            class="label <%= bg_color %>"
+            style="
+              font-weight:<%= @hide_colors ? "normal" : "bold" %>;
+              background-color:<%= bg_color.presence || "#f7f7f7" %>;
+            ">
+            <%= t["label"] %>
+          </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="marketing-footer">
+  <span>Powered by SpeakAnyWay</span>
+  <span class="cta">Make boards like this free at speakanyway.com/classroom</span>
+</div>

--- a/app/views/layouts/pdf_marketing.html.erb
+++ b/app/views/layouts/pdf_marketing.html.erb
@@ -1,0 +1,254 @@
+<%# Marketing-only variant of layouts/pdf.html.erb, selected by the internal
+    export_pdf endpoint's opt-in `style=marketing` param (AAC Classroom Kit).
+    Deliberately a COPY, not a refactor: the shared `pdf` layout backs real
+    users' board exports and must stay byte-identical, so the marketing skin
+    lives entirely in this separate pair (see print_marketing.html.erb).
+    Brand palette mirrors the marketing tag sheets (app/views/marketing/*). %>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Board PDF</title>
+
+    <style>
+      html, body {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      body {
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+        color: #1e293b;
+      }
+
+      @page {
+        margin: 0;
+        size: <%= @landscape ? "letter landscape" : "letter" %>;
+      }
+
+      .page {
+        box-sizing: border-box;
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+        padding: 3mm;
+
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        gap: 2mm;
+      }
+
+      /* ── Branded header band ─────────────────────────────────────────── */
+      .header {
+        min-height: 0;
+        background: linear-gradient(90deg, #7c3aed, #6366f1, #3b82f6);
+        border-radius: 2.5mm;
+        color: #fff;
+      }
+
+      .header-inner {
+        display: grid;
+        grid-template-columns: 12mm minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 6mm;
+        width: 100%;
+        padding: 2mm 3mm;
+        box-sizing: border-box;
+      }
+
+      .logo {
+        width: 12mm;
+      }
+
+      .logo img {
+        display: block;
+        max-width: 12mm;
+        height: auto;
+        object-fit: contain;
+        filter: brightness(0) invert(1);
+      }
+
+      .header-copy {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: center;
+        min-width: 0;
+        overflow: hidden;
+      }
+
+      .board-title {
+        font-size: 18pt;
+        color: #fff;
+        margin: 0;
+        font-weight: 800;
+        line-height: 1.1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+
+      .board-subtitle {
+        font-size: 8pt;
+        color: rgba(255, 255, 255, 0.85);
+        margin: 1mm 0 0;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+
+      .board-link {
+        font-size: 8pt;
+        color: rgba(255, 255, 255, 0.9);
+        padding-top: 1mm;
+        min-width: 0;
+        overflow: hidden;
+      }
+
+      .board-link a {
+        color: #fff;
+        font-weight: bold;
+        text-decoration: none;
+        word-break: break-all;
+        overflow-wrap: anywhere;
+      }
+
+      .qr-chip {
+        background: #fff;
+        border-radius: 1.5mm;
+        padding: 1mm;
+      }
+
+      .qr-chip img {
+        width: 0.72in;
+        height: 0.72in;
+        display: block;
+      }
+
+      /* ── Board grid (kept in lockstep with the shared layout) ────────── */
+      .board-wrap {
+        min-width: 0;
+        min-height: 0;
+        overflow: hidden;
+
+        display: flex;
+        align-items: flex-start;
+        justify-content: center;
+      }
+
+      .board-sizer {
+        flex: 0 0 auto;
+        max-width: 100%;
+        max-height: 100%;
+      }
+
+      .board-grid {
+        display: grid;
+        width: 100%;
+        height: 100%;
+        gap: 2pt;
+      }
+
+      .tile {
+        min-width: 0;
+        min-height: 0;
+        overflow: hidden;
+
+        position: relative;
+        border: 2pt solid #e2e8f0;
+        border-radius: 6pt;
+        background: #fff;
+
+        display: grid;
+        grid-template-rows: minmax(0, 1fr) auto;
+        box-sizing: border-box;
+      }
+
+      .tile-media {
+        min-width: 0;
+        min-height: 0;
+        overflow: hidden;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .tile img {
+        width: 100%;
+        height: 100%;
+        min-width: 0;
+        min-height: 0;
+        object-fit: contain;
+        display: block;
+      }
+
+      .tile-placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        min-width: 0;
+        min-height: 0;
+        padding: 2pt;
+        text-align: center;
+        color: #aaa;
+        font-size: 9pt;
+        line-height: 1.1;
+        box-sizing: border-box;
+      }
+
+      .label {
+        font-size: 9pt;
+        text-align: center;
+        padding: 1pt 2pt;
+        line-height: 1.1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        background: #f7f7f7;
+        box-sizing: border-box;
+      }
+
+      .green  { background-color: #b7f399; }
+      .yellow { background-color: #fdec00; }
+      .red    { background-color: #ff6464; }
+      .blue   { background-color: #81d9ff; }
+      .purple { background-color: #cb91eb; }
+      .orange { background-color: #ffc463; }
+      .black  { background-color: #000000d9; color: white; }
+      .white  { background-color: #ffffffd9; }
+      .gray   { background-color: #808080d9; }
+      .pink   { background-color: #ffc0e4; }
+      .teal   { background-color: #18ddda; }
+
+      /* ── Footer strip ────────────────────────────────────────────────── */
+      .marketing-footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 1mm 2mm;
+        border-top: 1px solid #e8eef6;
+        font-size: 7.5pt;
+        color: #94a3b8;
+        font-weight: 700;
+      }
+
+      .marketing-footer .cta {
+        color: #7c3aed;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="page">
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/marketing/device_tag_sheet.html.erb
+++ b/app/views/marketing/device_tag_sheet.html.erb
@@ -50,8 +50,10 @@
       .headline { font-size: 15pt; font-weight: 900; color: #0f172a; line-height: 1.05; margin: 0.03in 0; }
       .sub { font-size: 9pt; color: #475569; line-height: 1.25; }
       .qr { text-align: center; }
-      .qr img { width: 1.15in; height: 1.15in; display: block; }
-      .qr-blank { width: 1.15in; height: 1.15in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
+      /* 1.3in keeps the 41-module (ECC :l) QR at ~0.67mm per printed module —
+         comfortably above the ~0.5mm phone-camera detection floor. */
+      .qr img { width: 1.3in; height: 1.3in; display: block; }
+      .qr-blank { width: 1.3in; height: 1.3in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
       .qr .cap { font-size: 6.5pt; font-weight: 800; color: #64748b; text-transform: uppercase; letter-spacing: .05em; margin-top: 0.02in; }
       .footer { display: flex; align-items: center; justify-content: space-between; padding: 0.05in 0.16in; background: #f8fafc; border-top: 1px solid #e8eef6; font-size: 7pt; font-weight: 700; color: #94a3b8; }
       .footer .logo img { height: 0.16in; display: block; }

--- a/app/views/marketing/device_tag_sheet.html.erb
+++ b/app/views/marketing/device_tag_sheet.html.erb
@@ -22,6 +22,15 @@
         gap: 0.35in;
       }
 
+      .cut-hint {
+        text-align: center;
+        font-size: 8pt;
+        font-weight: 700;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+        color: #94a3b8;
+      }
+
       .tag {
         box-sizing: border-box;
         width: 4.6in; height: 2.5in;
@@ -50,6 +59,7 @@
   </head>
   <body>
     <div class="sheet">
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines</div>
       <% @card_count.times do %>
         <div class="tag">
           <div class="inner">

--- a/app/views/marketing/name_tag_sheet.html.erb
+++ b/app/views/marketing/name_tag_sheet.html.erb
@@ -24,8 +24,21 @@
         padding: 10mm;
         display: grid;
         grid-template-columns: 1fr 1fr;
+        /* First (explicit) row is the slim cut-hint strip; the card rows
+           stay equal-height 1fr via grid-auto-rows. */
+        grid-template-rows: auto;
         grid-auto-rows: 1fr;
         gap: 6mm;
+      }
+
+      .cut-hint {
+        grid-column: 1 / -1;
+        text-align: center;
+        font-size: 8pt;
+        font-weight: 700;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+        color: #94a3b8;
       }
 
       .card {
@@ -42,7 +55,7 @@
       .brand-rule {
         height: 6px;
         border-radius: 6px;
-        background: linear-gradient(90deg, #8b5cf6, #6366f1, #3b82f6);
+        background: linear-gradient(90deg, #7c3aed, #6366f1, #3b82f6);
         margin: -1mm -1mm 3mm;
       }
 

--- a/app/views/marketing/name_tag_sheet.html.erb
+++ b/app/views/marketing/name_tag_sheet.html.erb
@@ -20,7 +20,11 @@
       .sheet {
         box-sizing: border-box;
         width: 100vw;
-        min-height: 100vh;
+        /* Definite one-page height so the 1fr card rows divide the REMAINING
+           space after the hint row — with min-height the fr rows size to
+           content and the sheet spills onto a second page. */
+        height: 100vh;
+        overflow: hidden;
         padding: 10mm;
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -90,9 +94,11 @@
         margin-top: 3mm;
       }
       .qr { text-align: center; }
-      .qr img { width: 20mm; height: 20mm; display: block; }
+      /* 26mm keeps the 41-module (ECC :l) QR at ~0.53mm per printed module —
+         above the ~0.5mm phone-camera detection floor. Don't shrink this. */
+      .qr img { width: 26mm; height: 26mm; display: block; }
       .qr-blank {
-        width: 20mm; height: 20mm;
+        width: 26mm; height: 26mm;
         border: 1.5px dashed #cbd5e1; border-radius: 6px;
       }
       .qr-caption {
@@ -112,6 +118,7 @@
   </head>
   <body>
     <div class="sheet">
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the card outlines</div>
       <% @card_count.times do %>
         <div class="card">
           <div class="brand-rule"></div>

--- a/app/views/marketing/safety_tag_sheet.html.erb
+++ b/app/views/marketing/safety_tag_sheet.html.erb
@@ -22,6 +22,16 @@
         gap: 0.3in; justify-content: center;
       }
 
+      .cut-hint {
+        flex-basis: 100%;
+        text-align: center;
+        font-size: 8pt;
+        font-weight: 700;
+        letter-spacing: .05em;
+        text-transform: uppercase;
+        color: #94a3b8;
+      }
+
       .tag {
         box-sizing: border-box;
         width: 3.4in; height: 4.9in;
@@ -67,6 +77,7 @@
   </head>
   <body>
     <div class="sheet">
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines</div>
       <% @card_count.times do %>
         <div class="tag">
           <div class="inner">

--- a/app/views/marketing/safety_tag_sheet.html.erb
+++ b/app/views/marketing/safety_tag_sheet.html.erb
@@ -67,8 +67,10 @@
       .name-line { border-bottom: 1.5px solid #94a3b8; height: 0.28in; align-self: stretch; }
       .msg { font-size: 9pt; line-height: 1.3; color: #334155; margin-top: 0.12in; }
       .qr-row { margin-top: auto; display: flex; align-items: center; gap: 0.12in; width: 100%; }
-      .qr img { width: 0.92in; height: 0.92in; display: block; }
-      .qr-blank { width: 0.92in; height: 0.92in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
+      /* 1.15in keeps the 41-module (ECC :l) QR at ~0.6mm per printed module —
+         comfortably above the ~0.5mm phone-camera detection floor. */
+      .qr img { width: 1.15in; height: 1.15in; display: block; }
+      .qr-blank { width: 1.15in; height: 1.15in; border: 1.5px dashed #cbd5e1; border-radius: 0.06in; }
       .qr-copy { text-align: left; }
       .qr-copy .lead { font-size: 8.5pt; font-weight: 800; color: #7c3aed; }
       .qr-copy .sub { font-size: 7.5pt; color: #64748b; }

--- a/spec/requests/api/internal/board_pdf_export_spec.rb
+++ b/spec/requests/api/internal/board_pdf_export_spec.rb
@@ -45,6 +45,62 @@ RSpec.describe "API::Internal::Boards#export_pdf", type: :request do
       expect(response.body).to start_with("%PDF")
     end
 
+    it "renders the shared print template and pdf layout by default" do
+      expect_any_instance_of(API::Internal::BoardsController)
+        .to receive(:render_to_string)
+        .with(hash_including(template: "api/boards/print", layout: "pdf"))
+        .and_return("<html></html>")
+
+      get "/api/internal/boards/#{board.id}/export.pdf", headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the marketing template and layout when style=marketing" do
+      expect_any_instance_of(API::Internal::BoardsController)
+        .to receive(:render_to_string)
+        .with(hash_including(template: "api/boards/print_marketing", layout: "pdf_marketing"))
+        .and_return("<html></html>")
+
+      get "/api/internal/boards/#{board.id}/export.pdf",
+          params: { style: "marketing" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ignores unknown style values and falls back to the shared template" do
+      expect_any_instance_of(API::Internal::BoardsController)
+        .to receive(:render_to_string)
+        .with(hash_including(template: "api/boards/print", layout: "pdf"))
+        .and_return("<html></html>")
+
+      get "/api/internal/boards/#{board.id}/export.pdf",
+          params: { style: "fancy" },
+          headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "with real template rendering (ERB smoke test, Grover still stubbed)" do
+      before do
+        allow_any_instance_of(API::Internal::BoardsController)
+          .to receive(:render_to_string).and_call_original
+      end
+
+      it "renders the shared print template without error" do
+        get "/api/internal/boards/#{board.id}/export.pdf", headers: auth_headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the marketing template without error" do
+        get "/api/internal/boards/#{board.id}/export.pdf",
+            params: { style: "marketing", qr_code: "true", qr_target_url: "https://app.speakanyway.com/pb/test" },
+            headers: auth_headers
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     it "omits the QR code when qr_code is not true" do
       expect(Boards::RenderAssetData).to receive(:new).with(
         hash_including(include_qr: false),

--- a/spec/requests/api/internal/boards_from_vocab_set_spec.rb
+++ b/spec/requests/api/internal/boards_from_vocab_set_spec.rb
@@ -73,6 +73,70 @@ RSpec.describe "API::Internal::Boards from_vocab_set", type: :request do
         expect(clone.tags).to match_array(["marketing", "aac-kit"])
       end
 
+      describe "board_slug + replace_existing_slug (stable marketing slugs)" do
+        let(:kit_params) do
+          {
+            slug: "core-84",
+            name: "MKT — Core Words Poster",
+            tags: ["marketing", "aac-kit"],
+            board_slug: "mkt-core-words-poster",
+            replace_existing_slug: true,
+          }
+        end
+
+        it "gives the clone the exact requested board_slug" do
+          post "/api/internal/boards/from_vocab_set",
+               params: kit_params.to_json,
+               headers: json_headers
+
+          expect(response).to have_http_status(:created)
+          clone = Board.find(JSON.parse(response.body)["id"])
+          expect(clone.slug).to eq("mkt-core-words-poster")
+        end
+
+        it "destroys the previous admin-owned marketing board holding that slug" do
+          previous = create(:board, name: "MKT — Core Words Poster", slug: "mkt-core-words-poster",
+                                    user: admin_user, tags: ["marketing", "aac-kit"])
+
+          post "/api/internal/boards/from_vocab_set",
+               params: kit_params.to_json,
+               headers: json_headers
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(previous.id)).to be false
+          clone = Board.find(JSON.parse(response.body)["id"])
+          expect(clone.slug).to eq("mkt-core-words-poster")
+        end
+
+        it "leaves a non-marketing board holding that slug alone and suffixes instead" do
+          bystander = create(:board, name: "User Board", slug: "mkt-core-words-poster",
+                                     user: create(:user), tags: [])
+
+          post "/api/internal/boards/from_vocab_set",
+               params: kit_params.to_json,
+               headers: json_headers
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(bystander.id)).to be true
+          clone = Board.find(JSON.parse(response.body)["id"])
+          expect(clone.slug).to start_with("mkt-core-words-poster-")
+        end
+
+        it "applies board_slug without destroying anything when the flag is absent" do
+          previous = create(:board, name: "MKT — Core Words Poster", slug: "mkt-core-words-poster",
+                                    user: admin_user, tags: ["marketing", "aac-kit"])
+
+          post "/api/internal/boards/from_vocab_set",
+               params: kit_params.except(:replace_existing_slug).to_json,
+               headers: json_headers
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(previous.id)).to be true
+          clone = Board.find(JSON.parse(response.body)["id"])
+          expect(clone.slug).to start_with("mkt-core-words-poster-")
+        end
+      end
+
       it "returns 404 with an error body when the set is not seeded" do
         expect {
           post "/api/internal/boards/from_vocab_set",

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -166,6 +166,69 @@ RSpec.describe "API::Internal::Boards", type: :request do
         expect(job["args"][1]).to eq("ai_generated")
         expect(job["args"][2]).to eq({ "word_count" => 24 })
       end
+
+      describe "replace_existing_slug (stable marketing slugs)" do
+        let(:create_params) do
+          {
+            board: { name: "MKT — Story Time", slug: "mkt-storytime-board", tags: ["marketing", "aac-kit"] },
+            replace_existing_slug: true,
+          }
+        end
+
+        it "destroys the previous admin-owned marketing board and takes its exact slug" do
+          previous = create(:board, name: "MKT — Old Story Time", slug: "mkt-storytime-board",
+                                    user: admin_user, tags: ["marketing", "aac-kit"])
+
+          post "/api/internal/boards",
+               params: create_params.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(previous.id)).to be false
+          expect(Board.last.slug).to eq("mkt-storytime-board")
+        end
+
+        it "leaves a non-marketing board with that slug alone and suffixes the new slug" do
+          bystander = create(:board, name: "User Board", slug: "mkt-storytime-board",
+                                     user: create(:user), tags: [])
+
+          post "/api/internal/boards",
+               params: create_params.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(bystander.id)).to be true
+          new_board = Board.last
+          expect(new_board.slug).not_to eq("mkt-storytime-board")
+          expect(new_board.slug).to start_with("mkt-storytime-board-")
+        end
+
+        it "leaves an admin-owned but untagged board with that slug alone" do
+          untagged = create(:board, name: "Admin Board", slug: "mkt-storytime-board",
+                                    user: admin_user, tags: [])
+
+          post "/api/internal/boards",
+               params: create_params.to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(untagged.id)).to be true
+          expect(Board.last.slug).to start_with("mkt-storytime-board-")
+        end
+
+        it "does not destroy anything when the flag is absent" do
+          previous = create(:board, name: "MKT — Old Story Time", slug: "mkt-storytime-board",
+                                    user: admin_user, tags: ["marketing", "aac-kit"])
+
+          post "/api/internal/boards",
+               params: create_params.except(:replace_existing_slug).to_json,
+               headers: auth_headers.merge("Content-Type" => "application/json")
+
+          expect(response).to have_http_status(:created)
+          expect(Board.exists?(previous.id)).to be true
+          expect(Board.last.slug).to start_with("mkt-storytime-board-")
+        end
+      end
     end
   end
 

--- a/spec/services/marketing/qr_scannability_spec.rb
+++ b/spec/services/marketing/qr_scannability_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+# Regression guard for the "kit tag QRs won't scan" bug: rqrcode's default
+# ECC level (:h) turned the ~119-char /classroom UTM URL into a 57-module QR,
+# which at the tags' small printed size fell below the ~0.5mm-per-module
+# phone-camera detection floor. The sheets must encode at :l (41 modules) and
+# render a print-resolution source PNG. If these expectations start failing,
+# re-check the physical QR sizes in app/views/marketing/*_sheet.html.erb —
+# module density is a joint property of ECC level AND printed size.
+RSpec.describe "Marketing sheet QR scannability" do
+  let(:long_url) do
+    "https://speakanyway.com/classroom?utm_source=aac_kit&utm_medium=print&utm_campaign=classroom_kit&utm_content=safety_tag"
+  end
+
+  shared_examples "a scannable marketing QR" do
+    it "encodes at ECC level :l (not rqrcode's dense :h default)" do
+      expect(RQRCode::QRCode).to receive(:new).with(long_url, level: :l).and_call_original
+      data_url
+    end
+
+    it "renders a 480px print-resolution PNG data URL" do
+      expect(data_url).to start_with("data:image/png;base64,")
+      png = ChunkyPNG::Image.from_blob(Base64.strict_decode64(data_url.split(",", 2).last))
+      expect(png.width).to eq(480)
+      expect(png.height).to eq(480)
+    end
+
+    it "returns nil for a blank URL" do
+      expect(blank_data_url).to be_nil
+    end
+  end
+
+  describe Marketing::SafetyTagSheet do
+    subject(:sheet) { described_class.new(qr_target_url: long_url) }
+
+    let(:data_url) { sheet.send(:qr_data_url, long_url) }
+    let(:blank_data_url) { sheet.send(:qr_data_url, nil) }
+
+    it_behaves_like "a scannable marketing QR"
+  end
+
+  describe Marketing::NameTagSheet do
+    subject(:sheet) { described_class.new(qr_target_url: long_url) }
+
+    let(:data_url) { sheet.send(:qr_data_url) }
+    let(:blank_data_url) { described_class.new(qr_target_url: nil).send(:qr_data_url) }
+
+    it_behaves_like "a scannable marketing QR"
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the AAC Classroom Kit follow-ups (companion printables PR handles the square-up + kit script changes).

- **Stable slugs for kit boards.** `POST /api/internal/boards` and `POST /api/internal/boards/from_vocab_set` accept an opt-in `replace_existing_slug` boolean: the previous board holding the requested slug is destroyed and the new board takes the **exact** slug. Tightly scoped — only a board owned by the internal-API admin **and** tagged `marketing` is ever destroyed; anything else is left alone and the new board gets a suffixed slug (logged). On `from_vocab_set` the new-board slug rides `board_slug` (`slug` is the vocab-set key) and is claimed only after the clone persists, so a failed clone never destroys the live QR target. This keeps the printed kit's `/pb/<slug>` QR targets stable across regenerations and stops `MKT —` scratch boards accumulating.
- **Opt-in marketing print style.** `GET /api/internal/boards/:id/export.pdf?style=marketing` renders a marketing-branded template/layout pair (`api/boards/print_marketing` + `pdf_marketing`): gradient header band, white QR chip, footer CTA. The pair is a deliberate **copy**, not a refactor — the shared `print`/`pdf` pair backing real users' exports is untouched, and the default (no param / unknown style) renders exactly as before, spec-guarded.
- **Marketing sheet polish.** The tag/name-tag sheets (marketing-only templates) get a slim "print at 100% · cut along the dashed lines" hint strip and a unified brand gradient.

## Test plan

- `bundle exec rspec spec/requests/api/internal/boards_spec.rb spec/requests/api/internal/boards_from_vocab_set_spec.rb spec/requests/api/internal/board_pdf_export_spec.rb spec/requests/api/internal/marketing_artifacts_spec.rb` — **42 examples, 0 failures** locally.
- New coverage: replace-by-slug happy path + non-marketing/untagged/flag-absent bystander cases (create and from_vocab_set), `style` param template routing (default / marketing / unknown), and real-render ERB smoke tests for both the shared and marketing templates (Grover stubbed, templates rendered for real).
- CHANGELOG + CLAUDE.md updated; `.claude-notes` handoff doc updated locally (git-ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)