### PR TITLE
feat(marketing): free-account personalization CTA on kit tag sheets

### DIFF
--- a/app/views/marketing/device_tag_sheet.html.erb
+++ b/app/views/marketing/device_tag_sheet.html.erb
@@ -30,6 +30,14 @@
         text-transform: uppercase;
         color: #94a3b8;
       }
+      .personalize {
+        display: block;
+        margin-top: 3px;
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: 600;
+        color: #7c3aed;
+      }
 
       .tag {
         box-sizing: border-box;
@@ -61,7 +69,9 @@
   </head>
   <body>
     <div class="sheet">
-      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines</div>
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines
+        <span class="personalize">Make these personal &mdash; add a name, photo, and a live MySpeak QR with a free account at speakanyway.com</span>
+      </div>
       <% @card_count.times do %>
         <div class="tag">
           <div class="inner">

--- a/app/views/marketing/name_tag_sheet.html.erb
+++ b/app/views/marketing/name_tag_sheet.html.erb
@@ -44,6 +44,14 @@
         text-transform: uppercase;
         color: #94a3b8;
       }
+      .personalize {
+        display: block;
+        margin-top: 3px;
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: 600;
+        color: #7c3aed;
+      }
 
       .card {
         box-sizing: border-box;
@@ -118,7 +126,9 @@
   </head>
   <body>
     <div class="sheet">
-      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the card outlines</div>
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the card outlines
+        <span class="personalize">Make these personal &mdash; add a name, photo, and a live MySpeak QR with a free account at speakanyway.com</span>
+      </div>
       <% @card_count.times do %>
         <div class="card">
           <div class="brand-rule"></div>

--- a/app/views/marketing/safety_tag_sheet.html.erb
+++ b/app/views/marketing/safety_tag_sheet.html.erb
@@ -31,6 +31,14 @@
         text-transform: uppercase;
         color: #94a3b8;
       }
+      .personalize {
+        display: block;
+        margin-top: 3px;
+        text-transform: none;
+        letter-spacing: 0;
+        font-weight: 600;
+        color: #7c3aed;
+      }
 
       .tag {
         box-sizing: border-box;
@@ -79,7 +87,9 @@
   </head>
   <body>
     <div class="sheet">
-      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines</div>
+      <div class="cut-hint">&#9986; Print at 100% (actual size) &middot; cut along the dashed lines
+        <span class="personalize">Make these personal &mdash; add a name, photo, and a live MySpeak QR with a free account at speakanyway.com</span>
+      </div>
       <% @card_count.times do %>
         <div class="tag">
           <div class="inner">

--- a/spec/services/marketing/personalize_cta_spec.rb
+++ b/spec/services/marketing/personalize_cta_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+# The generic kit tag sheets carry a sheet-margin CTA pointing the printing
+# adult at the free-account personalized versions (name, photo, live MySpeak
+# QR). The line lives in the cut-away margin, not on the cut-out tags, and the
+# URL is printed text — never folded into the QR (see qr_scannability_spec).
+RSpec.describe "Marketing tag sheets — personalize CTA" do
+  let(:rendered_html) { [] }
+
+  before do
+    fake_grover = instance_double(Grover, to_pdf: "%PDF-fake")
+    allow(Grover).to receive(:new) do |html, **_opts|
+      rendered_html << html
+      fake_grover
+    end
+  end
+
+  [Marketing::SafetyTagSheet, Marketing::DeviceTagSheet, Marketing::NameTagSheet].each do |sheet_class|
+    it "#{sheet_class.name.demodulize} includes the free-account personalization line" do
+      sheet_class.new.to_pdf
+
+      expect(rendered_html.last).to include("free account at speakanyway.com")
+      expect(rendered_html.last).to include("MySpeak")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Part of pointing the classroom-kit funnel at "sign up free → get personalized tags." The three generic kit tag sheets (`safety_tag_sheet`, `device_tag_sheet`, `name_tag_sheet`) now carry one consistent line in the sheet margin, styled to match the existing print hint:

> Make these personal — add a name, photo, and a live MySpeak QR with a free account at speakanyway.com

Placement decisions:
- **Sheet margin, not the tags** — the CTA targets the printing adult and is trimmed away when the tags are cut out, so a child's backpack tag stays clean.
- **Printed text only, never the QR** — the QR payload is untouched; the scannability rule (short URL, ECC `:m`) stays guarded by `qr_scannability_spec`.
- Bare `speakanyway.com` per brand rules.

## After merge
The hosted kit PDF needs regeneration (printables repo `npm run build-kit` → re-POST to `/api/internal/marketing_assets`) for the live `KIT_DOWNLOAD_URL` bundle to pick this up — flagging rather than doing here.

## Test plan
- `bundle exec rspec spec/services/marketing/` — 15 examples, 0 failures (3 new CTA specs + existing QR scannability suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)