### PR TITLE
fix(security): stop mass-assignment of ownership/status fields via strong params (#27)

### DIFF
--- a/app/controllers/api/account/boards_controller.rb
+++ b/app/controllers/api/account/boards_controller.rb
@@ -180,13 +180,16 @@ class API::Account::BoardsController < API::Account::ApplicationController
   end
 
   def image_params
-    params.require(:image).permit(:label, :image_prompt, :display_image, audio_files: [], docs: [:id, :user_id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
+    # :user_id dropped from the nested docs — ownership is server-decided, never
+    # client-supplied via mass-assignment (#27).
+    params.require(:image).permit(:label, :image_prompt, :display_image, audio_files: [], docs: [:id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
   end
 
   # Only allow a list of trusted parameters through.
   def board_params
-    params.require(:board).permit(:user_id,
-                                  :name,
+    # :user_id dropped — a board's owner is server-decided (current_user), never
+    # client-supplied via mass-assignment (#27).
+    params.require(:board).permit(:name,
                                   :parent_id,
                                   :parent_type,
                                   :description,

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1348,7 +1348,10 @@ class API::BoardsController < API::ApplicationController
   end
 
   def image_params
-    params.require(:image).permit(:label, :image_prompt, :display_image, :part_of_speech, audio_files: [], docs: [:id, :user_id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
+    # :user_id is intentionally NOT permitted on the nested docs — the doc owner
+    # is assigned server-side (new_doc.user = current_user in #add_image), so a
+    # client can't set or reassign ownership via mass-assignment (#27).
+    params.require(:image).permit(:label, :image_prompt, :display_image, :part_of_speech, audio_files: [], docs: [:id, :image, :documentable_id, :documentable_type, :processed, :_destroy])
   end
 
   # Optional gestalt tile metadata for add_image (Script Collector). Free-form

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -535,7 +535,10 @@ class API::ChildAccountsController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def child_account_params
-    params.require(:child_account).permit(:user_id, :username, :name)
+    # :user_id is intentionally NOT permitted — ownership is assigned server-side
+    # (@child_account.owner = current_user in #create), so a client can't set or
+    # reassign ownership via mass-assignment (#27).
+    params.require(:child_account).permit(:username, :name)
   end
 
   # Issues #210 / #211 — content-mutating endpoints on the communicator

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -200,6 +200,9 @@ class API::DocsController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def doc_params
-    params.require(:doc).permit(:documentable_id, :documentable_type, :image, :raw, :current, :board_id, :user_id, :source_type)
+    # :user_id is intentionally NOT permitted — the owner is assigned server-side
+    # (@doc.user = current_user in #create), so a client can't set or reassign
+    # ownership via create/update mass-assignment (#27).
+    params.require(:doc).permit(:documentable_id, :documentable_type, :image, :raw, :current, :board_id, :source_type)
   end
 end

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -180,8 +180,12 @@ class API::MenusController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def menu_params
-    params.require(:menu).permit(:user_id, :name, :description, :token_limit, :predefined,
-                                 docs: [:id, :raw, :image, :_destroy, :user_id, :source_type])
+    # :user_id is intentionally NOT permitted (top-level or on the nested docs)
+    # — ownership is assigned server-side (@menu.user / doc.user = current_user
+    # in #create), so a client can't set or reassign ownership via create/update
+    # mass-assignment (#27).
+    params.require(:menu).permit(:name, :description, :token_limit, :predefined,
+                                 docs: [:id, :raw, :image, :_destroy, :source_type])
   end
 
   def check_board_create_permissions

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -39,18 +39,17 @@ class API::MessagesController < API::ApplicationController
 
   # POST /messages or /messages.json
   def create
-    # sender_id = params[:sender_id]
-    # current_user_id = current_user&.id
-    # unless sender_id == current_user_id
-    #   puts "Sender ID: #{sender_id}, Current User ID: #{current_user_id} - Unauthorized access"
-    #   render json: { error: "Unauthorized" }, status: :unauthorized
-    #   return
-    # end
     @message = Message.new(message_params)
+    # Ownership is server-decided: the sender is always the authenticated user
+    # (a client must not be able to forge a message "from" someone else), and
+    # the recipient is taken explicitly from the request rather than
+    # mass-assigned. Neither rides the permit list — see #message_params.
+    @message.sender_id = current_user.id
+    @message.recipient_id = params.dig(:message, :recipient_id)
 
     if @message.save
       @message.notify_recipient
-      render json: @message.show_api_view(current_user), status: :created, location: @message
+      render json: @message.show_api_view(current_user), status: :created
     else
       render json: @message.errors, status: :unprocessable_content
     end
@@ -59,7 +58,7 @@ class API::MessagesController < API::ApplicationController
   # PATCH/PUT /messages/1 or /messages/1.json
   def update
     if @message.update(message_params)
-      render json: @message, status: :ok, location: @message
+      render json: @message, status: :ok
     else
       render json: @message.errors, status: :unprocessable_content
     end
@@ -104,7 +103,10 @@ class API::MessagesController < API::ApplicationController
   end
 
   def message_params
-    params.require(:message).permit(:subject, :body, :sender_id, :recipient_id, :sent_at, :sender_deleted_at, :recipient_deleted_at, :read_at,
+    # :sender_id / :recipient_id are intentionally NOT permitted — ownership is
+    # assigned server-side in #create (sender = current_user, recipient taken
+    # explicitly) so a client can't forge or reassign them (mass-assignment, #27).
+    params.require(:message).permit(:subject, :body, :sent_at, :sender_deleted_at, :recipient_deleted_at, :read_at,
                                     attachments: [])
   end
 end

--- a/app/controllers/api/openai_prompts_controller.rb
+++ b/app/controllers/api/openai_prompts_controller.rb
@@ -71,6 +71,9 @@ class API::OpenaiPromptsController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def openai_prompt_params
-    params.require(:openai_prompt).permit(:user_id, :prompt_text, :revised_prompt, :send_now, :deleted_at, :sent_at, :private, :response_type, :age_range, :number_of_images, :token_limit)
+    # :user_id is intentionally NOT permitted — the owner comes from the
+    # current_user.openai_prompts association in #create, so a client can't set
+    # or reassign ownership via create/update mass-assignment (#27).
+    params.require(:openai_prompt).permit(:prompt_text, :revised_prompt, :send_now, :deleted_at, :sent_at, :private, :response_type, :age_range, :number_of_images, :token_limit)
   end
 end

--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -18,6 +18,10 @@ class API::OrganizationsController < API::ApplicationController
   private
 
   def organization_params
-    params.require(:organization).permit(:name, :admin_user_id, :settings, :stripe_customer_id, :plan_type)
+    # :admin_user_id (ownership), :plan_type (billing tier) and :stripe_customer_id
+    # are intentionally NOT permitted on this (non-admin) controller — they must
+    # not be client-settable via mass-assignment. Org billing/ownership is curated
+    # only through the admin-gated API::Admin::OrganizationsController (#27).
+    params.require(:organization).permit(:name, :settings)
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -250,7 +250,12 @@ class API::UsersController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def user_params
-    params.require(:user).permit(:name, :email, :base_words, :plan_type,
+    # :plan_type is intentionally NOT permitted here — a user must not be able to
+    # set their own paid tier via mass-assignment (payment bypass). Plan state is
+    # owned by the Stripe/RevenueCat webhook and admin paths. #update only reads
+    # :name today; dropping :plan_type also closes the latent hole if a future
+    # edit switches to `@user.update(user_params)` (#27).
+    params.require(:user).permit(:name, :email, :base_words,
                                  voice: [:name, :speed, :pitch, :rate, :volume, :language])
   end
 end

--- a/spec/requests/api/mass_assignment_spec.rb
+++ b/spec/requests/api/mass_assignment_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+# Regression coverage for #27 — strong-params permit lists must not let a client
+# mass-assign ownership fields. The owner of a created/updated record is always
+# derived server-side from the authenticated user, never from request params.
+RSpec.describe "Mass-assignment of ownership fields", type: :request do
+  let(:owner)    { create(:user) }
+  let(:attacker) { create(:user) }
+
+  describe "POST /api/child_accounts" do
+    it "ignores a client-supplied user_id and owns the communicator to the caller" do
+      post "/api/child_accounts",
+           params: { name: "Sam", username: "sam-#{SecureRandom.hex(2)}", user_id: attacker.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:created)
+      child = ChildAccount.order(:id).last
+      expect(child.owner_id).to eq(owner.id)
+      expect(child.owner_id).not_to eq(attacker.id)
+      expect(child.user_id).to eq(owner.id)
+    end
+  end
+end

--- a/spec/requests/api/messages_spec.rb
+++ b/spec/requests/api/messages_spec.rb
@@ -1,7 +1,50 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "API::Messages", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:sender)    { create(:user) }
+  let(:recipient) { create(:user) }
+  let(:attacker)  { create(:user) }
+
+  describe "POST /api/messages" do
+    it "creates a message from the authenticated user to the chosen recipient" do
+      post "/api/messages",
+           params: { message: { subject: "Hi", body: "Hello", recipient_id: recipient.id } },
+           headers: auth_headers(sender)
+
+      expect(response).to have_http_status(:created)
+      message = Message.last
+      expect(message.sender_id).to eq(sender.id)
+      expect(message.recipient_id).to eq(recipient.id)
+    end
+
+    # Regression for #27: a client must not be able to forge the sender.
+    it "ignores a client-supplied sender_id (mass-assignment)" do
+      post "/api/messages",
+           params: { message: { subject: "Spoofed", body: "Not from me",
+                                sender_id: attacker.id, recipient_id: recipient.id } },
+           headers: auth_headers(sender)
+
+      expect(response).to have_http_status(:created)
+      message = Message.last
+      expect(message.sender_id).to eq(sender.id)
+      expect(message.sender_id).not_to eq(attacker.id)
+    end
+  end
+
+  describe "PATCH /api/messages/:id" do
+    # Regression for #27: updating a message must not reassign the sender.
+    it "does not let a client change sender_id on update" do
+      message = Message.create!(subject: "S", body: "B",
+                                sender_id: sender.id, recipient_id: recipient.id)
+
+      patch "/api/messages/#{message.id}",
+            params: { message: { subject: "Edited", sender_id: attacker.id } },
+            headers: auth_headers(sender)
+
+      expect(response).to have_http_status(:ok)
+      message.reload
+      expect(message.sender_id).to eq(sender.id)
+      expect(message.subject).to eq("Edited")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the mass-assignment holes in #27: several API strong-params permit lists
allowed a client to set ownership/privilege fields (`:user_id`, `:sender_id`,
`:recipient_id`, and equivalents). Each such field is now **dropped from the
permit list and assigned server-side** from `current_user` (or a controlled,
explicit source), so a client can't forge or reassign ownership — or self-grant
a paid tier.

### Fixed (the six from the issue + verified equivalents)
| Controller | Field(s) removed | Where the value now comes from |
|---|---|---|
| `messages` `message_params` | `:sender_id`, `:recipient_id` | sender forced to `current_user`; recipient taken explicitly in `#create` |
| `docs` `doc_params` | `:user_id` | `@doc.user = current_user` (`#create`); closes owner-reassign on `#update` |
| `menus` `menu_params` | `:user_id` (top-level **and** nested docs) | `@menu.user` / `doc.user = current_user` |
| `openai_prompts` `openai_prompt_params` | `:user_id` | `current_user.openai_prompts` association |
| `child_accounts` `child_account_params` | `:user_id` | `@child_account.owner = current_user` (this permit was already unused; dropped for defense-in-depth) |
| `boards` `image_params` | nested docs `:user_id` | `new_doc.user = current_user` (`#add_image`) |
| `account/boards` `image_params` / `board_params` | nested docs `:user_id`, board `:user_id` | server-decided owner (these methods are currently dead code; cleaned for consistency) |

### Additional ownership/privilege fields found and fixed (were beyond the six)
- **`users` `user_params`** dropped **`:plan_type`** — a non-admin user must not
  be able to set their own paid tier (payment bypass). `#update` only reads
  `:name` today, so this is safe and closes the latent hole.
- **`organizations` `organization_params`** (non-admin, currently **unrouted**)
  dropped **`:admin_user_id`**, **`:plan_type`**, **`:stripe_customer_id`**. Org
  billing/ownership is curated only via the admin-gated
  `API::Admin::OrganizationsController` (unchanged, intentional).

### Drive-by
- Removed an invalid `location: @message` option on the messages create/update
  renders — messages live under `namespace :api`, so it called a non-existent
  `message_url` helper and **500'd every JSON create/update**. Dropping it makes
  the endpoints (and the new tests) work.

### Reported, NOT changed here (flagged for follow-up)
These are the same *privilege/status* class but need admin-gating in a hot path,
so they're out of scope for this focused fix:
- `boards#update` still mass-assigns **`:predefined`** / **`:published`** — any
  board editor can self-promote a board into the curated/predefined pool.
- `menus` create/update still allows **`:predefined`** self-promotion.
- `board_groups` already strips `:predefined` / `:featured` for non-admins — no
  action needed (this is the pattern the above two should adopt).
- Non-admin `organizations#update` / `docs#update` have **no authorization
  check** (broken access control, separate from mass-assignment) — worth a
  dedicated issue.

## Test plan
- Added `spec/requests/api/messages_spec.rb` and
  `spec/requests/api/mass_assignment_spec.rb`:
  - a client-supplied `sender_id` is ignored on message create; sender is the
    caller; recipient is honored,
  - `sender_id` can't be reassigned on message update,
  - a client-supplied `user_id` on `POST /api/child_accounts` is ignored; the
    communicator is owned by the caller.
- `bundle exec rspec spec/requests/api/messages_spec.rb spec/requests/api/mass_assignment_spec.rb` → **4 examples, 0 failures**.
- Regression run of the touched controllers
  (`menus_spec`, `boards_spec` incl. `add_image` doc upload,
  `child_accounts_*`, `doc_spec`) → **83 examples, 0 failures**.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)