### PR TITLE
feat(billing): cancellation-confirmation email on subscription.deleted (#196)

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -625,6 +625,14 @@ class API::WebhooksController < API::ApplicationController
     apply_free_plan(user)
     Rails.logger.info "[StripeWebhook] subscription deleted: downgraded user=#{user.id} to free"
 
+    # Confirm the cancellation to the user (#196). Skip admins — an admin's
+    # plan_type isn't a real paid subscription and they shouldn't get billing
+    # mail. deliver_later so a mailer hiccup can't fail the webhook.
+    unless user.admin?
+      UserMailer.subscription_canceled_email(user).deliver_later
+      Rails.logger.info "[StripeWebhook] subscription deleted: queued subscription_canceled_email user=#{user.id}"
+    end
+
     # Internal + PostHog analytics for the cancellation (itty-bitty-frontend#307).
     # Cancellation happens entirely inside Stripe's billing portal, so the
     # frontend never sees it — capture it server-side. $set plan -> "free"

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -204,6 +204,22 @@ class UserMailer < BaseMailer
     end
   end
 
+  # Confirmation that a paid subscription was canceled (Stripe fired
+  # customer.subscription.deleted and the user was downgraded to Free).
+  # Explains that boards over the Free limit are now read-only (one board
+  # stays editable, auto-pinned by pin_default_editable_board!) and offers a
+  # re-subscribe CTA. Not sent to admins.
+  def subscription_canceled_email(user)
+    @user = user
+    @user_name = @user.name
+    @plans_link = "#{ENV["FRONT_END_URL"] || "http://localhost:8100"}/pricing"
+    @dashboard_link = ENV["FRONT_END_URL"] || "http://localhost:8100"
+    Rails.logger.info "Sending subscription canceled email to #{@user.email}"
+    with_user_locale(@user) do
+      mail(to: @user.email, subject: I18n.t("user_mailer.subscription_canceled_email.subject"))
+    end
+  end
+
   def message_notification_email(message)
     @message = message
     @sender = message.sender

--- a/app/views/user_mailer/subscription_canceled_email.html.erb
+++ b/app/views/user_mailer/subscription_canceled_email.html.erb
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title><%= t("user_mailer.subscription_canceled_email.title") %></title>
+  <meta name="color-scheme" content="light only">
+  <style>
+    body { background-color: #f7f9fc; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .container { background-color: #ffffff; margin: auto; max-width: 620px; padding: 30px; border-radius: 12px; box-shadow: 0 6px 18px rgba(0,0,0,0.08); }
+    .logo img { max-width: 120px; display: block; margin: 0 auto 20px auto; }
+    h1 { font-size: 26px; color: #2a2a2a; text-align: center; margin: 10px 0 6px 0; }
+    .intro { font-size: 16px; color: #444444; line-height: 1.6; text-align: center; margin: 8px 0 22px 0; }
+    .button { display: inline-block; margin: 14px auto 0 auto; padding: 14px 28px; background-color: #7645ef; text-decoration: none; border-radius: 8px; color: #ffffff !important; font-weight: bold; font-size: 16px; }
+    .subtext { font-size: 12px; color: #6b6b6b; text-align: center; margin-top: 8px; }
+    .section { margin: 28px 0; }
+    .note { font-size: 14px; color: #444; line-height: 1.6; margin: 0; }
+    .footer { margin-top: 28px; font-size: 13px; text-align: center; color: #777777; }
+    .footer a { color: #7645ef; text-decoration: none; }
+    @media (max-width: 480px) { .container { padding: 22px; } h1 { font-size: 24px; } }
+  </style>
+</head>
+<body>
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;">
+    <%= t("user_mailer.subscription_canceled_email.preheader") %>
+  </div>
+
+  <div class="container">
+    <div class="logo">
+      <a href="https://www.speakanyway.com" target="_blank" rel="noopener">
+        <%= image_tag @logo.url, alt: "SpeakAnyWay Logo" %>
+      </a>
+    </div>
+
+    <h1><%= t("user_mailer.subscription_canceled_email.title") %></h1>
+
+    <p class="intro">
+      <%= @user.name.blank? ? t("user_mailer.subscription_canceled_email.greeting_no_name") : t("user_mailer.subscription_canceled_email.greeting_with_name", name: @user.name) %>
+      <br>
+      <%= t("user_mailer.subscription_canceled_email.intro") %>
+    </p>
+
+    <div class="section">
+      <p class="note"><%= t("user_mailer.subscription_canceled_email.access_note") %></p>
+      <p class="note" style="margin-top:12px;"><%= t("user_mailer.subscription_canceled_email.readonly_note") %></p>
+    </div>
+
+    <p style="text-align:center;">
+      <a href="<%= @plans_link %>" class="button"><%= t("user_mailer.subscription_canceled_email.cta") %></a>
+    </p>
+    <p class="subtext"><%= t("user_mailer.subscription_canceled_email.cta_fallback") %><br><span style="word-break:break-all;color:#6b6b6b;"><%= @plans_link %></span></p>
+
+    <div class="footer">
+      <p><%= t("user_mailer.subscription_canceled_email.questions_html").html_safe %></p>
+      <p><%= t("user_mailer.subscription_canceled_email.footer_thanks") %><br><%= t("user_mailer.subscription_canceled_email.footer_signature") %></p>
+      <p><a href="https://www.speakanyway.com" target="_blank"><%= t("user_mailer.subscription_canceled_email.footer_visit") %></a></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -274,6 +274,22 @@ en:
       sign_off: "Happy chatting!"
       copyright_html: "&copy; %{year} SpeakAnyWay. All rights reserved."
 
+    subscription_canceled_email:
+      subject: "Your SpeakAnyWay subscription was canceled"
+      preheader: "Your subscription was canceled — your account has moved to the Free plan."
+      title: "Your subscription was canceled"
+      greeting_with_name: "Hi %{name},"
+      greeting_no_name: "Hi there,"
+      intro: "This confirms that your SpeakAnyWay subscription has been canceled. Your account is now on the Free plan."
+      access_note: "Nothing was deleted. You keep your account, your communicators, and all of your boards — and communication itself keeps working."
+      readonly_note: "On the Free plan you can actively edit one board; any additional boards become read-only (you can still open them and use them, you just can't edit them). We've automatically kept one board editable for you, and you can change which one any time from your dashboard."
+      cta: "Resubscribe"
+      cta_fallback: "If the button doesn't work, copy and paste this link:"
+      questions_html: "Changed your mind or think this was a mistake? Just reply to this email or contact us at <a href=\"mailto:help@speakanyway.com\">help@speakanyway.com</a>."
+      footer_thanks: "Thank you for being part of SpeakAnyWay 💜"
+      footer_signature: "— The SpeakAnyWay Team"
+      footer_visit: "Visit our website"
+
   setup_mailer:
     myspeak_setup_email:
       subject: "MySpeak Setup Instructions"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -262,6 +262,22 @@ es:
       sign_off: "¡Feliz conversación!"
       copyright_html: "&copy; %{year} SpeakAnyWay. Todos los derechos reservados."
 
+    subscription_canceled_email:
+      subject: "Tu suscripción de SpeakAnyWay fue cancelada"
+      preheader: "Tu suscripción fue cancelada — tu cuenta pasó al plan Gratis."
+      title: "Tu suscripción fue cancelada"
+      greeting_with_name: "Hola %{name}:"
+      greeting_no_name: "Hola:"
+      intro: "Esto confirma que tu suscripción de SpeakAnyWay ha sido cancelada. Tu cuenta ahora está en el plan Gratis."
+      access_note: "No se eliminó nada. Conservas tu cuenta, tus comunicadores y todos tus tableros — y la comunicación sigue funcionando."
+      readonly_note: "En el plan Gratis puedes editar un tablero activamente; los tableros adicionales pasan a ser de solo lectura (puedes abrirlos y usarlos, pero no editarlos). Mantuvimos un tablero editable para ti automáticamente, y puedes cambiar cuál en cualquier momento desde tu panel."
+      cta: "Volver a suscribirte"
+      cta_fallback: "Si el botón no funciona, copia y pega este enlace:"
+      questions_html: "¿Cambiaste de opinión o crees que fue un error? Responde a este correo o escríbenos a <a href=\"mailto:help@speakanyway.com\">help@speakanyway.com</a>."
+      footer_thanks: "Gracias por ser parte de SpeakAnyWay 💜"
+      footer_signature: "— El equipo de SpeakAnyWay"
+      footer_visit: "Visita nuestro sitio web"
+
   setup_mailer:
     myspeak_setup_email:
       subject: "Instrucciones para configurar MySpeak"

--- a/spec/requests/api/webhooks_subscription_canceled_email_spec.rb
+++ b/spec/requests/api/webhooks_subscription_canceled_email_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+# Covers the cancellation-confirmation email fired from the Stripe
+# customer.subscription.deleted webhook (#196). Enqueued for non-admin users
+# after apply_free_plan downgrades them to Free; admins never receive it.
+# See API::WebhooksController#handle_subscription_deleted.
+RSpec.describe "POST /api/webhooks (subscription canceled email)", type: :request do
+  include StripeHelpers
+
+  let!(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_canceled_email",
+      plan_type: "pro",
+      plan_status: "active")
+  end
+
+  before do
+    ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy"
+    # Don't depend on analytics env in this spec.
+    allow(PosthogService).to receive(:capture_for_user)
+  end
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def build_subscription(customer: user.stripe_customer_id, id: "sub_cancel")
+    OpenStruct.new(id: id, customer: customer, status: "canceled", cancellation_details: nil)
+  end
+
+  it "downgrades to free and queues the cancellation email for a non-admin" do
+    mail = double(deliver_later: true)
+    allow(UserMailer).to receive(:subscription_canceled_email).and_return(mail)
+
+    stub_event(build_subscription, type: "customer.subscription.deleted")
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.plan_type).to eq("free")
+    expect(UserMailer).to have_received(:subscription_canceled_email).with(
+      an_object_having_attributes(id: user.id),
+    ).once
+  end
+
+  it "does NOT email admins" do
+    user.update!(role: "admin")
+    allow(UserMailer).to receive(:subscription_canceled_email)
+
+    stub_event(build_subscription, type: "customer.subscription.deleted")
+    post_webhook("{}", header_with_signature)
+
+    expect(UserMailer).not_to have_received(:subscription_canceled_email)
+  end
+
+  it "does not email when no user resolves for the subscription" do
+    allow(UserMailer).to receive(:subscription_canceled_email)
+
+    stub_event(build_subscription(customer: "cus_nobody"), type: "customer.subscription.deleted")
+    # No Stripe::Customer fallback match either.
+    allow(Stripe::Customer).to receive(:retrieve).and_return(OpenStruct.new(email: nil))
+    post_webhook("{}", header_with_signature)
+
+    expect(UserMailer).not_to have_received(:subscription_canceled_email)
+  end
+end


### PR DESCRIPTION
## Summary
When Stripe fires `customer.subscription.deleted`, `apply_free_plan` downgrades the user to Free and pins a default editable board — but sent no confirmation. This adds the confirmation email.

- New `UserMailer.subscription_canceled_email` + HTML template (en/es copy).
- Confirms the cancellation; reassures that **nothing was deleted**.
- Explains the Free read-only rule: one board stays editable (auto-pinned by `pin_default_editable_board!`), additional boards become read-only but still usable.
- **Resubscribe** CTA → `/pricing`.
- `deliver_later` so a mailer hiccup can't fail the webhook.

## Admins
The acceptance note assumed *"admins skip the apply_free_plan path"* — but the shared `Billing::PlanTransitions.apply_free_plan` does **not** special-case admins, so relying on that would still email them. Instead the guard lives on the email send (`unless user.admin?`), which satisfies the acceptance (admins don't receive it) without changing the existing downgrade behavior.

## Test plan
New `spec/requests/api/webhooks_subscription_canceled_email_spec.rb`:
- ✅ downgrades to free and queues the email **once** for a non-admin
- ✅ admins do **not** receive it
- ✅ no email when no user resolves for the subscription

```
bundle exec rspec spec/requests/api/webhooks_subscription_canceled_email_spec.rb   # 3 examples, 0 failures
bundle exec rspec spec/requests/api/webhooks_analytics_spec.rb                     # 14 examples, 0 failures (no regression)
```
Mailer render verified in en and es (no missing translations).

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)