### PR TITLE
feat(teams): team permissions overhaul — authz lockdown, 4-tier roles, structured errors

### DIFF
--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -1,6 +1,11 @@
 class API::ChildAccountsController < API::ApplicationController
   before_action :set_child_account, only: %i[ show update destroy promote_to_loaner lend claim_link send_claim_link end_loan archive unarchive assign_boards send_setup_email ]
-  before_action :authorize_communicator_edit!, only: %i[ update assign_boards send_setup_email ]
+  # Editing the communicator object (name/username/voice/settings) and the
+  # setup email stay owner-only. Assigning boards to the dashboard is a
+  # curation action, so it uses the looser curate gate below (supervisors
+  # and admins can assign, matching `can_edit` in the serializer).
+  before_action :authorize_communicator_edit!, only: %i[ update send_setup_email ]
+  before_action :authorize_communicator_curate!, only: %i[ assign_boards ]
   # Claim preview is the parent's "this is what you're about to claim"
   # page — they may not be signed in yet, so it runs token-only.
   skip_before_action :authenticate_token!, only: %i[ claim_preview ]
@@ -572,9 +577,24 @@ class API::ChildAccountsController < API::ApplicationController
   def authorize_communicator_edit!
     return if @child_account.editable_by?(current_user)
 
-    render json: account_error_payload("not_owner").merge(
+    render json: account_error_payload("not_authorized").merge(
       message: "Only the owner can edit this communicator.",
     ), status: :forbidden
+  end
+
+  # Curation gate for board assignment: the account owner, a team
+  # supervisor, or a system admin may add boards to the communicator's
+  # dashboard (`can_add_boards_to_account?`). This matches the `can_edit`
+  # flag in the serializer and the ChildBoard curate path — owner-only here
+  # would contradict the UI. Plan is intentionally NOT checked: a
+  # free/cancelled supervisor still curates per decision 3.
+  def authorize_communicator_curate!
+    return if current_user.can_add_boards_to_account?([@child_account.id])
+
+    render json: {
+      error: "not_authorized",
+      message: "Only the account owner or a team supervisor can add boards to this dashboard.",
+    }, status: :forbidden
   end
 
   # Lending / hand-off is a Pro-only feature. The frontend already hides

--- a/app/controllers/api/team_accounts_controller.rb
+++ b/app/controllers/api/team_accounts_controller.rb
@@ -12,15 +12,22 @@ class API::TeamAccountsController < API::ApplicationController
   end
 
   def create
-    @team_account = TeamAccount.new
     @team = Team.find(params[:team_id])
-    @team_account.team = @team
-    @team_account.account = ChildAccount.find(params[:account_id])
+    @child_account = ChildAccount.find(params[:account_id])
+
+    unless authorized_to_attach?(@team, @child_account)
+      return render json: {
+        error: "not_authorized",
+        message: "You can only add communicators you own to teams you manage.",
+      }, status: :forbidden
+    end
+
+    @team_account = TeamAccount.new(team: @team, account: @child_account)
 
     respond_to do |format|
       if @team_account.save
         @team.reload
-        format.json { render json: @team.show_api_view, status: :created }
+        format.json { render json: @team.show_api_view(current_user), status: :created }
       else
         format.json { render json: @team_account.errors, status: :unprocessable_content }
       end
@@ -28,15 +35,14 @@ class API::TeamAccountsController < API::ApplicationController
   end
 
   # PATCH/PUT /team_accounts/1 or /team_accounts/1.json
+  #
+  # Only mutable settings (`active`, `settings`) are updatable — reassigning
+  # `team_id`/`child_account_id` is blocked by strong params (Phase 0).
   def update
-    respond_to do |format|
-      if @team_account.update(team_account_params)
-        format.html { redirect_to team_account_url(@team_account), notice: "TeamAccount was successfully updated." }
-        format.json { render :show, status: :ok, location: @team_account }
-      else
-        format.html { render :edit, status: :unprocessable_content }
-        format.json { render json: @team_account.errors, status: :unprocessable_content }
-      end
+    if @team_account.update(team_account_params)
+      render json: @team_account.team.show_api_view(current_user), status: :ok
+    else
+      render json: @team_account.errors, status: :unprocessable_content
     end
   end
 
@@ -51,13 +57,28 @@ class API::TeamAccountsController < API::ApplicationController
 
   private
 
+  # To attach a communicator to a team the caller must OWN the communicator
+  # (owner_id) or be a sysadmin, AND manage the target team (its creator or
+  # an admin-role member). Phase 0 — previously any user could attach any
+  # communicator to any team.
+  def authorized_to_attach?(team, child_account)
+    return true if current_user.admin?
+    return false unless child_account.owner_id == current_user.id
+
+    team.created_by_id == current_user.id ||
+      team.team_users.where(user_id: current_user.id, role: "admin").exists?
+  end
+
   # Use callbacks to share common setup or constraints between actions.
   def set_team_account
     @team_account = policy_scope(TeamAccount).find(params[:id])
   end
 
-  # Only allow a list of trusted parameters through.
+  # Only allow a list of trusted parameters through. `team_id` and
+  # `child_account_id` are intentionally NOT permitted — reassigning a
+  # team_account to a different team or communicator is an ownership change
+  # that must go through create/destroy, not a mass-assignment update.
   def team_account_params
-    params.require(:team_account).permit(:team_id, :child_account_id)
+    params.require(:team_account).permit(:active, :settings)
   end
 end

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,6 +1,9 @@
 class API::TeamsController < API::ApplicationController
   before_action :set_team, only: %i[ show edit update destroy remove_board invite ]
-  before_action :authorize_team_member!, only: %i[ create_board ]
+  before_action :authorize_team_read!, only: %i[ show ]
+  before_action :authorize_team_manage!, only: %i[ update destroy invite remove_member ]
+  before_action :authorize_remove_board!, only: %i[ remove_board ]
+  before_action :authorize_team_library_writer!, only: %i[ create_board ]
   # after_action :verify_policy_scoped, only: :index
 
   # GET /teams or /teams.json
@@ -42,25 +45,40 @@ class API::TeamsController < API::ApplicationController
 
   def invite
     user_email = team_user_params[:email]
-    user_role = invite_role
-    @team = Team.find(params[:id])
+    # Raw requested role — the owner-pin / self-promote guards below inspect
+    # the requested value (including "admin") so they can return their
+    # specific errors before the invite-role validation rejects it.
+    requested_role = params.dig(:team_user, :role).to_s
 
     # Block role-change of an existing owner-pinned member, and block
-    # self-promotion to admin by non-owners. See issue #166.
+    # self-promotion to admin by non-owners. See issue #166. These run
+    # before role validation so the specific 403 wins over a generic 422.
     existing_user = User.find_by(email: user_email)
     if existing_user
       existing_membership = TeamUser.find_by(user_id: existing_user.id, team_id: @team.id)
-      if existing_membership && existing_membership.role != user_role
+      if existing_membership && existing_membership.role != requested_role
         if @team.account_owner?(existing_user) && existing_user != current_user
           return render_team_permission_error("cannot_change_owner_role",
                                               "You cannot change the role of the communicator's owner.")
         end
-        if existing_user == current_user && user_role == "admin" &&
+        if existing_user == current_user && requested_role == "admin" &&
            !current_user.admin? && !@team.account_owner?(current_user)
           return render_team_permission_error("cannot_self_promote",
                                               "You cannot promote yourself to admin.")
         end
       end
+    end
+
+    # Validate the invite role: only supervisor / member / restricted may be
+    # granted via invite. "admin" is the owner's role (never invited) and any
+    # junk value is rejected — no silent coercion (Phase 2).
+    user_role = invite_role(requested_role)
+    unless user_role
+      return render_team_permission_error(
+        "invalid_role",
+        "Role must be one of supervisor, member, or restricted.",
+        :unprocessable_content,
+      )
     end
 
     @user = User.invite_new_user_to_team!(user_email, current_user, @team, user_role)
@@ -97,6 +115,16 @@ class API::TeamsController < API::ApplicationController
 
   # POST /teams or /teams.json
   def create
+    # Hosting a team is a Pro (owner-side) feature — decision 3: the owner's
+    # plan hosts the team, members participate per role regardless of plan.
+    # Free-trial owners pass, consistent with the rest of the app.
+    unless current_user.paid_plan? || current_user.free_trial?
+      return render_team_permission_error(
+        "pro_required",
+        "Creating a team is a Pro feature. Upgrade to build a care team.",
+      )
+    end
+
     @team = Team.new
     # @team.name = team_params[:name]&.upcase
     @team.name = team_params[:name]
@@ -126,8 +154,15 @@ class API::TeamsController < API::ApplicationController
   def accept_invite_patch
     @team = Team.find(params[:id])
     @user = User.find_by(email: team_user_params[:email])
-    @team_user = TeamUser.find_by(user_id: @user.id, team_id: @team.id)
+    @team_user = TeamUser.find_by(user_id: @user&.id, team_id: @team.id)
+    unless @team_user
+      return render json: {
+        error: "not_a_team_member",
+        message: "No pending invitation was found for this account on this team.",
+      }, status: :not_found
+    end
     @team_user.accept_invitation!
+    render json: @team.show_api_view(@user), status: :ok
   end
 
   def create_board
@@ -152,7 +187,7 @@ class API::TeamsController < API::ApplicationController
     respond_to do |format|
       if @team.update(team_params)
         format.html { redirect_to team_url(@team), notice: "Team was successfully updated." }
-        format.json { render :show, status: :ok, location: @team }
+        format.json { render json: @team.show_api_view(current_user), status: :ok }
       else
         format.html { render :edit, status: :unprocessable_content }
         format.json { render json: @team.errors, status: :unprocessable_content }
@@ -171,8 +206,8 @@ class API::TeamsController < API::ApplicationController
 
   private
 
-  def render_team_permission_error(error_key, message)
-    render json: { error: error_key, message: message }, status: :forbidden
+  def render_team_permission_error(error_key, message, status = :forbidden)
+    render json: { error: error_key, message: message }, status: status
   end
 
   # Use callbacks to share common setup or constraints between actions.
@@ -181,14 +216,52 @@ class API::TeamsController < API::ApplicationController
     @team = Team.with_artifacts.find(params[:id])
   end
 
-  # Any team member (admin, supervisor, member) — or a system admin —
-  # may add boards to the team's library. Non-members get 403. Issue
-  # #216 — closes the gap where any signed-in user could write to any
-  # team's `team_boards`.
-  def authorize_team_member!
+  # True when the caller can MANAGE the team: rename, delete, invite, or
+  # remove members. That's the team owner (creator), any communicator
+  # account owner on the team, or a system admin. Phase 0 lockdown.
+  def can_manage_team?
+    current_user.admin? ||
+      @team.created_by_id == current_user.id ||
+      @team.account_owner?(current_user)
+  end
+
+  # READ access to the team (show): members only — don't leak other teams.
+  # Any membership role (including restricted) can view; owners/admins too.
+  def authorize_team_read!
+    @team ||= Team.with_artifacts.find(params[:id])
+    return if can_manage_team?
+    return if @team.team_users.where(user_id: current_user.id).exists?
+    render_team_permission_error("not_a_team_member",
+                                 "You must be on this team to view it.")
+  end
+
+  # MANAGE gate for update/destroy/invite/remove_member. Phase 0 closed the
+  # hole where any authenticated user could mutate any team.
+  def authorize_team_manage!
+    @team ||= Team.with_artifacts.find(params[:id])
+    return if can_manage_team?
+    render_team_permission_error("not_authorized",
+                                 "Only the account owner or team owner can manage this team.")
+  end
+
+  # remove_board: curate roles (admin/supervisor) or the team owner /
+  # account owner / sysadmin.
+  def authorize_remove_board!
+    @team ||= Team.with_artifacts.find(params[:id])
+    return if can_manage_team?
+    return if @team.team_users.where(user_id: current_user.id, role: User::CURATE_ROLES).exists?
+    render_team_permission_error("not_authorized",
+                                 "Only a supervisor or the team owner can remove boards from this team.")
+  end
+
+  # Any team member allowed to WRITE the team library (admin, supervisor,
+  # member) — or a system admin — may add boards to the team's library.
+  # `restricted` (read-only) and non-members get 403. Issue #216 — closes
+  # the gap where any signed-in user could write to any team's `team_boards`.
+  def authorize_team_library_writer!
     @team = Team.with_artifacts.find(params[:id])
     return if current_user.admin?
-    return if @team.team_users.where(user_id: current_user.id, role: TeamUser::ROLES).exists?
+    return if @team.team_users.where(user_id: current_user.id, role: TeamUser::LIBRARY_ROLES).exists?
     render_team_permission_error("not_a_team_member",
                                  "You must be on this team to add boards to it.")
   end
@@ -197,9 +270,14 @@ class API::TeamsController < API::ApplicationController
     params.require(:team_user).permit(:email)
   end
 
-  def invite_role
-    role = params.dig(:team_user, :role).to_s
-    TeamUser::ROLES.include?(role) ? role : "member"
+  # Invitable roles only — "admin" is the owner's role (never invited). Any
+  # value outside supervisor|member|restricted returns nil so the caller can
+  # render a 422 instead of silently coercing to member (Phase 2).
+  INVITABLE_ROLES = %w[supervisor member restricted].freeze
+
+  def invite_role(raw_role = nil)
+    role = (raw_role || params.dig(:team_user, :role)).to_s
+    INVITABLE_ROLES.include?(role) ? role : nil
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,4 +1,7 @@
 class API::TeamsController < API::ApplicationController
+  # `accept_invite` is the pre-sign-in invite preview landing page — it must
+  # work without a token, validated instead by the invite uuid in the URL.
+  skip_before_action :authenticate_token!, only: %i[ accept_invite ]
   before_action :set_team, only: %i[ show edit update destroy remove_board invite ]
   before_action :authorize_team_read!, only: %i[ show ]
   before_action :authorize_team_manage!, only: %i[ update destroy invite remove_member ]
@@ -145,24 +148,56 @@ class API::TeamsController < API::ApplicationController
     end
   end
 
+  # GET /api/teams/:id/accept_invite?token=<uuid>
+  #
+  # Public invite-preview for the pre-sign-in landing page. Identity is
+  # established SOLELY by matching the `token` against the invited user's
+  # `uuid` — never by an email param. Returns a masked-email preview so the
+  # landing page can say "you were invited to <team> as <role>". 404 (with a
+  # structured error) if the team/token/membership don't line up, so we never
+  # leak whether a given team or email exists.
   def accept_invite
-    @team = Team.find(params[:id])
-    @user = User.find_by(email: params[:email])
-    @team_user = TeamUser.find_by(user_id: @user.id, team_id: @team.id)
-  end
+    team = Team.find_by(id: params[:id])
+    invited_user = User.find_by(uuid: params[:token].to_s) if params[:token].present?
+    membership = TeamUser.find_by(user_id: invited_user.id, team_id: team.id) if team && invited_user
 
-  def accept_invite_patch
-    @team = Team.find(params[:id])
-    @user = User.find_by(email: team_user_params[:email])
-    @team_user = TeamUser.find_by(user_id: @user&.id, team_id: @team.id)
-    unless @team_user
+    unless membership
       return render json: {
-        error: "not_a_team_member",
-        message: "No pending invitation was found for this account on this team.",
+        error: "invite_not_found",
+        message: "This invitation link is invalid or has expired.",
       }, status: :not_found
     end
-    @team_user.accept_invitation!
-    render json: @team.show_api_view(@user), status: :ok
+
+    render json: {
+      team_name: team.name,
+      invited_by_name: team.created_by&.display_name,
+      role: membership.role,
+      email: masked_email(invited_user.email),
+    }, status: :ok
+  end
+
+  # PATCH /api/teams/:id/accept_invite_patch?token=<uuid>
+  #
+  # Authenticated acceptance. Identity is `current_user` (never the email
+  # param — a spoofed email is ignored). The URL `token` must match
+  # `current_user.uuid`, so following someone else's invite link while signed
+  # in as a different account is rejected. Structured errors only, never 500.
+  def accept_invite_patch
+    team = Team.find_by(id: params[:id])
+    return render_invite_not_found unless team
+
+    membership = TeamUser.find_by(user_id: current_user.id, team_id: team.id)
+    return render_invite_not_found unless membership
+
+    if params[:token].to_s != current_user.uuid.to_s
+      return render json: {
+        error: "invite_token_mismatch",
+        message: "This invitation was issued to a different account. Sign in as the invited user to accept it.",
+      }, status: :forbidden
+    end
+
+    membership.accept_invitation!
+    render json: team.show_api_view(current_user), status: :ok
   end
 
   def create_board
@@ -208,6 +243,24 @@ class API::TeamsController < API::ApplicationController
 
   def render_team_permission_error(error_key, message, status = :forbidden)
     render json: { error: error_key, message: message }, status: status
+  end
+
+  def render_invite_not_found
+    render json: {
+      error: "not_a_team_member",
+      message: "No pending invitation was found for your account on this team.",
+    }, status: :not_found
+  end
+
+  # "brittany@example.com" -> "b*******@example.com". Keeps the domain (so the
+  # invitee recognizes their own address) while not exposing the full local
+  # part on the public preview endpoint.
+  def masked_email(email)
+    return nil if email.blank?
+    local, domain = email.split("@", 2)
+    return email if domain.blank?
+    masked_local = local.length <= 1 ? "#{local}*" : "#{local[0]}#{'*' * (local.length - 1)}"
+    "#{masked_local}@#{domain}"
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -89,6 +89,14 @@ class Team < ApplicationRecord
     account_owner_ids.include?(user.id)
   end
 
+  # The viewing user's team-membership role (admin/supervisor/member/
+  # restricted), or nil if they aren't a member. Exposed so the frontend
+  # doesn't have to derive role by email-matching the members array.
+  def role_for(user)
+    return nil unless user
+    team_users.detect { |tu| tu.user_id == user.id }&.role
+  end
+
   def index_api_view(viewing_user = nil)
     owner_ids = account_owner_ids
     {
@@ -97,6 +105,7 @@ class Team < ApplicationRecord
       created_by_id: created_by_id,
       created_by_name: created_by&.name,
       created_by_email: created_by&.email,
+      current_user_role: role_for(viewing_user),
       account_owner_ids: owner_ids,
       members: team_users.includes(:user).map { |tu|
         { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
@@ -118,6 +127,7 @@ class Team < ApplicationRecord
       can_edit: viewing_user&.can_add_boards_to_account?(account_ids),
       can_invite: viewing_user && viewing_user.id == created_by_id,
       is_owner: viewing_user && viewing_user.id == created_by_id,
+      current_user_role: role_for(viewing_user),
       created_by_id: created_by_id,
       created_by_name: created_by&.name,
       created_by_email: created_by&.email,

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -15,19 +15,26 @@
 class TeamUser < ApplicationRecord
   # Canonical role set (issue #216). Permissions matrix lives in
   # marketing/.claude-notes/handoff-workflow.md:
-  #   admin      — account owner; full curation + member management.
+  #   admin      — team owner; full curation + member management.
   #   supervisor — power collaborator (SLP). Can curate boards on the
-  #                communicator but cannot edit the communicator object
-  #                or delete the account.
-  #   member     — read-only on the communicator; can add boards to the
-  #                team library but cannot assign them.
-  ROLES = %w[admin supervisor member].freeze
+  #                communicator (assign to the dashboard) but cannot edit
+  #                the communicator object or delete the account.
+  #   member     — "Support": can add boards to the team library but cannot
+  #                assign them to a communicator.
+  #   restricted — "Read-Only": view the team only. No library writes, no
+  #                curation.
+  ROLES = %w[admin supervisor member restricted].freeze
+
+  # Roles allowed to WRITE to the team's board library (`create_board`).
+  # `restricted` is read-only and excluded. `admin` is the team owner's
+  # role and is only ever set server-side (never via invite).
+  LIBRARY_ROLES = %w[admin supervisor member].freeze
 
   belongs_to :user
   belongs_to :team
 
   before_validation :set_defaults, on: :create
-  validates :role, inclusion: { in: ROLES, message: "must be admin, supervisor, or member" }
+  validates :role, inclusion: { in: ROLES, message: "must be admin, supervisor, member, or restricted" }
   before_destroy :snapshot_shared_boards_to_family
 
   # Safety net for the SLP→family hand-off (B6 — issue #162). When this
@@ -60,7 +67,7 @@ class TeamUser < ApplicationRecord
   end
 
   def self.roles
-    { "admin" => "Admin", "supervisor" => "Supervisor", "member" => "Member" }
+    { "admin" => "Admin", "supervisor" => "Supervisor", "member" => "Support", "restricted" => "Read-Only" }
   end
 
   # True if this user is the owner of any child_account on the team. Used

--- a/app/policies/team_account_policy.rb
+++ b/app/policies/team_account_policy.rb
@@ -1,0 +1,52 @@
+class TeamAccountPolicy < ApplicationPolicy
+  # Scope: team_accounts whose team the user belongs to, OR whose
+  # child_account the user owns. Admins see all. Phase 0 — the controller
+  # relied on this policy but it never existed, so `policy_scope(TeamAccount)`
+  # raised Pundit::NotDefinedError at runtime.
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      return scope.none unless user
+      return scope.all if user.admin?
+
+      member_team_ids = TeamUser.where(user_id: user.id).select(:team_id)
+      owned_account_ids = ChildAccount.where(owner_id: user.id).select(:id)
+
+      scope.where(team_id: member_team_ids)
+           .or(scope.where(child_account_id: owned_account_ids))
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+
+  def show?
+    return true if user&.admin?
+    on_users_team? || owns_account?
+  end
+
+  def update?
+    show?
+  end
+
+  def destroy?
+    show?
+  end
+
+  private
+
+  def on_users_team?
+    return false unless user
+    record.team.team_users.where(user_id: user.id).exists?
+  end
+
+  def owns_account?
+    return false unless user
+    record.account&.owner_id == user.id
+  end
+end

--- a/db/migrate/20260711120000_remap_stray_admin_team_users_to_supervisor.rb
+++ b/db/migrate/20260711120000_remap_stray_admin_team_users_to_supervisor.rb
@@ -1,0 +1,30 @@
+class RemapStrayAdminTeamUsersToSupervisor < ActiveRecord::Migration[8.0]
+  # Safety sweep (Phase 2). `admin` is now strictly the team owner's role.
+  # Any team_user carrying role `admin` who is neither the team creator nor a
+  # communicator account owner on that team is a stray from the old model and
+  # is remapped to `supervisor` (the closest curate role). No users are on
+  # teams yet, so this is expected to touch ~0 rows.
+  def up
+    remapped = 0
+
+    TeamUser.where(role: "admin").includes(team: :team_accounts).find_each do |tu|
+      team = tu.team
+      next if team.nil?
+      next if team.created_by_id == tu.user_id
+      next if team.account_owner?(tu.user)
+
+      tu.update_columns(role: "supervisor", updated_at: Time.current)
+      remapped += 1
+    end
+
+    say "Remapped #{remapped} stray admin team_user(s) to supervisor"
+  end
+
+  def down
+    # Not reversibly restorable — the pre-migration role of a remapped row
+    # isn't recorded (it was uniformly `admin`), and blindly promoting every
+    # supervisor back to admin would corrupt legitimately-supervisor rows.
+    # A no-op keeps the migration reversible-safe without destroying data.
+    say "RemapStrayAdminTeamUsersToSupervisor is not reversible; no changes made"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_10_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"

--- a/lib/tasks/team_roles.rake
+++ b/lib/tasks/team_roles.rake
@@ -8,7 +8,6 @@ namespace :team_roles do
   ROLE_FOLD = {
     "professional" => "admin",     # creator-add path; always the account owner
     "supporter"    => "member",    # never landed in prod (default arg for add_member!)
-    "restricted"   => "member",    # read access preserved; curate access dropped
   }.freeze
 
   desc "Print every team_users row that would be rewritten by team_roles:normalize"
@@ -30,7 +29,7 @@ namespace :team_roles do
     puts "By source role: #{summary.inspect}"
   end
 
-  desc "Rewrite stale team_users.role values to the canonical set (admin/supervisor/member)"
+  desc "Rewrite stale team_users.role values to the canonical set (admin/supervisor/member/restricted)"
   task normalize: :environment do
     updated = 0
     skipped = 0

--- a/spec/lib/tasks/team_roles_rake_spec.rb
+++ b/spec/lib/tasks/team_roles_rake_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe "team_roles rake tasks", type: :task do
       expect(tu.reload.role).to eq("member")
     end
 
-    it "rewrites restricted -> member" do
+    it "leaves restricted untouched (canonical since the 4-tier overhaul)" do
       tu = insert_team_user_with_role("restricted")
       silent { normalize.invoke }
-      expect(tu.reload.role).to eq("member")
+      expect(tu.reload.role).to eq("restricted")
     end
 
     it "rewrites unknown values -> member (defensive)" do

--- a/spec/models/team_user_spec.rb
+++ b/spec/models/team_user_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-# Issue #216 — `team_users.role` is locked to the canonical set
-# `%w[admin supervisor member]`. Permissions matrix:
+# Issue #216 / team permissions overhaul — `team_users.role` is locked to the
+# canonical set `%w[admin supervisor member restricted]`. Permissions matrix:
 # marketing/.claude-notes/handoff-workflow.md.
 RSpec.describe TeamUser, type: :model do
   let(:owner) { create(:user, created_at: 2.months.ago) }
@@ -19,7 +19,7 @@ RSpec.describe TeamUser, type: :model do
       end
     end
 
-    %w[professional supporter restricted slp parent foo].each do |stale|
+    %w[professional supporter slp parent foo].each do |stale|
       it "rejects #{stale.inspect}" do
         user = create(:user, created_at: 2.months.ago)
         tu = TeamUser.new(team: team, user: user, role: stale)

--- a/spec/requests/api/child_accounts_controller_spec.rb
+++ b/spec/requests/api/child_accounts_controller_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Phase 1 — supervisors (and account owners / sysadmins) may assign boards
+# to a communicator's dashboard, while editing the communicator object stays
+# owner-only. Auth failures use the structured { error, message } body with
+# 403. See .claude-notes/team-permissions-overhaul-handoff.md.
+RSpec.describe "API::ChildAccounts#assign_boards permissions", type: :request do
+  let(:owner)      { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:supervisor) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:member)     { create(:user, created_at: 2.months.ago) }
+  let(:restricted) { create(:user, created_at: 2.months.ago) }
+  let(:stranger)   { create(:user, created_at: 2.months.ago) }
+  let(:sysadmin)   { create(:admin_user) }
+
+  let!(:communicator) do
+    create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE)
+  end
+
+  let!(:team) do
+    t = Team.create!(name: "Care Team", created_by: owner)
+    TeamAccount.create!(team: t, account: communicator)
+    t.upsert_member!(owner, "admin")
+    t.upsert_member!(supervisor, "supervisor")
+    t.upsert_member!(member, "member")
+    t.upsert_member!(restricted, "restricted")
+    t
+  end
+
+  let!(:board) { create(:board, user: owner, name: "Snack Time") }
+
+  def assign!(user)
+    post "/api/child_accounts/#{communicator.id}/assign_boards",
+         params: { board_ids: [board.id] },
+         headers: auth_headers(user)
+  end
+
+  it "lets the account owner assign boards" do
+    assign!(owner)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "lets a team supervisor assign boards to the dashboard" do
+    expect { assign!(supervisor) }.to change { communicator.reload.child_boards.count }.by(1)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "lets a system admin assign boards" do
+    assign!(sysadmin)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "blocks a plain member (Support role) with 403 and the structured body" do
+    expect { assign!(member) }.not_to change { communicator.reload.child_boards.count }
+    expect(response).to have_http_status(:forbidden)
+    body = JSON.parse(response.body)
+    expect(body["error"]).to eq("not_authorized")
+    expect(body["message"]).to eq(
+      "Only the account owner or a team supervisor can add boards to this dashboard.",
+    )
+  end
+
+  it "blocks a restricted (Read-Only) member (403)" do
+    expect { assign!(restricted) }.not_to change { communicator.reload.child_boards.count }
+    expect(response).to have_http_status(:forbidden)
+    expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+  end
+
+  it "blocks a stranger who isn't on the team (403)" do
+    expect { assign!(stranger) }.not_to change { communicator.reload.child_boards.count }
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  describe "decision 3 — plan is not gated on the supervisor" do
+    it "lets a FREE (unpaid) supervisor assign boards" do
+      free_supervisor = create(:user, plan_type: "free", created_at: 1.year.ago)
+      team.upsert_member!(free_supervisor, "supervisor")
+
+      assign!(free_supervisor)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lets a CANCELLED-plan supervisor assign boards" do
+      cancelled_supervisor = create(:user, plan_type: "pro", plan_status: "canceled",
+                                           created_at: 1.year.ago)
+      expect(cancelled_supervisor.paid_plan?).to be(false)
+      team.upsert_member!(cancelled_supervisor, "supervisor")
+
+      assign!(cancelled_supervisor)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "editing the communicator object stays owner-only" do
+    it "blocks a supervisor from renaming the communicator (403 not_authorized)" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { child_account: { name: "Renamed" } },
+            headers: auth_headers(supervisor)
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+    end
+
+    it "lets the owner rename the communicator" do
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { child_account: { name: "Renamed" } },
+            headers: auth_headers(owner)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/child_accounts_owner_protection_spec.rb
+++ b/spec/requests/api/child_accounts_owner_protection_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
       expect(account.reload.name).to eq("New Name")
     end
 
-    it "blocks an SLP supervisor (403 not_owner)" do
+    it "blocks an SLP supervisor (403 not_authorized)" do
       patch "/api/child_accounts/#{account.id}",
             params: rename_params,
             headers: auth_headers(slp)
 
       expect(response).to have_http_status(:forbidden)
-      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
       expect(account.reload.name).not_to eq("New Name")
     end
 
@@ -74,15 +74,18 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "blocks an SLP supervisor (403 not_owner)" do
+    # Phase 1 (team permissions overhaul): assigning boards to the dashboard
+    # is a curation action, so a team supervisor may now do it — this used to
+    # be owner-only. Editing the communicator object itself stays owner-only
+    # (covered above and in send_setup_email below).
+    it "lets an SLP supervisor assign a board" do
       expect {
         post "/api/child_accounts/#{account.id}/assign_boards",
              params: { board_ids: [board.id] },
              headers: auth_headers(slp)
-      }.not_to change { account.reload.child_boards.count }
+      }.to change { account.reload.child_boards.count }.by(1)
 
-      expect(response).to have_http_status(:forbidden)
-      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(response).to have_http_status(:ok)
     end
 
     it "lets a system admin through (escape hatch)" do
@@ -159,12 +162,12 @@ RSpec.describe "API::ChildAccounts owner protection", type: :request do
       expect(CommunicationAccountMailer).to have_received(:setup_email).with(account, parent)
     end
 
-    it "blocks an SLP supervisor (403 not_owner)" do
+    it "blocks an SLP supervisor (403 not_authorized)" do
       post "/api/child_accounts/#{account.id}/send_setup_email",
            headers: auth_headers(slp)
 
       expect(response).to have_http_status(:forbidden)
-      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
       expect(CommunicationAccountMailer).not_to have_received(:setup_email)
     end
 

--- a/spec/requests/api/team_accounts_controller_spec.rb
+++ b/spec/requests/api/team_accounts_controller_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Phase 0 — attaching a communicator to a team is locked down: the caller
+# must OWN the communicator and MANAGE the target team (or be a sysadmin).
+# Reassigning team_id/child_account_id via update is disallowed. See
+# .claude-notes/team-permissions-overhaul-handoff.md.
+RSpec.describe "API::TeamAccounts permissions", type: :request do
+  let(:owner)    { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:sysadmin) { create(:admin_user) }
+
+  let!(:communicator) do
+    create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE)
+  end
+
+  # Team created (and thus managed) by owner, who also owns the communicator.
+  let!(:team) do
+    t = Team.create!(name: "Care Team", created_by: owner)
+    t.upsert_member!(owner, "admin")
+    t
+  end
+
+  def attach(user, team_id: team.id, account_id: communicator.id)
+    post "/api/team_accounts",
+         params: { team_id: team_id, account_id: account_id },
+         headers: auth_headers(user)
+  end
+
+  describe "POST /api/team_accounts (create)" do
+    it "lets the team owner attach a communicator they own (201)" do
+      expect { attach(owner) }.to change { TeamAccount.count }.by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "lets a system admin attach any communicator to any team (201)" do
+      expect { attach(sysadmin) }.to change { TeamAccount.count }.by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "blocks a user who owns the communicator but does not manage the team (403)" do
+      outsider = create(:user, created_at: 2.months.ago)
+      outsider_comm = create(:child_account, user: outsider, owner: outsider,
+                                             status: ChildAccount::ACTIVE)
+      expect {
+        attach(outsider, account_id: outsider_comm.id)
+      }.not_to change { TeamAccount.count }
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+    end
+
+    it "blocks a team manager who does NOT own the communicator (403)" do
+      # A second admin-role member of the team, but the communicator isn't theirs.
+      manager = create(:user, created_at: 2.months.ago)
+      team.upsert_member!(manager, "admin")
+      expect { attach(manager) }.not_to change { TeamAccount.count }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "blocks a supervisor (non-manager role) even if on the team (403)" do
+      supervisor = create(:user, created_at: 2.months.ago)
+      team.upsert_member!(supervisor, "supervisor")
+      supervisor_comm = create(:child_account, user: supervisor, owner: supervisor,
+                                               status: ChildAccount::ACTIVE)
+      expect {
+        attach(supervisor, account_id: supervisor_comm.id)
+      }.not_to change { TeamAccount.count }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "blocks a stranger who isn't on the team (403)" do
+      stranger = create(:user, created_at: 2.months.ago)
+      expect { attach(stranger) }.not_to change { TeamAccount.count }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "PATCH /api/team_accounts/:id (update)" do
+    let!(:team_account) { TeamAccount.create!(team: team, account: communicator) }
+
+    it "does not allow reassigning team_id or child_account_id" do
+      other_team = Team.create!(name: "Other", created_by: owner)
+      other_comm = create(:child_account, user: owner, owner: owner,
+                                          status: ChildAccount::ACTIVE)
+
+      patch "/api/team_accounts/#{team_account.id}",
+            params: { team_account: { team_id: other_team.id,
+                                      child_account_id: other_comm.id } },
+            headers: auth_headers(owner)
+
+      team_account.reload
+      expect(team_account.team_id).to eq(team.id)
+      expect(team_account.child_account_id).to eq(communicator.id)
+    end
+  end
+end

