### PR TITLE
fix(assets): size safety-card/device-tag PDF page to the card, not A4

### DIFF
--- a/app/services/communicators/base_asset_generator.rb
+++ b/app/services/communicators/base_asset_generator.rb
@@ -73,12 +73,15 @@ module Communicators
     end
 
     def generate_pdf_from_html(html, width:, height:, scale: 2)
+      # The page must match the card's fixed pixel size — a paper format like
+      # A4 is narrower than the 1200px-wide art and shorter than the safety
+      # card, which spills the card onto a second page.
       grover = Grover.new(
         html,
-        format: "A4",
         viewport: { width: width, height: height },
+        width: "#{width}px",
+        height: "#{height}px",
         print_background: true,
-        prefer_css_page_size: true,
         scale: 1,
       )
       grover.to_pdf

--- a/spec/services/communicators/asset_pdf_page_size_spec.rb
+++ b/spec/services/communicators/asset_pdf_page_size_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+# The safety ID card is fixed 1200x1800px art. Rendering its PDF onto a paper
+# format (A4) clipped the width and spilled the card onto a second page — the
+# PDF page must be sized to the card itself and stay a single page.
+RSpec.describe Communicators::BaseAssetGenerator, "#generate_pdf_from_html" do
+  # The method never touches the profile, so no persisted records are needed.
+  let(:generator) { Communicators::GenerateSafetyIdCard.new(nil) }
+
+  it "sizes the PDF page to the rendered card instead of a paper format" do
+    fake_grover = instance_double(Grover, to_pdf: "%PDF-fake")
+    captured_opts = nil
+
+    expect(Grover).to receive(:new) do |_html, **opts|
+      captured_opts = opts
+      fake_grover
+    end
+
+    pdf = generator.send(:generate_pdf_from_html, "<html></html>", width: 1200, height: 1800)
+
+    expect(pdf).to eq("%PDF-fake")
+    expect(captured_opts[:width]).to eq("1200px")
+    expect(captured_opts[:height]).to eq("1800px")
+    expect(captured_opts[:viewport]).to eq(width: 1200, height: 1800)
+    expect(captured_opts).not_to have_key(:format)
+    expect(captured_opts[:print_background]).to be(true)
+  end
+end


### PR DESCRIPTION
## Summary
The per-communicator asset PDFs (safety ID card, device tag) were rendered onto a forced A4 page. A4 (~794×1123px @96dpi) is narrower than the 1200px-wide card art and much shorter than the 1200×1800 safety ID card, so a user's downloaded safety-card PDF overflowed onto a second page (the known follow-up documented in `.claude-notes/marketing-assets.md`).

`Communicators::BaseAssetGenerator#generate_pdf_from_html` now sizes the PDF page to the rendered card dimensions (`width`/`height` in px, no `format`), so each asset exports as one correctly-sized page. PNG output is unchanged. The AAC Classroom Kit sheets are unaffected (they use `Marketing::SheetRendering`, a separate Letter-format path).

This matters more now: the classroom-kit funnel is being pointed at "sign up free → get the personalized tags," so the personalized exports need to print cleanly.

## Test plan
- `bundle exec rspec spec/services/communicators/` — 5 examples, 0 failures (new spec asserts the Grover page options: px-sized page, no paper format; existing QR-override specs still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)