### PR TITLE
feat(plans): raise Pro sandbox communicators from 1 to 2

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -460,10 +460,12 @@ sandbox" UI — even after the user became a paying Basic/Pro subscriber.
   the new slot limit is already in `settings` when the callback fires.
 - **Basic-only by design.** `BASIC_PLAN_LIMITS["demo_communicator_limit"] == 0`
   (no sandbox entitlement), so a Basic user's sandbox is always a stuck Free-era
-  leftover and is promoted. **Pro grants 1 sandbox slot**
-  (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 1`), so a Pro user's sandbox
-  is an intentional scratch/demo account and is left untouched — the guard is
-  `sandbox_limit_for(settings) > 0 → skip`.
+  leftover and is promoted. **Pro grants 2 sandbox slots**
+  (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 2`, ENV
+  `PRO_DEMO_COMMUNICATOR_LIMIT`; raised from 1 in 2026-07, backfilled onto
+  existing Pro users by `plans:bump_pro_sandbox_to_two`), so a Pro user's
+  sandboxes are intentional scratch/demo accounts and are left untouched — the
+  guard is `sandbox_limit_for(settings) > 0 → skip`.
 - **`ChildAccount#promote_to_active!`** — mirror of `promote_to_loaner!`: flips
   status to `active`, **mints a passcode if blank** (so sign-in actually works),
   and deletes the per-account `demo_board_limit` cap. Idempotent on an active

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Pro plan now includes 2 sandbox communicators (was 1)
+- `PRO_PLAN_LIMITS["demo_communicator_limit"]` default raised 1 → 2 (ENV
+  `PRO_DEMO_COMMUNICATOR_LIMIT`). Pro users can now keep two no-sign-in sandbox
+  communicators for trialing setups; sandboxes still don't count against
+  sign-in slots.
+- Existing Pro users are backfilled by the one-off task
+  `plans:bump_pro_sandbox_to_two` (dry-run with `DRY_RUN=true`; skips anyone an
+  admin tuned above 2). Production also requires the Hatchbox
+  `PRO_DEMO_COMMUNICATOR_LIMIT` env var set to `2`.
+
 ### Fixed — /api/boards no longer 500s on an orphaned communicator join row
 - `Board#api_view` read `child_account.id` on every `ChildBoard` returned by
   `communicator_child_boards`. If a `ChildBoard`'s `child_account` had been

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,7 +328,7 @@ class User < ApplicationRecord
     "board_limit" => ENV.fetch("PRO_BOARD_LIMIT", 300).to_i,
     "board_group_limit" => ENV.fetch("PRO_BOARD_GROUP_LIMIT", 50).to_i,
     "paid_communicator_limit" => ENV.fetch("PRO_PAID_COMMUNICATOR_LIMIT", 5).to_i,
-    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 1).to_i,
+    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 2).to_i,
   }.freeze
 
   def setup_partner_pro_plan

--- a/lib/tasks/plans.rake
+++ b/lib/tasks/plans.rake
@@ -132,6 +132,57 @@ namespace :plans do
     puts "(dry run — no rows were written)" if dry_run
   end
 
+  desc "One-off (2026-07): bump existing Pro users from 1 → 2 sandbox communicator slots. " \
+       "Skips anyone an admin has tuned above 2 so we never lower a deliberate value."
+  task bump_pro_sandbox_to_two: :environment do
+    dry_run = ENV["DRY_RUN"] == "true"
+    bumped = 0
+    skipped_higher = 0
+    skipped_other = 0
+
+    scope = User.where(plan_type: %w[pro pro_yearly partner_pro])
+
+    puts "[bump_pro_sandbox_to_two] starting (dry_run=#{dry_run}) — scope=#{scope.count} users"
+
+    scope.find_each(batch_size: 200) do |user|
+      user.settings ||= {}
+      current = user.settings["demo_communicator_limit"].to_i
+
+      if current >= 2
+        # Already at the new target or an admin has tuned it higher. Leave it.
+        skipped_higher += 1
+        next
+      end
+
+      if current != 1 && current != 0
+        # Anything other than 1 (or the missing-value sentinel 0) is unexpected
+        # for a Pro user — log it and skip rather than silently overwrite.
+        skipped_other += 1
+        warn "[bump_pro_sandbox_to_two] user #{user.id} has unexpected demo_communicator_limit=#{current.inspect} — skipping"
+        next
+      end
+
+      if dry_run
+        puts "  would bump user=#{user.id} plan=#{user.plan_type} #{current} → 2"
+      else
+        user.settings["demo_communicator_limit"] = 2
+        # update_columns to skip callbacks — plan_type isn't changing,
+        # so before_save :setup_limits should not re-run.
+        user.update_columns(settings: user.settings, updated_at: Time.current)
+      end
+      bumped += 1
+      print "." if !dry_run && bumped % 100 == 0
+    rescue => e
+      skipped_other += 1
+      warn "[bump_pro_sandbox_to_two] user #{user.id} failed: #{e.message}"
+    end
+
+    puts
+    puts "[bump_pro_sandbox_to_two] done. bumped=#{bumped} " \
+         "skipped_higher=#{skipped_higher} skipped_other=#{skipped_other}"
+    puts "(dry run — no rows were written)" if dry_run
+  end
+
   desc "Migrate users on the retired MySpeak plan tier to the free plan"
   task migrate_myspeak_to_free: :environment do
     migrated = 0

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Permissions::CommunicatorLimits do
         expect(allowed).to be(false)
         expect(http_status).to eq(:unprocessable_content)
       end
