### PR TITLE
feat: per-tile video actions (YouTube link or uploaded clip)

### DIFF
--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -1,8 +1,8 @@
 class API::BoardImagesController < API::ApplicationController
   respond_to :json
   before_action :set_board_image, only: %i[ show ]
-  before_action :set_owned_board_image, only: %i[ update destroy create_image_variation create_image_edit set_current_audio ]
-  before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation upload_audio reset_audio move destroy ]
+  before_action :set_owned_board_image, only: %i[ update destroy create_image_variation create_image_edit set_current_audio attach_youtube_video upload_video clear_video ]
+  before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation upload_audio reset_audio move destroy attach_youtube_video upload_video clear_video ]
 
   # GET /board_images or /board_images.json
   def index
@@ -35,6 +35,11 @@ class API::BoardImagesController < API::ApplicationController
   # PATCH/PUT /board_images/1 or /board_images/1.json
   def update
     data = params[:board_image][:data]
+    # The "video" key is only writable through the dedicated, validated
+    # actions below (attach_youtube_video / upload_video / clear_video).
+    # Stripping it here means a generic update can neither inject an
+    # unvalidated video config nor clobber an existing one.
+    data = data.except(:video) if data.respond_to?(:except)
     updatedData = @board_image.data.merge(data.to_unsafe_h) if data
 
     @board_image.data = updatedData if updatedData
@@ -259,6 +264,55 @@ class API::BoardImagesController < API::ApplicationController
     else
       render json: @board_image.errors, status: :unprocessable_content
     end
+  end
+
+  # POST /api/board_images/:id/attach_youtube_video
+  # Persists only the parsed 11-char video id — the raw URL is discarded, so
+  # client input can never reach an iframe src.
+  def attach_youtube_video
+    youtube_id = YoutubeUrlParser.video_id(params[:url])
+    unless youtube_id
+      render json: { error: "invalid_youtube_url" }, status: :unprocessable_content
+      return
+    end
+    @board_image.set_youtube_video!(youtube_id)
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
+  end
+
+  # POST /api/board_images/:id/upload_video (multipart: video_file)
+  # mp4/webm only, 25 MB cap — both enforced here regardless of client checks.
+  # The 30s duration cap is client-side only (no ffmpeg server-side in v1).
+  def upload_video
+    file = params[:video_file]
+    unless file.respond_to?(:content_type) && file.respond_to?(:size)
+      render json: { error: "video_required" }, status: :unprocessable_content
+      return
+    end
+    unless BoardImage::ALLOWED_VIDEO_CONTENT_TYPES.include?(file.content_type)
+      render json: { error: "invalid_video_type" }, status: :unprocessable_content
+      return
+    end
+    if file.size > BoardImage::MAX_VIDEO_BYTES
+      render json: { error: "video_too_large" }, status: :unprocessable_content
+      return
+    end
+
+    extension = file.content_type == "video/webm" ? "webm" : "mp4"
+    filename = "board-image-#{@board_image.id}-video-#{Time.now.strftime("%m%d%y%H%M%S")}.#{extension}"
+    @board_image.video_clip.purge_later if @board_image.video_clip.attached?
+    @board_image.video_clip.attach(io: file, filename: filename, content_type: file.content_type)
+    @board_image.reload
+    @board_image.set_uploaded_video!(@board_image.video_clip_url, file.content_type)
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
+  end
+
+  # POST /api/board_images/:id/clear_video
+  def clear_video
+    @board_image.clear_video!
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
   end
 
   def reset_audio

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -35,7 +35,11 @@ class BoardImage < ApplicationRecord
   belongs_to :image
   belongs_to :predictive_board, class_name: "Board", optional: true
   has_many_attached :audio_files
+  has_one_attached :video_clip
   attr_accessor :skip_create_voice_audio, :skip_initial_layout, :src
+
+  ALLOWED_VIDEO_CONTENT_TYPES = %w[video/mp4 video/webm].freeze
+  MAX_VIDEO_BYTES = 25.megabytes
 
   before_create :set_defaults
   # before_save :save_display_image_url, if: -> { display_image_url.blank? }
@@ -329,6 +333,11 @@ class BoardImage < ApplicationRecord
       ext_saw_board_id: board_id.to_s,
     }
     btn[:sound_id] = id.to_s if audio_url.present?
