### PR TITLE
feat(admin): user-page controls — plan changes, editing, Stripe links, email actions, demo cleanup

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -194,6 +194,19 @@ that without auto-downgrading (partners are high-value B2B leads managed by hand
   (`/admin/users/:id`) shows a **Partner Pilot** card (end date, days left,
   reminder-sent, expired-flagged) so you can action a partner in one place —
   extend by bumping `plan_expires_at`, or adjust plan by hand.
+- **Admin plan changes.** The user detail page can change plans directly
+  (`Admin::UsersController#change_plan`). All changes are **local-only —
+  Stripe is never touched**, so an active Stripe subscription's webhooks can
+  later overwrite them. Semantics: `free` runs
+  `Billing::PlanTransitions.apply_free_plan` (full cancellation);
+  `partner_pro` runs `User.handle_new_partner_pro_subscription` (full partner
+  onboarding); other paid plans set `plan_type` **and `plan_status: "active"`**
+  (without the status reset, a previously-canceled user would be
+  `plan_stranded?` and auto-reverted to free). `basic_trial` is not
+  admin-assignable — trials belong to the soft-trial flow. The page also
+  edits identity/flags and the manual `settings` limit overrides
+  (board/paid-communicator/demo-communicator), and has queue-only email
+  actions (welcome / setup / temp-login).
 
 **Phase 2 (not built):** if partner volume outgrows hand-management, move the
 pilot onto a real Stripe no-card trial (reuses the reverse-trial machinery

--- a/.claude-notes/marketing-integrations.md
+++ b/.claude-notes/marketing-integrations.md
@@ -13,6 +13,11 @@ GitHub build). Two distinct uses:
   (`record_new_subscriber`), tags by plan tier, and records sign-in/sign-up
   events. Fired async via `MailchimpEventJob` (event types `sign_up` /
   `sign_in`) from `API::V1::AuthsController` and the Stripe checkout controller.
+  **Tags apply to existing contacts too:** `record_new_subscriber` early-returns
+  when the contact is already in the audience, but it applies the passed tags
+  first — this is what lets a tag-triggered journey (e.g. the Partner journey's
+  "Partner Program" trigger tag) fire for users who were synced at signup and
+  promoted later. Don't reintroduce a pre-tag early return.
 - **Customer Journey triggers (email):** `MailchimpService#trigger_journey`
   enrols a contact into a journey's **API-trigger step** so Mailchimp sends the
   email designed in that journey. The accessor is resolved via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — admin user page: plan changes, editing, Stripe links, email actions
+- The admin dashboard user page (`/admin/users/:id`) can now **change a
+  user's plan** (local-only — Stripe is never modified; downgrading to free
+  applies full cancellation semantics, `partner_pro` runs full partner
+  onboarding, other paid plans also reset `plan_status` to active so
+  previously-canceled users aren't auto-reverted).
+- New **Edit Account** form: name, email, role, locked, play-demo, and
+  manual limit overrides (boards / paid communicators / demo communicators).
+- Stripe customer and subscription IDs now **link to the Stripe dashboard**
+  in a new tab.
+- **Email action buttons**: queue the plan-appropriate welcome email, the
+  setup email, or a temporary login link.
+- **Demo accounts excluded from admin metrics**: the admin dashboard counts
+  and all Mission Control overview/usage metrics now exclude demo/test
+  accounts and their activity (boards, word events, communicators, credits,
+  AI prompts). The dashboard shows a separate Demo Accounts card linking to
+  the demo-filtered user list.
+- **Per-user demo cleanup**: demo accounts get a "demo" badge and a Delete
+  button on the admin user page — same tombstone path as the Mission Control
+  batch cleanup (destroys all content, anonymizes PII, keeps the credit
+  ledger). Non-demo and admin accounts can't be deleted from here.
+
 ### Fixed — MySpeak onboarding no longer publishes emergency notes as public About Me
 - The MySpeak onboarding wizard used to save its care/emergency notes into the
   profile `bio`, which renders publicly as "About Me" on the open page. The
@@ -18,7 +40,6 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `DRY_RUN=false` to apply, `USER_ID=N` to scope) copies onboarding bios into
   blank emergency notes while keeping the bio. Frontend pairs with
   itty-bitty-frontend (splits the onboarding step and adds an About Me editor).
-
 ### Fixed — boards assigned to communicators now show it everywhere
 - Board Builder boards live directly on the communicator (`ChildBoard` with
   no `original_board_id`), but every "who has this board" surface only read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   in a new tab.
 - **Email action buttons**: queue the plan-appropriate welcome email, the
   setup email, or a temporary login link.
+
+### Fixed — Mailchimp tags now land on existing contacts
+- `MailchimpService#record_new_subscriber` used to return early when the
+  contact already existed in the audience — before applying tags. Since most
+  users are synced to Mailchimp at signup, promoting an existing user (e.g.
+  to Partner Pro) never applied the "Partner Program" journey trigger tag,
+  so they silently never entered the Partner Customer Journey. Tags are now
+  applied for existing contacts too, fixing the admin/API partner flows and
+  the `partners:backfill_mailchimp_tags` rake task in one place.
 - **Demo accounts excluded from admin metrics**: the admin dashboard counts
   and all Mission Control overview/usage metrics now exclude demo/test
   accounts and their activity (boards, word events, communicators, credits,

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,9 +1,13 @@
 module Admin
   class DashboardController < Admin::ApplicationController
+    include MissionControl::ExcludesDemo
+
     def index
-      @user_count   = User.count
-      @board_count  = Board.count
-      @today_signups = User.where("created_at >= ?", Time.zone.today.beginning_of_day).count
+      real_users = User.non_admin.non_demo
+      @user_count = real_users.count
+      @board_count = without_demo(Board.non_templates).count
+      @today_signups = real_users.where("created_at >= ?", Time.zone.today.beginning_of_day).count
+      @demo_user_count = User.demo_accounts.count
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,10 @@
 module Admin
   class UsersController < Admin::ApplicationController
+    EDITABLE_ROLES = %w[user admin partner vendor].freeze
+    # basic_trial is excluded — trials are owned by the soft-trial flow
+    # (DowngradeSoftTrialJob), not manual admin assignment.
+    CHANGEABLE_PLAN_TYPES = %w[free basic basic_yearly pro pro_yearly plus premium partner_pro].freeze
+
     def index
       @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count boards]) || "created_at"
       @dir = params[:dir].presence_in(%w[asc desc]) || "desc"
@@ -59,7 +64,118 @@ module Admin
       render json: { error: e.message }, status: :unprocessable_content
     end
 
