### PR TITLE
feat: warn+confirm board deletion, builder-set cascade, and destroy cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — deleting a board now warns when it's still in use
+- Deleting a board that other boards' folder buttons open, that sits on a
+  communicator's dashboard, that's shared with a team, or that is a Board
+  Builder set root now returns a **409 `board_in_use`** with a summary of
+  what references it; re-send with `confirm=true` to delete anyway. Boards
+  nothing references delete in one step, unchanged.
+- Confirmed deletion of a Board Builder **root** now removes the whole built
+  set (root + hidden sub-boards) instead of orphaning the sub-boards.
+- Deleting a board now also cleans up references it used to leave behind:
+  the free-plan editable-board pick, saved phrase/dynamic board pointers on
+  users and communicators, and scenarios generated from the board.
+- Removing a board from a communicator dashboard no longer hard-deletes a
+  template clone that another board's folder button still opens — it
+  detaches only.
+
 ### Added — user-picked image budget for menu boards
 - Building a board from a menu photo now has a real cost model: the flat
   `menu_create` fee (5 credits) covers the vision extraction, plus **3 credits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1363,6 +1363,42 @@ image pool:
   Signature: `from_obf(data, current_user, board_group = nil, board_id = nil,
   import_options: {})` — don't swap `current_user` and `board_group`.
 
