### PR TITLE
feat(board-builder): make the communicator account optional

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -740,6 +740,33 @@ Endpoints (`API::V1::BoardBuilderController`, all auth-gated):
   favorited root board's `api_view` (**201**). **422 `unknown_template`** /
   **422 `build_failed`** (the build is transactional — failure rolls back, no
   orphans). The frontend page ships separately in `itty-bitty-frontend`.
+  - **`communicator_id` is OPTIONAL — omit it to build an UNATTACHED set.**
+    A **present but unresolvable** id is still a 404; only an **absent** one
+    takes the unattached path, so every existing client is unaffected. The
+    requirement was never structural: `BoardGroup` (the set — what the plan
+    limit counts and what cascade-deletes the tree) is user-owned and has no
+    `child_account` at all. The single hard dependency is the `ChildBoard` join
+    (`child_accounts.child_account_id` is NOT NULL), so an unattached build
+    simply **doesn't create one** — no migration, no schema change. What
+    differs without a communicator:
+    - No `ChildBoard`, so no favorited root and the set isn't on anyone's
+      dashboard; it still lives in the user's Board Sets via its BoardGroup.
+    - `owner` is `current_user` instead of `communicator.owner || .user`.
+    - Voice falls back to the **owner's** default (`User#voice`);
+      `VoiceService.normalize_voice(nil)` would otherwise force `polly:kevin`.
+    - **No 409 re-run guard** — detection is inherently per-communicator
+      (`ChildAccount#builder_roots`), so each unattached build is just another
+      Board Set, capped by `at_board_group_limit?` (422). That 422 still
+      applies to both paths.
+    - Interests persist to `board_group.settings["interests"]` (the existing
+      jsonb) instead of `child_account.details["interests"]`.
+    - `CommunicatorProfile.for(communicator: nil)` returns nil, and every
+      consumer already treats "no profile" as "no personalization" — so an
+      unattached build gets no level recommendation, no GLP stage, and no
+      profile-guided AI prompts. `GET .../templates` needed no change: it
+      already returns nil recommendations when `communicator_id` is blank.
+    - `BuildBoardSetJob` receives a **nil** `communicator_id`; it fails the root
+      only when an id is **present and unresolvable** (a real dangling ref).
   - **Board-limit gated, but a tree counts as ONE board.** `create` returns
     **422 "Maximum number of boards reached"** when `current_user.at_board_limit?`
     (see the board read-only rule in `.claude-notes/billing-and-plans.md`). Because one wizard run persists a whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Board Builder no longer requires a communicator
+- `POST /api/v1/board_builder` now accepts an **omitted `communicator_id`** and
+  builds an **unattached** board set owned by the user, which they can assign to
+  a communicator later. Previously a user with no communicator couldn't build a
+  set at all — and since the manual Board Set form redirects non-admins to the
+  Board Builder, that meant they couldn't create a board set by any route.
+- Backward compatible: a `communicator_id` that's present but doesn't resolve
+  still returns **404 `communicator_not_found`**. Only an absent id is the new
+  path, so existing clients are unaffected.
+- Without a communicator there's no `ChildBoard` (so the set isn't on a
+  dashboard, but does appear in Board Sets), the board voice falls back to the
+  user's own default, interests persist on the set's `BoardGroup`, and there's
+  no 409 re-run guard — each build is just another Board Set, still capped by
+  the board-set limit. No migration.
+
 ### Added — Extra communicator add-on slots (Pro-only)
 - Pro users can buy communicator slots on top of the base 5: **$5/mo or $50/yr**
   recurring, or **$125 one-time** bundled with a `pro_5yr` 5-Year license.

--- a/app/controllers/api/v1/board_builder_controller.rb
+++ b/app/controllers/api/v1/board_builder_controller.rb
@@ -63,12 +63,18 @@ module API
       end
 
       def create
-        communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
-        unless communicator
-          render json: { error: "communicator_not_found",
-                         message: "We couldn't find that communicator on your account." },
-                 status: :not_found
-          return
+        # `communicator_id` is OPTIONAL: omit it to build an UNATTACHED set the
+        # user can assign to a communicator later. An id that's present but
+        # doesn't resolve is still a 404 — only an absent id takes the new path.
+        communicator = nil
+        if params[:communicator_id].present?
+          communicator = current_user.communicator_accounts.find_by(id: params[:communicator_id])
+          unless communicator
+            render json: { error: "communicator_not_found",
+                           message: "We couldn't find that communicator on your account." },
+                   status: :not_found
+            return
+          end
         end
 
         # Existing-set handling runs BEFORE the group-limit check so a user at