+    def update
+      @user = User.find(params[:id])
+      attrs = user_params
+      bool = ActiveModel::Type::Boolean.new
+
+      @user.name = attrs[:name] if attrs.key?(:name)
+      @user.email = attrs[:email] if attrs.key?(:email)
+      @user.role = attrs[:role] if EDITABLE_ROLES.include?(attrs[:role])
+      @user.play_demo = bool.cast(attrs[:play_demo]) if attrs.key?(:play_demo)
+
+      if attrs.key?(:locked)
+        locked = bool.cast(attrs[:locked]) || false
+        @user.locked = locked
+        @user.settings["locked"] = locked
+      end
+
+      # Limits live in settings; the model's *_limit= setters save immediately,
+      # so write the keys directly instead of assigning attributes.
+      @user.settings["board_limit"] = attrs[:board_limit].to_i if attrs[:board_limit].present?
+      @user.settings["paid_communicator_limit"] = attrs[:paid_communicator_limit].to_i if attrs[:paid_communicator_limit].present?
+      @user.settings["demo_communicator_limit"] = attrs[:demo_communicator_limit].to_i if attrs[:demo_communicator_limit].present?
+      @user.skip_plan_setup = true # parity with API admin; setup_limits only runs on plan_type changes anyway
+
+      if @user.save
+        redirect_to admin_dashboard_user_path(@user), notice: "User updated.", status: :see_other
+      else
+        redirect_to admin_dashboard_user_path(@user), alert: @user.errors.full_messages.to_sentence, status: :see_other
+      end
+    end
+
+    def change_plan
+      @user = User.find(params[:id])
+      new_plan = params[:plan_type].to_s
+
+      unless CHANGEABLE_PLAN_TYPES.include?(new_plan)
+        redirect_to admin_dashboard_user_path(@user), alert: "Unknown plan type: #{new_plan}", status: :see_other
+        return
+      end
+
+      if new_plan == @user.plan_type
+        redirect_to admin_dashboard_user_path(@user), notice: "No change — already on #{new_plan}.", status: :see_other
+        return
+      end
+
+      case new_plan
+      when "free"
+        Billing::PlanTransitions.apply_free_plan(@user, "canceled")
+      when "partner_pro"
+        @user.plan_type = "partner_pro"
+        @user.plan_status = "active"
+        @user.save!
+        User.handle_new_partner_pro_subscription(@user, "partner_pro")
+      else
+        @user.plan_type = new_plan
+        # Without an active status, a previously-canceled user would be
+        # plan_stranded? and reconcile_stranded_plan! would revert them to free.
+        @user.plan_status = "active"
+        @user.save!
+      end
+
+      redirect_to admin_dashboard_user_path(@user),
+                  notice: "Plan changed to #{new_plan}. Local-only: Stripe was not modified.",
+                  status: :see_other
+    rescue ActiveRecord::RecordInvalid => e
+      redirect_to admin_dashboard_user_path(@user), alert: e.record.errors.full_messages.to_sentence, status: :see_other
+    end
+
+    def send_welcome_email
+      @user = User.find(params[:id])
+      @user.send_welcome_email(@user.plan_type || "free")
+      redirect_to admin_dashboard_user_path(@user), notice: "Welcome email queued for #{@user.email}.", status: :see_other
+    end
+
+    def send_setup_email
+      @user = User.find(params[:id])
+      @user.send_setup_email
+      redirect_to admin_dashboard_user_path(@user), notice: "Setup email queued for #{@user.email}.", status: :see_other
+    end
+
+    def send_temp_login_email
+      @user = User.find(params[:id])
+      @user.send_temp_login_email
+      redirect_to admin_dashboard_user_path(@user), notice: "Temporary login email queued for #{@user.email}.", status: :see_other
+    end
+
+    # Demo-account cleanup only. Uses the same tombstone path as the Mission
+    # Control batch cleanup: destroys all content (boards, communicators,
+    # docs, ...), anonymizes PII, keeps one hidden row + credit ledger.
+    def destroy
+      @user = User.find(params[:id])
+
+      unless @user.demo_user? && !@user.admin?
+        redirect_to admin_dashboard_user_path(@user),
+                    alert: "Only demo accounts can be deleted from here.", status: :see_other
+        return
+      end
+
+      email = @user.email
+      @user.soft_delete_account!(reason: "demo_cleanup", actor_id: current_user.id) unless @user.soft_deleted?
+      redirect_to admin_dashboard_users_path,
+                  notice: "Demo account #{email} deleted (content destroyed, row anonymized).", status: :see_other
+    rescue => e
+      Rails.logger.error("[DemoCleanup] Failed to delete user #{params[:id]}: #{e.class} - #{e.message}")
+      redirect_to admin_dashboard_user_path(params[:id]), alert: "Delete failed — check logs.", status: :see_other
+    end
+
     private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :role, :locked, :play_demo,
+                                   :board_limit, :paid_communicator_limit, :demo_communicator_limit)
+    end
 
     def apply_filter(scope)
       case @filter

--- a/app/models/mailchimp_service.rb
+++ b/app/models/mailchimp_service.rb
@@ -7,6 +7,16 @@ class MailchimpService
     Digest::MD5.hexdigest(email.downcase)
   end
 
+  def apply_member_tags(list_id, subscriber_hash_email, tags)
+    return if tags.blank?
+
+    @client.lists.update_list_member_tags(
+      list_id,
+      subscriber_hash_email,
+      { tags: tags.map { |t| { name: t, status: "active" } } }
+    )
+  end
+
   def record_signin_event(user, opts = {})
     props = opts[:properties] || {}
     props[:current_sign_in_ip] = user.current_sign_in_ip&.to_s if user.current_sign_in_ip
@@ -70,6 +80,10 @@ class MailchimpService
       result = @client.lists.get_list_member(list_id, subscriber_hash_email)
       if result
         Rails.logger.info("[Mailchimp] Subscriber already exists for email #{email} in audience #{list_id}")
+        # Tags must still land on existing contacts — "Partner Program" is the
+        # trigger tag the Partner Customer Journey fires on, and most users are
+        # already in the audience by the time they're promoted.
+        apply_member_tags(list_id, subscriber_hash_email, tags)
         return result
       end
     rescue MailchimpMarketing::ApiError => e
@@ -86,14 +100,7 @@ class MailchimpService
       merge_fields: merge_fields,
     }
     response = @client.lists.set_list_member(list_id, subscriber_hash_email, body)
-    # Add tags if provided
-    unless tags.blank?
-      @client.lists.update_list_member_tags(
-        list_id,
-        subscriber_hash_email,
-        { tags: tags.map { |t| { name: t, status: "active" } } }
-      )
-    end
+    apply_member_tags(list_id, subscriber_hash_email, tags)
     response
   rescue MailchimpMarketing::ApiError => e
     # Swallowed so a Mailchimp blip can't break signup, but logged at error

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,6 +148,9 @@ class User < ApplicationRecord
 
   scope :non_admin, -> { where("role IS NULL OR role != ?", "admin") }
   scope :demo_accounts, -> { non_admin.where("email LIKE ? OR email LIKE ?", "%bhannajohns+%", "%@speakanyway.com") }
