### PR TITLE
feat(admin): sortable Last login column on users dashboard

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,7 +6,7 @@ module Admin
     CHANGEABLE_PLAN_TYPES = %w[free basic basic_yearly pro pro_yearly plus premium partner_pro].freeze
 
     def index
-      @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count boards]) || "created_at"
+      @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count current_sign_in_at boards]) || "created_at"
       @dir = params[:dir].presence_in(%w[asc desc]) || "desc"
       @filter = params[:filter]
       @search = params[:search]

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -51,6 +51,7 @@
           ["Plan",       "plan_type"],
           ["Boards",     "boards"],
           ["Sign-ins",   "sign_in_count"],
+          ["Last login", "current_sign_in_at"],
           ["Created",    "created_at"],
         ].each do |label, col| %>
           <th class="text-left text-xs font-medium text-t2 px-5 py-3">
@@ -97,6 +98,9 @@
           </td>
           <td class="px-5 py-3 text-xs text-t3 text-center">
             <%= user.sign_in_count %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap">
+            <%= user.current_sign_in_at&.strftime("%b %-d, %Y") || "—" %>
           </td>
           <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap">
             <%= user.created_at.strftime("%b %-d, %Y") %>

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "renders and sorts by last login" do
+      user1.update_columns(current_sign_in_at: 1.day.ago)
+      user2.update_columns(current_sign_in_at: 1.hour.ago)
+
+      get admin_dashboard_users_path(sort: "current_sign_in_at", dir: "desc")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Last login")
+      expect(response.body.index("bob@example.com")).to be < response.body.index("alice@example.com")
+    end
+
     it "filters demo accounts" do
       demo = create(:user, email: "bhannajohns+test@gmail.com")
       get admin_dashboard_users_path(filter: "demo")


### PR DESCRIPTION
## What changed

Adds a **Last login** column to the admin dashboard users table (`/admin/users`).

- Shows each user's most recent sign-in date (Devise `current_sign_in_at`), or `—` if they've never signed in.
- Sortable like the other columns — same header link pattern with the ↑/↓ indicator, and preserves the active search + filter when clicked.
- Backend: added `current_sign_in_at` to the sort allowlist in `Admin::UsersController#index`. It's a plain DB datetime, so it sorts through the existing generic `.order` branch — no special-casing needed (unlike the `boards` count).

## Why

Gives admins visibility into account activity / recency directly in the users list, consistent with the existing sortable columns.

## Note for reviewers

Used `current_sign_in_at` (the most recent login) rather than `last_sign_in_at` (the login *before* the current session), since "Last login" reads most naturally as "when they most recently logged in."

## Test plan

- Added a request spec asserting the "Last login" header renders and that sorting by `current_sign_in_at` desc orders the most-recently-logged-in user first.
- `bundle exec rspec spec/requests/admin/users_spec.rb` → **50 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)