@@ -80,7 +86,11 @@ module API
         #                  backward compat: old clients send it and silently
         #                  repurposing it to "replace" would destroy data)
         #   neither      — 409 so the client can offer both options
-        existing_roots = communicator.builder_roots.to_a
+        #
+        # Detection is inherently per-communicator (ChildAccount#builder_roots),
+        # so an UNATTACHED build has nothing to collide with: each one is just
+        # another Board Set, capped by the board-set limit below.
+        existing_roots = communicator ? communicator.builder_roots.to_a : []
         if existing_roots.any?
           if params[:replace].to_s == "true"
             destroy_existing_builder_sets!(existing_roots)
@@ -115,8 +125,8 @@ module API
         build_key = resolve_build_key
         root_name = resolve_root_name(build_key)
 
-        owner = communicator.owner || communicator.user
-        raise Boards::BoardTreeBuilder::BuildError, "communicator has no owning user" unless owner
+        owner = communicator ? (communicator.owner || communicator.user) : current_user
+        raise Boards::BoardTreeBuilder::BuildError, "no owning user" unless owner
 
         raw_interests = params[:interests]
         interests  = Boards::InterestWords.normalize_list(raw_interests)
@@ -128,14 +138,18 @@ module API
           root = Board.new(name: root_name, user: owner)
           root.board_type = "dynamic"
           root.assign_parent
-          root.voice = VoiceService.normalize_voice(communicator.voice)
+          root.voice = VoiceService.normalize_voice(communicator&.voice || owner.voice)
           root.generate_unique_slug
           root.settings = (root.settings || {}).merge("builder_root" => true)
           root.status = "building_board"
           root.save!
 
-          child_board = communicator.child_boards.create!(board: root, created_by_id: owner.id)
-          child_board.update!(favorite: true)
+          # Unattached sets have no communicator to favorite the root onto; the
+          # set still lives in the user's Board Sets via the BoardGroup below.
+          if communicator
+            child_board = communicator.child_boards.create!(board: root, created_by_id: owner.id)
+            child_board.update!(favorite: true)
+          end
 
           # The builder set's canonical container. Member boards (root + every
           # child the job builds) attach here; this is what the user's board-set
@@ -147,10 +161,17 @@ module API
           board_group.board_group_boards.create!(board: root, position: 0)
           board_group.update!(root_board_id: root.id)
 
-          communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
+          # Persist the normalized interests so the wizard is re-runnable /
+          # pre-fillable. They belong to the communicator when there is one;
+          # an unattached set keeps them on its own group instead.
+          if communicator
+            communicator.update!(details: (communicator.details || {}).merge("interests" => interests))
+          else
+            board_group.update!(settings: (board_group.settings || {}).merge("interests" => interests))
+          end
         end
 