+  # Exact complement of demo_accounts (admins are never demo). Growth/usage
+  # metrics use this so internal/test activity doesn't inflate the numbers.
+  scope :non_demo, -> { where.not(id: demo_accounts.select(:id)) }
   # SQL counterpart of #paid_plan?: a paid tier whose status isn't a
   # non-paying one. basic_trial / trialing count as paid while active, same
   # as the instance method. Excludes UNPAID_STATUSES (canceled/paused/etc.)

--- a/app/services/mission_control/excludes_demo.rb
+++ b/app/services/mission_control/excludes_demo.rb
@@ -1,0 +1,20 @@
+module MissionControl
+  # Demo accounts (User.demo_accounts — internal/test users) must not inflate
+  # growth or usage metrics. Mix this in and wrap any user-owned scope in
+  # without_demo(...) to strip demo-owned rows. NULL user_ids are kept (they
+  # are system rows, not demo activity).
+  module ExcludesDemo
+    private
+
+    def demo_user_ids
+      @demo_user_ids ||= User.demo_accounts.pluck(:id)
+    end
+
+    def without_demo(scope)
+      return scope if demo_user_ids.empty?
+
+      table = scope.model.arel_table
+      scope.where(table[:user_id].eq(nil).or(table[:user_id].not_in(demo_user_ids)))
+    end
+  end
+end

--- a/app/services/mission_control/overview_metrics.rb
+++ b/app/services/mission_control/overview_metrics.rb
@@ -1,28 +1,44 @@
 module MissionControl
   class OverviewMetrics
+    include ExcludesDemo
+
     def self.call = new.call
 
     def call
       {
-        signups_today:        User.non_admin.where(created_at: today).count,
-        signups_7d:           User.non_admin.where(created_at: 7.days.ago..).count,
-        signups_30d:          User.non_admin.where(created_at: 30.days.ago..).count,
+        signups_today:        real_users.where(created_at: today).count,
+        signups_7d:           real_users.where(created_at: 7.days.ago..).count,
+        signups_30d:          real_users.where(created_at: 30.days.ago..).count,
         signups_daily_7d:     signups_daily_7d,
-        total_users:          User.non_admin.count,
-        active_users_7d:      User.non_admin.where(last_sign_in_at: 7.days.ago..).count,
-        active_users_30d:     User.non_admin.where(last_sign_in_at: 30.days.ago..).count,
-        trial_users:          User.non_admin.where(plan_status: "trialing").count,
-        boards_today:         Board.non_templates.where(created_at: today).count,
-        boards_7d:            Board.non_templates.where(created_at: 7.days.ago..).count,
-        total_boards:         Board.non_templates.count,
-        word_events_today:    WordEvent.where(created_at: today).count,
-        word_events_7d:       WordEvent.where(created_at: 7.days.ago..).count,
-        communicator_accounts: ChildAccount.where.not(status: "archived").count,
-        myspeak_profiles:     Profile.where(profileable_type: "ChildAccount").count,
+        total_users:          real_users.count,
+        active_users_7d:      real_users.where(last_sign_in_at: 7.days.ago..).count,
+        active_users_30d:     real_users.where(last_sign_in_at: 30.days.ago..).count,
+        trial_users:          real_users.where(plan_status: "trialing").count,
+        boards_today:         real_boards.where(created_at: today).count,
+        boards_7d:            real_boards.where(created_at: 7.days.ago..).count,
+        total_boards:         real_boards.count,
+        word_events_today:    without_demo(WordEvent.where(created_at: today)).count,
+        word_events_7d:       without_demo(WordEvent.where(created_at: 7.days.ago..)).count,
+        communicator_accounts: real_communicators.count,
+        myspeak_profiles:     Profile.where(profileable_type: "ChildAccount",
+                                            profileable_id: without_demo(ChildAccount.all).select(:id)).count,
       }
     end
 
     private
+
+    # Real = the accounts the metrics are about: not admins, not demo/test.
+    def real_users
+      User.non_admin.non_demo
+    end
+
+    def real_boards
+      without_demo(Board.non_templates)
+    end
+
+    def real_communicators
+      without_demo(ChildAccount.where.not(status: "archived"))
+    end
 
     def today
       Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
@@ -31,10 +47,10 @@ module MissionControl
     # group_by_day buckets in Time.zone (not UTC) and zero-fills missing days,
     # so the chart aligns with the Time.zone-based "today" cards.
     def signups_daily_7d
-      User.non_admin
-          .group_by_day(:created_at, last: 7)
-          .count
-          .transform_keys(&:to_s)
+      real_users
+        .group_by_day(:created_at, last: 7)
+        .count
+        .transform_keys(&:to_s)
     end
   end
 end

--- a/app/services/mission_control/usage_metrics.rb
+++ b/app/services/mission_control/usage_metrics.rb
@@ -1,5 +1,7 @@
 module MissionControl
   class UsageMetrics
+    include ExcludesDemo
+
     def self.call = new.call
 
     def call
@@ -10,23 +12,23 @@ module MissionControl
         builder_sets_30d:       builder_roots.where(created_at: 30.days.ago..).count,
 
         # Credit usage
-        credits_spent_today:    CreditTransaction.spends.where(created_at: today).sum(:amount).abs,
-        credits_spent_7d:       CreditTransaction.spends.where(created_at: 7.days.ago..).sum(:amount).abs,
-        credits_spent_30d:      CreditTransaction.spends.where(created_at: 30.days.ago..).sum(:amount).abs,
+        credits_spent_today:    credit_spends.where(created_at: today).sum(:amount).abs,
+        credits_spent_7d:       credit_spends.where(created_at: 7.days.ago..).sum(:amount).abs,
+        credits_spent_30d:      credit_spends.where(created_at: 30.days.ago..).sum(:amount).abs,
 
         # Communicators
-        communicators_created_today: ChildAccount.where(created_at: today).count,
-        communicators_created_7d:    ChildAccount.where(created_at: 7.days.ago..).count,
+        communicators_created_today: communicators.where(created_at: today).count,
+        communicators_created_7d:    communicators.where(created_at: 7.days.ago..).count,
 
         # Communicator sessions (sign-ins)
-        communicator_sessions_7d:  ChildAccount.where(last_sign_in_at: 7.days.ago..).count,
-        communicator_sessions_30d: ChildAccount.where(last_sign_in_at: 30.days.ago..).count,
+        communicator_sessions_7d:  communicators.where(last_sign_in_at: 7.days.ago..).count,
+        communicator_sessions_30d: communicators.where(last_sign_in_at: 30.days.ago..).count,
 
         # AI prompts & failures (kept from original)
