### PR TITLE
chore(plans): Pro sandbox communicators 2 → 10 (match prod)

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -460,10 +460,10 @@ sandbox" UI — even after the user became a paying Basic/Pro subscriber.
   the new slot limit is already in `settings` when the callback fires.
 - **Basic-only by design.** `BASIC_PLAN_LIMITS["demo_communicator_limit"] == 0`
   (no sandbox entitlement), so a Basic user's sandbox is always a stuck Free-era
-  leftover and is promoted. **Pro grants 2 sandbox slots**
-  (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 2`, ENV
+  leftover and is promoted. **Pro grants 10 sandbox slots**
+  (`PRO_PLAN_LIMITS["demo_communicator_limit"] == 10`, ENV
   `PRO_DEMO_COMMUNICATOR_LIMIT`; raised from 1 in 2026-07, backfilled onto
-  existing Pro users by `plans:bump_pro_sandbox_to_two`), so a Pro user's
+  existing Pro users by `plans:bump_pro_sandbox_to_ten`), so a Pro user's
   sandboxes are intentional scratch/demo accounts and are left untouched — the
   guard is `sandbox_limit_for(settings) > 0 → skip`.
 - **`ChildAccount#promote_to_active!`** — mirror of `promote_to_loaner!`: flips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   lent-out `loaner` (HTTP 422, "End the loan first") — mirroring the archive
   guard so a family's live claim link is never orphaned mid-hand-off.
 
-### Changed — Pro plan now includes 2 sandbox communicators (was 1)
-- `PRO_PLAN_LIMITS["demo_communicator_limit"]` default raised 1 → 2 (ENV
-  `PRO_DEMO_COMMUNICATOR_LIMIT`). Pro users can now keep two no-sign-in sandbox
-  communicators for trialing setups; sandboxes still don't count against
-  sign-in slots.
+### Changed — Pro plan now includes 10 sandbox communicators (was 1)
+- `PRO_PLAN_LIMITS["demo_communicator_limit"]` default raised 1 → 10 (ENV
+  `PRO_DEMO_COMMUNICATOR_LIMIT`, already `10` in production). Pro users can keep
+  up to ten no-sign-in sandbox communicators for trialing setups; sandboxes
+  still don't count against sign-in slots.
 - Existing Pro users are backfilled by the one-off task
-  `plans:bump_pro_sandbox_to_two` (dry-run with `DRY_RUN=true`; skips anyone an
-  admin tuned above 2). Production also requires the Hatchbox
-  `PRO_DEMO_COMMUNICATOR_LIMIT` env var set to `2`.
+  `plans:bump_pro_sandbox_to_ten` (dry-run with `DRY_RUN=true`; skips anyone at
+  or above 10, incl. admin-tuned).
 
 ### Fixed — /api/boards no longer 500s on an orphaned communicator join row
 - `Board#api_view` read `child_account.id` on every `ChildBoard` returned by

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,7 +328,7 @@ class User < ApplicationRecord
     "board_limit" => ENV.fetch("PRO_BOARD_LIMIT", 300).to_i,
     "board_group_limit" => ENV.fetch("PRO_BOARD_GROUP_LIMIT", 50).to_i,
     "paid_communicator_limit" => ENV.fetch("PRO_PAID_COMMUNICATOR_LIMIT", 5).to_i,
-    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 2).to_i,
+    "demo_communicator_limit" => ENV.fetch("PRO_DEMO_COMMUNICATOR_LIMIT", 10).to_i,
   }.freeze
 
   def setup_partner_pro_plan

--- a/lib/tasks/plans.rake
+++ b/lib/tasks/plans.rake
@@ -132,9 +132,10 @@ namespace :plans do
     puts "(dry run — no rows were written)" if dry_run
   end
 
-  desc "One-off (2026-07): bump existing Pro users from 1 → 2 sandbox communicator slots. " \
-       "Skips anyone an admin has tuned above 2 so we never lower a deliberate value."
-  task bump_pro_sandbox_to_two: :environment do
+  desc "One-off (2026-07): bump existing Pro users up to 10 sandbox communicator slots. " \
+       "Skips anyone at/above 10 (incl. admin-tuned) so we never lower a deliberate value."
+  task bump_pro_sandbox_to_ten: :environment do
+    target = 10
     dry_run = ENV["DRY_RUN"] == "true"
     bumped = 0
     skipped_higher = 0
