### PR TITLE
feat: original menu image on board API + description-driven menu image prompts

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -928,8 +928,12 @@ class Board < ApplicationRecord
   # art. `max_generate` caps how many images are sent for (paid) generation —
   # tiles beyond the cap still land on the board, marked "skipped", with no
   # OpenAI call. nil = no cap (non-menu callers are unchanged).
+  # `menu_prompts` (normalized word => generation prompt) marks words as menu
+  # items: within budget they always get a fresh, private, description-driven
+  # image rather than a label match from the shared library; over budget they
+  # fall back to library reuse so the tile isn't left blank.
   # Returns the number of images queued for generation.
-  def find_or_create_images_from_word_list(word_list, max_generate: nil)
+  def find_or_create_images_from_word_list(word_list, max_generate: nil, menu_prompts: nil)
     if id.blank?
       self.save!
     end
@@ -957,22 +961,34 @@ class Board < ApplicationRecord
         end
       end
       Rails.logger.debug "Change detected: #{og_word} -> #{word}" unless og_word == word
-      image = user.images.find_by(label: word) if user_id
-
-      image = Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
-      new_image = Image.create(label: word) unless image
-      image ||= new_image
-      display_doc = image.display_tile_url(user)
+      menu_prompt = menu_prompts && menu_prompts[word.to_s.downcase.strip]
       skip_generation = false
-      if display_doc.blank?
-        admin_image_present = image.docs.any? { |doc| doc.user_id == User::DEFAULT_ADMIN_ID }
-        user_image_present = image.docs.any? { |doc| doc.user_id == user_id }
-        if !admin_image_present && !user_image_present
-          if max_generate.nil? || queued_count < max_generate
-            image_ids_to_generate << image.id
-            queued_count += 1
-          else
-            skip_generation = true
+      if menu_prompt && (max_generate.nil? || queued_count < max_generate)
+        # Menu labels ("single", "virginia") collide with unrelated library
+        # art, so menu items get a fresh image generated from the parsed dish
+        # description — private and user-owned so restaurant-specific art
+        # never enters the public library.
+        image = Image.create(label: word, user_id: user_id, is_private: true,
+                             image_type: "menu", image_prompt: menu_prompt)
+        image_ids_to_generate << image.id
+        queued_count += 1
+      else
+        image = user.images.find_by(label: word) if user_id
+
+        image = Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
+        new_image = Image.create(label: word) unless image
+        image ||= new_image
+        display_doc = image.display_tile_url(user)
+        if display_doc.blank?
+          admin_image_present = image.docs.any? { |doc| doc.user_id == User::DEFAULT_ADMIN_ID }
+          user_image_present = image.docs.any? { |doc| doc.user_id == user_id }
+          if !admin_image_present && !user_image_present
+            if max_generate.nil? || queued_count < max_generate
+              image_ids_to_generate << image.id
+              queued_count += 1
+            else
+              skip_generation = true
+            end
           end
         end
       end
@@ -1940,6 +1956,7 @@ class Board < ApplicationRecord
       image_parent_id: image_parent_id,
       parent_description: parent_type === "User" ? "User" : parent&.to_s,
       menu_description: parent_type === "Menu" ? parent&.description : nil,
+      original_menu_image_url: parent_type === "Menu" ? parent&.menu_image_url : nil,
       parent_prompt: parent_type === "OpenaiPrompt" ? parent.prompt_text : nil,
       predefined: predefined,
       favorite: favorite,

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -138,6 +138,7 @@ class Menu < ApplicationRecord
       Rails.logger.error "No menu items found in description for Menu #{id}"
       return nil
     end
+    menu_prompts = {}
     json_description["menu_items"].each do |food|
       if food["name"].blank? || food["image_description"].blank?
         Rails.logger.info "Blank name or image description for #{food.inspect}"
@@ -149,6 +150,7 @@ class Menu < ApplicationRecord
       end
       item_name = menu_item_name(food["name"])
       menu_item_list << item_name
+      menu_prompts[food["name"].to_s.downcase.strip] = menu_item_image_prompt(food)
     end
 
     begin
@@ -158,7 +160,7 @@ class Menu < ApplicationRecord
       board.update_column(:status, "finding_images")
       # token_limit is the user's image budget: at most this many tiles get a
       # paid AI generation; every item still lands on the board.
-      queued = board.find_or_create_images_from_word_list(words, max_generate: board.token_limit) || 0
+      queued = board.find_or_create_images_from_word_list(words, max_generate: board.token_limit, menu_prompts: menu_prompts) || 0
       board.update_column(:status, "complete")
       # Budget that wasn't needed (items reused existing art, or fewer novel
       # items than the budget) goes back to the user.
@@ -199,6 +201,14 @@ class Menu < ApplicationRecord
 
   def pending_images
     main_board&.pending_images
