### PR TITLE
fix(stripe): skip trial on promo checkouts so coupon minimum is met

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,22 @@ the non-active→active transition in the upsert; guarded so renewals don't
 double-count). Primary A/B metric is **net paid users per 100 signups**, not
 trial→paid rate.
 
+**Promo checkouts skip the trial (`apply_trial = promo.blank?`).** When a
+promotion code is applied (`params[:promo_code]`, or the auto-applied
+`partner_pro` pilot code), `#create` omits `subscription_data` entirely — the
+user subscribes at the discounted rate now (a card is collected if there's an
+amount due). This is required for correctness: a promotion code with a
+minimum-amount restriction — e.g. the **FOUNDING** coupon's `$50` floor, the
+mechanism gating it to the yearly plans — is validated against the Checkout
+Session's amount, and the 14-day trial zeroes that to `$0`, so Stripe rejects
+the code with *"This promotion code cannot be redeemed because the associated
+purchase does not meet the minimum amount requirement"* (prod 400s on the beta-
+end Founding Family launch, 2026-07-07). Without the trial the checkout carries
+the plan's real price (yearly `$80`/`$200` ≥ `$50`) and the discount applies.
+The `trial_started` AnalyticsEvent is likewise gated on `apply_trial`, so promo
+conversions don't pollute the trial→paid metric. Non-promo checkouts are
+unchanged (full no-card reverse trial).
+
 ### Partner Program (`partner_pro`)
 
 The `/sign-up/partner` flow (frontend `viewType="partner"`) posts to the normal

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -122,18 +122,36 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     else
       session_params[:allow_promotion_codes] = true
     end
-    session_params[:subscription_data] = {
-      trial_period_days: trial_days,
-      # When a no-card trial ends with no payment method on file, cancel the
-      # subscription instead of generating an unpayable invoice. The resulting
-      # `customer.subscription.deleted` webhook downgrades the user to Free in
-      # fallback mode (issue #264 + #255) — never an unexpected charge, never
-      # stuck `past_due`. Harmless on the card-required arm: a payment method
-      # is present, so this end_behavior never triggers and the card is charged.
-      trial_settings: {
-        end_behavior: { missing_payment_method: "cancel" },
-      },
-    }
+
+    # Only layer the no-card reverse trial (#264) onto non-promo checkouts. A
+    # promo means the user is committing to a discounted plan now, so we
+    # subscribe at the discounted rate immediately (a card is collected when
+    # there's an amount due today).
+    #
+    # This is also required for correctness: a promotion code with a
+    # minimum-amount restriction — e.g. the FOUNDING coupon's $50 floor, the
+    # mechanism that gates it to the yearly plans — is validated against the
+    # Checkout Session's amount, and a 14-day trial zeroes that amount to $0. So
+    # Stripe rejects the code with "This promotion code cannot be redeemed
+    # because the associated purchase does not meet the minimum amount
+    # requirement" (prod 400s, 2026-07-07). Without the trial the checkout
+    # carries the plan's real price (yearly $80/$200 ≥ $50), the minimum is
+    # satisfied, and the discount applies to the subscription.
+    apply_trial = promo.blank?
+    if apply_trial
+      session_params[:subscription_data] = {
+        trial_period_days: trial_days,
+        # When a no-card trial ends with no payment method on file, cancel the
+        # subscription instead of generating an unpayable invoice. The resulting
+        # `customer.subscription.deleted` webhook downgrades the user to Free in
+        # fallback mode (issue #264 + #255) — never an unexpected charge, never
+        # stuck `past_due`. Harmless on the card-required arm: a payment method
+        # is present, so this end_behavior never triggers and the card is charged.
+        trial_settings: {
+          end_behavior: { missing_payment_method: "cancel" },
+        },
+      }
+    end
 
     session = Stripe::Checkout::Session.create(session_params)
     current_user.update!(paid_plan_type: plan_key)
@@ -154,16 +172,20 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
       },
     )
     # Measure trial starts so trial→paid conversion is computable against the
-    # later `subscription_started` event (issue #264 A/B instrumentation).
-    AnalyticsEvent.track(
-      "trial_started",
-      user_id: current_user.id,
-      metadata: {
-        plan_key: plan_key,
-        require_card: require_card,
-        payment_method_collection: payment_method_collection,
-      },
-    )
+    # later `subscription_started` event (issue #264 A/B instrumentation). Only
+    # fires when a trial was actually created — promo checkouts subscribe
+    # immediately (no trial), so they don't pollute the trial→paid metric.
+    if apply_trial
+      AnalyticsEvent.track(
+        "trial_started",
+        user_id: current_user.id,
+        metadata: {
+          plan_key: plan_key,
+          require_card: require_card,
+          payment_method_collection: payment_method_collection,
+        },
+      )
+    end
     Rails.logger.info "session: #{session.inspect}"
     render json: { url: session.url }
   rescue StandardError => e

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -131,6 +131,63 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
     end
   end
 
