### PR TITLE
fix(pdf): render label-only tiles as text in exports and previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — label-only tiles now render as text in PDF export and board previews
+- Board PDF exports and the board cover/preview image showed a **picture** on
+  label-only tiles (e.g. an "I feel" header) even though the app renders them as
+  plain text. The print/preview pipeline resolved each tile's image via
+  `BoardImage#tile_image_url`, whose final fallback **borrows any same-label
+  public/admin image's art**, fabricating a picture the tile doesn't have.
+  `Boards::BoardPdfLayoutNormalizer` now resolves the picture the same way the
+  live board JSON does (`display_image_url → image.display_image_url →
+  image.src_url`, no label borrowing), so label-only tiles come through blank
+  and render as the label text — matching what users see on screen. The shared
+  `print` and marketing `print_marketing` templates also drop the now-redundant
+  caption beneath a label-only tile (the placeholder already shows the label).
+  `BoardImage#tile_image_url` itself is unchanged — its label-match fallback is
+  still used by Board Builder folder covers and OBF export.
+
 ### Added — stable slugs + marketing print style for the AAC Classroom Kit
 - The internal boards API (`POST /api/internal/boards` and
   `POST /api/internal/boards/from_vocab_set`) gains opt-in

--- a/app/services/boards/board_pdf_layout_normalizer.rb
+++ b/app/services/boards/board_pdf_layout_normalizer.rb
@@ -41,7 +41,7 @@ module Boards
             "w" => layout["w"] || 1,
             "h" => layout["h"] || 1,
             "label" => bi.display_label || bi.label || "",
-            "image_url" => bi.tile_image_url(@current_user),
+            "image_url" => tile_display_src(bi),
             "bg_color" => bi.bg_color || "#FFFFFF",
             "border_color" => bi.border_color || "#000000",
             "border_width" => bi.border_width || 0,
@@ -56,6 +56,20 @@ module Boards
     end
 
     private
+
+    # Resolve the tile picture the SAME way the live board JSON does
+    # (Board#api_view_with_predictive_images:
+    #   board_image.display_image_url || image.display_image_url || image.src_url).
+    # We deliberately do NOT use BoardImage#tile_image_url here: its final
+    # fallback borrows any same-label admin/public image's src_url, which
+    # fabricated a picture on label-only tiles (e.g. an "I feel" header) that
+    # the app renders as text. A blank result lets the print template draw the
+    # label via generate_placeholder_image, matching what the user sees on screen.
+    def tile_display_src(board_image)
+      board_image.display_image_url.presence ||
+        board_image.image&.display_image_url(@current_user).presence ||
+        board_image.image&.src_url.presence
+    end
 
     attr_reader :board, :screen_size
   end

--- a/app/views/api/boards/print.html.erb
+++ b/app/views/api/boards/print.html.erb
@@ -65,6 +65,7 @@
         <% else %>
           <% label_hidden = false %>
         <% end %>
+        <% has_image = t["image_url"].present? %>
         <% col_start = t["x"].to_i + 1 %>
         <% row_start = t["y"].to_i + 1 %>
         <% col_span = t["w"].to_i %>
@@ -83,7 +84,7 @@
 
         >
           <div class="tile-media">
-            <% if t["image_url"].present? %>
+            <% if has_image %>
               <img src="<%= t["image_url"] %>" alt="<%= t["label"] %>">
             <% else %>
               <img
@@ -94,7 +95,9 @@
             <% end %>
           </div>
 
-          <% unless label_hidden %>
+          <%# Label-only tiles (no picture) already render the label as the
+              placeholder image, so skip the redundant caption underneath. %>
+          <% if has_image && !label_hidden %>
             <div
             class="label <%= bg_color %>"
             style="

--- a/app/views/api/boards/print_marketing.html.erb
+++ b/app/views/api/boards/print_marketing.html.erb
@@ -62,6 +62,7 @@
         <% else %>
           <% label_hidden = false %>
         <% end %>