+  end
+
+  # Generation prompt for one parsed menu item — leads with the vision
+  # model's description of the dish so the art matches the actual food, not
+  # just the item's (often state-named) label.
+  def menu_item_image_prompt(food)
+    details = food["image_description"].to_s.strip
+    "#{details} #{Menu::PROMPT_ADDITION} Without any text or prices, with a transparent background."
   end
 
   def menu_item_name(item_name)

--- a/app/sidekiq/generate_images_job.rb
+++ b/app/sidekiq/generate_images_job.rb
@@ -23,7 +23,12 @@ class GenerateImagesJob
 
           user_id = image.user_id
           if board.board_type == "menu"
-            image.image_prompt = image.default_menu_image_prompt(board.name)
+            # Fresh menu-item images carry a description-driven prompt set at
+            # creation (Menu#create_images_from_description) — keep it. Reused
+            # or legacy images fall back to the label-based default.
+            unless image.menu? && image.image_prompt.present?
+              image.image_prompt = image.default_menu_image_prompt(board.name)
+            end
           else
             image.image_prompt = image.default_image_prompt
           end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -312,6 +312,71 @@ RSpec.describe Board, type: :model do
       end
     end
 
+    context "with menu_prompts (menu board items)" do
+      let(:words) { ["single", "virginia"] }
+      let(:prompts) do
+        {
+          "single" => "A single classic burger with fry sauce. Menu photo.",
+          "virginia" => "A burger topped with pimento cheese and ham. Menu photo.",
+        }
+      end
+      let(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+      before { GenerateImagesJob.clear }
+
+      it "creates a fresh private menu image with the description prompt even when the label exists in the library" do
+        existing = FactoryBot.create(:image, label: "single", user: admin_user)
+        FactoryBot.create(:doc, documentable: existing, user: admin_user, processed: "img")
+
+        queued = board.find_or_create_images_from_word_list(words, menu_prompts: prompts)
+
+        expect(queued).to eq(2)
+        fresh = board.images.find_by(label: "single")
+        expect(fresh.id).not_to eq(existing.id)
+        expect(fresh.is_private).to be(true)
+        expect(fresh.image_type).to eq("menu")
+        expect(fresh.user_id).to eq(user.id)
+        expect(fresh.image_prompt).to eq(prompts["single"])
+      end
+
+      it "matches prompts case-insensitively" do
+        queued = board.find_or_create_images_from_word_list(["Single"], menu_prompts: prompts)
+
+        expect(queued).to eq(1)
+        expect(board.images.find_by(label: "Single").image_type).to eq("menu")
+      end
+
+      it "falls back to library reuse for menu items over the budget" do
+        existing = FactoryBot.create(:image, label: "virginia", user: admin_user)
+        FactoryBot.create(:doc, documentable: existing, user: admin_user, processed: "img")
+
+        queued = board.find_or_create_images_from_word_list(words, max_generate: 1, menu_prompts: prompts)
+
+        expect(queued).to eq(1)
+        expect(board.images.find_by(label: "single").image_type).to eq("menu")
+        expect(board.images.find_by(label: "virginia").id).to eq(existing.id)
+        expect(board.board_images.where(status: "skipped").count).to eq(0)
+      end
+
+      it "marks over-budget menu items with no library art as skipped" do
+        queued = board.find_or_create_images_from_word_list(words, max_generate: 1, menu_prompts: prompts)
+
+        expect(queued).to eq(1)
+        expect(board.board_images.where(status: "skipped").count).to eq(1)
+      end
+
+      it "reuses library art without generating when max_generate is zero" do
+        existing = FactoryBot.create(:image, label: "single", user: admin_user)
+        FactoryBot.create(:doc, documentable: existing, user: admin_user, processed: "img")
+
+        queued = board.find_or_create_images_from_word_list(words, max_generate: 0, menu_prompts: prompts)
+
+        expect(queued).to eq(0)
+        expect(board.images.find_by(label: "single").id).to eq(existing.id)
+        expect(GenerateImagesJob.jobs).to be_empty
+      end
+    end
+
     context "when some words already exist" do
       context "by the admin user" do
         let(:admin_user) { FactoryBot.create(:user, role: "admin", id: User::DEFAULT_ADMIN_ID) }
@@ -740,6 +805,34 @@ RSpec.describe Board, type: :model do
         expect(entry[:preview_image_url]).to eq(parent.preview_image_url)
         expect(entry[:display_image_url]).to eq(parent.preview_image_url)
       end
+    end
+  end
+
+  describe "#api_view_with_predictive_images original_menu_image_url" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:menu) { FactoryBot.create(:menu, user: user, name: "Joe's Diner") }
+    let(:board) do
+      FactoryBot.create(:board, user: user, board_type: "menu",
+                                parent_type: "Menu", parent_id: menu.id)
+    end
+
+    it "exposes the original uploaded menu image URL for menu boards" do
+      allow_any_instance_of(Menu).to receive(:menu_image_url)
+        .and_return("https://cdn.example.com/menu.jpg")
+
+      view = board.api_view_with_predictive_images(user)
+
+      expect(view[:original_menu_image_url]).to eq("https://cdn.example.com/menu.jpg")
+    end
+
+    it "is nil when the menu has no image attached" do
+      expect(board.api_view_with_predictive_images(user)[:original_menu_image_url]).to be_nil
+    end
+
+    it "is nil for non-menu boards" do
+      plain = FactoryBot.create(:board, user: user)
+
+      expect(plain.api_view_with_predictive_images(user)[:original_menu_image_url]).to be_nil
     end
   end
 

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe Menu, type: :model do
       expect(board.board_images.where(status: "skipped").count).to eq(1)
     end
 
