### PR TITLE
fix(mailers): embed logo inline in all emails, remove MySpeak logo

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,18 +5,11 @@ class ApplicationMailer < ActionMailer::Base
   def initialize(*args)
     super
     logo
-    myspeak_logo
   end
 
   def logo
     attachments.inline["logo.png"] =
       File.read(Rails.root.join("public/logo_bubble.png"))
     @logo = attachments["logo.png"]
-  end
-
-  def myspeak_logo
-    attachments.inline["myspeak_logo.png"] =
-      File.read(Rails.root.join("public/myspeak_logo.png"))
-    @myspeak_logo = attachments["myspeak_logo.png"]
   end
 end

--- a/app/views/admin_mailer/disk_space_alert.html.erb
+++ b/app/views/admin_mailer/disk_space_alert.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <%= render "layouts/email_logo" %>
     <div class="header">
         <p>Server disk space <%= @severity == :critical ? "CRITICAL" : "warning" %></p>
     </div>

--- a/app/views/admin_mailer/new_feedback_email.erb
+++ b/app/views/admin_mailer/new_feedback_email.erb
@@ -1,5 +1,6 @@
 
 <div class="container">
+  <%= render "layouts/email_logo" %>
     <div class="header">
         <p>SpeakAnyWay has a new user! 🎉</p>
     </div>

--- a/app/views/admin_mailer/new_user_email.html.erb
+++ b/app/views/admin_mailer/new_user_email.html.erb
@@ -1,5 +1,6 @@
 
 <div class="container">
+  <%= render "layouts/email_logo" %>
     <div class="header">
         <p>SpeakAnyWay has a new user! 🎉</p>
     </div>

--- a/app/views/admin_mailer/partner_pilot_review.html.erb
+++ b/app/views/admin_mailer/partner_pilot_review.html.erb
@@ -11,6 +11,9 @@
         <td align="center">
           <table width="640" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
             <tr>
+              <td><%= render "layouts/email_logo" %></td>
+            </tr>
+            <tr>
               <td style="color:#333333; font-size:15px; line-height:1.5;">
                 <h2 style="margin-top:0;">Partner pilot review</h2>
                 <p>These Partner Pro pilots need a decision — convert, extend, or downgrade. Nobody was auto-downgraded.</p>

--- a/app/views/base_mailer/team_invitation_email.html.erb
+++ b/app/views/base_mailer/team_invitation_email.html.erb
@@ -43,6 +43,7 @@
 </head>
 <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
         <div class="header">
             <%= t("base_mailer.team_invitation_email.heading") %>
         </div>

--- a/app/views/communication_account_mailer/claim_link_email.html.erb
+++ b/app/views/communication_account_mailer/claim_link_email.html.erb
@@ -14,6 +14,7 @@
 </head>
 <body>
   <div class="container">
+  <%= render "layouts/email_logo" %>
     <%
       owner = @owner_name.presence || t("communication_account_mailer.claim_link_email.default_owner_name")
       child = @child_name.presence || t("communication_account_mailer.claim_link_email.default_child_name")

--- a/app/views/communication_account_mailer/safety_cards_updated.html.erb
+++ b/app/views/communication_account_mailer/safety_cards_updated.html.erb
@@ -46,6 +46,7 @@
 </head>
 <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
         <div class="header">Updated safety cards for <%= @child_name %></div>
         <div class="content">
             <p>We've given <%= @child_name %>'s safety profile a new secure link.

--- a/app/views/communication_account_mailer/setup_email.html.erb
+++ b/app/views/communication_account_mailer/setup_email.html.erb
@@ -43,6 +43,7 @@
 </head>
 <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
         <div class="header">
             <%= t("communication_account_mailer.setup_email.heading") %>
         </div>

--- a/app/views/layouts/_email_logo.html.erb
+++ b/app/views/layouts/_email_logo.html.erb
@@ -1,0 +1,11 @@
+<%# Inline SpeakAnyWay logo header for transactional emails. Renders the logo
+   that ApplicationMailer attaches as an inline (cid) image so mail clients show
+   it in the body instead of listing it as a downloadable attachment. Guarded so
+   templates without @logo (e.g. Devise mailers) simply render nothing. %>
+<% if @logo %>
+  <div style="text-align:center; padding:4px 0 20px 0;">
+    <a href="https://app.speakanyway.com" target="_blank" rel="noopener" style="text-decoration:none; border:0;">
+      <%= image_tag @logo.url, alt: "SpeakAnyWay", width: 48, height: 48, style: "width:48px; height:48px; display:inline-block; border:0; outline:none;" %>
+    </a>
+  </div>
+<% end %>

