### PR TITLE
fix: surface communicator assignment for direct-attach (builder) boards

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -665,10 +665,29 @@ still works for backward compat.
   this the builder root never surfaced under the `in_use` scope even though it's
   literally assigned. The clone-source path is unaffected (clones are
   `is_template: true`, excluded from the index anyway).
+  - `in_use` is refreshed by **`ChildBoard` `after_create`/`after_destroy`**
+    (`recalculate_boards_in_use` → `Board#recalculate_in_use!`), not just by
+    Board's own `before_save` — the builder attaches the root **after** its
+    last save and detach never saves the board, so the save-time hook alone
+    left builder roots stuck at `false`.
+  - `Board#assigned_to_communicator?` guards against a **nil id** (unsaved
+    record): without it, `where(original_board_id: nil)` matched every
+    direct-attach row and flagged every brand-new board `in_use = true`.
+  - Communicator lists in the API views (`communicator_accounts`,
+    `communicator_account_data`, `child_boards` on the show payload;
+    `in_use_by` on the index; `ChildAccount#index_api_view`'s
+    `communicator_board_ids`) all read **both join paths** via
+    `Board#communicator_child_boards` — never only `original_child_boards`,
+    or builder boards vanish from "assigned to" UI (the Assign-to-communicator
+    popup pre-check matches the viewed board id against
+    `communicator_board_ids`).
 - **Backfill for pre-fix sets:** `rake board_builder:reclassify_builder_sets`
   (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope) re-saves
   each existing built set so the root recomputes `in_use` and every child page