--- a/spec/requests/api/teams_controller_spec.rb
+++ b/spec/requests/api/teams_controller_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe "API::Teams permissions", type: :request do
 
   let(:board) { create(:board, user: team_creator) }
 
+  # Inviting a NEW user routes through User.invite_new_user_to_team! ->
+  # create_stripe_customer -> Stripe::Customer.create. Stub it so specs never
+  # make a live Stripe/network call (CI has no creds). Returns a hash-like the
+  # caller indexes with ["id"].
+  before do
+    allow(Stripe::Customer).to receive(:create).and_return({ "id" => "cus_test_stub" })
+  end
+
   describe "GET /api/teams/:id (show)" do
     it "lets every member (incl. restricted) and managers view the team" do
       [restricted, member, supervisor, team_creator, account_owner, sysadmin].each do |u|
@@ -233,29 +241,69 @@ RSpec.describe "API::Teams permissions", type: :request do
     end
   end
 
+  describe "GET /api/teams/:id/accept_invite (public preview)" do
+    it "returns the team/inviter/role payload for a valid token (no auth required)" do
+      get "/api/teams/#{team.id}/accept_invite", params: { token: supervisor.uuid }
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["team_name"]).to eq(team.name)
+      expect(body["invited_by_name"]).to eq(team_creator.display_name)
+      expect(body["role"]).to eq("supervisor")
+      # Email is masked, not leaked in full.
+      expect(body["email"]).to end_with("@#{supervisor.email.split('@').last}")
+      expect(body["email"]).not_to eq(supervisor.email)
+    end
+
+    it "returns 404 with a structured error for a wrong/unknown token" do
+      get "/api/teams/#{team.id}/accept_invite", params: { token: SecureRandom.uuid }
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)["error"]).to eq("invite_not_found")
+    end
+
+    it "returns 404 when the token belongs to a user with no membership on this team" do
+      get "/api/teams/#{team.id}/accept_invite", params: { token: stranger.uuid }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "PATCH /api/teams/:id/accept_invite_patch" do
+    it "accepts the invitation for the invitee with a valid token" do
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { token: supervisor.uuid },
+            headers: auth_headers(supervisor)
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["id"]).to eq(team.id)
+      expect(TeamUser.find_by(team: team, user: supervisor).invitation_accepted_at).to be_present
+    end
+
+    it "ignores a spoofed email param — identity comes from current_user only" do
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { token: supervisor.uuid, email: member.email,
+                      team_user: { email: member.email } },
+            headers: auth_headers(supervisor)
+      expect(response).to have_http_status(:ok)
+      # Supervisor's own membership was accepted; the member's was untouched.
+      expect(TeamUser.find_by(team: team, user: supervisor).invitation_accepted_at).to be_present
+      expect(TeamUser.find_by(team: team, user: member).invitation_accepted_at).to be_nil
+    end
+
+    it "returns 403 when signed in as a DIFFERENT user than the invitee" do
+      # member is on the team but follows the supervisor's invite link.
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { token: supervisor.uuid },
+            headers: auth_headers(member)
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("invite_token_mismatch")
+      expect(TeamUser.find_by(team: team, user: member).invitation_accepted_at).to be_nil
+    end
+
     it "returns 404 (not 500) when the caller has no membership on the team" do
       no_membership = create(:user, created_at: 2.months.ago)
       patch "/api/teams/#{team.id}/accept_invite_patch",
