### PR TITLE
feat(billing): payment-failed email on active→past_due (#220)

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -581,8 +581,19 @@ class API::WebhooksController < API::ApplicationController
     end
     return if user.admin?
 
+    # Only email on the active -> past_due transition. Stripe redelivers
+    # invoice.payment_failed on every dunning retry (and can redeliver the
+    # same event), so gating on the prior status keeps us from emailing on
+    # each retry within the same past_due window (#220).
+    already_past_due = user.plan_status == "past_due"
+
     user.update!(plan_status: "past_due")
     Rails.logger.info "[StripeWebhook][invoice_failed] marked user=#{user.id} plan_status=past_due sub=#{sub_id}"
+
+    unless already_past_due
+      UserMailer.payment_failed_email(user).deliver_later
+      Rails.logger.info "[StripeWebhook][invoice_failed] queued payment_failed_email user=#{user.id}"
+    end
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_invoice_payment_failed error: #{e.class} - #{e.message}"
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -220,6 +220,21 @@ class UserMailer < BaseMailer
     end
   end
 
+  # Sent once when a renewal charge fails and the subscription moves
+  # active -> past_due. Stripe redelivers invoice.payment_failed on every
+  # dunning retry, so the webhook gates this on the status transition — this
+  # method only composes the message. Access continues while Stripe retries;
+  # if the retries exhaust, the subscription cancels and the user drops to Free.
+  def payment_failed_email(user)
+    @user = user
+    @user_name = @user.name
+    @billing_link = "#{ENV["FRONT_END_URL"] || "http://localhost:8100"}/billing"
+    Rails.logger.info "Sending payment failed email to #{@user.email}"
+    with_user_locale(@user) do
+      mail(to: @user.email, subject: I18n.t("user_mailer.payment_failed_email.subject"))
+    end
+  end
+
   def message_notification_email(message)
     @message = message
     @sender = message.sender

--- a/app/views/user_mailer/payment_failed_email.html.erb
+++ b/app/views/user_mailer/payment_failed_email.html.erb
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title><%= t("user_mailer.payment_failed_email.title") %></title>
+  <meta name="color-scheme" content="light only">
+  <style>
+    body { background-color: #f7f9fc; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .container { background-color: #ffffff; margin: auto; max-width: 620px; padding: 30px; border-radius: 12px; box-shadow: 0 6px 18px rgba(0,0,0,0.08); }
+    .logo img { max-width: 120px; display: block; margin: 0 auto 20px auto; }
+    h1 { font-size: 26px; color: #2a2a2a; text-align: center; margin: 10px 0 6px 0; }
+    .intro { font-size: 16px; color: #444444; line-height: 1.6; text-align: center; margin: 8px 0 22px 0; }
+    .button { display: inline-block; margin: 14px auto 0 auto; padding: 14px 28px; background-color: #7645ef; text-decoration: none; border-radius: 8px; color: #ffffff !important; font-weight: bold; font-size: 16px; }
+    .subtext { font-size: 12px; color: #6b6b6b; text-align: center; margin-top: 8px; }
+    .section { margin: 28px 0; }
+    .note { font-size: 14px; color: #444; line-height: 1.6; margin: 0; }
+    .footer { margin-top: 28px; font-size: 13px; text-align: center; color: #777777; }
+    .footer a { color: #7645ef; text-decoration: none; }
+    @media (max-width: 480px) { .container { padding: 22px; } h1 { font-size: 24px; } }
+  </style>
+</head>
+<body>
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+    <%= t("user_mailer.payment_failed_email.preheader") %>
+  </div>
+
+  <div class="container">
+    <div class="logo">
+      <a href="https://www.speakanyway.com" target="_blank" rel="noopener">
+        <%= image_tag @logo.url, alt: "SpeakAnyWay Logo" %>
+      </a>
+    </div>
+
+    <h1><%= t("user_mailer.payment_failed_email.title") %></h1>
+
+    <p class="intro">
+      <%= @user.name.blank? ? t("user_mailer.payment_failed_email.greeting_no_name") : t("user_mailer.payment_failed_email.greeting_with_name", name: @user.name) %>
+      <br>
+      <%= t("user_mailer.payment_failed_email.intro") %>
+    </p>
+
+    <p style="text-align:center;">
+      <a href="<%= @billing_link %>" class="button"><%= t("user_mailer.payment_failed_email.cta") %></a>
+    </p>
+    <p class="subtext"><%= t("user_mailer.payment_failed_email.cta_fallback") %><br><span style="word-break:break-all;color:#6b6b6b;"><%= @billing_link %></span></p>
+
+    <div class="section">
+      <p class="note"><%= t("user_mailer.payment_failed_email.retry_note") %></p>
+      <p class="note" style="margin-top:12px;"><%= t("user_mailer.payment_failed_email.cancel_note") %></p>
+    </div>
+
+    <div class="footer">
+      <p><%= t("user_mailer.payment_failed_email.questions_html").html_safe %></p>
+      <p><%= t("user_mailer.payment_failed_email.footer_signature") %></p>
+      <p><a href="https://www.speakanyway.com" target="_blank"><%= t("user_mailer.payment_failed_email.footer_visit") %></a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -290,6 +290,21 @@ en:
       footer_signature: "— The SpeakAnyWay Team"
       footer_visit: "Visit our website"
 
+    payment_failed_email:
+      subject: "We couldn't process your SpeakAnyWay payment"
+      preheader: "Your last payment didn't go through — update your payment method to keep your plan."
+      title: "We couldn't charge your card"
+      greeting_with_name: "Hi %{name},"
+      greeting_no_name: "Hi there,"
+      intro: "We tried to process the payment for your SpeakAnyWay subscription, but it didn't go through."
+      cta: "Update Payment Method"
+      cta_fallback: "If the button doesn't work, copy and paste this link:"
+      retry_note: "No need to worry just yet — your access continues for a few days while we automatically retry the charge. Updating your payment method now is the quickest way to keep everything running."
+      cancel_note: "If the retries don't succeed, your subscription will be canceled automatically and your account will move to the Free plan."
+      questions_html: "Questions? Just reply to this email or contact us at <a href=\"mailto:help@speakanyway.com\">help@speakanyway.com</a>."
+      footer_signature: "— The SpeakAnyWay Team"
+      footer_visit: "Visit our website"
+
   setup_mailer:
     myspeak_setup_email:
       subject: "MySpeak Setup Instructions"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -278,6 +278,21 @@ es:
       footer_signature: "— El equipo de SpeakAnyWay"
       footer_visit: "Visita nuestro sitio web"
 
+    payment_failed_email:
+      subject: "No pudimos procesar tu pago de SpeakAnyWay"
+      preheader: "Tu último pago no se completó — actualiza tu método de pago para conservar tu plan."
+      title: "No pudimos cobrar tu tarjeta"
+      greeting_with_name: "Hola %{name}:"
+      greeting_no_name: "Hola:"
+      intro: "Intentamos procesar el pago de tu suscripción de SpeakAnyWay, pero no se completó."
+      cta: "Actualizar método de pago"
+      cta_fallback: "Si el botón no funciona, copia y pega este enlace:"
+      retry_note: "No te preocupes todavía: tu acceso continúa durante unos días mientras reintentamos el cobro automáticamente. Actualizar tu método de pago ahora es la forma más rápida de mantener todo funcionando."
+      cancel_note: "Si los reintentos no tienen éxito, tu suscripción se cancelará automáticamente y tu cuenta pasará al plan Gratis."
+      questions_html: "¿Preguntas? Responde a este correo o escríbenos a <a href=\"mailto:help@speakanyway.com\">help@speakanyway.com</a>."
+      footer_signature: "— El equipo de SpeakAnyWay"
+      footer_visit: "Visita nuestro sitio web"
+
   setup_mailer:
     myspeak_setup_email:
       subject: "Instrucciones para configurar MySpeak"

--- a/spec/requests/api/webhooks_payment_failed_spec.rb
+++ b/spec/requests/api/webhooks_payment_failed_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+# Covers the payment-failed email fired from the Stripe invoice.payment_failed
+# webhook (#220). The email must fire exactly once on the active -> past_due
+# transition, and NOT again on a redelivery of the same event or a subsequent
+# dunning retry while the user is already past_due.
+# See API::WebhooksController#handle_invoice_payment_failed.
+RSpec.describe "POST /api/webhooks (payment failed email)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_payment_failed",
+      plan_type: "basic",
+      plan_status: "active")
+  end
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  # Minimal subscription the handler retrieves via Stripe::Subscription.retrieve.
+  def build_subscription(status: "past_due", customer: user.stripe_customer_id, id: "sub_pf")
+    OpenStruct.new(id: id, customer: customer, status: status)
+  end
+
+  # invoice.payment_failed carries only the subscription id here; the handler
+  # then retrieves the subscription and resolves the user from its customer.
+  def build_invoice(subscription_id: "sub_pf")
+    OpenStruct.new(subscription: subscription_id)
+  end
+
+  def stub_payment_failed(subscription: build_subscription, event_id: "evt_pf")
+    allow(Stripe::Subscription).to receive(:retrieve).with(subscription.id).and_return(subscription)
+    stub_event(build_invoice(subscription_id: subscription.id),
+      type: "invoice.payment_failed", event_id: event_id)
+  end
+
+  describe "active -> past_due transition" do
+    it "flips the user to past_due and queues the payment_failed email once" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:payment_failed_email).and_return(mail)
+
+      stub_payment_failed
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.plan_status).to eq("past_due")
+      expect(UserMailer).to have_received(:payment_failed_email).with(
+        an_object_having_attributes(id: user.id),
+      ).once
+    end
+  end
+
+  describe "idempotency" do
+    it "does NOT re-send when the user is already past_due (a later retry)" do
+      user.update!(plan_status: "past_due")
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:payment_failed_email).and_return(mail)
+
+      stub_payment_failed
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.plan_status).to eq("past_due")
+      expect(UserMailer).not_to have_received(:payment_failed_email)
+    end
+
+    it "sends only once across two deliveries of the failure" do
+      mail = double(deliver_later: true)
+      allow(UserMailer).to receive(:payment_failed_email).and_return(mail)
+
+      # First failure: active -> past_due, email fires.
+      stub_payment_failed(event_id: "evt_pf_1")
+      post_webhook("{}", header_with_signature)
+
+      # Redelivery / next retry: already past_due, no second email.
+      stub_payment_failed(event_id: "evt_pf_2")
+      post_webhook("{}", header_with_signature)
+
+      expect(UserMailer).to have_received(:payment_failed_email).once
+    end
+  end
+
+  describe "admins" do
+    it "does not touch plan_status or email admin users" do
+      user.update!(role: "admin")
+      allow(UserMailer).to receive(:payment_failed_email)
+
+      stub_payment_failed
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.plan_status).to eq("active")
+      expect(UserMailer).not_to have_received(:payment_failed_email)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
When Stripe can't collect a renewal charge, `invoice.payment_failed` already flips `plan_status` to `past_due` (paid gates short-circuit), but the user was never told. This adds a one-time notification.

- New `UserMailer.payment_failed_email` + HTML template (en/es copy).
- CTA: **Update Payment Method** → `/billing`.
- Sets expectations: access continues during Stripe's retry window; the plan cancels to Free if retries exhaust (hands off to #196).

## Idempotency
Stripe redelivers `invoice.payment_failed` on **every** dunning retry (and can redeliver the same event). The email fires **only on the `active → past_due` transition** — the handler captures `plan_status` before the update and skips the send when the user is already `past_due`. Admins return before the status flip, so they never get it.

## Test plan
New `spec/requests/api/webhooks_payment_failed_spec.rb`:
- ✅ flips to `past_due` and queues the email **once** on the transition
- ✅ no email when the user is **already** `past_due` (a later retry)
- ✅ sends **only once** across two separate deliveries of the failure
- ✅ admins: no status change, no email

```
bundle exec rspec spec/requests/api/webhooks_payment_failed_spec.rb
4 examples, 0 failures
```
Mailer render verified in both en and es (no missing translations).

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)