### PR TITLE
feat: seed predefined keyboard template boards (ABC + QWERTY)

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -313,3 +313,29 @@ losing a tile.
   without recomputing column counts) recomputes proportional md/sm columns and
   reflows existing boards, skipping fully-customized screens.
 
+
+## Keyboard boards & action tiles
+
+Predefined keyboard template boards ("ABC Keyboard" / "QWERTY Keyboard",
+slugs `keyboard-abc` / `keyboard-qwerty`) are seeded by
+`db/seeds/keyboard_boards.rb` (`rake keyboard_boards:seed`, idempotent):
+`board_type: "keyboard"` (also `Board.keyboards` / `#keyboard?`), 26 letter
+tiles + Space/Delete.
+
+- **Tile behavior contract (frontend keys off this, not board_type):** letter
+  tiles carry `board_images.data["tile_type"] == "letter"`; action tiles carry
+  `data["tile_type"] == "action"` and `data["tile_action"] == "space" |
+  "backspace"`. Future action tiles (e.g. play-a-video) add new `tile_action`
+  string values plus an optional `data["action_params"]` object — keep
+  `tile_action` a bare string. `data` already flows through
+  `api_view_for_native_grid`, `BoardImage#api_view`, and `clone_with_images`
+  (tiles are `dup`ed), so no serializer/clone changes are needed for new flags.
+- **Publish gate:** the seeds create the boards `published: false` because
+  frontends without keyboard support render Space/Delete as ordinary speakable
+  word tiles. Flip `published: true` only after the frontend keyboard support
+  deploys; re-running the seed never unpublishes.
+- **Layouts:** authored identically for all screen sizes with equal column
+  counts (6 ABC / 10 QWERTY), and `settings["custom_screen_layouts"] = ["md",
+  "sm"]` so an lg edit doesn't reflow away the QWERTY stagger or wide space bar.
+- Word-as-written playback needs no backend work: the frontend composes the
+  string and uses the existing `POST /api/images/generate_audio`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Keyboard template boards (ABC + QWERTY), unpublished until frontend support ships
+- New predefined "ABC Keyboard" and "QWERTY Keyboard" boards
+  (`rake keyboard_boards:seed`): 26 letter tiles plus new Space/Delete
+  **action tiles** (`board_images.data["tile_type"]`/`["tile_action"]`), the
+  first tiles whose behavior is an action instead of a spoken word. Seeded
+  `published: false` on purpose — flip to published after the frontend
+  keyboard support (letter composition + read-words-as-written play) deploys.
+
 ### Fixed — MySpeak onboarding no longer publishes emergency notes as public About Me
 - The MySpeak onboarding wizard used to save its care/emergency notes into the
   profile `bio`, which renders publicly as "About Me" on the open page. The

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -140,7 +140,8 @@ class Board < ApplicationRecord
   scope :preset, -> { where(predefined: true) }
   scope :welcome, -> { where(category: "welcome", predefined: true) }
   scope :published, -> { where(published: true) }
-  POSSIBLE_BOARD_TYPES = %w[board category user image menu].freeze
+  scope :keyboards, -> { where(board_type: "keyboard") }
+  POSSIBLE_BOARD_TYPES = %w[board category user image menu keyboard].freeze
 
   scope :dynamic_defaults, -> { where(name: "Dynamic Default", parent_type: "PredefinedResource") }
 
@@ -789,6 +790,13 @@ class Board < ApplicationRecord
 
   def category?
     resource_type == "category"
+  end
+
+  # Unlike dynamic?/predictive?/static? above (resource_type-based), keyboard
+  # is a board_type: the seeded letter/action-tile template boards
+  # (db/seeds/keyboard_boards.rb) and their clones.
+  def keyboard?
+    board_type == "keyboard"
   end
 
   def self.create_dynamic_default_for_user(new_user)