--- a/app/views/partner_mailer/pilot_ending_email.html.erb
+++ b/app/views/partner_mailer/pilot_ending_email.html.erb
@@ -11,6 +11,9 @@
         <td align="center">
           <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
             <tr>
+              <td><%= render "layouts/email_logo" %></td>
+            </tr>
+            <tr>
               <td style="color:#333333; font-size:16px; line-height:1.5;">
                 <p><%= t("partner_mailer.pilot_ending_email.greeting_html", name: @user.name).html_safe %></p>
 

--- a/app/views/partner_mailer/welcome_email.html.erb
+++ b/app/views/partner_mailer/welcome_email.html.erb
@@ -11,6 +11,9 @@
             <td align="center">
             <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
                 <tr>
+                <td><%= render "layouts/email_logo" %></td>
+                </tr>
+                <tr>
                 <td style="color:#333333; font-size:16px; line-height:1.5;">
                 <p><%= t("partner_mailer.welcome_email.greeting_html", name: @user.name).html_safe %></p>
 

--- a/app/views/safety_profile_mailer/viewed_alert.html.erb
+++ b/app/views/safety_profile_mailer/viewed_alert.html.erb
@@ -2,45 +2,61 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= t("safety_profile_mailer.viewed_alert.title") %></title>
   <style>
