### PR TITLE
feat(billing): Pro extra communicator add-on slots (monthly/yearly/license)

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -567,6 +567,50 @@ years via `plan_expires_at`. Not a subscription — there is **no**
   `plan_type` to `free`, so the user leaves the scope. `partner_pro`/`clinician`
   are deliberately excluded.
 
+### Extra communicator add-on slots (Pro-only)
+
+Pro users can buy communicator slots **on top of** their plan's base 5 —
+$5/mo or $50/yr recurring, or $125 one-time bundled with a `pro_5yr` license.
+`Billing::ExtraCommunicators` is the single home for the add-on (price ENV keys,
+`clamp`, item-matching). The whole feature funnels into **one settings key**,
+`settings["extra_communicator_slots"]`, which
+`Permissions::CommunicatorLimits.slot_limit_for` **adds to the base limit** —
+so a purchased slot is finally creatable through the one creation gate. Before
+this, the gate read a `communicator_slot_limit` override that no code ever
+wrote, so the half-built `basic_extra_comm` path granted nothing.
+
+- **Additive everywhere.** `slot_limit_for` = base + `extra_communicator_slots`.
+  `User#comm_account_limit`, `#comm_account_limit_reached`, and the api_view
+  `comm_limit`/`communicator_slot_limit` all include the extras so the client
+  sees consistent numbers. `User#apply_extra_communicator_slots!(n)` clamps
+  (`MAX_EXTRA_COMMUNICATORS`, default 20), persists, and re-runs
+  `reconcile_communicator_fallback!` so buying slots restores over-limit
+  communicators out of fallback. It's a no-op when unchanged.
+- **Pro-only.** Every writer gates on `User#pro?` (which already covers
+  `pro`/`pro_yearly`/`pro_5yr`/`partner_pro`). A non-Pro plan always resolves to
+  0 extras.
+- **Monthly / yearly (subscription).** `POST /api/subscriptions/communicator_addon`
+  `{ quantity: N }` upserts a recurring add-on **subscription item** on the
+  user's active Pro subscription to exactly N (0 removes it), interval matched to
+  the plan price. Prices: `STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY` /
+  `STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY`. Entitlement is then **re-derived from the
+  live subscription** in `handle_subscription_upsert` (via
+  `ExtraCommunicators.quantity_from_subscription`), so add / remove / cancel /
+  downgrade self-heals on the next `customer.subscription.updated`.
+  `first_price_from_subscription` skips the add-on item so it can never be read
+  as the plan price.
+- **One-time (license bundle).** `POST /api/stripe/checkout_sessions/license`
+  accepts `extra_communicators: N` **only** for `pro_5yr` (400 otherwise, or if
+  `STRIPE_PRICE_PRO_EXTRA_COMM_5YR` is unset). The count rides the checkout
+  metadata; `handle_license_completed` applies it. It expires with the license.
+- **Cleared on downgrade.** `Billing::PlanTransitions.apply_free_plan` deletes
+  `extra_communicator_slots`, so a cancelled subscription or an expired license
+  takes its extras with it (over-limit communicators retained in fallback, per
+  the downgrade invariant). **Known gap:** a Stripe *plan* downgrade (Pro→Basic
+  via portal/`change_plan`) drops the entitlement to 0 but does **not** auto-
+  remove a lingering add-on subscription item — the item should be cleaned up in
+  that flow (follow-up; noted on the frontend issue).
+
 ### SpeakAnyWay for Clinicians (`clinician`)
 
 A **free**, manually-approved plan for verified SLPs/OTs/AT specialists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Extra communicator add-on slots (Pro-only)
+- Pro users can buy communicator slots on top of the base 5: **$5/mo or $50/yr**
+  recurring, or **$125 one-time** bundled with a `pro_5yr` 5-Year license.
+- Recurring: `POST /api/subscriptions/communicator_addon { quantity }` sets a
+  recurring add-on subscription item; the subscription webhook re-derives the
+  entitlement from the live subscription so add/remove/cancel self-heals.
+- One-time: `POST /api/stripe/checkout_sessions/license` now accepts
+  `extra_communicators` (Pro license only); the license webhook grants them and
+  they expire with the license.
+- Fixes the long-standing gap where the communicator-limit gate read a
+  `communicator_slot_limit` override that nothing ever wrote — purchased slots
+  are now actually creatable. New ENV: `STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY`,
+  `STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY`, `STRIPE_PRICE_PRO_EXTRA_COMM_5YR`,
+  `MAX_EXTRA_COMMUNICATORS` (default 20).
+
 ### Added — 5-Year licenses, SpeakAnyWay for Clinicians, and a plan-expiry enforcer
 - **5-Year licenses** (`basic_5yr` $199 / `pro_5yr` $499): a one-time Stripe
   payment (`POST /api/stripe/checkout_sessions/license`, `mode: "payment"`, promo

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -294,9 +294,28 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
       return
     end
 
+    # Optional Pro-only extra communicator slots bundled with the license
+    # (one-time, expiring with the license). Basic licenses don't offer extras.
+    extra_communicators = Billing::ExtraCommunicators.clamp(params[:extra_communicators])
+    extra_price_id = nil
+    if extra_communicators.positive?
+      if plan_key != "pro_5yr"
+        render json: { error: "Extra communicators are only available on the Pro license" }, status: :bad_request
+        return
+      end
+      extra_price_id = Billing::ExtraCommunicators.price_id("license")
+      if extra_price_id.blank?
+        render json: { error: "Extra communicators are not available" }, status: :bad_request
+        return
+      end
+    end
+
     ensure_customer!
 
     monthly_credits = CreditService.monthly_credits_for(plan_key)
+
+    line_items = [{ price: price_id, quantity: 1 }]
+    line_items << { price: extra_price_id, quantity: extra_communicators } if extra_price_id
 
     # NOTE: `payment_method_collection` is only valid on subscription-mode
     # Checkout Sessions — Stripe rejects it on mode=payment ("You can only set
@@ -310,7 +329,7 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
       mode: "payment",
       customer: current_user.stripe_customer_id,
       client_reference_id: current_user.id.to_s,
-      line_items: [{ price: price_id, quantity: 1 }],
+      line_items: line_items,
       success_url: "#{frontend_base_url}/billing/success?session_id={CHECKOUT_SESSION_ID}&type=license",
       cancel_url: "#{frontend_base_url}/pricing",
       allow_promotion_codes: true,
@@ -320,6 +339,7 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
         plan_type: plan_key,
         license_years: LICENSE_YEARS,
         monthly_credits: monthly_credits,
+        extra_communicators: extra_communicators,
         source: source,
       },
     )
