### PR TITLE
feat: let a team member leave a team

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -37,6 +37,13 @@ any non-owner. Full matrix in issue #166. Server-side rules:
 - `DELETE /api/teams/:id/remove_member` returns **HTTP 403
   `cannot_remove_owner`** if the target is owner-pinned and the caller is
   neither that user nor a system admin. The owner can remove themselves.
+- `DELETE /api/teams/:id/leave` — self-scoped: a member removes their own
+  membership (uses `current_user`, never an email param, so it can't remove
+  anyone else). Returns **HTTP 403 `creator_cannot_leave`** for the team
+  creator (`created_by_id`) — they use "Delete team" instead, since leaving
+  would orphan the team. Destroying the `TeamUser` fires the same
+  `before_destroy` board-snapshot safety net as `remove_member`, so the
+  departing member's shared boards stay with the family.
 - `POST /api/teams/:id/invite`, when it would change an *existing*
   membership's role, returns **HTTP 403 `cannot_change_owner_role`** if
   the target is owner-pinned (and the caller isn't that user). It also

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -116,6 +116,27 @@ class API::TeamsController < API::ApplicationController
     render json: @team.show_api_view(current_user)
   end
 
+  # DELETE /api/teams/:id/leave — the signed-in user removes their own
+  # membership. Self-scoped (uses current_user, never an email param), so
+  # it can't be used to remove anyone else. Destroying the TeamUser fires
+  # the before_destroy board-snapshot safety net (issue #162), so the
+  # departing member's shared boards stay with the family.
+  def leave
+    @team = Team.find(params[:id])
+    @team_user = TeamUser.find_by(user_id: current_user.id, team_id: @team.id)
+    return render json: { error: "Not a team member" }, status: :not_found unless @team_user
+
+    # The team creator can't leave — that would orphan the team. They use
+    # "Delete Team" (or hand the team off) instead.
+    if @team.created_by_id == current_user.id
+      return render_team_permission_error("creator_cannot_leave",
+                                          "As the team creator, you can't leave. Delete the team instead.")
+    end
+
+    @team_user.destroy!
+    render json: { status: "ok" }
+  end
+
   # POST /teams or /teams.json
   def create
     # Hosting a team is a Pro (owner-side) feature — decision 3: the owner's

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
       member do
         post "invite"
         delete "remove_member"
+        delete "leave"
         get "accept_invite"
         patch "accept_invite_patch"
         post "add_board"

--- a/spec/requests/api/team_permissions_spec.rb
+++ b/spec/requests/api/team_permissions_spec.rb
@@ -72,6 +72,48 @@ RSpec.describe "API::Teams owner protection", type: :request do
     end
   end
 
+  describe "DELETE /api/teams/:id/leave" do
+    # A plain support member who joined the team but neither created it
+    # nor owns a communicator on it — the common "let me off this team" case.
+    let(:aide) { create(:user) }
+    before { team.upsert_member!(aide, "member") }
+
+    it "lets a member leave the team on their own" do
+      expect {
+        delete "/api/teams/#{team.id}/leave", headers: auth_headers(aide)
+      }.to change { TeamUser.where(team: team, user: aide).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["status"]).to eq("ok")
+    end
+
+    it "blocks the team creator from leaving (403)" do
+      # slp created this team via ensure_team! and is a member, so the
+      # block — not a missing TeamUser — is what must stop them.
+      expect {
+        delete "/api/teams/#{team.id}/leave", headers: auth_headers(slp)
+      }.not_to change { TeamUser.where(team: team).count }
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("creator_cannot_leave")
+    end
+
+    it "returns 404 when the caller is not a member" do
+      stranger = create(:user)
+      delete "/api/teams/#{team.id}/leave", headers: auth_headers(stranger)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "lets the parent owner leave via their own action (owner-pin does not block self-leave)" do
+      expect {
+        delete "/api/teams/#{team.id}/leave", headers: auth_headers(parent)
+      }.to change { TeamUser.where(team: team, user: parent).count }.from(1).to(0)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "POST /api/teams/:id/invite (role change path)" do
     it "blocks an SLP supervisor from demoting the parent owner (403)" do
       post "/api/teams/#{team.id}/invite",


### PR DESCRIPTION
## Summary
Adds a way for a team member to leave a team — the previously missing counterpart to the owner-only "remove member".

- **New `DELETE /api/teams/:id/leave`** — self-scoped: removes `current_user`'s own membership. Uses `current_user`, never an email param, so it can only ever remove the caller (unlike `remove_member`, which is owner-driven and takes an email).
- The **team creator is blocked** (`403 creator_cannot_leave`) — leaving would orphan the team; they use "Delete team" instead.
- Destroying the `TeamUser` fires the existing `before_destroy` board-snapshot safety net (issue #162), so a departing member's shared boards stay with the family.
- Doc note added to `.claude-notes/boards-and-teams.md`.

Frontend counterpart: brittanyjohns/itty-bitty-frontend `claude/team-leave`.

## Test plan
- `bundle exec rspec spec/requests/api/team_permissions_spec.rb` → **13 examples, 0 failures**.
- New specs: member leaves (200 + membership gone), creator blocked (403 `creator_cannot_leave`), non-member (404), account-owner self-leave allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)