### PR TITLE
fix: gate docs#update and organizations#update authorization (#469)

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -84,10 +84,20 @@ class API::DocsController < API::ApplicationController
 
   # PATCH/PUT /docs/1 or /docs/1.json
   def update
+    # Broken-access-control gate (#469): set_doc uses Doc.unscoped.find, so
+    # without this check any authenticated user could mutate any doc's content.
+    unless current_user&.can_edit?(@doc)
+      respond_to do |format|
+        format.html { redirect_back_or_to root_url, notice: "You do not have permission to edit this doc." }
+        format.json { render json: { error: "Unauthorized" }, status: :forbidden }
+      end
+      return
+    end
+
     respond_to do |format|
       if @doc.update(doc_params)
         format.html { redirect_to doc_url(@doc), notice: "Doc was successfully updated." }
-        format.json { render :show, status: :ok, location: @doc }
+        format.json { render json: @doc.api_view(current_user), status: :ok }
       else
         format.html { render :edit, status: :unprocessable_content }
         format.json { render json: @doc.errors, status: :unprocessable_content }

--- a/app/controllers/api/organizations_controller.rb
+++ b/app/controllers/api/organizations_controller.rb
@@ -1,6 +1,4 @@
 class API::OrganizationsController < API::ApplicationController
-  skip_before_action :authenticate_token!, only: %i[public]
-
   def show
     @organization = Organization.find(params[:id])
     render json: @organization
@@ -8,6 +6,13 @@ class API::OrganizationsController < API::ApplicationController
 
   def update
     @organization = Organization.find(params[:id])
+    # Broken-access-control gate (#469): only the org's admin_user (owner) or a
+    # site admin may mutate an organization. The endpoint is currently unrouted,
+    # but the gate must exist before it's ever wired up.
+    unless current_user&.admin? || @organization.admin_user_id == current_user&.id
+      render json: { error: "Unauthorized" }, status: :forbidden
+      return
+    end
     if @organization.update(organization_params)
       render json: @organization.api_view(current_user)
     else

--- a/spec/controllers/api/organizations_controller_spec.rb
+++ b/spec/controllers/api/organizations_controller_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+# Issue #469 (broken access control): API::OrganizationsController#update had no
+# ownership/admin gate. The endpoint is currently unrouted, so a temporary route
+# is drawn here to exercise the action directly and prove the gate rejects a
+# non-owner while owner/admin can still update.
+RSpec.describe API::OrganizationsController, type: :controller do
+  # The endpoint is unrouted in the real app; use an ISOLATED RouteSet so the
+  # temporary route doesn't clobber Rails.application.routes for the rest of the
+  # suite.
+  before do
+    @routes = ActionDispatch::Routing::RouteSet.new
+    @routes.draw { patch "api/organizations/:id" => "api/organizations#update" }
+  end
+
+  let!(:owner)      { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:admin)      { create(:admin_user) }
+  let!(:organization) { create(:organization, admin_user_id: owner.id, name: "Original") }
+
+  def authenticate(user)
+    request.headers["Authorization"] = "Bearer #{user.authentication_token}"
+  end
+
+  it "rejects a non-owner with 403 and does not mutate the organization" do
+    authenticate(other_user)
+    patch :update, params: { id: organization.id, organization: { name: "Hacked" } }, as: :json
+
+    expect(response).to have_http_status(:forbidden)
+    expect(organization.reload.name).to eq("Original")
+  end
+
+  it "rejects an unauthenticated request with 401" do
+    patch :update, params: { id: organization.id, organization: { name: "Hacked" } }, as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(organization.reload.name).to eq("Original")
+  end
+
+  it "lets the owner update the organization" do
+    authenticate(owner)
+    patch :update, params: { id: organization.id, organization: { name: "Renamed" } }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(organization.reload.name).to eq("Renamed")
+  end
+
+  it "lets a site admin update any organization" do
+    authenticate(admin)
+    patch :update, params: { id: organization.id, organization: { name: "Admin Renamed" } }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(organization.reload.name).to eq("Admin Renamed")
+  end
+end

