### PR TITLE
fix(handoff): communicator roster correctness — owner-scope, delete guard, handed-off filter

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -34,6 +34,13 @@ any non-owner. Full matrix in issue #166. Server-side rules:
   non-admin callers. Covers the `active→loaner` lend path too, which skips the
   slot check. The frontend `LoanerControls` Pro gate is now defense-in-depth,
   not the only guard.
+- **Roster + delete are owner-scoped.** `ChildAccountsController#index` scopes
+  on `owner_id` (the canonical ownership column that slot counts and serializers
+  use), not the legacy `user_id` mirror — so the listed communicators can't
+  diverge from the "X of Y" slot numbers, and a loaner stays listed under its
+  lender until claimed. `#destroy` authorizes on `owner_id` and, like `#archive`,
+  **refuses a `loaner`** (HTTP 422, "End the loan first via end_loan.") so a live
+  claim link is never orphaned mid-hand-off.
 - `DELETE /api/teams/:id/remove_member` returns **HTTP 403
   `cannot_remove_owner`** if the target is owner-pinned and the caller is
   neither that user nor a system admin. The owner can remove themselves.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — communicator roster + delete hardening around the SLP hand-off
+- `GET /api/child_accounts` now scopes on `owner_id` (the column slot counts and
+  serializers use) instead of the legacy `user_id` mirror, so the listed
+  communicators can't diverge from the "X of Y" slot numbers.
+- `DELETE /api/child_accounts/:id` authorizes on `owner_id` and refuses a
+  lent-out `loaner` (HTTP 422, "End the loan first") — mirroring the archive
+  guard so a family's live claim link is never orphaned mid-hand-off.
+
 ### Changed — Pro plan now includes 2 sandbox communicators (was 1)
 - `PRO_PLAN_LIMITS["demo_communicator_limit"]` default raised 1 → 2 (ENV
   `PRO_DEMO_COMMUNICATOR_LIMIT`). Pro users can now keep two no-sign-in sandbox

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -18,7 +18,11 @@ class API::ChildAccountsController < API::ApplicationController
   # unscopes `archived_at` and filters to non-null. Without the param,
   # behavior is unchanged.
   def index
-    scope = ChildAccount.with_boards.where(user_id: current_user.id)
+    # Scope on owner_id — the canonical ownership column that slot counts,
+    # serializers, and every other action use. (user_id is the legacy parent
+    # mirror; scoping on it could diverge from the "X of Y" counts.) A loaner
+    # keeps owner_id = the lender, so it stays listed until a family claims it.
+    scope = ChildAccount.with_boards.where(owner_id: current_user.id)
     scope = scope.archived if ActiveModel::Type::Boolean.new.cast(params[:archived])
     @child_accounts = scope.order(name: :asc)
     render json: @child_accounts.map(&:index_api_view)
@@ -539,10 +543,19 @@ class API::ChildAccountsController < API::ApplicationController
   # DELETE /child_accounts/1
   # DELETE /child_accounts/1.json
   def destroy
-    unless @child_account.user == current_user || current_user.admin?
+    unless @child_account.owner_id == current_user.id || current_user.admin?
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
+
+    # A lent-out communicator has a live claim link a family may be about to
+    # use — deleting it would orphan that link mid-hand-off. Mirror the archive
+    # guard: end the loan first. (reclaim! frees the slot and clears the token.)
+    if @child_account.loaner?
+      render json: account_error_payload("End the loan first via end_loan."), status: :unprocessable_content
+      return
+    end
+
     @child_account.destroy!
   end
 

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -18,12 +18,27 @@ class API::ChildAccountsController < API::ApplicationController
   # unscopes `archived_at` and filters to non-null. Without the param,
   # behavior is unchanged.
   def index