-        ai_prompts_today:       OpenaiPrompt.where(created_at: today).count,
-        ai_prompts_30d:         OpenaiPrompt.where(created_at: 30.days.ago..).count,
-        ai_failures_today:      AnalyticsEvent.for_event("ai_generation_failed").today.count,
-        ai_failures_7d:         AnalyticsEvent.for_event("ai_generation_failed").since(7.days.ago).count,
+        ai_prompts_today:       ai_prompts.where(created_at: today).count,
+        ai_prompts_30d:         ai_prompts.where(created_at: 30.days.ago..).count,
+        ai_failures_today:      without_demo(AnalyticsEvent.for_event("ai_generation_failed").today).count,
+        ai_failures_7d:         without_demo(AnalyticsEvent.for_event("ai_generation_failed").since(7.days.ago)).count,
       }
     end
 
@@ -37,7 +39,19 @@ module MissionControl
     end
 
     def builder_roots
-      Board.where("(settings->>'builder_root')::boolean = true")
+      without_demo(Board.where("(settings->>'builder_root')::boolean = true"))
+    end
+
+    def credit_spends
+      without_demo(CreditTransaction.spends)
+    end
+
+    def communicators
+      without_demo(ChildAccount.all)
+    end
+
+    def ai_prompts
+      without_demo(OpenaiPrompt.all)
     end
   end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -9,7 +9,10 @@
 
 <%# Quick stats %>
 <section class="mb-10">
-  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">At a Glance</h2>
+  <div class="flex items-baseline gap-3 mb-4">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2">At a Glance</h2>
+    <span class="text-[10px] text-t3">Excludes admin and demo accounts</span>
+  </div>
   <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
     <div class="admin-card border rounded-xl p-5">
       <p class="text-xs text-t2 mb-1">Total Users</p>
@@ -19,6 +22,13 @@
     <div class="admin-card border rounded-xl p-5">
       <p class="text-xs text-t2 mb-1">Total Boards</p>
       <p class="text-2xl font-semibold text-t1"><%= number_with_delimiter(@board_count) %></p>
+    </div>
+    <div class="admin-card border rounded-xl p-5">
+      <p class="text-xs text-t2 mb-1">Demo Accounts</p>
+      <p class="text-2xl font-semibold text-t1"><%= number_with_delimiter(@demo_user_count) %></p>
+      <p class="text-xs mt-0.5">
+        <%= link_to "View & clean up →", admin_dashboard_users_path(filter: "demo"), class: "text-accent hover:underline" %>
+      </p>
     </div>
   </div>
 </section>

--- a/app/views/admin/mission_control/show.html.erb
+++ b/app/views/admin/mission_control/show.html.erb
@@ -4,7 +4,10 @@
 <div class="flex items-center justify-between mb-8">
   <div>
     <h1 class="text-2xl font-semibold text-t1 tracking-tight">Overview</h1>
-    <p class="text-sm text-t3 mt-0.5"><%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %></p>
+    <p class="text-sm text-t3 mt-0.5">
+      <%= Time.zone.now.strftime("%A, %B %-d %Y · %H:%M %Z") %>
+      · All metrics exclude admin and demo accounts
+    </p>
   </div>
   <a href="<%= admin_mission_control_path %>"
      class="text-xs text-t2 hover:text-t1 border rounded px-3 py-1.5 transition-colors"

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -15,15 +15,26 @@
       <% end %>
     </p>
   </div>
-  <div class="flex items-center gap-2">
-    <span class="<%= plan_badge_class(@user) %> inline-block text-xs rounded px-2.5 py-1">
-      <%= @user.plan_type || "none" %>
-    </span>
-    <% if @user.admin? %>
-      <span class="bg-yellow-900/60 text-yellow-300 inline-block text-xs rounded px-2.5 py-1">admin</span>
-    <% end %>
-    <% if @user.locked? %>
-      <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2.5 py-1">locked</span>
+  <div class="flex flex-col items-end gap-2">
+    <div class="flex items-center gap-2">
+      <span class="<%= plan_badge_class(@user) %> inline-block text-xs rounded px-2.5 py-1">
+        <%= @user.plan_type || "none" %>
+      </span>
+      <% if @user.admin? %>
+        <span class="bg-yellow-900/60 text-yellow-300 inline-block text-xs rounded px-2.5 py-1">admin</span>
+      <% end %>
+      <% if @user.demo_user? && !@user.admin? %>
+        <span class="bg-yellow-900/60 text-yellow-300 inline-block text-xs rounded px-2.5 py-1">demo</span>
+      <% end %>
+      <% if @user.locked? %>
+        <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2.5 py-1">locked</span>
+      <% end %>
+    </div>
+    <% if @user.demo_user? && !@user.admin? %>
+      <%= button_to "Delete demo account", admin_dashboard_user_path(@user),
+            method: :delete,
+            class: "text-xs font-medium px-3 py-1.5 rounded cursor-pointer bg-red-900/60 text-red-300 hover:bg-red-900/80 transition-colors",
+            form: { data: { turbo_confirm: "Delete demo account #{@user.email}? All boards, communicators, and content are destroyed and the account is anonymized. This cannot be undone." } } %>
     <% end %>
   </div>
 </div>
@@ -172,6 +183,127 @@
   });
 </script>
 