+## Board deletion safety (warn + confirm)
+
+`DELETE /api/boards/:id` is a **warn+confirm** flow. `Boards::UsageCheck`
+(`app/services/boards/`) reports what still references the board: folder tiles
+on other boards (`board_images.predictive_board_id`, self-links excluded),
+communicator dashboards (`child_boards`), team shares (`team_boards`), and
+whether it's a Board Builder root. When anything matches and the request lacks
+`confirm=true`, destroy returns **409** `{ error: "board_in_use", message,
+board: { id, name }, usage: { referencing_boards, communicators, teams,
+builder_set } }` (counts exact, name lists capped at 10). Unreferenced boards
+delete in one step as before.
+
+- **Builder roots cascade the whole set.** A confirmed delete of a
+  `builder_root` board routes through its builder BoardGroup
+  (`Board#builder_board_group` → `group.destroy!`), so the #407 cascade
+  destroys every member board instead of orphaning the hidden children. This
+  routing lives **only in the controller** — a Board `before_destroy` that
+  destroyed the group would recurse with the group's `destroy_all` of members.
+  A root whose group is gone (legacy data) falls back to a plain destroy.
+- **Cleanup on destroy.** Folder tiles pointing at the deleted board are
+  nullified by the `predictive_board_images dependent: :nullify` association
+  (the old manual loop in `#destroy` was redundant and only covered
+  `board_type == "predictive"`). `docs.board_id` is nullified
+  (`dependent: :nullify`; docs are user content owned via `documentable`).
+  `BoardDestroyCleanupJob` (`app/sidekiq/`, enqueued `after_destroy`, rescue-
+  wrapped so a Redis blip can't fail the destroy) scrubs the pointers
+  `dependent:` can't reach: `users.editable_board_id`, the
+  `dynamic_board_id`/`phrase_board_id` keys in users' and child_accounts'
+  settings JSONB, and `Scenario` rows for the board. `word_events` keep their
+  `board_id` deliberately (analytics history).
+- **`orphan_template?`** (`ChildBoardsController`) also refuses to hard-delete
+  a detached template that another board's folder tile still opens
+  (`predictive_board_id` reference check) — detach-only in that case.
+- Frontend companion: handle the 409 with a confirm dialog and re-send with
+  `confirm=true` (special copy for builder roots — it deletes the whole set).
+
 ## Board Sets (BoardGroup) — user CRUD + limits
 
 Board Sets (`BoardGroup`, user-facing name "Board Sets") are user-owned

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1036,13 +1036,36 @@ class API::BoardsController < API::ApplicationController
   end
 
   # # DELETE /boards/1 or /boards/1.json
+  #
+  # Warn+confirm: deleting a board that's still in use (a folder tile on
+  # another board points at it, it's on a communicator dashboard, shared with
+  # a team, or it's a Board Builder root) returns 409 with a usage summary
+  # unless the client re-sends with confirm=true. Boards nothing references
+  # delete in one step, as before. Folder tiles pointing at the deleted board
+  # are nullified by the predictive_board_images dependent: :nullify
+  # association (all board types — the old manual loop here only covered
+  # board_type "predictive" and was redundant).
   def destroy
-    if @board.board_type == "predictive"
-      BoardImage.where(predictive_board_id: @board.id).all.each do |board_image|
-        board_image.update(predictive_board_id: nil)
-      end
+    usage = Boards::UsageCheck.new(@board)
+    if usage.in_use? && params[:confirm].to_s != "true"
+      render json: {
+               error: "board_in_use",
+               message: "\"#{@board.name}\" is still in use — deleting it will remove it from the boards, communicators, or teams that reference it.",
+               board: { id: @board.id, name: @board.name },
+               usage: usage.summary,
+             }, status: :conflict
+      return
     end
-    @board.destroy!
+
+    # A builder root's tree is owned by its builder BoardGroup (issue #407);
+    # destroying the group cascades every member board. Routing lives HERE,
+    # not in a Board callback — a before_destroy on Board that destroyed the
+    # group would recurse with the group's destroy_all of its members.
+    if (group = usage.builder_group)
+      group.destroy!
+    else
+      @board.destroy!
+    end
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/api/child_boards_controller.rb
+++ b/app/controllers/api/child_boards_controller.rb
@@ -80,6 +80,9 @@ class API::ChildBoardsController < API::ApplicationController
   def orphan_template?(board)
     return false if board.team_boards.exists?
     return false if board.child_boards.exists?
+    # A folder tile on another board still opens this one — deleting it would
+    # nullify that tile into a dead button. Detach only.
+    return false if BoardImage.where(predictive_board_id: board.id).where.not(board_id: board.id).exists?
     board.user_id == current_user&.id
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -68,7 +68,10 @@ class Board < ApplicationRecord
   has_many :board_images, dependent: :destroy
   has_many :visible_board_images, -> { where(hidden: false) }, class_name: "BoardImage"
   has_many :images, through: :board_images
-  has_many :docs
+  # Docs are user content owned via the polymorphic documentable; they must
+  # survive board deletion, so the back-pointer is nullified (Doc#board is
+  # belongs_to optional).
+  has_many :docs, dependent: :nullify
   has_many :team_boards, dependent: :destroy
   has_many :teams, through: :team_boards
   has_many :team_users, through: :teams
@@ -207,6 +210,34 @@ class Board < ApplicationRecord
   before_create :set_screen_sizes, :set_number_of_columns
   after_initialize :set_initial_layout, if: :layout_empty?
   after_update_commit :retranslate_on_language_change
+  # Scrub the pointers destroy's dependent: options can't reach — integer/JSONB
+  # references on users and child_accounts (editable_board_id,
+  # dynamic_board_id/phrase_board_id) and scenarios. Off-request because the
+  # JSONB scans aren't indexed.
+  after_destroy :enqueue_destroy_cleanup
+
+  def enqueue_destroy_cleanup
+    BoardDestroyCleanupJob.perform_async(id)
+  rescue => e
+    # A Redis blip must never fail the destroy itself; the stale pointers
+    # self-heal on read (effective_editable_board_id, predictive_default).
+    Rails.logger.error("[Board] destroy cleanup enqueue failed board=#{id}: #{e.class} - #{e.message}")
+  end
+
+  # A Board Builder ROOT — the board the wizard attaches to the communicator
+  # and marks settings["builder_root"] (see BoardTreeBuilder/SeededSetCloner).
+  def builder_root?
+    settings.is_a?(Hash) && !!settings["builder_root"]
+  end
+
+  # The builder BoardGroup that owns this root's built tree (issue #407).
+  # Destroying that group cascades every member board; deleting the root row
+  # directly would orphan the ~dozen hidden builder_child sub-boards.
+  def builder_board_group
+    return nil unless builder_root?
+    BoardGroup.where(builder: true, root_board_id: id).first ||
+      board_groups.where(builder: true).first
+  end
 
   def retranslate_on_language_change
     return unless saved_change_to_language?
@@ -496,10 +527,6 @@ class Board < ApplicationRecord
 
   validates :name, presence: true
 
-  def clean_up_scenarios
-    Scenario.where(board_id: id).destroy_all
-  end
-
   def validate_data
     self.data ||= {}
     self.data["personable_explanation"] = data["personable_explanation"].gsub("Personable Explanation: ", "") if data["personable_explanation"]
@@ -662,7 +689,7 @@ class Board < ApplicationRecord
     # otherwise make the root look like a sub-board (it has "parent" boards) and
     # drop it out of the main_boards scope / the communicator's dashboard. Pin it
     # as a main board regardless of who links to it.
-    if settings.is_a?(Hash) && settings["builder_root"]
+    if builder_root?
       self.sub_board = false
       remove_tag(IS_SUB_BOARD_TAG)
       return

--- a/app/services/boards/usage_check.rb
+++ b/app/services/boards/usage_check.rb
@@ -1,0 +1,88 @@
+module Boards
+  # Read-only "who still references this board?" check backing the
+  # warn+confirm delete flow. A board is in use when another board's folder
+  # tile points at it (predictive_board_id), it sits on a communicator
+  # dashboard (ChildBoard), it's shared with a team (TeamBoard), or it's the
+  # root of a Board Builder set (deleting it takes the whole built tree).
+  class UsageCheck
+    # Counts in the summary are exact; name lists are capped so a widely
+    # referenced board (e.g. a predefined one) can't blow up the payload.
+    NAME_SAMPLE_LIMIT = 10
+
+    def initialize(board)
+      @board = board
+    end
+
+    def in_use?
+      referencing_tiles.exists? ||
+        board.child_boards.exists? ||
+        board.team_boards.exists? ||
+        builder_group.present?
+    end
+
+    def summary
+      {
+        referencing_boards: referencing_boards_summary,
+        communicators: communicators_summary,
+        teams: teams_summary,
+        builder_set: builder_set_summary,
+      }
+    end
+
+    # The builder BoardGroup that owns this board's built tree, when this
+    # board is a Board Builder root. Deletion routes through the group so the
+    # #407 cascade destroys the whole set instead of orphaning the children.
+    def builder_group
+      return @builder_group if defined?(@builder_group)
+      @builder_group = board.builder_board_group
+    end
+
+    private
+
+    attr_reader :board
+
+    # Folder tiles on OTHER boards. A board's own tile pointing back at
+    # itself (self-link) must never block deletion.
+    def referencing_tiles
+      # reorder(nil): BoardImage's default position ordering breaks
+      # SELECT DISTINCT board_id.
+      BoardImage.where(predictive_board_id: board.id).where.not(board_id: board.id).reorder(nil)
+    end
+
+    def referencing_boards_summary
+      board_ids = referencing_tiles.distinct.pluck(:board_id)
+      {
+        count: board_ids.size,
+        names: Board.where(id: board_ids.first(NAME_SAMPLE_LIMIT)).pluck(:name),
+      }
+    end
+
+    def communicators_summary
+      account_ids = board.child_boards.distinct.pluck(:child_account_id)
+      {
+        count: account_ids.size,
+        names: ChildAccount.where(id: account_ids.first(NAME_SAMPLE_LIMIT)).pluck(:name),
+      }
+    end
+
+    def teams_summary
+      team_ids = board.team_boards.distinct.pluck(:team_id)
+      {
+        count: team_ids.size,
+        names: Team.where(id: team_ids.first(NAME_SAMPLE_LIMIT)).pluck(:name),
+      }
+    end
+
+    def builder_set_summary
+      group = builder_group
+      return nil unless group
+
+      {
+        root: true,
+        board_group_id: group.id,
+        name: group.name,
+        member_board_count: group.board_group_boards.count,
+      }
+    end
+  end
+end

--- a/app/sidekiq/board_destroy_cleanup_job.rb
+++ b/app/sidekiq/board_destroy_cleanup_job.rb
@@ -1,0 +1,44 @@
+# Scrubs the references a Board destroy's dependent: options can't reach:
+# users.editable_board_id (plain integer, no FK), the dynamic_board_id /
+# phrase_board_id pointers stored in users/child_accounts settings JSONB
+# (written by BuildBoardSetJob and the predictive-board flows), and scenarios
+# generated from the board. word_events are intentionally left alone —
+# they're analytics history.
+#
+# Enqueued from Board#enqueue_destroy_cleanup (after_destroy). Idempotent:
+# every statement is a no-op on re-run, and the board row being long gone is
+# expected.
+class BoardDestroyCleanupJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 3, backtrace: true
+
+  SETTINGS_POINTER_KEYS = %w[dynamic_board_id phrase_board_id].freeze
+
+  def perform(board_id)
+    User.where(editable_board_id: board_id).update_all(editable_board_id: nil)
+    scrub_settings_pointers(User, board_id)
+    scrub_settings_pointers(ChildAccount, board_id)
+    Scenario.where(board_id: board_id).destroy_all
+  end
+
+  private
+
+  # The ->> comparisons aren't indexed, hence a background job rather than
+  # inline destroy work. Values may be stored as integers or strings; ->>
+  # normalizes both to text.
+  def scrub_settings_pointers(klass, board_id)
+    id = board_id.to_s
+    klass
+      .where("settings->>'dynamic_board_id' = :id OR settings->>'phrase_board_id' = :id", id: id)
+      .find_each do |record|
+        settings = record.settings || {}
+        matched = SETTINGS_POINTER_KEYS.select { |key| settings[key].to_s == id }
+        next if matched.empty?
+
+        matched.each { |key| settings.delete(key) }
+        # update_columns: skip the models' heavy save callbacks; this is a
+        # pure pointer scrub.
+        record.update_columns(settings: settings)
+      end
+  end
+end

--- a/spec/requests/api/boards_destroy_spec.rb
+++ b/spec/requests/api/boards_destroy_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+# Warn+confirm delete flow: DELETE /api/boards/:id returns 409 board_in_use
+# with a usage summary when anything still references the board (folder tiles
+# on other boards, communicator dashboards, team shares, or a builder set
+# root), unless the client re-sends with confirm=true. Unreferenced boards
+# delete in one step, unchanged.
+RSpec.describe "API::Boards destroy safety", type: :request do
+  let(:user)  { create(:user) }
+  let(:board) { create(:board, user: user, name: "Deletable") }
+
+  def delete_board(target, as:, confirm: nil)
+    params = confirm.nil? ? {} : { confirm: confirm }
+    delete "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
+  end
+
+  describe "a board nothing references" do
+    it "deletes in one step without confirm" do
+      delete_board(board, as: user)
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+    end
+  end
+
+  describe "a board referenced by a folder tile on another board" do
+    let!(:referencing_board) { create(:board, user: user, name: "Home Grid") }
+    let!(:folder_tile) do
+      create(:board_image, board: referencing_board, predictive_board_id: board.id)
+    end
+
+    it "returns 409 board_in_use with the referencing board in the usage payload" do
+      delete_board(board, as: user)
+      expect(response).to have_http_status(:conflict)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("board_in_use")
+      expect(body["board"]).to include("id" => board.id, "name" => "Deletable")
+      expect(body["usage"]["referencing_boards"]["count"]).to eq(1)
+      expect(body["usage"]["referencing_boards"]["names"]).to include("Home Grid")
+      expect(Board.exists?(board.id)).to be true
+    end
+
+    it "deletes with confirm=true and nullifies the referencing folder tile" do
+      delete_board(board, as: user, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+      expect(folder_tile.reload.predictive_board_id).to be_nil
+    end
+
+    it "is not blocked by the board's own self-referencing tile" do
+      folder_tile.destroy!
+      create(:board_image, board: board, predictive_board_id: board.id)
+      delete_board(board, as: user)
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+    end
+  end
+
+  describe "a board on a communicator dashboard" do
+    let(:communicator) { create(:child_account, user: user, name: "Milo") }
+    let!(:child_board) { create(:child_board, board: board, child_account: communicator) }
+
+    it "returns 409 with the communicator named" do
+      delete_board(board, as: user)
+      expect(response).to have_http_status(:conflict)
+      usage = JSON.parse(response.body)["usage"]
+      expect(usage["communicators"]).to eq({ "count" => 1, "names" => ["Milo"] })
+    end
+
+    it "deletes with confirm=true, removing the dashboard entry" do
+      delete_board(board, as: user, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(ChildBoard.exists?(child_board.id)).to be false
+    end
+  end
+
+  describe "a board shared with a team" do
+    let(:team) { create(:team, name: "Room 4", created_by: user) }
+
+    before { TeamBoard.create!(team: team, board: board) }
+
+    it "returns 409 with the team named" do
+      delete_board(board, as: user)
+      expect(response).to have_http_status(:conflict)
+      usage = JSON.parse(response.body)["usage"]
+      expect(usage["teams"]).to eq({ "count" => 1, "names" => ["Room 4"] })
+    end
+  end
+
+  describe "a Board Builder root" do
+    let(:communicator) { create(:child_account, user: user) }
+    let!(:root) do
+      create(:board, user: user, name: "Built Set",
+                     settings: { "builder_root" => true })
+    end
+    let!(:child_page) do
+      create(:board, user: user, name: "Food",
+                     settings: { "builder_child" => true })
+    end
+    let!(:group) do
+      group = create(:board_group, user: user, builder: true, name: "Built Set")
+      group.board_group_boards.create!(board: root)
+      group.board_group_boards.create!(board: child_page)
+      group.update!(root_board_id: root.id)
+      group
+    end
+    let!(:child_board) { create(:child_board, board: root, child_account: communicator) }
+
+    it "returns 409 describing the whole set" do
+      delete_board(root, as: user)
+      expect(response).to have_http_status(:conflict)
+      usage = JSON.parse(response.body)["usage"]
+      expect(usage["builder_set"]).to include(
+        "root" => true,
+        "board_group_id" => group.id,
+        "member_board_count" => 2,
+      )
+    end
+
+    it "confirm=true cascades the whole set: group, members, and dashboard entry" do
+      delete_board(root, as: user, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(BoardGroup.exists?(group.id)).to be false
+      expect(Board.exists?(root.id)).to be false
+      expect(Board.exists?(child_page.id)).to be false
+      expect(ChildBoard.exists?(child_board.id)).to be false
+    end
+
+    it "a root whose builder group is gone falls back to a plain destroy" do
+      group.board_group_boards.destroy_all
+      group.delete
+      delete_board(root, as: user, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(root.id)).to be false
+      # legacy orphan behavior, documented: the child page survives
+      expect(Board.exists?(child_page.id)).to be true
+    end
+  end
+
+  describe "authorization" do
+    let(:admin)      { create(:admin_user) }
+    let(:other_user) { create(:user) }
+
+    it "lets an admin confirm-delete another user's in-use board" do
+      referencing = create(:board, user: user)
+      create(:board_image, board: referencing, predictive_board_id: board.id)
+      delete_board(board, as: admin, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+    end
+
+    it "still refuses another user's board before any usage check" do
+      delete_board(board, as: other_user)
+      expect(response.status).to be_in([401, 403, 404])
+      expect(Board.exists?(board.id)).to be true
+    end
+  end
+
+  describe "cleanup job" do
+    it "enqueues BoardDestroyCleanupJob on destroy" do
+      expect {
+        delete_board(board, as: user, confirm: "true")
+      }.to change(BoardDestroyCleanupJob.jobs, :size).by(1)
+      expect(BoardDestroyCleanupJob.jobs.last["args"]).to eq([board.id])
+    end
+  end
+end

--- a/spec/requests/api/child_boards_handoff_removal_spec.rb
+++ b/spec/requests/api/child_boards_handoff_removal_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe "API::ChildBoards non-destructive removal", type: :request do
     expect(Board.exists?(board.id)).to be(true)
   end
 
+  it "detaches but preserves a template board another board's folder tile still opens" do
+    board = create(:board, user: parent, name: "Linked sub-board", is_template: true)
+    cb = create(:child_board, board: board, child_account: child_account)
+    home = create(:board, user: parent, name: "Home")
+    create(:board_image, board: home, predictive_board_id: board.id)
+
+    delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+
+    expect(response).to have_http_status(:ok)
+    expect(ChildBoard.exists?(cb.id)).to be(false)
+    expect(Board.exists?(board.id)).to be(true)
+  end
+
   it "still deletes a throwaway template clone nothing else references (cleanup preserved)" do
     board = create(:board, user: parent, name: "Throwaway", is_template: true)
     cb = create(:child_board, board: board, child_account: child_account)

--- a/spec/sidekiq/board_destroy_cleanup_job_spec.rb
+++ b/spec/sidekiq/board_destroy_cleanup_job_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe BoardDestroyCleanupJob do
+  subject(:run) { described_class.new.perform(board_id) }
+
+  let(:user)     { create(:user) }
+  let(:board)    { create(:board, user: user) }
+  let(:board_id) { board.id }
+
+  it "nullifies users.editable_board_id pointing at the board" do
+    user.update_columns(editable_board_id: board_id)
+    run
+    expect(user.reload.editable_board_id).to be_nil
+  end
+
+  it "strips matching pointer keys from user settings, leaving other keys" do
+    user.update_columns(settings: {
+      "dynamic_board_id" => board_id,
+      "phrase_board_id" => board_id.to_s,
+      "board_limit" => 5,
+    })
+    run
+    settings = user.reload.settings
+    expect(settings).not_to have_key("dynamic_board_id")
+    expect(settings).not_to have_key("phrase_board_id")
+    expect(settings["board_limit"]).to eq(5)
+  end
+
+  it "strips matching pointer keys from child_account settings" do
+    communicator = create(:child_account, user: user)
+    communicator.update_columns(settings: { "phrase_board_id" => board_id })
+    run
+    expect(communicator.reload.settings).not_to have_key("phrase_board_id")
+  end
+
+  it "leaves pointers at OTHER boards alone" do
+    other = create(:board, user: user)
+    user.update_columns(settings: { "phrase_board_id" => other.id }, editable_board_id: other.id)
+    run
+    expect(user.reload.settings["phrase_board_id"]).to eq(other.id)
+    expect(user.editable_board_id).to eq(other.id)
+  end
+
+  it "destroys scenarios generated from the board" do
+    scenario = create(:scenario, user: user, board_id: board_id)
+    run
+    expect(Scenario.exists?(scenario.id)).to be false
+  end
+
+  it "leaves word_events untouched (analytics history)" do
+    event = WordEvent.create!(user: user, board_id: board_id, word: "go")
+    run
+    expect(WordEvent.exists?(event.id)).to be true
+    expect(event.reload.board_id).to eq(board_id)
+  end
+
+  it "is idempotent and tolerates the board row being gone" do
+    user.update_columns(editable_board_id: board_id, settings: { "dynamic_board_id" => board_id })
+    board.destroy!
+    expect { 2.times { run } }.not_to raise_error
+    expect(user.reload.editable_board_id).to be_nil
+    expect(user.settings).not_to have_key("dynamic_board_id")
+  end
+end


### PR DESCRIPTION
## Summary

PR 1 of 3 from the board-deletion / clone-correctness investigation.

- **Warn+confirm delete.** `DELETE /api/boards/:id` now returns **409 `board_in_use`** with a usage summary (referencing folder tiles, communicator dashboards, team shares, builder set) when anything still references the board, unless the client re-sends with `confirm=true`. New `Boards::UsageCheck` service; counts exact, name lists capped at 10; self-referencing tiles never block. Unreferenced boards delete in one step, unchanged.
- **Builder-root cascade.** A confirmed delete of a `builder_root` board routes through its builder BoardGroup (`Board#builder_board_group` → `group.destroy!`) so the whole built tree is destroyed via the existing #407 cascade instead of orphaning ~12–19 hidden sub-boards. Routing lives only in the controller to avoid Board↔BoardGroup destroy recursion; group-less legacy roots fall back to a plain destroy.
- **Destroy cleanup.** New `BoardDestroyCleanupJob` (after_destroy, rescue-wrapped) scrubs `users.editable_board_id`, `dynamic_board_id`/`phrase_board_id` in user + child_account settings JSONB, and scenarios. `docs.board_id` now `dependent: :nullify`. `word_events` intentionally untouched (analytics history). Removed the redundant manual predictive-nullify loop in `#destroy` (the `dependent: :nullify` association covers all board types).
- **`orphan_template?` hole fix.** Removing a board from a communicator dashboard no longer hard-deletes a template clone that another board's folder tile still opens — detach only.

Docs: CLAUDE.md section + CHANGELOG entry.

## Frontend follow-up (itty-bitty-frontend, separate PR)
Handle the 409 with a confirm dialog rendering `usage`, re-send with `confirm=true`; special copy for builder roots ("deletes the whole set, N boards").

## Test plan
- New `spec/requests/api/boards_destroy_spec.rb` (13 examples): one-step delete, 409 per usage signal with payload assertions, self-link exclusion, confirm path, builder-root cascade (group + members + ChildBoard destroyed), group-less fallback, admin + cross-user auth, cleanup job enqueue.
- New `spec/sidekiq/board_destroy_cleanup_job_spec.rb` (7 examples): pointer scrubs, other-board pointers untouched, scenario destroy, word_events preserved, idempotent with board row gone.
- Extended `spec/requests/api/child_boards_handoff_removal_spec.rb` with the predictive-reference detach case.
- Ran: the three spec files above + `spec/requests/api/boards_spec.rb`, `spec/models/board_group_spec.rb`, `spec/models/board_spec.rb` — **178 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)