### PR TITLE
feat(security): rate limiting on auth, token-lookup, and AI-generation routes (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — rate limiting on auth, token-lookup, and AI-generation routes (#30)
+- Rack::Attack now throttles the abuse-prone surfaces that previously had no
+  per-IP / per-user limits: **sign-in** (`POST /users/sign_in`,
+  `/api/v1/users/sign_in`, `/api/v1/child_accounts/login` — per IP and per
+  email), **password reset** (`forgot_password`/`reset_password*` — per IP),
+  **access-granting token lookups** (`/api/temp-login/:token`,
+  `/api/communicator_claims/:token` — per IP), and the **AI / audio generation**
+  routes (`/api/*/generate*`, `generate_audio`, `regenerate_images`,
+  `generate_preview_image`, board generation — per user, on top of the existing
+  credit-balance gate). Throttled requests get a clean **429** with a
+  `Retry-After` header and a generic `{ "error": "rate_limited" }` body (no
+  internals leaked).
+- Scoped to WRITE/auth/AI-generation abuse only — the AAC read, board-load, and
+  **audio-playback** paths a nonspeaking user relies on are never throttled. The
+  `/up` health check is safelisted so BetterStack monitoring isn't rate-limited.
+- All limits are ENV-tunable (`RACK_ATTACK_LOGIN_LIMIT`,
+  `RACK_ATTACK_LOGIN_EMAIL_LIMIT`, `RACK_ATTACK_AI_LIMIT`,
+  `RACK_ATTACK_TOKEN_LIMIT`, `RACK_ATTACK_PASSWORD_RESET_LIMIT`, and matching
+  `_PERIOD` vars) with sensible defaults. Rack::Attack counts against Redis
+  directly (not `Rails.cache`), so throttling works regardless of the cache
+  store. **Adds the `rack-attack` gem.**
+
 ### Fixed — label-only tiles now render as text in PDF export and board previews
 - Board PDF exports and the board cover/preview image showed a **picture** on
   label-only tiles (e.g. an "I feel" header) even though the app renders them as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,52 @@ BetterStack (uptime). This is the first true APM in the app.
   pings don't skew throughput/latency percentiles. Params/session filtering
   drops `password`/`token`/`secret`/`jwt` so no PII/secrets reach AppSignal.
 
+## Rate limiting (Rack::Attack, issue #30)
+
+`config/initializers/rack_attack.rb` throttles the abuse-prone surfaces. The
+middleware is inserted automatically by the gem's Railtie — there is **no**
+`config.middleware.use Rack::Attack` (a manual insert would double-count).
+Scope is deliberately narrow: only **WRITE / auth / AI-generation** paths are
+throttled. **The AAC read / board-load / audio-PLAYBACK paths are never
+throttled** (`GET /api/audio/play`, board reads) so speech output can't break —
+"usage must never break." When unsure whether a route is read-critical, it's
+left unthrottled.
+
+- **Throttles (all ENV-tunable):**
+  - **Auth** — sign-in (`POST /users/sign_in`, `/api/v1/users/sign_in`,
+    `/api/v1/child_accounts/login`) per **IP** (`RACK_ATTACK_LOGIN_LIMIT`, 20)
+    and per **email** (`RACK_ATTACK_LOGIN_EMAIL_LIMIT`, 10), window
+    `RACK_ATTACK_LOGIN_PERIOD` (60s). Email is read from form-encoded (`user[email]`)
+    or JSON body (rewound, rescued).
+  - **Password reset** — `forgot_password`/`reset_password`/`reset_password_invite`
+    per IP (`RACK_ATTACK_PASSWORD_RESET_LIMIT`, 5 per
+    `RACK_ATTACK_PASSWORD_RESET_PERIOD`, 3600s).
+  - **Token-access lookups** — `/api/temp-login/:token`,
+    `/api/communicator_claims/:token` per IP (`RACK_ATTACK_TOKEN_LIMIT`, 20 per
+    `RACK_ATTACK_TOKEN_PERIOD`, 60s). **`GET /api/generated_boards/:token` is
+    intentionally NOT throttled** — the frontend polls it while a board renders.
+  - **AI / audio generation** — `POST /api/*/generate*`, `generate_audio`,
+    `regenerate_images`, `generate_preview_image`, and `POST /api/generated_boards`,
+    per **user** (`RACK_ATTACK_AI_LIMIT`, 30 per `RACK_ATTACK_AI_PERIOD`, 60s).
+    These gate on credit balance only; this adds a request-frequency ceiling.
+    `/api/internal/*` is excluded (server-to-server, `INTERNAL_API_KEY`-gated).
+  - **Public profile enumeration** (pre-existing) — `public_profile/ip` and
+    `check_slug/ip`, now ENV-tunable via `RACK_ATTACK_PROFILE_*`.
+- **Per-user discriminator** = SHA256 of the `Authorization` header token
+  (the stable `authentication_token` the API auths on — see
+  `API::ApplicationController#token`), hashed so no secret hits a Redis key/log;
+  falls back to `ip:<addr>` when unauthenticated.
+- **Safelist:** `/up` (BetterStack health check every 3 min) is never throttled.
+- **429 response** is generic: `{ "error": "rate_limited", "retry_after": N }`
+  with a `Retry-After` header, no rule name / internals leaked.
+- **Counter store is Redis, set explicitly** — `Rack::Attack.cache.store` is a
+  `RedisCacheStore` (`RACK_ATTACK_REDIS_URL` → `REDIS_URL`), **not** `Rails.cache`,
+  which is `:null_store` in test and would silently disable every throttle. The
+  store's `error_handler` fails open (a Redis blip can't 500 a request).
+- **Disabled in the test env by default** (`Rack::Attack.enabled = !Rails.env.test?`)
+  so it doesn't perturb other request specs; `spec/requests/rack_attack_spec.rb`
+  opts in and swaps a `MemoryStore` per example.
+
 ## Safety-profile view alerts (issue #384)
 
 Public safety (MySpeak) pages have two surfaces. The **open page**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - `POSTHOG_API_KEY` - PostHog project API key for server-side capture of subscription lifecycle events (use the same project the frontend reports to). When blank, server-side capture no-ops.
   - `POSTHOG_HOST` - PostHog ingestion host (optional; defaults to `https://us.i.posthog.com`)
   - `POSTHOG_CAPTURE_ENABLED` - Set to `true` to fire server-side PostHog events outside production (dev/staging opt-in). Production fires automatically; staging stays off unless this is set.
+  - `RACK_ATTACK_*` - Optional rate-limit tuning (all have sensible defaults). Limits/windows for auth, password-reset, token-lookup, and AI-generation throttles — e.g. `RACK_ATTACK_LOGIN_LIMIT`, `RACK_ATTACK_LOGIN_EMAIL_LIMIT`, `RACK_ATTACK_AI_LIMIT`, `RACK_ATTACK_TOKEN_LIMIT`, `RACK_ATTACK_PASSWORD_RESET_LIMIT` (+ matching `_PERIOD`). `RACK_ATTACK_REDIS_URL` overrides the Redis used for counters (defaults to `REDIS_URL`). See the "Rate limiting" section in `CLAUDE.md`.
 
 - Database creation:
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,22 +1,162 @@
 # frozen_string_literal: true
 
-# Rate-limit public profile endpoints to prevent enumeration / scraping.
-# These endpoints skip authentication, so IP-based throttling is the
-# primary defence.
+# Rate limiting for SpeakAnyWay (issue #30).
 #
-# Limits:
-#   /api/profiles/public/:slug  — 30 req/min per IP
-#   /api/profiles/check_slug    — 10 req/min per IP
+# The Rack::Attack middleware is inserted automatically by the gem's Railtie
+# (rack-attack >= 5), so there is no `config.middleware.use Rack::Attack` here —
+# a manual insert would double-count every request.
 #
-# Blocked requests receive 429 Too Many Requests with a JSON body and a
-# Retry-After header.
+# Scope is deliberately narrow: only WRITE / auth / AI-generation abuse
+# surfaces are throttled. This is an AAC app — the read / board-load / audio
+# *playback* paths a nonspeaking user hits constantly (e.g. `GET
+# /api/audio/play`, board reads) are left untouched so speech output never
+# breaks. When in doubt, a route is left unthrottled.
+#
+# Throttled requests get a clean 429 with a Retry-After header and a generic
+# JSON body (no internals leaked). All limits are ENV-tunable with sensible
+# defaults.
 
 class Rack::Attack
-  ### Throttles ###
+  # --- Tunable limits (ENV-overridable, sensible defaults) ------------------
+
+  def self.env_int(name, default)
+    Integer(ENV.fetch(name, default.to_s))
+  rescue ArgumentError, TypeError
+    default
+  end
+
+  # Auth / sign-in (per IP + per email) — blunt brute force.
+  LOGIN_LIMIT           = env_int("RACK_ATTACK_LOGIN_LIMIT", 20)
+  LOGIN_EMAIL_LIMIT     = env_int("RACK_ATTACK_LOGIN_EMAIL_LIMIT", 10)
+  LOGIN_PERIOD          = env_int("RACK_ATTACK_LOGIN_PERIOD", 60)
+
+  # Password reset (per IP) — tighter, low-frequency.
+  PASSWORD_RESET_LIMIT  = env_int("RACK_ATTACK_PASSWORD_RESET_LIMIT", 5)
+  PASSWORD_RESET_PERIOD = env_int("RACK_ATTACK_PASSWORD_RESET_PERIOD", 3600)
+
+  # Token-access lookups (per IP) — temp-login / communicator-claim links.
+  TOKEN_LIMIT           = env_int("RACK_ATTACK_TOKEN_LIMIT", 20)
+  TOKEN_PERIOD          = env_int("RACK_ATTACK_TOKEN_PERIOD", 60)
+
+  # AI / audio generation (per user) — these gate on credit balance only, so
+  # add a per-request-frequency ceiling on top.
+  AI_LIMIT              = env_int("RACK_ATTACK_AI_LIMIT", 30)
+  AI_PERIOD             = env_int("RACK_ATTACK_AI_PERIOD", 60)
+
+  # Public profile lookups (per IP) — existing anti-enumeration limits.
+  PROFILE_PUBLIC_LIMIT  = env_int("RACK_ATTACK_PROFILE_PUBLIC_LIMIT", 30)
+  PROFILE_SLUG_LIMIT    = env_int("RACK_ATTACK_PROFILE_SLUG_LIMIT", 10)
+  PROFILE_PERIOD        = env_int("RACK_ATTACK_PROFILE_PERIOD", 60)
+
+  # --- Path matchers --------------------------------------------------------
+
+  # POST sign-in surfaces: web devise, JSON API, and child passcode login.
+  LOGIN_PATHS = %r{\A/(users/sign_in|api/v1/users/sign_in|api/v1/child_accounts/login)(\.\w+)?\z}
+
+  # POST password-reset surfaces.
+  PASSWORD_RESET_PATHS = %r{\A/api/v1/(forgot_password|reset_password|reset_password_invite)(\.\w+)?\z}
+
+  # Access-granting token lookups (enumeration-sensitive). Deliberately does
+  # NOT include `GET /api/generated_boards/:token` — the frontend polls that
+  # while a board renders, and throttling it could break generation.
+  TOKEN_ACCESS_PATHS = %r{\A/api/(temp-login|communicator_claims)/}
+
+  # AI-generation path suffixes (the issue's `/generate*` + audio generation).
+  AI_GEN_SUFFIXES = %w[generate generate_audio generate_preview_image regenerate_images].freeze
+
+  # --- Discriminator helpers ------------------------------------------------
+
+  # Per-user key from the API auth token (a stable `authentication_token` sent
+  # in the Authorization header — see API::ApplicationController#token). Hashed
+  # so no secret ever lands in a Redis key or log. Falls back to IP for
+  # unauthenticated callers.
+  def self.user_discriminator(req)
+    token = req.get_header("HTTP_AUTHORIZATION").to_s.split(" ").last
+    if token.present?
+      "user:#{Digest::SHA256.hexdigest(token)[0, 20]}"
+    else
+      "ip:#{req.ip}"
+    end
+  end
+
+  # Email for per-account login throttling. Handles both form-encoded devise
+  # posts (`user[email]`) and the JSON API (`{ "email": ... }`). Reads and
+  # rewinds the request body so the controller still sees it. Any parse
+  # failure yields nil (no email throttle for that request).
+  def self.login_email(req)
+    email = req.params["email"] || req.params.dig("user", "email")
+    email ||= json_body_email(req)
+    normalized = email.to_s.strip.downcase
+    normalized.presence
+  rescue StandardError
+    nil
+  end
+
+  def self.json_body_email(req)
+    return nil unless req.content_type.to_s.include?("json")
+
+    body = req.body.read
+    req.body.rewind
+    return nil if body.blank?
+
+    parsed = JSON.parse(body)
+    return nil unless parsed.is_a?(Hash)
+
+    parsed["email"] || parsed.dig("user", "email")
+  rescue StandardError
+    nil
+  end
+
+  def self.ai_generation_request?(req)
+    return false unless req.post?
+
+    path = req.path.sub(/\.\w+\z/, "")
+    return false unless path.start_with?("/api/")
+    return false if path.start_with?("/api/internal/") # server-to-server, key-gated
+
+    return true if path == "/api/generated_boards"
+
+    AI_GEN_SUFFIXES.any? { |suffix| path.end_with?("/#{suffix}") }
+  end
+
+  # --- Safelists ------------------------------------------------------------
+
+  # Never throttle the health check — BetterStack hits /up every 3 minutes.
+  safelist("health-check") do |req|
+    req.path == "/up" || req.path.start_with?("/up/")
+  end
+
+  # --- Throttles: auth ------------------------------------------------------
+
+  throttle("login/ip", limit: LOGIN_LIMIT, period: LOGIN_PERIOD) do |req|
+    req.ip if req.post? && req.path.match?(LOGIN_PATHS)
+  end
+
+  throttle("login/email", limit: LOGIN_EMAIL_LIMIT, period: LOGIN_PERIOD) do |req|
+    login_email(req) if req.post? && req.path.match?(LOGIN_PATHS)
+  end
+
+  throttle("password_reset/ip", limit: PASSWORD_RESET_LIMIT, period: PASSWORD_RESET_PERIOD) do |req|
+    req.ip if req.post? && req.path.match?(PASSWORD_RESET_PATHS)
+  end
+
+  # --- Throttles: token-access lookups -------------------------------------
+
+  throttle("token_access/ip", limit: TOKEN_LIMIT, period: TOKEN_PERIOD) do |req|
+    req.ip if req.path.match?(TOKEN_ACCESS_PATHS)
+  end
+
+  # --- Throttles: AI / audio generation (per user) -------------------------
+
+  throttle("ai_generation/user", limit: AI_LIMIT, period: AI_PERIOD) do |req|
+    user_discriminator(req) if ai_generation_request?(req)
+  end
+
+  # --- Throttles: public profile enumeration (existing) --------------------
 
   # Public profile lookup — generous enough for normal browsing but stops
   # automated scraping.
-  throttle("public_profile/ip", limit: 30, period: 60) do |req|
+  throttle("public_profile/ip", limit: PROFILE_PUBLIC_LIMIT, period: PROFILE_PERIOD) do |req|
     if req.path.match?(%r{\A/api/profiles/public(/|\z)}) && req.get?
       req.ip
     end
@@ -24,7 +164,7 @@ class Rack::Attack
 
   # Slug availability check — tighter limit since it's only used during
   # onboarding / profile editing, not normal page views.
-  throttle("check_slug/ip", limit: 10, period: 60) do |req|
+  throttle("check_slug/ip", limit: PROFILE_SLUG_LIMIT, period: PROFILE_PERIOD) do |req|
     if req.path.match?(%r{\A/api/profiles/check_slug(/|\z)}) && req.get?
       req.ip
     end
@@ -32,9 +172,13 @@ class Rack::Attack
 
   ### Custom response ###
 
+  # Clean 429 with Retry-After. Generic body — never leak which rule matched
+  # or any internals to the client.
   self.throttled_responder = lambda do |req|
     match_data = req.env["rack.attack.match_data"] || {}
-    retry_after = (match_data[:period] || 60) - (Time.now.to_i % (match_data[:period] || 60))
+    period = match_data[:period].to_i
+    period = 60 if period <= 0
+    retry_after = period - (Time.now.to_i % period)
 
     [
       429,
@@ -45,4 +189,33 @@ class Rack::Attack
       [{ error: "rate_limited", retry_after: retry_after }.to_json],
     ]
   end
+end
+
+# --- Counter store -----------------------------------------------------------
+#
+# Rack::Attack needs a real store to count against. The app's Rails.cache is
+# :null_store in test (and toggled in dev), which would silently disable every
+# throttle. Point Rack::Attack at Redis explicitly — the app already runs it.
+# The error handler keeps a Redis blip from 500ing a request (fail open).
+Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(
+  url: ENV.fetch("RACK_ATTACK_REDIS_URL", ENV.fetch("REDIS_URL", "redis://localhost:6379/0")),
+  namespace: "rack_attack",
+  error_handler: lambda { |method:, returning:, exception:|
+    Rails.logger.warn("[rack-attack] cache #{method} error: #{exception.class}")
+  }
+)
+
+# Opt out of throttling in the test environment by default so the existing
+# request specs aren't affected by these limits; the rack_attack spec enables
+# it explicitly (and swaps in a MemoryStore).
+Rack::Attack.enabled = !Rails.env.test?
+
+# Lightweight, non-leaking observability: log throttled requests so ops can see
+# abuse without exposing anything to the client.
+ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
+  req = payload[:request]
+  next unless req
+
+  matched = req.env["rack.attack.matched"]
+  Rails.logger.warn("[rack-attack] throttled rule=#{matched} ip=#{req.ip} path=#{req.path}")
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+# Rate limiting (issue #30). Rack::Attack is disabled in the test env by
+# default (so it doesn't perturb other request specs); this spec opts in and
+# swaps in a fresh in-memory counter store per example, since the app's
+# Rails.cache is :null_store in test and would never count.
+RSpec.describe "Rack::Attack rate limiting", type: :request do
+  around do |example|
+    prev_enabled = Rack::Attack.enabled
+    prev_store = Rack::Attack.cache.store
+
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    example.run
+
+    Rack::Attack.cache.store = prev_store
+    Rack::Attack.enabled = prev_enabled
+  end
+
+  describe "auth sign-in throttle (per IP)" do
+    let(:limit) { Rack::Attack::LOGIN_LIMIT }
+
+    # Distinct emails so only the per-IP rule (not the tighter per-email rule)
+    # accumulates.
+    def failed_login(n)
+      post "/api/v1/users/sign_in",
+        params: { email: "attacker#{n}@example.com", password: "wrong" },
+        as: :json
+    end
+
+    it "lets a normal request rate through" do
+      3.times { |i| failed_login(i) }
+      expect(response).to have_http_status(:unauthorized) # 401, not 429
+    end
+
+    it "returns 429 once the burst passes the limit" do
+      limit.times { |i| failed_login(i) }
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      failed_login(limit) # one over
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns a clean 429 with Retry-After and no internals leaked" do
+      (limit + 1).times { |i| failed_login(i) }
+
+      expect(response).to have_http_status(:too_many_requests)
+      expect(response.headers["Retry-After"].to_i).to be > 0
+
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("rate_limited")
+      # Body must not leak which rule matched or any stack/internal detail.
+      expect(response.body).not_to match(/login|throttle|rack|attack|backtrace/i)
+    end
+  end
+
+  describe "auth sign-in throttle (per email)" do
+    it "throttles repeated attempts against a single account" do
+      email_limit = Rack::Attack::LOGIN_EMAIL_LIMIT
+
+      email_limit.times do
+        post "/api/v1/users/sign_in",
+          params: { email: "victim@example.com", password: "guess" },
+          as: :json
+      end
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      post "/api/v1/users/sign_in",
+        params: { email: "victim@example.com", password: "guess" },
+        as: :json
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "password reset throttle (per IP)" do
+    it "returns 429 past the limit" do
+      limit = Rack::Attack::PASSWORD_RESET_LIMIT
+
+      limit.times do
+        post "/api/v1/forgot_password", params: { email: "someone@example.com" }, as: :json
+      end
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      post "/api/v1/forgot_password", params: { email: "someone@example.com" }, as: :json
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "token-access lookup throttle (per IP)" do
+    it "returns 429 past the limit" do
+      limit = Rack::Attack::TOKEN_LIMIT
+
+      limit.times { get "/api/temp-login/deadbeef" }
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      get "/api/temp-login/deadbeef"
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "AI / audio generation throttle" do
+    # Unauthenticated requests still pass through Rack::Attack (middleware runs
+    # before the controller's auth), so we can exercise the throttle cheaply —
+    # each request 401s at the controller, but the throttle counter still ticks.
+    it "throttles the /generate* surface past the limit" do
+      limit = Rack::Attack::AI_LIMIT
+
+      limit.times { post "/api/images/generate", params: {}, as: :json }
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      post "/api/images/generate", params: {}, as: :json
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "buckets per user via the auth token, not shared globally" do
+      env_for = ->(token) do
+        Rack::Attack.user_discriminator(
+          Rack::Request.new(Rack::MockRequest.env_for("/api/images/generate", "HTTP_AUTHORIZATION" => "Bearer #{token}"))
+        )
+      end
+
+      key_a = env_for.call("token-aaa")
+      key_b = env_for.call("token-bbb")
+
+      expect(key_a).to start_with("user:")
+      expect(key_a).not_to eq(key_b)          # different users → different buckets
+      expect(key_a).not_to include("token-aaa") # raw token never used as the key
+    end
+
+    it "falls back to an IP bucket when unauthenticated" do
+      key = Rack::Attack.user_discriminator(
+        Rack::Request.new(Rack::MockRequest.env_for("/api/images/generate", "REMOTE_ADDR" => "9.9.9.9"))
+      )
+      expect(key).to eq("ip:9.9.9.9")
+    end
+  end
+
+  describe "health-check safelist" do
+    it "never throttles /up even under a heavy burst" do
+      (Rack::Attack::LOGIN_LIMIT * 3).times { get "/up" }
+      expect(response).not_to have_http_status(:too_many_requests)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds Rack::Attack throttling to the abuse-prone endpoints called out in #30. The app previously had **no** per-IP / per-user rate limiting on auth or AI routes — auth was open to brute force, and AI generation gated on credit balance only (no request-frequency ceiling).

This **extends the existing** `config/initializers/rack_attack.rb` (which already carried public-profile enumeration throttles) rather than creating it from scratch.

### 🔎 Gem note (no new gem)
`rack-attack` is **already a dependency** on `main` — it was added with the profile-enumeration throttles in a prior PR. This PR reuses it, so **nothing new is being installed.** (Flagging explicitly given the "gems need a yes" rule; there's nothing to approve here.)

## What's throttled (all ENV-tunable, sensible defaults)

| Surface | Routes | Key | Default |
|---|---|---|---|
| Sign-in | `POST /users/sign_in`, `/api/v1/users/sign_in`, `/api/v1/child_accounts/login` | per **IP** + per **email** | 20/min IP, 10/min email |
| Password reset | `forgot_password`, `reset_password`, `reset_password_invite` | per IP | 5/hr |
| Token-access lookups | `/api/temp-login/:token`, `/api/communicator_claims/:token` | per IP | 20/min |
| AI / audio generation | `/api/*/generate*`, `generate_audio`, `regenerate_images`, `generate_preview_image`, `POST /api/generated_boards` | per **user** | 30/min |

Per-user key = SHA256 of the `Authorization` token (hashed — no secret in Redis keys/logs), falling back to IP when unauthenticated.

## AAC guardrails ("usage must never break")
- **Read / board-load / audio-PLAYBACK paths are never throttled** — `GET /api/audio/play`, board reads, etc. Only WRITE/auth/AI-generation surfaces are limited.
- **`GET /api/generated_boards/:token` is intentionally left unthrottled** — the frontend polls it while a board renders.
- **`/up` is safelisted** so BetterStack's 3-min health checks aren't rate-limited.
- `/api/internal/*` (server-to-server, `INTERNAL_API_KEY`-gated) is excluded from the AI throttle.

## Response & infra
- Throttled requests get a clean **429** with a `Retry-After` header and a generic body `{ "error": "rate_limited", "retry_after": N }` — no rule name or internals leaked.
- Counter store is **Redis, set explicitly** (`Rack::Attack.cache.store`), not `Rails.cache` — which is `:null_store` in test and would silently disable throttling. Store `error_handler` fails open (a Redis blip can't 500 a request).
- Middleware is auto-inserted by the gem's Railtie (no manual `config.middleware.use`, which would double-count).
- Disabled in the **test** env by default so it doesn't perturb other request specs; the new spec opts in with a per-example `MemoryStore`.

## Test plan
- **New:** `spec/requests/rack_attack_spec.rb` — 10 examples, all green:
  - burst past the limit → 429 with `Retry-After` and a generic (non-leaking) body
  - a normal request rate passes (401, not 429)
  - per-email login throttle
  - password-reset and token-access throttles
  - AI `/generate*` throttle; per-user bucketing (distinct tokens ≠ same bucket; raw token never used as key); IP fallback
  - `/up` never throttled under a heavy burst
- **Regression:** existing auth request specs (`child_auths_spec`, `email_signup_spec`, `auths_current_spec`) — 26 examples, 0 failures.

```
bundle exec rspec spec/requests/rack_attack_spec.rb   # 10 examples, 0 failures
```

## Docs
- `CHANGELOG.md`, backend `CLAUDE.md` (new "Rate limiting" section), and `README.md` (env vars) updated.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)