### PR TITLE
feat: add demo:myspeak_communicators seed task

### DIFF
--- a/lib/tasks/demo_myspeak.rake
+++ b/lib/tasks/demo_myspeak.rake
@@ -6,7 +6,7 @@
 #   bundle exec rake demo:myspeak_communicators              # dedicated demo owner
 #   bundle exec rake demo:myspeak_communicators USER_ID=740  # attach to a specific user
 namespace :demo do
-  DEMO_OWNER_EMAIL = "demo-myspeak@speakanyway.dev".freeze
+  DEMO_OWNER_EMAIL = "hello+demo@speakanyway.com".freeze
 
   DEMO_COMMUNICATORS = [
     {

--- a/lib/tasks/demo_myspeak.rake
+++ b/lib/tasks/demo_myspeak.rake
@@ -1,0 +1,120 @@
+# lib/tasks/demo_myspeak.rake
+# Seed 3 fictional demo communicators as MySpeak pages (AAC profile + gated
+# safety data). Idempotent / re-runnable. All data is fictional: phone numbers
+# use the 555-01xx fiction range; emails use the reserved @example.com domain.
+#
+#   bundle exec rake demo:myspeak_communicators              # dedicated demo owner
+#   bundle exec rake demo:myspeak_communicators USER_ID=740  # attach to a specific user
+namespace :demo do
+  DEMO_OWNER_EMAIL = "demo-myspeak@speakanyway.dev".freeze
+
+  DEMO_COMMUNICATORS = [
+    {
+      name: "Mateo Rivera",
+      username: "mateo-rivera",
+      details: { "aac_level" => "emerging", "vocab_type" => "core", "age_band" => "4-6", "glp_stage" => 1 },
+      settings: {
+        "pronouns" => "he/him",
+        "headline" => "Learning new words every day 🌱",
+        "device_notes" => "iPad in a red case, volume all the way up. Mateo taps with his whole hand, so give him a second after each press. If the app freezes, close and reopen it — his boards save automatically.",
+        "role_badges" => ["Communicator"],
+        "show_email" => false,
+        "allergies" => "Peanuts and tree nuts — severe. Carries an EpiPen in his backpack's front pocket.",
+        "medical_conditions" => "Autism; mild asthma.",
+        "medications" => "Albuterol (rescue inhaler) as needed for wheezing.",
+        "emergency_notes" => "Mateo is a runner — he may bolt toward water, roads, or exits when overwhelmed, so keep a hand nearby in open spaces. He covers his ears and may drop to the floor around loud noises (fire alarms, hand dryers). Deep pressure (a firm hug) and his \"Twinkle Twinkle\" song help him settle. He uses mostly single words on his device plus pointing and gestures — give him time, he understands more than he can say.",
+        "ice_contact_1" => { "name" => "Daniela Rivera", "phone" => "(216) 555-0142", "relationship" => "Mother" },
+        "ice_contact_2" => { "name" => "Marco Rivera", "phone" => "(216) 555-0143", "relationship" => "Father" },
+        "ice_contact_3" => { "name" => "Rosa Delgado", "phone" => "(216) 555-0144", "relationship" => "Grandmother" }
+      }
+    },
+    {
+      name: "Ava Chen",
+      username: "ava-chen",
+      details: { "aac_level" => "proficient", "vocab_type" => "balanced", "age_band" => "11-14", "glp_stage" => 4 },
+      settings: {
+        "pronouns" => "she/her",
+        "headline" => "Big feelings, big vocabulary.",
+        "device_notes" => "Ava navigates fast and knows her folders well — please don't \"help\" by tapping for her. She keeps her device on a lanyard. If she hands it to you, she wants you to read the message out loud.",
+        "role_badges" => ["Communicator", "Gestalt Language Processor"],
+        "show_email" => false,
+        "allergies" => "Penicillin (rash + swelling). Mild seasonal pollen.",
+        "medical_conditions" => "Autism; absence (petit mal) seizures.",
+        "medications" => "Levetiracetam (Keppra), morning and night.",
+        "emergency_notes" => "Ava's seizures look like brief staring spells (5–15 seconds) where she stops and blinks. Most pass on their own — note the time and keep her safe from stairs/edges. Call 911 if a seizure lasts over 5 minutes or they cluster back-to-back. As a gestalt language processor, Ava often communicates in scripted phrases (\"time to go home\") that may mean something different from the literal words — ask her to show you on her device. Loud, crowded rooms overwhelm her fast; a quiet corner and her AAC device help her regulate.",
+        "ice_contact_1" => { "name" => "Grace Chen", "phone" => "(216) 555-0118", "relationship" => "Mother" },
+        "ice_contact_2" => { "name" => "David Chen", "phone" => "(216) 555-0119", "relationship" => "Father" },
+        "ice_contact_3" => { "name" => "Ms. Herrera (SLP)", "phone" => "(216) 555-0120", "relationship" => "Speech-language pathologist" }
+      }
+    },
+    {
+      name: "Jordan Whitfield",
+      username: "jordan-whitfield",
+      details: { "aac_level" => "proficient", "vocab_type" => "balanced", "age_band" => "adult", "glp_stage" => 6 },
+      settings: {
+        "pronouns" => "they/them",
+        "headline" => "Same-old me — just louder now.",
+        "device_notes" => "Jordan uses a rugged tablet on a wheelchair mount and communicates with AAC plus a few signs (more, done, help). Give them the full sentence before responding — they build longer messages than people expect. Charger lives in the side pouch.",
+        "role_badges" => ["Communicator"],
+        "show_email" => false,
+        "allergies" => "Latex — use latex-free gloves only.",
+        "medical_conditions" => "Autism; epilepsy (tonic-clonic seizures); Type 1 diabetes.",
+        "medications" => "Lamotrigine (seizures); insulin (mealtime + long-acting). Has a VNS implant — magnet is clipped inside their bag.",
+        "emergency_notes" => "For a tonic-clonic (grand mal) seizure: time it, ease them to the floor, cushion the head, turn on their side, do not restrain or put anything in their mouth. Swiping the VNS magnet across the chest device can help stop a seizure. Call 911 if it lasts over 5 minutes. Type 1 diabetes — if shaky, sweaty, or confused, that's likely low blood sugar; glucose gel is in the front bag pocket. Jordan is calm and social but needs extra processing time in stressful moments.",
+        "ice_contact_1" => { "name" => "Patricia Whitfield", "phone" => "(216) 555-0173", "relationship" => "Mother / guardian" },
+        "ice_contact_2" => { "name" => "Andre Whitfield", "phone" => "(216) 555-0174", "relationship" => "Brother" },
+        "ice_contact_3" => { "name" => "Lakeside Adult Day Services", "phone" => "(216) 555-0150", "relationship" => "Day program" }
+      }
+    }
+  ].freeze
+
+  desc "Seed 3 fictional demo communicators as MySpeak pages (idempotent; USER_ID=N to override owner)"
+  task myspeak_communicators: :environment do
+    owner =
+      if ENV["USER_ID"].present?
+        User.find(ENV["USER_ID"])
+      else
+        # Devise :validatable requires an email + a password (6..128 chars).
+        # plan_type/plan_status are real columns; setting plan_type "pro"
+        # explicitly survives the before_create free-plan default (it only
+        # fills a blank plan_type) and fires setup_pro_limits on save.
+        User.find_or_create_by!(email: DEMO_OWNER_EMAIL) do |u|
+          u.password = SecureRandom.alphanumeric(16)
+          u.plan_type = "pro"
+          u.plan_status = "active"
+          u.settings ||= {}
+        end
+      end
+
+    puts "== demo:myspeak_communicators == owner ##{owner.id} #{owner.email}"
+
+    DEMO_COMMUNICATORS.each do |data|
+      ca = ChildAccount.find_or_initialize_by(username: data[:username])
+      created = ca.new_record?
+      ca.name   = data[:name]
+      # owner_id is the canonical ownership column (slot counts + team scope key);
+      # user_id is set too as the legacy/optional alias, mirroring how the create
+      # controller assigns a real communicator.
+      ca.owner  = owner
+      ca.user   = owner
+      ca.status = ChildAccount::ACTIVE
+      ca.passcode = SecureRandom.alphanumeric(8) if ca.passcode.blank?
+      # AAC profile → details (typed; normalized/validated on save). The values
+      # are already valid enums, so the merge round-trips them unchanged.
+      ca.details = (ca.details || {}).merge(data[:details])
+      ca.save!
+
+      # create_profile! is a no-op when a profile already exists (re-run) and
+      # doesn't populate the in-memory has_one cache on a fresh create, so read
+      # through the return value / reload rather than a possibly-stale ca.profile.
+      profile = ca.profile || ca.create_profile! || ca.reload.profile
+      # Merge safety/public keys — never clobber, so a re-run is a no-op.
+      profile.settings = (profile.settings || {}).merge(data[:settings])
+      profile.save!
+
+      puts "  #{created ? 'created' : 'updated'} ##{ca.id} #{ca.name} → /#{profile.slug} (safety_info=#{profile.has_safety_info?})"
+    end
+
+    puts "== Done."
+  end
+end

--- a/spec/lib/tasks/demo_myspeak_rake_spec.rb
+++ b/spec/lib/tasks/demo_myspeak_rake_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
     it "seeds 3 active communicators owned by a pro demo user" do
       run_task
 
-      owner = User.find_by(email: "demo-myspeak@speakanyway.dev")
+      owner = User.find_by(email: "hello+demo@speakanyway.com")
       expect(owner).to be_present
       expect(owner.plan_type).to eq("pro")
       expect(owner.plan_status).to eq("active")
@@ -75,7 +75,7 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
       run_task
 
       expect(ChildAccount.where(username: usernames).count).to eq(3)
-      expect(User.where(email: "demo-myspeak@speakanyway.dev").count).to eq(1)
+      expect(User.where(email: "hello+demo@speakanyway.com").count).to eq(1)
       expect(ChildAccount.where(username: usernames).order(:username).pluck(:id)).to eq(first_ids)
       second_slugs = Profile.where(profileable_type: "ChildAccount", profileable_id: first_ids).pluck(:slug).sort
       expect(second_slugs).to eq(first_slugs)
@@ -91,7 +91,7 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
       run_task
 
       expect(ChildAccount.where(username: usernames).pluck(:owner_id).uniq).to eq([existing_owner.id])
-      expect(User.where(email: "demo-myspeak@speakanyway.dev")).to be_empty
+      expect(User.where(email: "hello+demo@speakanyway.com")).to be_empty
     end
   end
 end

--- a/spec/lib/tasks/demo_myspeak_rake_spec.rb
+++ b/spec/lib/tasks/demo_myspeak_rake_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "demo:myspeak_communicators rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["demo:myspeak_communicators"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  let(:usernames) { %w[mateo-rivera ava-chen jordan-whitfield] }
+
+  after do
+    ENV.delete("USER_ID")
+  end
+
+  describe "default demo owner" do
+    it "seeds 3 active communicators owned by a pro demo user" do
+      run_task
+
+      owner = User.find_by(email: "demo-myspeak@speakanyway.dev")
+      expect(owner).to be_present
+      expect(owner.plan_type).to eq("pro")
+      expect(owner.plan_status).to eq("active")
+
+      comms = ChildAccount.where(username: usernames)
+      expect(comms.count).to eq(3)
+      expect(comms.pluck(:status).uniq).to eq([ChildAccount::ACTIVE])
+      # owner_id is canonical; user_id is set as the legacy alias too.
+      expect(comms.pluck(:owner_id).uniq).to eq([owner.id])
+      expect(comms.pluck(:user_id).uniq).to eq([owner.id])
+    end
+
+    it "stores AAC profile fields on details, round-tripping the integer glp_stage" do
+      run_task
+
+      mateo = ChildAccount.find_by(username: "mateo-rivera")
+      expect(mateo.details).to include(
+        "aac_level" => "emerging",
+        "vocab_type" => "core",
+        "age_band" => "4-6",
+        "glp_stage" => 1,
+      )
+      expect(mateo.details["glp_stage"]).to be_an(Integer)
+    end
+
+    it "populates gated safety data on each communicator's MySpeak profile" do
+      run_task
+
+      mateo = ChildAccount.find_by(username: "mateo-rivera")
+      profile = mateo.profile
+      expect(profile).to be_present
+      expect(profile.slug).to eq("mateo-rivera")
+      expect(profile.has_safety_info?).to be(true)
+      expect(profile.settings["ice_contact_1"]).to include(
+        "name" => "Daniela Rivera",
+        "phone" => "(216) 555-0142",
+        "relationship" => "Mother",
+      )
+      expect(profile.settings["emergency_notes"]).to be_present
+    end
+
+    it "is idempotent — a second run adds no rows and keeps slugs stable" do
+      run_task
+      first_ids = ChildAccount.where(username: usernames).order(:username).pluck(:id)
+      first_slugs = Profile.joins("INNER JOIN child_accounts ON profiles.profileable_id = child_accounts.id")
+                           .where(profileable_type: "ChildAccount", child_accounts: { username: usernames })
+                           .pluck(:slug).sort
+
+      run_task
+
+      expect(ChildAccount.where(username: usernames).count).to eq(3)
+      expect(User.where(email: "demo-myspeak@speakanyway.dev").count).to eq(1)
+      expect(ChildAccount.where(username: usernames).order(:username).pluck(:id)).to eq(first_ids)
+      second_slugs = Profile.where(profileable_type: "ChildAccount", profileable_id: first_ids).pluck(:slug).sort
+      expect(second_slugs).to eq(first_slugs)
+    end
+  end
+
+  describe "USER_ID override" do
+    let!(:existing_owner) { create(:user, plan_type: "pro", plan_status: "active") }
+
+    it "attaches the communicators to the given user instead of the demo owner" do
+      ENV["USER_ID"] = existing_owner.id.to_s
+
+      run_task
+
+      expect(ChildAccount.where(username: usernames).pluck(:owner_id).uniq).to eq([existing_owner.id])
+      expect(User.where(email: "demo-myspeak@speakanyway.dev")).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an idempotent rake task `demo:myspeak_communicators` that seeds 3 fictional demo communicators as MySpeak pages, each with an AAC profile + full gated safety data. Implements `.claude-notes/demo-myspeak-seed-handoff.md`.

- **Owner:** found-or-created `hello+demo@speakanyway.com` (`plan_type: pro`, `plan_status: active`), or `USER_ID=N` to attach to a specific user.
- **Data:** embedded inline in the `.rake` file (fictional — 555-01xx phone range). AAC fields (`aac_level`, `vocab_type`, `age_band`, integer `glp_stage`) go to `details`; safety/public keys go to `profile.settings`.
- **Status:** communicators created `active` (`ChildAccount::ACTIVE`).
- **Idempotent:** re-run merges without clobbering, adds no rows, keeps slugs stable.

Files: `lib/tasks/demo_myspeak.rake`, `spec/lib/tasks/demo_myspeak_rake_spec.rb`. No migration, no new ENV var.

## Schema details verified against the code (the 3 the handoff flagged)

1. **Ownership column** — a real communicator create (`child_accounts_controller.rb:371-372`) sets `owner = current_user` (canonical — the slot-count/team-scope column, per the comment at line 35) **and** `user = current_user` as the legacy/optional alias. Task mirrors both.
2. **Pro demo user required fields** — Devise `:validatable` needs email + password (6..128; random 16-char fits); `plan_type`/`plan_status` are real columns. `before_create :setup_new_user_free_plan` only defaults a *blank* `plan_type`, so explicit `"pro"` sticks and `setup_pro_limits` runs on save. `jti`/`uuid` auto-populate.
3. **`details=` round-trip** — `normalize_aac_profile_fields` downcases the string enums (already lowercase → unchanged) and coerces `glp_stage` with `to_i` (integer → unchanged); all values pass `validate_aac_profile_fields`. Verified in console: `details["glp_stage"]` is `1` (Integer).

One extra fix beyond the sketch: `create_profile!` doesn't populate the in-memory `has_one :profile` cache on a fresh create, so the task reads the profile via `ca.profile || ca.create_profile! || ca.reload.profile` to avoid a stale-nil.

## Test plan

**Ran the task twice (idempotency):**
```
== demo:myspeak_communicators == owner #564 hello+demo@speakanyway.com
  created #268 Mateo Rivera → /mateo-rivera (safety_info=true)
  created #269 Ava Chen → /ava-chen (safety_info=true)
  created #270 Jordan Whitfield → /jordan-whitfield (safety_info=true)
-- second run --
  updated #268 Mateo Rivera → /mateo-rivera (safety_info=true)
  updated #269 Ava Chen → /ava-chen (safety_info=true)
  updated #270 Jordan Whitfield → /jordan-whitfield (safety_info=true)
```
Same IDs, same owner, same slugs, no new rows, no validation errors.

**Console checks:**
```
aac_level:           "emerging"
glp_stage:           1 (Integer)
vocab_type:          "core"
age_band:            "4-6"
has_safety_info?:    true
ice_contact_1 phone: "(216) 555-0142"
emergency_notes?:    true
owner_id/user_id:    564 / 564
status:              "active"
owner plan:          pro/active
child_accounts:      3   (no dupes across 2 runs)
demo owner users:    1
```

**RSpec:** `spec/lib/tasks/demo_myspeak_rake_spec.rb` — 5 examples, 0 failures (default owner: seeds 3 active pro-owned comms, AAC details incl. integer glp_stage, gated safety data, idempotency; plus USER_ID override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