@@ -382,6 +402,10 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
         current_user.plan_expires_at ||= license_years_from_metadata(session.metadata).years.from_now
         current_user.setup_limits
         current_user.save!
+        # Mirror any Pro-only extra-communicator slots the license bundled (the
+        # webhook is still the authority; this only reflects it faster).
+        extra = session.metadata&.extra_communicators.to_i
+        current_user.apply_extra_communicator_slots!(extra) if license_plan == "pro_5yr" && extra.positive?
         MailchimpEventJob.perform_async(current_user.id, "sign_up")
       end
       render json: { success: true }

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -301,7 +301,66 @@ class API::SubscriptionsController < API::ApplicationController
     render json: { error: "Failed to update subscription" }, status: :bad_request
   end
 
+  # POST /api/subscriptions/communicator_addon  { quantity: N }
+  #
+  # Set the Pro extra-communicator add-on to EXACTLY N recurring slots on the
+  # user's active subscription (0 removes it). Pro-only; the billing interval
+  # (monthly/yearly) matches the user's current plan price. Stripe's own
+  # proration applies. The resulting customer.subscription.updated webhook
+  # re-derives entitlements; we also sync immediately so this response reflects
+  # the new slot limit without waiting for the webhook. See
+  # Billing::ExtraCommunicators.
+  def communicator_addon
+    quantity = Billing::ExtraCommunicators.clamp(params[:quantity])
+
+    unless current_user.pro?
+      render json: { error: "Extra communicators are available on the Pro plan" }, status: :forbidden
+      return
+    end
+
+    customer_id = current_user.ensure_stripe_customer!
+    subscription = active_subscription_for(customer_id)
+    if subscription.nil?
+      render json: { error: "No active subscription to modify" }, status: :unprocessable_content
+      return
+    end
+
+    interval = billing_interval_for_subscription(subscription)
+    price_id = Billing::ExtraCommunicators.recurring_price_id(interval)
+    if price_id.blank?
+      render json: { error: "Extra communicators are not available" }, status: :unprocessable_content
+      return
+    end
+
+    existing = subscription.items.data.find { |item| Billing::ExtraCommunicators.extra_comm_item?(item) }
+
+    if quantity.zero?
+      Stripe::SubscriptionItem.delete(existing.id) if existing
+    elsif existing
+      Stripe::SubscriptionItem.update(existing.id, { quantity: quantity })
+    else
+      Stripe::Subscription.update(subscription.id, { items: [{ price: price_id, quantity: quantity }] })
+    end
+
+    current_user.apply_extra_communicator_slots!(quantity)
+
+    render json: {
+      quantity: quantity,
+      communicator_slot_limit: Permissions::CommunicatorLimits.slot_limit_for(current_user.settings || {}),
+    }, status: 200
+  rescue Stripe::StripeError => e
+    Rails.logger.error "subscriptions#communicator_addon: #{e.class} - #{e.message} (user #{current_user.id})"
+    render json: { error: "Failed to update subscription" }, status: :bad_request
+  end
+
   private
+
+  # "yearly" when the plan (non-add-on) item bills annually, else "monthly".
+  def billing_interval_for_subscription(subscription)
+    plan_item = subscription.items.data.find { |item| !Billing::ExtraCommunicators.extra_comm_item?(item) }
+    interval = plan_item&.price&.recurring&.interval
+    interval == "year" ? "yearly" : "monthly"
+  end
 
   # The subscription a plan-change should act on: the customer's current
   # active/trialing/past_due subscription. Trialing is included so a no-card

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -304,6 +304,13 @@ class API::WebhooksController < API::ApplicationController
     user.settings.delete("renewal_notice_sent_at")
     user.save!
 
+    # Pro-only extra communicator slots bundled with a pro_5yr license. They live
+    # for the license term and are cleared when it expires (apply_free_plan).
+    extra_communicators = metadata["extra_communicators"].to_i
+    if plan_type == "pro_5yr" && extra_communicators.positive?
+      user.apply_extra_communicator_slots!(extra_communicators)
+    end
+
     # First month's credit allowance. Idempotent on the event id — webhooks are
     # the sole credit-grant authority. A monthly bucket (grant_plan! caps the
     # window at ~35 days); RefreshFreeTierCreditsJob re-grants monthly thereafter