+<%# ─── Edit account ───────────────────────────────────────── %>
+<div class="admin-card border rounded-xl p-6 mb-8">
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Edit Account</h2>
+
+  <%= form_with url: admin_dashboard_user_path(@user), method: :patch, scope: :user, local: true do |f| %>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Name</label>
+        <%= f.text_field :name, value: @user.name,
+              class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Email</label>
+        <%= f.email_field :email, value: @user.email, required: true,
+              class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Role</label>
+        <%= f.select :role, options_for_select(Admin::UsersController::EDITABLE_ROLES, @user.role),
+              {}, class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Board limit</label>
+        <%= f.number_field :board_limit, value: @user.board_limit, min: 0,
+              class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Paid communicator limit</label>
+        <%= f.number_field :paid_communicator_limit, value: @user.comm_account_limit, min: 0,
+              class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+      <div>
+        <label class="block text-[10px] text-t3 mb-1">Demo communicator limit</label>
+        <%= f.number_field :demo_communicator_limit, value: @user.settings["demo_communicator_limit"] || 0, min: 0,
+              class: "admin-input w-full text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-6 mb-4">
+      <label class="flex items-center gap-2 text-xs text-t1">
+        <%= f.check_box :locked, checked: @user.locked? %>
+        Locked
+      </label>
+      <label class="flex items-center gap-2 text-xs text-t1">
+        <%= f.check_box :play_demo, checked: @user.play_demo %>
+        Play demo
+      </label>
+    </div>
+
+    <div class="flex items-center gap-4">
+      <%= f.submit "Save changes",
+            class: "text-sm font-medium px-4 py-1.5 rounded transition-colors cursor-pointer",
+            style: "background: var(--text-accent); color: #fff;" %>
+      <p class="text-[10px] text-t3">
+        Limits override the plan defaults. Changing the plan re-applies plan defaults and replaces these.
+      </p>
+    </div>
+  <% end %>
+</div>
+
+<%# ─── Change plan + Email actions ───────────────────────── %>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Change Plan</h2>
+
+    <%= form_with url: change_plan_admin_dashboard_user_path(@user), method: :post, local: true do |f| %>
+      <div class="flex flex-wrap items-end gap-3 mb-3">
+        <div>
+          <label class="block text-[10px] text-t3 mb-1">Plan</label>
+          <%= select_tag :plan_type,
+                options_for_select(Admin::UsersController::CHANGEABLE_PLAN_TYPES, @user.plan_type),
+                class: "admin-input text-sm px-2.5 py-1.5 rounded border bg-transparent text-t1" %>
+        </div>
+        <%= f.submit "Change plan",
+              class: "text-sm font-medium px-4 py-1.5 rounded transition-colors cursor-pointer",
+              style: "background: var(--text-accent); color: #fff;",
+              data: { turbo_confirm: "Change plan for #{@user.email}? This is local-only — it does not modify Stripe, and an active Stripe subscription's webhooks may overwrite it." } %>
+      </div>
+    <% end %>
+
+    <p class="text-[10px] text-t3">
+      Local-only: never creates or cancels a Stripe subscription.
+      Free = full cancellation semantics (limits reset, free credits granted, subscription id cleared).
+      partner_pro runs full partner onboarding (role, 3-month pilot, credits, Mailchimp).
+      plus/premium don't auto-apply limits — set manual limits above.
+    </p>
+  </div>
+
+  <div class="admin-card border rounded-xl p-6">
+    <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Email Actions</h2>
+
+    <div class="space-y-3">
+      <div class="flex items-center gap-3">
+        <%= button_to "Send welcome email", send_welcome_email_admin_dashboard_user_path(@user),
+              method: :post,
+              class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1",
+              form: { data: { turbo_confirm: "Send welcome email to #{@user.email}?" } } %>
+        <span class="text-[10px] text-t3">Plan-appropriate welcome. Marks welcome_email_sent, notifies admin, syncs Mailchimp.</span>
+      </div>
+      <div class="flex items-center gap-3">
+        <%= button_to "Send setup email", send_setup_email_admin_dashboard_user_path(@user),
+              method: :post,
+              class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1",
+              form: { data: { turbo_confirm: "Send setup email to #{@user.email}?" } } %>
+        <span class="text-[10px] text-t3">Vendor/Pro/Free setup email. Basic-plan users receive nothing.</span>
+      </div>
+      <div class="flex items-center gap-3">
+        <%= button_to "Send temp login email", send_temp_login_email_admin_dashboard_user_path(@user),
+              method: :post,
+              class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1",
+              form: { data: { turbo_confirm: "Send a temporary login link to #{@user.email}?" } } %>
+        <span class="text-[10px] text-t3">Issues a fresh <%= User::TEMP_LOGIN_TOKEN_EXPIRY_HOURS %>-hour login link.</span>
+      </div>
+    </div>
+  </div>
+</div>
+
 <%# ─── Two-column: Account + Activity ────────────────────── %>
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
 
@@ -184,8 +316,12 @@
         ["Plan type",        @user.plan_type],
         ["Plan status",      @user.plan_status],
         ["Paid plan type",   @user.paid_plan_type.presence || "—"],
-        ["Stripe customer",  @user.stripe_customer_id.presence || "—"],
-        ["Stripe sub",       @user.stripe_subscription_id.presence || "—"],
+        ["Stripe customer",  @user.stripe_customer_id.present? ?
+          link_to(@user.stripe_customer_id, "https://dashboard.stripe.com/customers/#{@user.stripe_customer_id}",
+                  target: "_blank", rel: "noopener", class: "text-accent hover:underline") : "—"],
+        ["Stripe sub",       @user.stripe_subscription_id.present? ?
+          link_to(@user.stripe_subscription_id, "https://dashboard.stripe.com/subscriptions/#{@user.stripe_subscription_id}",
+                  target: "_blank", rel: "noopener", class: "text-accent hover:underline") : "—"],
         ["Created",          @user.created_at.strftime("%b %-d, %Y %H:%M %Z")],
         ["Last sign-in",     @user.last_sign_in_at&.strftime("%b %-d, %Y %H:%M %Z") || "Never"],
         ["Last sign-in IP",  @user.last_sign_in_ip.presence || "—"],

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -18,7 +18,9 @@
       },
       "user_input": "(:BRAKEMAN_SAFE_LITERAL or \"desc\").upcase",
       "confidence": "Medium",
-      "cwe_id": [89],
+      "cwe_id": [
+        89
+      ],
       "user_note": "False positive: sort_order is validated against an explicit allowlist (%w[asc desc]) before being used in Arel.sql. No user input reaches this interpolation unchecked."
     },
     {
@@ -39,8 +41,33 @@
       },
       "user_input": "Doc.find_by(:id => doc_id)",
       "confidence": "Weak",
-      "cwe_id": [22],
-      "user_note": "False positive: the path is a Tempfile created by the job itself. The model attribute (doc.id, an integer PK) is used only as part of a temp filename prefix — no user-supplied path traversal is possible."
+      "cwe_id": [
+        22
+      ],
+      "user_note": "False positive: the path is a Tempfile created by the job itself. The model attribute (doc.id, an integer PK) is used only as part of a temp filename prefix \u2014 no user-supplied path traversal is possible."
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "31f4c5d3cb5e430076abb74adbde989089663fcf39d7b4bc559abcbef32ad283",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/admin/users_controller.rb",
+      "line": 176,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:user).permit(:name, :email, :role, :locked, :play_demo, :board_limit, :paid_communicator_limit, :demo_communicator_limit)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::UsersController",
+        "method": "user_params"
+      },
+      "user_input": ":role",
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "user_note": "False positive: Admin::UsersController is gated by require_admin! (admins only), and :role is validated against the EDITABLE_ROLES allowlist (%w[user admin partner vendor]) before assignment \u2014 a non-listed role is ignored."
     }
   ]
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,8 +59,14 @@ Rails.application.routes.draw do
     resource :mission_control, only: [:show], controller: 'mission_control' do
       post :cleanup_demo
     end
-    resources :users, only: [:index, :show], as: :dashboard_users do
-      post :adjust_credits, on: :member
+    resources :users, only: [:index, :show, :update, :destroy], as: :dashboard_users do
+      member do
+        post :adjust_credits
+        post :change_plan
+        post :send_welcome_email
+        post :send_setup_email
+        post :send_temp_login_email
+      end
     end
   end
 

--- a/spec/models/mailchimp_service_spec.rb
+++ b/spec/models/mailchimp_service_spec.rb
@@ -11,6 +11,61 @@ RSpec.describe MailchimpService do
     allow(client).to receive(:customerJourneys).and_return(journeys)
   end
 