+    if (video = video_config)
+      btn[:ext_saw_video_source] = video["source"]
+      btn[:ext_saw_video_youtube_id] = video["youtube_id"] if video["youtube_id"].present?
+      btn[:ext_saw_video_url] = video["url"] if video["url"].present?
+    end
     if predictive_board_id
       target = Board.find_by(id: predictive_board_id)
       if target
@@ -496,6 +505,51 @@ class BoardImage < ApplicationRecord
 
   def description
     image.image_prompt || board.description
+  end
+
+  # --- Tile video (data["video"]) -------------------------------------------
+  # Video config lives inside the `data` jsonb under a single "video" key:
+  #   { "source" => "youtube", "youtube_id" => "..." }
+  #   { "source" => "upload",  "url" => "<cdn url>", "content_type" => "video/mp4" }
+  # It is only ever written by the dedicated controller actions
+  # (attach_youtube_video / upload_video / clear_video) — the generic update
+  # path strips the key so unvalidated client input can't reach it.
+
+  def video_config
+    data&.dig("video").presence
+  end
+
+  def video?
+    video_config.present?
+  end
+
+  def set_youtube_video!(youtube_id)
+    video_clip.purge_later if video_clip.attached?
+    self.data = (data || {}).merge("video" => { "source" => "youtube", "youtube_id" => youtube_id })
+    save!
+  end
+
+  def set_uploaded_video!(url, content_type)
+    self.data = (data || {}).merge("video" => { "source" => "upload", "url" => url, "content_type" => content_type })
+    save!
+  end
+
+  def clear_video!
+    video_clip.purge_later if video_clip.attached?
+    self.data = (data || {}).except("video")
+    save!
+  end
+
+  # CDN-aware URL for the attached clip — same resolution scheme as
+  # AudioHelper#default_audio_url so playback URLs are stable and cacheable.
+  def video_clip_url
+    blob = video_clip.attached? ? video_clip.blob : nil
+    return nil unless blob
+    if ENV["ACTIVE_STORAGE_SERVICE"] == "amazon" || Rails.env.production?
+      "#{ENV["CDN_HOST"]}/#{blob.key}"
+    else
+      video_clip.url
+    end
   end
 
   def has_custom_audio?

--- a/app/services/youtube_url_parser.rb
+++ b/app/services/youtube_url_parser.rb
@@ -1,0 +1,52 @@
+# Parses a user-pasted YouTube URL into a validated 11-character video id.
+#
+# Only the id is ever persisted or used to build an embed URL — the raw URL is
+# discarded, so client input can never reach an iframe src. Non-YouTube hosts
+# and malformed ids are rejected (returns nil).
+class YoutubeUrlParser
+  ALLOWED_HOSTS = %w[
+    youtube.com
+    www.youtube.com
+    m.youtube.com
+    music.youtube.com
+    youtu.be
+    youtube-nocookie.com
+    www.youtube-nocookie.com
+  ].freeze
+
+  VIDEO_ID_RE = /\A[A-Za-z0-9_-]{11}\z/
+
+  # Returns the 11-char video id, or nil when the URL isn't a recognizable
+  # YouTube video link.
+  def self.video_id(raw_url)
+    return nil if raw_url.blank?
+
+    uri = begin
+      URI.parse(raw_url.to_s.strip)
+    rescue URI::InvalidURIError
+      return nil
+    end
+    # Tolerate URLs pasted without a scheme ("youtu.be/abc...").
+    if uri.host.nil? && !raw_url.to_s.strip.start_with?("/")
+      return video_id("https://#{raw_url.to_s.strip}")
+    end
+    return nil unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+    return nil unless ALLOWED_HOSTS.include?(uri.host&.downcase)
+
+    candidate =
+      if uri.host&.downcase == "youtu.be"
+        uri.path.to_s.delete_prefix("/").split("/").first
+      elsif uri.path.to_s.start_with?("/embed/", "/shorts/", "/live/")
+        uri.path.to_s.split("/")[2]
+      else
+        Rack::Utils.parse_query(uri.query.to_s)["v"]
+      end
+
+    candidate.presence&.match?(VIDEO_ID_RE) ? candidate : nil
+  end
+
+  # Canonical privacy-enhanced embed URL for a validated id.
+  def self.embed_url(video_id)
+    "https://www.youtube-nocookie.com/embed/#{video_id}"
+  end
+end

--- a/app/services/youtube_url_parser.rb
+++ b/app/services/youtube_url_parser.rb
@@ -44,9 +44,4 @@ class YoutubeUrlParser
 
     candidate.presence&.match?(VIDEO_ID_RE) ? candidate : nil
   end
