### PR TITLE
feat(partners): partners:restart rake task (one-time pilot reset)

### DIFF
--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -1,4 +1,79 @@
 namespace :partners do
+  # One-time "restart everyone brand new": put an explicit set of partners onto
+  # a fresh no-card Stripe trial (Phase 2), regardless of their current state
+  # (free / pro / partner_pro, with or without a stale subscription). For each
+  # id in IDS:
+  #   1. Cancel + clear any existing Stripe subscription (e.g. the leftover $0
+  #      "free" subs some downgraded partners still carry) so the fresh trial
+  #      isn't skipped by ensure_partner_pro_trial_subscription!'s guard.
+  #   2. Set a staggered trial_end (now + MONTHS + index*STAGGER_DAYS) so the
+  #      partner_pilot_wrap nudges ~3 months out don't all fire the same day.
+  #   3. Run the standard partner onboarding (handle_new_partner_pro_subscription):
+  #      resets plan_type=partner_pro + limits + 1500 credits, creates the fresh
+  #      trial subscription, pre-seeds the welcome guard, and re-tags Mailchimp
+  #      "Partner Program" + the monthly cohort so the journey can fire.
+  #
+  # IDS is REQUIRED and explicit (comma-separated) — no role-based default, so a
+  # stray run can't touch test/demo accounts. Dry-run by default.
+  #
+  #   IDS=244,258,419 bin/rails partners:restart                 # dry run
+  #   IDS=244,258,419 MONTHS=3 STAGGER_DAYS=1 DRY_RUN=false bin/rails partners:restart
+  desc "Restart specific partners on a fresh no-card Stripe trial (IDS=required, dry-run default)"
+  task restart: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    months = (ENV["MONTHS"] || 3).to_i
+    stagger = (ENV["STAGGER_DAYS"] || 1).to_i
+
+    ids = ENV["IDS"].to_s.split(",").map { |s| s.strip.to_i }.reject(&:zero?)
+    abort "IDS is required (e.g. IDS=244,258 bin/rails partners:restart)" if ids.empty?
+
+    users = User.where(id: ids).order(:id).to_a
+    missing = ids - users.map(&:id)
+    puts "\n=== partners:restart (#{dry_run ? 'DRY RUN' : 'APPLYING'}) ==="
+    puts "Requested: #{ids.size}  Found: #{users.size}#{missing.any? ? "  Missing: #{missing.join(', ')}" : ''}"
+    puts "Trial length: #{months} months, staggered +#{stagger} day(s) per partner\n\n"
+
+    base = Time.current
+    done = 0
+    users.each_with_index do |user, i|
+      trial_end = base + months.months + (i * stagger).days
+      label = "##{user.id}  #{user.email.to_s.ljust(36)}"
+      old = "#{user.plan_type}/#{user.plan_status}"
+      sub_note = user.stripe_subscription_id.present? ? "cancel #{user.stripe_subscription_id}" : "no existing sub"
+      puts "#{label}  #{old} -> partner_pro/trialing  ends #{trial_end.strftime('%Y-%m-%d')}  (#{sub_note})"
+      next if dry_run
+
+      begin
+        # 1. Cancel + clear any existing subscription so the fresh trial is created.
+        if user.stripe_subscription_id.present?
+          begin
+            Stripe::Subscription.cancel(user.stripe_subscription_id)
+          rescue Stripe::InvalidRequestError => e
+            Rails.logger.warn "[PartnerRestart] cancel #{user.stripe_subscription_id} for ##{user.id}: #{e.message}"
+          end
+          user.update_columns(stripe_subscription_id: nil)
+        end
+
+        # 2. Clear pilot flags + prior welcome guard so this is a clean slate,
+        #    and set the staggered end date (handle_new_... keeps a non-nil one).
+        %w[partner_pilot_ending_notified partner_pilot_expired partner_pilot_expired_at
+           plan_welcome_sent_for].each { |k| user.settings.delete(k) }
+        user.plan_type = "partner_pro"
+        user.plan_expires_at = trial_end
+        user.save!
+
+        # 3. Standard partner onboarding: fresh trial sub + credits + Mailchimp tags.
+        User.handle_new_partner_pro_subscription(user, "partner_pro")
+        done += 1
+      rescue => e
+        puts "   !! failed for ##{user.id}: #{e.class} - #{e.message}"
+      end
+    end
+
+    puts "\n#{dry_run ? 'Would restart' : 'Restarted'} #{dry_run ? users.size : done} partner(s)."
+    puts "Re-run with DRY_RUN=false to apply.\n\n" if dry_run
+  end
+
   # Read-only snapshot of where every Partner Pro pilot sits relative to its
   # 3-month window. Mirrors the categories PartnerPilotEndingJob acts on so you
   # can see who's ending soon / already ended without waiting for the daily