-    # Scope on owner_id — the canonical ownership column that slot counts,
-    # serializers, and every other action use. (user_id is the legacy parent
-    # mirror; scoping on it could diverge from the "X of Y" counts.) A loaner
-    # keeps owner_id = the lender, so it stays listed until a family claims it.
-    scope = ChildAccount.with_boards.where(owner_id: current_user.id)
-    scope = scope.archived if ActiveModel::Type::Boolean.new.cast(params[:archived])
+    if ActiveModel::Type::Boolean.new.cast(params[:handed_off])
+      # Communicators this user handed off to a family: they were claimed
+      # (claimed_at set) and the user stayed on the team as a supervisor, but
+      # no longer owns them. There's no previous_owner_id column — supervisor +
+      # claimed + not-owner is the canonical hand-off fingerprint (claim_by!
+      # demotes the previous owner to supervisor). distinct because a user may
+      # sit on more than one of the communicator's teams.
+      scope = ChildAccount.with_boards
+        .joins(:team_users)
+        .where(team_users: { user_id: current_user.id, role: "supervisor" })
+        .where.not(owner_id: current_user.id)
+        .where.not(claimed_at: nil)
+        .distinct
+    else
+      # Scope on owner_id — the canonical ownership column that slot counts,
+      # serializers, and every other action use. (user_id is the legacy parent
+      # mirror; scoping on it could diverge from the "X of Y" counts.) A loaner
+      # keeps owner_id = the lender, so it stays listed until a family claims it.
+      scope = ChildAccount.with_boards.where(owner_id: current_user.id)
+      scope = scope.archived if ActiveModel::Type::Boolean.new.cast(params[:archived])
+    end
     @child_accounts = scope.order(name: :asc)
     render json: @child_accounts.map(&:index_api_view)
   end

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -1218,6 +1218,7 @@ class ChildAccount < ApplicationRecord
       username: username,
       name: name,
       parent_name: user.display_name,
+      claimed_at: claimed_at,
       board_count: @child_boards.size,
       board_list_sample: current_board_list,
       # Every board id this communicator "has", across both join paths: the

--- a/spec/requests/api/child_accounts_index_destroy_spec.rb
+++ b/spec/requests/api/child_accounts_index_destroy_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Hardening: the roster index scopes on owner_id (matching the "X of Y" slot
+# counts), and destroy blocks a lent-out communicator so a live claim link is
+# never orphaned mid-hand-off.
+RSpec.describe "API::ChildAccounts index + destroy", type: :request do
+  let(:owner) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+  describe "GET /api/child_accounts" do
+    it "returns the caller's owned communicators, including a lent-out loaner" do
+      active = create(:child_account, owner: owner, user: owner, status: "active",
+                                      username: "ac-#{SecureRandom.hex(2)}")
+      loaner = create(:child_account, owner: owner, user: owner, status: "loaner",
+                                      username: "ln-#{SecureRandom.hex(2)}")
+
+      get "/api/child_accounts", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).to contain_exactly(active.id, loaner.id)
+    end
+
+    it "excludes a communicator owned by someone else (scoped on owner_id)" do
+      other = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      mine = create(:child_account, owner: owner, user: owner, status: "active",
+                                    username: "mine-#{SecureRandom.hex(2)}")
+      # A row whose legacy user_id points at the caller but whose canonical
+      # owner is someone else must NOT appear — this is the divergence the
+      # owner_id scope fixes.
+      create(:child_account, owner: other, user: owner, status: "active",
+                             username: "theirs-#{SecureRandom.hex(2)}")
+
+      get "/api/child_accounts", headers: auth_headers(owner)
+
+      ids = JSON.parse(response.body).map { |a| a["id"] }
+      expect(ids).to eq([mine.id])
+    end
+  end
+
+  describe "DELETE /api/child_accounts/:id" do
+    it "lets the owner delete a sandbox communicator" do
+      sandbox = create(:child_account, owner: owner, user: owner, status: "sandbox",
+                                       username: "sb-#{SecureRandom.hex(2)}")
+
+      delete "/api/child_accounts/#{sandbox.id}", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:no_content).or have_http_status(:ok)
+      expect(ChildAccount.exists?(sandbox.id)).to be(false)
+    end
+
+    it "blocks deleting a lent-out loaner with end_loan guidance" do
+      loaner = create(:child_account, owner: owner, user: owner, status: "loaner",
+                                      username: "ln-#{SecureRandom.hex(2)}")
+
+      delete "/api/child_accounts/#{loaner.id}", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to match(/end_loan/i)
+      expect(ChildAccount.exists?(loaner.id)).to be(true)
+    end
+
+    it "rejects a non-owner" do
+      other = create(:user)
+      sandbox = create(:child_account, owner: owner, user: owner, status: "sandbox",
+                                       username: "sb-#{SecureRandom.hex(2)}")
+
+      delete "/api/child_accounts/#{sandbox.id}", headers: auth_headers(other)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(ChildAccount.exists?(sandbox.id)).to be(true)
+    end
+  end
+end