--- a/db/seeds/keyboard_boards.rb
+++ b/db/seeds/keyboard_boards.rb
@@ -1,0 +1,148 @@
+# Seed the predefined Keyboard template boards ("ABC Keyboard" and
+# "QWERTY Keyboard"): 26 letter tiles plus two action tiles (Space, Delete).
+#
+# Tile behavior contract with the frontend (BoardNativeGridPage):
+#   * letter tile:  data["tile_type"] == "letter"
+#   * action tile:  data["tile_type"] == "action",
+#                   data["tile_action"] == "space" | "backspace"
+# Future action tiles add new tile_action string values (plus an optional
+# data["action_params"] object); keep tile_action a bare string.
+#
+# Boards seed with published: false ON PURPOSE — frontends without keyboard
+# support would render Space/Delete as ordinary speakable word tiles. After
+# the frontend keyboard support deploys, flip them live:
+#   Board.where(slug: %w[keyboard-abc keyboard-qwerty]).update_all(published: true)
+# Re-running this seed never unpublishes an already-published board.
+#
+# Layouts are authored identically for every screen size (the column count is
+# part of what makes it a keyboard), and md/sm are marked as customized
+# screens so a later lg edit doesn't reflow away the QWERTY stagger or the
+# wide space bar.
+#
+# Idempotent — safe to re-run. Upserts boards by slug and tiles by label, and
+# re-asserts data flags, colors, positions, and layouts on existing tiles.
+#
+# Run:
+#   bin/rails runner db/seeds/keyboard_boards.rb
+# Or:
+#   bin/rails keyboard_boards:seed
+
+admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || User.where(role: "admin").order(:id).first
+abort "No admin user found (User::DEFAULT_ADMIN_ID=#{User::DEFAULT_ADMIN_ID})." unless admin
+
+vowels = %w[A E I O U]
+colors = { letter: "#DBEAFE", vowel: "#FDE68A", action: "#E5E7EB" }
+text_color = "#000000"
+
+# 6 columns: A–F / G–L / M–R / S–X / Y Z [Space][Space][Delete][Delete]
+abc_tiles = ("A".."Z").each_with_index.map do |ch, i|
+  { label: ch, x: i % 6, y: i / 6, w: 1 }
+end
+abc_tiles << { label: "Space", x: 2, y: 4, w: 2, action: "space" }
+abc_tiles << { label: "Delete", x: 4, y: 4, w: 2, action: "backspace" }
+
+# 10 columns: the three staggered QWERTY rows, Delete at the end of the Z
+# row, and a wide centered space bar on the bottom row.
+qwerty_rows = [%w[Q W E R T Y U I O P], %w[A S D F G H J K L], %w[Z X C V B N M]]
+qwerty_tiles = qwerty_rows.each_with_index.flat_map do |row, y|
+  row.each_with_index.map { |ch, x| { label: ch, x: x, y: y, w: 1 } }
+end
+qwerty_tiles << { label: "Delete", x: 7, y: 2, w: 3, action: "backspace" }
+qwerty_tiles << { label: "Space", x: 2, y: 3, w: 6, action: "space" }
+
+keyboards = [
+  {
+    slug: "keyboard-abc",
+    name: "ABC Keyboard",
+    description: "Spell any word, letter by letter — alphabetical layout with Space and Delete keys.",
+    columns: 6,
+    tiles: abc_tiles,
+  },
+  {
+    slug: "keyboard-qwerty",
+    name: "QWERTY Keyboard",
+    description: "Spell any word, letter by letter — familiar QWERTY layout with Space and Delete keys.",
+    columns: 10,
+    tiles: qwerty_tiles,
+  },
+]
+
+find_or_create_image = lambda do |label|
+  image = Image.find_by(label: label, user_id: admin.id)
+  return image if image
+
+  image = Image.new(label: label, user_id: admin.id, part_of_speech: "default")
+  # Single letters aren't dictionary words — without this flag ensure_defaults
+  # would make a synchronous OpenAI categorization call per tile at seed time.
+  image.skip_categorize = true
+  image.save!
+  image
+end
+
+keyboards.each do |attrs|
+  board = Board.find_by(slug: attrs[:slug]) || Board.new(slug: attrs[:slug])
+  newly_created = board.new_record?
+  board.assign_attributes(
+    name: attrs[:name],
+    description: attrs[:description],
+    category: "letters",
+    user: admin,
+    parent: admin,
+    predefined: true,
+    is_template: false,
+    sub_board: false,
+    board_type: "keyboard",
+    voice: VoiceService.normalize_voice(board.voice),
+    number_of_columns: attrs[:columns],
+    small_screen_columns: attrs[:columns],
+    medium_screen_columns: attrs[:columns],
+    large_screen_columns: attrs[:columns],
+  )
+  board.published = false if newly_created
+  board.settings = (board.settings || {}).merge("custom_screen_layouts" => %w[md sm])
+  board.add_tag("keyboard")
+  board.save!
+
+  attrs[:tiles].each_with_index do |tile, position|
+    color = if tile[:action]
+        colors[:action]
+      elsif vowels.include?(tile[:label])
+        colors[:vowel]
+      else
+        colors[:letter]
+      end
+    tile_data = if tile[:action]
+        { "tile_type" => "action", "tile_action" => tile[:action] }
+      else
+        { "tile_type" => "letter" }
+      end
+
+    image = find_or_create_image.call(tile[:label])
+    board_image = board.board_images.find_by(label: tile[:label])
+    unless board_image
+      board_image = board.board_images.new(
+        image_id: image.id,
+        voice: board.voice,
+        language: board.language,
+        bg_color: color,
+        text_color: text_color,
+        position: position,
+      )
+      board_image.skip_initial_layout = true
+      board_image.save!
+    end
+
+    layout = %w[lg md sm xs xxs].index_with do |_screen|
+      { "i" => board_image.id.to_s, "x" => tile[:x], "y" => tile[:y], "w" => tile[:w], "h" => 1 }
+    end
+    board_image.update!(
+      position: position,
+      data: (board_image.data || {}).merge(tile_data),
+      bg_color: color,
+      text_color: text_color,
+      layout: layout,
+    )
+  end
+
+  puts "[keyboard-boards] ok: #{board.slug} (id=#{board.id}, tiles=#{board.board_images.count}, published=#{board.published})"
+end