+  describe "#record_new_subscriber" do
+    let(:lists) { double("lists") }
+    let(:hash) { Digest::MD5.hexdigest("parent@example.com") }
+
+    before do
+      allow(client).to receive(:lists).and_return(lists)
+      stub_const("ENV", ENV.to_h.merge("MAILCHIMP_AUDIENCE_ID" => "aud_123"))
+    end
+
+    it "still applies tags when the contact already exists in the audience" do
+      allow(lists).to receive(:get_list_member).with("aud_123", hash).and_return({ "id" => hash })
+
+      expect(lists).not_to receive(:set_list_member)
+      expect(lists).to receive(:update_list_member_tags).with(
+        "aud_123",
+        hash,
+        { tags: [
+          { name: "Partner Program", status: "active" },
+          { name: "PartnerPro_Jul", status: "active" },
+          { name: "FreePlan", status: "active" },
+        ] },
+      )
+
+      described_class.new.record_new_subscriber(user, tags: ["Partner Program", "PartnerPro_Jul"])
+    end
+
+    it "creates the contact and applies tags when it doesn't exist yet" do
+      not_found = MailchimpMarketing::ApiError.new(status: 404)
+      allow(lists).to receive(:get_list_member).with("aud_123", hash).and_raise(not_found)
+
+      expect(lists).to receive(:set_list_member).with(
+        "aud_123",
+        hash,
+        hash_including(email_address: "parent@example.com", status: "subscribed"),
+      ).and_return({ "id" => hash })
+      expect(lists).to receive(:update_list_member_tags).with(
+        "aud_123",
+        hash,
+        { tags: [
+          { name: "Partner Program", status: "active" },
+          { name: "FreePlan", status: "active" },
+        ] },
+      )
+
+      described_class.new.record_new_subscriber(user, tags: ["Partner Program"])
+    end
+
+    it "swallows Mailchimp API errors and returns nil" do
+      allow(lists).to receive(:get_list_member)
+        .and_raise(MailchimpMarketing::ApiError.new(status: 500))
+
+      expect(described_class.new.record_new_subscriber(user, tags: ["Partner Program"])).to be_nil
+    end
+  end
+
   describe "#record_lead" do
     let(:lists) { double("lists") }
 

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Dashboard", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let_it_be(:admin) { create(:admin_user) }
+  let_it_be(:real_user) { create(:user, email: "real@example.com") }
+  let_it_be(:demo_user) { create(:user, email: "bhannajohns+dash@gmail.com") }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+      .to receive(:javascript_include_tag).and_return("")
+    sign_in admin
+  end
+
+  describe "GET /admin" do
+    it "counts users excluding admins and demo accounts" do
+      get admin_root_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Total Users")
+      # real_user only — admin and demo_user excluded
+      expect(response.body).to match(/Total Users.*?>1</m)
+    end
+
+    it "counts boards excluding demo-owned ones" do
+      create(:board, user: real_user)
+      create(:board, user: demo_user)
+
+      get admin_root_path
+
+      expect(response.body).to match(/Total Boards.*?>1</m)
+    end
+
+    it "shows the demo account count with a cleanup link" do
+      get admin_root_path
+
+      expect(response.body).to include("Demo Accounts")
+      expect(response.body).to include(admin_dashboard_users_path(filter: "demo"))
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in real_user
+      end
+
+      it "redirects to root" do
+        get admin_root_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -190,4 +190,308 @@ RSpec.describe "Admin::Users", type: :request do
       end
     end
   end
