### PR TITLE
feat: deep-clone board assignment, per-communicator assign cap, orphan sweep (re-land #480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — boards assigned to a communicator are now fully independent copies
+- Assigning a board to a communicator now copies its linked sub-boards too
+  and points the folder buttons at the copies. Previously only the top
+  board was copied, so folder buttons kept opening the original owner's
+  live sub-boards — edits or deletions by the original owner would change
+  or break the communicator's board.
+- Removing such a board from the dashboard cleans up its now-unused
+  sub-board copies (unless something else still references them).
+- Each communicator's dashboard now has a sanity cap on assigned boards
+  (default 80, matching the favorites cap).
+
 ### Changed — deleting a board now warns when it's still in use
 - Deleting a board that other boards' folder buttons open, that sits on a
   communicator's dashboard, that's shared with a team, or that is a Board

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1029,6 +1029,41 @@ known backend-enforcement gaps — lives in
 `marketing/.claude-notes/handoff-workflow.md`. Keep that doc and this
 section in sync when the rules change.
 
+### Board assignment is a DEEP clone (`Boards::AssignmentCloner`)
+
+Putting a board on a communicator (`assign_boards`, `assign_accounts`, the
+MySpeak starter attach) goes through **`Boards::AssignmentCloner`**
+(`app/services/boards/`), not a bare `clone_with_images`. The old shallow
+clone copied `predictive_board_id` verbatim, so an assigned board's folder
+tiles kept opening the **source owner's live sub-boards** — shared state that
+changed/broke when the source owner edited or deleted them.
+
+- The cloner BFS-collects the linked set (**`Boards::PredictiveLinkSet`**,
+  extracted from `SeededSetCloner` and shared with it), depth-capped by
+  `BOARD_ASSIGN_CLONE_DEPTH` (default 3), clones each sub-board for the same
+  owner, and rewires the folder tiles to the clones. Pointers past the depth
+  cap are **kept verbatim** (assignment sets are arbitrary user boards —
+  nulling would break deep sets), unlike the builder's `:null` policy.
+- Root clone contract unchanged: `is_template: true` + ChildBoard on the
+  communicator (created inside `clone_with_images`). Sub-clones are also
+  `is_template` (via the new `force_template:` kwarg on `clone_with_images`),
+  get **no ChildBoard rows**, and carry `settings["assignment_child"]` +
+  `["assignment_root_id"]` so `ChildBoardsController#destroy`'s **orphan
+  sweep** can delete them when the root clone is removed and hard-deleted
+  (same `orphan_template?` guards per sub-board; iterates until a pass
+  deletes nothing so nested folders unwind).
+- **Per-communicator assigned-board cap** (`ChildAccount.max_assigned_boards`,
+  ENV `MAX_ASSIGNED_BOARDS_PER_COMMUNICATOR`, default 80 — matches the
+  favorites cap): assigned clones are deliberately uncounted toward the
+  owner's board limit (the original already counted), so this cap is what
+  stops assignment minting unlimited board rows. `assign_boards` returns
+  **422 `assigned_board_limit`** `{ error, message, limit, count }`;
+  `assign_accounts` appends a per-communicator message to its existing
+  `record_errors` 422 array.
+- Legacy shallow clones (no `assignment_root_id` marker) behave as before —
+  nothing migrates them; the delete-safety 409 now correctly warns source
+  owners that their sub-boards are still referenced.
+
 ### Board removal after hand-off (non-destructive)
 
 Boards put on a communicator via `assign_boards` are **cloned** (a new

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1008,8 +1008,23 @@ class API::BoardsController < API::ApplicationController
             next
           end
         end
+        # Per-communicator cap — assigned clones are uncounted toward the
+        # owner's board limit, so this is the bound on assignment minting.
+        if communicator_account.at_assigned_board_limit?
+          record_errors << "Board limit reached for #{communicator_account.name} - limit: #{ChildAccount.max_assigned_boards}"
+          next
+        end
         voice = communicator_account.voice
-        communicator_board_copy = @board.clone_with_images(current_user&.id, @board.name, voice, communicator_account)
+        begin
+          # Deep clone: linked sub-boards are cloned + rewired too, so the
+          # communicator's set is self-contained (not shared with the source).
+          Boards::AssignmentCloner.new(@board, owner: current_user,
+                                               communicator: communicator_account,
+                                               voice: voice, name: @board.name).call
+        rescue Boards::AssignmentCloner::CloneError => e
+          Rails.logger.error "[assign_accounts] #{e.message}"
+          record_errors << "Could not assign board to #{communicator_account.name}"
+        end
       end
       if record_errors.empty?
         @board.in_use = true

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -505,10 +505,28 @@ class API::ChildAccountsController < API::ApplicationController
       end
     end
 
+    # Assigned clones don't count toward the owner's board limit, so this
+    # per-communicator cap is what keeps assignment from minting unlimited
+    # board rows.
+    if @child_account.at_assigned_board_limit?(board_ids.size)
+      render json: { error: "assigned_board_limit",
+                     message: "This communicator can hold up to #{ChildAccount.max_assigned_boards} boards.",
+                     limit: ChildAccount.max_assigned_boards,
+                     count: @child_account.child_boards.count },
+             status: :unprocessable_content
+      return
+    end
+
     board_ids.each do |board_id|
       board = Board.find(board_id)
       voice = @child_account.voice || "polly:kevin"
-      board.clone_with_images(current_user&.id, board.name, voice, @child_account)
+      # Deep clone: linked sub-boards are cloned + rewired too, so the
+      # communicator's set is self-contained (not shared with the source).
+      Boards::AssignmentCloner.new(board, owner: current_user,
+                                          communicator: @child_account,
+                                          voice: voice, name: board.name).call
+    rescue Boards::AssignmentCloner::CloneError => e
+      Rails.logger.error "[assign_boards] #{e.message}"
     end
     render json: @child_account.api_view(current_user), status: :ok
   end

--- a/app/controllers/api/child_boards_controller.rb
+++ b/app/controllers/api/child_boards_controller.rb
@@ -61,7 +61,12 @@ class API::ChildBoardsController < API::ApplicationController
     # while preserving the old cleanup for a self-created template clone.
     if @board && @board.is_template && orphan_template?(@board)
       Rails.logger.info "Deleting orphaned template board ID: #{@board.id}"
+      # Deep-cloned sub-boards (Boards::AssignmentCloner) are marked with the
+      # root clone's id; collect them before the root goes so they can be
+      # swept once the root's folder tiles no longer reference them.
+      sweepable = assignment_sub_templates(@board)
       @board.destroy
+      sweep_orphaned_sub_templates!(sweepable)
     else
       Rails.logger.info "Detached child_board #{params[:id]}; preserved board ID: #{@board&.id}"
     end
@@ -84,6 +89,31 @@ class API::ChildBoardsController < API::ApplicationController
     # nullify that tile into a dead button. Detach only.
     return false if BoardImage.where(predictive_board_id: board.id).where.not(board_id: board.id).exists?
     board.user_id == current_user&.id
+  end
+
+  # Sub-board clones minted by Boards::AssignmentCloner for this root clone.
+  def assignment_sub_templates(root_board)
+    Board.where(user_id: current_user&.id, is_template: true)
+         .where("settings->>'assignment_root_id' = ?", root_board.id.to_s)
+         .to_a
+  end
+
+  # Destroy the set's sub-templates that are now orphans, applying the same
+  # never-delete-something-referenced guards. Nested folders reference each
+  # other, so destroying a parent frees its children — iterate until a pass
+  # deletes nothing. (A reference cycle between two sub-boards leaves both in
+  # place; acceptable, they're invisible template rows.)
+  def sweep_orphaned_sub_templates!(sweepable)
+    until sweepable.empty?
+      deletable = sweepable.select { |b| orphan_template?(b) }
+      break if deletable.empty?
+
+      deletable.each do |board|
+        Rails.logger.info "Sweeping orphaned assignment sub-template board ID: #{board.id}"
+        board.destroy
+      end
+      sweepable -= deletable
+    end
   end
 
   def load_child_board

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -195,15 +195,22 @@ module API
             return
           end
 
-          cloned = board.clone_with_images(current_user.id, board.name, child.voice, child)
-          unless cloned&.persisted?
-            Rails.logger.warn "[Onboarding::Myspeak] clone failed for board #{board.id}"
+          # Deep clone: a starter board with folder tiles gets its linked
+          # sub-boards cloned + rewired too (usually a no-op — starters are
+          # flat today).
+          begin
+            cloned = Boards::AssignmentCloner.new(board, owner: current_user,
+                                                         communicator: child,
+                                                         voice: child.voice,
+                                                         name: board.name).call
+          rescue Boards::AssignmentCloner::CloneError => e
+            Rails.logger.warn "[Onboarding::Myspeak] clone failed for board #{board.id}: #{e.message}"
             return
           end
 
-          # clone_with_images creates the ChildBoard join row. Mark it the
-          # communicator's favorite to match the old behavior (the wizard's
-          # pick is the home board).
+          # The root clone gets a ChildBoard join row (inside
+          # clone_with_images). Mark it the communicator's favorite to match
+          # the old behavior (the wizard's pick is the home board).
           child_board = ChildBoard.find_by(child_account: child, board: cloned)
           child_board&.update(favorite: true)
         end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1086,7 +1086,11 @@ class Board < ApplicationRecord
     new_board_image
   end
 
-  def clone_with_images(cloned_user_id, new_name = nil, updated_voice = nil, communicator_account = nil)
+  # force_template: mark the clone is_template even without a communicator —
+  # used by Boards::AssignmentCloner for the sub-boards of an assigned set,
+  # which get no ChildBoard of their own but must stay out of the owner's
+  # normal board scopes (and the board-limit count) like the root clone does.
+  def clone_with_images(cloned_user_id, new_name = nil, updated_voice = nil, communicator_account = nil, force_template: false)
     if new_name.blank?
       new_name = name
     end
@@ -1126,7 +1130,7 @@ class Board < ApplicationRecord
     @cloned_board.board_images_count = 0
     @cloned_board.generate_unique_slug
     @cloned_board.voice = updated_voice || voice
-    @cloned_board.is_template = communicator_account.present?
+    @cloned_board.is_template = communicator_account.present? || force_template
     @cloned_board.save
 
     unless @cloned_board.persisted?
@@ -1188,24 +1192,6 @@ class Board < ApplicationRecord
     else
       Rails.logger.error "Error cloning board: #{@cloned_board}"
     end
-  end
-
-  def clone_and_update_predictive_board(original_board_image, new_board_image, updated_voice, cloned_user_id)
-    return unless original_board_image.predictive_board_id
-    predictive_board = Board.find_by(id: original_board_image.predictive_board_id)
-    return unless predictive_board
-    if predictive_board.user_id == cloned_user_id
-      new_board_image.predictive_board_id = predictive_board.id
-      new_board_image.save
-      return
-    end
-    if predictive_board.public_board?
-      new_board_image.predictive_board_id = predictive_board.id
-      new_board_image.save
-      return
-    end
-
-    CloneBoardJob.perform_async(predictive_board.id, new_board_image.id)
   end
 
   def update_user_boards_after_cloning(source_board, cloned_user_id)

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -50,6 +50,20 @@ class ChildAccount < ApplicationRecord
   # DEMO_ACCOUNT_BOARD_LIMIT so Free families get a usable starter set (3
   # boards) on their demo communicator, not just one.
   FREE_DEMO_BOARD_LIMIT = 3
+
+  # Sanity ceiling on dashboard boards per communicator. Assigned clones are
+  # deliberately excluded from the owner's board-limit count (the original
+  # already counted), so without a per-communicator cap the assign endpoints
+  # could mint unlimited board rows. 80 matches ChildBoard#toggle_favorite's
+  # favorites cap — a dashboard can't meaningfully hold more.
+  def self.max_assigned_boards
+    ENV.fetch("MAX_ASSIGNED_BOARDS_PER_COMMUNICATOR", 80).to_i
+  end
+
+  def at_assigned_board_limit?(adding = 1)
+    child_boards.count + adding > self.class.max_assigned_boards
+  end
+
   belongs_to :user, optional: true
   belongs_to :vendor, optional: true
   belongs_to :owner, class_name: "User", optional: true

--- a/app/services/boards/assignment_cloner.rb
+++ b/app/services/boards/assignment_cloner.rb
@@ -1,0 +1,70 @@
+module Boards
+  # Deep-clone counterpart of Board#clone_with_images for the "put this board
+  # on a communicator" paths (assign_boards, assign_accounts, MySpeak starter
+  # attach). The shallow clone copied predictive_board_id verbatim, so an
+  # assigned board's folder tiles kept opening the SOURCE owner's live
+  # sub-boards — shared state that changed or broke when the source owner
+  # edited/deleted them. This clones the linked sub-boards too (depth-capped)
+  # and rewires the folder tiles to the clones, mirroring what
+  # SeededSetCloner already does for builder sets.
+  #
+  #   root_clone = Boards::AssignmentCloner.new(
+  #     board, owner: current_user, communicator: child, voice: "echo"
+  #   ).call
+  #
+  # Root clone: unchanged contract — is_template, ChildBoard on the
+  # communicator (created inside clone_with_images), UpdateUserBoardsJob.
+  # Sub-board clones: is_template (via force_template), owned by the same
+  # user, NO ChildBoard rows (they surface only through folder navigation),
+  # marked settings["assignment_child"] + ["assignment_root_id"] so
+  # ChildBoardsController's orphan sweep can find them when the root clone is
+  # removed and deleted.
+  class AssignmentCloner
+    class CloneError < StandardError; end
+
+    # Root + this many levels of linked sub-boards. Deeper links are left
+    # pointing at the source (exactly the pre-deep-clone behavior), not nulled.
+    def self.depth_cap
+      ENV.fetch("BOARD_ASSIGN_CLONE_DEPTH", 3).to_i
+    end
+
+    def initialize(source_root, owner:, communicator:, voice: nil, name: nil)
+      @source_root  = source_root
+      @owner        = owner
+      @communicator = communicator
+      @voice        = voice
+      @name         = name
+    end
+
+    # Returns the cloned root Board. Transactional: a mid-clone failure leaves
+    # no orphan sub-board clones or dangling ChildBoard.
+    def call
+      ActiveRecord::Base.transaction do
+        sources = PredictiveLinkSet.collect(@source_root, max_depth: self.class.depth_cap)
+
+        root_clone = @source_root.clone_with_images(@owner.id, @name || @source_root.name, @voice, @communicator)
+        raise CloneError, "failed to clone board #{@source_root.id}" if root_clone.nil?
+
+        map = { @source_root.id => root_clone }
+        sources.each do |src|
+          next if src.id == @source_root.id
+
+          clone = src.clone_with_images(@owner.id, nil, @voice, nil, force_template: true)
+          raise CloneError, "failed to clone sub-board #{src.id}" if clone.nil?
+
+          clone.settings = (clone.settings || {}).merge(
+            "assignment_child" => true,
+            "assignment_root_id" => root_clone.id,
+          )
+          clone.save!
+          map[src.id] = clone
+        end
+
+        # :keep — a pointer past the depth cap stays on the source board, the
+        # (known, now bounded) status quo; :null would silently break deep sets.
+        PredictiveLinkSet.rewire!(map, out_of_set: :keep)
+        root_clone
+      end
+    end
+  end
+end

--- a/app/services/boards/predictive_link_set.rb
+++ b/app/services/boards/predictive_link_set.rb
@@ -1,0 +1,57 @@
+module Boards
+  # Shared helpers for working with a LINKED BOARD SET — the graph formed by
+  # BoardImage#predictive_board_id folder-tile pointers. Extracted from
+  # Boards::SeededSetCloner so the assignment deep-clone
+  # (Boards::AssignmentCloner) reuses the same BFS + rewire instead of
+  # reimplementing them.
+  module PredictiveLinkSet
+    module_function
+
+    # BFS over predictive_board_id links from the root, bounded to max_depth
+    # and cycle-safe (visited set). A board reachable twice is collected once;
+    # the root is first in the returned list. `exclude` (optional callable) can
+    # veto non-root boards from the walk.
+    def collect(root, max_depth:, exclude: nil)
+      visited = {}
+      ordered = []
+      queue   = [[root, 0]]
+
+      until queue.empty?
+        board, depth = queue.shift
+        next if board.nil? || visited[board.id]
+        next if board.id != root.id && exclude&.call(board)
+
+        visited[board.id] = true
+        ordered << board
+        next if depth >= max_depth
+
+        board.board_images.where.not(predictive_board_id: nil).each do |bi|
+          sub = Board.find_by(id: bi.predictive_board_id)
+          queue << [sub, depth + 1] if sub
+        end
+      end
+
+      ordered
+    end
+
+    # Clones copy predictive_board_id verbatim, so a cloned folder tile points
+    # at the SOURCE sub-board. Translate every pointer through the map
+    # ({ source_board_id => cloned Board }). Pointers that leave the set:
+    #   :null — nulled (builder sets: never leave a user tile opening an
+    #           admin-owned seed board)
+    #   :keep — left verbatim (assignment: arbitrary user sets; a link past
+    #           the depth cap keeps working exactly as before)
+    def rewire!(map, out_of_set: :null)
+      map.each_value do |cloned|
+        cloned.board_images.where.not(predictive_board_id: nil).find_each do |bi|
+          target = map[bi.predictive_board_id]
+          if target
+            bi.update!(predictive_board_id: target.id)
+          elsif out_of_set == :null
+            bi.update!(predictive_board_id: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -78,30 +78,11 @@ module Boards
       @root.present?
     end
 
-    # BFS over predictive_board_id links from the root, bounded to MAX_DEPTH and
-    # cycle-safe (visited set). A board reachable twice is collected once. Root
-    # is first in the returned list.
+    # BFS over predictive_board_id links from the root (shared with
+    # Boards::AssignmentCloner via PredictiveLinkSet).
     def collect_source_boards(root)
-      visited = {}
-      ordered = []
-      queue   = [[root, 0]]
-
-      until queue.empty?
-        board, depth = queue.shift
-        next if board.nil? || visited[board.id]
-        next if board.id != root.id && excluded_fringe?(board)
-
-        visited[board.id] = true
-        ordered << board
-        next if depth >= MAX_DEPTH
-
-        board.board_images.where.not(predictive_board_id: nil).each do |bi|
-          sub = Board.find_by(id: bi.predictive_board_id)
-          queue << [sub, depth + 1] if sub
-        end
-      end
-
-      ordered
+      Boards::PredictiveLinkSet.collect(root, max_depth: MAX_DEPTH,
+                                              exclude: method(:excluded_fringe?))
     end
 
     def excluded_fringe?(board)
@@ -214,18 +195,12 @@ module Boards
       end
     end
 
-    # clone_with_images copies predictive_board_id verbatim, so a cloned folder
-    # tile points at the SOURCE sub-board. Translate every pointer to the cloned
-    # counterpart via the map. A pointer that leaves the set (out of depth, or a
-    # cycle target we didn't collect) is nulled — never leave a user tile opening
-    # an admin-owned board.
+    # Translate every cloned folder tile's pointer to its cloned counterpart.
+    # A pointer that leaves the set (out of depth, or a cycle target we didn't
+    # collect) is nulled — never leave a user tile opening an admin-owned board.
+    # (Shared with Boards::AssignmentCloner via PredictiveLinkSet.)
     def rewire_predictive_links!
-      @map.each_value do |cloned|
-        cloned.board_images.where.not(predictive_board_id: nil).find_each do |bi|
-          target = @map[bi.predictive_board_id]
-          bi.update!(predictive_board_id: target&.id)
-        end
-      end
+      Boards::PredictiveLinkSet.rewire!(@map, out_of_set: :null)
     end
 
     # Root counts as one board; every other board in the set is excluded from

--- a/spec/requests/api/child_accounts_assign_boards_spec.rb
+++ b/spec/requests/api/child_accounts_assign_boards_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+# Assignment deep-clone + per-communicator cap. Putting a board on a
+# communicator clones the board AND its linked sub-boards (rewired to the
+# clones), so the communicator's set is self-contained; the cap bounds how
+# many boards a dashboard can hold since assigned clones are uncounted
+# toward the owner's board limit.
+RSpec.describe "API::ChildAccounts assign_boards", type: :request do
+  let(:owner)        { create(:user, plan_type: "pro") }
+  let(:communicator) { create(:child_account, user: owner, status: ChildAccount::ACTIVE) }
+
+  def assign!(board_ids)
+    post "/api/child_accounts/#{communicator.id}/assign_boards",
+         params: { board_ids: board_ids },
+         headers: auth_headers(owner)
+  end
+
+  describe "deep clone" do
+    let!(:source_root) { create(:board, user: owner, name: "Home") }
+    let!(:source_sub)  { create(:board, user: owner, name: "Food") }
+
+    before do
+      tile = create(:board_image, board: source_root, image: create(:image, label: "Food"))
+      tile.update!(predictive_board_id: source_sub.id)
+    end
+
+    it "clones the board and its linked sub-boards, rewired to the clones" do
+      assign!([source_root.id])
+      expect(response).to have_http_status(:ok)
+
+      child_board = communicator.child_boards.find_by(original_board_id: source_root.id)
+      expect(child_board).to be_present
+
+      root_clone = child_board.board
+      folder = root_clone.board_images.where.not(predictive_board_id: nil).first
+      expect(folder.predictive_board_id).not_to eq(source_sub.id)
+
+      sub_clone = Board.find(folder.predictive_board_id)
+      expect(sub_clone.user_id).to eq(owner.id)
+      expect(sub_clone.is_template).to be true
+      expect(sub_clone.settings["assignment_root_id"]).to eq(root_clone.id)
+    end
+
+    it "does not change the owner's countable board count" do
+      expect { assign!([source_root.id]) }.not_to change { owner.reload.countable_board_count }
+    end
+  end
+
+  describe "assigned-board cap" do
+    let!(:board) { create(:board, user: owner, name: "One More") }
+
+    before { allow(ChildAccount).to receive(:max_assigned_boards).and_return(1) }
+
+    it "returns 422 assigned_board_limit at the cap" do
+      create(:child_board, board: create(:board, user: owner), child_account: communicator)
+
+      assign!([board.id])
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("assigned_board_limit")
+      expect(body["limit"]).to eq(1)
+      expect(body["count"]).to eq(1)
+    end
+
+    it "allows assignment under the cap" do
+      assign!([board.id])
+      expect(response).to have_http_status(:ok)
+      expect(communicator.child_boards.count).to eq(1)
+    end
+  end
+end

--- a/spec/requests/api/child_boards_handoff_removal_spec.rb
+++ b/spec/requests/api/child_boards_handoff_removal_spec.rb
@@ -83,6 +83,43 @@ RSpec.describe "API::ChildBoards non-destructive removal", type: :request do
     expect(response).to have_http_status(:ok)
   end
 
+  describe "orphan sweep of deep-cloned sub-templates" do
+    # Shape Boards::AssignmentCloner leaves behind: a root template on the
+    # dashboard whose folder tile opens a sub-template marked with the root id.
+    def build_assigned_set!(assigner)
+      root = create(:board, user: assigner, name: "Assigned Home", is_template: true)
+      sub  = create(:board, user: assigner, name: "Assigned Food", is_template: true,
+                            settings: { "assignment_child" => true, "assignment_root_id" => root.id })
+      tile = create(:board_image, board: root, image: create(:image, label: "Food"))
+      tile.update!(predictive_board_id: sub.id)
+      cb = create(:child_board, board: root, child_account: child_account)
+      [root, sub, cb]
+    end
+
+    it "sweeps the sub-templates when the root template is removed and deleted" do
+      root, sub, cb = build_assigned_set!(parent)
+
+      delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(Board.exists?(root.id)).to be(false)
+      expect(Board.exists?(sub.id)).to be(false)
+    end
+
+    it "spares a sub-template that another surface still references" do
+      root, sub, cb = build_assigned_set!(parent)
+      elsewhere = create(:board, user: parent, name: "Elsewhere")
+      external_tile = create(:board_image, board: elsewhere, image: create(:image, label: "link"))
+      external_tile.update!(predictive_board_id: sub.id)
+
+      delete "/api/child_boards/#{cb.id}", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:ok)
+      expect(Board.exists?(root.id)).to be(false)
+      expect(Board.exists?(sub.id)).to be(true)
+    end
+  end
+
   it "exposes can_remove on the dashboard boards for the communicator owner" do
     board = create(:board, user: slp, name: "Inherited", is_template: true)
     create(:child_board, board: board, child_account: child_account)

--- a/spec/services/boards/assignment_cloner_spec.rb
+++ b/spec/services/boards/assignment_cloner_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Boards::AssignmentCloner do
+  let(:slp)          { create(:user) }
+  let(:owner)        { create(:user) }
+  let(:communicator) { create(:child_account, user: owner) }
+
+  # SLP-authored set: root -> Food -> Snacks, plus a tile past the depth cap.
+  let!(:source_root) { create(:board, user: slp, name: "Home") }
+  let!(:source_food) { create(:board, user: slp, name: "Food") }
+
+  def link!(from_board, to_board, label:)
+    tile = create(:board_image, board: from_board, image: create(:image, label: label))
+    tile.update!(predictive_board_id: to_board.id)
+    tile
+  end
+
+  before do
+    create(:board_image, board: source_root, image: create(:image, label: "want"))
+    link!(source_root, source_food, label: "Food")
+    create(:board_image, board: source_food, image: create(:image, label: "apple"))
+  end
+
+  def call!
+    described_class.new(source_root, owner: owner, communicator: communicator,
+                                     voice: "echo", name: source_root.name).call
+  end
+
+  it "clones the root with the existing contract: is_template + ChildBoard on the communicator" do
+    root_clone = call!
+    expect(root_clone.user_id).to eq(owner.id)
+    expect(root_clone.is_template).to be true
+    expect(communicator.child_boards.where(board_id: root_clone.id, original_board_id: source_root.id)).to exist
+  end
+
+  it "deep-clones linked sub-boards and rewires the folder tiles to the clones" do
+    root_clone = call!
+    folder = root_clone.board_images.where.not(predictive_board_id: nil).first
+    expect(folder.predictive_board_id).not_to eq(source_food.id)
+
+    sub_clone = Board.find(folder.predictive_board_id)
+    expect(sub_clone.user_id).to eq(owner.id)
+    expect(sub_clone.name).to eq("Food")
+    expect(sub_clone.board_images.map(&:label)).to include("apple")
+  end
+
+  it "marks sub-clones as templates with assignment markers and NO ChildBoard rows" do
+    root_clone = call!
+    sub_clone = Board.find(root_clone.board_images.where.not(predictive_board_id: nil).first.predictive_board_id)
+
+    expect(sub_clone.is_template).to be true
+    expect(sub_clone.settings["assignment_child"]).to be true
+    expect(sub_clone.settings["assignment_root_id"]).to eq(root_clone.id)
+    expect(ChildBoard.where(board_id: sub_clone.id)).not_to exist
+  end
+
+  it "leaves a pointer past the depth cap on the source board (out_of_set: :keep)" do
+    snacks = create(:board, user: slp, name: "Snacks")
+    deep   = create(:board, user: slp, name: "Too Deep")
+    link!(source_food, snacks, label: "Snacks")
+    link!(snacks, deep, label: "Deep")
+    allow(described_class).to receive(:depth_cap).and_return(1)
+
+    root_clone = call!
+    food_clone = Board.find(root_clone.board_images.where.not(predictive_board_id: nil).first.predictive_board_id)
+    snacks_tile = food_clone.board_images.where.not(predictive_board_id: nil).first
+    # Food is at the cap, so its Snacks tile keeps pointing at the SOURCE board.
+    expect(snacks_tile.predictive_board_id).to eq(snacks.id)
+  end
+
+  it "does not change the owner's countable board count (clones are templates)" do
+    expect { call! }.not_to change { owner.reload.countable_board_count }
+  end
+
+  it "rolls back everything when a sub-board clone fails" do
+    allow_any_instance_of(Board).to receive(:clone_with_images).and_wrap_original do |m, *args, **kwargs|
+      m.receiver.name == "Food" ? nil : m.call(*args, **kwargs)
+    end
+
+    expect { call! }.to raise_error(described_class::CloneError)
+    expect(Board.where(user_id: owner.id)).to be_empty
+    expect(communicator.reload.child_boards).to be_empty
+  end
+end

--- a/spec/services/boards/predictive_link_set_spec.rb
+++ b/spec/services/boards/predictive_link_set_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Boards::PredictiveLinkSet do
+  let(:user) { create(:user) }
+
+  def link!(from_board, to_board, label: "folder")
+    tile = create(:board_image, board: from_board,
+                                image: create(:image, label: "#{label}-#{from_board.id}-#{to_board.id}"))
+    tile.update!(predictive_board_id: to_board.id)
+    tile
+  end
+
+  describe ".collect" do
+    it "walks predictive links breadth-first, root first, bounded by max_depth" do
+      root  = create(:board, user: user, name: "root")
+      mid   = create(:board, user: user, name: "mid")
+      deep  = create(:board, user: user, name: "deep")
+      past  = create(:board, user: user, name: "past-cap")
+      link!(root, mid)
+      link!(mid, deep)
+      link!(deep, past)
+
+      collected = described_class.collect(root, max_depth: 2)
+      expect(collected.first).to eq(root)
+      expect(collected).to contain_exactly(root, mid, deep)
+    end
+
+    it "is cycle-safe and collects a board reachable twice only once" do
+      root = create(:board, user: user, name: "root")
+      sub  = create(:board, user: user, name: "sub")
+      link!(root, sub)
+      link!(root, sub, label: "again")
+      link!(sub, root) # back-link cycle
+
+      collected = described_class.collect(root, max_depth: 3)
+      expect(collected).to contain_exactly(root, sub)
+    end
+
+    it "lets exclude veto non-root boards" do
+      root = create(:board, user: user, name: "root")
+      keep = create(:board, user: user, name: "keep")
+      skip = create(:board, user: user, name: "skip")
+      link!(root, keep)
+      link!(root, skip)
+
+      collected = described_class.collect(root, max_depth: 2,
+                                                exclude: ->(b) { b.name == "skip" })
+      expect(collected).to contain_exactly(root, keep)
+    end
+  end
+
+  describe ".rewire!" do
+    let(:source_root) { create(:board, user: user, name: "src root") }
+    let(:source_sub)  { create(:board, user: user, name: "src sub") }
+    let(:outside)     { create(:board, user: user, name: "outside") }
+
+    it "translates in-set pointers to the clones and nulls out-of-set pointers with :null" do
+      clone_root = create(:board, user: user, name: "clone root")
+      clone_sub  = create(:board, user: user, name: "clone sub")
+      in_set  = link!(clone_root, source_sub)
+      out_set = link!(clone_root, outside)
+
+      described_class.rewire!({ source_root.id => clone_root, source_sub.id => clone_sub },
+                              out_of_set: :null)
+
+      expect(in_set.reload.predictive_board_id).to eq(clone_sub.id)
+      expect(out_set.reload.predictive_board_id).to be_nil
+    end
+
+    it "keeps out-of-set pointers verbatim with :keep" do
+      clone_root = create(:board, user: user, name: "clone root")
+      out_set = link!(clone_root, outside)
+
+      described_class.rewire!({ source_root.id => clone_root }, out_of_set: :keep)
+
+      expect(out_set.reload.predictive_board_id).to eq(outside.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Re-lands #480 against `main`. #480 was accidentally merged into its stacked base branch (the already-merged #479 branch) instead of being retargeted to `main` first, so its changes never reached `main`. This is the identical commit rebased onto current `main` (which already contains #479). The revert PR #483 is unnecessary (it targeted the same dead branch) and has been closed.

Original description ↓

- **Deep-clone assignment.** `assign_boards`, `assign_accounts`, and the MySpeak starter attach now go through new `Boards::AssignmentCloner`: linked sub-boards are cloned too (depth cap `BOARD_ASSIGN_CLONE_DEPTH`, default 3) and folder tiles rewired to the clones. Fixes the shallow-clone bug where an assigned board's folder tiles kept opening the **source owner's live sub-boards**. Pointers past the depth cap stay verbatim.
- **Shared BFS+rewire.** Extracted `Boards::PredictiveLinkSet` (`collect` / `rewire!` with `:null`/`:keep` policies) from `SeededSetCloner`, which now delegates — its 22 existing specs pass unchanged.
- **Sub-clone contract.** Sub-clones are `is_template` (new `force_template:` kwarg), owned by the same user, **no ChildBoard rows**, marked `settings["assignment_child"]`/`["assignment_root_id"]`. Uncounted toward the board limit.
- **Orphan sweep.** Removing the root clone from a dashboard sweeps its sub-clones under the same never-delete-something-referenced guards.
- **Assign gate.** Per-communicator cap `MAX_ASSIGNED_BOARDS_PER_COMMUNICATOR` (default 80): `assign_boards` → 422 `assigned_board_limit`; `assign_accounts` → per-communicator `record_errors` message.
- Removed dead `Board#clone_and_update_predictive_board`.

## Test plan
Same as #480 (all specs unchanged, CI was green there): `predictive_link_set_spec`, `assignment_cloner_spec`, `child_accounts_assign_boards_spec`, extended `child_boards_handoff_removal_spec`, plus regression suites. CI will re-verify on this branch.

**Merge order:** this PR first, then #481 (already retargeted to stack on this branch — retarget it to `main` once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)