+        <% has_image = t["image_url"].present? %>
         <% col_start = t["x"].to_i + 1 %>
         <% row_start = t["y"].to_i + 1 %>
         <% col_span = t["w"].to_i %>
@@ -80,7 +81,7 @@
 
         >
           <div class="tile-media">
-            <% if t["image_url"].present? %>
+            <% if has_image %>
               <img src="<%= t["image_url"] %>" alt="<%= t["label"] %>">
             <% else %>
               <img
@@ -91,7 +92,9 @@
             <% end %>
           </div>
 
-          <% unless label_hidden %>
+          <%# Label-only tiles (no picture) already render the label as the
+              placeholder image, so skip the redundant caption underneath. %>
+          <% if has_image && !label_hidden %>
             <div
             class="label <%= bg_color %>"
             style="

--- a/spec/services/boards/board_pdf_layout_normalizer_spec.rb
+++ b/spec/services/boards/board_pdf_layout_normalizer_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Boards::BoardPdfLayoutNormalizer, type: :service do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  def tile_for(label)
+    described_class.call(board, "lg").find { |t| t["label"] == label }
+  end
+
+  def add_tile(image, **attrs)
+    create(:board_image, board: board, image: image, skip_create_voice_audio: true, **attrs)
+  end
+
+  describe "tile picture resolution" do
+    it "renders the tile's real picture" do
+      image = create(:image, label: "dog", src_url: "https://cdn.example/dog.png")
+      add_tile(image)
+
+      expect(tile_for("dog")["image_url"]).to eq("https://cdn.example/dog.png")
+    end
+
+    it "leaves a label-only tile blank instead of borrowing a same-label library image" do
+      # The 'I feel' header case: the tile's own image carries no art, and its
+      # display_label differs from the underlying image label. A same-label
+      # public/admin image WITH art exists in the shared library.
+      own = create(:image, label: "tired", src_url: nil, user_id: user.id)
+      create(:image, label: "tired", src_url: "https://cdn.example/tired-face.png", user_id: nil)
+      board_image = add_tile(own, display_label: "I feel")
+
+      # The normalizer must NOT borrow the library art — a blank result lets the
+      # template draw the label as text, matching what the app shows.
+      expect(tile_for("I feel")["image_url"]).to be_blank
+
+      # Guard the deliberate divergence: the model helper still borrows, because
+      # other callers (Board Builder folder covers, OBF export) rely on that.
+      expect(board_image.tile_image_url).to eq("https://cdn.example/tired-face.png")
+    end
+  end
+end

--- a/spec/views/api/boards/print_template_spec.rb
+++ b/spec/views/api/boards/print_template_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+require "nokogiri"
+
+# Renders the shared board print template (used for the user PDF export and the
+# preview/cover PNG) with controlled tile data, to lock in how label-only tiles
+# are drawn: as the placeholder-image label, with NO duplicate caption beneath.
+RSpec.describe "api/boards/print.html.erb", type: :view do
+  def tile(label:, image_url:, hide_label: false)
+    {
+      "x" => 0, "y" => 0, "w" => 1, "h" => 1,
+      "label" => label,
+      "image_url" => image_url,
+      "bg_color" => "#FFFFFF",
+      "border_color" => "#000000",
+      "border_width" => 0,
+      "border_radius" => 0,
+      "hide_label" => hide_label,
+      "i" => label,
+    }
+  end
+
+  def render_print(tiles)
+    ApplicationController.render(
+      template: "api/boards/print",
+      layout: "pdf",
+      assigns: {
+        hide_header: true,
+        hide_colors: false,
+        logo: nil,
+        board_title: "Test",
+        board_expires_at: nil,
+        qr_data_url: nil,
+        qr_target_url: nil,
+        columns: tiles.size,
+        rows: 1,
+        tiles: tiles,
+        board_render_width_mm: 200,
+        board_render_height_mm: 100,
+        landscape: false,
+        bw: false,
+      },
+    )
+  end
+
+  def tile_nodes(html)
+    Nokogiri::HTML(html).css(".board-grid > .tile")
+  end
+
+  it "renders an image tile with its picture and a caption underneath" do
+    html = render_print([tile(label: "happy", image_url: "https://cdn.example/happy.png")])
+    node = tile_nodes(html).first
+
+    expect(node.at_css(".tile-media img")["src"]).to eq("https://cdn.example/happy.png")
+    expect(node.at_css(".label")&.text&.strip).to eq("happy")
+  end
+
+  it "renders a label-only tile as placeholder text with NO duplicate caption" do
+    html = render_print([tile(label: "I feel", image_url: nil)])
+    node = tile_nodes(html).first
+
+    # The label is drawn as the generated placeholder image (an inline SVG),
+    # never a borrowed picture...
+    placeholder = node.at_css(".tile-media img.tile-placeholder-image")
+    expect(placeholder).to be_present
+    expect(placeholder["src"]).to start_with("data:image/svg+xml")
+
+    # ...and the separate caption <div class="label"> is suppressed so the
+    # label doesn't appear twice.
+    expect(node.at_css(".label")).to be_nil
+  end
+
+  it "still suppresses the caption on an image tile when hide_label is set" do
+    html = render_print([tile(label: "cat", image_url: "https://cdn.example/cat.png", hide_label: true)])
+    node = tile_nodes(html).first
+
+    expect(node.at_css(".tile-media img")["src"]).to eq("https://cdn.example/cat.png")
+    expect(node.at_css(".label")).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

