### PR TITLE
feat(api): include public_url in ChildAccount index_api_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — `public_url` on the communicator index payload
+- `ChildAccount#index_api_view` now includes `public_url` (the canonical
+  slug-based MySpeak URL, e.g. `/my/s-8bdsv4`). The user payload's
+  `communicator_accounts` use this lighter serializer, so the frontend
+  dashboards previously had no `public_url` and fell back to a
+  `/my/<username>` link that doesn't resolve. Now they show the same link as
+  the full `api_view` / ViewCommunicator screen. Frontend pairs with
+  itty-bitty-frontend (drops the username fallback).
+
 ### Added — Board Builder "replace existing set" option
 - Re-running the Board Builder for a communicator that already has a built
   set can now **replace** it (`replace=true`): the old set — root and all

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -1235,6 +1235,12 @@ class ChildAccount < ApplicationRecord
       # profile: profile&.api_view,
       week_chart: week_chart,
       avatar_url: profile&.avatar_url,
+      # Canonical MySpeak URL (profile-slug based, e.g. /my/s-8bdsv4). The
+      # dashboards read this off the user payload's communicator_accounts and
+      # must show the same link as the full api_view / ViewCommunicator screen.
+      # Without it the frontend used to fall back to /my/<username>, a slug that
+      # doesn't resolve for randomized safety slugs.
+      public_url: public_url,
       device_tag_url: device_tag_url,
       safety_id_url: safety_id_url,
       is_demo: is_demo?,

--- a/spec/models/child_account_status_spec.rb
+++ b/spec/models/child_account_status_spec.rb
@@ -91,5 +91,15 @@ RSpec.describe ChildAccount, "status lifecycle", type: :model do
       account = FactoryBot.create(:child_account, user: user, status: "loaner")
       expect(account.index_api_view[:status]).to eq("loaner")
     end
+
+    it "emits the canonical public_url so dashboards match the full api_view" do
+      account = FactoryBot.create(:child_account, user: user, username: "molly")
+      Profile.create!(profileable: account, username: "molly", slug: "s-8bdsv4")
+      account.reload
+
+      expect(account.index_api_view[:public_url]).to eq(account.public_url)
+      expect(account.index_api_view[:public_url]).to eq(account.api_view(user)[:public_url])
+      expect(account.index_api_view[:public_url]).to end_with("/my/s-8bdsv4")
+    end
   end
 end


### PR DESCRIPTION
## Summary

The user payload's `communicator_accounts` are serialized with the lighter `ChildAccount#index_api_view`, which omitted `public_url`. The frontend dashboards read that payload and, with no `public_url`, fell back to a `/my/<username>` link that **doesn't resolve** — the MySpeak slug is a randomized safety slug unrelated to the username (e.g. `/my/molly` vs the real `/my/s-8bdsv4` shown on the ViewCommunicator screen).

This adds `public_url` to `index_api_view` so dashboards can show the same canonical link as the full `api_view`.

Pairs with the frontend PR that drops the `/my/<username>` fallback (brittanyjohns/itty-bitty-frontend).

## Test plan

- Added a spec: `index_api_view[:public_url]` equals `api_view`'s and ends with `/my/<slug>`.
- `bundle exec rspec spec/models/child_account_status_spec.rb -e "index_api_view"` → **2 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)