--- a/spec/requests/api/docs_update_authorization_spec.rb
+++ b/spec/requests/api/docs_update_authorization_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+# Issue #469 (broken access control): API::DocsController#set_doc loads the doc
+# with `Doc.unscoped.find` and #update had no owner/admin gate, so any
+# authenticated user could mutate any doc's content. These specs prove the
+# non-owner path is now rejected (403) and the owner/admin paths still work,
+# and that the JSON success path renders instead of 500ing on a missing view.
+RSpec.describe "API::Docs#update authorization", type: :request do
+  let!(:owner)      { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:admin)      { create(:admin_user) }
+
+  let!(:doc) { create(:doc, user: owner, raw: "original") }
+
+  it "rejects a non-owner with 403 and does not mutate the doc" do
+    patch "/api/docs/#{doc.id}",
+          params: { doc: { raw: "hacked" } },
+          headers: auth_headers(other_user)
+
+    expect(response).to have_http_status(:forbidden)
+    expect(doc.reload.raw).to eq("original")
+  end
+
+  it "rejects an unauthenticated request with 401" do
+    patch "/api/docs/#{doc.id}", params: { doc: { raw: "hacked" } }
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(doc.reload.raw).to eq("original")
+  end
+
+  it "lets the owner update and renders JSON (no 500 on the success path)" do
+    patch "/api/docs/#{doc.id}",
+          params: { doc: { raw: "updated" } },
+          headers: auth_headers(owner)
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["id"]).to eq(doc.id)
+    expect(body["raw"]).to eq("updated")
+    expect(doc.reload.raw).to eq("updated")
+  end
+
+  it "lets an admin update any doc (cross-user access preserved)" do
+    patch "/api/docs/#{doc.id}",
+          params: { doc: { raw: "admin edit" } },
+          headers: auth_headers(admin)
+
+    expect(response).to have_http_status(:ok)
+    expect(doc.reload.raw).to eq("admin edit")
+  end
+end


### PR DESCRIPTION
Closes #469.

## Problem
Two update endpoints had **broken access control** (missing authorization), surfaced during the #27 mass-assignment audit — a different vuln class deliberately left out of #466/#468.

## Changes
**`API::DocsController#update`** (routed, live)
- `set_doc` loads via `Doc.unscoped.find`, so any authenticated user could edit **any** doc's content. Added an owner-or-admin gate (`current_user.can_edit?(@doc)`, the same helper `#move`/`#destroy` semantics rely on) → **403** for JSON, redirect for HTML.
- Fixed the JSON success path: it called `render :show`, which 500'd on a missing `app/views/api/docs` template. Now renders `Doc#api_view(current_user)`.

**`API::OrganizationsController#update`** (currently unrouted, latent)
- Added an owner (`admin_user_id`) or site-admin gate before update → **403** otherwise.
- Removed a dead `skip_before_action :authenticate_token!, only: %i[public]` that referenced a nonexistent `public` action (Rails 7.1 raises `ActionNotFound` on missing callback actions, so the controller couldn't even be exercised).

Per the invariant in CLAUDE.md, permission/plan gates use **403**; unauthenticated requests continue to 401 via the base controller.

## Test plan
New specs (both pass, and pass alongside route-dependent specs to confirm no route-set pollution):

- `spec/requests/api/docs_update_authorization_spec.rb` — non-owner → 403 (no mutation), unauthenticated → 401, owner → 200 + JSON body, admin → 200.
- `spec/controllers/api/organizations_controller_spec.rb` — uses an **isolated `ActionDispatch::Routing::RouteSet`** (endpoint is unrouted) to exercise the action: non-owner → 403 (no mutation), unauthenticated → 401, owner → 200, site-admin → 200.

```
bundle exec rspec spec/requests/api/docs_update_authorization_spec.rb \
  spec/controllers/api/organizations_controller_spec.rb
# 8 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)