@@ -142,30 +143,31 @@ namespace :plans do
 
     scope = User.where(plan_type: %w[pro pro_yearly partner_pro])
 
-    puts "[bump_pro_sandbox_to_two] starting (dry_run=#{dry_run}) — scope=#{scope.count} users"
+    puts "[bump_pro_sandbox_to_ten] starting (dry_run=#{dry_run}) — scope=#{scope.count} users"
 
     scope.find_each(batch_size: 200) do |user|
       user.settings ||= {}
       current = user.settings["demo_communicator_limit"].to_i
 
-      if current >= 2
+      if current >= target
         # Already at the new target or an admin has tuned it higher. Leave it.
         skipped_higher += 1
         next
       end
 
-      if current != 1 && current != 0
-        # Anything other than 1 (or the missing-value sentinel 0) is unexpected
-        # for a Pro user — log it and skip rather than silently overwrite.
+      # Expected pre-bump values are 0 (unset), 1 (the original Pro default),
+      # or 2 (the interim default). Anything else (3..9) is an unexpected
+      # deliberate value — log it and skip rather than silently overwrite.
+      unless [0, 1, 2].include?(current)
         skipped_other += 1
-        warn "[bump_pro_sandbox_to_two] user #{user.id} has unexpected demo_communicator_limit=#{current.inspect} — skipping"
+        warn "[bump_pro_sandbox_to_ten] user #{user.id} has unexpected demo_communicator_limit=#{current.inspect} — skipping"
         next
       end
 
       if dry_run
-        puts "  would bump user=#{user.id} plan=#{user.plan_type} #{current} → 2"
+        puts "  would bump user=#{user.id} plan=#{user.plan_type} #{current} → #{target}"
       else
-        user.settings["demo_communicator_limit"] = 2
+        user.settings["demo_communicator_limit"] = target
         # update_columns to skip callbacks — plan_type isn't changing,
         # so before_save :setup_limits should not re-run.
         user.update_columns(settings: user.settings, updated_at: Time.current)
@@ -174,11 +176,11 @@ namespace :plans do
       print "." if !dry_run && bumped % 100 == 0
     rescue => e
       skipped_other += 1
-      warn "[bump_pro_sandbox_to_two] user #{user.id} failed: #{e.message}"
+      warn "[bump_pro_sandbox_to_ten] user #{user.id} failed: #{e.message}"
     end
 
     puts
-    puts "[bump_pro_sandbox_to_two] done. bumped=#{bumped} " \
+    puts "[bump_pro_sandbox_to_ten] done. bumped=#{bumped} " \
          "skipped_higher=#{skipped_higher} skipped_other=#{skipped_other}"
     puts "(dry run — no rows were written)" if dry_run
   end

--- a/spec/helpers/permissions/communicator_limits_spec.rb
+++ b/spec/helpers/permissions/communicator_limits_spec.rb
@@ -105,8 +105,9 @@ RSpec.describe Permissions::CommunicatorLimits do
         expect(http_status).to eq(:unprocessable_content)
       end
 
-      it "allows two sandbox communicators, blocks the third" do
-        2.times { create(:child_account, user: user, owner: user, status: ChildAccount::SANDBOX) }
+      it "allows sandbox communicators up to the Pro limit, then blocks" do
+        limit = User::PRO_PLAN_LIMITS["demo_communicator_limit"]
+        limit.times { create(:child_account, user: user, owner: user, status: ChildAccount::SANDBOX) }
 
         allowed, http_status, _error = described_class.can_create?(user: user, status: ChildAccount::SANDBOX)
         expect(allowed).to be(false)

--- a/spec/lib/tasks/plans_rake_spec.rb
+++ b/spec/lib/tasks/plans_rake_spec.rb
@@ -131,16 +131,25 @@ RSpec.describe "plans rake task", type: :task do
     end
   end
 
-  describe "plans:bump_pro_sandbox_to_two" do
-    let(:task) { Rake::Task["plans:bump_pro_sandbox_to_two"] }
+  describe "plans:bump_pro_sandbox_to_ten" do
+    let(:task) { Rake::Task["plans:bump_pro_sandbox_to_ten"] }
 