-        BuildBoardSetJob.perform_async(root.id, communicator.id, build_key, interests, categories,
+        BuildBoardSetJob.perform_async(root.id, communicator&.id, build_key, interests, categories,
                                        { "include_phrases" => include_phrases_param,
                                          "board_group_id" => board_group.id })
 

--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -2,8 +2,9 @@
 #
 # Deterministic backend for the Board Builder. Takes a nested "blueprint"
 # (a root board + linked sub-boards) and persists it as real, linked Board
-# records, then attaches the root to a communicator (child_account) via a
-# ChildBoard join.
+# records, then — when a communicator is given — attaches the root to it
+# (child_account) via a ChildBoard join. The communicator is optional: a set
+# can be built for a user alone and assigned to a communicator later.
 #
 # A tile is a BoardImage. A tile becomes a *folder* when its
 # predictive_board_id points at another board, so "build a set" = create
@@ -37,10 +38,15 @@ module Boards
     # under the root the controller returned with status "building_board".
     # When a root is adopted, the caller owns the ChildBoard attach/favorite;
     # this builder only adds tiles and sub-boards under it.
-    def initialize(blueprint, communicator:, favorite_root: false, root: nil)
+    #
+    # `communicator:` is OPTIONAL — a set can be built for a user with no
+    # communicator at all and assigned later. Without one there's no ChildBoard
+    # attach and the voice falls back to the owner's default. Pass `owner:`
+    # explicitly in that case; with a communicator it's derived as before.
+    def initialize(blueprint, communicator: nil, owner: nil, favorite_root: false, root: nil)
       @blueprint     = blueprint.deep_symbolize_keys
       @communicator  = communicator
-      @owner         = communicator.owner || communicator.user
+      @owner         = owner || communicator&.owner || communicator&.user
       @favorite_root = favorite_root
       @root          = root
     end
@@ -50,11 +56,11 @@ module Boards
     # the rollback strips every child/tile and leaves the bare root for the
     # caller to mark "failed"). Returns the root Board.
     def call
-      raise BuildError, "communicator has no owning user" unless @owner
+      raise BuildError, "no owning user" unless @owner
 
       ActiveRecord::Base.transaction do
         root = build_board(@blueprint, depth: 0)
-        attach_root_to_communicator(root) unless adopted_root?
+        attach_root_to_communicator(root) if @communicator && !adopted_root?
         root
       end
     end
@@ -102,7 +108,7 @@ module Boards
       board = Board.new(name: node[:name], user: @owner)
       board.board_type = board_type_for(node, depth) # "dynamic" or "static"
       board.assign_parent                            # => parent is the owning User
-      board.voice = VoiceService.normalize_voice(@communicator.voice)
+      board.voice = VoiceService.normalize_voice(@communicator&.voice || @owner.voice)
       board.generate_unique_slug
       # Sub-boards (folders) don't count against the user's board limit — the
       # whole tree counts as one via its root. See User#countable_board_count.

--- a/app/services/boards/phrases_page_builder.rb
+++ b/app/services/boards/phrases_page_builder.rb
@@ -14,7 +14,9 @@ module Boards
   class PhrasesPageBuilder
     PHRASES_BOARD_NAME = "Phrases".freeze
 
-    def initialize(communicator:, owner:)
+    # `communicator:` is optional — an unattached set still gets the Phrases
+    # layer, just with the owner's default voice.
+    def initialize(owner:, communicator: nil)
       @communicator = communicator
       @owner = owner
     end
@@ -44,7 +46,7 @@ module Boards
       board = Board.new(name: name, user: @owner)
       board.board_type = "static"
       board.assign_parent
-      board.voice = VoiceService.normalize_voice(@communicator.voice)
+      board.voice = VoiceService.normalize_voice(@communicator&.voice || @owner.voice)
       board.generate_unique_slug
       board.settings = (board.settings || {}).merge("builder_child" => true)
       board.save!

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -39,10 +39,15 @@ module Boards
     # When a root is adopted, the source root's CONTENT (tiles, layout columns)
     # is cloned INTO it instead of dup-ing a fresh board, and the caller owns
     # the ChildBoard attach/favorite.
-    def initialize(source_root, communicator:, interests: [], favorite_root: true, root: nil, explicit_categories: {}, exclude_fringe: [])
+    #
+    # `communicator:` is OPTIONAL — a set can be cloned for a user with no
+    # communicator at all and assigned later. Without one there's no ChildBoard
+    # attach and the voice falls back to the owner's default. Pass `owner:`
+    # explicitly in that case; with a communicator it's derived as before.
+    def initialize(source_root, communicator: nil, owner: nil, interests: [], favorite_root: true, root: nil, explicit_categories: {}, exclude_fringe: [])
       @source_root          = source_root
       @communicator         = communicator
-      @owner                = communicator.owner || communicator.user
+      @owner                = owner || communicator&.owner || communicator&.user
       @interests            = normalize_interests(interests)
       @favorite_root        = favorite_root
       @root                 = root
@@ -55,7 +60,7 @@ module Boards
     # adopted root, the rollback strips every fringe board/tile and leaves the
     # bare root for the caller to mark "failed"). Returns the cloned root Board.
     def call
-      raise CloneError, "communicator has no owning user" unless @owner
+      raise CloneError, "no owning user" unless @owner
       raise CloneError, "no source root board" if @source_root.nil?
 
       ActiveRecord::Base.transaction do
@@ -64,7 +69,7 @@ module Boards
         mark_builder_settings!
 
         root = @map.fetch(@source_root.id)
-        attach_root_to_communicator(root) unless adopted_root?
+        attach_root_to_communicator(root) if @communicator && !adopted_root?
         route_interests!(root)
         # clone_with_images leaves the in-memory clones with a stale
         # board_images_count / association cache; hand back a fresh root.
@@ -310,7 +315,7 @@ module Boards
       favorites = Board.new(name: FAVORITES_NAME, user: @owner)
       favorites.board_type = "static"
       favorites.assign_parent
-      favorites.voice = VoiceService.normalize_voice(@communicator.voice)
+      favorites.voice = VoiceService.normalize_voice(@communicator&.voice || @owner.voice)
       favorites.generate_unique_slug
       favorites.settings = (favorites.settings || {}).merge("builder_child" => true)
       favorites.save!

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -3,8 +3,10 @@
 # Async half of the Board Builder (POST /api/v1/board_builder). The controller
 # does every synchronous pre-check (404 / 422 board-limit / 409 duplicate-set),
 # creates the ROOT board with status "building_board", attaches it to the
-# communicator (ChildBoard + favorite), and enqueues this job. This job builds
-# everything else under that pre-created root:
+# communicator (ChildBoard + favorite) WHEN there is one, and enqueues this job.
+# `communicator_id` is nil for an UNATTACHED set — one built for the user alone,
+# to be assigned to a communicator later. This job builds everything else under
+# that pre-created root:
 #
 #   - fringe/sub boards + their tiles
 #   - predictive_board_id folder links
@@ -48,8 +50,12 @@ class BuildBoardSetJob
       return
     end
 
-    communicator = ChildAccount.find_by(id: communicator_id)
-    unless communicator
+    # A nil communicator_id is the UNATTACHED path: the user built a set without
+    # a communicator (they can assign it later), so there's nothing to look up.
+    # An id that's present but unresolvable is a real dangling reference — still
+    # a failure.
+    communicator = communicator_id ? ChildAccount.find_by(id: communicator_id) : nil
+    if communicator_id && communicator.nil?
       Rails.logger.error "BuildBoardSetJob: ChildAccount with ID #{communicator_id} not found for Board ID #{root_board_id}."
       root.update_column(:status, "failed")
       return
@@ -89,12 +95,27 @@ class BuildBoardSetJob
     Boards::StructurePlanner::LEVELS.key?(value.to_s.downcase)
   end
 
+  # The user who owns the built set. With a communicator this is its owning user
+  # (unchanged); without one it's the root's own user — which the controller set
+  # to the same owner in both cases, so this is equivalent either way.
+  def owner_for(root, communicator)
+    communicator&.owner || communicator&.user || root.user
+  end
+
+  # The voice a newly created board in this set defaults to: the communicator's
+  # when there is one, else the owner's own default.
+  def voice_for(communicator, owner)
+    VoiceService.normalize_voice(communicator&.voice || owner.voice)
+  end
+
   # Phase 2: StructurePlanner-driven hybrid build. Gestalt phrases are no longer
   # a separate build target — every set gets the full core+fringe vocabulary
   # PLUS an integrated "Phrases" layer (Boards::PhrasesPageBuilder), with
   # prominence tuned to the communicator's NLA stage.
   def build_with_structure_planner(root, communicator, level, interests, explicit_categories, include_phrases = nil)
-    owner = communicator.owner || communicator.user
+    owner = owner_for(root, communicator)
+    # Nil without a communicator — CommunicatorProfile treats "no profile" as
+    # "no personalization", which StructurePlanner already handles.
     profile = CommunicatorProfile.for(communicator: communicator)
 
     plan = Boards::StructurePlanner.new(
@@ -110,7 +131,7 @@ class BuildBoardSetJob
     if robust_root
       seed_set_interests = collect_seed_set_interests(plan)
       Boards::SeededSetCloner.new(
-        robust_root, communicator: communicator,
+        robust_root, communicator: communicator, owner: owner,
         interests: seed_set_interests, root: root,
         explicit_categories: explicit_categories,
         # Clone the authored core set INTACT. Excluding "unplanned" seed pages
@@ -138,7 +159,7 @@ class BuildBoardSetJob
     root.reload
     return nil if root_open_cells(root) < 1
 
-    phrases_board = Boards::PhrasesPageBuilder.new(communicator: communicator, owner: owner).call
+    phrases_board = Boards::PhrasesPageBuilder.new(owner: owner, communicator: communicator).call
     return nil unless phrases_board
 
     add_folder_tile!(root, owner, Boards::PhrasesPageBuilder::PHRASES_BOARD_NAME, phrases_board.id)
@@ -302,9 +323,10 @@ class BuildBoardSetJob
   # The new Phrases board doubles as the communicator's phrase board (the
   # sentence-builder save target + quick-phrase source). Wire it on the
   # communicator and backfill the owner — but only when blank, never clobbering
-  # a phrase board the user already picked.
+  # a phrase board the user already picked. An unattached set has no
+  # communicator to wire, so it only backfills the owner.
   def wire_phrase_board!(communicator, owner, phrases_board)
-    if communicator.settings["phrase_board_id"].blank?
+    if communicator && communicator.settings["phrase_board_id"].blank?
       communicator.update!(settings: (communicator.settings || {}).merge("phrase_board_id" => phrases_board.id))
     end
     if owner.settings["phrase_board_id"].blank?
@@ -486,7 +508,7 @@ class BuildBoardSetJob
     fringe = Board.new(name: blueprint[:name], user: owner)
     fringe.board_type = "static"
     fringe.assign_parent
-    fringe.voice = VoiceService.normalize_voice(communicator.voice)
+    fringe.voice = voice_for(communicator, owner)
     fringe.generate_unique_slug
     fringe.settings = (fringe.settings || {}).merge("builder_child" => true)
     fringe.save!
@@ -505,7 +527,7 @@ class BuildBoardSetJob
   def add_to_favorites!(root, communicator, words)
     return if words.blank?
 
-    owner = communicator.owner || communicator.user
+    owner = owner_for(root, communicator)
     root.reload
 
     favorites = root.board_images
@@ -522,7 +544,7 @@ class BuildBoardSetJob
       favorites = Board.new(name: "My Favorites", user: owner)
       favorites.board_type = "static"
       favorites.assign_parent
-      favorites.voice = VoiceService.normalize_voice(communicator.voice)
+      favorites.voice = voice_for(communicator, owner)
       favorites.generate_unique_slug
       favorites.settings = (favorites.settings || {}).merge("builder_child" => true)
       favorites.save!
@@ -585,15 +607,15 @@ class BuildBoardSetJob
   # Legacy path: backward-compatible with direct template keys (core-60, core-84, home, etc.)
   def build_legacy(root, communicator, template, interests, explicit_categories)
     robust_root = Boards::RobustSets.find_root(template)
+    owner = owner_for(root, communicator)
 
     if robust_root
       Boards::SeededSetCloner.new(
-        robust_root, communicator: communicator,
+        robust_root, communicator: communicator, owner: owner,
         interests: interests, root: root,
         explicit_categories: explicit_categories,
       ).call
     else
-      owner = communicator.owner || communicator.user
       assembler = Boards::BlueprintAssembler.new(
         template:  template,
         interests: interests,
@@ -603,7 +625,7 @@ class BuildBoardSetJob
       blueprint = assembler.call
 
       Boards::BoardTreeBuilder.new(
-        blueprint, communicator: communicator, root: root,
+        blueprint, communicator: communicator, owner: owner, root: root,
       ).call
     end
   end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -396,6 +396,106 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
       end
     end
 
+    # An UNATTACHED build: no communicator_id at all. The set is the user's own
+    # Board Set, assignable to a communicator later.
+    context "without a communicator" do
+      it "returns 201 and builds the set for the user, with no ChildBoard" do
+        expect {
+          post "/api/v1/board_builder",
+               params: { template: "home", interests: ["dinosaurs"] }.to_json,
+               headers: headers
+        }.to change { BuildBoardSetJob.jobs.size }.by(1)
+          .and change { ChildBoard.count }.by(0)
+
+        expect(response).to have_http_status(:created)
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.user_id).to eq(user.id)
+        expect(root.settings["builder_root"]).to be(true)
+        expect(root.status).to eq("building_board")
+
+        # The set still lives in the user's Board Sets via its builder group —
+        # that's what the plan limit counts and what cascade-deletes the tree.
+        group = user.board_groups.find_by(builder: true, root_board_id: root.id)
+        expect(group).to be_present
+        # Interests have no communicator to live on, so the group holds them.
+        expect(group.settings["interests"]).to eq(["dinosaurs"])
+
+        # The job gets a nil communicator_id — the unattached signal.
+        expect(BuildBoardSetJob.jobs.last["args"])
+          .to eq([root.id, nil, "home", ["dinosaurs"], {},
+                  { "include_phrases" => nil, "board_group_id" => group.id }])
+      end
+
+      it "builds the full tree and completes (job drained)" do
+        post "/api/v1/board_builder",
+             params: { template: "home", interests: ["dinosaurs", "grandma"] }.to_json,
+             headers: headers
+        expect(response).to have_http_status(:created)
+
+        BuildBoardSetJob.drain
+
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.status).to eq("complete")
+        expect(ChildBoard.count).to eq(0)
+
+        # Interests route exactly as they do for an attached build.
+        play_tile = root.board_images.find { |bi| bi.label == "Play" }
+        play_board = Board.find(play_tile.predictive_board_id)
+        expect(play_board.board_images.map(&:label)).to include("dinosaurs")
+
+        favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+        favorites_board = Board.find(favorites_tile.predictive_board_id)
+        expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
+      end
+
+      it "falls back to the owner's voice" do
+        user.update!(settings: { "voice" => { "name" => "openai:nova" } })
+
+        post "/api/v1/board_builder",
+             params: { template: "home" }.to_json, headers: headers
+
+        root = Board.find(JSON.parse(response.body)["id"])
+        expect(root.voice).to eq("openai:nova")
+      end
+
+      # The 409 re-run guard is keyed on the communicator, so an unattached
+      # build has nothing to collide with. Room in the set limit is raised here
+      # so this isolates the absence of a 409 from the 422 cap below.
+      it "does not 409 on a second build — each is just another Board Set" do
+        user.update!(settings: (user.settings || {}).merge("board_group_limit" => 5))
+
+        2.times do
+          post "/api/v1/board_builder",
+               params: { template: "home" }.to_json, headers: headers
+          expect(response).to have_http_status(:created)
+        end
+
+        expect(user.board_groups.where(builder: true).count).to eq(2)
+      end
+
+      it "still enforces the board-set limit" do
+        allow_any_instance_of(User).to receive(:at_board_group_limit?).and_return(true)
+
+        expect {
+          post "/api/v1/board_builder",
+               params: { template: "home" }.to_json, headers: headers
+        }.not_to change { Board.count }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      # Only an ABSENT id is the unattached path — a present-but-bad one is
+      # still a client error.
+      it "still 404s when a communicator_id is given but doesn't resolve" do
+        post "/api/v1/board_builder",
+             params: { communicator_id: -1, template: "home" }.to_json,
+             headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)["error"]).to eq("communicator_not_found")
+      end
+    end
+
     context "with a GLP template" do
       def seed_glp_templates!
         Boards::GlpTemplates.seed!(admin: create(:admin_user))