+  # Regression: the FOUNDING coupon's $50 minimum-amount restriction (the gate
+  # that keeps it to yearly plans) was being validated against the no-card
+  # trial's $0 checkout amount, so every promo'd checkout 400'd with
+  # "does not meet the minimum amount requirement" (prod, 2026-07-07). Fix:
+  # a promo checkout drops the trial so it carries the plan's real price.
+  describe "promo code + no-card trial interaction (founding-family fix)" do
+    let(:captured) { {} }
+    let(:promo) { OpenStruct.new(id: "promo_founding_id") }
+
+    before do
+      user.update!(stripe_customer_id: "cus_existing")
+      allow(Stripe::PromotionCode).to receive(:list)
+        .with(hash_including(code: "FOUNDING", active: true))
+        .and_return(OpenStruct.new(data: [promo]))
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured.replace(params)
+        OpenStruct.new(url: "https://stripe.test/x")
+      end
+    end
+
+    it "applies the promo as a discount and omits the trial so the coupon minimum is met" do
+      do_post.call({ plan_key: "basic_yearly", promo_code: "FOUNDING" })
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:discounts]).to eq([{ promotion_code: "promo_founding_id" }])
+      expect(captured).not_to have_key(:allow_promotion_codes)
+      # No trial → the checkout carries the plan's real price ($80/$200 ≥ $50),
+      # so a minimum-amount promotion code isn't redeemed against a $0 invoice.
+      expect(captured).not_to have_key(:subscription_data)
+    end
+
+    it "does not record a trial_started event for a promo checkout (no trial began)" do
+      expect {
+        do_post.call({ plan_key: "basic_yearly", promo_code: "FOUNDING" })
+      }.not_to change { AnalyticsEvent.for_event("trial_started").count }
+    end
+
+    it "still fires checkout_started for a promo checkout" do
+      expect(PosthogService).to receive(:capture_for_user).with(
+        an_object_having_attributes(id: user.id),
+        "checkout_started",
+        properties: hash_including(plan: "basic", billing_interval: "yearly"),
+      )
+      do_post.call({ plan_key: "basic_yearly", promo_code: "FOUNDING" })
+    end
+
+    it "keeps the 14-day no-card trial when no promo is applied" do
+      do_post.call({ plan_key: "basic_yearly" })
+
+      expect(captured[:subscription_data][:trial_period_days]).to eq(14)
+      expect(captured[:subscription_data][:trial_settings]).to eq(
+        end_behavior: { missing_payment_method: "cancel" },
+      )
+      expect(captured[:allow_promotion_codes]).to eq(true)
+    end
+  end
+
   describe "server-side checkout_started analytics (itty_bitty_boards#452 / frontend #505)" do
     before do
       user.update!(stripe_customer_id: "cus_existing")


### PR DESCRIPTION
## Summary

Production fix (2026-07-07): every FOUNDING promo checkout was returning **400** with
`Stripe::InvalidRequestError - This promotion code cannot be redeemed because the associated purchase does not meet the minimum amount requirement`, so no one could upgrade via the founding-family link.

**Root cause — two features colliding:**
- The FOUNDING coupon has a **minimum-amount restriction** (the mechanism that gates it to the yearly plans).
- Basic/Pro checkouts create a **14-day no-card reverse trial** (#264), which zeroes the Checkout Session amount to **$0**.

Stripe validates the coupon minimum against that $0 → rejects the code. This failed for **every** promo checkout, yearly included — the trial's $0 is below any minimum.

**Fix:** skip the trial when a promo is applied (`apply_trial = promo.blank?`). The checkout then carries the plan's real price (yearly $80/$200), the coupon minimum is satisfied, and the discount rides the subscription. Non-promo checkouts keep the full no-card reverse trial. The `trial_started` analytics event is gated on `apply_trial` so promo conversions don't pollute the trial→paid metric.

Once this is live, the coupon's minimum (e.g. $40) works as intended: yearly ($80/$200) clears it, monthly ($8/$20) is blocked — so FOUNDING stays yearly-only and monthly can't get half price.

## Changes
- `app/controllers/api/stripe/checkout_sessions_controller.rb` — conditional trial + gated `trial_started`.
- `spec/requests/api/stripe/checkout_sessions_spec.rb` — 4 new cases.
- `CLAUDE.md` — documented promo-skips-trial under the no-card reverse trial section.

## Test plan
- `bundle exec rspec spec/requests/api/stripe/checkout_sessions_spec.rb` → **26 examples, 0 failures** (local).
- New cases: promo → discount + no `subscription_data`; promo → no `trial_started`; promo → `checkout_started` still fires; no-promo → 14-day trial preserved.
- `ruby -c` on the controller: Syntax OK.

## Deploy / rollout note
Pairs with a Stripe dashboard change (no code): keep the FOUNDING coupon's minimum around **$40** (blocks monthly $8/$20, allows yearly $80/$200). After deploy, verify in Stripe **test mode**: `basic_yearly`+FOUNDING succeeds, `basic` (monthly)+FOUNDING is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)