### PR TITLE
feat(billing): partner_pro signups create a no-card Stripe trial

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -144,12 +144,32 @@ The `/sign-up/partner` flow (frontend `viewType="partner"`) posts to the normal
 `POST /api/v1/users` with `plan_type=partner_pro`. `API::V1::AuthsController#sign_up`
 then sets `plan_type=partner_pro`, `plan_status=active`, `role=partner`, and calls
 `User.handle_new_partner_pro_subscription`, which sets
-`plan_expires_at = Time.now + 3.months` (only if nil), tags Mailchimp, and sends
-`PartnerMailer.welcome_email` (the free welcome + welcome journey are skipped).
-Entitlements equal Pro (`setup_partner_pro_plan` → 300 boards / 5 communicators /
-1500 credits). **No Stripe subscription, no card, no promo code** — the grant is
-local DB fields, which is why partners get Pro free for the pilot. `partner_pro`
-is in `RefreshFreeTierCreditsJob`'s refreshable set, so credits re-grant monthly.
+`plan_expires_at = now + PARTNER_PILOT_TRIAL_MONTHS.months` (3, ENV-overridable;
+only if nil), tags Mailchimp, and sends `PartnerMailer.welcome_email` (the free
+welcome + welcome journey are skipped). Entitlements equal Pro
+(`setup_partner_pro_plan` → 300 boards / 5 communicators / 1500 credits).
+
+**A real no-card Stripe trial backs the pilot (Phase 2, built).**
+`handle_new_partner_pro_subscription` calls
+`user.ensure_partner_pro_trial_subscription!(trial_end:)`, which creates a
+`Stripe::Subscription` on the **Partner Pro price** (`STRIPE_PRICE_PARTNER_PRO`,
+$10/mo, `metadata.plan_type=partner_pro`) with `trial_end = plan_expires_at`,
+`trial_settings.end_behavior.missing_payment_method: "cancel"`, and no card
+collected. This reuses the #264 reverse-trial machinery: the subscription rides
+`trialing` for 3 months, fires `trial_will_end` ~3 days out, and — if no card is
+ever added — cancels cleanly at the end → `customer.subscription.deleted` →
+`apply_free_plan` → **Free (content retained via fallback mode)**. Because the
+price metadata is `partner_pro`, the `handle_subscription_upsert` webhook keeps
+the user on `partner_pro` (not plain `pro`) and grants the 1500 allowance.
+Creation is **fail-soft**: a Stripe error is logged and swallowed so signup
+never 500s — the synchronous local grant (below) still provisions the partner,
+and the subscription can be backfilled later. `partner_pro` is in
+`RefreshFreeTierCreditsJob`'s refreshable set, so credits re-grant monthly.
+
+To avoid a double welcome, onboarding pre-seeds
+`settings["plan_welcome_sent_for"] = ["partner_pro"]` so the subscription
+webhook's `send_plan_welcome_email_once!` is a no-op (partners get
+`PartnerMailer.welcome_email`, not the generic Pro welcome).
 
 **Partner Pro is Pro-equivalent everywhere — `User#pro?` returns true for it.**
 `pro?` is `%w[pro pro_yearly partner_pro].include?(plan_type)`, so a partner is
@@ -171,36 +191,43 @@ already exists. So `handle_new_partner_pro_subscription` calls
 (partners stuck on the free allowance) with `rake partners:grant_pro_credits`
 (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope).
 