--- a/spec/services/boards/board_tree_builder_spec.rb
+++ b/spec/services/boards/board_tree_builder_spec.rb
@@ -267,5 +267,47 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
         expect(Board.where(user_id: owner.id).where.not(id: root.id).count).to eq(0)
       end
     end
+
+    # A set built for a user with no communicator — assignable to one later.
+    context "without a communicator" do
+      let(:blueprint) do
+        { name: "Home",
+          tiles: [
+            { label: "I", image_id: image_id_for("I") },
+            { label: "Food", image_id: image_id_for("Food"), children: {
+              name: "Food", tiles: [{ label: "apple", image_id: image_id_for("apple") }],
+            } },
+          ] }
+      end
+
+      it "builds the tree for the owner and creates no ChildBoard" do
+        root = nil
+        expect {
+          root = described_class.new(blueprint, owner: owner, favorite_root: true).call
+        }.not_to change { ChildBoard.count }
+
+        expect(root.user_id).to eq(owner.id)
+        expect(root.settings["builder_root"]).to be(true)
+
+        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        food_board = Board.find(food_tile.predictive_board_id)
+        expect(food_board.board_images.map(&:label)).to eq(["apple"])
+        expect(food_board.settings["builder_child"]).to be(true)
+      end
+
+      it "falls back to the owner's voice" do
+        owner.update!(settings: { "voice" => { "name" => "openai:nova" } })
+
+        root = described_class.new(blueprint, owner: owner).call
+
+        expect(root.voice).to eq("openai:nova")
+      end
+
+      it "raises without an owner or a communicator to derive one from" do
+        expect {
+          described_class.new(blueprint).call
+        }.to raise_error(described_class::BuildError, /no owning user/)
+      end
+    end
   end
 end

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -287,6 +287,49 @@ RSpec.describe Boards::SeededSetCloner do
   end
 
   # Regression for #278: seed BOTH real sets, then clone each.