-    it "bumps an existing Pro user from 1 → 2 sandbox slots" do
+    it "bumps an existing Pro user from 1 → 10 sandbox slots" do
       pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
       pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 1))
 
       run_task
 
-      expect(pro.reload.settings["demo_communicator_limit"]).to eq(2)
+      expect(pro.reload.settings["demo_communicator_limit"]).to eq(10)
+    end
+
+    it "also bumps a user left at the interim value of 2" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 2))
+
+      run_task
+
+      expect(pro.reload.settings["demo_communicator_limit"]).to eq(10)
     end
 
     it "applies to partner_pro and pro_yearly users" do
@@ -151,11 +160,20 @@ RSpec.describe "plans rake task", type: :task do
 
       run_task
 
-      expect(partner.reload.settings["demo_communicator_limit"]).to eq(2)
-      expect(yearly.reload.settings["demo_communicator_limit"]).to eq(2)
+      expect(partner.reload.settings["demo_communicator_limit"]).to eq(10)
+      expect(yearly.reload.settings["demo_communicator_limit"]).to eq(10)
     end
 
-    it "preserves an admin-tuned value above the target" do
+    it "preserves an admin-tuned value at or above the target" do
+      pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
+      pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 15))
+
+      run_task
+
+      expect(pro.reload.settings["demo_communicator_limit"]).to eq(15)
+    end
+
+    it "skips an unexpected mid-range value rather than overwriting it" do
       pro = create(:user, plan_type: "pro", created_at: 2.months.ago)
       pro.update!(settings: pro.settings.merge("demo_communicator_limit" => 5))
 

--- a/spec/models/user_plan_limits_spec.rb
+++ b/spec/models/user_plan_limits_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe User, "plan limits", type: :model do
   describe "sandbox (legacy demo) communicator limits" do
     # Every Free user gets one sandbox communicator (the MySpeak ID).
-    # Pro gets two; Basic has none.
-    it "grants one sandbox communicator to Free, two to Pro, none to Basic" do
+    # Pro gets ten; Basic has none.
+    it "grants one sandbox communicator to Free, ten to Pro, none to Basic" do
       expect(User::FREE_PLAN_LIMITS["demo_communicator_limit"]).to eq(1)
       expect(User::BASIC_PLAN_LIMITS["demo_communicator_limit"]).to eq(0)
-      expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(2)
+      expect(User::PRO_PLAN_LIMITS["demo_communicator_limit"]).to eq(10)
     end
 
     it "no longer defines a MySpeak plan tier" do


### PR DESCRIPTION
Production already runs `PRO_DEMO_COMMUNICATOR_LIMIT=10`, and that's the intended entitlement. #503 shipped an interim default of **2**, which never actually took effect in prod (the env var overrides it). This aligns the code, backfill, specs, and docs with the real prod value of **10**.

## Changes
- `PRO_PLAN_LIMITS["demo_communicator_limit"]` default **2 → 10**.
- Backfill task renamed `bump_pro_sandbox_to_two` → **`bump_pro_sandbox_to_ten`**, target 10: bumps `0/1/2` up to 10, skips anyone `>= 10` (incl. admin-tuned), skips unexpected `3..9` with a warning. `DRY_RUN=true` aware.
- Specs: Pro sandbox limit asserts 10; the sandbox-cap test is now **limit-relative** (creates `PRO_PLAN_LIMITS["demo_communicator_limit"]` sandboxes, asserts the next is blocked) so it won't need editing if the number changes again. Rake specs cover bump-from-1, bump-from-interim-2, preserve `>=10`, and skip mid-range.
- `billing-and-plans.md` + `CHANGELOG` updated.

## Prod rollout
`PRO_DEMO_COMMUNICATOR_LIMIT=10` is **already set in Hatchbox** — no env change needed. To lift existing Pro users whose persisted `settings["demo_communicator_limit"]` is still below 10, run `plans:bump_pro_sandbox_to_ten` (dry-run first).

## Test plan
- `rspec spec/models/user_plan_limits_spec.rb spec/helpers/permissions/communicator_limits_spec.rb spec/lib/tasks/plans_rake_spec.rb` — **56 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)