+
+  describe "GET /admin/users/:id (Stripe links)" do
+    it "links the Stripe customer and subscription to the Stripe dashboard in a new tab" do
+      user1.update_columns(stripe_customer_id: "cus_test123", stripe_subscription_id: "sub_test456")
+
+      get admin_dashboard_user_path(user1)
+
+      expect(response.body).to include("https://dashboard.stripe.com/customers/cus_test123")
+      expect(response.body).to include("https://dashboard.stripe.com/subscriptions/sub_test456")
+      expect(response.body).to include('target="_blank"')
+    end
+
+    it "shows a dash when there is no Stripe customer" do
+      user1.update_columns(stripe_customer_id: nil, stripe_subscription_id: nil)
+      get admin_dashboard_user_path(user1)
+      expect(response.body).not_to include("dashboard.stripe.com")
+    end
+  end
+
+  describe "PATCH /admin/users/:id" do
+    it "updates name, email, and role" do
+      patch admin_dashboard_user_path(user1),
+        params: { user: { name: "Alice Updated", email: "alice-new@example.com", role: "partner" } }
+
+      expect(response).to redirect_to(admin_dashboard_user_path(user1))
+      user1.reload
+      expect(user1.name).to eq("Alice Updated")
+      expect(user1.email).to eq("alice-new@example.com")
+      expect(user1.role).to eq("partner")
+    end
+
+    it "ignores a role outside the whitelist" do
+      patch admin_dashboard_user_path(user1), params: { user: { role: "superuser" } }
+      expect(user1.reload.role).not_to eq("superuser")
+    end
+
+    it "locks the user, setting both the column and settings" do
+      patch admin_dashboard_user_path(user1), params: { user: { locked: "1" } }
+
+      user1.reload
+      expect(user1.locked).to be(true)
+      expect(user1.settings["locked"]).to be(true)
+    end
+
+    it "unlocks the user, clearing both the column and settings" do
+      user1.update_columns(locked: true)
+      user1.update(settings: user1.settings.merge("locked" => true))
+
+      patch admin_dashboard_user_path(user1), params: { user: { locked: "0" } }
+
+      user1.reload
+      expect(user1.locked).to be(false)
+      expect(user1.settings["locked"]).to be(false)
+    end
+
+    it "toggles play_demo" do
+      patch admin_dashboard_user_path(user1), params: { user: { play_demo: "0" } }
+      expect(user1.reload.play_demo).to be(false)
+    end
+
+    it "writes limit overrides into settings without touching plan_type" do
+      patch admin_dashboard_user_path(user1),
+        params: { user: { board_limit: 42, paid_communicator_limit: 7, demo_communicator_limit: 3 } }
+
+      user1.reload
+      expect(user1.settings["board_limit"]).to eq(42)
+      expect(user1.settings["paid_communicator_limit"]).to eq(7)
+      expect(user1.settings["demo_communicator_limit"]).to eq(3)
+      expect(user1.plan_type).to eq("free")
+    end
+
+    it "rejects a duplicate email with an alert and leaves the user unchanged" do
+      patch admin_dashboard_user_path(user1), params: { user: { email: user2.email } }
+
+      expect(response).to redirect_to(admin_dashboard_user_path(user1))
+      expect(flash[:alert]).to be_present
+      expect(user1.reload.email).to eq("alice@example.com")
+    end
+
+    context "when not signed in" do
+      before { sign_out admin }
+
+      it "redirects" do
+        patch admin_dashboard_user_path(user1), params: { user: { name: "Nope" } }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in user1
+      end
+
+      it "redirects to root and does not update" do
+        patch admin_dashboard_user_path(user2), params: { user: { name: "Nope" } }
+        expect(response).to redirect_to(root_path)
+        expect(user2.reload.name).to eq("Bob")
+      end
+    end
+  end
+
+  describe "POST /admin/users/:id/change_plan" do
+    it "upgrades free to pro, applying pro limits and an active status" do
+      freshie = create(:user, email: "freshie@example.com")
+
+      post change_plan_admin_dashboard_user_path(freshie), params: { plan_type: "pro" }
+
+      expect(response).to redirect_to(admin_dashboard_user_path(freshie))
+      expect(flash[:notice]).to include("Plan changed to pro")
+      freshie.reload
+      expect(freshie.plan_type).to eq("pro")
+      expect(freshie.plan_status).to eq("active")
+      expect(freshie.settings["board_limit"]).to eq(User::PRO_PLAN_LIMITS["board_limit"])
+      expect(freshie.paid_plan?).to be(true)
+    end
+
+    it "upgrades a previously-canceled user without leaving them stranded" do
+      canceled = create(:user, email: "canceled@example.com")
+      canceled.update_columns(plan_status: "canceled")
+
+      post change_plan_admin_dashboard_user_path(canceled), params: { plan_type: "basic" }
+
+      canceled.reload
+      expect(canceled.plan_type).to eq("basic")
+      expect(canceled.plan_status).to eq("active")
+      expect(canceled.plan_stranded?).to be(false)
+    end
+
+    it "downgrades to free with full cancellation semantics" do
+      pro = create(:user, email: "downgrade@example.com", plan_type: "pro")
+      pro.update_columns(stripe_subscription_id: "sub_abc", plan_status: "active")
+
+      expect {
+        post change_plan_admin_dashboard_user_path(pro), params: { plan_type: "free" }
+      }.to change { CreditTransaction.where(user: pro, kind: "plan_grant").count }.by(1)
+
+      pro.reload
+      expect(pro.plan_type).to eq("free")
+      expect(pro.paid_plan_type).to eq("pro")
+      expect(pro.plan_status).to eq("canceled")
+      expect(pro.stripe_subscription_id).to be_nil
+    end
+
+    it "runs full partner onboarding for partner_pro" do
+      allow(MailchimpService).to receive(:new)
+        .and_return(instance_double(MailchimpService, record_new_subscriber: true))
+      newbie = create(:user, email: "partner-to-be@example.com")
+
+      post change_plan_admin_dashboard_user_path(newbie), params: { plan_type: "partner_pro" }
+
+      newbie.reload
+      expect(newbie.plan_type).to eq("partner_pro")
+      expect(newbie.role).to eq("partner")
+      expect(newbie.plan_status).to eq("active")
+      expect(newbie.plan_expires_at).to be_within(1.day).of(3.months.from_now)
+    end
+
+    it "is a no-op when the plan is unchanged" do
+      post change_plan_admin_dashboard_user_path(user1), params: { plan_type: "free" }
+
+      expect(flash[:notice]).to include("No change")
+      expect(user1.reload.plan_type).to eq("free")
+    end
+
+    it "rejects an unknown plan type" do
+      post change_plan_admin_dashboard_user_path(user1), params: { plan_type: "platinum" }
+
+      expect(flash[:alert]).to include("Unknown plan type")
+      expect(user1.reload.plan_type).to eq("free")
+    end
+
+    context "when not signed in" do
+      before { sign_out admin }
+
+      it "redirects" do
+        post change_plan_admin_dashboard_user_path(user1), params: { plan_type: "pro" }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in user1
+      end
+
+      it "redirects to root and does not change the plan" do
+        post change_plan_admin_dashboard_user_path(user2), params: { plan_type: "free" }
+        expect(response).to redirect_to(root_path)
+        expect(user2.reload.plan_type).to eq("pro")
+      end
+    end
+  end
+
+  describe "DELETE /admin/users/:id" do
+    let(:demo) { create(:user, email: "bhannajohns+doomed@gmail.com") }
+
+    it "tombstones a demo account and destroys its content" do
+      create(:board, user: demo, name: "Demo Board")
+
+      delete admin_dashboard_user_path(demo)
+
+      expect(response).to redirect_to(admin_dashboard_users_path)
+      expect(flash[:notice]).to include("deleted")
+
+      tombstone = User.unscoped.find(demo.id)
+      expect(tombstone.deleted_at).to be_present
+      expect(tombstone.email).to include("deleted-#{demo.id}")
+      expect(Board.where(user_id: demo.id)).to be_empty
+    end
+
+    it "refuses to delete a non-demo account" do
+      delete admin_dashboard_user_path(user2)
+
+      expect(response).to redirect_to(admin_dashboard_user_path(user2))
+      expect(flash[:alert]).to include("Only demo accounts")
+      expect(user2.reload.deleted_at).to be_nil
+    end
+
+    it "refuses to delete an admin even with a demo-pattern email" do
+      demo_admin = create(:admin_user, email: "bhannajohns+admin@gmail.com")
+
+      delete admin_dashboard_user_path(demo_admin)
+
+      expect(flash[:alert]).to include("Only demo accounts")
+      expect(demo_admin.reload.deleted_at).to be_nil
+    end
+
+    context "when not signed in" do
+      before { sign_out admin }
+
+      it "redirects" do
+        delete admin_dashboard_user_path(demo)
+        expect(response).to redirect_to(new_user_session_path)
+        expect(demo.reload.deleted_at).to be_nil
+      end
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in user1
+      end
+
+      it "redirects to root without deleting" do
+        delete admin_dashboard_user_path(demo)
+        expect(response).to redirect_to(root_path)
+        expect(demo.reload.deleted_at).to be_nil
+      end
+    end
+  end
+
+  describe "email actions" do
+    it "queues a plan-appropriate welcome email and marks it sent" do
+      freshie = create(:user, email: "welcome-me@example.com")
+
+      expect {
+        post send_welcome_email_admin_dashboard_user_path(freshie)
+      }.to have_enqueued_mail(UserMailer, :welcome_free_email)
+
+      expect(response).to redirect_to(admin_dashboard_user_path(freshie))
+      expect(flash[:notice]).to include("Welcome email queued")
+      expect(freshie.reload.settings["welcome_email_sent"]).to be(true)
+    end
+
+    it "queues the pro welcome email for pro users" do
+      expect {
+        post send_welcome_email_admin_dashboard_user_path(user2)
+      }.to have_enqueued_mail(UserMailer, :welcome_pro_email)
+    end
+
+    it "queues the pro setup email for pro users" do
+      expect {
+        post send_setup_email_admin_dashboard_user_path(user2)
+      }.to have_enqueued_mail(SetupMailer, :pro_setup_email)
+      expect(flash[:notice]).to include("Setup email queued")
+    end
+
+    it "queues a temp login email and issues a token" do
+      expect {
+        post send_temp_login_email_admin_dashboard_user_path(user1)
+      }.to have_enqueued_mail(UserMailer, :temporary_login_email)
+
+      user1.reload
+      expect(user1.temp_login_token).to be_present
+      expect(user1.temp_login_expires_at).to be > Time.current
+      expect(flash[:notice]).to include("Temporary login email queued")
+    end
+
+    context "when signed in as non-admin" do
+      before do
+        sign_out admin
+        sign_in user1
+      end
+
+      it "redirects to root without sending" do
+        expect {
+          post send_welcome_email_admin_dashboard_user_path(user2)
+        }.not_to have_enqueued_mail
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/services/mission_control/overview_metrics_spec.rb
+++ b/spec/services/mission_control/overview_metrics_spec.rb
@@ -56,5 +56,30 @@ RSpec.describe MissionControl::OverviewMetrics do
       expect(result).to have_key(:communicator_accounts)
       expect(result).to have_key(:myspeak_profiles)
     end
