### PR TITLE
feat: expose + sanitize MySpeak page theme on public payload (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — MySpeak page themes (backend) (#476)
+- Communicator MySpeak safety pages (`/my/<slug>`) can now carry an owner-picked
+  visual theme, stored on `profile.settings["theme"]`. `"theme"` is whitelisted
+  into `Profile::SAFETY_PAGE_KEYS`, so it flows through `#safety_view` onto the
+  public payload (`GET /api/profiles/public/:slug`). A `before_save`
+  sanitizer validates it server-side — hex fields (`accent`, `bg_color`,
+  `border_color`, `text_color`) must be `#RRGGBB`, `preset`/`bg_style` must be
+  simple slugs, and everything else is dropped — because the values render into
+  inline CSS on an unauthenticated page (CSS-injection defense). No migration, no
+  new endpoints; the theme round-trips through the existing owner-gated
+  `PATCH /api/profiles/:id`. Ships silently until the frontend picker lands.
+
 ### Fixed — AAC Classroom Kit QR codes wouldn't scan
 - The kit's name/safety/device backpack tags encoded the ~119-char
   `/classroom?utm_...` funnel URL, which forced a dense 41-module (version-6) QR;

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -72,6 +72,7 @@ class Profile < ApplicationRecord
 
   before_save :set_kind
   before_save :touch_slug_changed_at
+  before_save :sanitize_theme_settings
 
   has_rich_text :public_about
   has_rich_text :public_intro
@@ -442,6 +443,7 @@ class Profile < ApplicationRecord
   SAFETY_PAGE_KEYS = %w[
     pronouns
     device_notes
+    theme
   ].freeze
 
   # Sensitive safety settings — medical details + emergency contacts +
@@ -468,6 +470,17 @@ class Profile < ApplicationRecord
   # Kept for any external reference; the full set of keys the safety page can
   # surface across the open page + the gated reveal.
   SAFETY_PUBLIC_KEYS = (SAFETY_PAGE_KEYS + SAFETY_SENSITIVE_KEYS).freeze
+
+  # --- MySpeak page theme (issue #476) ---
+  # Owner-picked visual theme stored on settings["theme"]. Values render into
+  # inline CSS on an unauthenticated public page, so the sanitizer below is the
+  # server-side CSS-injection defense. Presets/palettes live frontend-only; the
+  # backend only stores + validates. Whitelist, not blocklist — unknown keys
+  # are dropped.
+  THEME_HEX_KEYS = %w[accent bg_color border_color text_color].freeze
+  THEME_SLUG_KEYS = %w[preset bg_style].freeze
+  THEME_HEX_FORMAT = /\A#[0-9a-fA-F]{6}\z/.freeze
+  THEME_SLUG_FORMAT = /\A[a-z0-9_-]{1,40}\z/.freeze
 
   PUBLIC_PAGE_KEYS = %w[
     public_page
@@ -830,6 +843,38 @@ class Profile < ApplicationRecord
     return unless slug_changed?
     return if new_record?
     self.slug_changed_at = Time.current
+  end
+
+  # Whitelist + format-validate settings["theme"] on every save. Theme values
+  # render into inline CSS on an unauthenticated public page, so this is the
+  # CSS-injection defense. Hex fields must be #RRGGBB; preset/bg_style must be
+  # simple slugs; everything else is dropped. A non-hash or empty theme clears
+  # the key entirely (issue #476).
+  def sanitize_theme_settings
+    return unless settings.is_a?(Hash)
+    return unless settings.key?("theme")
+
+    raw = settings["theme"]
+    unless raw.is_a?(Hash)
+      settings.delete("theme")
+      return
+    end
+
+    clean = {}
+    THEME_HEX_KEYS.each do |k|
+      v = raw[k].to_s.strip
+      clean[k] = v if v.match?(THEME_HEX_FORMAT)
+    end
+    THEME_SLUG_KEYS.each do |k|
+      v = raw[k].to_s.strip
+      clean[k] = v if v.match?(THEME_SLUG_FORMAT)
+    end
+
+    if clean.empty?
+      settings.delete("theme")
+    else
+      settings["theme"] = clean
+    end
   end
 
   public

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -217,6 +217,81 @@ RSpec.describe Profile, type: :model do
       expect(view).not_to have_key(:communicator_account)
       expect(view).not_to have_key(:email)
     end
+
+    it "exposes a sanitized theme in the page-safe settings" do
+      profile.update!(settings: { "theme" => { "preset" => "ocean", "accent" => "#0EA5E9" } })
+      expect(profile.safety_view[:settings]["theme"]).to eq("preset" => "ocean", "accent" => "#0EA5E9")
+    end
+
+    it "never exposes sensitive safety keys in the page-safe settings" do
+      profile.update!(settings: { "allergies" => "peanuts", "ice_contact_1" => "Mom" })
+      expect(profile.safety_view[:settings]).not_to have_key("allergies")
+      expect(profile.safety_view[:settings]).not_to have_key("ice_contact_1")
+    end
+  end
+
+  describe "sanitize_theme_settings callback" do
+    let(:profile) { build_profile(slug: "theme-page").tap(&:save!) }
+
+    it "keeps valid hex and slug values" do
+      profile.update!(settings: {
+        "theme" => {
+          "preset" => "sunset",
+          "bg_style" => "gradient",
+          "accent" => "#0EA5E9",
+          "bg_color" => "#F0F9FF",
+          "border_color" => "#BAE6FD",
+          "text_color" => "#0C4A6E",
+        },
+      })
+      expect(profile.reload.settings["theme"]).to eq(
+        "accent" => "#0EA5E9",
+        "bg_color" => "#F0F9FF",
+        "border_color" => "#BAE6FD",
+        "text_color" => "#0C4A6E",
+        "preset" => "sunset",
+        "bg_style" => "gradient",
+      )
+    end
+
+    it "drops invalid hex values (named color, short hex)" do
+      profile.update!(settings: { "theme" => { "accent" => "red", "bg_color" => "#fff" } })
+      expect(profile.reload.settings).not_to have_key("theme")
+    end
+
+    it "drops a CSS-injection attempt in a hex field" do
+      profile.update!(settings: { "theme" => { "accent" => "#fff; background:url(javascript:alert(1))" } })
+      expect(profile.reload.settings).not_to have_key("theme")
+    end
+
+    it "drops slug values that aren't simple slugs" do
+      profile.update!(settings: { "theme" => { "preset" => "Ocean Blue!", "accent" => "#0EA5E9" } })
+      theme = profile.reload.settings["theme"]
+      expect(theme).to eq("accent" => "#0EA5E9")
+      expect(theme).not_to have_key("preset")
+    end
+
+    it "strips unknown keys (whitelist, not blocklist)" do
+      profile.update!(settings: { "theme" => { "accent" => "#0EA5E9", "evil" => "boom", "font" => "Comic Sans" } })
+      expect(profile.reload.settings["theme"]).to eq("accent" => "#0EA5E9")
+    end
+
+    it "deletes the key when theme is not a hash" do
+      profile.update!(settings: { "theme" => "hacker" })
+      expect(profile.reload.settings).not_to have_key("theme")
+    end
+
+    it "deletes the key when every theme value is invalid" do
+      profile.update!(settings: { "theme" => { "accent" => "nope", "preset" => "" } })
+      expect(profile.reload.settings).not_to have_key("theme")
+    end
+
+    it "leaves non-theme settings untouched" do
+      profile.update!(settings: { "pronouns" => "she/her", "theme" => { "accent" => "#0EA5E9" } })
+      settings = profile.reload.settings
+      expect(settings["pronouns"]).to eq("she/her")
+      expect(settings["theme"]).to eq("accent" => "#0EA5E9")
+    end
   end
 
   describe "#public_page_view" do

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -272,4 +272,77 @@ RSpec.describe "API::Profiles", type: :request do
       expect(JSON.parse(response.body)["reason"]).to eq("taken")
     end
   end
+
+  # MySpeak page theme (issue #476): owner-picked theme round-trips through
+  # PATCH /api/profiles/:id and surfaces on the public safety_view payload.
+  describe "MySpeak page theme (settings.theme)" do
+    let(:owner) { FactoryBot.create(:user) }
+    let(:other_user) { FactoryBot.create(:user) }
+    let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+    let!(:profile) do
+      Profile.new(profileable: child, username: "sky-theme", slug: "sky-theme").tap(&:save!)
+    end
+
+    before do
+      # generate_attachments! shells out to Grover/puppeteer; not what these
+      # specs exercise and unavailable on CI.
+      allow_any_instance_of(Profile).to receive(:generate_attachments!).and_return(true)
+    end
+
+    it "persists a valid theme and returns it on api_view" do
+      put "/api/profiles/#{profile.id}",
+          params: { profile: { settings: { theme: { preset: "ocean", accent: "#0EA5E9", bg_color: "#F0F9FF" } } } },
+          headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      theme = JSON.parse(response.body).dig("settings", "theme")
+      expect(theme).to eq("preset" => "ocean", "accent" => "#0EA5E9", "bg_color" => "#F0F9FF")
+      expect(profile.reload.settings["theme"]).to eq(theme)
+    end
+
+    it "drops invalid theme values on write" do
+      put "/api/profiles/#{profile.id}",
+          params: { profile: { settings: { theme: { accent: "red", preset: "javascript:alert(1)", bg_color: "#0EA5E9" } } } },
+          headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(profile.reload.settings["theme"]).to eq("bg_color" => "#0EA5E9")
+    end
+
+    it "surfaces the theme on the public safety_view payload" do
+      profile.update!(settings: { "theme" => { "preset" => "ocean", "accent" => "#0EA5E9" } })
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(response).to have_http_status(:ok)
+      theme = JSON.parse(response.body).dig("settings", "theme")
+      expect(theme).to eq("preset" => "ocean", "accent" => "#0EA5E9")
+    end
+
+    it "still withholds sensitive safety keys from the public payload" do
+      profile.update!(settings: {
+        "theme" => { "accent" => "#0EA5E9" },
+        "allergies" => "peanuts",
+        "ice_contact_1" => "Mom 555-1234",
+      })
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      body = JSON.parse(response.body)
+      expect(body.dig("settings", "theme")).to eq("accent" => "#0EA5E9")
+      expect(body["settings"]).not_to have_key("allergies")
+      expect(body["settings"]).not_to have_key("ice_contact_1")
+      expect(response.body).not_to include("peanuts")
+    end
+
+    it "forbids a non-owner from changing the theme" do
+      put "/api/profiles/#{profile.id}",
+          params: { profile: { settings: { theme: { accent: "#0EA5E9" } } } },
+          headers: auth_headers(other_user)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(profile.reload.settings["theme"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Closes #476.

## Summary

Backend piece for MySpeak page themes — communicator safety pages (`/my/<slug>`) get owner-picked visual themes (preset palettes + optional color overrides), stored on `profile.settings["theme"]`. Ships safely alone; nothing reads the key until the frontend picker lands.

- **Whitelist the key** — added `"theme"` to `Profile::SAFETY_PAGE_KEYS`, so it flows through `#public_settings(kind: :safety)` → `#safety_view` → `GET /api/profiles/public/:slug`.
- **Sanitize on write** — new `before_save :sanitize_theme_settings`. Theme values render into inline CSS on an **unauthenticated** public page, so this is the server-side CSS-injection defense:
  - hex fields (`accent`, `bg_color`, `border_color`, `text_color`) must match `#RRGGBB`, else dropped;
  - `preset` / `bg_style` must be simple slugs (`[a-z0-9_-]{1,40}`), else dropped;
  - unknown keys dropped (whitelist, not blocklist); a non-hash or all-invalid theme clears the key entirely.
- No migration, no ENV vars, no new endpoints — theme round-trips through the existing owner-gated `PATCH /api/profiles/:id` (already permits `settings: {}`).

The sensitive emergency-info wall (`SAFETY_SENSITIVE_KEYS`) is untouched and still withheld from the open page.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/requests/api/profiles_spec.rb` → **86 examples, 0 failures**.

New coverage:
- **Model** — valid hex/slug kept; named color / short hex / CSS-injection string dropped; non-slug preset dropped; unknown keys stripped; non-hash theme deletes key; all-invalid deletes key; non-theme settings untouched; `safety_view` exposes theme but never sensitive keys.
- **Request** — PATCH round-trip persists + returns theme on `api_view`; invalid values dropped on write; public `safety_view` payload includes the theme; sensitive safety keys still absent from the public payload; non-owner PATCH still 403s `not_owner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)