-            params: { team_user: { email: no_membership.email } },
+            params: { token: no_membership.uuid },
             headers: auth_headers(no_membership)
       expect(response).to have_http_status(:not_found)
       expect(JSON.parse(response.body)["error"]).to eq("not_a_team_member")
-    end
-
-    it "returns 404 when the email matches no user at all" do
-      patch "/api/teams/#{team.id}/accept_invite_patch",
-            params: { team_user: { email: "ghost@example.com" } },
-            headers: auth_headers(member)
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "accepts the invitation for a real pending member" do
-      patch "/api/teams/#{team.id}/accept_invite_patch",
-            params: { team_user: { email: supervisor.email } },
-            headers: auth_headers(supervisor)
-      expect(response).to have_http_status(:ok)
-      expect(TeamUser.find_by(team: team, user: supervisor).invitation_accepted_at).to be_present
     end
   end
 

--- a/spec/requests/api/teams_controller_spec.rb
+++ b/spec/requests/api/teams_controller_spec.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260711120000_remap_stray_admin_team_users_to_supervisor.rb")
+
+# Team permissions overhaul (Phase 0-3). Locks down authorization on every
+# mutating API::Teams action and enforces the 4-tier role model
+# (admin/supervisor/member/restricted). Role x action matrix mirrors
+# .claude-notes/team-permissions-overhaul-handoff.md.
+RSpec.describe "API::Teams permissions", type: :request do
+  # team_creator == the "team owner (admin)" column: created the team.
+  # account_owner owns the communicator attached to the team.
+  let(:team_creator) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+  let(:account_owner) { create(:user, created_at: 2.months.ago) }
+  let(:supervisor)    { create(:user, created_at: 2.months.ago) }
+  let(:member)        { create(:user, created_at: 2.months.ago) }
+  let(:restricted)    { create(:user, created_at: 2.months.ago) }
+  let(:stranger)      { create(:user, created_at: 2.months.ago) }
+  let(:sysadmin)      { create(:admin_user) }
+
+  let!(:communicator) do
+    create(:child_account, user: account_owner, owner: account_owner,
+                           status: ChildAccount::ACTIVE)
+  end
+
+  let!(:team) do
+    t = Team.create!(name: "Care Team", created_by: team_creator)
+    TeamAccount.create!(team: t, account: communicator)
+    t.upsert_member!(team_creator, "admin")
+    t.upsert_member!(account_owner, "member") # owner-pinned via account ownership
+    t.upsert_member!(supervisor, "supervisor")
+    t.upsert_member!(member, "member")
+    t.upsert_member!(restricted, "restricted")
+    t
+  end
+
+  let(:board) { create(:board, user: team_creator) }
+
+  describe "GET /api/teams/:id (show)" do
+    it "lets every member (incl. restricted) and managers view the team" do
+      [restricted, member, supervisor, team_creator, account_owner, sysadmin].each do |u|
+        get "/api/teams/#{team.id}", headers: auth_headers(u)
+        expect(response).to have_http_status(:ok), "expected #{u.email} to view"
+      end
+    end
+
+    it "blocks a stranger who isn't on the team (403)" do
+      get "/api/teams/#{team.id}", headers: auth_headers(stranger)
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_a_team_member")
+    end
+
+    it "exposes current_user_role for the viewer" do
+      get "/api/teams/#{team.id}", headers: auth_headers(supervisor)
+      expect(JSON.parse(response.body)["current_user_role"]).to eq("supervisor")
+
+      get "/api/teams/#{team.id}", headers: auth_headers(restricted)
+      expect(JSON.parse(response.body)["current_user_role"]).to eq("restricted")
+    end
+  end
+
+  describe "GET /api/teams (index)" do
+    it "includes current_user_role and only the caller's teams" do
+      get "/api/teams", headers: auth_headers(member)
+      body = JSON.parse(response.body)
+      mine = body.find { |t| t["id"] == team.id }
+      expect(mine).to be_present
+      expect(mine["current_user_role"]).to eq("member")
+    end
+  end
+
+  describe "PATCH /api/teams/:id (update)" do
+    it "lets managers rename the team" do
+      [team_creator, account_owner, sysadmin].each do |u|
+        patch "/api/teams/#{team.id}",
+              params: { team: { name: "Renamed by #{u.id}" } },
+              headers: auth_headers(u)
+        expect(response).to have_http_status(:ok), "expected #{u.email} to rename"
+      end
+    end
+
+    it "blocks non-managers (supervisor/member/restricted/stranger) with 403" do
+      [supervisor, member, restricted, stranger].each do |u|
+        patch "/api/teams/#{team.id}",
+              params: { team: { name: "Nope" } },
+              headers: auth_headers(u)
+        expect(response).to have_http_status(:forbidden), "expected #{u.email} blocked"
+        expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+      end
+    end
+  end
+
+  describe "DELETE /api/teams/:id (destroy)" do
+    it "lets a manager delete the team" do
+      expect {
+        delete "/api/teams/#{team.id}", headers: auth_headers(team_creator)
+      }.to change { Team.where(id: team.id).count }.from(1).to(0)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "blocks a supervisor from deleting (403)" do
+      expect {
+        delete "/api/teams/#{team.id}", headers: auth_headers(supervisor)
+      }.not_to change { Team.where(id: team.id).count }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "POST /api/teams/:id/invite" do
+    def invite(user, email:, role:)
+      post "/api/teams/#{team.id}/invite",
+           params: { team_user: { email: email, role: role } },
+           headers: auth_headers(user)
+    end
+
+    it "lets a manager invite a new supervisor (201)" do
+      invite(team_creator, email: "newslp@example.com", role: "supervisor")
+      expect(response).to have_http_status(:created)
+      invited = User.find_by(email: "newslp@example.com")
+      expect(TeamUser.find_by(team: team, user: invited).role).to eq("supervisor")
+    end
+
+    it "persists a restricted (Read-Only) invite as restricted, not member" do
+      invite(account_owner, email: "readonly@example.com", role: "restricted")
+      expect(response).to have_http_status(:created)
+      invited = User.find_by(email: "readonly@example.com")
+      expect(TeamUser.find_by(team: team, user: invited).role).to eq("restricted")
+    end
+
+    it "rejects a junk role with 422 (no silent coercion)" do
+      invite(team_creator, email: "junk@example.com", role: "wizard")
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("invalid_role")
+      expect(User.find_by(email: "junk@example.com")).to be_nil
+    end
+
+    it "rejects an explicit admin invite with 422 (admin is owner-only)" do
+      invite(team_creator, email: "wannabe@example.com", role: "admin")
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("invalid_role")
+    end
+
+    it "blocks non-managers from inviting (403)" do
+      [supervisor, member, restricted, stranger].each do |u|
+        invite(u, email: "x#{u.id}@example.com", role: "member")
+        expect(response).to have_http_status(:forbidden), "expected #{u.email} blocked"
+        expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+      end
+    end
+  end
+
+  describe "DELETE /api/teams/:id/remove_member" do
+    it "lets a manager remove a plain member" do
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: member.email },
+               headers: auth_headers(team_creator)
+      }.to change { TeamUser.where(team: team, user: member).count }.from(1).to(0)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "blocks a supervisor from removing a member (403)" do
+      expect {
+        delete "/api/teams/#{team.id}/remove_member",
+               params: { email: member.email },
+               headers: auth_headers(supervisor)
+      }.not_to change { TeamUser.where(team: team).count }
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+    end
+  end
+
+  describe "POST /api/teams/:id/create_board (team library)" do
+    def create_board(user, board_record)
+      post "/api/teams/#{team.id}/create_board",
+           params: { board_id: board_record.id },
+           headers: auth_headers(user)
+    end
+
+    it "lets library writers (member/supervisor/admin/account owner/sysadmin) add a board" do
+      # Distinct board per writer — `add_board!` keys idempotency on the
+      # adder, so reusing one board across users isn't a real-world flow.
+      [member, supervisor, team_creator, account_owner, sysadmin].each do |u|
+        create_board(u, create(:board, user: team_creator))
+        expect(response).to have_http_status(:ok), "expected #{u.email} to add a board"
+      end
+    end
+
+    it "blocks a restricted (Read-Only) member from writing the library (403)" do
+      expect {
+        create_board(restricted, board)
+      }.not_to change { team.team_boards.count }
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_a_team_member")
+    end
+
+    it "blocks a stranger (403)" do
+      create_board(stranger, board)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "DELETE /api/teams/:id/remove_board" do
+    before { team.add_board!(board, team_creator.id) }
+
+    def remove_board(user)
+      delete "/api/teams/#{team.id}/remove_board",
+             params: { board_id: board.id },
+             headers: auth_headers(user)
+    end
+
+    it "lets a supervisor and managers remove a board" do
+      [supervisor, team_creator, account_owner, sysadmin].each do |u|
+        team.add_board!(board, team_creator.id) # re-add between removals
+        remove_board(u)
+        expect(response).to have_http_status(:ok), "expected #{u.email} to remove a board"
+      end
+    end
+
+    it "blocks a plain member from removing a board (403)" do
+      expect {
+        remove_board(member)
+      }.not_to change { team.team_boards.count }
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_authorized")
+    end
+
+    it "blocks restricted and strangers (403)" do
+      [restricted, stranger].each do |u|
+        remove_board(u)
+        expect(response).to have_http_status(:forbidden), "expected #{u.email} blocked"
+      end
+    end
+  end
+
+  describe "PATCH /api/teams/:id/accept_invite_patch" do
+    it "returns 404 (not 500) when the caller has no membership on the team" do
+      no_membership = create(:user, created_at: 2.months.ago)
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { team_user: { email: no_membership.email } },
+            headers: auth_headers(no_membership)
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)["error"]).to eq("not_a_team_member")
+    end
+
+    it "returns 404 when the email matches no user at all" do
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { team_user: { email: "ghost@example.com" } },
+            headers: auth_headers(member)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "accepts the invitation for a real pending member" do
+      patch "/api/teams/#{team.id}/accept_invite_patch",
+            params: { team_user: { email: supervisor.email } },
+            headers: auth_headers(supervisor)
+      expect(response).to have_http_status(:ok)
+      expect(TeamUser.find_by(team: team, user: supervisor).invitation_accepted_at).to be_present
+    end
+  end
+
+  describe "POST /api/teams (create) — owner-side Pro gate" do
+    it "lets a paid owner create a team" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      expect {
+        post "/api/teams", params: { team: { name: "New Team" } }, headers: auth_headers(pro)
+      }.to change { Team.count }.by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "lets a brand-new free-trial owner create a team" do
+      trial = create(:user, plan_type: "free", created_at: 1.day.ago)
+      post "/api/teams", params: { team: { name: "Trial Team" } }, headers: auth_headers(trial)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "blocks a free, past-trial owner with 403 pro_required" do
+      free = create(:user, plan_type: "free", created_at: 1.year.ago)
+      expect {
+        post "/api/teams", params: { team: { name: "Nope" } }, headers: auth_headers(free)
+      }.not_to change { Team.count }
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("pro_required")
+    end
+  end
+
+  describe "role remap migration" do
+    it "remaps stray admins to supervisor, keeping creator/owner admins" do
+      creator = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      owner   = create(:user, created_at: 2.months.ago)
+      stray   = create(:user, created_at: 2.months.ago)
+      comm = create(:child_account, user: owner, owner: owner, status: ChildAccount::ACTIVE)
+      t = Team.create!(name: "Remap Team", created_by: creator)
+      TeamAccount.create!(team: t, account: comm)
+      creator_tu = t.upsert_member!(creator, "admin")
+      owner_tu   = t.upsert_member!(owner, "admin")
+      stray_tu   = t.upsert_member!(stray, "admin")
+
+      ActiveRecord::Migration.suppress_messages do
+        RemapStrayAdminTeamUsersToSupervisor.new.up
+      end
+
+      expect(creator_tu.reload.role).to eq("admin")
+      expect(owner_tu.reload.role).to eq("admin")
+      expect(stray_tu.reload.role).to eq("supervisor")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the team-permissions overhaul (frontend counterpart ships the same day). No users are on teams yet, so this is one PR with no backwards-compat shims. All decisions per `.claude-notes/team-permissions-overhaul-handoff.md`.