@@ -491,6 +498,13 @@ class API::WebhooksController < API::ApplicationController
     user.setup_limits
 
     user.save!
+
+    # Re-derive Pro-only extra-communicator add-on slots from the LIVE
+    # subscription items, so adding, removing, or cancelling the add-on
+    # self-heals on the next customer.subscription.updated. Non-Pro plans get 0
+    # (a downgrade drops the entitlement even if the Stripe item lingers).
+    extra_qty = user.pro? ? Billing::ExtraCommunicators.quantity_from_subscription(subscription) : 0
+    user.apply_extra_communicator_slots!(extra_qty)
 
     # Send the plan-correct welcome once we know what plan they're on. This is
     # the only path that delivers welcome_basic_email / welcome_pro_email to
@@ -876,9 +890,18 @@ class API::WebhooksController < API::ApplicationController
   end
 
   def first_price_from_subscription(subscription)
-    item = subscription.items&.data&.first
-    return nil unless item
-    item.price
+    items = subscription.items&.data || []
+    return nil if items.empty?
+
+    # Never let the extra-communicator add-on item be read as the plan price.
+    # Prefer the item whose Price carries plan_type metadata (the real plan),
+    # then any non-add-on item, then fall back to the first item.
+    plan_item = items.find do |item|
+      meta = item.price&.metadata || {}
+      meta["plan_type"].present? && !Billing::ExtraCommunicators.extra_comm_item?(item)
+    end
+    plan_item ||= items.find { |item| !Billing::ExtraCommunicators.extra_comm_item?(item) }
+    (plan_item || items.first).price
   end
 
   # Map a Stripe Price's recurring interval to the frontend's billing_interval

--- a/app/helpers/permissions/communicator_limits.rb
+++ b/app/helpers/permissions/communicator_limits.rb
@@ -67,7 +67,16 @@ module Permissions
     end
 
     def slot_limit_for(settings)
-      (settings["communicator_slot_limit"] || settings["paid_communicator_limit"] || 0).to_i
+      base = (settings["communicator_slot_limit"] || settings["paid_communicator_limit"] || 0).to_i
+      base + extra_communicator_slots_for(settings)
+    end
+
+    # Pro-only add-on slots purchased on top of the plan's base limit. Kept as a
+    # literal key (not the Billing::ExtraCommunicators constant) so this
+    # low-level permission helper carries no service dependency. See
+    # Billing::ExtraCommunicators for the purchase paths that write it.
+    def extra_communicator_slots_for(settings)
+      (settings["extra_communicator_slots"] || 0).to_i
     end
 
     def sandbox_limit_for(settings)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -507,7 +507,29 @@ class User < ApplicationRecord
   end
 
   def comm_account_limit
-    settings["paid_communicator_limit"] || FREE_PLAN_LIMITS["paid_communicator_limit"]
+    base = (settings["paid_communicator_limit"] || FREE_PLAN_LIMITS["paid_communicator_limit"]).to_i
+    base + extra_communicator_slots
+  end
+
+  # Pro-only add-on slots purchased on top of the plan's base communicator limit,
+  # stored in settings["extra_communicator_slots"]. See Billing::ExtraCommunicators.
+  def extra_communicator_slots
+    ((settings || {})["extra_communicator_slots"] || 0).to_i
+  end
+
+  # Set the purchased extra-communicator count (clamped to the allowed range),
+  # then reconcile fallback so newly-affordable slots restore any communicators
+  # that had dropped into fallback mode. No-op when the count is unchanged, so
+  # it's cheap to call on every subscription webhook. Pro-gating is the caller's
+  # job (the webhook / endpoint pass 0 for non-Pro plans).
+  def apply_extra_communicator_slots!(count)
+    clamped = Billing::ExtraCommunicators.clamp(count)
+    self.settings ||= {}
+    return if settings["extra_communicator_slots"].to_i == clamped
+
+    settings["extra_communicator_slots"] = clamped
+    save!
+    reconcile_communicator_fallback!
   end
 
   # Every signed-in user needs at least one communicator slot — otherwise
@@ -1399,7 +1421,7 @@ class User < ApplicationRecord
   end
 
   def comm_account_limit_reached
-    settings["paid_communicator_limit"].to_i + settings["demo_communicator_limit"].to_i <= communicator_accounts.count
+    settings["paid_communicator_limit"].to_i + extra_communicator_slots + settings["demo_communicator_limit"].to_i <= communicator_accounts.count
   end
 
   def admin_api_view
@@ -1787,7 +1809,7 @@ class User < ApplicationRecord
     plan_exp = plan_expires_at&.strftime("%x")
 
     # ---- Limits from Stripe/user settings ----
-    comm_limit = (settings["paid_communicator_limit"] || 0).to_i          # REAL communicators included
+    comm_limit = (settings["paid_communicator_limit"] || 0).to_i + extra_communicator_slots # REAL communicators included (base + Pro add-on slots)
     demo_limit = (settings["demo_communicator_limit"] || 0).to_i     # DEMO communicators allowed
     board_limit = (settings["board_limit"] || 1).to_i
 

