### PR TITLE
fix: fall back to label placeholder on broken tile images in PDF export

### DIFF
--- a/app/views/api/boards/print.html.erb
+++ b/app/views/api/boards/print.html.erb
@@ -83,12 +83,17 @@
           "
 
         >
+          <% placeholder_src = generate_placeholder_image(t["label"]) %>
           <div class="tile-media">
             <% if has_image %>
-              <img src="<%= t["image_url"] %>" alt="<%= t["label"] %>">
+              <img
+                src="<%= t["image_url"] %>"
+                alt="<%= t["label"] %>"
+                onerror="this.onerror=null; this.src='<%= placeholder_src %>'; this.classList.add('tile-placeholder-image'); var lbl=this.closest('.tile').querySelector('.label'); if(lbl) lbl.style.display='none';"
+              >
             <% else %>
               <img
-                src="<%= generate_placeholder_image(t["label"]) %>"
+                src="<%= placeholder_src %>"
                 alt="<%= t["label"] %>"
                 class="tile-placeholder-image"
               >

--- a/app/views/api/boards/print_marketing.html.erb
+++ b/app/views/api/boards/print_marketing.html.erb
@@ -80,12 +80,17 @@
           "
 
         >
+          <% placeholder_src = generate_placeholder_image(t["label"]) %>
           <div class="tile-media">
             <% if has_image %>
-              <img src="<%= t["image_url"] %>" alt="<%= t["label"] %>">
+              <img
+                src="<%= t["image_url"] %>"
+                alt="<%= t["label"] %>"
+                onerror="this.onerror=null; this.src='<%= placeholder_src %>'; this.classList.add('tile-placeholder-image'); var lbl=this.closest('.tile').querySelector('.label'); if(lbl) lbl.style.display='none';"
+              >
             <% else %>
               <img
-                src="<%= generate_placeholder_image(t["label"]) %>"
+                src="<%= placeholder_src %>"
                 alt="<%= t["label"] %>"
                 class="tile-placeholder-image"
               >


### PR DESCRIPTION
## Summary

- Added inline `onerror` handler on tile `<img>` tags in both `print.html.erb` and `print_marketing.html.erb` so broken image URLs fall back to the label-as-text placeholder SVG instead of rendering a broken-image icon in the exported PDF.
- The handler also hides the redundant text label caption below the tile (the placeholder SVG already shows the label as big centered text).
- Pre-computes the placeholder data URI per tile to avoid calling the helper twice.
- Works because Grover renders via headless Chrome with `wait_until: "networkidle0"`, so JS executes before PDF capture.

Companion frontend PR: brittanyjohns/itty-bitty-frontend `claude/broken-image-fallback` (adds the same fallback to the web tile components).

## Test plan

- [x] `bundle exec rspec spec/views/` — 3 examples, 0 failures
- [ ] Export a PDF of a board with tiles that have broken/missing images — verify they show the label as big centered text instead of broken-image icons
- [ ] Verify tiles with working images still show the image + label as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)