### PR TITLE
fix: split MySpeak onboarding About Me from emergency notes

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -67,6 +67,33 @@ info** — medical details + emergency contacts + emergency notes
   swallow a safety alert. The per-profile hourly throttle is the only timing gate.
 
 
+## About Me (public bio) vs emergency notes (private)
+
+The MySpeak page has two distinct free-text fields that were historically
+conflated:
+
+- **About Me = `profiles.bio`** (a text column) — the PUBLIC blurb shown on the
+  open page. Editable via `PATCH /api/profiles/:id` (`profile_params` already
+  permits `:bio`).
+- **Emergency notes = `settings["emergency_notes"]`** — one of the
+  `SAFETY_SENSITIVE_KEYS`, withheld from page-open and revealed only by the
+  gated `safety_view` POST. Also printed on the Safety ID card.
+
+**Onboarding writes them separately** (`API::V1::Onboarding::MyspeakController`):
+`about_me` → `bio`, `emergency_notes` → `settings["emergency_notes"]`.
+Previously the wizard sent a single `care_notes` field that was written into
+`bio`, publishing safety text on the open page. **Legacy compatibility:** a
+request that sends only `care_notes` (an old frontend still deployed) routes
+that text to the PRIVATE `emergency_notes`, never the public bio — privacy wins
+during the deploy gap. When no `about_me` is sent, `bio` is left blank so
+`Profile#set_defaults` fills the placeholder rather than leaking notes.
+
+**One-time cleanup:** `rake profiles:copy_onboarding_bio_to_emergency_notes`
+(dry-run by default, `DRY_RUN=false` to apply, `USER_ID=N` to scope) copies
+existing onboarding bios into blank `emergency_notes` for child-account safety
+profiles, keeping the bio (no public page goes blank). Skips generated
+placeholder bios and profiles that already have emergency notes; idempotent.
+
 ## Random slugs for safety profiles
 
 Safety profiles (`profile_kind = "safety"`, i.e. a `Profile` whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — MySpeak onboarding no longer publishes emergency notes as public About Me
+- The MySpeak onboarding wizard used to save its care/emergency notes into the
+  profile `bio`, which renders publicly as "About Me" on the open page. The
+  onboarding endpoint now accepts two separate fields: `about_me` → the public
+  bio, and `emergency_notes` → the private, gated `settings["emergency_notes"]`
+  (revealed only behind the emergency-info wall and printed on the Safety ID
+  card). Legacy clients that still send only `care_notes` now route that text to
+  the private emergency notes, not the public bio.
+- One-time cleanup for existing data:
+  `rake profiles:copy_onboarding_bio_to_emergency_notes` (dry-run by default;
+  `DRY_RUN=false` to apply, `USER_ID=N` to scope) copies onboarding bios into
+  blank emergency notes while keeping the bio. Frontend pairs with
+  itty-bitty-frontend (splits the onboarding step and adds an About Me editor).
+
 ### Fixed — boards assigned to communicators now show it everywhere
 - Board Builder boards live directly on the communicator (`ChildBoard` with
   no `original_board_id`), but every "who has this board" surface only read

--- a/app/controllers/api/v1/onboarding/myspeak_controller.rb
+++ b/app/controllers/api/v1/onboarding/myspeak_controller.rb
@@ -43,7 +43,18 @@ module API
           end
 
           pronouns       = params[:pronouns].to_s.strip
+          # About Me is the PUBLIC bio shown on the open MySpeak page.
+          # Emergency notes are PRIVATE — they live behind the gated
+          # safety_view reveal (Profile::SAFETY_SENSITIVE_KEYS) and print on
+          # the Safety ID card. The wizard now collects the two separately.
+          about_me       = params[:about_me].to_s
+          emergency_notes = params[:emergency_notes].to_s
+          # Legacy fallback: an old frontend sends only `care_notes`. It was
+          # framed as safety info, so route it to the PRIVATE emergency notes
+          # (never the public bio) — privacy wins during the deploy gap.
           care_notes     = params[:care_notes].to_s
+          resolved_emergency_notes =
+            emergency_notes.presence || (about_me.blank? ? care_notes.presence : nil)
           board_id       = params[:board_id]
           photo_data_url = params[:photo_data_url].to_s
           contacts       = Array(params[:contacts])
@@ -82,12 +93,19 @@ module API
 
             # No `slug:` — left blank so Profile#ensure_slug assigns the random
             # `s-xxxxxx` safety slug (slug_type "random", not user-editable).
+            # bio = About Me (public). Left blank when a legacy client sends
+            # only care_notes, so Profile#set_defaults fills the placeholder
+            # bio rather than leaking safety text onto the public page.
             profile = Profile.new(
               profileable: child,
               profile_kind: "safety",
               username: unique,
-              bio: care_notes,
-              settings: build_settings(pronouns: pronouns, contacts: contacts),
+              bio: about_me,
+              settings: build_settings(
+                pronouns: pronouns,
+                contacts: contacts,
+                emergency_notes: resolved_emergency_notes,
+              ),
             )
 
             attach_photo(profile, photo_data_url, unique) if photo_data_url.present?
@@ -127,9 +145,12 @@ module API
 
         private
 
-        def build_settings(pronouns:, contacts:)
+        def build_settings(pronouns:, contacts:, emergency_notes: nil)
           settings = {}
           settings["pronouns"] = pronouns if pronouns.present?
+          # Sensitive: withheld from page-open, revealed only by the gated
+          # safety_view POST (Profile::SAFETY_SENSITIVE_KEYS).
+          settings["emergency_notes"] = emergency_notes if emergency_notes.present?
 
           slot = 1
           contacts.each do |c|

--- a/lib/tasks/profiles.rake
+++ b/lib/tasks/profiles.rake
@@ -58,4 +58,74 @@ namespace :profiles do
     migrated_ids.each { |id| RegenerateSafetyCardsJob.perform_later(id) }
     puts "Jobs enqueued: #{migrated_ids.size}"
   end
+
+  # One-time cleanup for the About Me / emergency notes split.
+  #
+  # Before the split, MySpeak onboarding wrote its care/emergency notes into
+  # `bio` (the PUBLIC About Me). This copies that text into the PRIVATE
+  # `settings["emergency_notes"]` (behind the gated safety_view reveal) for
+  # child-account safety profiles whose emergency notes are still blank. Bio
+  # is KEPT — no public page goes blank; the parent can then edit both fields
+  # from the new editors. Idempotent (re-run skips profiles already set) and
+  # skips the generated placeholder bios.
+  #
+  # Read-only by default (reports what would change). Apply with DRY_RUN=false.
+  #
+  #   rake profiles:copy_onboarding_bio_to_emergency_notes                 # preview
+  #   DRY_RUN=false rake profiles:copy_onboarding_bio_to_emergency_notes   # apply
+  #   DRY_RUN=false USER_ID=740 rake profiles:copy_onboarding_bio_to_emergency_notes
+  desc "Copy onboarding bios into blank emergency_notes for safety profiles (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task copy_onboarding_bio_to_emergency_notes: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    user_id = ENV["USER_ID"].presence
+
+    # Generated placeholder bios (Profile#set_defaults and the placeholder
+    # factories) are not real About Me text — never migrate them.
+    default_bios = [
+      "Write a short bio about yourself. This will help others understand who you are and what you do.",
+      "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+    ].freeze
+
+    scope = Profile.where(profile_kind: "safety", profileable_type: "ChildAccount")
+    if user_id
+      child_ids = ChildAccount.where(user_id: user_id).pluck(:id)
+      scope = scope.where(profileable_id: child_ids)
+    end
+
+    copied = 0
+    skipped = 0
+
+    scope.find_each(batch_size: 100) do |profile|
+      bio = profile.bio.to_s.strip
+      raw = profile.settings.is_a?(Hash) ? profile.settings : {}
+
+      # Skip: no real bio, a generated default, or emergency notes already set.
+      if bio.blank? || default_bios.include?(bio) || raw["emergency_notes"].present?
+        skipped += 1
+        next
+      end
+
+      if dry_run
+        puts "[DRY RUN] profile ##{profile.id} #{profile.slug.inspect} → copy bio into emergency_notes"
+        copied += 1
+        next
+      end
+
+      new_settings = raw.merge("emergency_notes" => bio)
+      profile.update_columns(settings: new_settings, updated_at: Time.current)
+      copied += 1
+    rescue => e
+      Rails.logger.error("Failed to copy bio→emergency_notes for profile #{profile.id}: #{e.message}")
+      puts "  ! profile ##{profile.id} failed: #{e.message}"
+      skipped += 1
+    end
+
+    if dry_run
+      puts "Dry run only — #{copied} profile(s) would get bio copied into emergency_notes " \
+           "(#{skipped} skipped). Re-run with DRY_RUN=false to apply."
+      next
+    end
+
+    puts "Copied: #{copied}, Skipped: #{skipped}"
+  end
 end

--- a/spec/lib/tasks/profiles_copy_onboarding_bio_spec.rb
+++ b/spec/lib/tasks/profiles_copy_onboarding_bio_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "profiles:copy_onboarding_bio_to_emergency_notes rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["profiles:copy_onboarding_bio_to_emergency_notes"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    original = ENV.to_hash.slice("DRY_RUN", "USER_ID")
+    example.run
+    ENV["DRY_RUN"] = original["DRY_RUN"]
+    ENV["USER_ID"] = original["USER_ID"]
+  end
+
+  let(:owner) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Emma") }
+
+  # A profile whose onboarding notes were saved into the public bio, with no
+  # emergency notes yet — the migration target.
+  let!(:target) do
+    Profile.new(
+      profileable: child,
+      username: "emma-jones",
+      slug: "emma-jones",
+      bio: "Has seizures. Calming phrase: 'you are safe.'",
+    ).tap(&:save!)
+  end
+
+  before do
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+  end
+
+  it "previews without changing anything in dry-run (default)" do
+    run_task
+
+    target.reload
+    expect(target.settings["emergency_notes"]).to be_nil
+    expect(target.bio).to include("Has seizures")
+  end
+
+  it "copies bio into blank emergency_notes when applied, keeping the bio" do
+    ENV["DRY_RUN"] = "false"
+    run_task
+
+    target.reload
+    expect(target.settings["emergency_notes"]).to eq("Has seizures. Calming phrase: 'you are safe.'")
+    # Bio is KEPT — no public page goes blank.
+    expect(target.bio).to include("Has seizures")
+  end
+
+  it "skips profiles that already have emergency notes" do
+    target.update!(settings: target.settings.merge("emergency_notes" => "existing note"))
+    ENV["DRY_RUN"] = "false"
+    run_task
+
+    expect(target.reload.settings["emergency_notes"]).to eq("existing note")
+  end
+
+  it "skips the generated placeholder bio" do
+    placeholder_child = FactoryBot.create(:child_account, user: owner, owner: owner, name: "Max")
+    placeholder = Profile.new(
+      profileable: placeholder_child,
+      username: "max-power",
+      slug: "max-power",
+      bio: "Write a short bio about yourself. This will help others understand who you are and what you do.",
+    ).tap(&:save!)
+
+    ENV["DRY_RUN"] = "false"
+    run_task
+
+    expect(placeholder.reload.settings["emergency_notes"]).to be_nil
+  end
+
+  it "is idempotent — a second run is a no-op" do
+    ENV["DRY_RUN"] = "false"
+    run_task
+    first = target.reload.settings["emergency_notes"]
+
+    run_task
+    expect(target.reload.settings["emergency_notes"]).to eq(first)
+  end
+
+  it "leaves user (non-child-account) safety-less profiles untouched" do
+    page = Profile.new(profileable: owner, profile_kind: "public_page", username: "pat-smith", bio: "hello").tap(&:save!)
+    ENV["DRY_RUN"] = "false"
+    run_task
+
+    expect(page.reload.settings["emergency_notes"]).to be_nil
+  end
+
+  it "scopes to a single user via USER_ID" do
+    other_owner = FactoryBot.create(:user)
+    other_child = FactoryBot.create(:child_account, user: other_owner, owner: other_owner, name: "Kit")
+    other = Profile.new(
+      profileable: other_child,
+      username: "kit-stone",
+      slug: "kit-stone",
+      bio: "Loves music.",
+    ).tap(&:save!)
+
+    ENV["DRY_RUN"] = "false"
+    ENV["USER_ID"] = owner.id.to_s
+    run_task
+
+    expect(target.reload.settings["emergency_notes"]).to include("Has seizures")
+    expect(other.reload.settings["emergency_notes"]).to be_nil
+  end
+end

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
       pronouns: "they/them",
       photo_data_url: PNG_DATA_URL,
       board_id: "later",
-      care_notes: "Loves big hugs. Use a calm voice when overwhelmed.",
+      about_me: "Loves big hugs and dinosaurs. Ask me about my rock collection.",
+      emergency_notes: "Has seizures. Use a calm voice when overwhelmed.",
       contacts: [
         { name: "Sam Stone", relationship: "Parent", phone: "555-0101" },
         { name: "Kit Stone", relationship: "Aunt",   phone: "555-0102" },
@@ -79,7 +80,9 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(profile.slug_type).to eq("random")
         # ...but the username stays readable (it's the handle, not the public URL).
         expect(profile.username).to eq("river-stone")
+        # About Me → public bio; emergency notes → private (gated) settings.
         expect(profile.bio).to include("Loves big hugs")
+        expect(profile.settings["emergency_notes"]).to include("Has seizures")
         expect(profile.avatar).to be_attached
         expect(profile.settings["pronouns"]).to eq("they/them")
         expect(profile.settings["ice_contact_1"]).to eq(
@@ -93,6 +96,59 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(body["profile_kind"]).to eq("safety")
         expect(body["settings"]["pronouns"]).to eq("they/them")
         expect(body["settings"]["ice_contact_1"]["phone"]).to eq("555-0101")
+      end
+    end
+
+    context "About Me vs emergency notes split" do
+      it "routes about_me to the public bio and emergency_notes to the gated settings" do
+        post "/api/v1/onboarding/myspeak", params: base_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        profile = user.communicator_accounts.last.profile
+        # Public About Me = bio; withheld from the open page's settings.
+        expect(profile.bio).to include("dinosaurs")
+        expect(profile.public_settings(kind: :safety)).not_to include("emergency_notes")
+        # Private emergency notes live behind the gated reveal.
+        expect(profile.settings["emergency_notes"]).to include("Has seizures")
+        expect(profile.has_safety_info?).to be(true)
+        expect(profile.safety_sensitive_settings["emergency_notes"]).to include("Has seizures")
+      end
+
+      it "keeps the default placeholder bio when only emergency_notes is provided" do
+        payload = base_payload.except(:about_me)
+        post "/api/v1/onboarding/myspeak", params: payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        profile = user.communicator_accounts.last.profile
+        # No About Me typed → bio falls back to the generated placeholder, so no
+        # safety text leaks onto the public page.
+        expect(profile.bio).to include("Write a short bio")
+        expect(profile.settings["emergency_notes"]).to include("Has seizures")
+      end
+
+      it "does not populate emergency_notes when only about_me is provided" do
+        payload = base_payload.except(:emergency_notes)
+        post "/api/v1/onboarding/myspeak", params: payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:created)
+        profile = user.communicator_accounts.last.profile
+        expect(profile.bio).to include("dinosaurs")
+        expect(profile.settings["emergency_notes"]).to be_nil
+      end
+
+      context "legacy client (care_notes only)" do
+        it "routes care_notes to the PRIVATE emergency notes, never the public bio" do
+          payload = base_payload.except(:about_me, :emergency_notes)
+                                .merge(care_notes: "Allergic to peanuts. Calming phrase: 'you are safe.'")
+          post "/api/v1/onboarding/myspeak", params: payload.to_json, headers: headers
+
+          expect(response).to have_http_status(:created)
+          profile = user.communicator_accounts.last.profile
+          # Old framing was safety info — privacy wins: it must NOT be public bio.
+          expect(profile.bio).not_to include("peanuts")
+          expect(profile.bio).to include("Write a short bio")
+          expect(profile.settings["emergency_notes"]).to include("peanuts")
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

The MySpeak onboarding wizard collected a single free-text notes field and the backend wrote it into `profiles.bio` — which renders **publicly** as "About Me" on the open MySpeak page. Because the onboarding step is framed as safety info, parents typed medical/emergency details that ended up published openly instead of behind the gated emergency-info reveal.

This PR separates the two fields:

- **`about_me`** → `profiles.bio` (the public About Me).
- **`emergency_notes`** → `settings["emergency_notes"]`, one of `Profile::SAFETY_SENSITIVE_KEYS` — withheld from page-open, revealed only by the gated `safety_view` POST, and printed on the Safety ID card.

**Legacy compatibility:** a request that still sends only `care_notes` (an old frontend during the deploy gap) now routes that text to the **private** emergency notes, never the public bio. When no `about_me` is sent, `bio` is left blank so `Profile#set_defaults` fills the placeholder rather than leaking notes.

**One-time cleanup:** `rake profiles:copy_onboarding_bio_to_emergency_notes` (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope) copies existing onboarding bios into blank `emergency_notes` for child-account safety profiles, **keeping the bio** so no public page goes blank. Skips generated placeholder bios and profiles that already have emergency notes; idempotent. Run the dry-run against production first.

No schema change — `bio` and the `emergency_notes` jsonb key already exist. The profiles update endpoint already permits `:bio` and `settings: {}`, so the frontend's new About Me editor needs no backend change.

Pairs with an itty-bitty-frontend PR that splits the onboarding step into two labeled fields and adds an About Me editor on the communicator account page. This backend ships first and is safe alone (still accepts `care_notes`, just routes it privately).

## Test plan

Ran the targeted specs — **30 examples, 0 failures**:

- `spec/requests/api/v1/onboarding/myspeak_spec.rb` — new "About Me vs emergency notes split" context: `about_me` → public bio, `emergency_notes` → gated settings, about-me-only, emergency-notes-only, and legacy `care_notes`-only routing to private notes without leaking to bio.
- `spec/lib/tasks/profiles_copy_onboarding_bio_spec.rb` — dry-run no-op, apply copies bio→emergency_notes keeping bio, skips existing notes, skips placeholder bios, idempotent, USER_ID scoping.

```
bundle exec rspec spec/requests/api/v1/onboarding/myspeak_spec.rb spec/lib/tasks/profiles_copy_onboarding_bio_spec.rb
# 30 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)