+
+      it "allows two sandbox communicators, blocks the third" do
+        2.times { create(:child_account, user: user, owner: user, status: ChildAccount::SANDBOX) }
+
+        allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::SANDBOX)
+        expect(allowed).to be(false)
+        expect(http_status).to eq(:unprocessable_content)
+      end
     end
   end
 

--- a/spec/lib/tasks/plans_rake_spec.rb
+++ b/spec/lib/tasks/plans_rake_spec.rb
@@ -131,6 +131,76 @@ RSpec.describe "plans rake task", type: :task do
     end
   end
 
+  describe "plans:bump_pro_sandbox_to_two" do
+    let(:task) { Rake::Task["plans:bump_pro_sandbox_to_two"] }
+
+    it "bumps an existing Pro user from 1 → 2 sandbox slots" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 1))
+
+      run_task
+
+      expect(pro.reload.settings["demo_communicator_limit"]).to eq(2)
+    end
+
+    it "applies to partner_pro and pro_yearly users" do
+      partner = create(:user, plan_type: "partner_pro", created_at: 2.months.ago)
+      partner.update!(settings: partner.settings.merge("demo_communicator_limit" => 1))
+      yearly = create(:user, plan_type: "pro_yearly", created_at: 2.months.ago)
+      yearly.update!(settings: yearly.settings.merge("demo_communicator_limit" => 1))
+
+      run_task
+
+      expect(partner.reload.settings["demo_communicator_limit"]).to eq(2)
+      expect(yearly.reload.settings["demo_communicator_limit"]).to eq(2)
+    end
+
+    it "preserves an admin-tuned value above the target" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 5))
+
+      run_task
+
+      expect(pro.reload.settings["demo_communicator_limit"]).to eq(5)
+    end
+
+    it "leaves Basic and Free users untouched" do
+      basic = create(:user, plan_type: "basic", created_at: 2.months.ago)
+      basic.update!(settings: basic.settings.merge("demo_communicator_limit" => 0))
+      free = create(:user, plan_type: "free", created_at: 2.months.ago)
+      free.update!(settings: free.settings.merge("demo_communicator_limit" => 1))
+
+      run_task
+
+      expect(basic.reload.settings["demo_communicator_limit"]).to eq(0)
+      expect(free.reload.settings["demo_communicator_limit"]).to eq(1)
+    end
+
+    it "is idempotent — a second run makes no further changes" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 1))
+
+      run_task
+      first = pro.reload.settings.dup
+
+      task.reenable
+      task.invoke
+      expect(pro.reload.settings).to eq(first)
+    end
+
+    it "honors DRY_RUN by reporting but not writing" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 1))
+
+      ENV["DRY_RUN"] = "true"
+      begin
+        expect { run_task }.not_to(change { pro.reload.settings["demo_communicator_limit"] })
+      ensure
+        ENV.delete("DRY_RUN")
+      end
+    end
+  end
+
   describe "plans:reconcile_stranded_paid" do
     let(:task) { Rake::Task["plans:reconcile_stranded_paid"] }
 

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe User, "plan limits", type: :model do
   describe "sandbox (legacy demo) communicator limits" do
     # Every Free user gets one sandbox communicator (the MySpeak ID).
-    # Pro also gets one. Basic has none.
-    it "grants one sandbox communicator to Free and Pro, none to Basic" do
+    # Pro gets two; Basic has none.
+    it "grants one sandbox communicator to Free, two to Pro, none to Basic" do
       expect(User::FREE_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
       expect(User::BASIC_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
-      expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
+      expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(2)
     end
 
     it "no longer defines a MySpeak plan tier" do


### PR DESCRIPTION
Pro now includes **two** no-sign-in sandbox communicators (was one) for trialing setups. Sandboxes still don't count against sign-in slots. Aligns the product with the pricing copy.

## Changes
- `PRO_PLAN_LIMITS["demo_communicator_limit"]` default **1 → 2** (ENV `PRO_DEMO_COMMUNICATOR_LIMIT`).
- New backfill task **`plans:bump_pro_sandbox_to_two`** — updates existing Pro users' persisted `settings` (limits are stored per-user and only rewritten on plan change, so a constant bump alone doesn't move current users). Skip-safe: leaves anyone an admin tuned above 2; `DRY_RUN=true` aware. Mirrors the proven `bump_pro_to_five_communicators` pattern.
- Docs: `.claude-notes/billing-and-plans.md` + `CHANGELOG.md`.

## ⚠️ Production rollout (not automatic from this merge)
These limits are ENV-driven, so merging the code default is not enough:
1. Set Hatchbox **`PRO_DEMO_COMMUNICATOR_LIMIT=2`**.
2. Run **`plans:bump_pro_sandbox_to_two`** (dry-run first) to backfill existing Pro users.

## Test plan
- `rspec` on the affected specs — **54 examples, 0 failures**: `user_plan_limits_spec`, `communicator_limits_spec` (new "allows two sandboxes, blocks the third"), `plans_rake_spec` (new backfill-task coverage: bump, partner_pro/pro_yearly, preserve-higher, skip Basic/Free, idempotent, DRY_RUN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)