+  # A set cloned for a user with no communicator — assignable to one later.
+  describe "#call without a communicator" do
+    it "clones the whole set for the owner and creates no ChildBoard" do
+      root = nil
+      expect {
+        root = described_class.new(@source[:root], owner: owner).call
+      }.not_to change { ChildBoard.count }
+
+      expect(root.user_id).to eq(owner.id)
+      expect(root.settings["builder_root"]).to be(true)
+      expect(owner.boards.count).to eq(3)
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      expect(root.board_images.find_by(label: "Food").predictive_board_id).to eq(cloned_food.id)
+    end
+
+    it "routes interests into the cloned fringe pages and My Favorites" do
+      root = described_class.new(@source[:root], owner: owner,
+                                                 interests: ["apple", "grandma"]).call
+
+      cloned_food = owner.boards.find_by(name: "Food")
+      expect(cloned_food.board_images.map(&:label)).to include("apple")
+
+      favorites = owner.boards.find_by(name: "My Favorites")
+      expect(favorites.board_images.map(&:label)).to contain_exactly("grandma")
+      expect(root.board_images.find_by(label: "My Favorites")).to be_present
+    end
+
+    it "falls back to the owner's voice for boards it creates" do
+      owner.update!(settings: { "voice" => { "name" => "openai:nova" } })
+
+      described_class.new(@source[:root], owner: owner, interests: ["grandma"]).call
+
+      expect(owner.boards.find_by(name: "My Favorites").voice).to eq("openai:nova")
+    end
+
+    it "raises without an owner or a communicator to derive one from" do
+      expect {
+        described_class.new(@source[:root]).call
+      }.to raise_error(described_class::CloneError, /no owning user/)
+    end
+  end
+
   describe "cloning a real seeded robust set" do
     before_all do
       register_openai_webmock_stub!

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -537,6 +537,68 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
+  # A nil communicator_id is the UNATTACHED path (built for the user alone);
+  # a present-but-unresolvable one is a real dangling reference.
+  describe "without a communicator" do
+    def precreate_unattached_root!(name:, owner: user)
+      root = Board.new(name: name, user: owner)
+      root.board_type = "dynamic"
+      root.assign_parent
+      root.voice = VoiceService.normalize_voice(owner.voice)
+      root.generate_unique_slug
+      root.settings = (root.settings || {}).merge("builder_root" => true)
+      root.status = "building_board"
+      root.save!
+      root
+    end
+
+    it "builds the whole tree and completes, creating no ChildBoard" do
+      root = precreate_unattached_root!(name: "Home")
+
+      expect {
+        described_class.new.perform(root.id, nil, "home", ["dinosaurs"])
+      }.not_to change { ChildBoard.count }
+
+      root.reload
+      expect(root.status).to eq("complete")
+      expect(root.board_images.count).to be > 0
+
+      play_tile = root.board_images.find { |bi| bi.label == "Play" }
+      play_board = Board.find(play_tile.predictive_board_id)
+      expect(play_board.board_images.map(&:label)).to include("dinosaurs")
+    end
+
+    it "builds a robust seeded set unattached" do
+      seed_robust_set!
+      root = precreate_unattached_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, nil, "core-60", [])
+
+      root.reload
+      expect(root.status).to eq("complete")
+      expect(root.board_images.map(&:label)).to include("I", "Food")
+      expect(ChildBoard.count).to eq(0)
+    end
+
+    it "uses the owner's voice for boards it creates" do
+      user.update!(settings: { "voice" => { "name" => "openai:nova" } })
+      root = precreate_unattached_root!(name: "Home")
+
+      described_class.new.perform(root.id, nil, "home", ["grandma"])
+
+      favorites = Board.find_by(name: "My Favorites", user_id: user.id)
+      expect(favorites.voice).to eq("openai:nova")
+    end
+
+    it "still fails the root when a communicator_id is given but missing" do
+      root = precreate_unattached_root!(name: "Home")
+
+      described_class.new.perform(root.id, -1, "home", [])
+
+      expect(root.reload.status).to eq("failed")
+    end
+  end
+
   # Part 2: a leftover interest goes onto an existing matching board where one
   # exists in the set, and only falls through to My Favorites when none does.
   describe "#route_catch_all_to_existing_boards!" do