--- a/spec/requests/api/child_accounts_index_destroy_spec.rb
+++ b/spec/requests/api/child_accounts_index_destroy_spec.rb
@@ -39,6 +39,55 @@ RSpec.describe "API::ChildAccounts index + destroy", type: :request do
     end
   end
 
+  describe "GET /api/child_accounts?handed_off=true" do
+    # Simulate the post-hand-off state: a family now owns the communicator and
+    # the original SLP (the caller) remains on its team as a supervisor.
+    let(:family) { create(:user, plan_type: "pro", created_at: 2.months.ago) }
+
+    def handed_off_communicator(supervisor:, claimed: true)
+      account = create(:child_account, owner: family, user: family, status: "active",
+                                       claimed_at: (claimed ? Time.current : nil),
+                                       username: "ho-#{SecureRandom.hex(3)}")
+      team = create(:team, created_by: family)
+      TeamAccount.create!(team: team, account: account)
+      TeamUser.create!(team: team, user: family, role: "admin")
+      TeamUser.create!(team: team, user: supervisor, role: "supervisor")
+      account
+    end
+
+    it "lists claimed communicators the caller supervises but no longer owns" do
+      handed = handed_off_communicator(supervisor: owner)
+      # A communicator the caller still owns must not appear in this view.
+      create(:child_account, owner: owner, user: owner, status: "active",
+                             username: "own-#{SecureRandom.hex(2)}")
+
+      get "/api/child_accounts?handed_off=true", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.map { |a| a["id"] }).to eq([handed.id])
+      expect(body.first["parent_name"]).to eq(family.display_name)
+      expect(body.first["claimed_at"]).to be_present
+    end
+
+    it "excludes a supervised communicator that was never claimed" do
+      handed_off_communicator(supervisor: owner, claimed: false)
+
+      get "/api/child_accounts?handed_off=true", headers: auth_headers(owner)
+
+      expect(JSON.parse(response.body)).to be_empty
+    end
+
+    it "does not leak communicators the caller doesn't supervise" do
+      stranger = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      handed_off_communicator(supervisor: stranger)
+
+      get "/api/child_accounts?handed_off=true", headers: auth_headers(owner)
+
+      expect(JSON.parse(response.body)).to be_empty
+    end
+  end
+
   describe "DELETE /api/child_accounts/:id" do
     it "lets the owner delete a sandbox communicator" do
       sandbox = create(:child_account, owner: owner, user: owner, status: "sandbox",


### PR DESCRIPTION
Correctness + one additive filter on the communicator roster (`child_accounts#index`), surfaced in the communicator review.

## Fixes
- **Roster scope.** `GET /api/child_accounts` scoped on `user_id` (legacy parent mirror) while slot counts/serializers use `owner_id`. Now `owner_id` — the list can't diverge from the "X of Y" counts, and a loaner stays listed under its lender until claimed.
- **Delete guard.** `DELETE /api/child_accounts/:id` had no loaner guard (unlike `#archive`) and authorized on `user_id`. A lent-out communicator could be hard-deleted, orphaning the family's live claim link. Now authorizes on `owner_id` and refuses a `loaner` with **HTTP 422 "End the loan first"**.

## Feature (backend half of the "Handed off" tab)
- **`GET /api/child_accounts?handed_off=true`** returns communicators the caller handed off: claimed, and the caller remains a team `supervisor` but no longer owns them (supervisor + `claimed_at` + not-owner — there's no `previous_owner_id` column). Adds `claimed_at` to `index_api_view` so the tab can show when each was handed off. The matching frontend tab is a separate PR that depends on this.

## Deliberately out of scope
The documented-but-absent `loaner_or_active_must_have_login` passcode validation — every real transition path already mints/keeps a passcode, and the `:child_account` factory defaults to a passcode-less status across ~200 specs, so adding it safely needs a factory refactor + audit. Tracked as a follow-up.

## Test plan
- `child_accounts_index_destroy_spec.rb`: owner-scoped listing, delete-loaner-blocked, non-owner rejected, **plus** handed-off filter (lists supervised+claimed; excludes never-claimed and un-supervised) — 8 examples.
- Full `spec/requests/api/child_accounts_*` suite green (86 → 89 examples with the new cases). Existing `claim_link`/`send_claim_link`/`end_loan`/mailer specs already covered those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)