-
-  # Canonical privacy-enhanced embed URL for a validated id.
-  def self.embed_url(video_id)
-    "https://www.youtube-nocookie.com/embed/#{video_id}"
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,9 @@ Rails.application.routes.draw do
         post "upload_audio", to: "board_images#upload_audio"
         post "reset_audio", to: "board_images#reset_audio"
         post "set_current_audio", to: "board_images#set_current_audio"
+        post "attach_youtube_video", to: "board_images#attach_youtube_video"
+        post "upload_video", to: "board_images#upload_video"
+        post "clear_video", to: "board_images#clear_video"
       end
       collection do
         put "update", to: "board_images#update_multiple"

--- a/lib/tasks/video_demo.rake
+++ b/lib/tasks/video_demo.rake
@@ -1,0 +1,113 @@
+# Seeds the predefined "Video Demo" board: one tile per curated kid-safe
+# YouTube video. Tapping a tile speaks its label and then opens the video in
+# the tile video modal (data["video"] config — see BoardImage#video_config).
+module VideoDemoSeeder
+  BOARD_NAME = "Video Demo".freeze
+  COLUMNS = 3
+
+  # Curated kid-safe videos. REVIEW BEFORE SEEDING PRODUCTION: every entry
+  # must be hand-verified (plays, is the intended video, embeds allowed) —
+  # YouTube ids are not guessable and links rot. The seed task validates URL
+  # shape via YoutubeUrlParser and fails loudly on malformed entries, but it
+  # cannot verify content.
+  CURATED_VIDEOS = [
+    { label: "Baby Shark", url: "https://www.youtube.com/watch?v=XqZsoesa55w" },
+    { label: "Wheels on the Bus", url: "https://www.youtube.com/watch?v=e_04ZrNroTo" },
+    { label: "Twinkle Twinkle", url: "https://www.youtube.com/watch?v=yCjJyiqpAuU" },
+    { label: "Happy and You Know It", url: "https://www.youtube.com/watch?v=l4WNrvVjiTw" },
+    { label: "Head Shoulders Knees and Toes", url: "https://www.youtube.com/watch?v=h4eueDYPTIg" },
+    { label: "Old MacDonald", url: "https://www.youtube.com/watch?v=_6HzoUcx3eo" },
+    { label: "Itsy Bitsy Spider", url: "https://www.youtube.com/watch?v=w_lCi8U49mY" },
+    { label: "Five Little Ducks", url: "https://www.youtube.com/watch?v=pZw9veQ76fo" },
+    { label: "Row Row Row Your Boat", url: "https://www.youtube.com/watch?v=7otAJa3jui8" },
+    { label: "BINGO", url: "https://www.youtube.com/watch?v=9mmF8zOlh_g" },
+  ].freeze
+
+  module_function
+
+  # Same reuse-don't-generate policy as core_boards: prefer an existing public
+  # image with artwork, else create one without queuing generation.
+  def find_or_build_image(label)
+    matches = Image.default_public.where(label: label).order(:created_at)
+    matches.find { |img| img.docs.any? } || matches.last ||
+      Image.default_public.new(label: label) do |img|
+        img.image_prompt = label
+        unless img.save
+          Rails.logger.warn "video_demo: failed to save image #{label.inspect}: #{img.errors.full_messages.join(", ")}"
+        end
+      end
+  end
+
+  def configure_board!(board, admin)
+    board.assign_attributes(
+      description: "A demo board of sing-along videos — tap a tile to hear the " \
+                   "word and watch the video.",
+      predefined: true,
+      published: true,
+      board_type: "default",
+      number_of_columns: COLUMNS,
+      small_screen_columns: COLUMNS,
+      medium_screen_columns: COLUMNS,
+      large_screen_columns: COLUMNS,
+      tags: ["videos", "songs", "demo"],
+    )
+    board.parent = admin
+    board.layout ||= {}
+    board.generate_unique_slug if board.slug.blank?
+    board.save!
+    board
+  end
+end
+
+namespace :video_demo do
+  desc "Create the public 'Video Demo' board (curated kid-safe YouTube tiles). " \
+       "Idempotent — skips when the board already has tiles. ENV: DRY_RUN=1. " \
+       "Usage: bin/rails video_demo:seed"
+  task seed: :environment do
+    ActiveRecord::Base.logger.level = Logger::WARN
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+    dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase)
+
+    # Fail loudly on a malformed curated entry before touching the database.
+    parsed = VideoDemoSeeder::CURATED_VIDEOS.map do |entry|
+      youtube_id = YoutubeUrlParser.video_id(entry[:url])
+      raise "video_demo: unparseable YouTube URL for #{entry[:label].inspect}: #{entry[:url]}" unless youtube_id
+      entry.merge(youtube_id: youtube_id)
+    end
+
+    puts ""
+    puts "=" * 60
+    puts "Video Demo board seeding#{dry_run ? " (DRY RUN)" : ""}"
+    puts "=" * 60
+    puts "  Admin user: #{admin.email} (id=#{admin.id})"
+    puts "  Videos (#{parsed.size}): #{parsed.map { |v| v[:label] }.join(", ")}"
+
+    board = Board.find_or_initialize_by(
+      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
+    )
+    if board.persisted? && board.board_images.exists?
+      puts "  Board already seeded (id=#{board.id}, #{board.board_images.count} tiles) — skipping."
+      next
+    end
+    next if dry_run
+
+    VideoDemoSeeder.configure_board!(board, admin)
+    parsed.each do |entry|
+      image = VideoDemoSeeder.find_or_build_image(entry[:label])
+      board_image = board.add_image(image.id)
+      unless board_image
+        puts "  ! could not add tile for #{entry[:label].inspect} — skipped"
+        next
+      end
+      board_image.set_youtube_video!(entry[:youtube_id])
+      puts "  + #{entry[:label]} (#{entry[:youtube_id]})"
+    end
+
+    board.update_column(:layout, {}) if board.layout.nil?
+    %w[lg md sm].each { |screen| board.calculate_grid_layout_for_screen_size(screen, true) }
+    board.set_current_word_list
+    board.save!
+
+    puts "  Done: board id=#{board.id}, slug=#{board.slug}, #{board.board_images.count} tiles."
+  end
+end

