### PR TITLE
fix: /api/boards 500 on orphaned communicator ChildBoard row

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -130,6 +130,14 @@ should be able to clear/curate the dashboard **without losing boards**.
   `can_edit` (board ownership, gates clone-to-edit), so the frontend can
   show the remove control to a hand-off owner who doesn't own the board.
   (Frontend wiring to consume `can_remove` is a companion change.)
+- **`Board#communicator_child_boards` filters orphaned join rows.** It unions
+  `original_child_boards` (FK `original_board_id`, `dependent: :nullify`) with
+  `child_boards`, then `.select(&:child_account)` — a `ChildBoard` whose
+  `child_account` was deleted (account teardown, or older DBs lacking an
+  enforced `child_account_id` FK) is dropped. The `api_view` /
+  `api_view_with_predictive_images` serializers read `cb.child_account.id`
+  directly, so a single orphan otherwise 500s the whole `/api/boards` index.
+  Filter at this one chokepoint, not per call site.
 ### Editing the communicator object itself
 
 `ChildAccount#editable_by?(user)` returns true iff the user is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — /api/boards no longer 500s on an orphaned communicator join row
+- `Board#api_view` read `child_account.id` on every `ChildBoard` returned by
+  `communicator_child_boards`. If a `ChildBoard`'s `child_account` had been
+  deleted (account teardown leaves an orphan; `original_child_boards` is
+  `dependent: :nullify`), a single orphaned row raised `NoMethodError` and
+  500'd the entire boards index for that owner. `communicator_child_boards`
+  now filters out orphaned rows at the source, protecting every serializer.
+
 ### Added — admin user page: plan changes, editing, Stripe links, email actions
 - The admin dashboard user page (`/admin/users/:id`) can now **change a
   user's plan** (local-only — Stripe is never modified; downgrading to free

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2254,9 +2254,17 @@ class Board < ApplicationRecord
   # clone-source (original_board_id) and direct-attach (board_id — Board
   # Builder roots, and the assignment clones themselves).
   def communicator_child_boards
+    # Reject orphaned join rows whose child_account has been deleted:
+    # original_child_boards is dependent: :nullify (not :destroy), and account
+    # teardown can leave a ChildBoard pointing at a gone child_account. The
+    # api_view serializers below read cb.child_account.id directly, so an
+    # orphan would 500 the whole /api/boards index. Filtering here protects
+    # every call site at once.
     @communicator_child_boards ||=
       (original_child_boards.includes(child_account: :profile).to_a +
-       child_boards.includes(child_account: :profile).to_a).uniq
+       child_boards.includes(child_account: :profile).to_a)
+      .uniq
+      .select(&:child_account)
   end
 
   # Whether viewing_user may edit this board's content. Owner/admin gate plus

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -206,6 +206,42 @@ RSpec.describe Board, type: :model do
       expect(view[:communicator_account_data]).to eq([])
       expect(view[:child_boards]).to eq([])
     end
+
+    context "when a ChildBoard is orphaned (its child_account was deleted)" do
+      # original_child_boards is dependent: :nullify, and older DBs lack an
+      # enforced child_account_id FK, so account teardown can leave a ChildBoard
+      # pointing at a gone child_account. api_view reads cb.child_account.id
+      # directly — an orphan used to 500 /api/boards. The test DB enforces the
+      # FK, so the dangling row can't be inserted; simulate it in memory.
+      let(:orphan) { ChildBoard.new(board: board, original_board: board, status: "active") }
+
+      before do
+        board.update_column(:in_use, true)
+        allow(orphan).to receive(:child_account).and_return(nil)
+        allow(orphan).to receive(:child_account_id).and_return(999_999)
+        stub_rel = ->(rows) { double(includes: rows) }
+        allow(board).to receive(:original_child_boards).and_return(stub_rel.call([orphan]))
+        allow(board).to receive(:child_boards).and_return(stub_rel.call([]))
+      end
+
+      it "filters the orphan out of communicator_child_boards" do
+        expect(board.communicator_child_boards).to eq([])
+      end
+
+      it "does not raise in the index api_view and skips the orphan" do
+        view = nil
+        expect { view = board.api_view(user) }.not_to raise_error
+        expect(view[:communicator_account_data]).to eq([])
+      end
+
+      it "does not raise in the show api_view and skips the orphan" do
+        view = nil
+        expect { view = board.api_view_with_predictive_images(user) }.not_to raise_error
+        expect(view[:communicator_account_data]).to eq([])
+        expect(view[:communicator_accounts]).to eq([])
+        expect(view[:child_boards]).to eq([])
+      end
+    end
   end
 
   describe "#check_is_sub_board (before_save)" do


### PR DESCRIPTION
## Summary

Found while testing on staging: `GET /api/boards` returned **500** for one user with `NoMethodError (undefined method 'id' for nil)` at `app/models/board.rb` in `api_view`.

**Root cause:** `Board#communicator_child_boards` unions `original_child_boards` (FK `original_board_id`, `dependent: :nullify`) with `child_boards`. When a `ChildBoard`'s `child_account` has been deleted — account teardown, or an older DB without an enforced `child_account_id` FK — the join row is left orphaned. `api_view` (and `api_view_with_predictive_images`) map over these and read `cb.child_account.id` / `.name` directly, so a **single orphaned row 500s the entire boards index** for that owner. Sibling code paths (`board.rb:1928`, `:2256`) already `.compact` these away; the serializers just missed the guard.

**Fix:** filter orphaned rows out at the single chokepoint — `communicator_child_boards` now `.select(&:child_account)` — so every serializer/consumer is protected at once, not per call site.

Not user-facing behavior beyond "the endpoint stops crashing": a communicator whose account no longer exists shouldn't appear in the payload anyway.

## Scope

Independent of the keyboard-boards work (PR #501) — this bug is on `main`; the keyboard branch just happened to be deployed to staging when a pre-existing orphan surfaced. Branched off `origin/main`.

**Staging already unblocked:** the one orphaned row on staging (`ChildBoard` 29 → deleted `child_account` 11, board 194) was deleted, and board 194's `api_view` now renders. This PR prevents recurrence and protects prod.

## Test plan

- `bundle exec rspec spec/models/board_spec.rb` — **95 examples, 0 failures**, incl. 3 new specs under "communicator assignment in api views" that reproduce an orphaned `ChildBoard` (simulated in-memory, since the test DB enforces the FK) and assert `communicator_child_boards` filters it and neither serializer raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)