+
+    context "with demo accounts" do
+      let!(:demo_user) do
+        create(:user, email: "bhannajohns+metrics@gmail.com",
+                      created_at: 1.hour.ago, last_sign_in_at: 1.hour.ago)
+      end
+      let!(:demo_board) { create(:board, user: demo_user, created_at: 1.hour.ago) }
+      let!(:demo_word_event) { create(:word_event, user: demo_user, created_at: 1.hour.ago) }
+      let!(:demo_communicator) { create(:child_account, user: demo_user) }
+      let!(:real_board) { create(:board, user: user_today, created_at: 1.hour.ago) }
+
+      it "excludes demo users from signup and activity counts" do
+        expect(result[:signups_today]).to eq(1)
+        expect(result[:total_users]).to eq(5)
+        expect(result[:active_users_7d]).to eq(2)
+        expect(result[:signups_daily_7d][Time.zone.today.to_s]).to eq(1)
+      end
+
+      it "excludes demo-owned boards, word events, and communicators" do
+        expect(result[:total_boards]).to eq(1)
+        expect(result[:boards_today]).to eq(1)
+        expect(result[:word_events_today]).to eq(0)
+        expect(result[:communicator_accounts]).to eq(0)
+      end
+    end
   end
 end

--- a/spec/services/mission_control/usage_metrics_spec.rb
+++ b/spec/services/mission_control/usage_metrics_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe MissionControl::UsageMetrics do
+  describe ".call" do
+    let!(:real_user) { create(:user) }
+    let!(:demo_user) { create(:user, email: "bhannajohns+usage@gmail.com") }
+
+    subject(:result) { described_class.call }
+
+    it "excludes demo-owned builder sets" do
+      create(:board, user: real_user, settings: { "builder_root" => true })
+      create(:board, user: demo_user, settings: { "builder_root" => true })
+
+      expect(result[:builder_sets_30d]).to eq(1)
+    end
+
+    it "excludes demo users' credit spends" do
+      CreditTransaction.create!(user: real_user, kind: "spend", source: "plan", amount: -5)
+      CreditTransaction.create!(user: demo_user, kind: "spend", source: "plan", amount: -7)
+
+      expect(result[:credits_spent_30d]).to eq(5)
+    end
+
+    it "excludes demo-owned communicators" do
+      create(:child_account, user: real_user)
+      create(:child_account, user: demo_user)
+
+      expect(result[:communicators_created_7d]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Expands the HTML admin dashboard user page (`/admin/users/:id`) with the controls needed to stop using the React frontend's admin surface, and makes admin metrics demo-free.

### Change Plan
- New **Change Plan** card with confirm dialog. All changes are **local-only** (Stripe is never created/canceled; active-subscription webhooks may later overwrite).
- `free` → `Billing::PlanTransitions.apply_free_plan` (full cancellation: limits reset, `paid_plan_type` snapshot, free credits granted, subscription id cleared).
- `partner_pro` → `User.handle_new_partner_pro_subscription` (role, 3-month pilot, partner credits, Mailchimp).
- Other paid plans set `plan_type` **and `plan_status: "active"`** — without the status reset, a previously-canceled user would be `plan_stranded?` and auto-reverted to free by `reconcile_stranded_plan!`.
- `basic_trial` is not admin-assignable (owned by the soft-trial flow).

### Edit Account
- name, email, role (whitelisted: user/admin/partner/vendor), locked (column + `settings["locked"]`), play_demo, and manual limit overrides (`board_limit` / `paid_communicator_limit` / `demo_communicator_limit` written directly into settings — the model's limit setters self-save, so `assign_attributes` is avoided).

### Stripe links & email actions
- Stripe customer/subscription IDs link to dashboard.stripe.com in a new tab.
- Buttons to queue the plan-appropriate welcome email, setup email, and 4-hour temp-login link (all `deliver_later`; flash says "queued").

### Demo accounts
- New `User.non_demo` scope (exact complement of `demo_accounts`) + `MissionControl::ExcludesDemo` helper (NULL-safe `user_id` filter).
- Admin dashboard counts and **all Mission Control overview/usage metrics** exclude demo accounts and their activity (boards, word events, communicators, builder sets, credit spends, AI prompts); both pages say so.
- Dashboard gets a **Demo Accounts** card linking to the demo-filtered user list.
- Demo users get a **badge + per-user Delete button** — same tombstone path (`soft_delete_account!`) as the existing Mission Control batch cleanup: destroys all content, anonymizes PII, keeps one hidden row + the credit ledger. Refuses non-demo accounts and admins. (Chosen over true hard delete to preserve the immutable credit ledger and avoid FK issues.)

## Reviewer notes
- Changing `plan_type` fires the model's reconciliation callbacks (`setup_limits`, communicator fallback/restore, sandbox promotion) — intended.
- `plus`/`premium` don't auto-apply limits (no `setup_limits` branch); the UI notes to use manual limit overrides.
- The users index default list intentionally still shows demo accounts (per scoping discussion); only metrics/counts exclude them.

## Test plan
- `bundle exec rspec spec/requests/admin/ spec/services/mission_control/overview_metrics_spec.rb spec/services/mission_control/usage_metrics_spec.rb` — **76 examples, 0 failures** (targeted per PR conventions).
- Covers: update (attrs, lock/unlock, limits, duplicate email, auth gating), change_plan (upgrade, stranded-user upgrade, downgrade-to-free credit grant + snapshot, partner onboarding, no-op, invalid plan, auth gating), email actions (enqueued mailers, welcome flag, temp-login token), destroy (tombstone + content destruction, non-demo/admin refusal, auth gating), demo exclusions in both metrics services and dashboard counts, Stripe link rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Mailchimp tag fix (added after review discussion)
`MailchimpService#record_new_subscriber` early-returned for contacts already in the audience — **before applying tags**. Since nearly all users are synced to Mailchimp at signup, promoting an existing user to Partner Pro never applied the "Partner Program" journey trigger tag, so they never entered the Partner Customer Journey. Tags now apply on the exists path too (shared `apply_member_tags` helper), fixing the admin flow, the API admin flow, and `partners:backfill_mailchimp_tags` at once. Covered by new `record_new_subscriber` specs (existing-contact tagging, new-contact create+tag, API-error swallow).
