### PR TITLE
feat: complete demo MySpeak profiles (intro headline, About Me, random slug)

### DIFF
--- a/lib/tasks/demo_myspeak.rake
+++ b/lib/tasks/demo_myspeak.rake
@@ -1,7 +1,8 @@
 # lib/tasks/demo_myspeak.rake
-# Seed 3 fictional demo communicators as MySpeak pages (AAC profile + gated
-# safety data). Idempotent / re-runnable. All data is fictional: phone numbers
-# use the 555-01xx fiction range; emails use the reserved @example.com domain.
+# Seed 3 fictional demo communicators as complete MySpeak pages: AAC profile,
+# public intro headline + About Me bio, an unguessable random safety slug, and
+# gated emergency/safety data. Idempotent / re-runnable. All data is fictional;
+# phone numbers use the 555-01xx fiction range.
 #
 #   bundle exec rake demo:myspeak_communicators              # dedicated demo owner
 #   bundle exec rake demo:myspeak_communicators USER_ID=740  # attach to a specific user
@@ -12,10 +13,12 @@ namespace :demo do
     {
       name: "Mateo Rivera",
       username: "mateo-rivera",
+      intro: "Just getting started — and already unstoppable. 🦖",
+      bio: "Hi, I'm Mateo! I'm 5 and I love dinosaurs, splashing in water, and anything with wheels. I'm just getting started with my talker, so I use single words, pointing, and lots of gestures — give me a beat and I'll get there. I understand way more than I can say yet. Sing \"Twinkle Twinkle\" with me and we'll be fast friends.",
       details: { "aac_level" => "emerging", "vocab_type" => "core", "age_band" => "4-6", "glp_stage" => 1 },
       settings: {
         "pronouns" => "he/him",
-        "headline" => "Learning new words every day 🌱",
+        "headline" => "Just getting started — and already unstoppable. 🦖",
         "device_notes" => "iPad in a red case, volume all the way up. Mateo taps with his whole hand, so give him a second after each press. If the app freezes, close and reopen it — his boards save automatically.",
         "role_badges" => ["Communicator"],
         "show_email" => false,
@@ -31,10 +34,12 @@ namespace :demo do
     {
       name: "Ava Chen",
       username: "ava-chen",
+      intro: "I script, I sketch, I speak my mind.",
+      bio: "I'm Ava, I'm 12, and I have a lot to say. I love drawing manga, marine biology, and my cat Mochi. I'm a gestalt language processor, so sometimes I talk in scripts and phrases that mean more than the words — ask me and I'll show you on my device. I navigate my AAC app fast, so please don't tap for me. Quiet corners are my happy place.",
       details: { "aac_level" => "proficient", "vocab_type" => "balanced", "age_band" => "11-14", "glp_stage" => 4 },
       settings: {
         "pronouns" => "she/her",
-        "headline" => "Big feelings, big vocabulary.",
+        "headline" => "I script, I sketch, I speak my mind.",
         "device_notes" => "Ava navigates fast and knows her folders well — please don't \"help\" by tapping for her. She keeps her device on a lanyard. If she hands it to you, she wants you to read the message out loud.",
         "role_badges" => ["Communicator", "Gestalt Language Processor"],
         "show_email" => false,
@@ -50,10 +55,12 @@ namespace :demo do
     {
       name: "Jordan Whitfield",
       username: "jordan-whitfield",
+      intro: "Same me, new voice — still the loudest laugh in the room.",
+      bio: "Hey, I'm Jordan. I'm 27 and I use AAC plus a few signs to get my point across — I build longer sentences than people expect, so give me space to finish. I'm into basketball on TV, cooking shows, and hanging out at my day program. I'm easygoing and social; I just need a little extra time when things get stressful.",
       details: { "aac_level" => "proficient", "vocab_type" => "balanced", "age_band" => "adult", "glp_stage" => 6 },
       settings: {
         "pronouns" => "they/them",
-        "headline" => "Same-old me — just louder now.",
+        "headline" => "Same me, new voice — still the loudest laugh in the room.",
         "device_notes" => "Jordan uses a rugged tablet on a wheelchair mount and communicates with AAC plus a few signs (more, done, help). Give them the full sentence before responding — they build longer messages than people expect. Charger lives in the side pouch.",
         "role_badges" => ["Communicator"],
         "show_email" => false,
@@ -104,15 +111,39 @@ namespace :demo do
       ca.details = (ca.details || {}).merge(data[:details])
       ca.save!
 
-      # create_profile! is a no-op when a profile already exists (re-run) and
-      # doesn't populate the in-memory has_one cache on a fresh create, so read
-      # through the return value / reload rather than a possibly-stale ca.profile.
-      profile = ca.profile || ca.create_profile! || ca.reload.profile
+      # Build the MySpeak safety profile the way onboarding does (not
+      # ChildAccount#create_profile!, which forces a name-derived slug): leave
+      # `slug` blank so Profile#ensure_slug assigns an unguessable random
+      # `s-xxxxxx` slug (slug_type "random"), matching real safety pages so a
+      # child's /my/<slug> can't be found by guessing their name.
+      profile = ca.profile || Profile.create!(
+        profileable: ca,
+        profile_kind: "safety",
+        username: ca.username,
+      )
+
+      # Migrate any pre-existing name-derived (legacy) slug to a random one,
+      # once. The slug_type guard keeps re-runs idempotent — a random slug is
+      # never regenerated, so the URL is stable after the first migration.
+      if profile.slug_type != "random"
+        profile.slug = Profile.generate_random_slug
+        profile.slug_type = "random"
+      end
+
+      # About Me (bio) + on-page intro headline are the PUBLIC blurbs the
+      # safety page renders; overwrite to the seeded copy so the profile reads
+      # as complete instead of Profile#set_defaults' placeholder text.
+      profile.intro = data[:intro]
+      profile.bio   = data[:bio]
       # Merge safety/public keys — never clobber, so a re-run is a no-op.
       profile.settings = (profile.settings || {}).merge(data[:settings])
       profile.save!
 
-      puts "  #{created ? 'created' : 'updated'} ##{ca.id} #{ca.name} → /#{profile.slug} (safety_info=#{profile.has_safety_info?})"
+      # Generated initials avatar (Safety ID card + device tag embed it).
+      profile.set_fake_avatar unless profile.avatar.attached?
+
+      puts "  #{created ? 'created' : 'updated'} ##{ca.id} #{ca.name} → /#{profile.slug} " \
+           "(slug_type=#{profile.slug_type} safety_info=#{profile.has_safety_info?})"
     end
 
     puts "== Done."

--- a/spec/lib/tasks/demo_myspeak_rake_spec.rb
+++ b/spec/lib/tasks/demo_myspeak_rake_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
       mateo = ChildAccount.find_by(username: "mateo-rivera")
       profile = mateo.profile
       expect(profile).to be_present
-      expect(profile.slug).to eq("mateo-rivera")
       expect(profile.has_safety_info?).to be(true)
       expect(profile.settings["ice_contact_1"]).to include(
         "name" => "Daniela Rivera",
@@ -63,6 +62,29 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
         "relationship" => "Mother",
       )
       expect(profile.settings["emergency_notes"]).to be_present
+    end
+
+    it "gives each communicator a public intro headline + About Me bio (not placeholders)" do
+      run_task
+
+      profile = ChildAccount.find_by(username: "mateo-rivera").profile
+      expect(profile.intro).to eq("Just getting started — and already unstoppable. 🦖")
+      expect(profile.bio).to start_with("Hi, I'm Mateo!")
+      # set_defaults placeholder copy must have been overwritten.
+      expect(profile.intro).not_to include("Personalize your page")
+      expect(profile.bio).not_to include("Write a short bio")
+      # Public headline setting stays in sync with the on-page intro.
+      expect(profile.settings["headline"]).to eq(profile.intro)
+    end
+
+    it "gives each safety profile an unguessable random slug, not the username" do
+      run_task
+
+      ChildAccount.where(username: usernames).each do |ca|
+        expect(ca.profile.slug_type).to eq("random")
+        expect(ca.profile.slug).to match(/\As-[a-z0-9]{6}\z/)
+        expect(ca.profile.slug).not_to eq(ca.username)
+      end
     end
 
     it "is idempotent — a second run adds no rows and keeps slugs stable" do
@@ -79,6 +101,23 @@ RSpec.describe "demo:myspeak_communicators rake task", type: :task do
       expect(ChildAccount.where(username: usernames).order(:username).pluck(:id)).to eq(first_ids)
       second_slugs = Profile.where(profileable_type: "ChildAccount", profileable_id: first_ids).pluck(:slug).sort
       expect(second_slugs).to eq(first_slugs)
+    end
+
+    it "migrates a pre-existing legacy (username-derived) slug to a random one, then keeps it stable" do
+      # Mirror an already-seeded communicator whose profile still has the old
+      # name-derived slug (slug_type "legacy"), as created before this change.
+      ca = create(:child_account, username: "mateo-rivera")
+      legacy = Profile.create!(profileable: ca, profile_kind: "safety",
+                               username: "mateo-rivera", slug: "mateo-rivera", slug_type: "legacy")
+      expect(legacy.slug_type).to eq("legacy")
+
+      run_task
+      migrated_slug = legacy.reload.slug
+      expect(legacy.slug_type).to eq("random")
+      expect(migrated_slug).to match(/\As-[a-z0-9]{6}\z/)
+
+      run_task
+      expect(legacy.reload.slug).to eq(migrated_slug)
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #509. Rounds out `demo:myspeak_communicators` so each seeded communicator is a **complete MySpeak page**, not just gated safety data.

- **Public intro headline** (`profile.intro`) + **About Me bio** (`profile.bio`) — written in-character and public-safe (no medical specifics; those stay behind the gated emergency reveal). Overwrites `Profile#set_defaults`' placeholder copy so the page reads as complete. `settings["headline"]` is kept in sync with the on-page intro.
- **Unguessable random safety slug** (`s-xxxxxx`, `slug_type "random"`). Real safety pages use random slugs so a child's `/my/<slug>` can't be found by guessing their name (per `.claude-notes/safety-profiles.md`). The seed now builds the profile the way `API::V1::Onboarding::MyspeakController` does — a **blank slug** so `Profile#ensure_slug` assigns the random one — instead of `ChildAccount#create_profile!`, which forces a name-derived slug (the spoke notes that path "does not yet auto-randomize on create").
- **Migrates existing legacy slugs.** The 3 communicators already seeded (via #509) have name-derived slugs like `/mateo-rivera`. The task now migrates any `slug_type != "random"` profile to a random slug **once**, guarded on `slug_type` so re-runs are idempotent and the URL stays stable after the first migration.

### New copy

| Communicator | Intro headline | About Me (bio, excerpt) |
|---|---|---|
| Mateo | "Just getting started — and already unstoppable. 🦖" | "Hi, I'm Mateo! I'm 5 and I love dinosaurs, splashing in water…" |
| Ava | "I script, I sketch, I speak my mind." | "I'm Ava, I'm 12, and I have a lot to say. I love drawing manga…" |
| Jordan | "Same me, new voice — still the loudest laugh in the room." | "Hey, I'm Jordan. I'm 27 and I use AAC plus a few signs…" |

Files: `lib/tasks/demo_myspeak.rake`, `spec/lib/tasks/demo_myspeak_rake_spec.rb`. No migration, no new ENV var.

## Test plan

**Ran the task twice locally** (against rows left legacy by #509 — demonstrates the migration + idempotency):
```
-- run 1 (migrates legacy → random) --
  updated #268 Mateo Rivera    → /s-msh4cb (slug_type=random safety_info=true)
  updated #269 Ava Chen        → /s-6zw5cx (slug_type=random safety_info=true)
  updated #270 Jordan Whitfield → /s-fabmav (slug_type=random safety_info=true)
-- run 2 (idempotent — slugs stable) --
  updated #268 Mateo Rivera    → /s-msh4cb (slug_type=random safety_info=true)
  updated #269 Ava Chen        → /s-6zw5cx (slug_type=random safety_info=true)
  updated #270 Jordan Whitfield → /s-fabmav (slug_type=random safety_info=true)
```

**Console check (Mateo):**
```
slug:      /s-msh4cb (random)
intro:     Just getting started — and already unstoppable. 🦖
bio:       Hi, I'm Mateo! I'm 5 and I love dinosaurs, splashing in wate...
headline:  Just getting started — and already unstoppable. 🦖
safety?:   true
editable?: false   # random safety slug is not user-editable
```

**RSpec:** `spec/lib/tasks/demo_myspeak_rake_spec.rb` — 8 examples, 0 failures (adds: intro headline + About Me not placeholders; random `s-xxxxxx` slug ≠ username; legacy→random migration then stable).

## Note on production

The 3 demo communicators already live on prod (seeded via #509) still have `/mateo-rivera`-style slugs. Once this is merged + deployed, re-running `demo:myspeak_communicators` on prod will migrate them to random slugs and fill in the intro/bio — idempotently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)