### PR DESCRIPTION
## Summary

A user with no communicator couldn't build a board set. And since `NewBoardGroup.tsx` redirects all non-admins to the Board Builder, that meant **they couldn't create a board set by any route at all**. This makes the communicator optional.

`POST /api/v1/board_builder` now accepts an **omitted `communicator_id`** and builds an **unattached** set owned by the user, assignable to a communicator later.

## The requirement was never structural

`BoardGroup` — the thing that *is* a board set, counts against the plan limit, and cascade-deletes the tree — is **user-owned** and has no `child_account` column, association, or validation. The board tree itself is user-owned too.

There is exactly **one** hard dependency: the `ChildBoard` join (`child_boards.child_account_id` is `NOT NULL`). An unattached build simply **doesn't create one** — so there's **no migration and no schema change**.

Inside the build services the communicator was only ever used for three things: deriving `owner`, the default `voice`, and the ChildBoard attach — and that attach is already skipped on the async path (the controller pre-creates the root, so the services take the adopted-root branch).

## Backward compatible

A `communicator_id` that is **present but unresolvable still 404s**. Only an **absent** id takes the new path, so every existing client is unaffected and this can deploy before the frontend.

## What differs without a communicator

- No `ChildBoard` — not on a dashboard, but still in Board Sets via its BoardGroup.
- `owner` is `current_user`; voice falls back to `User#voice` (otherwise `normalize_voice(nil)` would force `polly:kevin`).
- **No 409 re-run guard.** Detection is inherently per-communicator (`ChildAccount#builder_roots`), so each unattached build is just another Board Set — capped by `at_board_group_limit?` (422), which still applies to both paths.
- Interests persist to `board_group.settings["interests"]` (existing jsonb) instead of `child_account.details["interests"]`.
- No profile → no level recommendation or profile-guided AI prompts. `CommunicatorProfile.for(communicator: nil)` already returns nil and every consumer treats that as "no personalization". `GET .../templates` needed **no change** — it already returned nil recommendations for a blank `communicator_id`.
- `BuildBoardSetJob` gets a nil `communicator_id`; it fails the root only when an id is **present and unresolvable** (a real dangling reference).

