### PR TITLE
fix(user): free_trial? excludes paid-plan users (#433)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1223,8 +1223,16 @@ class User < ApplicationRecord
 
   TRAIL_PERIOD = 14.days
 
+  # True only while the user is within the 14-day free signup window AND has
+  # NOT converted to a paid plan. Measures trial *state*, not raw account age:
+  # a user who paid within their first 14 days is no longer "on a free trial"
+  # (see #433). This matches how the frontend already treats the flag
+  # (`free_trial && !paid_plan` in useTrialStatus) and prevents a bogus trial
+  # countdown / free-dashboard misroute for new paying customers. `basic_trial`
+  # and Stripe `trialing` count as paid_plan?, so they're excluded here too.
   def free_trial?
     return true unless created_at
+    return false if paid_plan?
     created_at > TRAIL_PERIOD.ago
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -479,4 +479,36 @@ RSpec.describe User, type: :model do
       expect(user.reconcile_stranded_plan!).to be(false)
     end
   end
+
+  # #433 — free_trial? measures trial *state*, not raw account age. A user who
+  # converted to a paid plan within their first 14 days is no longer on a free
+  # trial.
+  describe "#free_trial?" do
+    it "is true for a free user within the 14-day signup window" do
+      user = FactoryBot.build(:user, plan_type: "free", created_at: 5.days.ago)
+      expect(user.free_trial?).to be(true)
+    end
+
+    it "is false for a free user past the 14-day window" do
+      user = FactoryBot.build(:user, plan_type: "free", created_at: 20.days.ago)
+      expect(user.free_trial?).to be(false)
+    end
+
+    it "is false for a paid (pro) user within the window — age is not trial state" do
+      user = FactoryBot.build(:user, plan_type: "pro", created_at: 5.days.ago)
+      expect(user.paid_plan?).to be(true)
+      expect(user.free_trial?).to be(false)
+    end
+
+    it "is false for a paid (basic) user within the window" do
+      user = FactoryBot.build(:user, plan_type: "basic", created_at: 5.days.ago)
+      expect(user.free_trial?).to be(false)
+    end
+
+    it "is false for a basic_trial user (paid_plan? treats the soft trial as paid)" do
+      user = FactoryBot.build(:user, plan_type: "basic_trial", created_at: 5.days.ago)
+      expect(user.paid_plan?).to be(true)
+      expect(user.free_trial?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`User#free_trial?` measured raw **account age**, not trial **state** — it returned `true` for any user in their first 14 days, including customers who **paid** within that window. Two concrete leaks:

- [`Home.tsx`](https://github.com/brittanyjohns/itty-bitty-frontend/blob/main/src/pages/Home.tsx) shows a "X days left" banner on raw `free_trial` → new paying customers saw a bogus trial countdown.
- [`dashboardPath.ts`](https://github.com/brittanyjohns/itty-bitty-frontend/blob/main/src/data/dashboardPath.ts) routes `free || free_trial` → `/free/dashboard` → a customer who paid within 14 days could land on the *free* dashboard.

This gates `free_trial?` on `!paid_plan?`, so it now means **"within the 14-day signup window AND not converted to a paid plan."**

## Why no frontend change is needed

The canonical [`useTrialStatus`](https://github.com/brittanyjohns/itty-bitty-frontend/blob/main/src/hooks/useTrialStatus.ts) hook already computes the trial banner as `free_trial && !paid_plan` — it was defensively filtering the paid case out. This change brings the raw backend flag in line with that treatment, so the direct consumers (`Home.tsx`, `dashboardPath.ts`) are corrected without touching the frontend.

## Scope

- **Only behavior change:** paid users within 14 days of signup now get `free_trial? == false` (was `true`) — a strict correction.
- `basic_trial` and Stripe `trialing` count as `paid_plan?`, so they're excluded too (consistent with existing gating).
- `can_sign_in?`'s non-paid branch (`user.free_trial?`) is **unchanged** — it's only reached by non-paid users, whom this doesn't touch.
- **Out of scope (per the issue's own deferral):** the disabled `can_sign_in?` plan-gate "time-bomb" (concern #2), and `trial_expired?` (= `!free_trial?`, unused in frontend UI; a paid user now reads `trial_expired: true` in admin debug views only).

## Test plan

- Added `spec/models/user_spec.rb` `#free_trial?` cases: free user <14d → true; free user >14d → false; **pro/basic user <14d → false**; `basic_trial` user <14d → false.
- `bundle exec rspec spec/models/user_spec.rb spec/requests/api/revenue_cat_webhook_spec.rb` → **91 examples, 0 failures**.

Closes #433