--- a/spec/fixtures/files/tiny_video.mp4
+++ b/spec/fixtures/files/tiny_video.mp4
@@ -1,0 +1,1 @@
+fake-mp4-bytes-for-upload-spec

--- a/spec/requests/api/board_images_idor_spec.rb
+++ b/spec/requests/api/board_images_idor_spec.rb
@@ -61,6 +61,25 @@ RSpec.describe "API::BoardImages IDOR", type: :request do
            headers: auth_headers(user)
       expect(response).to have_http_status(:not_found)
     end
+
+    it "POST /api/board_images/:id/attach_youtube_video" do
+      post "/api/board_images/#{other_board_image.id}/attach_youtube_video",
+           params: { url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/upload_video" do
+      post "/api/board_images/#{other_board_image.id}/upload_video",
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /api/board_images/:id/clear_video" do
+      post "/api/board_images/#{other_board_image.id}/clear_video",
+           headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "the owner and admins are not blocked (no regression)" do

--- a/spec/requests/api/board_images_video_spec.rb
+++ b/spec/requests/api/board_images_video_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+# Tile video actions: video config lives in board_images.data["video"] and is
+# only writable through the dedicated validated endpoints — never through the
+# generic update path (which strips the key).
+RSpec.describe "API::BoardImages video", type: :request do
+  let!(:user)        { create(:user) }
+  let!(:board)       { create(:board, user: user) }
+  let!(:board_image) { create(:board_image, board: board) }
+
+  let(:valid_youtube_url) { "https://www.youtube.com/watch?v=dQw4w9WgXcQ" }
+
+  def upload_file(content_type: "video/mp4")
+    Rack::Test::UploadedFile.new(
+      Rails.root.join("spec/fixtures/files/tiny_video.mp4"),
+      content_type,
+    )
+  end
+
+  describe "POST /api/board_images/:id/attach_youtube_video" do
+    it "persists only the parsed video id" do
+      post "/api/board_images/#{board_image.id}/attach_youtube_video",
+           params: { url: valid_youtube_url },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      video = board_image.reload.data["video"]
+      expect(video).to eq({ "source" => "youtube", "youtube_id" => "dQw4w9WgXcQ" })
+      expect(JSON.parse(response.body).dig("data", "video", "youtube_id")).to eq("dQw4w9WgXcQ")
+    end
+
+    it "rejects a non-YouTube URL with 422 and writes nothing" do
+      post "/api/board_images/#{board_image.id}/attach_youtube_video",
+           params: { url: "https://evil.example/watch?v=dQw4w9WgXcQ" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("invalid_youtube_url")
+      expect(board_image.reload.data&.dig("video")).to be_nil
+    end
+
+    it "preserves unrelated data keys" do
+      board_image.update!(data: { "hide_label" => true })
+      post "/api/board_images/#{board_image.id}/attach_youtube_video",
+           params: { url: valid_youtube_url },
+           headers: auth_headers(user)
+
+      expect(board_image.reload.data["hide_label"]).to eq(true)
+      expect(board_image.data["video"]["youtube_id"]).to eq("dQw4w9WgXcQ")
+    end
+  end
+
+  describe "POST /api/board_images/:id/upload_video" do
+    it "attaches an mp4 and stores the upload config" do
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      board_image.reload
+      expect(board_image.video_clip).to be_attached
+      video = board_image.data["video"]
+      expect(video["source"]).to eq("upload")
+      expect(video["content_type"]).to eq("video/mp4")
+      expect(video["url"]).to be_present
+    end
+
+    it "rejects a disallowed content type with 422 and attaches nothing" do
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file(content_type: "video/quicktime") },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("invalid_video_type")
+      expect(board_image.reload.video_clip).not_to be_attached
+    end
+
+    it "rejects an oversized file with 422" do
+      stub_const("BoardImage::MAX_VIDEO_BYTES", 10)
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("video_too_large")
+      expect(board_image.reload.video_clip).not_to be_attached
+    end
+
+    it "rejects a missing file with 422" do
+      post "/api/board_images/#{board_image.id}/upload_video",
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("video_required")
+    end
+
+    it "replaces a previous youtube config" do
+      board_image.set_youtube_video!("dQw4w9WgXcQ")
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file },
+           headers: auth_headers(user)
+
+      video = board_image.reload.data["video"]
+      expect(video["source"]).to eq("upload")
+      expect(video["youtube_id"]).to be_nil
+    end
+  end
+
+  describe "POST /api/board_images/:id/clear_video" do
+    it "removes the video config and purges the clip, keeping other data keys" do
+      board_image.update!(data: { "hide_label" => true })
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file },
+           headers: auth_headers(user)
+      expect(board_image.reload.video_clip).to be_attached
+
+      post "/api/board_images/#{board_image.id}/clear_video",
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      board_image.reload
+      expect(board_image.data["video"]).to be_nil
+      expect(board_image.data["hide_label"]).to eq(true)
+    end
+  end
+
+  describe "generic update cannot touch video config" do
+    it "strips an injected video key instead of persisting it" do
+      patch "/api/board_images/#{board_image.id}",
+            params: { board_image: { data: { video: { source: "upload", url: "https://evil.example/x.mp4" } } } },
+            headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(board_image.reload.data&.dig("video")).to be_nil
+    end
+
+    it "does not clobber an existing video config on unrelated updates" do
+      board_image.set_youtube_video!("dQw4w9WgXcQ")
+      patch "/api/board_images/#{board_image.id}",
+            params: { board_image: { bg_color: "#ffffff", data: { hide_label: true, video: nil } } },
+            headers: auth_headers(user),
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      board_image.reload
+      expect(board_image.data["video"]["youtube_id"]).to eq("dQw4w9WgXcQ")
+      expect(board_image.data["hide_label"]).to eq(true)
+    end
+  end
+
+  describe "board payload passthrough" do
+    it "includes the video config in the bulk board serialization via data" do
+      board_image.set_youtube_video!("dQw4w9WgXcQ")
+      payload = board.api_view_with_predictive_images(user)
+      tile = payload[:images].find { |img| img[:id] == board_image.id }
+      expect(tile[:data]["video"]["youtube_id"]).to eq("dQw4w9WgXcQ")
+    end
+  end
+
+  describe "OBF export" do
+    it "adds ext_saw_video keys only when a video is configured" do
+      expect(board_image.to_obf_button_format).not_to have_key(:ext_saw_video_source)
+
+      board_image.set_youtube_video!("dQw4w9WgXcQ")
+      btn = board_image.reload.to_obf_button_format
+      expect(btn[:ext_saw_video_source]).to eq("youtube")
+      expect(btn[:ext_saw_video_youtube_id]).to eq("dQw4w9WgXcQ")
+    end
+  end
+end

