### PR TITLE
fix(security): scope API resource lookups to current_user (IDOR #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Security — scope API resource lookups to the caller (IDOR, issue #26)
+- Several `API::Images`, `API::BoardImages`, and `API::Boards` endpoints loaded
+  a record with a bare `Image.find` / `BoardImage.find(params[:id])` before any
+  ownership check, so an authenticated user could act on **another user's**
+  private image or board tile by guessing its id. Lookups are now scoped:
+  image endpoints resolve **the caller's own image or a public library image**
+  (a non-owner asking for someone else's *private* image gets a 404), while
+  destructive/owner-only endpoints (`destroy_audio`, board-image
+  edit/variation/audio/update/delete) resolve **only the caller's own** record.
+  Admins keep cross-user access; the public/unauthenticated AAC audio path and
+  the admin-only merge stay intentionally unscoped. The shared image library
+  remains fully usable — only cross-user access to *private* records is closed.
+
 ### Fixed — label-only tiles now render as text in PDF export and board previews
 - Board PDF exports and the board cover/preview image showed a **picture** on
   label-only tiles (e.g. an "I feel" header) even though the app renders them as

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -1,6 +1,7 @@
 class API::BoardImagesController < API::ApplicationController
   respond_to :json
-  before_action :set_board_image, only: %i[ show update destroy create_image_variation create_image_edit set_current_audio ]
+  before_action :set_board_image, only: %i[ show ]
+  before_action :set_owned_board_image, only: %i[ update destroy create_image_variation create_image_edit set_current_audio ]
   before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation upload_audio reset_audio move destroy ]
 
   # GET /board_images or /board_images.json
@@ -14,7 +15,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def save_layout
-    @board_image = BoardImage.find(params[:id])
+    @board_image = owned_board_image
     layout = params[:layout]
     screen_size = params[:screen_size]
     @board_image.update_layout(layout, screen_size)
@@ -22,7 +23,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def set_current_audio
-    @board_image = BoardImage.find(params[:id])
+    # @board_image is loaded owner-scoped by set_owned_board_image.
     if @board_image.update(audio_url: board_image_params[:audio_url], voice: board_image_params[:voice])
       render json: @board_image.api_view(current_user)
     else
@@ -200,11 +201,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def create_image_edit
-    @board_image = BoardImage.find(params[:id])
-    if @board_image.nil?
-      render json: { error: "Board image not found" }, status: :unprocessable_content
-      return
-    end
+    # @board_image is loaded owner-scoped by set_owned_board_image.
     begin
       return unless check_credits!(feature_key: "image_edit", feature_name: "AI Image Edits")
       prompt = params[:prompt] || ""
@@ -225,11 +222,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def create_image_variation
-    @board_image = BoardImage.find(params[:id])
-    if @board_image.nil?
-      render json: { error: "Board image not found" }, status: :unprocessable_content
-      return
-    end
+    # @board_image is loaded owner-scoped by set_owned_board_image.
     return unless check_credits!(feature_key: "image_variation", feature_name: "AI Image Variations")
 
     @image_variation = @board_image.create_image_variation!
@@ -243,11 +236,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def upload_audio
-    @board_image = BoardImage.find(params[:id])
-    unless @board_image.user_id == current_user.id || current_user.admin?
-      render json: { status: "error", message: "You are not authorized to upload audio for this board image." }
-      return
-    end
+    @board_image = owned_board_image
     default_file_name = @board_image.label.downcase.gsub(" ", "-").gsub("_", "-")
     default_file_name = !default_file_name.blank? ? default_file_name : "board-image-audio"
     random_number = Time.now.strftime("%m%d%y%H%M%S")
@@ -273,11 +262,7 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   def reset_audio
-    @board_image = BoardImage.find(params[:id])
-    unless @board_image.user_id == current_user.id || current_user.admin?
-      render json: { status: "error", message: "You are not authorized to reset audio for this board image." }
-      return
-    end
+    @board_image = owned_board_image
 
     default_audio_url = @board_image.default_audio_url
     @board_image.data ||= {}
@@ -378,6 +363,23 @@ class API::BoardImagesController < API::ApplicationController
       render json: { error: "Board image not found" }, status: :unprocessable_content
       return
     end
+  end
+
+  # Issue #26 (IDOR): load a board image the current user is allowed to mutate,
+  # scoped to boards they own so a non-owner gets a 404 instead of being able to
+  # edit/delete another user's tile. Admins may act cross-user.
+  def set_owned_board_image
+    @board_image = owned_board_image
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Board image not found" }, status: :not_found
+  end
+
+  # A board image owned by the current user (its board's user_id matches).
+  # Raises ActiveRecord::RecordNotFound (=> 404) for a non-owner. Admins bypass.
+  def owned_board_image(id = params[:id])
+    return BoardImage.find(id) if current_user.admin?
+
+    BoardImage.joins(:board).where(boards: { user_id: current_user.id }).find(id)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -896,7 +896,14 @@ class API::BoardsController < API::ApplicationController
   end
 
   def associate_image
-    @image = Image.find(params[:image_id])
+    # Issue #26 (IDOR): a user may add their own image or any public library
+    # image to a board, but not reference another user's PRIVATE image. A
+    # non-owner asking for someone else's private image gets a 404. Admins bypass.
+    @image = if current_user.admin?
+      Image.find(params[:image_id])
+    else
+      Image.where("images.is_private IS NOT TRUE OR images.user_id = ?", current_user.id).find(params[:image_id])
+    end
     screen_size = params[:screen_size] || "lg"
     if @board.images.include?(@image)
       render json: { error: "Image already associated with board" }, status: :unprocessable_content

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -73,7 +73,7 @@ class API::ImagesController < API::ApplicationController
 
     label = image_params[:label]
     image_id = params["image"]["id"]
-    @image = Image.find(image_id) if image_id.present?
+    @image = accessible_image(image_id) if image_id.present?
     @image = Image.find_by(label: label, user_id: @current_user.id) unless @image
     @image = Image.create(label: label, user_id: @current_user.id) unless @image
     @doc = attach_doc_to_image(@image, @current_user, params[:cropped_image], params[:file_extension])
@@ -95,7 +95,7 @@ class API::ImagesController < API::ApplicationController
   def save_temp_doc
     @current_user = current_user
     if params[:imageId].present?
-      @existing_image = Image.find(params[:imageId])
+      @existing_image = accessible_image(params[:imageId])
     end
 
     label = params[:query]
@@ -133,6 +133,8 @@ class API::ImagesController < API::ApplicationController
       render json: { status: "error", message: "You are not authorized to merge images." }, status: :forbidden
       return
     end
+    # Admin-only (gated above): merging is a cross-user library operation, so the
+    # lookup is intentionally unscoped. Non-admins never reach here (issue #26).
     @image = Image.find(params[:id])
     @images_to_merge = Image.where(id: params[:merge_image_ids])
     if @images_to_merge.empty?
@@ -291,6 +293,9 @@ class API::ImagesController < API::ApplicationController
   end
 
   def public_audio
+    # Intentionally public + unscoped (skip_before_action :authenticate_token!):
+    # this is an AAC audio-playback path that must work for unauthenticated
+    # viewers of a shared page, so it is left unscoped by design (issue #26).
     @image = Image.find(params[:id])
     # voice = params[:voice] || @image.voice || "alloy"
     voice = @image.voice || "alloy"
@@ -351,7 +356,7 @@ class API::ImagesController < API::ApplicationController
   end
 
   def add_doc
-    @image = Image.find(params[:id])
+    @image = accessible_image
     @doc = @image.docs.new(image_params[:docs])
     @doc.user = current_user
     @doc.processed = true
@@ -388,7 +393,7 @@ class API::ImagesController < API::ApplicationController
   end
 
   def create_predictive_board
-    @image = Image.find(params[:id])
+    @image = accessible_image
     board_id = params[:board_id]
     @board = Board.with_artifacts.find_by(id: board_id) if board_id.present?
     unless @board.nil?
@@ -430,7 +435,7 @@ class API::ImagesController < API::ApplicationController
   ADMIN_SYMBOL_LIMIT = ENV["ADMIN_SYMBOL_LIMIT"] || 10
 
   def create_symbol
-    @image = Image.find(params[:id])
+    @image = accessible_image
     if @image.open_symbol_status == "disabled"
       render json: { status: "error", message: "Symbol generation is disabled for this image." }, status: :unprocessable_content
       return
@@ -463,7 +468,7 @@ class API::ImagesController < API::ApplicationController
     stripped_prompt = image_prompt.gsub("[[REPLACE_LABEL]]", "").strip
 
     if !params[:id].blank?
-      @image = Image.find(params[:id])
+      @image = accessible_image
     else
       @image = Image.find_or_create_by(label: label, user_id: @current_user.id, private: false, image_prompt: stripped_prompt, image_type: "Generated")
     end
@@ -534,7 +539,7 @@ class API::ImagesController < API::ApplicationController
 
   def prompt_suggestion
     @current_user = current_user
-    @image = Image.find(params[:id])
+    @image = accessible_image
     prompt = @image.get_image_prompt_suggestion
     scrubbed_prompt = prompt.gsub('"', "")
     render json: { prompt: scrubbed_prompt }
@@ -609,7 +614,7 @@ class API::ImagesController < API::ApplicationController
   end
 
   def clear_current
-    @image = Image.find(params[:id])
+    @image = accessible_image
     if @image.nil?
       render json: { status: "error", message: "Image not found." }
     else
@@ -677,7 +682,7 @@ class API::ImagesController < API::ApplicationController
   end
 
   def hide_doc
-    @image = Image.find(params[:id])
+    @image = accessible_image
     @doc = @image.docs.find(params[:doc_id])
     unless (@doc.user_id == current_user.id) || current_user.admin?
       render json: { status: "error", message: "You are not authorized to delete this document." }
@@ -722,7 +727,9 @@ class API::ImagesController < API::ApplicationController
   end
 
   def destroy_audio
-    @image = Image.find(params[:id])
+    # Owner-only: purging audio is destructive, so scope to the caller's own
+    # images (matches upload_audio / set_current_audio). Issue #26 (IDOR).
+    @image = current_user.images.find(params[:id])
     unless params[:audio_file_id].present?
       render json: { status: "error", message: "No audio file id provided." }
       return
@@ -756,6 +763,19 @@ class API::ImagesController < API::ApplicationController
   end
 
   private
+
+  # Issue #26 (IDOR): images are a shared library. A row is either PUBLIC
+  # (is_private false/nil — e.g. the admin-owned symbol library, mirrors the
+  # `public_img` scope) or a user's PRIVATE image. This replaces bare
+  # `Image.find`, so a caller can load their own image or any public library
+  # image, but a non-owner asking for someone else's PRIVATE image gets a 404
+  # (ActiveRecord::RecordNotFound => 404). The public AAC library stays usable.
+  # Admins may act cross-user.
+  def accessible_image(id = params[:id], relation = Image)
+    return relation.find(id) if current_user.admin?
+
+    relation.where("images.is_private IS NOT TRUE OR images.user_id = ?", current_user.id).find(id)
+  end
 
   def needs_replacement?(label, image_prompt)
     normalized_label = label.to_s.strip.downcase

--- a/spec/requests/api/board_images_idor_spec.rb
+++ b/spec/requests/api/board_images_idor_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+# Issue #26 (IDOR): board-image mutations must be scoped to the caller's own
+# boards. Before this fix, `BoardImage.find(params[:id])` (and the unscoped
+# `set_board_image` before_action) loaded any board image, and the existing
+# `check_board_image_editable!` gate does NOT enforce ownership — it returns
+# true for boards you don't own — so any authenticated user could edit or
+# delete another user's tile. These specs prove a non-owner now gets a 404.
+RSpec.describe "API::BoardImages IDOR", type: :request do
+  let!(:user)       { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:admin)      { create(:admin_user) }
+
+  let!(:board)       { create(:board, user: user) }
+  let!(:board_image) { create(:board_image, board: board) }
+
+  let!(:other_board)       { create(:board, user: other_user) }
+  let!(:other_board_image) { create(:board_image, board: other_board) }
+
+  describe "a non-owner is rejected with 404 (not the record)" do
+    it "PATCH /api/board_images/:id (update)" do
+      patch "/api/board_images/#{other_board_image.id}",
+            params: { board_image: { bg_color: "#fff" } },
+            headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "DELETE /api/board_images/:id (destroy)" do
+      delete "/api/board_images/#{other_board_image.id}", headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/set_current_audio" do
+      post "/api/board_images/#{other_board_image.id}/set_current_audio",
+           params: { board_image: { audio_url: "http://x", voice: "alloy" } },
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/create_edit" do
+      post "/api/board_images/#{other_board_image.id}/create_edit",
+           params: { prompt: "x" },
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/create_variation" do
+      post "/api/board_images/#{other_board_image.id}/create_variation",
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/upload_audio" do
+      post "/api/board_images/#{other_board_image.id}/upload_audio",
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/reset_audio" do
+      post "/api/board_images/#{other_board_image.id}/reset_audio",
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "the owner and admins are not blocked (no regression)" do
+    it "lets the owner set current audio on their own tile" do
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { board_image: { audio_url: "http://x", voice: "alloy" } },
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lets the owner destroy their own tile" do
+      delete "/api/board_images/#{board_image.id}", headers: auth_headers(user)
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "lets an admin destroy another user's tile (cross-user access preserved)" do
+      delete "/api/board_images/#{other_board_image.id}", headers: auth_headers(admin)
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/boards_associate_image_idor_spec.rb
+++ b/spec/requests/api/boards_associate_image_idor_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+# Issue #26 (IDOR): PUT /api/boards/:id/associate_image loaded the image with a
+# bare `Image.find(params[:image_id])`. A user may add their own image or any
+# public library image to a board, but must not be able to reference another
+# user's PRIVATE image by id. These specs prove the private-image case now 404s
+# while the shared library stays usable.
+RSpec.describe "API::Boards#associate_image IDOR", type: :request do
+  let!(:user)       { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:admin)      { create(:admin_user) }
+
+  let!(:board) { create(:board, user: user) }
+
+  let!(:other_private_image) { create(:image, user: other_user, is_private: true) }
+  let!(:public_image)        { create(:image, user: other_user, is_private: false) }
+  let!(:own_image)           { create(:image, user: user, is_private: true) }
+
+  it "404s when adding another user's PRIVATE image" do
+    put "/api/boards/#{board.id}/associate_image",
+        params: { image_id: other_private_image.id },
+        headers: auth_headers(user)
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "allows adding a PUBLIC library image (no regression)" do
+    put "/api/boards/#{board.id}/associate_image",
+        params: { image_id: public_image.id },
+        headers: auth_headers(user)
+    expect(response).not_to have_http_status(:not_found)
+  end
+
+  it "allows adding the caller's own image" do
+    put "/api/boards/#{board.id}/associate_image",
+        params: { image_id: own_image.id },
+        headers: auth_headers(user)
+    expect(response).not_to have_http_status(:not_found)
+  end
+
+  it "lets an admin add another user's private image (cross-user access preserved)" do
+    admin_board = create(:board, user: admin)
+    put "/api/boards/#{admin_board.id}/associate_image",
+        params: { image_id: other_private_image.id },
+        headers: auth_headers(admin)
+    expect(response).not_to have_http_status(:not_found)
+  end
+end

--- a/spec/requests/api/images_spec.rb
+++ b/spec/requests/api/images_spec.rb
@@ -70,4 +70,114 @@ RSpec.describe "API::Images", type: :request do
       end
     end
   end
+
+  # Issue #26 (IDOR): resource lookups must be scoped so a caller can't load
+  # another user's PRIVATE image by guessing its id. Images are a shared
+  # library, so PUBLIC images (is_private false/nil) and the caller's own
+  # images stay reachable; only another user's private image 404s.
+  describe "IDOR — image lookups scoped to accessible images" do
+    let!(:admin)              { create(:admin_user) }
+    let!(:other_private_image) { create(:image, user: other_user, is_private: true) }
+    let!(:public_image)        { create(:image, user: other_user, is_private: false) }
+
+    # Endpoints that build/enrich the shared library: own OR public reachable,
+    # another user's private image => 404.
+    describe "accessible-scoped endpoints reject a non-owner's private image with 404" do
+      it "POST /api/images/crop" do
+        post "/api/images/crop",
+             params: { image: { id: other_private_image.id, label: "x" }, file_extension: "png" },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/save_temp_doc" do
+        post "/api/images/save_temp_doc",
+             params: { imageId: other_private_image.id, query: "x" },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/:id/add_doc" do
+        post "/api/images/#{other_private_image.id}/add_doc",
+             params: { image: { label: "x" } },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/:id/create_predictive_board" do
+        post "/api/images/#{other_private_image.id}/create_predictive_board",
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/:id/create_symbol" do
+        post "/api/images/#{other_private_image.id}/create_symbol",
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/generate" do
+        post "/api/images/generate",
+             params: { id: other_private_image.id, image: { label: "x", image_prompt: "a longer prompt" } },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "GET /api/images/:id/prompt_suggestion" do
+        get "/api/images/#{other_private_image.id}/prompt_suggestion",
+            headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/:id/clear_current" do
+        post "/api/images/#{other_private_image.id}/clear_current",
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "POST /api/images/:id/hide_doc" do
+        post "/api/images/#{other_private_image.id}/hide_doc",
+             params: { doc_id: 0 },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "shared library stays reachable (no regression)" do
+      # update_all avoids an unrelated pre-existing crash in clear_current when
+      # called with no board_id (it dereferences a nil @board); the accessible
+      # scope is what we're exercising here.
+      it "lets a non-owner act on a PUBLIC image (not 404)" do
+        post "/api/images/#{public_image.id}/clear_current",
+             params: { update_all: true }, headers: auth_headers(user)
+        expect(response).not_to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "lets the owner act on their own image (not 404)" do
+        post "/api/images/#{image.id}/clear_current",
+             params: { update_all: true }, headers: auth_headers(user)
+        expect(response).not_to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "lets an admin act cross-user on a private image (not 404)" do
+        post "/api/images/#{other_private_image.id}/clear_current",
+             params: { update_all: true }, headers: auth_headers(admin)
+        expect(response).not_to have_http_status(:not_found)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    # destroy_audio is owner-only (destructive), so even a PUBLIC image owned by
+    # someone else is off-limits — matches upload_audio/set_current_audio.
+    describe "owner-only DELETE /api/images/:id/destroy_audio" do
+      it "404s for a non-owner even on a public image" do
+        delete "/api/images/#{public_image.id}/destroy_audio",
+               params: { audio_file_id: 1 },
+               headers: auth_headers(user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the IDOR in issue #26: several API controllers loaded a record from
global scope (`Image.find` / `BoardImage.find(params[:id])`) **before** any
ownership check, so an authenticated user could act on **another user's**
private image or board tile by guessing its id.

The fix scopes every flagged lookup, distinguishing two cases because **images
are a shared library** (a row is either PUBLIC — `is_private` false/nil, e.g.
the admin-owned symbol library — or a user's PRIVATE image):

- **Shared-library endpoints** resolve *the caller's own image OR a public
  library image*. A non-owner asking for someone else's **private** image now
  gets a **404**, but the public AAC library stays fully usable (building/
  enriching shared images is a core flow). Covers `images#crop`,
  `save_temp_doc`, `add_doc`, `create_predictive_board`, `create_symbol`,
  `generate`, `prompt_suggestion`, `clear_current`, `hide_doc`, and
  `boards#associate_image`.
- **Owner-only / destructive endpoints** resolve *only the caller's own*
  record. Covers `images#destroy_audio` and board-image `save_layout`,
  `set_current_audio`, `create_image_edit`, `create_image_variation`,
  `upload_audio`, `reset_audio`, `update`, `destroy`.

### Notes / decisions
- **`board_images#update` and `#destroy` were extended beyond the verified
  inventory.** They shared the same unscoped `set_board_image` loader and were
  equally exploitable — the existing `check_board_image_editable!` gate does
  **not** enforce ownership (`board_editable?` returns true for boards you
  don't own). Leaving `PATCH`/`DELETE /api/board_images/:id` open in an IDOR
  fix would be indefensible, so `set_board_image` now serves only the `show`
  read and a new owner-scoped `set_owned_board_image` backs the mutations.
- **Admin cross-user access is preserved** everywhere it legitimately existed
  (admins bypass the scoping).
- **Left intentionally unscoped, with inline comments:** `images#public_audio`
  (unauthenticated, public AAC audio playback that must work for shared-page
  viewers) and `images#merge` (already gated to admins only).
- The weak manual checks in `board_images#upload_audio`/`reset_audio` (which
  rendered an error body with **HTTP 200**) are replaced by proper 404
  owner-scoping.

### Known related gaps (not in scope for this PR)
- `check_board_editable!` / `board_editable?` don't enforce board **ownership**
  (only the downgrade read-only rule), so some board-level mutations still rely
  on the resource scoping rather than a board-owner gate. Worth a follow-up.
- `board_images#move` is marked unused and has a pre-existing broken auth check
  (renders an error without `return`); left untouched.
- `images#clear_current` has a pre-existing crash when called with no
  `board_id` and no `update_all` (dereferences a nil `@board`); left untouched.

## Test plan
Added request specs proving a non-owner gets **404** on each fixed endpoint,
plus no-regression coverage that public images, own images, and admins still
get through:
- `spec/requests/api/images_spec.rb` (new IDOR block)
- `spec/requests/api/board_images_idor_spec.rb` (new)
- `spec/requests/api/boards_associate_image_idor_spec.rb` (new)

Ran locally, all green:
- New IDOR specs: **36 examples, 0 failures**
- `board_images_label_case`, `board_images_rate_limit`, `board_read_only`: **20 examples, 0 failures**
- `boards_spec`: **61 examples, 0 failures**

This is the concrete slice of #50 (regression specs) for these controllers.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)