-  gets `freeze_board` + `sub_board`.
+  gets `freeze_board` + `sub_board`. For the `in_use` flag alone (both
+  directions, including boards wrongly stuck at `true` from the nil-id bug),
+  `rake boards:recalculate_in_use` (dry-run by default; `DRY_RUN=false` to
+  apply) recomputes the flag straight from the `child_boards` rows.
 - **Tile images prefer the curated "default" image (`Boards::ImageResolver`).**
   All three build paths (cloner, `BlueprintAssembler`, `BuildBoardSetJob`)
   resolve a tile label via `Boards::ImageResolver.resolve(label, owner:)`. When

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — boards assigned to communicators now show it everywhere
+- Board Builder boards live directly on the communicator (`ChildBoard` with
+  no `original_board_id`), but every "who has this board" surface only read
+  the clone-source path — so the Board View page's In-use info, the
+  Assign-to-communicator popup's "Already has this board" state, and the
+  boards-list `in_use_by` label were all empty for built sets. All of them
+  (including `ChildAccount#index_api_view`'s `communicator_board_ids`) now
+  read both join paths.
+- `Board.in_use` stays accurate: `ChildBoard` create/destroy now refreshes
+  the flag on the attached board and the clone source (the builder attaches
+  the root after the board's last save, so the save-time hook never saw it),
+  and a nil-id guard stops brand-new boards from being marked in-use by
+  unrelated direct-attach rows. Backfill for existing data:
+  `rake boards:recalculate_in_use` (dry-run by default; `DRY_RUN=false`).
+
 ### Added — `public_url` on the communicator index payload
 - `ChildAccount#index_api_view` now includes `public_url` (the canonical
   slug-based MySpeak URL, e.g. `/my/s-8bdsv4`). The user payload's

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -676,8 +676,23 @@ class Board < ApplicationRecord
   # Without case 2, builder roots stayed in_use=false and never surfaced under
   # the "in use" scope even though they're literally assigned to a communicator.
   def check_in_use
-    self.in_use = ChildBoard.where(original_board_id: id).exists? ||
-      ChildBoard.where(board_id: id).exists?
+    self.in_use = assigned_to_communicator?
+  end
+
+  # Both join paths, guarded against unsaved records: with a nil id,
+  # `where(original_board_id: nil)` matches every direct-attach row and would
+  # mark every brand-new board in_use.
+  def assigned_to_communicator?
+    return false if id.nil?
+    ChildBoard.where(original_board_id: id).or(ChildBoard.where(board_id: id)).exists?
+  end
+
+  # ChildBoard create/destroy happens outside this board's save cycle (the
+  # builder attaches the root AFTER its last save; detach never saves the
+  # board), so the stored flag is refreshed directly. update_column: the flag
+  # is derived state — re-running the full callback chain here is unwanted.
+  def recalculate_in_use!
+    update_column(:in_use, assigned_to_communicator?)
   end
 
   IS_SUB_BOARD_TAG = "sub-board".freeze
@@ -1900,11 +1915,9 @@ class Board < ApplicationRecord
       @board_images = visible_board_images.includes({ image: [:docs, :audio_files_attachments, :audio_files_blobs, :predictive_boards] }, :predictive_board).distinct
     end
     current_colors = @board_images.map { |bi| bi.bg_color }.flatten.compact.uniq
-    if in_use
-      @original_child_boards = original_child_boards.includes(child_account: :profile)
-    end
+    # Not gated on the stored in_use flag — it can lag the join rows.
     @parent_boards = parent_boards(viewing_user&.id)
-    @child_accounts = @original_child_boards&.map(&:child_account).compact.uniq if @original_child_boards
+    @child_accounts = communicator_child_boards.map(&:child_account).compact.uniq
 
     @root_board = root_board
     same_user = viewing_user && user_id == viewing_user.id
@@ -1922,11 +1935,11 @@ class Board < ApplicationRecord
       board_id: id,
       word_sample: word_sample,
       user_name: user&.display_name,
-      communicator_account_data: @original_child_boards&.map { |cb| { acct_id: cb.child_account.id, board_id: cb.board_id, original_board_id: cb.original_board_id, acct_name: cb.child_account.name, board_name: cb.board.name, acct_avatar_url: cb.child_account.profile&.avatar_url } },
-      communicator_accounts: @child_accounts&.map { |ca| { id: ca.id, name: ca.name } },
+      communicator_account_data: communicator_child_boards.map { |cb| { acct_id: cb.child_account.id, board_id: cb.board_id, original_board_id: cb.original_board_id, acct_name: cb.child_account.name, board_name: cb.board.name, acct_avatar_url: cb.child_account.profile&.avatar_url } },
+      communicator_accounts: @child_accounts.map { |ca| { id: ca.id, name: ca.name } },
       communicator_account: communicator_account ? { id: communicator_account.id, name: communicator_account.name } : nil,
       communicator_board: communicator_board ? { id: communicator_board.id, name: communicator_board.name, board_id: communicator_board.board_id, original_board_id: communicator_board.original_board_id } : nil,
-      child_boards: @original_child_boards&.map { |cb| { board_id: cb.board_id, name: cb.name, child_account_id: cb.child_account_id, username: cb.child_account&.username } },
+      child_boards: communicator_child_boards.map { |cb| { board_id: cb.board_id, name: cb.name, child_account_id: cb.child_account_id, username: cb.child_account&.username } },
       in_use: in_use,
       is_template: is_template,
       parent_boards: @parent_boards&.map { |pb| { id: pb.id, name: pb.name, slug: pb.slug, board_type: pb.board_type, display_image_url: pb.display_image_url || pb.preview_image_url, preview_image_url: pb.preview_image_url } },
@@ -2232,10 +2245,18 @@ class Board < ApplicationRecord
 
   def in_use_by
     if in_use
-      @original_child_boards = original_child_boards.includes(child_account: :profile)
-      @communicator_accounts = @original_child_boards&.map(&:child_account).compact.uniq
+      @communicator_accounts = communicator_child_boards.map(&:child_account).compact.uniq
       @communicator_accounts&.map(&:name)&.join(", ")
     end
+  end
+
+  # ChildBoard rows tying this board to communicators, across both join paths:
+  # clone-source (original_board_id) and direct-attach (board_id — Board
+  # Builder roots, and the assignment clones themselves).
+  def communicator_child_boards
+    @communicator_child_boards ||=
+      (original_child_boards.includes(child_account: :profile).to_a +
+       child_boards.includes(child_account: :profile).to_a).uniq
   end
 
   # Whether viewing_user may edit this board's content. Owner/admin gate plus
@@ -2289,7 +2310,7 @@ class Board < ApplicationRecord
       published: published,
       in_use: in_use,
       in_use_by: in_use_by,
-      communicator_account_data: in_use ? @original_child_boards&.map { |cb| { acct_id: cb.child_account.id, board_id: cb.board_id, original_board_id: cb.original_board_id, acct_name: cb.child_account.name, board_name: cb.board.name, acct_avatar_url: cb.child_account.profile&.avatar_url } } : nil,
+      communicator_account_data: in_use ? communicator_child_boards.map { |cb| { acct_id: cb.child_account.id, board_id: cb.board_id, original_board_id: cb.original_board_id, acct_name: cb.child_account.name, board_name: cb.board.name, acct_avatar_url: cb.child_account.profile&.avatar_url } } : nil,
       can_edit: can_edit,
       locked: locked,
       lock_reason: locked ? "free_plan_board_limit" : nil,

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -1220,7 +1220,12 @@ class ChildAccount < ApplicationRecord
       parent_name: user.display_name,
       board_count: @child_boards.size,
       board_list_sample: current_board_list,
-      communicator_board_ids: @child_boards.pluck(:original_board_id).compact,
+      # Every board id this communicator "has", across both join paths: the
+      # clone source (original_board_id — assign_boards/assign_accounts) AND
+      # the board actually on the dashboard (board_id — Board Builder roots
+      # have no original). The assign-to-communicator popup matches the viewed
+      # board's id against this list.
+      communicator_board_ids: @child_boards.pluck(:original_board_id, :board_id).flatten.compact.uniq,
       user_id: user_id,
       last_sign_in_at_str: last_sign_in_at&.strftime("%a, %b %e at %l:%M %p"),
       last_sign_in_at: last_sign_in_at,

--- a/app/models/child_board.rb
+++ b/app/models/child_board.rb
@@ -29,6 +29,13 @@ class ChildBoard < ApplicationRecord
   # unique (board_id, child_account_id) index.
   validates :board_id, uniqueness: { scope: :child_account_id }
 
+  # Board#in_use is derived from these rows, but Board's own before_save can't
+  # see an attach/detach that happens outside a board save — the builder
+  # creates this row AFTER the root's last save, and detach never saves the
+  # board at all. Refresh the flag on both referenced boards here.
+  after_create :recalculate_boards_in_use
+  after_destroy :recalculate_boards_in_use
+
   # scope :with_artifacts, -> { includes(board: :images) }
   scope :with_artifacts, -> { includes({ board: [{ images: [:docs, :audio_files_attachments, :audio_files_blobs] }] }, :image_parent) }
 
@@ -129,6 +136,10 @@ class ChildBoard < ApplicationRecord
       bg_color: board.bg_color,
       text_color: board.text_color,
     }
+  end
+
+  def recalculate_boards_in_use
+    [board, original_board].compact.uniq.each(&:recalculate_in_use!)
   end
 
   def api_view_with_images

--- a/lib/tasks/recalculate_in_use.rake
+++ b/lib/tasks/recalculate_in_use.rake
@@ -1,0 +1,34 @@
+namespace :boards do
+  # Backfill for two historical in_use drifts:
+  #   1. Builder roots stuck at false — the ChildBoard attach happens after the
+  #      root's last save, so check_in_use never saw it (fixed by ChildBoard's
+  #      recalculate_boards_in_use callback going forward).
+  #   2. Unrelated boards stuck at true — check_in_use on a NEW record ran with
+  #      a nil id, so `where(original_board_id: nil)` matched every
+  #      direct-attach row and marked every brand-new board in_use (fixed by
+  #      the nil-id guard in Board#assigned_to_communicator?).
+  #
+  # Read-only by default. Apply with DRY_RUN=false.
+  desc "Recompute Board.in_use from child_boards rows, both directions (DRY_RUN=false to apply)"
+  task recalculate_in_use: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    attached_ids = ChildBoard.pluck(:board_id, :original_board_id).flatten.compact.uniq
+
+    should_be_true = Board.where(in_use: false, id: attached_ids)
+    should_be_false = Board.where(in_use: true).where.not(id: attached_ids)
+
+    puts "Boards attached to a communicator but in_use=false: #{should_be_true.count}"
+    puts "Boards not attached to any communicator but in_use=true: #{should_be_false.count}"
+
+    if dry_run
+      puts "DRY RUN — no changes. Re-run with DRY_RUN=false to apply."
+      next
+    end
+
+    # The flag is derived state; update_all skips the unrelated save callbacks.
+    flipped_on = should_be_true.update_all(in_use: true, updated_at: Time.current)
+    flipped_off = should_be_false.update_all(in_use: false, updated_at: Time.current)
+    puts "Done. Set in_use=true on #{flipped_on} boards, in_use=false on #{flipped_off} boards."
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -151,6 +151,61 @@ RSpec.describe Board, type: :model do
       board.save!
       expect(board.reload.in_use).to be(true)
     end
+
+    it "does not mark a brand-new board in_use because unrelated direct-attach rows exist (nil-id guard)" do
+      communicator = FactoryBot.create(:child_account, user: user)
+      communicator.child_boards.create!(board: board, created_by_id: user.id)
+
+      # With a nil id at first save, the unguarded query matched the row above
+      # via `original_board_id: nil` and flagged every new board in_use.
+      fresh = FactoryBot.create(:board, user: user, name: "Fresh")
+      expect(fresh.reload.in_use).to be(false)
+    end
+  end
+
+  describe "communicator assignment in api views" do
+    let(:user)         { FactoryBot.create(:user) }
+    let(:communicator) { FactoryBot.create(:child_account, user: user, name: "Mason") }
+    let(:board)        { FactoryBot.create(:board, user: user, name: "Core 60") }
+
+    context "when attached directly (Board Builder path — no original_board_id)" do
+      before { communicator.child_boards.create!(board: board, created_by_id: user.id) }
+
+      it "lists the communicator in the show payload" do
+        view = board.reload.api_view_with_predictive_images(user)
+
+        expect(view[:communicator_accounts]).to eq([{ id: communicator.id, name: "Mason" }])
+        expect(view[:communicator_account_data].map { |d| d[:acct_id] }).to eq([communicator.id])
+        expect(view[:child_boards].map { |cb| cb[:child_account_id] }).to eq([communicator.id])
+        expect(view[:in_use]).to be(true)
+      end
+
+      it "names the communicator in in_use_by" do
+        expect(board.reload.in_use_by).to eq("Mason")
+      end
+    end
+
+    context "when it is the source of an assigned clone (original_board_id path)" do
+      before do
+        clone = FactoryBot.create(:board, user: user, name: "Core 60 copy", is_template: true)
+        communicator.child_boards.create!(board: clone, original_board: board, created_by_id: user.id)
+      end
+
+      it "lists the communicator in the show payload" do
+        view = board.reload.api_view_with_predictive_images(user)
+
+        expect(view[:communicator_accounts]).to eq([{ id: communicator.id, name: "Mason" }])
+        expect(view[:in_use]).to be(true)
+      end
+    end
+
+    it "returns empty communicator lists for an unassigned board" do
+      view = board.reload.api_view_with_predictive_images(user)
+
+      expect(view[:communicator_accounts]).to eq([])
+      expect(view[:communicator_account_data]).to eq([])
+      expect(view[:child_boards]).to eq([])
+    end
   end
 
   describe "#check_is_sub_board (before_save)" do

--- a/spec/models/child_account_status_spec.rb
+++ b/spec/models/child_account_status_spec.rb
@@ -101,5 +101,21 @@ RSpec.describe ChildAccount, "status lifecycle", type: :model do
       expect(account.index_api_view[:public_url]).to eq(account.api_view(user)[:public_url])
       expect(account.index_api_view[:public_url]).to end_with("/my/s-8bdsv4")
     end
+
+    it "emits communicator_board_ids across both join paths (clone source AND direct attach)" do
+      account = FactoryBot.create(:child_account, user: user)
+
+      builder_root = FactoryBot.create(:board, user: user, name: "Built set")
+      account.child_boards.create!(board: builder_root, created_by_id: user.id)
+
+      source = FactoryBot.create(:board, user: user, name: "Assigned source")
+      clone = FactoryBot.create(:board, user: user, name: "Assigned copy", is_template: true)
+      account.child_boards.create!(board: clone, original_board: source, created_by_id: user.id)
+
+      ids = account.index_api_view[:communicator_board_ids]
+      expect(ids).to include(builder_root.id) # direct attach (Board Builder)
+      expect(ids).to include(source.id)       # clone source (assign)
+      expect(ids).to include(clone.id)        # the board actually on the dashboard
+    end
   end
 end

--- a/spec/models/child_board_spec.rb
+++ b/spec/models/child_board_spec.rb
@@ -44,4 +44,39 @@ RSpec.describe ChildBoard, type: :model do
       expect(build(:child_board, board: board, child_account: other)).to be_valid
     end
   end
+
+  describe "in_use recalculation on attach/detach" do
+    it "flags a directly-attached board in_use on create (Board Builder path)" do
+      expect(board.reload.in_use).to be(false)
+
+      child_board = create(:child_board, board: board, child_account: communicator)
+
+      expect(board.reload.in_use).to be(true)
+
+      child_board.destroy!
+      expect(board.reload.in_use).to be(false)
+    end
+
+    it "flags the clone source in_use via original_board (assign path)" do
+      clone = create(:board, user: user, is_template: true)
+
+      child_board = create(:child_board, board: clone, original_board: board, child_account: communicator)
+
+      expect(board.reload.in_use).to be(true)
+      expect(clone.reload.in_use).to be(true)
+
+      child_board.destroy!
+      expect(board.reload.in_use).to be(false)
+      expect(clone.reload.in_use).to be(false)
+    end
+
+    it "keeps in_use true while another communicator still has the board" do
+      other = create(:child_account, user: user)
+      keeper = create(:child_board, board: board, child_account: communicator)
+      create(:child_board, board: board, child_account: other)
+
+      keeper.destroy!
+      expect(board.reload.in_use).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Boards assigned to communicators weren't showing that assignment on the Board View page, in the Assign-to-communicator popup, or reliably under the "In use" filter — most visibly for Board Builder sets (e.g. a built Core 60 assigned to a communicator showed no communicator info at all).

Root cause: there are two join paths from a board to a communicator —
- **clone source**: `ChildBoard#original_board_id` (assign_boards / assign_accounts), and
- **direct attach**: `ChildBoard#board_id` with no original (the Board Builder root),

and every "who has this board" surface only read the first one.

### Changes

- **`Board#communicator_child_boards`** (new, memoized) reads both join paths. Used by:
  - the show payload (`api_view_with_predictive_images`): `communicator_accounts`, `communicator_account_data`, `child_boards` — no longer gated on the stored `in_use` flag, which can lag the join rows;
  - the index payload: `in_use_by` / `communicator_account_data`;
  - **`ChildAccount#index_api_view`**: `communicator_board_ids` now includes `board_id` as well as `original_board_id` — this is the field the Assign-to-communicator popup matches the viewed board against, so the assigned communicator now shows its "Already has this board" state.
- **`in_use` accuracy** — two bugs fixed:
  - `ChildBoard` `after_create`/`after_destroy` now refreshes `in_use` on the attached board and the clone source. The builder attaches the root **after** the board's last save, so Board's own `before_save` hook never saw the attach and builder roots stayed `in_use = false`; detach similarly never cleared it.
  - Nil-id guard in `Board#assigned_to_communicator?`: on a brand-new record `where(original_board_id: nil)` matched every direct-attach row and marked **every newly created board** `in_use = true`, polluting the "In use" filter in the other direction.
- **Backfill**: `rake boards:recalculate_in_use` recomputes the flag from `child_boards` rows in both directions (dry-run by default, `DRY_RUN=false` to apply). Run once after deploy.
- Docs: `.claude-notes/board-builder.md` invariant updated; CHANGELOG entry added.

No frontend changes needed — the popup, the "In use (N)" chip, and the BoardsPage filter all consume these fields as-is.

### After deploy

Run `DRY_RUN=false rake boards:recalculate_in_use` on production to heal existing data (builder roots stuck at false, unrelated boards stuck at true).

## Test plan

- `bundle exec rspec spec/models/board_spec.rb spec/models/child_board_spec.rb spec/models/child_account_status_spec.rb spec/models/child_account_spec.rb` — new coverage: both join paths in the show payload / `in_use_by` / `communicator_board_ids`, attach/detach recalculation, nil-id guard — **passed**
- `bundle exec rspec spec/services/boards/assignment_cloner_spec.rb spec/services/boards/board_tree_builder_spec.rb spec/services/boards/seeded_set_cloner_spec.rb spec/requests/api/child_accounts_assign_boards_spec.rb spec/requests/api/child_boards_handoff_removal_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/boards_destroy_spec.rb spec/requests/api/board_read_only_spec.rb spec/requests/api/boards spec/sidekiq/build_board_set_job_spec.rb spec/sidekiq/build_board_set_job_grid_spec.rb` — **passed**
- Total across runs: 295 examples, 0 failures
- `bin/rails zeitwerk:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)