+    it "generates fresh menu images with description-driven prompts" do
+      menu.create_images_from_description(board)
+
+      img = board.images.find_by(label: "cheeseburger")
+      expect(img.image_type).to eq("menu")
+      expect(img.is_private).to be(true)
+      expect(img.user_id).to eq(user.id)
+      expect(img.image_prompt).to include("A cheeseburger.")
+      expect(img.image_prompt).to include(Menu::PROMPT_ADDITION)
+    end
+
     it "refunds the whole image budget when the build raises" do
       allow(board).to receive(:find_or_create_images_from_word_list).and_raise("boom")
 

--- a/spec/sidekiq/generate_images_job_spec.rb
+++ b/spec/sidekiq/generate_images_job_spec.rb
@@ -21,6 +21,29 @@ RSpec.describe GenerateImagesJob, type: :job do
     ))
   end
 
+  describe "menu prompt selection" do
+    before do
+      allow_any_instance_of(Image).to receive(:create_image_doc).and_return(nil)
+    end
+
+    it "keeps the description-driven prompt on fresh menu images" do
+      prompt = "A burger topped with apple butter and bacon. Menu photo."
+      menu_image = FactoryBot.create(:image, user: user, image_type: "menu",
+                                             image_prompt: prompt)
+      board.add_image(menu_image.id)
+
+      described_class.new.perform([menu_image.id], board.id)
+
+      expect(menu_image.reload.image_prompt).to eq(prompt)
+    end
+
+    it "falls back to the label-based menu prompt for reused images" do
+      described_class.new.perform([image.id], board.id)
+
+      expect(image.reload.image_prompt).to eq(image.default_menu_image_prompt(board.name))
+    end
+  end
+
   describe "menu image failure refunds" do
     before do
       allow_any_instance_of(Image).to receive(:create_image_doc).and_return(nil)


### PR DESCRIPTION
## Summary

Two improvements to menu-type boards (companion frontend PR: brittanyjohns/itty-bitty-frontend — "View Menu button + original-menu-photo modal"):

1. **Expose the original menu photo on the board API.** The uploaded menu is already durably stored on `Menu#menu_image`, but the board's `preview_image` gets replaced by the grid snapshot, so the board loses its visible link to the source menu. `Board#api_view_with_predictive_images` now returns `original_menu_image_url` (from `parent.menu_image_url`) for menu boards, so the frontend can show the real menu in a popup. No new ActiveStorage record needed.

2. **Menu-item images are generated from the parsed dish description, not just the label.** The vision parse already produces an `image_description` per item ("A burger topped with apple butter, American cheese, bacon, and caramelized onions"), but generation only used the bare label — and worse, `find_or_create_images_from_word_list` reused any global library image whose label matched, which is why menu items named "single", "double", "virginia", or "ohio" rendered as a person, a peace sign, a cartoon woman, and the state of Ohio. Now:
   - `Menu#create_images_from_description` builds a per-item prompt from `image_description` + `Menu::PROMPT_ADDITION` and passes it through.
   - Within the image budget, menu items always get a **fresh** image generated from that prompt — created private (`is_private: true`), user-owned, `image_type: "menu"`, so restaurant-specific art never pollutes the public library.
   - Over-budget items fall back to the old library-reuse behavior so tiles aren't left blank; items with no art are still marked `skipped`.
   - `GenerateImagesJob` keeps the description-driven prompt on fresh menu images (this also improves the prompt pre-filled in the tile editor's "Make new image" box); reused/legacy images keep the label-based default.

Budget/refund semantics (`token_limit`, `menu_credit` reservation, `Menus::CreditRefunds`) are unchanged.

## Test plan

- `bundle exec rspec spec/models/board_spec.rb spec/models/menu_spec.rb spec/sidekiq/generate_images_job_spec.rb` — **101 examples, 0 failures**
- New coverage: fresh private menu images with description prompts (incl. case-insensitive matching), over-budget fallback to reuse, `max_generate: 0` reuse-only, skipped marking, `GenerateImagesJob` prompt selection, `original_menu_image_url` serializer field (menu board, menu without image, non-menu board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)