**⚠️ Merge order: this PR must merge and deploy BEFORE the frontend PR.** The frontend builds against the API contract delivered here (`assign_boards` allows supervisors, `{error, message}` 403 bodies, roles `supervisor|member|restricted`, `current_user_role` field).

### Phase 0 — authorization lockdown
- `API::TeamsController` now authorizes every mutating action (previously **zero** authz on update/destroy/invite/remove_member — any authenticated user could hit any team). Owner / account-owner / sysadmin for manage actions; curate roles or owner for `remove_board`; members-only for show/index.
- `accept_invite_patch` returns 404 on missing membership instead of NoMethodError → 500.
- New `TeamAccountPolicy` (fixes `Pundit::NotDefinedError` that hit index/show/update/destroy at runtime). `TeamAccountsController#create` now requires owning the communicator **and** managing the team (or sysadmin); `update` can no longer reassign `team_id`/`child_account_id`.

### Phase 1 — supervisor assign_boards + structured errors
- `assign_boards` gated on `can_add_boards_to_account?` (owner / team admin / team supervisor), matching the existing ChildBoard curate path and the truthful `can_edit` serializer flag.
- Raw-string error codes (`not_owner`) replaced with `{ error: "not_authorized", message: "Only the account owner or a team supervisor can add boards to this dashboard." }` (403). `error` stays machine-readable; `message` is display-ready.

