### PR TITLE
perf(cache): Redis-backed production cache store (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Performance — Redis-backed production cache store (#474)
+- Production `Rails.cache` now uses a **Redis cache store** instead of Rails'
+  default `:file_store` (which was per-box and grew unbounded under `tmp/cache`
+  — a real risk on the single EC2 box). Uses the Redis that already backs
+  Sidekiq / Rack::Attack, namespaced `ibb_cache` so keys can't collide, with a
+  fail-open error handler (a Redis blip logs and returns nil rather than 500ing
+  a request). `CACHE_REDIS_URL` optionally points the cache at a separate
+  Redis/db (defaults to `REDIS_URL`). No user-facing behavior change; caching
+  is simply faster and shared across the puma + sidekiq processes.
+
 ### Security — upgrade Rails 7.1 (EOL) → 8.0 (#56)
 - Bumped Rails from `~> 7.1.2` (EOL 2025-10-01, no security backports) to
   `~> 8.0.0` (locked 8.0.5). Resolves **CVE-2026-33658** (ActiveStorage DoS via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,14 @@ When writing or updating backend CLAUDE.md, ALWAYS verify claims against the act
 - **Auth:** Devise + devise-jwt
 - **Authorization:** Pundit
 - **Background jobs:** Sidekiq (v7) + Redis
+- **Cache:** `Rails.cache` is a **Redis cache store** in production
+  (`config/environments/production.rb`, issue #474) — namespaced `ibb_cache` so
+  keys can't collide with Sidekiq / Rack::Attack on the shared Redis, with a
+  fail-open `error_handler` (a Redis blip logs + returns nil, never 500s a
+  request). `CACHE_REDIS_URL` overrides the instance/db (defaults to
+  `REDIS_URL`). Replaced the prior unconfigured `:file_store` default, which
+  grew unbounded under `tmp/cache`. Dev = `:memory_store`/`:null_store`,
+  test = `:null_store` (unchanged — stub `Rails.cache` in specs that need it).
 - **Payments:** Stripe and RevenueCat (via webhook). Admin revenue metrics combine both via `MissionControl::RevenueMetrics` (see "Mission Control revenue metrics" under the RevenueCat / Apple IAP section).
 - **File storage:** S3 (Active Storage)
 - **Email:** Action Mailer over Gmail SMTP. Both environments authenticate against `smtp.gmail.com` when `SMTP_USERNAME`/`SMTP_PASSWORD` are set (a Google Workspace account + App Password); production falls back to the `smtp-relay.gmail.com` IP-allowlisted relay when no credentials are present. `SMTP_ADDRESS` overrides the SMTP host. The `mailgun-ruby` gem is in the Gemfile but is not the active delivery transport. Diagnose delivery with `bin/rails 'mail:test[you@example.com]'`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - `POSTHOG_HOST` - PostHog ingestion host (optional; defaults to `https://us.i.posthog.com`)
   - `POSTHOG_CAPTURE_ENABLED` - Set to `true` to fire server-side PostHog events outside production (dev/staging opt-in). Production fires automatically; staging stays off unless this is set.
   - `RACK_ATTACK_*` - Optional rate-limit tuning (all have sensible defaults). Limits/windows for auth, password-reset, token-lookup, and AI-generation throttles — e.g. `RACK_ATTACK_LOGIN_LIMIT`, `RACK_ATTACK_LOGIN_EMAIL_LIMIT`, `RACK_ATTACK_AI_LIMIT`, `RACK_ATTACK_TOKEN_LIMIT`, `RACK_ATTACK_PASSWORD_RESET_LIMIT` (+ matching `_PERIOD`). `RACK_ATTACK_REDIS_URL` overrides the Redis used for counters (defaults to `REDIS_URL`). See the "Rate limiting" section in `CLAUDE.md`.
+  - `CACHE_REDIS_URL` - Optional. Overrides the Redis instance/db used for the production `Rails.cache` store (defaults to `REDIS_URL`). Production caches through a namespaced (`ibb_cache`), fail-open Redis cache store.
 
 - Database creation:
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,8 +91,27 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Use Redis as the shared cache store in production (issue #474). Redis
+  # already backs Sidekiq and Rack::Attack, so this adds no new infrastructure
+  # — it just replaces Rails' default `:file_store`, which is per-box and grows
+  # unbounded under `tmp/cache` (a real risk on the single EC2 box; see the
+  # disk-full outage that prompted DiskSpaceAlertJob), with a fast cache shared
+  # across the puma and sidekiq processes.
+  #
+  # Namespaced so cache keys can't collide with Sidekiq / Rack::Attack keys on
+  # the shared instance (and `Rails.cache.clear` only clears namespaced keys,
+  # never FLUSHDBs the queue). `error_handler` fails open — a Redis blip logs
+  # and returns nil rather than 500ing a request (mirrors rack_attack).
+  # `CACHE_REDIS_URL` lets ops point the cache at a separate Redis/db without a
+  # code change; it falls back to the shared `REDIS_URL`.
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch("CACHE_REDIS_URL", ENV.fetch("REDIS_URL", "redis://localhost:6379/0")),
+    namespace: "ibb_cache",
+    reconnect_attempts: 1,
+    error_handler: lambda do |method:, returning:, exception:|
+      Rails.logger.warn("[cache] Redis #{method} failed: #{exception.class}: #{exception.message}")
+    end
+  }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq

--- a/spec/config/production_cache_store_spec.rb
+++ b/spec/config/production_cache_store_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+# Coverage for issue #474: production had no explicit `config.cache_store`, so
+# it fell back to Rails' default `:file_store` — per-box and unbounded under
+# `tmp/cache` — while real code paths cache through `Rails.cache`. Production
+# now uses a namespaced, fail-open Redis cache store (Redis already backs
+# Sidekiq / Rack::Attack, so no new infrastructure).
+#
+# Rails only loads `config/environments/production.rb` when `Rails.env` is
+# production, so we assert against the file's contents in an isolated context
+# rather than flipping the environment under the test runner (mirrors
+# production_smtp_timeouts_spec).
+RSpec.describe "config/environments/production.rb cache store" do
+  let(:production_env_path) { Rails.root.join("config/environments/production.rb") }
+  let(:contents) { File.read(production_env_path) }
+
+  it "configures a redis_cache_store" do
+    expect(contents).to match(/config\.cache_store\s*=\s*:redis_cache_store/)
+  end
+
+  it "does not leave the cache store on the default (commented-out) line" do
+    expect(contents).not_to match(/^\s*#\s*config\.cache_store\s*=/)
+  end
+
+  it "sources the Redis URL from ENV (no hardcoded production host)" do
+    expect(contents).to match(/url:\s*ENV\.fetch\("CACHE_REDIS_URL"/)
+    expect(contents).to match(/ENV\.fetch\("REDIS_URL"/)
+  end
+
+  it "namespaces the cache so keys can't collide with Sidekiq / Rack::Attack" do
+    expect(contents).to match(/namespace:\s*"ibb_cache"/)
+  end
+
+  it "fails open with an error_handler so a Redis blip can't 500 a request" do
+    expect(contents).to match(/error_handler:/)
+  end
+end


### PR DESCRIPTION
Item **#1** of #474 (the post-Rails-8 optimizations). The one with real ROI.

## Problem

`config/environments/production.rb` never set `config.cache_store`, so production fell back to Rails' default **`:file_store`** — per-box and **unbounded under `tmp/cache`** — while real code paths cache through `Rails.cache` (`MissionControl::StripeRevenueSource`, `Board`, `Stats::StripeRevenue`, `AacWordCategorizer`). On the single EC2 box that's slow *and* a disk-growth risk (cf. the disk-full outage that prompted `DiskSpaceAlertJob`).

## Change

Switch production to a **Redis cache store**. Redis already backs Sidekiq and Rack::Attack, so this adds **no new infrastructure**:

- **Namespaced** `ibb_cache` — cache keys can't collide with Sidekiq / Rack::Attack on the shared instance, and `Rails.cache.clear` only clears namespaced keys (never `FLUSHDB`s the queue).
- **Fail-open** `error_handler` — a Redis blip logs and returns nil instead of 500ing a request (mirrors the Rack::Attack store's philosophy).
- **`CACHE_REDIS_URL`** overrides the instance/db without a code change; falls back to the shared `REDIS_URL`.

Dev (`:memory_store`/`:null_store`) and test (`:null_store`) are unchanged.

## Not in this PR (by design)

- **#2 — verify YJIT in prod:** `load_defaults 8.0` already enables it; that's a prod-console verification, not a code change.
- **#3 — remove the `new_framework_defaults_*.rb` escape hatches:** deferred until Rails 8.0 has soaked in production, per the issue.

## Test plan

- `spec/config/production_cache_store_spec.rb` (new, 5 examples) — asserts production is configured with a namespaced, ENV-driven, fail-open `redis_cache_store` and no longer sits on the commented default. Mirrors the existing `production_smtp_timeouts_spec` pattern (production.rb only loads under `RAILS_ENV=production`, so we assert on file contents).
- `bundle exec rspec spec/config` → **17 examples, 0 failures**.
- Validated the `RedisCacheStore` option set instantiates cleanly on Rails 8.0.
- `ruby -c config/environments/production.rb` → Syntax OK.
- **Real-env validation:** staging runs `RAILS_ENV=production`, so deploying this branch to staging exercises the actual cache store against a live Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)