--- a/lib/tasks/keyboard_boards.rake
+++ b/lib/tasks/keyboard_boards.rake
@@ -1,0 +1,6 @@
+namespace :keyboard_boards do
+  desc "Seed the predefined keyboard template boards (ABC + QWERTY). Idempotent."
+  task seed: :environment do
+    load Rails.root.join("db/seeds/keyboard_boards.rb")
+  end
+end

--- a/spec/db/seeds/keyboard_boards_seed_spec.rb
+++ b/spec/db/seeds/keyboard_boards_seed_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe "db/seeds/keyboard_boards.rb", type: :model do
+  let(:seed_path) { Rails.root.join("db/seeds/keyboard_boards.rb") }
+
+  def run_seed
+    load seed_path.to_s
+  end
+
+  before do
+    FactoryBot.create(:user, id: User::DEFAULT_ADMIN_ID)
+    allow(SaveAudioJob).to receive(:perform_async)
+    allow(CategorizeImageJob).to receive(:perform_async)
+  end
+
+  it "creates both keyboard boards, unpublished, with 28 tiles each" do
+    run_seed
+
+    boards = Board.keyboards
+    expect(boards.pluck(:slug)).to match_array(%w[keyboard-abc keyboard-qwerty])
+
+    boards.each do |b|
+      expect(b.keyboard?).to be(true)
+      expect(b.predefined).to be(true)
+      expect(b.published).to be(false)
+      expect(b.is_template).to be(false)
+      expect(b.category).to eq("letters")
+      expect(b.tags).to include("keyboard")
+      expect(b.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      expect(b.board_images.count).to eq(28)
+      expect(b.settings["custom_screen_layouts"]).to match_array(%w[md sm])
+    end
+  end
+
+  it "flags letter tiles and action tiles via the data contract" do
+    run_seed
+    board = Board.find_by!(slug: "keyboard-abc")
+
+    letter = board.board_images.find_by!(label: "A")
+    expect(letter.data).to include("tile_type" => "letter")
+
+    space = board.board_images.find_by!(label: "Space")
+    expect(space.data).to include("tile_type" => "action", "tile_action" => "space")
+
+    delete = board.board_images.find_by!(label: "Delete")
+    expect(delete.data).to include("tile_type" => "action", "tile_action" => "backspace")
+  end
+
+  it "authors keyboard-shaped layouts for every screen size" do
+    run_seed
+
+    abc_space = Board.find_by!(slug: "keyboard-abc").board_images.find_by!(label: "Space")
+    qwerty = Board.find_by!(slug: "keyboard-qwerty")
+    qwerty_space = qwerty.board_images.find_by!(label: "Space")
+    qwerty_delete = qwerty.board_images.find_by!(label: "Delete")
+    qwerty_a = qwerty.board_images.find_by!(label: "A")
+
+    %w[lg md sm xs xxs].each do |screen|
+      expect(abc_space.layout[screen]).to include("w" => 2, "y" => 4)
+      expect(qwerty_space.layout[screen]).to include("w" => 6, "y" => 3)
+      expect(qwerty_delete.layout[screen]).to include("w" => 3, "y" => 2)
+      # QWERTY stagger: A starts the second row, not the first
+      expect(qwerty_a.layout[screen]).to include("x" => 0, "y" => 1)
+    end
+
+    expect(qwerty.large_screen_columns).to eq(10)
+    expect(qwerty.small_screen_columns).to eq(10)
+  end
+
+  it "colors vowels, consonants, and action tiles distinctly" do
+    run_seed
+    board = Board.find_by!(slug: "keyboard-abc")
+
+    expect(board.board_images.find_by!(label: "A").bg_color).to eq("#FDE68A")
+    expect(board.board_images.find_by!(label: "B").bg_color).to eq("#DBEAFE")
+    expect(board.board_images.find_by!(label: "Space").bg_color).to eq("#E5E7EB")
+  end
+
+  it "is idempotent — re-running does not duplicate boards or tiles" do
+    run_seed
+    counts_before = Board.keyboards.map { |b| [b.slug, b.board_images.count] }.to_h
+
+    run_seed
+    counts_after = Board.keyboards.map { |b| [b.slug, b.board_images.count] }.to_h
+
+    expect(Board.keyboards.count).to eq(2)
+    expect(counts_after).to eq(counts_before)
+  end
+
+  it "never unpublishes an already-published keyboard on re-run" do
+    run_seed
+    Board.find_by!(slug: "keyboard-abc").update!(published: true)
+
+    run_seed
+    expect(Board.find_by!(slug: "keyboard-abc").published).to be(true)
+  end
+
+  it "stays out of public_boards until published, then appears" do
+    run_seed
+    expect(Board.public_boards.pluck(:slug)).not_to include("keyboard-abc", "keyboard-qwerty")
+
+    Board.keyboards.update_all(published: true)
+    expect(Board.public_boards.pluck(:slug)).to include("keyboard-abc", "keyboard-qwerty")
+  end
+
+  it "serializes the tile data contract in the native grid payload" do
+    run_seed
+    payload = Board.find_by!(slug: "keyboard-abc").api_view_for_native_grid(nil)
+
+    expect(payload[:board_type]).to eq("keyboard")
+
+    space = payload[:images].find { |img| img[:label] == "Space" }
+    expect(space[:data]).to include("tile_type" => "action", "tile_action" => "space")
+
+    letter = payload[:images].find { |img| img[:label] == "Q" }
+    expect(letter[:data]).to include("tile_type" => "letter")
+  end
+
+  it "preserves tile data flags when a user clones a keyboard board" do
+    run_seed
+    user = FactoryBot.create(:user)
+    source = Board.find_by!(slug: "keyboard-abc")
+
+    clone = source.clone_with_images(user.id, "My Keyboard")
+
+    expect(clone).to be_persisted
+    expect(clone.board_type).to eq("keyboard")
+    expect(clone.keyboard?).to be(true)
+    expect(clone.predefined).to be(false)
+    expect(clone.board_images.count).to eq(28)
+
+    cloned_space = clone.board_images.find_by!(label: "Space")
+    expect(cloned_space.data).to include("tile_type" => "action", "tile_action" => "space")
+    expect(clone.board_images.find_by!(label: "A").data).to include("tile_type" => "letter")
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the keyboard board feature (plan: `speakanyway/drafts/keyboard-board-plan.md`; frontend follows in itty-bitty-frontend).

- Seeds two admin-owned predefined boards — **ABC Keyboard** (`keyboard-abc`, 6 columns) and **QWERTY Keyboard** (`keyboard-qwerty`, 10 columns, real stagger + wide space bar) — via `db/seeds/keyboard_boards.rb` / `rake keyboard_boards:seed` (idempotent).
- Introduces the **action tile** contract on the existing `board_images.data` jsonb: letters carry `{"tile_type": "letter"}`, Space/Delete carry `{"tile_type": "action", "tile_action": "space"|"backspace"}`. Future actions (e.g. play-a-video) add new `tile_action` values + optional `action_params`. No migrations; `data` already flows through `api_view_for_native_grid`, `BoardImage#api_view`, and `clone_with_images` (verified by specs).
- Adds `keyboard` to `POSSIBLE_BOARD_TYPES`, plus `Board.keyboards` scope and `#keyboard?`.
- Letter images are created with `skip_categorize` so seeding doesn't make ~30 synchronous OpenAI categorization calls.
- Docs: new "Keyboard boards & action tiles" section in `.claude-notes/boards-and-teams.md`; CHANGELOG entry.

**Publish gate:** boards seed `published: false` on purpose — current frontends would render Space/Delete as speakable word tiles. After the frontend PR deploys, flip them live:
```ruby
Board.where(slug: %w[keyboard-abc keyboard-qwerty]).update_all(published: true)
```
Re-running the seed never unpublishes. Safe to ship alone.

## Test plan

- `bundle exec rspec spec/db/seeds/keyboard_boards_seed_spec.rb` — 9 examples, 0 failures (shape/flags/layouts/colors, idempotency, publish gating incl. never-unpublish, native-grid payload contract, clone preserves tile data).
- `bundle exec rspec spec/models/board_spec.rb spec/models/board_image_spec.rb` — 107 examples, 0 failures.
- After merge: run `rake keyboard_boards:seed` on staging and spot-check letter audio (A, I, W) pronounces letter names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)