### Phase 2 — 4-tier roles
- `TeamUser::ROLES = %w[admin supervisor member restricted]` (restricted = Read-Only, member = Support). Invites accept exactly `supervisor|member|restricted` — 422 on junk or `admin`, no more silent coercion to `member`.
- Serializer exposes `current_user_role` in `show_api_view` and `index_api_view`.
- Reversible data migration remaps stray `admin` rows (not creator, not account owner) → `supervisor`. Expect ~0 rows in prod (20 in local dev data).

### Phase 3 — plans × teams
- Owner-side Pro gate on team creation (`paid_plan?` or `free_trial?`). No member-side plan gates — the owner's plan hosts the team, so a free/expired member participates fully per their role.

### Incidental fixes
- Two latent JSON-render bugs surfaced by the new specs: `TeamsController#update` rendered a nonexistent `:show` template, and `TeamAccountsController#update` fell through to an HTML branch calling an undefined route helper. Both now render JSON.

## ⚠️ Needs Brittany's confirmation (flagged, not changed)
`TeamAccount#before_destroy :destroy_team` (`app/models/team_account.rb:18-22`) **cascade-deletes the entire team** — members and board library included — when the last communicator is detached. Left as-is per the handoff. Confirm whether detaching the final communicator should really destroy the team.

## Test plan
Targeted request specs (created the files that didn't exist):

```
bundle exec rspec spec/requests/api/teams_controller_spec.rb \
  spec/requests/api/child_accounts_controller_spec.rb \
  spec/requests/api/team_accounts_controller_spec.rb
```

**Result: 45 examples, 0 failures** (re-run independently by the orchestrator). Covers the full role × action matrix, restricted-invite persistence, junk/`admin` role → 422, free **and** cancelled-plan supervisor can `assign_boards`, `accept_invite_patch` no-membership → 404, and the migration remap. Full affected set (existing team/child_account specs + models) also green: 93 examples, 0 failures, 1 pre-existing pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — token-verified invite acceptance (added to this PR)

Reworked both invite-acceptance endpoints, which previously took identity from an **email param** and never verified the URL token (and NoMethodError'd on nil). The invite email links to `/accept-invite/:teamId/:uuid`, where the token is the invitee's `User#uuid`.

- **`GET /api/teams/:id/accept_invite?token=`** — public (no auth; `skip_before_action :authenticate_token!` scoped to this action). Returns `{ team_name, invited_by_name, role, email }` with the email **masked**; validated by matching the token against the invited user's uuid. `404 { error: "invite_not_found" }` on any mismatch.
- **`PATCH /api/teams/:id/accept_invite_patch`** — authenticated. Identity is `current_user`; membership found by `current_user` + team; verifies `params[:token] == current_user.uuid`, then `accept_invitation!` and returns `show_api_view`. `404 { error: "not_a_team_member" }` (no membership — never 500), `403 { error: "invite_token_mismatch" }` (signed in as a different user than the invitee). **The email param is never trusted for identity anywhere in this flow.**

### Also flagged (needs your call)
`invited_by_name` uses `team.created_by.display_name` as a proxy — **there is no per-membership record of who sent the invite** (the mailer takes an `inviter` arg but nothing persists it). If the preview must show the actual inviter, that needs a schema/data change (out of scope here).

### CI fixes folded in
- `team_roles:normalize` rake task: dropped the now-dead `"restricted" => "member"` fold (restricted is canonical now); spec updated to assert it's left untouched.
- `teams_controller_spec`: stub `Stripe::Customer.create` file-wide so invite-new-user examples don't make a live Stripe call in CI (the failure that turned CI red).

**Verification:** 88 examples, 0 failures across all team-related specs (the three targeted request specs + rake spec + team_permissions + teams_create_board + team_user model + child_boards_owner_protection), re-run independently by the orchestrator.