-**The 3-month window is surfaced but NOT enforced (Phase 1, deliberate).**
-`plan_expires_at` was previously set and never read — partners kept Pro forever
-with no signal. `PartnerPilotEndingJob` (daily 5:30am UTC, sidekiq-cron) closes
-that without auto-downgrading (partners are high-value B2B leads managed by hand):
+**Expiry is enforced by Stripe now; `PartnerPilotEndingJob` is digest-only.**
+The trial subscription auto-downgrades at the end (above), so the daily job
+(5:30am UTC, sidekiq-cron) no longer needs to police `plan_expires_at`. It stays
+as an **admin heads-up** so Brittany can convert/extend before the auto-drop:
 
 - **Reminder pass** — partners within `PARTNER_PILOT_REMINDER_LEAD_DAYS` (default
-  14) of `plan_expires_at`, not yet reminded, get `PartnerMailer.pilot_ending_email`
-  (a heads-up, not a shutoff — copy in `partner_mailer.pilot_ending_email`,
-  en + es). Flags `settings["partner_pilot_ending_notified"]` so it fires once.
-- **Expired pass** — partners past `plan_expires_at`, still `partner_pro`, get
-  flagged `settings["partner_pilot_expired"]` + `partner_pilot_expired_at`. **No
-  plan change.** Once-only via the flag.
+  14) of `plan_expires_at` are added to the admin digest once (flagged
+  `settings["partner_pilot_ending_notified"]`). The **partner-facing** nudge is
+  now owned by Stripe's `trial_will_end` webhook + the Mailchimp trial-wrap
+  journey, so the job no longer emails the partner unless
+  `PARTNER_PILOT_LEGACY_REMINDER=true` (kept as an escape hatch).
+- **Expired pass** — partners past `plan_expires_at`, still `partner_pro` (i.e.
+  Stripe's cancel webhook hasn't landed yet), get flagged
+  `settings["partner_pilot_expired"]` + `partner_pilot_expired_at`. Once-only.
 - Both feed a single `AdminMailer.partner_pilot_review` digest to `ADMIN_EMAIL`
   (only sent when there's something) so Brittany can convert/extend/downgrade.
 - `rake partners:pilot_status` — read-only list of pilots by status (ended /
   ending-soon / active / no-date), respects the lead-days ENV.
+- `rake partners:extend USER_ID=N [MONTHS=3] [DRY_RUN=false]` — Stripe-aware
+  extension: moves **both** `plan_expires_at` and the subscription's `trial_end`
+  (via `User#extend_partner_pro_trial!`) so Stripe re-arms the reminder +
+  auto-cancel, and clears the once-flags. Dry-run by default.
 - **Admin dashboard surface.** `Admin::MissionControlHelper#partner_pilot_status`
   computes the same status (never mutates). The server-rendered admin
   (`/admin/users`) has a **Partner** filter and chips non-active pilots
   (`Pilot ended` / `Ending soon`) on the row; the user detail page
   (`/admin/users/:id`) shows a **Partner Pilot** card (end date, days left,
   reminder-sent, expired-flagged) so you can action a partner in one place —
-  extend by bumping `plan_expires_at`, or adjust plan by hand.
+  extend with `rake partners:extend` (Stripe-aware), or adjust plan by hand.
 - **Admin plan changes.** The user detail page can change plans directly
-  (`Admin::UsersController#change_plan`). All changes are **local-only —
-  Stripe is never touched**, so an active Stripe subscription's webhooks can
-  later overwrite them. Semantics: `free` runs
-  `Billing::PlanTransitions.apply_free_plan` (full cancellation);
-  `partner_pro` runs `User.handle_new_partner_pro_subscription` (full partner
-  onboarding); other paid plans set `plan_type` **and `plan_status: "active"`**
+  (`Admin::UsersController#change_plan`). Most changes are **local-only** (Stripe
+  untouched), so an active Stripe subscription's webhooks can later overwrite
+  them. Semantics: `free` runs `Billing::PlanTransitions.apply_free_plan` (full
+  cancellation); `partner_pro` runs `User.handle_new_partner_pro_subscription`
+  (full partner onboarding — this **does** create a Stripe trial subscription,
+  the one exception to local-only); other paid plans set `plan_type` **and
+  `plan_status: "active"`**
   (without the status reset, a previously-canceled user would be
   `plan_stranded?` and auto-reverted to free). `basic_trial` is not
   admin-assignable — trials belong to the soft-trial flow. The page also
@@ -208,10 +235,20 @@ that without auto-downgrading (partners are high-value B2B leads managed by hand
   (board/paid-communicator/demo-communicator), and has queue-only email
   actions (welcome / setup / temp-login).
 
-**Phase 2 (not built):** if partner volume outgrows hand-management, move the
-pilot onto a real Stripe no-card trial (reuses the reverse-trial machinery
-above — auto-expiry, `trial_will_end` reminder, clean cancel→Free, one-click
-conversion) and retire this job + the bespoke `partner_pro` grant.
+**Phase 2 (built):** the pilot now runs on a real Stripe no-card trial (see the
+signup section above) — auto-expiry to Free, `trial_will_end` reminder, clean
+cancel, one-click conversion (add a card → $10/mo Partner Pro). Two pieces are
+deliberately retained for the transition rather than retired: the synchronous
+local credit grant (instant credits + fail-soft when Stripe is down) and
+`PartnerPilotEndingJob` (now digest-only). A follow-up will **backfill** existing
+`partner_pro` users (no `stripe_subscription_id`) onto trial subscriptions using
+their current `plan_expires_at` as `trial_end`.
+
+**Requires `STRIPE_PRICE_PARTNER_PRO` to point at a $10/mo price with
+`metadata.plan_type=partner_pro`.** The old value was a **$0** price
+(`metadata.plan_type=pro`) — a $0 subscription never lapses and would never
+downgrade, so it must be repointed to the paid Partner Pro price for the trial to
+expire correctly.
 
 ### Email-only (passwordless) signup — paid-intent path
 

--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -199,8 +199,10 @@ as an **admin heads-up** so Brittany can convert/extend before the auto-drop:
 - **Reminder pass** — partners within `PARTNER_PILOT_REMINDER_LEAD_DAYS` (default
   14) of `plan_expires_at` are added to the admin digest once (flagged
   `settings["partner_pilot_ending_notified"]`). The **partner-facing** nudge is
-  now owned by Stripe's `trial_will_end` webhook + the Mailchimp trial-wrap
-  journey, so the job no longer emails the partner unless
+  now owned by Stripe's `trial_will_end` webhook → `MailchimpTrialWrapJob`, which
+  fires the **`partner_pilot_wrap`** journey for partners (names the $10/mo rate,
+  offers "add a card to continue" or "reply to re-up") instead of the generic
+  `trial_wrap`. So the job no longer emails the partner unless
   `PARTNER_PILOT_LEGACY_REMINDER=true` (kept as an escape hatch).
 - **Expired pass** — partners past `plan_expires_at`, still `partner_pro` (i.e.
   Stripe's cancel webhook hasn't landed yet), get flagged

--- a/.claude-notes/marketing-integrations.md
+++ b/.claude-notes/marketing-integrations.md
@@ -69,6 +69,14 @@ GitHub build). Two distinct uses:
       then triggers — so the copy can say "you made N boards, M communicators;
       keep them by continuing." Requires those 3 merge fields to exist in the
       Mailchimp audience (tag names ≤10 chars: `TRIAL_END`, `BOARDS`, `COMMS`).
+    - `partner_pilot_wrap` — the **partner** variant of `trial_wrap`. Same
+      `MailchimpTrialWrapJob`, same `trial_will_end` seam, same merge fields —
+      but when `user.partner_pro?` the job triggers this key instead, so
+      partners get pilot-specific copy (names the $10/mo Partner Pro rate, offers
+      "reply to re-up your partner program" alongside "add a card to continue")
+      rather than the generic reverse-trial nudge. Wire
+      `MAILCHIMP_JOURNEY_PARTNER_PILOT_WRAP_ID` / `_STEP`; unset = no-op (partners
+      simply get no wrap email until the journey is built).
     - `win_back` — enqueued by `MailchimpWinBackJob` (daily, 4:30am UTC)
       re-engaging recently-dormant active users: non-admin, **≥1 board**, last
       sign-in `WIN_BACK_DORMANT_MIN_DAYS`–`WIN_BACK_DORMANT_MAX_DAYS` (default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   both `plan_expires_at` and the Stripe trial end so reminders/auto-cancel
   re-arm. Subscription creation is fail-soft (a Stripe outage never blocks
   signup). Partner-facing "pilot wrapping up" nudges are now owned by Stripe's
-  `trial_will_end` + the Mailchimp trial-wrap journey.
+  `trial_will_end` webhook, which fires a dedicated **`partner_pilot_wrap`**
+  Mailchimp journey for partners (names the $10/mo rate; "add a card to continue"
+  or "reply to re-up your partner program"). Requires
+  `MAILCHIMP_JOURNEY_PARTNER_PILOT_WRAP_ID` / `_STEP` to be set and the journey
+  built in Mailchimp.
 - **Deploy note:** repoint `STRIPE_PRICE_PARTNER_PRO` from the old $0 price to
   the new $10/mo Partner Pro price `price_1TtA0nGfsUBE8bl3knjA2WOD`
   (metadata `plan_type=partner_pro`) — a $0 subscription never lapses and would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Partner Program pilots now run on a real Stripe no-card trial
+- Partner sign-up (`plan_type=partner_pro`) now creates a Stripe subscription on
+  the Partner Pro price ($10/mo, `metadata.plan_type=partner_pro`) with a 3-month
+  no-card trial. When the pilot ends with no card on file, Stripe cancels it
+  cleanly and the user auto-downgrades to Free (content retained) — no more
+  partners sitting on Pro forever. Adding a card converts them at $10/mo.
+- Extend a pilot with `rake partners:extend USER_ID=N [MONTHS=3]`, which moves
+  both `plan_expires_at` and the Stripe trial end so reminders/auto-cancel
+  re-arm. Subscription creation is fail-soft (a Stripe outage never blocks
+  signup). Partner-facing "pilot wrapping up" nudges are now owned by Stripe's
+  `trial_will_end` + the Mailchimp trial-wrap journey.
+- **Deploy note:** repoint `STRIPE_PRICE_PARTNER_PRO` from the old $0 price to
+  the new $10/mo Partner Pro price `price_1TtA0nGfsUBE8bl3knjA2WOD`
+  (metadata `plan_type=partner_pro`) — a $0 subscription never lapses and would
+  not downgrade.
+
 ### Fixed — communicator roster + delete hardening around the SLP hand-off
 - `GET /api/child_accounts` now scopes on `owner_id` (the column slot counts and
   serializers use) instead of the legacy `user_id` mirror, so the listed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,6 +331,11 @@ class User < ApplicationRecord
     "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 2).to_i,
   }.freeze
 
+  # Length of the Partner Program pilot. Signup creates a real Stripe no-card
+  # trial of this length; extend a pilot by moving the subscription's
+  # `trial_end` (rake partners:extend), which the reverse-trial webhooks honor.
+  PARTNER_PILOT_TRIAL_MONTHS = ENV.fetch("PARTNER_PILOT_TRIAL_MONTHS", 3).to_i
+
   def setup_partner_pro_plan
     self.settings ||= {}
     self.settings["paid_communicator_limit"] = PRO_PLAN_LIMITS["paid_communicator_limit"]
@@ -510,10 +515,24 @@ class User < ApplicationRecord
     Rails.logger.info "Handling Partner Pro subscription for user: #{user.email} with plan_nickname: #{plan_nickname}"
     user.role = "partner"
     user.plan_status = "active"
-    user.plan_expires_at = Time.now + 3.months if user.plan_expires_at.nil?
+    trial_end = user.plan_expires_at || (Time.now + PARTNER_PILOT_TRIAL_MONTHS.months)
+    user.plan_expires_at = trial_end
     partner_group = user.get_partner_group
     user.settings["partner_group"] = partner_group
+    # Partners get PartnerMailer.welcome_email at signup, so mark the generic
+    # plan welcome as already sent — otherwise the Stripe subscription webhook
+    # (send_plan_welcome_email_once!) would send a second, Pro-branded welcome
+    # when the trial subscription lands as `trialing`.
+    already_welcomed = Array(user.settings["plan_welcome_sent_for"])
+    user.settings["plan_welcome_sent_for"] = (already_welcomed + ["partner_pro"]).uniq
     user.save
+
+    # Phase 2: create a real no-card Stripe trial subscription so the pilot
+    # rides the reverse-trial machinery (#264) — auto-expiry to Free at trial
+    # end, the `trial_will_end` reminder, and one-click conversion. Fail-soft:
+    # if Stripe is unreachable the partner is still fully provisioned by the
+    # local grant below, and the subscription can be backfilled later.
+    user.ensure_partner_pro_trial_subscription!(trial_end: trial_end)
 
     # Grant the Partner Pro (Pro-equivalent) credit allowance IMMEDIATELY.
     # The after_create :grant_initial_plan_credits hook already ran while the
@@ -604,6 +623,67 @@ class User < ApplicationRecord
     return stripe_customer_id if stripe_customer_id.present?
     update!(stripe_customer_id: User.create_stripe_customer(email))
     stripe_customer_id
+  end
+
+  # Create a no-card Stripe trial subscription on the Partner Pro price so the
+  # pilot rides the reverse-trial machinery (#264): `trialing` now, a
+  # `trial_will_end` reminder ~3 days out, and — if no card is ever added — a
+  # clean cancel → `customer.subscription.deleted` → downgrade to Free at trial
+  # end (content retained via fallback mode). The Partner Pro price carries
+  # `metadata.plan_type=partner_pro`, so the webhook keeps the user on
+  # `partner_pro` and grants the 1500-credit allowance. No-op if a subscription
+  # already exists. Fail-soft: any Stripe error is logged and swallowed so a
+  # partner signup never 500s — the caller's local grant still provisions them.
+  def ensure_partner_pro_trial_subscription!(trial_end:)
+    return stripe_subscription_id if stripe_subscription_id.present?
+
+    price_id = ENV.fetch("STRIPE_PRICE_PARTNER_PRO", nil).presence
+    if price_id.blank?
+      Rails.logger.error "[PartnerPilot] STRIPE_PRICE_PARTNER_PRO unset; skipping Stripe subscription for user=#{id}"
+      return nil
+    end
+
+    ensure_stripe_customer!
+
+    subscription = Stripe::Subscription.create(
+      customer: stripe_customer_id,
+      items: [{ price: price_id }],
+      trial_end: trial_end.to_i,
+      # No card up front; if the trial ends with none on file, cancel cleanly
+      # instead of cutting an unpayable invoice (mirrors the #264 reverse trial).
+      trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
+      metadata: { user_id: id, plan_key: "partner_pro", source: "partner_pilot_signup" },
+    )
+    update_columns(stripe_subscription_id: subscription.id) if subscription.id.present?
+    Rails.logger.info "[PartnerPilot] created trial subscription #{subscription.id} for user=#{id} trial_end=#{trial_end}"
+    subscription
+  rescue => e
+    Rails.logger.error "[PartnerPilot] failed to create trial subscription for user=#{id}: #{e.class} - #{e.message}"
+    nil
+  end
+
+  # Extend a partner pilot: push both the local `plan_expires_at` and the Stripe
+  # subscription's `trial_end` out to `new_end` so Stripe re-arms the
+  # `trial_will_end` reminder and the auto-cancel. Keeps the two in sync (the
+  # reverse-trial webhooks are driven by the Stripe date). Returns the updated
+  # subscription, or nil if there's no Stripe subscription to move.
+  def extend_partner_pro_trial!(new_end:)
+    update!(plan_expires_at: new_end)
+
+    if stripe_subscription_id.blank?
+      Rails.logger.warn "[PartnerPilot] extend: user=#{id} has no stripe_subscription_id; updated plan_expires_at only"
+      return nil
+    end
+
+    subscription = Stripe::Subscription.update(
+      stripe_subscription_id,
+      { trial_end: new_end.to_i, proration_behavior: "none" },
+    )
+    Rails.logger.info "[PartnerPilot] extended trial for user=#{id} sub=#{stripe_subscription_id} to #{new_end}"
+    subscription
+  rescue => e
+    Rails.logger.error "[PartnerPilot] failed to extend trial for user=#{id}: #{e.class} - #{e.message}"
+    nil
   end
 
   def all_required_settings

--- a/app/sidekiq/mailchimp_trial_wrap_job.rb
+++ b/app/sidekiq/mailchimp_trial_wrap_job.rb
@@ -11,6 +11,12 @@
 # Merge-field tags (create these in the Mailchimp audience, ≤10 chars each):
 #   TRIAL_END · BOARDS · COMMS
 #
+# Partner pilots ride the same Stripe reverse trial, so this same webhook path
+# covers them — but they get a DIFFERENT journey (`partner_pilot_wrap`): copy
+# that names the $10/mo Partner Pro rate and offers "reply to re-up your partner
+# program" instead of the generic "add a card to keep your plan" nudge. Which
+# journey fires is chosen by `partner_pro?`; both use the same merge fields.
+#
 # Self-contained gating (mirrors MailchimpEventJob's journey path) so it
 # no-ops cleanly when journeys are disabled or the key isn't configured.
 class MailchimpTrialWrapJob
@@ -19,19 +25,22 @@ class MailchimpTrialWrapJob
   sidekiq_options queue: :default, retry: 3
 
   JOURNEY_KEY = "trial_wrap".freeze
+  PARTNER_JOURNEY_KEY = "partner_pilot_wrap".freeze
 
   def perform(user_id, trial_end_epoch = nil)
     user = User.find_by(id: user_id)
     return unless user
 
+    journey_key = user.partner_pro? ? PARTNER_JOURNEY_KEY : JOURNEY_KEY
+
     unless MailchimpClient.journeys_enabled?
-      Rails.logger.info("[Mailchimp] Journeys disabled; skipping #{JOURNEY_KEY} for user #{user_id}")
+      Rails.logger.info("[Mailchimp] Journeys disabled; skipping #{journey_key} for user #{user_id}")
       return
     end
 
-    journey = MailchimpClient.journey(JOURNEY_KEY)
+    journey = MailchimpClient.journey(journey_key)
     unless journey
-      Rails.logger.warn("[Mailchimp] No journey configured for '#{JOURNEY_KEY}'; skipping")
+      Rails.logger.warn("[Mailchimp] No journey configured for '#{journey_key}'; skipping")
       return
     end
 

--- a/app/sidekiq/partner_pilot_ending_job.rb
+++ b/app/sidekiq/partner_pilot_ending_job.rb
@@ -9,9 +9,12 @@
 # job:
 #
 #   1. REMINDER pass — partners whose `plan_expires_at` is within the lead
-#      window (PARTNER_PILOT_REMINDER_LEAD_DAYS, default 14) and not yet
-#      reminded get a "your pilot is wrapping up" email. Flags
-#      settings["partner_pilot_ending_notified"] so it fires once per pilot.
+#      window (PARTNER_PILOT_REMINDER_LEAD_DAYS, default 14) are added to the
+#      admin digest once (flagged settings["partner_pilot_ending_notified"]).
+#      The partner-facing nudge itself is now owned by Stripe's `trial_will_end`
+#      webhook + the Mailchimp trial-wrap journey (Phase 2 made the pilot a real
+#      no-card Stripe trial), so this pass no longer emails the partner unless
+#      PARTNER_PILOT_LEGACY_REMINDER=true.
 #   2. EXPIRED pass — partners whose `plan_expires_at` has passed and who are
 #      still `partner_pro` get flagged settings["partner_pilot_expired"] (with
 #      partner_pilot_expired_at) so they're findable and counted once. NO plan
@@ -22,10 +25,11 @@
 # flags make the job idempotent: a partner is reminded once and included in the
 # digest once, no matter how many days the cron runs before she deals with them.
 #
-# Deliberately NOT enforcing a downgrade here is Phase 1 of the partner-expiry
-# work (see backend CLAUDE.md "Partner Program"). If partner volume ever
-# outgrows hand-management, Phase 2 moves the pilot onto a real Stripe no-card
-# trial and this job is retired.
+# Downgrade is no longer this job's concern: Phase 2 put the pilot on a real
+# Stripe no-card trial, so expiry now flows through the reverse-trial webhooks
+# (trial lapses → cancel → `customer.subscription.deleted` → Free). This job is
+# now digest-only — an admin heads-up so Brittany can convert/extend before the
+# auto-downgrade lands. It can be retired once that flow is trusted in prod.
 class PartnerPilotEndingJob
   include Sidekiq::Job
 
@@ -49,10 +53,18 @@ class PartnerPilotEndingJob
         flag_expired!(user)
         expired << user
       elsif ends_at <= reminder_cutoff
-        # Ending soon and not yet reminded.
+        # Ending soon and not yet counted for the admin digest.
         next if flagged?(user, REMINDER_FLAG)
 
-        PartnerMailer.pilot_ending_email(user).deliver_now
+        # The partner-facing "your pilot is wrapping up" nudge is now owned by
+        # Stripe's `trial_will_end` webhook + the Mailchimp trial-wrap journey
+        # (the pilot is a real no-card Stripe trial as of Phase 2). This job no
+        # longer emails the partner directly — it only feeds the admin digest so
+        # Brittany still gets a heads-up to convert/extend. Set
+        # PARTNER_PILOT_LEGACY_REMINDER=true to re-enable the bespoke email.
+        if ENV["PARTNER_PILOT_LEGACY_REMINDER"] == "true"
+          PartnerMailer.pilot_ending_email(user).deliver_now
+        end
         flag!(user, REMINDER_FLAG)
         expiring << user
       end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -92,7 +92,8 @@
       </div>
     </dl>
     <p class="text-[10px] text-t3 mt-3">
-      Partners are never auto-downgraded. Convert, extend (bump <span class="font-mono">plan_expires_at</span>), or downgrade by hand.
+      The pilot is a no-card Stripe trial that auto-downgrades to Free at the end. Extend with
+      <span class="font-mono">rake partners:extend USER_ID=<%= @user.id %></span> (moves the Stripe trial too), or convert/downgrade by hand.
       <span class="font-mono">rake partners:pilot_status</span> lists all pilots.
     </p>
   </div>

--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -83,6 +83,51 @@ namespace :partners do
     puts "Re-run with DRY_RUN=false to apply.\n\n" if dry_run
   end
 
+  # Extend a partner pilot by N months (default 3). Moves BOTH the local
+  # plan_expires_at and the Stripe subscription's trial_end so Stripe re-arms
+  # the trial_will_end reminder and the auto-cancel. Extends from the later of
+  # "now" and the current plan_expires_at, so an already-expired pilot gets a
+  # fresh full window and an active one is pushed further out. Dry-run by
+  # default; apply with DRY_RUN=false. Requires USER_ID=N.
+  #
+  #   USER_ID=42 bin/rails partners:extend                 # dry run, +3 months
+  #   USER_ID=42 MONTHS=6 DRY_RUN=false bin/rails partners:extend
+  desc "Extend a Partner Pro pilot (local plan_expires_at + Stripe trial_end)"
+  task extend: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    months = (ENV["MONTHS"] || 3).to_i
+
+    user_id = ENV["USER_ID"]
+    abort "USER_ID is required (e.g. USER_ID=42 bin/rails partners:extend)" if user_id.blank?
+
+    user = User.find_by(id: user_id)
+    abort "No user with id=#{user_id}" if user.nil?
+    unless user.plan_type == "partner_pro"
+      abort "User ##{user.id} (#{user.email}) is not on partner_pro (plan_type=#{user.plan_type})"
+    end
+
+    base = [Time.current, user.plan_expires_at].compact.max
+    new_end = base + months.months
+
+    puts "\n=== partners:extend (#{dry_run ? 'DRY RUN' : 'APPLYING'}) ==="
+    puts "  User:        ##{user.id}  #{user.email}"
+    puts "  Current end: #{user.plan_expires_at&.strftime('%Y-%m-%d') || '—'}"
+    puts "  New end:     #{new_end.strftime('%Y-%m-%d')} (+#{months} month(s))"
+    puts "  Stripe sub:  #{user.stripe_subscription_id.presence || '(none — local plan_expires_at only)'}"
+
+    if dry_run
+      puts "\nRe-run with DRY_RUN=false to apply.\n\n"
+    else
+      user.extend_partner_pro_trial!(new_end: new_end)
+      # Clear the once-flags so a re-extended pilot can be reminded/flagged again.
+      user.settings.delete("partner_pilot_ending_notified")
+      user.settings.delete("partner_pilot_expired")
+      user.settings.delete("partner_pilot_expired_at")
+      user.save!
+      puts "\nExtended. plan_expires_at is now #{user.reload.plan_expires_at.strftime('%Y-%m-%d')}.\n\n"
+    end
+  end
+
   # One-off: (re)record existing partners in Mailchimp with the stable
   # "Partner Program" trigger tag plus their monthly PartnerPro_<Month> cohort
   # tag. Needed because the signup-time tagging call was broken (passed a String

--- a/spec/lib/tasks/partners_extend_rake_spec.rb
+++ b/spec/lib/tasks/partners_extend_rake_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "partners:extend rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["partners:extend"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    saved = ENV.slice("USER_ID", "MONTHS", "DRY_RUN")
+    example.run
+  ensure
+    %w[USER_ID MONTHS DRY_RUN].each { |k| ENV.delete(k) }
+    saved.each { |k, v| ENV[k] = v }
+  end
+
+  let!(:partner) do
+    create(:user, plan_type: "partner_pro", role: "partner").tap do |u|
+      u.update_columns(stripe_subscription_id: "sub_x", plan_expires_at: 10.days.from_now)
+    end
+  end
+
+  it "aborts without USER_ID" do
+    expect { run_task }.to raise_error(SystemExit)
+  end
+
+  it "aborts for a non-partner user" do
+    other = create(:user, plan_type: "free")
+    ENV["USER_ID"] = other.id.to_s
+    expect { run_task }.to raise_error(SystemExit)
+  end
+
+  it "does not modify anything on a dry run" do
+    ENV["USER_ID"] = partner.id.to_s
+    expect(partner).not_to receive(:extend_partner_pro_trial!)
+    expect { run_task }.not_to change { partner.reload.plan_expires_at }
+  end
+
+  it "extends via the model and clears the once-flags when applied" do
+    partner.update!(settings: partner.settings.merge(
+      "partner_pilot_ending_notified" => true,
+      "partner_pilot_expired" => true,
+    ))
+    ENV["USER_ID"] = partner.id.to_s
+    ENV["MONTHS"] = "3"
+    ENV["DRY_RUN"] = "false"
+
+    allow(Stripe::Subscription).to receive(:update).and_return(double(id: "sub_x"))
+
+    run_task
+
+    partner.reload
+    expect(partner.plan_expires_at).to be > 80.days.from_now
+    expect(partner.settings["partner_pilot_ending_notified"]).to be_nil
+    expect(partner.settings["partner_pilot_expired"]).to be_nil
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,6 +108,104 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "Partner Pro trial subscription (Stripe)" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_test") }
+
+    around do |example|
+      original = ENV["STRIPE_PRICE_PARTNER_PRO"]
+      ENV["STRIPE_PRICE_PARTNER_PRO"] = "price_partner_test"
+      example.run
+    ensure
+      ENV["STRIPE_PRICE_PARTNER_PRO"] = original
+    end
+
+    describe "#ensure_partner_pro_trial_subscription!" do
+      it "creates a no-card trial subscription on the partner price and stores the id" do
+        trial_end = 3.months.from_now
+        expect(Stripe::Subscription).to receive(:create).with(
+          hash_including(
+            customer: "cus_test",
+            items: [{ price: "price_partner_test" }],
+            trial_end: trial_end.to_i,
+            trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
+          ),
+        ).and_return(double(id: "sub_123"))
+
+        user.ensure_partner_pro_trial_subscription!(trial_end: trial_end)
+        expect(user.reload.stripe_subscription_id).to eq("sub_123")
+      end
+
+      it "is a no-op when a subscription already exists" do
+        user.update_columns(stripe_subscription_id: "sub_existing")
+        expect(Stripe::Subscription).not_to receive(:create)
+
+        expect(user.ensure_partner_pro_trial_subscription!(trial_end: 3.months.from_now))
+          .to eq("sub_existing")
+      end
+
+      it "returns nil and skips Stripe when the price env is unset" do
+        ENV["STRIPE_PRICE_PARTNER_PRO"] = ""
+        expect(Stripe::Subscription).not_to receive(:create)
+
+        expect(user.ensure_partner_pro_trial_subscription!(trial_end: 3.months.from_now)).to be_nil
+      end
+
+      it "fails soft on a Stripe error (never raises, leaves the id nil)" do
+        allow(Stripe::Subscription).to receive(:create).and_raise(Stripe::StripeError.new("boom"))
+
+        expect { user.ensure_partner_pro_trial_subscription!(trial_end: 3.months.from_now) }
+          .not_to raise_error
+        expect(user.reload.stripe_subscription_id).to be_nil
+      end
+    end
+
+    describe "#extend_partner_pro_trial!" do
+      it "moves both plan_expires_at and the Stripe trial_end" do
+        user.update_columns(stripe_subscription_id: "sub_123", plan_expires_at: 1.month.from_now)
+        new_end = 4.months.from_now
+        expect(Stripe::Subscription).to receive(:update).with(
+          "sub_123", hash_including(trial_end: new_end.to_i),
+        ).and_return(double(id: "sub_123"))
+
+        user.extend_partner_pro_trial!(new_end: new_end)
+        expect(user.reload.plan_expires_at).to be_within(1.second).of(new_end)
+      end
+
+      it "updates plan_expires_at only when there is no Stripe subscription" do
+        new_end = 4.months.from_now
+        expect(Stripe::Subscription).not_to receive(:update)
+
+        expect(user.extend_partner_pro_trial!(new_end: new_end)).to be_nil
+        expect(user.reload.plan_expires_at).to be_within(1.second).of(new_end)
+      end
+    end
+
+    describe ".handle_new_partner_pro_subscription with Stripe" do
+      before do
+        allow(MailchimpService).to receive(:new)
+          .and_return(instance_double(MailchimpService, record_new_subscriber: true))
+      end
+
+      it "creates the trial subscription and pre-seeds the plan welcome as sent" do
+        allow(Stripe::Subscription).to receive(:create).and_return(double(id: "sub_abc"))
+
+        User.handle_new_partner_pro_subscription(user)
+
+        expect(user.reload.stripe_subscription_id).to eq("sub_abc")
+        expect(Array(user.settings["plan_welcome_sent_for"])).to include("partner_pro")
+        expect(user.plan_expires_at).to be_present
+      end
+
+      it "still provisions the partner (role + credits) when Stripe creation fails" do
+        allow(Stripe::Subscription).to receive(:create).and_raise(Stripe::StripeError.new("down"))
+
+        expect { User.handle_new_partner_pro_subscription(user) }.not_to raise_error
+        expect(user.reload.role).to eq("partner")
+        expect(user.plan_credits_balance).to eq(CreditService.monthly_credits_for("partner_pro"))
+      end
+    end
+  end
+
   after(:all) do
     Team.destroy_all
     User.destroy_all

--- a/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
+++ b/spec/sidekiq/mailchimp_trial_wrap_job_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe MailchimpTrialWrapJob, type: :job do
       job.perform(user.id, nil)
     end
 
+    context "for a partner pilot" do
+      let(:user) { create(:user, plan_type: "partner_pro", role: "partner") }
+
+      it "triggers the partner_pilot_wrap journey instead of the generic one" do
+        allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+        allow(MailchimpClient).to receive(:journey).with("partner_pilot_wrap")
+          .and_return(journey_id: 70, step_id: 80)
+        allow(mailchimp).to receive(:update_merge_fields)
+
+        expect(MailchimpClient).not_to receive(:journey).with("trial_wrap")
+        expect(mailchimp).to receive(:trigger_journey).with(
+          user, journey_id: 70, step_id: 80
+        )
+
+        job.perform(user.id, nil)
+      end
+    end
+
     it "skips when the trial_wrap journey isn't configured" do
       allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
       allow(MailchimpClient).to receive(:journey).with("trial_wrap").and_return(nil)

--- a/spec/sidekiq/partner_pilot_ending_job_spec.rb
+++ b/spec/sidekiq/partner_pilot_ending_job_spec.rb
@@ -22,21 +22,34 @@ RSpec.describe PartnerPilotEndingJob, type: :job do
 
   describe "#perform" do
     context "a partner ending within the lead window" do
-      it "emails the partner and flags them reminded" do
+      it "flags them for the digest without emailing the partner (Stripe/Mailchimp own the nudge)" do
         user = create_partner(plan_expires_at: 5.days.from_now)
 
         expect { job.perform }
           .to change { user.reload.settings["partner_pilot_ending_notified"] }.to(true)
+        expect(partner_reminder_mails).to be_empty
+      end
+
+      it "emails the partner when the legacy reminder is explicitly re-enabled" do
+        create_partner(plan_expires_at: 5.days.from_now)
+
+        climate = ENV["PARTNER_PILOT_LEGACY_REMINDER"]
+        ENV["PARTNER_PILOT_LEGACY_REMINDER"] = "true"
+        begin
+          job.perform
+        ensure
+          ENV["PARTNER_PILOT_LEGACY_REMINDER"] = climate
+        end
+
         expect(partner_reminder_mails).not_to be_empty
       end
 
-      it "does not re-email an already-reminded partner" do
-        create_partner(plan_expires_at: 5.days.from_now,
-                       settings: { "partner_pilot_ending_notified" => true })
+      it "does not re-flag an already-flagged partner" do
+        user = create_partner(plan_expires_at: 5.days.from_now,
+                              settings: { "partner_pilot_ending_notified" => true })
 
-        job.perform
-
-        expect(partner_reminder_mails).to be_empty
+        expect { job.perform }
+          .not_to change { user.reload.settings["partner_pilot_ending_notified"] }
       end
 
       it "does not change plan_type (no downgrade)" do


### PR DESCRIPTION
## Summary

Partner Program pilots used to set local DB fields only (`partner_pro` + `plan_expires_at`) with **no Stripe subscription** — so partners kept Pro forever and nothing auto-downgraded them. This moves the pilot onto a **real Stripe no-card trial** (the documented "Phase 2"), reusing the #264 reverse-trial machinery.

**Flow now:** partner signup → `Stripe::Subscription` on the Partner Pro price ($10/mo, `metadata.plan_type=partner_pro`) with a 3-month trial, no card, `trial_settings.end_behavior.missing_payment_method: "cancel"`. Trial ends with no card → Stripe cancels → `customer.subscription.deleted` → `apply_free_plan` → **Free, content retained**. Adding a card converts them at $10/mo. The existing webhook already handles all of this — no webhook code changed.

### What's in here
- `User#ensure_partner_pro_trial_subscription!` — creates the trial subscription, **fail-soft** (a Stripe outage never 500s signup; the synchronous local grant still provisions the partner).
- `User#extend_partner_pro_trial!` + `rake partners:extend USER_ID=N [MONTHS=3]` — moves **both** `plan_expires_at` and the Stripe `trial_end` so reminders/auto-cancel re-arm.
- Pre-seeds `plan_welcome_sent_for=["partner_pro"]` so the subscription webhook doesn't send a second (Pro-branded) welcome on top of `PartnerMailer.welcome_email`.
- `PartnerPilotEndingJob` is now **digest-only**; the partner-facing "wrapping up" nudge is owned by Stripe `trial_will_end` + the Mailchimp trial-wrap journey (`PARTNER_PILOT_LEGACY_REMINDER=true` re-enables the old email).
- Docs: billing spoke (Phase 2 → built), CHANGELOG, admin partner-card copy.

### ⚠️ Deploy step (required, not in code)
Repoint **`STRIPE_PRICE_PARTNER_PRO`** in Hatchbox to the new price **`price_1TtA0nGfsUBE8bl3knjA2WOD`** ($10/mo, `metadata.plan_type=partner_pro`). The old value is a **$0** price — a $0 subscription never lapses, so it would never downgrade. Until this is set, subscription creation fail-softs (logs + skips) and partners are still provisioned via the local grant, so deploying the code ahead of the env change is safe.

### Follow-up (not in this PR)
Backfill existing `partner_pro` users (no `stripe_subscription_id`) onto trial subscriptions using their current `plan_expires_at` as `trial_end`.

## Test plan
Ran the changed-code specs — **218 examples, 0 failures**:
- `spec/models/user_spec.rb` (new: subscription create success / no-op / price-unset / fail-soft; extend with & without a sub; `handle_new_partner_pro_subscription` create + welcome pre-seed + fail-soft provisioning)
- `spec/sidekiq/partner_pilot_ending_job_spec.rb` (reminder now digest-only; legacy flag re-enables email)
- `spec/lib/tasks/partners_extend_rake_spec.rb` (new)
- `spec/requests/api/auth_spec.rb`, `webhooks_plan_type_spec.rb`, `webhooks_plan_welcome_spec.rb`, `stripe/checkout_sessions_spec.rb`, `mailers/partner_mailer_spec.rb`, `admin/users_spec.rb`

Full suite not run (targeted per PR convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)