-    body { background-color: #f0f0f0; font-family: Arial, sans-serif; margin: 0; padding: 20px; }
-    .container { background-color: #ffffff; margin: auto; max-width: 600px; padding: 24px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-    .header { font-size: 22px; margin-bottom: 16px; color: #153a62; }
-    .content { font-size: 16px; color: #444444; line-height: 1.6; }
-    .detail { margin: 6px 0; }
+    body { background-color: #f0f0f0; font-family: Arial, Helvetica, sans-serif; margin: 0; padding: 20px; color: #444444; }
+    .container { background-color: #ffffff; margin: auto; max-width: 600px; padding: 32px 28px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .logo { text-align: center; margin-bottom: 20px; }
+    .logo img { width: 56px; height: 56px; display: inline-block; }
+    .header { font-family: Arial, Helvetica, sans-serif; font-size: 22px; font-weight: bold; text-align: center; margin-bottom: 20px; color: #153a62; }
+    .content { font-family: Arial, Helvetica, sans-serif; font-size: 16px; color: #444444; line-height: 1.6; }
+    .content p { margin: 0 0 16px 0; }
+    .detail-box { background-color: #f6f8fb; border-radius: 6px; padding: 16px 20px; margin: 20px 0; }
+    .detail { margin: 4px 0; }
     .label { font-weight: bold; color: #153a62; }
-    .button { display: inline-block; margin-top: 16px; padding: 10px 20px; background-color: #153a62; text-decoration: none; border-radius: 5px; color: #ffffff; }
-    .footer { margin-top: 24px; font-size: 13px; color: #888888; line-height: 1.5; }
+    .location-note { font-size: 13px; color: #888888; }
+    .button-wrap { text-align: center; margin: 28px 0 8px 0; }
+    .button { display: inline-block; padding: 12px 28px; background-color: #153a62; text-decoration: none; border-radius: 6px; color: #ffffff !important; font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: bold; line-height: 1.2; }
+    .footer { margin-top: 28px; padding-top: 20px; border-top: 1px solid #eeeeee; font-family: Arial, Helvetica, sans-serif; font-size: 13px; color: #888888; line-height: 1.5; }
+    .footer p { margin: 0 0 8px 0; }
   </style>
 </head>
 <body>
   <div class="container">
+    <div class="logo">
+      <%= image_tag @logo.url, alt: "SpeakAnyWay", width: 56, height: 56 %>
+    </div>
+
     <div class="header">
       <%= t("safety_profile_mailer.viewed_alert.heading", child_name: @child_name) %>
     </div>
+
     <div class="content">
       <p><%= t("safety_profile_mailer.viewed_alert.intro", child_name: @child_name) %></p>
 
-      <p class="detail">
-        <span class="label"><%= t("safety_profile_mailer.viewed_alert.when_label") %></span>
-        <%= @viewed_at_display %>
-      </p>
-
-      <% if @approx_location %>
+      <div class="detail-box">
         <p class="detail">
-          <span class="label"><%= t("safety_profile_mailer.viewed_alert.location_label") %></span>
-          <%= @approx_location %>
-          <br>
-          <em style="font-size: 13px; color: #888;"><%= t("safety_profile_mailer.viewed_alert.location_note") %></em>
+          <span class="label"><%= t("safety_profile_mailer.viewed_alert.when_label") %></span>
+          <%= @viewed_at_display %>
         </p>
-      <% end %>
+
+        <% if @approx_location %>
+          <p class="detail">
+            <span class="label"><%= t("safety_profile_mailer.viewed_alert.location_label") %></span>
+            <%= @approx_location %>
+          </p>
+          <p class="detail location-note">
+            <em><%= t("safety_profile_mailer.viewed_alert.location_note") %></em>
+          </p>
+        <% end %>
+      </div>
 
       <p><%= t("safety_profile_mailer.viewed_alert.reassurance") %></p>
 
-      <p style="text-align: center;">
+      <div class="button-wrap">
         <a href="<%= @manage_url %>" class="button"><%= t("safety_profile_mailer.viewed_alert.cta") %></a>
-      </p>
+      </div>
     </div>
 
     <div class="footer">

--- a/app/views/setup_mailer/basic_setup_email.html.erb
+++ b/app/views/setup_mailer/basic_setup_email.html.erb
@@ -48,6 +48,7 @@
   </head>
   <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
       <h1><%= t("setup_mailer.basic_setup_email.title") %></h1>
 
       <p>

--- a/app/views/setup_mailer/myspeak_setup_email.html.erb
+++ b/app/views/setup_mailer/myspeak_setup_email.html.erb
@@ -38,6 +38,7 @@
   </head>
   <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
       <h1><%= t("setup_mailer.myspeak_setup_email.title") %></h1>
 
       <p>

--- a/app/views/setup_mailer/pro_setup_email.html.erb
+++ b/app/views/setup_mailer/pro_setup_email.html.erb
@@ -48,6 +48,7 @@
   </head>
   <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
       <h1><%= t("setup_mailer.pro_setup_email.title") %></h1>
 
       <p>

--- a/app/views/setup_mailer/vendor_setup_email.html.erb
+++ b/app/views/setup_mailer/vendor_setup_email.html.erb
@@ -48,6 +48,7 @@
   </head>
   <body>
     <div class="container">
+  <%= render "layouts/email_logo" %>
       <h1><%= t("setup_mailer.vendor_setup_email.title") %></h1>
 
       <p>

--- a/app/views/user_mailer/confirm_update_email.html.erb
+++ b/app/views/user_mailer/confirm_update_email.html.erb
@@ -1,3 +1,4 @@
+  <%= render "layouts/email_logo" %>
 <p><%= t("user_mailer.confirm_update_email.greeting", email: @user.email) %></p>
 <p><%= t("user_mailer.confirm_update_email.intro") %></p>
 <p><%= t("user_mailer.confirm_update_email.old_email_label") %> <%= @old_email %></p>

--- a/app/views/user_mailer/delete_account_email.html.erb
+++ b/app/views/user_mailer/delete_account_email.html.erb
@@ -11,6 +11,10 @@
   <tr>
     <td align="center" style="padding:24px 12px;">
       <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="width:600px;max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e7e7ef;">
+        <!-- Logo -->
+        <tr>
+          <td style="padding:20px 24px 0;"><%= render "layouts/email_logo" %></td>
+        </tr>
         <!-- Header -->
         <tr>
           <td style="padding:22px 24px;background:#0f172a;">

--- a/app/views/user_mailer/temporary_login_email.html.erb
+++ b/app/views/user_mailer/temporary_login_email.html.erb
@@ -11,6 +11,10 @@
           <table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px; background:#ffffff; border-radius:8px; padding:32px;">
 
             <tr>
+              <td><%= render "layouts/email_logo" %></td>
+            </tr>
+
+            <tr>
               <td style="text-align:center;">
                 <h1 style="margin:0 0 16px; font-size:22px; color:#222;">
                   <%= t("user_mailer.temporary_login_email.title") %>

--- a/app/views/user_mailer/welcome_with_claim_link_email.erb
+++ b/app/views/user_mailer/welcome_with_claim_link_email.erb
@@ -51,9 +51,9 @@
   </div>
 
   <div class="container">
-    <!-- MySpeak Logo -->
-    <a href="https://www.speakanyway.com/myspeak-info" target="_blank" rel="noopener" class="logo">
-      <%= image_tag @myspeak_logo.url, alt: "MySpeak Logo" %>
+    <!-- SpeakAnyWay Logo -->
+    <a href="https://app.speakanyway.com" target="_blank" rel="noopener" class="logo">
+      <%= image_tag @logo.url, alt: "SpeakAnyWay Logo" %>
     </a>
 
     <div style="text-align:center;">
@@ -184,11 +184,6 @@
     <p style="font-size:14px; line-height:1.6; text-align:center;">
       <%= t("user_mailer.welcome_with_claim_link_email.questions_html").html_safe %>
     </p>
-
-    <!-- Brand footer -->
-    <a href="https://app.speakanyway.com" target="_blank" rel="noopener" class="logo" style="margin-top:16px;">
-      <%= image_tag @logo.url, alt: "SpeakAnyWay Logo" %>
-    </a>
 
     <div class="footer">
       <%= t("user_mailer.welcome_with_claim_link_email.footer_received") %><br>

--- a/spec/mailers/safety_profile_mailer_spec.rb
+++ b/spec/mailers/safety_profile_mailer_spec.rb
@@ -41,6 +41,25 @@ RSpec.describe SafetyProfileMailer, type: :mailer do
       expect(body).not_to include("/dashboard/myspeak")
     end
 
+    it "embeds the SpeakAnyWay logo inline rather than as a file attachment" do
+      view = profile.profile_views.create!(viewed_at: Time.utc(2026, 6, 24, 15, 5))
+      mail = described_class.viewed_alert(profile, view)
+
+      logo = mail.attachments["logo.png"]
+      expect(logo).to be_present
+      expect(logo.inline?).to be(true)
+      # The HTML references the logo by its content-id so clients render it in
+      # the body instead of listing it as a downloadable attachment.
+      expect(mail.html_part.body.encoded).to include(logo.cid)
+    end
+
+    it "does not attach the MySpeak logo" do
+      view = profile.profile_views.create!(viewed_at: Time.utc(2026, 6, 24, 15, 5))
+      mail = described_class.viewed_alert(profile, view)
+
+      expect(mail.attachments.map(&:filename)).not_to include("myspeak_logo.png")
+    end
+
     it "does not deliver when the profile has no owner" do
       orphan = Profile.create!(username: "orphan-1", slug: "orphan-1")
       view = ProfileView.create!(profile: orphan)


### PR DESCRIPTION
## Summary

Transactional emails were showing the SpeakAnyWay (and MySpeak) logo as **downloadable file attachments** instead of inline in the message body. Root cause: `ApplicationMailer#initialize` force-attached `logo.png` **and** `myspeak_logo.png` as inline attachments to *every* email, but most templates never referenced them via `cid:`. Unreferenced inline attachments render as attachments in Gmail.

This PR embeds the SpeakAnyWay logo inline everywhere and removes the MySpeak logo from emails entirely.

## What changed

**MySpeak logo — removed completely**
- Deleted the `myspeak_logo` attach method from `ApplicationMailer` (it attached `myspeak_logo.png` to every email).
- `welcome_with_claim_link_email` was the only template rendering it — swapped its header to the SpeakAnyWay logo and removed the now-redundant duplicate footer logo.
- The unused `public/myspeak_logo.png` file is left in place (nothing else references it; removing a served asset felt out of scope).

**SpeakAnyWay logo — embedded inline in every email**
- New shared partial `app/views/layouts/_email_logo.html.erb` renders the attached logo as an inline `cid:` image (centered, 48px, links to app.speakanyway.com). Guarded with `if @logo` so it no-ops where the logo isn't attached.
- Included it in the **17 templates** that went through `ApplicationMailer` but never referenced the logo (admin, setup, partner, communication-account, base team-invite, and the remaining user emails). Placement adapts per layout: top of the card for `container` templates, a logo row for table-based ones, and a white band above the dark header for the account-deletion email.
- The 13 templates that already embedded `@logo` were correct and left untouched.

**Safety-profile `viewed_alert` email**
- Embedded the logo, fixed the button font (explicit `font-family`/`font-weight`/`font-size` — it was rendering in the client default serif), and tidied the layout (boxed detail panel, footer divider).

## Not touched (intentional)
Devise auth emails (password reset, unlock, email-changed, password-change) inherit `Devise::Mailer`, not `ApplicationMailer`. They never attached the logo and have no attachment problem, so they're left as-is. They currently show no logo — happy to add it in a follow-up if desired.

## Test plan
- Added specs: `viewed_alert` embeds the logo inline (referenced by its `cid`) and does **not** attach the MySpeak logo.
- `bundle exec rspec spec/mailers/` → **68 examples, 0 failures**.
- Grep confirms zero remaining `myspeak_logo` references in mailers/views.
- Visually rendered representative emails (safety alert, account-deletion dark-header, container-based setup) — logo embeds correctly, no orphan attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)