--- a/app/services/billing/extra_communicators.rb
+++ b/app/services/billing/extra_communicators.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Billing
+  # Pro-only "extra communicator" add-on slots. A user's total communicator slot
+  # limit is their plan's base limit PLUS settings["extra_communicator_slots"]
+  # (see Permissions::CommunicatorLimits.slot_limit_for). Buying extras is the
+  # thing that finally makes purchased slots creatable — the settings key is read
+  # by the single creation gate.
+  #
+  # Three purchase paths, all funnelling into settings["extra_communicator_slots"]:
+  #   - monthly / yearly — a recurring Stripe subscription item on the Pro
+  #     subscription (quantity = number of extras). The subscription webhook
+  #     re-derives the count from the live subscription items, so add / remove /
+  #     cancel self-heals (POST /api/subscriptions/communicator_addon drives it).
+  #   - license (one-time) — bundled with a pro_5yr 5-Year license purchase; the
+  #     count rides the checkout metadata and is granted by the license webhook.
+  #     It expires with the license (PlanExpiryJob -> apply_free_plan clears it).
+  #
+  # Slots are Pro-only: a non-Pro plan always resolves to 0 extras (the webhook
+  # and endpoint both gate on User#pro?).
+  module ExtraCommunicators
+    module_function
+
+    # The single settings key every path writes and slot_limit_for reads.
+    SETTINGS_KEY = "extra_communicator_slots"
+
+    # kind => ENV var holding the Stripe Price id. Resolved at call time (not a
+    # frozen constant value) so deploy/test ENV changes take effect without a
+    # class-cache reset — same pattern as the license/top-up price keys.
+    PRICE_ENV_KEYS = {
+      "monthly" => "STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY",
+      "yearly" => "STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY",
+      "license" => "STRIPE_PRICE_PRO_EXTRA_COMM_5YR",
+    }.freeze
+
+    # Max extra slots a single account can buy — guards runaway quantity input.
+    def max
+      ENV.fetch("MAX_EXTRA_COMMUNICATORS", 20).to_i
+    end
+
+    def clamp(count)
+      count.to_i.clamp(0, max)
+    end
+
+    # Stripe Price id for a purchase kind ("monthly"|"yearly"|"license"), or nil
+    # when that price is unconfigured in this environment.
+    def price_id(kind)
+      env_key = PRICE_ENV_KEYS[kind.to_s]
+      env_key && ENV[env_key].presence
+    end
+
+    # The recurring add-on price for a billing interval. Anything other than
+    # "yearly" falls back to the monthly price.
+    def recurring_price_id(interval)
+      price_id(interval.to_s == "yearly" ? "yearly" : "monthly")
+    end
+
+    # Every configured add-on price id (recurring + license), for matching a
+    # Stripe line/subscription item back to "this is an extra-communicator charge".
+    def price_ids
+      PRICE_ENV_KEYS.keys.map { |k| price_id(k) }.compact
+    end
+
+    # A Stripe line/subscription item is an extra-comm charge when its price id is
+    # one we configured OR its price metadata is tagged `kind=extra_communicator`.
+    # The metadata tag keeps matching robust even if a price id is rotated.
+    def extra_comm_item?(item)
+      price = item.respond_to?(:price) ? item.price : item["price"]
+      return false unless price
+
+      id = price.respond_to?(:id) ? price.id : price["id"]
+      return true if price_ids.include?(id)
+
+      meta = price.respond_to?(:metadata) ? price.metadata : price["metadata"]
+      return false unless meta
+
+      tag = meta.respond_to?(:[]) ? (meta["kind"] || meta[:kind]) : nil
+      tag.to_s == "extra_communicator"
+    end
+
+    # Total extra-comm quantity across a Stripe subscription's items (0 if none).
+    def quantity_from_subscription(subscription)
+      items = subscription&.items&.data || []
+      items.sum do |item|
+        next 0 unless extra_comm_item?(item)
+
+        qty = item.respond_to?(:quantity) ? item.quantity : item["quantity"]
+        qty.to_i
+      end
+    end
+  end
+end

--- a/app/services/billing/plan_transitions.rb
+++ b/app/services/billing/plan_transitions.rb
@@ -23,6 +23,10 @@ module Billing
       user.setup_free_limits
       user.stripe_subscription_id = nil
       user.settings.delete("trial_ends_at")
+      # Pro-only extra-communicator add-on slots don't survive a downgrade: a
+      # cancelled subscription or an expired license takes its extras with it.
+      # (Over-limit communicators are retained in fallback by the reconciler.)
+      user.settings.delete(Billing::ExtraCommunicators::SETTINGS_KEY)
       user.save!
       user.pin_default_editable_board!
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
         post "preview_plan_change"
         post "change_plan"
         post "add_item"
+        post "communicator_addon"
         post "create_customer_session"
         get "list"
       end

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -59,6 +59,35 @@ STRIPE_PRICE_TOPUP_LARGE=price_...
 > Final dollar prices and credit amounts are a marketing call —
 > see `docs/credits-handoff.md` §3. The table above is the working proposal.
 