--- a/spec/services/youtube_url_parser_spec.rb
+++ b/spec/services/youtube_url_parser_spec.rb
@@ -41,10 +41,4 @@ RSpec.describe YoutubeUrlParser do
     end
   end
 
-  describe ".embed_url" do
-    it "builds the privacy-enhanced nocookie embed URL" do
-      expect(described_class.embed_url("dQw4w9WgXcQ"))
-        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
-    end
-  end
 end

--- a/spec/services/youtube_url_parser_spec.rb
+++ b/spec/services/youtube_url_parser_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe YoutubeUrlParser do
+  describe ".video_id" do
+    valid_cases = {
+      "standard watch URL" => "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "watch URL with extra params" => "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&si=abc",
+      "short youtu.be URL" => "https://youtu.be/dQw4w9WgXcQ",
+      "youtu.be with query cruft" => "https://youtu.be/dQw4w9WgXcQ?si=xyz123",
+      "embed URL" => "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "nocookie embed URL" => "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+      "shorts URL" => "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "mobile host" => "https://m.youtube.com/watch?v=dQw4w9WgXcQ",
+      "no scheme" => "youtube.com/watch?v=dQw4w9WgXcQ",
+      "http scheme" => "http://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    }
+
+    valid_cases.each do |desc, url|
+      it "extracts the id from a #{desc}" do
+        expect(described_class.video_id(url)).to eq("dQw4w9WgXcQ")
+      end
+    end
+
+    invalid_cases = {
+      "nil" => nil,
+      "blank" => "",
+      "non-YouTube host" => "https://vimeo.com/12345",
+      "lookalike host" => "https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ",
+      "javascript scheme" => "javascript:alert(1)",
+      "bare id (not a URL)" => "dQw4w9WgXcQ",
+      "wrong id length" => "https://www.youtube.com/watch?v=short",
+      "id with invalid chars" => "https://www.youtube.com/watch?v=dQw4w9WgXc!",
+      "channel URL (no video)" => "https://www.youtube.com/@somechannel",
+      "malformed URI" => "https://youtube.com/watch?v=%%%",
+    }
+
+    invalid_cases.each do |desc, url|
+      it "rejects #{desc}" do
+        expect(described_class.video_id(url)).to be_nil
+      end
+    end
+  end
+
+  describe ".embed_url" do
+    it "builds the privacy-enhanced nocookie embed URL" do
+      expect(described_class.embed_url("dQw4w9WgXcQ"))
+        .to eq("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Board tiles can now carry an optional video: tap the tile in view/use mode and it speaks its label, then opens a video player (frontend PR: brittanyjohns/itty-bitty-frontend — claude/video-tiles).

- **Data model:** video config lives in `board_images.data["video"]` (`{source: "youtube", youtube_id}` or `{source: "upload", url, content_type}`). No migration; the `data` jsonb already flows through both board serializers, so board-load performance and eager loading are untouched.
- **Endpoints** (all owner-scoped via `set_owned_board_image` → 404 for non-owners, and gated by `check_board_image_editable!`):
  - `POST /api/board_images/:id/attach_youtube_video` — parses the pasted URL with the new `YoutubeUrlParser` (host allowlist, 11-char id validation) and persists **only the id**; raw URLs are discarded so client input can never reach an iframe src.
  - `POST /api/board_images/:id/upload_video` — multipart mp4/webm only, 25 MB cap enforced server-side, attaches to `has_one_attached :video_clip`, caches a CDN-style URL (same pattern as `audio_url`).
  - `POST /api/board_images/:id/clear_video` — removes config + purges the blob.
- The generic `update` action strips the `video` key so it can be neither injected nor clobbered outside the validated endpoints.
- OBF export adds `ext_saw_video_*` keys (videoless tiles export byte-identical).
- `video_demo:seed` rake task builds a predefined "Video Demo" board from a curated YouTube list.

⚠️ **Before seeding production:** the curated links in `lib/tasks/video_demo.rake` need hand-verification (play + correct video + embedding allowed) — flagged in the file.

Known v1 limits (follow-up issues): the 30s duration cap is client-side only (server-side needs ffmpeg), no OBF import round-trip.

## Test plan

- `bundle exec rspec spec/services/youtube_url_parser_spec.rb spec/requests/api/board_images_video_spec.rb spec/requests/api/board_images_idor_spec.rb spec/requests/api/board_images_label_case_spec.rb spec/models/board_image_spec.rb` — all green (66 examples, 0 failures): URL-shape table for the parser, happy/sad paths for all three endpoints, injection-guard specs on generic update, IDOR 404s, bulk-payload passthrough, OBF export.
- `DRY_RUN=1 bin/rails video_demo:seed` verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)