## Test plan

`RAILS_ENV=test bundle exec rspec spec/services/boards spec/services/vocab_sets_spec.rb spec/services/communicator_profile_spec.rb spec/services/credit_service_spec.rb spec/sidekiq/build_board_set_job_spec.rb spec/requests/api/v1/board_builder_spec.rb`

**419 examples, 0 failures** — including the full pre-existing suite, which passed unchanged before any new tests were added (confirming backward compatibility).

New coverage:
- **Request:** unattached build → 201 with no `ChildBoard`, root owned by the user, interests on the group, nil `communicator_id` in the job args; full tree builds and completes on drain; owner voice fallback; **no 409** on a second build; set limit **still 422s**; present-but-bad id **still 404s**.
- **Job:** builds unattached (starter + robust paths); owner voice; still fails the root on a dangling id.
- **Services:** `BoardTreeBuilder` / `SeededSetCloner` build with `owner:` and no communicator, create no `ChildBoard`, route interests, fall back to owner voice, and raise when neither an owner nor a communicator is given.

## Docs

`.claude-notes/board-builder.md` endpoint contract + `CHANGELOG.md`.

## Follow-up (not in this PR)

The frontend change is separate — this deploys first. Worth a look later: with board sets now reachable for communicator-less users, the Board Sets empty state may deserve attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)