Board **PDF exports** and the **board cover/preview image** drew a *picture* on label-only tiles (e.g. an "I feel" header) even though the app renders them as plain text.

Both surfaces share one pipeline: `RenderAssetData` → `BoardPdfLayoutNormalizer` → `print.html.erb`/`print_marketing.html.erb` → Grover. The normalizer resolved each tile's image via `BoardImage#tile_image_url`, whose final fallback **borrows any same-label public/admin image's `src_url`** — fabricating a picture the tile doesn't actually have. The live board JSON (`Board#api_view_with_predictive_images`) has no such fallback, so a label-only tile is blank there and renders as text.

### Changes
- **`Boards::BoardPdfLayoutNormalizer`** — resolves the tile picture the same way the live board JSON does (`board_image.display_image_url → image.display_image_url → image.src_url`, no label borrowing). Label-only tiles come through blank and the template's existing placeholder branch draws the label as text. One change fixes all three surfaces (user PDF, preview PNG, marketing PDF).
- **`print.html.erb` + `print_marketing.html.erb`** — suppress the now-redundant caption beneath a label-only tile (the placeholder already shows the label).
- **`BoardImage#tile_image_url` is intentionally unchanged** — its label-match fallback is legitimately used by Board Builder folder covers (`BuildBoardSetJob`) and OBF export (`to_obf_image_format`), so the fix is scoped to the print/preview normalizer.
- CHANGELOG entry added.

## Test plan
New + related specs, all green (33 examples, 0 failures):

- `spec/services/boards/board_pdf_layout_normalizer_spec.rb` (new) — real art renders; a label-only tile stays blank instead of borrowing a same-label library image; documents that `tile_image_url` still borrows for its other callers.
- `spec/views/api/boards/print_template_spec.rb` (new) — label-only tile → placeholder text with no duplicate caption; image tile → picture + caption; `hide_label` still suppresses the caption.
- Regression: `board_pdf_spec`, `generate_preview_assets_spec`, `internal/board_pdf_export_spec`, `asset_rendering_spec`, `generate_board_preview_job_spec`.

```
bundle exec rspec spec/services/boards/board_pdf_layout_normalizer_spec.rb \
  spec/views/api/boards/print_template_spec.rb \
  spec/requests/api/board_pdf_spec.rb \
  spec/services/boards/generate_preview_assets_spec.rb \
  spec/requests/api/internal/board_pdf_export_spec.rb \
  spec/services/boards/asset_rendering_spec.rb \
  spec/sidekiq/generate_board_preview_job_spec.rb
# => 33 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)