--- a/spec/lib/tasks/partners_restart_rake_spec.rb
+++ b/spec/lib/tasks/partners_restart_rake_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "partners:restart rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["partners:restart"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    saved = ENV.slice("IDS", "MONTHS", "STAGGER_DAYS", "DRY_RUN", "STRIPE_PRICE_PARTNER_PRO")
+    ENV["STRIPE_PRICE_PARTNER_PRO"] = "price_partner_test"
+    example.run
+  ensure
+    %w[IDS MONTHS STAGGER_DAYS DRY_RUN].each { |k| ENV.delete(k) }
+    saved.each { |k, v| ENV[k] = v }
+  end
+
+  before do
+    allow(MailchimpService).to receive(:new)
+      .and_return(instance_double(MailchimpService, record_new_subscriber: true))
+  end
+
+  it "aborts without IDS" do
+    expect { run_task }.to raise_error(SystemExit)
+  end
+
+  it "does not change anything on a dry run" do
+    partner = create(:user, plan_type: "pro", role: "partner")
+    ENV["IDS"] = partner.id.to_s
+    expect(Stripe::Subscription).not_to receive(:create)
+
+    expect { run_task }.not_to change { partner.reload.plan_type }
+  end
+
+  context "when applied" do
+    it "cancels the stale sub, creates a fresh trial, and resets to partner_pro" do
+      partner = create(:user, plan_type: "free", role: "partner", stripe_customer_id: "cus_x")
+      partner.update_columns(stripe_subscription_id: "sub_stale")
+      partner.update!(settings: partner.settings.merge("partner_pilot_expired" => true))
+
+      ENV["IDS"] = partner.id.to_s
+      ENV["DRY_RUN"] = "false"
+
+      expect(Stripe::Subscription).to receive(:cancel).with("sub_stale")
+      expect(Stripe::Subscription).to receive(:create).and_return(double(id: "sub_new"))
+
+      run_task
+
+      partner.reload
+      expect(partner.plan_type).to eq("partner_pro")
+      expect(partner.stripe_subscription_id).to eq("sub_new")
+      expect(partner.plan_expires_at).to be > 80.days.from_now
+      expect(partner.settings["partner_pilot_expired"]).to be_nil
+    end
+
+    it "staggers trial ends across multiple partners" do
+      p1 = create(:user, plan_type: "pro", role: "partner", stripe_customer_id: "cus_1")
+      p2 = create(:user, plan_type: "pro", role: "partner", stripe_customer_id: "cus_2")
+      ENV["IDS"] = "#{p1.id},#{p2.id}"
+      ENV["STAGGER_DAYS"] = "3"
+      ENV["DRY_RUN"] = "false"
+      allow(Stripe::Subscription).to receive(:create).and_return(double(id: "sub_a"), double(id: "sub_b"))
+
+      run_task
+
+      # Second partner's trial ends later than the first (staggered).
+      expect(p2.reload.plan_expires_at).to be > p1.reload.plan_expires_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary

One-time operational task to **restart existing partners brand new** on the no-card Stripe trial that #505 shipped. Follows up on that PR.

`partners:restart` takes an explicit `IDS=` list and, for each partner:
1. **Cancels + clears** any existing Stripe subscription — several downgraded partners still carry a stale **$0 free-price** subscription, and `ensure_partner_pro_trial_subscription!` skips anyone who already has a `stripe_subscription_id`, so they'd be silently missed otherwise.
2. Sets a **staggered** `trial_end` (`now + MONTHS + index*STAGGER_DAYS`) so the `partner_pilot_wrap` nudges ~3 months out don't all fire the same day.
3. Runs standard partner onboarding (`handle_new_partner_pro_subscription`): resets to `partner_pro` + 1500 credits, creates the fresh no-card trial subscription, pre-seeds the welcome guard, and re-tags Mailchimp `Partner Program` + monthly cohort.

**Safety:** `IDS` is required and explicit — there is no role-based default, so a stray run can't sweep in test/demo accounts. **Dry-run by default** (`DRY_RUN=false` to apply).

```
IDS=244,258,419,565,596,622,769 bin/rails partners:restart              # dry run
IDS=244,258,419,565,596,622,769 DRY_RUN=false bin/rails partners:restart
```

## Context

Prod cross-check (DB + Stripe + Mailchimp) found 11 `role: partner` accounts in inconsistent states (free/pro/partner_pro), two with stale $0 subs, and mostly missing the `Partner Program` Mailchimp tag. This task normalizes the 7 real partners onto one fresh pilot.

## Test plan
`spec/lib/tasks/partners_restart_rake_spec.rb` — aborts without IDS; dry-run mutates nothing; apply cancels the stale sub + creates a fresh trial + resets to partner_pro + clears pilot flags; multi-partner stagger. Ran restart + extend rake specs: **8 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)