+## 2b. Extra communicator add-on Prices (Pro-only)
+
+Pro users can buy communicator slots on top of the base 5. Create one Product
+("Extra Communicator") with three Prices — tag each with
+`metadata.kind = extra_communicator` so the app can identify the charge even if
+a Price id rotates:
+
+| Price | Type | Metadata |
+|---|---|---|
+| $5.00 USD / month | recurring (monthly) | `kind: extra_communicator` |
+| $50.00 USD / year | recurring (yearly) | `kind: extra_communicator` |
+| $125.00 USD one-time | one_time (bundled with a `pro_5yr` license) | `kind: extra_communicator` |
+
+Then set env vars to the resulting Price IDs:
+
+```
+STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY=price_...
+STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY=price_...
+STRIPE_PRICE_PRO_EXTRA_COMM_5YR=price_...
+# optional: cap per-account extras (default 20)
+MAX_EXTRA_COMMUNICATORS=20
+```
+
+The recurring prices back `POST /api/subscriptions/communicator_addon`; the
+one-time price is added as a second line item by
+`POST /api/stripe/checkout_sessions/license` when `extra_communicators > 0` on a
+`pro_5yr` license. See `.claude-notes/billing-and-plans.md` → "Extra communicator
+add-on slots".
+
 ## 3. Webhook endpoint
 
 There's already a Stripe webhook configured at `/api/webhooks` that uses

--- a/spec/models/user_extra_communicators_spec.rb
+++ b/spec/models/user_extra_communicators_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+# Pro-only extra-communicator add-on slots (settings["extra_communicator_slots"]).
+# The add-on is additive to the plan's base communicator limit and flows through
+# the single creation gate (Permissions::CommunicatorLimits.slot_limit_for).
+RSpec.describe User, "extra communicator slots", type: :model do
+  let(:user) { FactoryBot.create(:user, plan_type: "pro") }
+
+  it "defaults to 0 extra slots" do
+    expect(user.extra_communicator_slots).to eq(0)
+    expect(Permissions::CommunicatorLimits.slot_limit_for(user.settings)).to eq(5)
+  end
+
+  it "adds purchased extras on top of the base plan limit" do
+    user.apply_extra_communicator_slots!(3)
+
+    expect(user.reload.extra_communicator_slots).to eq(3)
+    # Base Pro limit (5) + 3 add-on slots.
+    expect(Permissions::CommunicatorLimits.slot_limit_for(user.settings)).to eq(8)
+    expect(user.comm_account_limit).to eq(8)
+  end
+
+  it "clamps the count to the allowed range" do
+    ENV["MAX_EXTRA_COMMUNICATORS"] = "6"
+    user.apply_extra_communicator_slots!(999)
+    expect(user.reload.extra_communicator_slots).to eq(6)
+
+    user.apply_extra_communicator_slots!(-1)
+    expect(user.reload.extra_communicator_slots).to eq(0)
+  ensure
+    ENV.delete("MAX_EXTRA_COMMUNICATORS")
+  end
+
+  it "is a no-op (no save) when the count is unchanged" do
+    user.apply_extra_communicator_slots!(2)
+    expect(user).not_to receive(:save!)
+    user.apply_extra_communicator_slots!(2)
+  end
+
+  it "is cleared on downgrade to Free (apply_free_plan)" do
+    user.apply_extra_communicator_slots!(3)
+    expect(user.reload.extra_communicator_slots).to eq(3)
+
+    Billing::PlanTransitions.apply_free_plan(user, "canceled")
+
+    expect(user.reload.extra_communicator_slots).to eq(0)
+    expect(Permissions::CommunicatorLimits.slot_limit_for(user.settings)).to eq(1) # Free base only
+  end
+
+  it "raises the creation gate so an over-base communicator can be created" do
+    # At the base limit (5 owned slots), the gate blocks a 6th...
+    5.times { FactoryBot.create(:child_account, user: user, status: ChildAccount::ACTIVE) }
+    allowed, = Permissions::CommunicatorLimits.can_create?(user: user, status: ChildAccount::ACTIVE)
+    expect(allowed).to be(false)
+
+    # ...buying 2 extras lifts the ceiling to 7.
+    user.apply_extra_communicator_slots!(2)
+    allowed, = Permissions::CommunicatorLimits.can_create?(user: user.reload, status: ChildAccount::ACTIVE)
+    expect(allowed).to be(true)
+  end
+end

--- a/spec/requests/api/stripe/checkout_sessions_license_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_license_spec.rb
@@ -69,4 +69,61 @@ RSpec.describe "POST /api/stripe/checkout_sessions/license", type: :request do
 
     expect(response).to have_http_status(:bad_request)
   end
