### PR TITLE
fix(security): block non-admin self-promotion of predefined/published boards & menus (#27)

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -440,7 +440,10 @@ class API::BoardsController < API::ApplicationController
       # by the dedicated endpoints (#set_display_image / #update_preset_display_image),
       # so a generic save (name/colors/tiles) can never clobber the chosen cover.
       @board.bg_color = board_params["bg_color"] if board_params["bg_color"].present?
-      @board.predefined = board_params["predefined"]
+      # Only assign when present. `predefined` is admin-only and stripped from
+      # board_params for non-admins (#27), so a missing key must leave the saved
+      # value untouched rather than null it out.
+      @board.predefined = board_params["predefined"] if board_params.key?("predefined")
       @board.category = board_params["category"]
       @board.tags = board_params["tags"] if board_params["tags"].present?
       @board.language = board_params["language"] if board_params["language"].present?
@@ -1393,7 +1396,7 @@ class API::BoardsController < API::ApplicationController
 
   # Only allow a list of trusted parameters through.
   def board_params
-    params.require(:board).permit(:name,
+    permitted = params.require(:board).permit(:name,
                                   :slug,
                                   :text_color,
                                   :bg_color,
@@ -1418,6 +1421,15 @@ class API::BoardsController < API::ApplicationController
                                   :query,
                                   :page,
                                   :display_image_url, :category, :image_ids_to_remove, :board_type, settings: {}, margin_settings: {}, tags: [])
+    # Only admins may curate `predefined`/`published` boards — those flags decide
+    # whether a board enters the public/curated gallery. Strip them for everyone
+    # else so a regular user can't self-promote their own board (#27, mirrors the
+    # board_groups_controller pattern).
+    unless current_user&.admin?
+      permitted.delete(:predefined)
+      permitted.delete(:published)
+    end
+    permitted
   end
 
   def attach_image_to_board(image_data, file_extension)

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -184,8 +184,12 @@ class API::MenusController < API::ApplicationController
     # — ownership is assigned server-side (@menu.user / doc.user = current_user
     # in #create), so a client can't set or reassign ownership via create/update
     # mass-assignment (#27).
-    params.require(:menu).permit(:name, :description, :token_limit, :predefined,
-                                 docs: [:id, :raw, :image, :_destroy, :source_type])
+    permitted = params.require(:menu).permit(:name, :description, :token_limit, :predefined,
+                                             docs: [:id, :raw, :image, :_destroy, :source_type])
+    # `predefined` promotes a menu into the curated/admin pool — admin-only.
+    # Strip it for everyone else so a regular user can't self-promote (#27).
+    permitted.delete(:predefined) unless current_user&.admin?
+    permitted
   end
 
   def check_board_create_permissions

--- a/spec/requests/api/mass_assignment_spec.rb
+++ b/spec/requests/api/mass_assignment_spec.rb
@@ -20,4 +20,49 @@ RSpec.describe "Mass-assignment of ownership fields", type: :request do
       expect(child.user_id).to eq(owner.id)
     end
   end
+
+  # #27 — `predefined`/`published` decide whether a board enters the public
+  # curated gallery; a non-admin must not be able to self-promote via update.
+  describe "PATCH /api/boards/:id (predefined/published self-promotion)" do
+    let(:board) { create(:board, user: owner, predefined: false, published: false) }
+
+    it "ignores predefined/published from a non-admin owner" do
+      patch "/api/boards/#{board.id}",
+            params: { board: { predefined: true, published: true } },
+            headers: auth_headers(owner)
+
+      board.reload
+      expect(board.predefined).to be_falsey
+      expect(board.published).to be_falsey
+    end
+
+    it "still lets an admin curate predefined/published" do
+      admin = create(:admin_user)
+      admin_board = create(:board, user: admin, predefined: false, published: false)
+
+      patch "/api/boards/#{admin_board.id}",
+            params: { board: { predefined: true, published: true } },
+            headers: auth_headers(admin)
+
+      admin_board.reload
+      expect(admin_board.predefined).to be true
+      expect(admin_board.published).to be true
+    end
+  end
+
+  # #27 — same rule for menus: a non-admin can't flip `predefined`.
+  describe "PATCH /api/menus/:id (predefined self-promotion)" do
+    it "ignores predefined from a non-admin owner" do
+      menu = Menu.create!(user: owner, name: "My Menu", predefined: false)
+
+      patch "/api/menus/#{menu.id}",
+            params: { menu: { name: "Renamed", predefined: true } },
+            headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      menu.reload
+      expect(menu.predefined).to be_falsey
+      expect(menu.name).to eq("Renamed")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #466 (merged). That PR closed the ownership-field mass-assignment
holes; this one closes the remaining **privilege/status** class flagged in the
same audit: `boards#update` and `menus` create/update still mass-assigned the
flags that decide whether a record enters the **public curated gallery**, so any
board/menu editor could self-promote their own content.

## Changes
- **`boards` `board_params`** — strip `:predefined` / `:published` for
  non-admins (mirrors the existing `board_groups_controller` admin-strip
  pattern). Also guard the `#update` assignment
  (`@board.predefined = ... if board_params.key?("predefined")`) so an
  absent/stripped value leaves the saved flag untouched rather than nulling it.
- **`menus` `menu_params`** — strip `:predefined` for non-admins.

Admins retain full curation of both.

## Test plan
Added to `spec/requests/api/mass_assignment_spec.rb`:
- a non-admin owner PATCHing `predefined: true` / `published: true` on their own
  board is ignored (both stay false),
- an **admin** can still set `predefined`/`published` (curation preserved),
- a non-admin owner can't flip `predefined` on their own menu.

Local runs (this branch, on top of merged #466):
- `mass_assignment_spec` + `menus_spec` + `board_groups_spec` → **35 examples, 0 failures**
- `boards_spec` + `board_read_only_spec` → **72 examples, 0 failures**

Relates to #27 (kept open per the original request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)