+
+  describe "bundled extra communicators (Pro license only)" do
+    before { ENV["STRIPE_PRICE_PRO_EXTRA_COMM_5YR"] = "price_extra_5yr_test" }
+    after { ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_5YR") }
+
+    it "adds a second line item + metadata for a pro_5yr license with extras" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_lic_pro_extra")
+      end
+
+      post "/api/stripe/checkout_sessions/license",
+           params: { plan_key: "pro_5yr", extra_communicators: 3 },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:line_items]).to eq([
+        { price: "price_pro_5yr_test", quantity: 1 },
+        { price: "price_extra_5yr_test", quantity: 3 },
+      ])
+      expect(captured[:metadata][:extra_communicators]).to eq(3)
+    end
+
+    it "carries extra_communicators: 0 and only the plan line item when none requested" do
+      captured = nil
+      allow(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_lic_pro")
+      end
+
+      post "/api/stripe/checkout_sessions/license",
+           params: { plan_key: "pro_5yr" },
+           headers: auth_headers(user)
+
+      expect(captured[:line_items]).to eq([{ price: "price_pro_5yr_test", quantity: 1 }])
+      expect(captured[:metadata][:extra_communicators]).to eq(0)
+    end
+
+    it "400s when extras are requested on a basic license" do
+      post "/api/stripe/checkout_sessions/license",
+           params: { plan_key: "basic_5yr", extra_communicators: 2 },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "400s when extras are requested but the add-on price is unconfigured" do
+      ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_5YR")
+
+      post "/api/stripe/checkout_sessions/license",
+           params: { plan_key: "pro_5yr", extra_communicators: 2 },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
 end

--- a/spec/requests/api/subscriptions_communicator_addon_spec.rb
+++ b/spec/requests/api/subscriptions_communicator_addon_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+# POST /api/subscriptions/communicator_addon — set the Pro extra-communicator
+# add-on to an exact quantity on the user's active subscription.
+RSpec.describe "POST /api/subscriptions/communicator_addon", type: :request do
+  let(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_addon",
+      plan_type: "pro",
+      plan_status: "active")
+  end
+
+  before { ENV["STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY"] = "price_extra_m" }
+  after { ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY") }
+
+  def plan_item
+    OpenStruct.new(id: "si_plan", quantity: 1,
+      price: OpenStruct.new(id: "price_pro", metadata: { "plan_type" => "pro" }, recurring: OpenStruct.new(interval: "month")))
+  end
+
+  def addon_item(quantity: 1)
+    OpenStruct.new(id: "si_addon", quantity: quantity,
+      price: OpenStruct.new(id: "price_extra_m", metadata: { "kind" => "extra_communicator" }, recurring: OpenStruct.new(interval: "month")))
+  end
+
+  def stub_subscription(items:)
+    sub = OpenStruct.new(id: "sub_addon", status: "active", items: OpenStruct.new(data: items))
+    allow(Stripe::Subscription).to receive(:list).and_return(OpenStruct.new(data: [sub]))
+    sub
+  end
+
+  it "403s for a non-Pro user" do
+    user.update!(plan_type: "basic")
+    post "/api/subscriptions/communicator_addon", params: { quantity: 2 }, headers: auth_headers(user)
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "422s when there is no active subscription" do
+    allow(Stripe::Subscription).to receive(:list).and_return(OpenStruct.new(data: []))
+    post "/api/subscriptions/communicator_addon", params: { quantity: 2 }, headers: auth_headers(user)
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it "adds a new add-on item and applies the slots when none exists" do
+    stub_subscription(items: [plan_item])
+    expect(Stripe::Subscription).to receive(:update)
+      .with("sub_addon", { items: [{ price: "price_extra_m", quantity: 2 }] })
+      .and_return(OpenStruct.new(id: "sub_addon"))
+
+    post "/api/subscriptions/communicator_addon", params: { quantity: 2 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["quantity"]).to eq(2)
+    expect(body["communicator_slot_limit"]).to eq(7) # base 5 + 2
+    expect(user.reload.extra_communicator_slots).to eq(2)
+  end
+
+  it "updates the existing add-on item's quantity" do
+    stub_subscription(items: [plan_item, addon_item(quantity: 1)])
+    expect(Stripe::SubscriptionItem).to receive(:update)
+      .with("si_addon", { quantity: 4 })
+      .and_return(OpenStruct.new(id: "si_addon"))
+
+    post "/api/subscriptions/communicator_addon", params: { quantity: 4 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.extra_communicator_slots).to eq(4)
+  end
+
+  it "removes the add-on item and clears the slots when quantity is 0" do
+    user.apply_extra_communicator_slots!(3)
+    stub_subscription(items: [plan_item, addon_item(quantity: 3)])
+    expect(Stripe::SubscriptionItem).to receive(:delete).with("si_addon").and_return(true)
+
+    post "/api/subscriptions/communicator_addon", params: { quantity: 0 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.extra_communicator_slots).to eq(0)
+  end
+end

--- a/spec/requests/api/webhooks_extra_communicators_spec.rb
+++ b/spec/requests/api/webhooks_extra_communicators_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+# The Stripe subscription webhook re-derives Pro-only extra-communicator add-on
+# slots from the LIVE subscription items, so add / remove / downgrade self-heals.
+RSpec.describe "POST /api/webhooks (extra communicator add-on)", type: :request do
+  include StripeHelpers
+
+  let(:user) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_extra_comm",
+      plan_type: "pro",
+      plan_status: "active")
+  end
+
+  before do
+    ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy"
+    ENV["STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY"] = "price_extra_m"
+  end
+
+  after { ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY") }
+
+  def build_metadata(hash)
+    Class.new do
+      def initialize(h) = (@h = h.transform_keys(&:to_s))
+      def [](k) = @h[k.to_s]
+      def presence = @h.presence
+      def to_h = @h
+    end.new(hash)
+  end
+
+  def price(plan_type: nil, id: "price_plan", kind: nil)
+    meta = {}
+    meta["plan_type"] = plan_type if plan_type
+    meta["kind"] = kind if kind
+    OpenStruct.new(id: id, metadata: build_metadata(meta), recurring: OpenStruct.new(interval: "month"))
+  end
+
+  def item(price_obj, quantity: 1)
+    OpenStruct.new(price: price_obj, quantity: quantity)
+  end
+
+  def build_subscription(items:, status: "active")
+    OpenStruct.new(
+      id: "sub_#{SecureRandom.hex(3)}",
+      customer: user.stripe_customer_id,
+      status: status,
+      current_period_end: 30.days.from_now.to_i,
+      trial_end: nil,
+      items: OpenStruct.new(data: items),
+    )
+  end
+
+  def stub_event(object, type: "customer.subscription.updated")
+    event = OpenStruct.new(id: "evt_#{SecureRandom.hex(4)}", type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  it "derives the add-on quantity from the subscription and keeps the plan price" do
+    sub = build_subscription(items: [
+      item(price(plan_type: "pro", id: "price_pro")),
+      item(price(id: "price_extra_m", kind: "extra_communicator"), quantity: 2),
+    ])
+    stub_event(sub)
+
+    post_webhook("{}", header_with_signature)
+
+    user.reload
+    expect(user.plan_type).to eq("pro")           # add-on item didn't hijack the plan price
+    expect(user.extra_communicator_slots).to eq(2)
+    expect(Permissions::CommunicatorLimits.slot_limit_for(user.settings)).to eq(7)
+  end
+
+  it "clears the add-on when a Pro user downgrades to Basic" do
+    user.apply_extra_communicator_slots!(3)
+    expect(user.reload.extra_communicator_slots).to eq(3)
+
+    sub = build_subscription(items: [item(price(plan_type: "basic", id: "price_basic"))])
+    stub_event(sub)
+
+    post_webhook("{}", header_with_signature)
+
+    user.reload
+    expect(user.plan_type).to eq("basic")
+    expect(user.extra_communicator_slots).to eq(0)
+  end
+
+  it "resets extras to 0 when the add-on item is removed but the user stays on Pro" do
+    user.apply_extra_communicator_slots!(4)
+
+    sub = build_subscription(items: [item(price(plan_type: "pro", id: "price_pro"))])
+    stub_event(sub)
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.extra_communicator_slots).to eq(0)
+  end
+end

--- a/spec/requests/api/webhooks_license_spec.rb
+++ b/spec/requests/api/webhooks_license_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe "POST /api/webhooks (5-Year license)", type: :request do
     }.not_to change { user.reload.plan_type }
   end
 
+  it "applies bundled extra communicator slots for a pro_5yr license" do
+    session = build_license_session(metadata: { "extra_communicators" => "3" })
+    stub_event(session)
+
+    post_webhook("{}", header_with_signature)
+
+    user.reload
+    expect(user.plan_type).to eq("pro_5yr")
+    expect(user.extra_communicator_slots).to eq(3)
+    # Base Pro limit (5) + 3 add-on slots.
+    expect(Permissions::CommunicatorLimits.slot_limit_for(user.settings)).to eq(8)
+  end
+
+  it "ignores extra communicators on a basic_5yr license (Pro-only add-on)" do
+    session = build_license_session(metadata: { "plan_type" => "basic_5yr", "extra_communicators" => "2" })
+    stub_event(session)
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.extra_communicator_slots).to eq(0)
+  end
+
   it "does not grant when no matching user can be resolved" do
     session = build_license_session(
       customer: nil,

--- a/spec/services/billing/extra_communicators_spec.rb
+++ b/spec/services/billing/extra_communicators_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Billing::ExtraCommunicators do
+  around do |example|
+    keys = %w[
+      STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY
+      STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY
+      STRIPE_PRICE_PRO_EXTRA_COMM_5YR
+      MAX_EXTRA_COMMUNICATORS
+    ]
+    saved = keys.index_with { |k| ENV[k] }
+    example.run
+    saved.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+
+  describe ".clamp" do
+    it "coerces nil/blank to 0 and floors negatives at 0" do
+      expect(described_class.clamp(nil)).to eq(0)
+      expect(described_class.clamp("")).to eq(0)
+      expect(described_class.clamp(-4)).to eq(0)
+    end
+
+    it "passes through in-range values" do
+      expect(described_class.clamp("3")).to eq(3)
+      expect(described_class.clamp(5)).to eq(5)
+    end
+
+    it "caps at the configured max" do
+      ENV["MAX_EXTRA_COMMUNICATORS"] = "7"
+      expect(described_class.clamp(999)).to eq(7)
+    end
+  end
+
+  describe ".price_id / .recurring_price_id" do
+    it "resolves configured prices and returns nil when unset" do
+      ENV["STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY"] = "price_m"
+      ENV["STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY"] = "price_y"
+      ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_5YR")
+
+      expect(described_class.price_id("monthly")).to eq("price_m")
+      expect(described_class.recurring_price_id("yearly")).to eq("price_y")
+      expect(described_class.recurring_price_id("anything_else")).to eq("price_m")
+      expect(described_class.price_id("license")).to be_nil
+    end
+  end
+
+  describe ".extra_comm_item? / .quantity_from_subscription" do
+    def item(price_id: nil, kind: nil, quantity: 1)
+      meta = kind ? { "kind" => kind } : {}
+      OpenStruct.new(quantity: quantity, price: OpenStruct.new(id: price_id, metadata: meta))
+    end
+
+    it "matches by configured price id" do
+      ENV["STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY"] = "price_extra_m"
+      expect(described_class.extra_comm_item?(item(price_id: "price_extra_m"))).to be(true)
+      expect(described_class.extra_comm_item?(item(price_id: "price_pro"))).to be(false)
+    end
+
+    it "matches by metadata tag even when no price id is configured" do
+      ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY")
+      ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY")
+      ENV.delete("STRIPE_PRICE_PRO_EXTRA_COMM_5YR")
+      expect(described_class.extra_comm_item?(item(kind: "extra_communicator"))).to be(true)
+      expect(described_class.extra_comm_item?(item(kind: "plan"))).to be(false)
+    end
+
+    it "sums extra-comm quantities across a subscription, ignoring the plan item" do
+      ENV["STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY"] = "price_extra_m"
+      sub = OpenStruct.new(items: OpenStruct.new(data: [
+        item(price_id: "price_pro", quantity: 1),                 # plan item — ignored
+        item(price_id: "price_extra_m", quantity: 3),             # add-on
+      ]))
+      expect(described_class.quantity_from_subscription(sub)).to eq(3)
+    end
+
+    it "returns 0 for a subscription with no add-on item" do
+      sub = OpenStruct.new(items: OpenStruct.new(data: [item(price_id: "price_pro", quantity: 1)]))
+      expect(described_class.quantity_from_subscription(sub)).to eq(0)
+      expect(described_class.quantity_from_subscription(nil)).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Makes the advertised **"add a communicator to Pro"** functionality real. Pro users can now buy communicator slots **on top of** the base 5:

- **$5/mo** or **$50/yr** — recurring add-on on their Pro subscription
- **$125 one-time** — bundled with a `pro_5yr` 5-Year license (expires with the license)

> **Pricing** was mine to pick (per Brittany). Rationale: Pro's $20 ÷ 5 = **$4/communicator blended** is *unit economics*, not an add-on price. Selling marginal slots at $4 would carry no premium over the bundle; **$5/mo ($50/yr)** is a clean ~25% premium and matches the existing `pricing-redesign-notes.md` draft. The one-time **$125** mirrors the license's own steep prepay discount (~58% off $5×60mo). Easy to retune via the Stripe dashboard prices.

### The core fix
The communicator-limit gate (`Permissions::CommunicatorLimits.slot_limit_for`) already read a `settings["communicator_slot_limit"]` override — but **no code ever wrote it**, so the half-built `basic_extra_comm` path charged the card and granted nothing. This wires a real entitlement: everything funnels into one key, `settings["extra_communicator_slots"]`, which `slot_limit_for` now **adds to the base limit**. Purchased slots are finally creatable through the single gate.

## Changes
- **`Billing::ExtraCommunicators`** — single home for price ENV keys, `clamp`, and Stripe item-matching (by price id or `metadata.kind=extra_communicator`).
- **Recurring:** `POST /api/subscriptions/communicator_addon { quantity }` upserts a recurring add-on subscription item to exactly N (0 removes). `handle_subscription_upsert` **re-derives** the entitlement from the live subscription → add/remove/cancel/downgrade self-heals. `first_price_from_subscription` skips the add-on item so it can't be read as the plan price.
- **One-time:** `checkout_sessions#license` accepts `extra_communicators` (Pro license only; 400 otherwise). `handle_license_completed` grants them.
- **Cleanup:** `apply_free_plan` clears extras on downgrade (over-limit communicators retained in fallback, per the invariant). Pro-only throughout (`User#pro?`).
- **Consistency:** `comm_account_limit`, `comm_account_limit_reached`, and the api_view include extras.
- Docs: `.claude-notes/billing-and-plans.md`, `docs/stripe-setup.md`, `CHANGELOG.md`.

### New ENV
`STRIPE_PRICE_PRO_EXTRA_COMM_MONTHLY` · `STRIPE_PRICE_PRO_EXTRA_COMM_YEARLY` · `STRIPE_PRICE_PRO_EXTRA_COMM_5YR` · `MAX_EXTRA_COMMUNICATORS` (default 20). Create the Stripe prices per `docs/stripe-setup.md` §2b — **the add-on is inert until these exist** (unconfigured price → the endpoint 422s / license 400s, nothing else breaks).

## Known gap
A Stripe *plan* downgrade (Pro→Basic via portal/`change_plan`) drops the entitlement to 0 but does **not** auto-remove a lingering add-on subscription item — cleanup in those flows is a follow-up (noted on the frontend issue).

## Frontend
Backend-only. Frontend surfaces (buy-slot UI + limit-reached upsell) are tracked in brittanyjohns/itty-bitty-frontend#552.

## Test plan
Targeted specs, all green:
- `spec/services/billing/extra_communicators_spec.rb`
- `spec/models/user_extra_communicators_spec.rb`
- `spec/requests/api/stripe/checkout_sessions_license_spec.rb` (extended)
- `spec/requests/api/webhooks_license_spec.rb` (extended)
- `spec/requests/api/webhooks_extra_communicators_spec.rb`
- `spec/requests/api/subscriptions_communicator_addon_spec.rb`

Regression run (142 ex) on the rebased-onto-`main` branch: webhooks plan_type/plan_credits/canceled, subscriptions lazy/change_plan, user_plan_types, plan_expiry_job, checkout_sessions, communicator_limits + fallback + sandbox — **0 failures**.

> Originally opened stacked on #510 (the 5-Year license PR, since the one-time path is license-only). #510 has since been squash-merged, and this branch was rebased onto `main` — it is now a single commit with no dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)