### PR TITLE
feat(board-builder): unfreeze built pages, align the nav row across every set page

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -631,31 +631,49 @@ still works for backward compat.
   predictive links, scoped to the owner's boards). So tapping a folder navigates
   without speaking the folder's own label; word tiles are untouched.
   `update_column` skips the audio hook/validations. Idempotent.
-- **Scope classification + sub-board freeze.**
-  `BuildBoardSetJob#finalize_sub_boards!` runs at the same end-of-build chokepoint
-  (beside `mute_dynamic_tile_names!`) and, for every `builder_child` board in the
-  set (everything but the root, walked via `set_board_ids`): sets
-  `settings["freeze_board"] = true` and re-saves it so `Board#check_is_sub_board`
-  recomputes against the now-wired `predictive_board_id` links and sets the
-  `sub_board` column **true**. Two problems this fixes: (1) child pages used to
-  leak into the **`main_boards`** scope (`sub_board: [false, nil]`) because their
-  last save happened before the parent linked them, so `sub_board` stayed false;
-  (2) navigating into a child page auto-returned home on the next tap. Freezing is
-  the lever — there is **no separate `return_home` setting**; `freeze_board: true`
-  is what stops auto-return, and the `frozen`/`freeze_parent_board`/`board_frozen`
-  flags the api_view exposes are what the frontend's return-home affordance keys
-  off. The **root is intentionally left unfrozen and `sub_board: false`** so it
-  stays a main board. Default-on but user-overridable in the editor. Idempotent.
+- **Scope classification.** `BuildBoardSetJob#classify_sub_boards!` runs at the
+  same end-of-build chokepoint (beside `mute_dynamic_tile_names!`) and re-saves
+  every `builder_child` board in the set (everything but the root, walked via
+  `set_board_ids`) so `Board#check_is_sub_board` recomputes against the now-wired
+  `predictive_board_id` links and sets the `sub_board` column **true**. Without
+  it child pages leak into the **`main_boards`** scope (`sub_board: [false, nil]`)
+  because their last save happened before the parent linked them. The **root
+  keeps `sub_board: false`** so it stays a main board. Idempotent.
+  - **Builder pages are NOT frozen.** They behave like any other board — a word
+    tap returns to home. (Freezing is still available per-board; builder sets
+    just don't opt into it. There is no separate `return_home` setting:
+    `freeze_board: true` is what stops auto-return, and the
+    `frozen`/`freeze_parent_board`/`board_frozen` flags the api_view exposes are
+    what the frontend's return-home affordance keys off.) Sets built before this
+    was true are unfrozen by `rake board_builder:reclassify_builder_sets`.
   - **The root is pinned as a main board in the model, not just by being skipped
-    here.** The seed's child pages each carry an authored **"Home" tile** whose
-    `predictive_board_id` points back at the root, so once those links are wired
-    the root *has* parent boards — and any later `root.save!` (e.g.
-    `allow_scroll_if_grown!`) would flip it to `sub_board: true` and drop it out
-    of the `main_boards` scope / the communicator dashboard. `Board#check_is_sub_board`
-    now **short-circuits to `sub_board: false` for any `settings["builder_root"]`
-    board**, regardless of inbound links, so the Home tiles keep working as
-    navigation while the root stays a main board. `rake board_builder:reclassify_builder_sets`
-    re-saves existing roots, so the guard heals already-built sets too.
+    here.** Every child page carries an authored tile whose `predictive_board_id`
+    points back at the root (the **self tile** — see the nav-row rule below), so
+    once those links are wired the root *has* parent boards, and any later
+    `root.save!` (e.g. `allow_scroll_if_grown!`) would flip it to
+    `sub_board: true` and drop it out of the `main_boards` scope / the
+    communicator dashboard. `Board#check_is_sub_board` **short-circuits to
+    `sub_board: false` for any `settings["builder_root"]` board**, regardless of
+    inbound links, so the back-links keep working as navigation while the root
+    stays a main board. `rake board_builder:reclassify_builder_sets` re-saves
+    existing roots, so the guard heals already-built sets too.
+- **The nav row is identical on every board in a set (motor planning).** The
+  seeded set's root authors a bottom **nav row** of folder tiles; every child
+  reproduces it **cell-for-cell** at the root's grid dimensions, so a category is
+  the same reach from any page. The tile for the page you're on links back to the
+  **root** rather than at itself — it's both the you-are-here anchor and the way
+  home, which is why there's no separate `Home` tile. The rule, its two authoring
+  traps (button-id stability, `TileDeduper` label collisions), and the enforcing
+  spec (`spec/db/seeds/board_builder_sets_spec.rb`) are documented in
+  `db/seeds/board_builder_sets/README.md`.
+  - The **self tile is the one folder tile that speaks** — `mute_dynamic_tile_names!`
+    exempts a dynamic tile whose label matches its own board's name.
+  - Alignment holds on the **lg** layout only. `Boards::ScreenReflow` repacks
+    md/sm from the lg reading order and compacts gaps, so the nav row does not
+    stay pinned to the bottom row on phones/tablets.
+  - Built sets are **clones taken at build time**, so reseeding an aligned
+    template only affects **new** builds; already-built sets keep the layout they
+    were cloned with.
 - **Built roots register as `in_use`.** The set's root lives **directly** on the
   communicator (the `ChildBoard` has `board_id = root.id`, `original_board_id =
   nil` — unlike the clone-source `assign_boards`/`assign_accounts` path). So
@@ -684,7 +702,7 @@ still works for backward compat.
 - **Backfill for pre-fix sets:** `rake board_builder:reclassify_builder_sets`
   (dry-run by default; `DRY_RUN=false` to apply, `USER_ID=N` to scope) re-saves
   each existing built set so the root recomputes `in_use` and every child page
-  gets `freeze_board` + `sub_board`. For the `in_use` flag alone (both
+  gets `sub_board` and has `freeze_board` **cleared**. For the `in_use` flag alone (both
   directions, including boards wrongly stuck at `true` from the nil-id bug),
   `rake boards:recalculate_in_use` (dry-run by default; `DRY_RUN=false` to
   apply) recomputes the flag straight from the `child_boards` rows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed — Board Builder pages are no longer frozen
+- Pages inside a built board set now behave like any other board: tapping a word
+  returns to the home board. Previously every page of a built set was created
+  **frozen**, which kept you on that page after a tap.
+- Freezing is unchanged as a per-board option — builder sets simply don't turn it
+  on by default.
+- Existing built sets are unfrozen by
+  `DRY_RUN=false rake board_builder:reclassify_builder_sets` (dry-run by default,
+  `USER_ID=N` to scope to one user).
+
+### Fixed — Board Builder nav row now lines up across a whole set
+- The category strip along the bottom of a built set (People, Feelings, Food, …)
+  now sits in the **exact same grid cell on every page**, so a word is the same
+  reach no matter where you are — what AAC motor planning depends on. Previously
+  the strip drifted: `Drinks` was missing from every sub-page, which shifted
+  every tile after it one cell left, and Core 84's sub-pages were a row shorter
+  than the home board and dropped `Time`, `Describe` and `School` entirely.
+- The tile for the page you're on is now **present rather than a blank gap** — on
+  the People page, `People` sits exactly where you tapped it, speaks its label,
+  and takes you back home. It replaces the old `Home` tile.
+- Applies to **newly built sets**. Sets are copied from the template when built,
+  so already-built sets keep their existing layout.
+
 ### Added — Board Builder no longer requires a communicator
 - `POST /api/v1/board_builder` now accepts an **omitted `communicator_id`** and
   builds an **unattached** board set owned by the user, which they can assign to

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -700,11 +700,12 @@ class Board < ApplicationRecord
 
   def check_is_sub_board
     # A Board Builder ROOT is a MAIN board that lives directly on the
-    # communicator, even though each of its child pages carries a "Home" tile
-    # whose predictive_board_id points back at the root. Those back-links would
-    # otherwise make the root look like a sub-board (it has "parent" boards) and
-    # drop it out of the main_boards scope / the communicator's dashboard. Pin it
-    # as a main board regardless of who links to it.
+    # communicator, even though each of its child pages carries a self tile (the
+    # "People" tile on the People page) whose predictive_board_id points back at
+    # the root. Those back-links would otherwise make the root look like a
+    # sub-board (it has "parent" boards) and drop it out of the main_boards scope
+    # / the communicator's dashboard. Pin it as a main board regardless of who
+    # links to it.
     if builder_root?
       self.sub_board = false
       remove_tag(IS_SUB_BOARD_TAG)

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -215,22 +215,56 @@ module VocabSets
     end
   end
 
-  # Destroy board_images on each seeded board whose label is no longer present in
-  # the source OBF's buttons (e.g. #276 removed please/thank you/and from the
-  # homes, "more" from fringe pages, and the self-link folder tiles). Matching is
-  # by image label, case-insensitively — the same value Board.from_obf resolves a
-  # button to. Admin-owned set boards only; user clones are separate rows.
+  # Destroy board_images on each seeded board whose authored button is gone from
+  # the source OBF (e.g. #276 removed please/thank you/and from the homes, "more"
+  # from fringe pages, and the self-link folder tiles).
+  #
+  # A tile stamped with an obf_button_id is matched by THAT id — the same stable
+  # key repair_layout! pins coordinates with, and the only one that can tell two
+  # buttons sharing a label apart. Label matching alone is case-insensitive, so a
+  # removed folder tile survived whenever the board also authored a word of the
+  # same name: dropping the "Home" folder from places.obf left the tile in place
+  # (the page still authors the WORD "home"), and repair_layout! then couldn't
+  # move it — its button id is gone from the source — so it kept its old cell and
+  # collided with whatever now sits there. Tiles seeded before button ids were
+  # stamped carry none, and still fall back to the label check.
+  #
+  # Admin-owned set boards only; user clones are separate rows.
   def prune_removed_tiles!(slug, boards_by_obf_id)
     labels_by_id = source_labels_by_obf_id(slug)
+    button_ids_by_id = source_button_ids_by_obf_id(slug)
 
     boards_by_obf_id.each do |obf_id, board|
       next unless labels_by_id.key?(obf_id) # never blank-prune a board we can't source
 
       keep = labels_by_id[obf_id].map { |l| l.to_s.strip.downcase }
+      keep_button_ids = button_ids_by_id[obf_id] || []
       board.board_images.includes(:image).find_each do |bi|
+        button_id = bi.data.is_a?(Hash) ? bi.data["obf_button_id"].presence : nil
+        if button_id
+          bi.destroy unless keep_button_ids.include?(button_id.to_s)
+          next
+        end
+
         label = (bi.image&.label || bi.label).to_s.strip.downcase
         bi.destroy unless keep.include?(label)
       end
+    end
+  end
+
+  # { obf_id => [button ids] } parsed straight from the authored source for a
+  # slug — the stable ids prune_removed_tiles! / repair_layout! match tiles on.
+  def source_button_ids_by_obf_id(slug)
+    dir = SETS_DIR.join(slug)
+    manifest = JSON.parse(File.read(dir.join("manifest.json")))
+    paths = (manifest.dig("paths", "boards") || {}).values.uniq
+
+    paths.each_with_object({}) do |rel, acc|
+      file = dir.join(rel)
+      next unless File.file?(file)
+
+      obf = JSON.parse(File.read(file))
+      acc[obf["id"].to_s] = Array(obf["buttons"]).filter_map { |b| b["id"].presence&.to_s }
     end
   end
 

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -77,7 +77,7 @@ class BuildBoardSetJob
       # boards the build services add outside SeededSetCloner/BoardTreeBuilder.
       attach_set_to_group!(root, board_group_id)
       mute_dynamic_tile_names!(root)
-      finalize_sub_boards!(root)
+      classify_sub_boards!(root)
       reflow_screen_layouts!(root)
       set_sub_board_previews_from_tiles!(root)
       generate_preview!(root)
@@ -197,32 +197,34 @@ class BuildBoardSetJob
   # "mute_name" flag to true on every dynamic tile across the freshly built set
   # (root + linked sub-boards). Display-only flag; update_column skips the audio
   # hook + validations. Idempotent — a no-op once already muted.
+  #
+  # The SELF tile is the exception. Each seeded page carries the nav-row tile for
+  # its own category (the "People" tile on the People page), positioned to match
+  # the root's cell and linked back to the root. It's the page's you-are-here
+  # anchor and its way home, so it speaks its label like any word tile.
+  # Identified by label == its own board's name.
   def mute_dynamic_tile_names!(root)
+    names_by_board_id = Board.where(id: set_board_ids(root)).pluck(:id, :name).to_h
+
     BoardImage
-      .where(board_id: set_board_ids(root))
+      .where(board_id: names_by_board_id.keys)
       .where.not(predictive_board_id: nil)
       .where("predictive_board_id <> board_id")
       .find_each do |bi|
         data = bi.data || {}
         next if data["mute_name"] == true
+        next if self_tile?(bi, names_by_board_id[bi.board_id])
 
         bi.update_column(:data, data.merge("mute_name" => true))
       end
   end
 
-  # Every sub-board of a builder set (the builder_child pages — everything in
-  # the set EXCEPT the root) is finalized as a real "page":
-  #
-  #   - settings["freeze_board"] = true so navigating into it doesn't auto-return
-  #     to home on the next tap; the frontend's return-home affordance keys off
-  #     the freeze_parent_board/board_frozen flags the api_view then exposes.
-  #   - re-saved so Board#check_is_sub_board recomputes against the now-wired
-  #     predictive_board_id links and sets the sub_board column true. Without this
-  #     the children leaked into the `main_boards` scope (their last save happened
-  #     before the parent linked them, so sub_board stayed false).
-  #
-  # The root is intentionally left unfrozen and sub_board=false so it stays a
-  # main board. A no-op once already frozen + classified (idempotent on retry).
+  def self_tile?(board_image, board_name)
+    return false if board_name.blank?
+
+    board_image.label.to_s.strip.casecmp?(board_name.to_s.strip)
+  end
+
   # Derive each board's medium/small layout from its authored large layout so
   # the whole set reads well on tablets and phones — the build grows the grid
   # with interest tiles, which can overflow the narrower sm/md grids unless we
@@ -235,13 +237,23 @@ class BuildBoardSetJob
     end
   end
 
-  def finalize_sub_boards!(root)
+  # Every page of a builder set (the builder_child boards — everything in the set
+  # EXCEPT the root) is re-saved so Board#check_is_sub_board recomputes against
+  # the now-wired predictive_board_id links and sets the sub_board column true.
+  # Without this the children leak into the `main_boards` scope: their last save
+  # happened before the parent linked them, so sub_board stayed false.
+  #
+  # The root keeps sub_board=false so it stays a main board — check_is_sub_board
+  # pins a builder_root? explicitly, because every child links back to it.
+  #
+  # Builder pages are deliberately NOT frozen: they behave like any other board,
+  # so a word tap returns to home. (lib/tasks/board_builder.rake unfreezes sets
+  # built before that was true.) Idempotent on retry.
+  def classify_sub_boards!(root)
     child_ids = set_board_ids(root) - [root.id]
     Board.where(id: child_ids).find_each do |board|
-      settings = board.settings || {}
-      next if settings["freeze_board"] == true && board.sub_board == true
+      next if board.sub_board == true
 
-      board.settings = settings.merge("freeze_board" => true)
       board.save! # save recomputes check_is_sub_board => sub_board: true
     end
   end

--- a/db/seeds/board_builder_sets/README.md
+++ b/db/seeds/board_builder_sets/README.md
@@ -116,8 +116,8 @@ same namespaced ids.
 Why: `Board.from_obf` resolves the target board by `(user_id, obf_id)`, and both
 sets seed as the same admin user. Before namespacing, Core 60 and Core 84 shared
 the bare ids (`people`, `food`, …), so both roots ended up linked to **one**
-shared fringe board and the last set seeded won the in-set Home pointer — leaving
-the other set's cloned pages with dead Home tiles (#278).
+shared fringe board and the last set seeded won that page's back-link to its root
+— leaving the other set's cloned pages with a dead way home (#278).
 
 What is NOT namespaced:
 
@@ -129,6 +129,39 @@ What is NOT namespaced:
 Adding a board to a set = give its `.obf` a `"<slug>:<name>"` id and add the same
 key to the manifest. The seeder's destructive sync (below) cleans up any board or
 tile you remove.
+
+## The nav row must be identical on every board in a set
+
+The root's **bottom row** is the set's **nav row** — the strip of folder tiles
+that reaches every page. It is authored under one rule, enforced by
+`spec/db/seeds/board_builder_sets_spec.rb`:
+
+> Every child board has the **same grid dimensions as the root** and reproduces
+> the root's nav row **cell-for-cell**. On the page you are currently on, that
+> page's own tile links back to the **root** instead of at itself. Any folder
+> tile the root places **outside** the nav row (Core 84's `More`) sits at that
+> same cell on every child.
+
+Why: motor planning. An AAC user learns *where* a word is, not what it looks
+like — `Food` must be the same cell on every page of the set, so the reach is
+the same everywhere. The tile you just tapped stays put under your finger and
+becomes the way back.
+
+This is why there is no `Home` tile: the self-tile is home. On the People page,
+`People` is both the you-are-here anchor and the way back to the root. It is the
+one nav tile that speaks its label (`BuildBoardSetJob#mute_dynamic_tile_names!`
+mutes folder tiles, but exempts a tile whose label matches its own board's name).
+
+Two traps when editing a nav row:
+
+- **Don't renumber existing buttons.** The seeder upserts tiles on the authored
+  button `id` (`obf_button_id`) and re-pins their cells by it, so *moving* a
+  button = keep its id, change only `grid.order`. A new id forks a new tile.
+- **Don't author the same label twice with the same kind** (word vs folder) on
+  one board — `Boards::TileDeduper` collapses those on seed, keeping the
+  lowest-position copy, which silently deletes the nav-row one. That's why
+  `more.obf` carries `this`/`that` only in the nav row, and why `food.obf`'s
+  `Drinks` link lives in the nav row rather than in the content grid.
 
 ## Fringe board names are load-bearing
 

--- a/db/seeds/board_builder_sets/core-60/boards/body.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/body.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        21,
+        29,
         22,
         23,
         24,
+        30,
         25,
         26,
-        null,
+        31,
         28,
-        null,
-        null
+        32
       ]
     ]
   },
@@ -183,14 +183,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -237,6 +229,32 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 29,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 30,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "Body",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/drinks.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/drinks.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        17,
+        25,
         18,
         19,
         20,
+        26,
         21,
         22,
         23,
         24,
-        null,
-        null
+        27
       ]
     ]
   },
@@ -158,14 +158,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 17,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 18,
       "label": "People",
       "part_of_speech": "noun",
@@ -220,6 +212,24 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 25,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 26,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 27,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/feelings.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/feelings.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        21,
+        29,
         22,
-        null,
+        30,
         24,
+        31,
         25,
         26,
         27,
         28,
-        null,
-        null
+        32
       ]
     ]
   },
@@ -183,14 +183,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -237,6 +229,32 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 29,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 30,
+      "label": "Feelings",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/food.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/food.obf
@@ -32,7 +32,7 @@
         null
       ],
       [
-        21,
+        null,
         null,
         null,
         null,
@@ -68,16 +68,16 @@
         null
       ],
       [
-        22,
+        32,
         23,
         24,
-        null,
+        33,
+        21,
         26,
         27,
         28,
         29,
-        null,
-        null
+        34
       ]
     ]
   },
@@ -191,14 +191,6 @@
       }
     },
     {
-      "id": 22,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 23,
       "label": "People",
       "part_of_speech": "noun",
@@ -250,6 +242,24 @@
       "id": 31,
       "label": "more",
       "part_of_speech": "social"
+    },
+    {
+      "id": 32,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 33,
+      "label": "Food",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/more.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/more.obf
@@ -15,8 +15,8 @@
         5,
         6,
         7,
-        8,
-        9,
+        null,
+        null,
         10
       ],
       [
@@ -68,16 +68,16 @@
         null
       ],
       [
-        21,
+        8,
         22,
         23,
         24,
+        34,
         25,
         26,
         27,
-        null,
-        null,
-        null
+        35,
+        9
       ]
     ]
   },
@@ -183,14 +183,6 @@
       "part_of_speech": "adverb"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -252,6 +244,22 @@
       "id": 33,
       "label": "and",
       "part_of_speech": "conjunction"
+    },
+    {
+      "id": 34,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "More",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/people.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/people.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        17,
-        null,
+        25,
+        26,
         19,
         20,
+        27,
         21,
         22,
         23,
         24,
-        null,
-        null
+        28
       ]
     ]
   },
@@ -163,14 +163,6 @@
       "part_of_speech": "noun"
     },
     {
-      "id": 17,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 19,
       "label": "Feelings",
       "part_of_speech": "noun",
@@ -217,6 +209,32 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 25,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 26,
+      "label": "People",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 27,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 28,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/places.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/places.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        21,
+        29,
         22,
         23,
         24,
+        30,
         25,
-        null,
+        31,
         27,
         28,
-        null,
-        null
+        32
       ]
     ]
   },
@@ -183,14 +183,6 @@
       "part_of_speech": "preposition"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -237,6 +229,32 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 29,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 30,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "Places",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-60/boards/play.obf
+++ b/db/seeds/board_builder_sets/core-60/boards/play.obf
@@ -68,16 +68,16 @@
         null
       ],
       [
-        21,
+        29,
         22,
         23,
         24,
-        null,
+        30,
+        31,
         26,
         27,
         28,
-        null,
-        null
+        32
       ]
     ]
   },
@@ -183,14 +183,6 @@
       "part_of_speech": "noun"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-60.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -237,6 +229,32 @@
       "load_board": {
         "path": "boards/more.obf"
       }
+    },
+    {
+      "id": 29,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 30,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "Play",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-60.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/body.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/body.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Body",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        28,
+        null
+      ],
+      [
+        30,
         22,
         23,
         24,
+        31,
         25,
         26,
-        29,
-        28,
-        null,
-        null,
-        null,
-        null
+        32,
+        33,
+        34,
+        35,
+        36
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -251,9 +257,54 @@
       }
     },
     {
-      "id": 29,
-      "label": "body",
-      "part_of_speech": "noun"
+      "id": 30,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 31,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "Body",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/describe.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/describe.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Describe",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        28,
+        null
+      ],
+      [
+        30,
         22,
         23,
         24,
+        31,
         25,
         26,
         27,
-        28,
-        29,
-        null,
-        null,
-        null
+        32,
+        33,
+        34,
+        35
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -259,9 +265,46 @@
       }
     },
     {
-      "id": 29,
-      "label": "describe",
-      "part_of_speech": "noun"
+      "id": 30,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 31,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/drinks.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/drinks.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Drinks",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        17,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        24,
+        null
+      ],
+      [
+        26,
         18,
         19,
         20,
+        27,
         21,
         22,
         23,
-        24,
-        25,
-        null,
-        null,
-        null
+        28,
+        29,
+        30,
+        31
       ]
     ]
   },
@@ -170,14 +184,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 17,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 18,
       "label": "People",
       "part_of_speech": "noun",
@@ -234,9 +240,46 @@
       }
     },
     {
-      "id": 25,
-      "label": "drinks",
-      "part_of_speech": "noun"
+      "id": 26,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 27,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 28,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 29,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 30,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/feelings.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/feelings.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Feelings",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        28,
+        null
+      ],
+      [
+        30,
         22,
-        29,
+        31,
         24,
+        32,
         25,
         26,
         27,
-        28,
-        null,
-        null,
-        null,
-        null
+        33,
+        34,
+        35,
+        36
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "adjective"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -251,9 +257,54 @@
       }
     },
     {
-      "id": 29,
-      "label": "feelings",
-      "part_of_speech": "noun"
+      "id": 30,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 31,
+      "label": "Feelings",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/food.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/food.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Food",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -29,7 +29,7 @@
         17,
         18,
         19,
-        21,
+        null,
         31,
         20,
         null,
@@ -78,18 +78,32 @@
         null
       ],
       [
-        22,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        29,
+        null
+      ],
+      [
+        33,
         23,
         24,
-        32,
+        34,
+        21,
         26,
         27,
         28,
-        29,
-        null,
-        null,
-        null,
-        null
+        35,
+        36,
+        37,
+        38
       ]
     ]
   },
@@ -203,14 +217,6 @@
       }
     },
     {
-      "id": 22,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 23,
       "label": "People",
       "part_of_speech": "noun",
@@ -264,9 +270,46 @@
       "part_of_speech": "social"
     },
     {
-      "id": 32,
-      "label": "food",
-      "part_of_speech": "noun"
+      "id": 33,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 34,
+      "label": "Food",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 37,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 38,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/more.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/more.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "More",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -15,8 +15,8 @@
         5,
         6,
         7,
-        8,
-        9,
+        null,
+        null,
         10,
         11,
         12
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        35,
+        null
+      ],
+      [
+        8,
         22,
         23,
         24,
+        36,
         25,
         26,
         27,
-        34,
-        null,
-        null,
-        null,
-        null
+        37,
+        38,
+        39,
+        9
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "adverb"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -266,9 +272,44 @@
       "part_of_speech": "conjunction"
     },
     {
-      "id": 34,
-      "label": "more",
-      "part_of_speech": "noun"
+      "id": 35,
+      "label": "More",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 37,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 38,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 39,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/people.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/people.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "People",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        17,
-        25,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        24,
+        null
+      ],
+      [
+        26,
+        27,
         19,
         20,
+        28,
         21,
         22,
         23,
-        24,
-        null,
-        null,
-        null,
-        null
+        29,
+        30,
+        31,
+        32
       ]
     ]
   },
@@ -175,14 +189,6 @@
       "part_of_speech": "noun"
     },
     {
-      "id": 17,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 19,
       "label": "Feelings",
       "part_of_speech": "noun",
@@ -231,9 +237,54 @@
       }
     },
     {
-      "id": 25,
-      "label": "people",
-      "part_of_speech": "noun"
+      "id": 26,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 27,
+      "label": "People",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 28,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 29,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 30,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/places.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/places.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Places",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        28,
+        null
+      ],
+      [
+        30,
         22,
         23,
         24,
+        31,
         25,
-        29,
+        32,
         27,
-        28,
-        null,
-        null,
-        null,
-        null
+        33,
+        34,
+        35,
+        36
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "preposition"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -251,9 +257,54 @@
       }
     },
     {
-      "id": 29,
-      "label": "places",
-      "part_of_speech": "noun"
+      "id": 30,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 31,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "Places",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/play.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/play.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Play",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        21,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        28,
+        null
+      ],
+      [
+        30,
         22,
         23,
         24,
-        29,
+        31,
+        32,
         26,
         27,
-        28,
-        null,
-        null,
-        null,
-        null
+        33,
+        34,
+        35,
+        36
       ]
     ]
   },
@@ -195,14 +209,6 @@
       "part_of_speech": "noun"
     },
     {
-      "id": 21,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 22,
       "label": "People",
       "part_of_speech": "noun",
@@ -251,9 +257,54 @@
       }
     },
     {
-      "id": 29,
-      "label": "play",
-      "part_of_speech": "noun"
+      "id": 30,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 31,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "Play",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 34,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 35,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 36,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/school.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/school.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "School",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        19,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        26,
+        null
+      ],
+      [
+        28,
         20,
         21,
         22,
+        29,
         23,
         24,
         25,
-        26,
-        27,
-        null,
-        null,
-        null
+        30,
+        31,
+        32,
+        33
       ]
     ]
   },
@@ -185,14 +199,6 @@
       "part_of_speech": "noun"
     },
     {
-      "id": 19,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 20,
       "label": "People",
       "part_of_speech": "noun",
@@ -249,9 +255,46 @@
       }
     },
     {
-      "id": 27,
-      "label": "school",
-      "part_of_speech": "noun"
+      "id": 28,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 29,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 30,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/time.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 32,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 33,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/db/seeds/board_builder_sets/core-84/boards/time.obf
+++ b/db/seeds/board_builder_sets/core-84/boards/time.obf
@@ -4,7 +4,7 @@
   "locale": "en",
   "name": "Time",
   "grid": {
-    "rows": 6,
+    "rows": 7,
     "columns": 12,
     "order": [
       [
@@ -78,18 +78,32 @@
         null
       ],
       [
-        17,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        24,
+        null
+      ],
+      [
+        26,
         18,
         19,
         20,
+        27,
         21,
         22,
         23,
-        24,
-        25,
-        null,
-        null,
-        null
+        28,
+        29,
+        30,
+        31
       ]
     ]
   },
@@ -175,14 +189,6 @@
       "part_of_speech": "social"
     },
     {
-      "id": 17,
-      "label": "Home",
-      "part_of_speech": "noun",
-      "load_board": {
-        "path": "boards/core-84.obf"
-      }
-    },
-    {
       "id": 18,
       "label": "People",
       "part_of_speech": "noun",
@@ -239,9 +245,46 @@
       }
     },
     {
-      "id": 25,
-      "label": "time",
-      "part_of_speech": "noun"
+      "id": 26,
+      "label": "this",
+      "part_of_speech": "determiner"
+    },
+    {
+      "id": 27,
+      "label": "Drinks",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/drinks.obf"
+      }
+    },
+    {
+      "id": 28,
+      "label": "Time",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/core-84.obf"
+      }
+    },
+    {
+      "id": 29,
+      "label": "Describe",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/describe.obf"
+      }
+    },
+    {
+      "id": 30,
+      "label": "School",
+      "part_of_speech": "noun",
+      "load_board": {
+        "path": "boards/school.obf"
+      }
+    },
+    {
+      "id": 31,
+      "label": "that",
+      "part_of_speech": "determiner"
     }
   ],
   "images": [],

--- a/docs/superpowers/specs/2026-07-16-board-builder-defaults-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-16-board-builder-defaults-alignment-design.md
@@ -1,0 +1,138 @@
+# Board Builder: unfrozen sub-boards + nav-row alignment
+
+Date: 2026-07-16
+Branch: `claude/board-builder-defaults-alignment-f10d86`
+
+## Problem
+
+Two independent defects in Board Builder output.
+
+**1. Built sub-boards are frozen.** `BuildBoardSetJob#finalize_sub_boards!` sets
+`settings["freeze_board"] = true` on every child of a built set. Frozen means
+"tapping a tile keeps you on this board" — the child never auto-returns home
+after a word tap. Builder sets should behave like any other board.
+
+**2. The nav row does not line up across a set.** Every board in a seeded
+robust set (Core 60 / Core 84) carries a bottom nav row of category folder
+tiles. For motor planning, a given category must sit in the same grid cell on
+every page of the set. It does not.
+
+Core 60 root bottom row (6×10 grid, row 5):
+
+```
+this  People  Feelings  Food  Drinks  Play  Places  Body  More  that
+```
+
+Its children today:
+
+| child   | row 5 |
+|---------|-------|
+| people  | `Home · (blank) · Feelings · Food · Play · Places · Body · More · · ` |
+| food    | `Home · People · Feelings · (blank) · Play · Places · Body · More · · ` |
+| play    | `Home · People · Feelings · Food · (blank) · Places · Body · More · · ` |
+
+`Drinks` is absent from every child, so every tile after column 3 shifts one
+cell left. The self-tile is a blank gap, and on `play.obf` even the gap is
+wrong (column 4; the root's `Play` is column 5).
+
+Core 84 is worse. Children drop `Drinks`, `Time`, `Describe` and `School`, add
+a `More` that lives on a different row on the root, and are **6 rows** against
+the root's **7** — so the nav row is not even at the same height on screen.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Self-tile (the tile for the page you're on) | Same tile, same cell, **not muted**, links back to the root. Speaks its label, then navigates. |
+| Nav coverage | **Full mirror** of the root's nav row — every category, every column. |
+| `this` / `that` / `Home` | Identical row on every page. `Home` is dropped; the self-tile is the way back. |
+| Screen sizes | Large layout only. sm/md are out of scope. |
+| Existing frozen sets | Backfill via rake. |
+
+## Design
+
+### Part 1 — unfreeze
+
+`BuildBoardSetJob#finalize_sub_boards!` does double duty: it freezes children,
+and its `save!` is what makes `Board#check_is_sub_board` recompute and set
+`sub_board: true` (which keeps children out of the `main_boards` scope). Drop
+only the freeze; keep the save.
+
+- Rename to `classify_sub_boards!` — freezing was half its purpose.
+- Guard becomes `next if board.sub_board == true`.
+- The doc comment currently sitting above `reflow_screen_layouts!` actually
+  describes this method (pre-existing misplacement). Move and rewrite it.
+- `lib/tasks/board_builder.rake:179` freezes children in a backfill task. Invert
+  it to clear `freeze_board`, keeping the `sub_board` recompute. This is the
+  task to run on production for already-built sets.
+
+`Board#is_frozen?`, the `frozen` api_view field, and the frontend's freeze
+affordances are untouched — freezing stays available, builder sets just don't
+opt into it.
+
+### Part 2 — nav-row alignment
+
+Rule to document in `db/seeds/board_builder_sets/README.md`:
+
+> The root's bottom row is the **nav row**. Every child board in the set has the
+> same grid dimensions as the root and reproduces that row cell-for-cell. On the
+> page you are currently on, that page's own tile links back to the root instead
+> of to itself. Any folder tile the root places outside the nav row sits at the
+> same cell on every child.
+
+**Core 60** — children are already 6×10 with the nav row at row 5. Row 5 becomes:
+
+```
+this  People  Feelings  Food  Drinks  Play  Places  Body  More  that
+```
+
+**Core 84** — children grow 6 → 7 rows. Rows 2–4 are empty on every child, so
+nothing moves except the nav row sliding r5 → r6. Row 6 becomes:
+
+```
+this  People  Feelings  Food  Drinks  Play  Places  Body  Time  Describe  School  that
+```
+
+plus `More` at r5c10, mirroring the root.
+
+Self-tile: `load_board` points at the set root (`boards/core-60.obf` /
+`boards/core-84.obf`) rather than at its own file.
+
+**TileDeduper hazard.** `Boards::TileDeduper.collapse_duplicates!` runs during
+seeding (`app/services/vocab_sets.rb:198`) and removes tiles sharing a label and
+kind, keeping the lowest position. Both `more.obf` files already carry `this`
+and `that` as word tiles in row 0, so the new nav-row copies would be silently
+deleted and alignment would break on that page only. Remove `this`/`that` from
+those two content rows — the nav row is their home now.
+
+**Mute exception.** `BuildBoardSetJob#mute_dynamic_tile_names!` mutes every
+dynamic tile, which would silence the self-tile. Skip tiles whose label matches
+their own board's name.
+
+### Why the root stays a main board
+
+Children link back to the root, which would normally make the root look like a
+sub-board. `Board#check_is_sub_board` already pins a `builder_root?` as a main
+board for exactly this reason (the existing `Home` tile creates the same
+back-link), so replacing `Home` with the self-tile changes nothing structurally.
+
+## Testing
+
+- **Seed-data spec** — reads the `.obf` JSON directly (no DB): for both sets,
+  every child has the root's grid dimensions and its nav row matches the root's
+  cell-for-cell, with the self cell linking to the root. Guards future template
+  edits.
+- **Job spec** — children are not frozen but are still `sub_board: true`; the
+  self-tile escapes `mute_name`; other dynamic tiles are still muted.
+- Invert the existing frozen expectation at
+  `spec/sidekiq/build_board_set_job_spec.rb:163`.
+
+## Out of scope (follow-up issues)
+
+- **Existing built sets keep the misaligned nav row.** Sets are cloned from the
+  seed at build time, so reseeding only affects new builds. Realigning existing
+  user sets is a separate migration.
+- **sm/md alignment.** `Boards::ScreenReflow` repacks smaller screens from the
+  lg reading order and compacts gaps, so the nav row will not stay pinned to the
+  bottom on phones/tablets. Making it gap-preserving touches a service that
+  non-builder boards also use.

--- a/lib/tasks/board_builder.rake
+++ b/lib/tasks/board_builder.rake
@@ -145,18 +145,21 @@ namespace :board_builder do
   #     directly, and the old Board#check_in_use only counted clone sources), so
   #     they never surfaced under the "in use" scope, AND
   #   - sub-boards (builder_child) that leaked into the `main_boards` scope
-  #     (their sub_board column was never set true) and weren't frozen.
+  #     (their sub_board column was never set true), AND
+  #   - sub-boards left FROZEN (settings["freeze_board"] = true), so a word tap
+  #     never returned to home. Builder pages behave like any other board now.
   #
   # This re-saves each built set so Board#check_in_use / #check_is_sub_board
-  # recompute against the now-complete relations, and freezes every child page
-  # (settings["freeze_board"] = true) so navigating in doesn't auto-return home —
-  # exactly what BuildBoardSetJob#finalize_sub_boards! now does at build time.
+  # recompute against the now-complete relations, and clears freeze_board from
+  # every child page — matching what BuildBoardSetJob#classify_sub_boards! does
+  # at build time. Only ever unfreezes builder_child pages, so a board the user
+  # froze themselves elsewhere is untouched.
   #
   # Read-only by default. Apply with DRY_RUN=false; scope with USER_ID=N:
   #   rake board_builder:reclassify_builder_sets               # preview all
   #   DRY_RUN=false rake board_builder:reclassify_builder_sets  # apply all
   #   DRY_RUN=false USER_ID=740 rake board_builder:reclassify_builder_sets
-  desc "Reclassify built Board Builder sets: root in_use, children sub_board+frozen (DRY_RUN=false to apply; USER_ID=N to scope)"
+  desc "Reclassify built Board Builder sets: root in_use, children sub_board + unfrozen (DRY_RUN=false to apply; USER_ID=N to scope)"
   task reclassify_builder_sets: :environment do
     dry_run = ENV["DRY_RUN"] != "false"
 
@@ -164,28 +167,29 @@ namespace :board_builder do
     roots = roots.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
 
     sets_touched = 0
-    children_frozen = 0
+    children_unfrozen = 0
 
     roots.find_each do |root|
       child_ids = builder_set_child_ids(root)
       sets_touched += 1
-      puts "#{dry_run ? '[DRY RUN] ' : ''}set ##{root.id} #{root.name.inspect} (owner #{root.user_id}): root in_use, #{child_ids.size} child page(s) frozen + sub_board"
+      puts "#{dry_run ? '[DRY RUN] ' : ''}set ##{root.id} #{root.name.inspect} (owner #{root.user_id}): root in_use, #{child_ids.size} child page(s) sub_board + unfrozen"
 
       next if dry_run
 
       # Re-save the root so check_in_use picks up its direct ChildBoard.
       root.save!
       Board.where(id: child_ids).find_each do |child|
-        child.settings = (child.settings || {}).merge("freeze_board" => true)
+        was_frozen = child.settings&.dig("freeze_board") == true
+        child.settings = (child.settings || {}).except("freeze_board")
         child.save! # recomputes check_is_sub_board => sub_board: true
-        children_frozen += 1
+        children_unfrozen += 1 if was_frozen
       end
     end
 
     if dry_run
       puts "Dry run only — #{sets_touched} built set(s) to reclassify. Re-run with DRY_RUN=false to apply."
     else
-      puts "Reclassified #{sets_touched} set(s); froze #{children_frozen} child page(s)."
+      puts "Reclassified #{sets_touched} set(s); unfroze #{children_unfrozen} child page(s)."
     end
   end
 

--- a/spec/db/seeds/board_builder_sets_spec.rb
+++ b/spec/db/seeds/board_builder_sets_spec.rb
@@ -1,0 +1,143 @@
+# Guards the authored Board Builder seed sets (db/seeds/board_builder_sets).
+#
+# Reads the .obf JSON directly — no DB, no seeding — so it's fast and fails the
+# moment a template edit breaks the nav-row rule documented in that dir's
+# README.md: every child reproduces the root's nav row cell-for-cell, so a
+# category is always the same reach no matter which page you're on.
+require "rails_helper"
+
+module BoardBuilderSeedSets
+  DIR = Rails.root.join("db", "seeds", "board_builder_sets")
+
+  module_function
+
+  def slugs
+    Dir.children(DIR).select { |n| File.file?(DIR.join(n, "manifest.json")) }.sort
+  end
+
+  def load_obf(path) = JSON.parse(File.read(path))
+
+  def manifest(slug) = load_obf(DIR.join(slug, "manifest.json"))
+
+  def root_rel(slug) = manifest(slug).fetch("root")
+
+  def child_rels(slug)
+    manifest(slug).dig("paths", "boards").values.uniq.reject { |p| p == root_rel(slug) }.sort
+  end
+
+  def folder?(button) = button["load_board"].present?
+
+  def board_path(button) = button.dig("load_board", "path")
+
+  # [{label:, path:}] for one grid row, nil for an empty cell.
+  def row_spec(obf, y)
+    buttons = obf["buttons"].index_by { |b| b["id"] }
+    obf.dig("grid", "order")[y].map do |id|
+      next nil if id.nil?
+
+      button = buttons.fetch(id)
+      { label: button["label"], path: board_path(button) }
+    end
+  end
+end
+
+RSpec.describe "Board Builder seed sets" do
+  include BoardBuilderSeedSets
+  H = BoardBuilderSeedSets
+
+  it "finds the authored sets" do
+    expect(H.slugs).to include("core-60", "core-84")
+  end
+
+  H.slugs.each do |slug|
+    describe slug do
+      let(:dir) { H::DIR.join(slug) }
+      let(:root_rel) { H.root_rel(slug) }
+      let(:root) { H.load_obf(dir.join(root_rel)) }
+      # The nav row is the root's bottom row.
+      let(:nav_y) { root.dig("grid", "rows") - 1 }
+      let(:root_nav) { H.row_spec(root, nav_y) }
+      # Folder tiles the root places outside the nav row (Core 84's More),
+      # as [[y, x, spec]].
+      let(:root_off_nav) do
+        buttons = root["buttons"].index_by { |b| b["id"] }
+        root.dig("grid", "order").take(nav_y).flat_map.with_index do |row, y|
+          row.filter_map.with_index do |id, x|
+            button = id && buttons.fetch(id)
+            next unless button && H.folder?(button)
+
+            [y, x, { label: button["label"], path: H.board_path(button) }]
+          end
+        end
+      end
+
+      it "has children" do
+        expect(H.child_rels(slug)).not_to be_empty
+      end
+
+      it "authors a nav row of folder tiles on the root" do
+        expect(root_nav.compact.count { |t| t[:path] }).to be > 1
+      end
+
+      H.child_rels(slug).each do |rel|
+        context File.basename(rel) do
+          let(:child) { H.load_obf(dir.join(rel)) }
+          let(:me) { "boards/#{File.basename(rel)}" }
+
+          # What the child's nav row must be: the root's, except the tile
+          # pointing at THIS page instead links back to the root.
+          let(:expected_nav) do
+            root_nav.map do |tile|
+              next nil if tile.nil?
+              next tile.merge(path: root_rel) if tile[:path] == me
+
+              tile
+            end
+          end
+
+          it "has the root's grid dimensions" do
+            expect(child["grid"].slice("rows", "columns"))
+              .to eq(root["grid"].slice("rows", "columns"))
+          end
+
+          it "reproduces the root's nav row cell-for-cell" do
+            expect(H.row_spec(child, nav_y)).to eq(expected_nav)
+          end
+
+          it "puts the root's off-nav folder tiles at the same cells" do
+            root_off_nav.each do |y, x, tile|
+              expected = (tile[:path] == me) ? tile.merge(path: root_rel) : tile
+              expect(H.row_spec(child, y)[x]).to eq(expected), "expected #{tile[:label]} at r#{y}c#{x}"
+            end
+          end
+
+          it "links its own tile back to the root, never at itself" do
+            selfies = child["buttons"].select { |b| H.board_path(b) == me }
+            expect(selfies).to be_empty, "self-linking tile(s): #{selfies.map { |b| b['label'] }}"
+
+            home = child["buttons"].select { |b| H.board_path(b) == root_rel }
+            expect(home.map { |b| b["label"] }).to eq([child["name"]])
+          end
+
+          # Boards::TileDeduper collapses same-label same-kind tiles on seed,
+          # keeping the lowest position — which would silently eat the nav-row
+          # copy. See the README.
+          it "never authors the same label twice with the same kind" do
+            dupes = child["buttons"]
+              .group_by { |b| [b["label"].to_s.strip.downcase, H.folder?(b)] }
+              .select { |_key, group| group.size > 1 }
+            expect(dupes).to be_empty, "TileDeduper would collapse: #{dupes.keys}"
+          end
+
+          it "gives every authored button a unique id and a cell" do
+            ids = child["buttons"].map { |b| b["id"] }
+            expect(ids.uniq).to eq(ids)
+
+            placed = child.dig("grid", "order").flatten.compact
+            expect(placed.uniq.sort).to eq(ids.sort)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -339,8 +339,11 @@ RSpec.describe Boards::SeededSetCloner do
       VocabSets.seed_slug!("core-84")
     end
 
+    # Each fringe page's way home is its SELF tile — the "People" tile on the
+    # People page (see db/seeds/board_builder_sets/README.md). It must point at
+    # the CLONED root, never the admin source it was cloned from.
     %w[core-60 core-84].each do |slug|
-      it "gives #{slug} clones a working Home tile on every fringe page" do
+      it "gives #{slug} clones a working self tile home from every fringe page" do
         source_root = Boards::RobustSets.find_root(slug)
         cloned_root = described_class.new(source_root, communicator: communicator).call
 
@@ -348,9 +351,20 @@ RSpec.describe Boards::SeededSetCloner do
         expect(fringe.count).to be > 0
 
         fringe.each do |board|
-          home = board.board_images.find_by(label: "Home")
-          expect(home).to be_present, "expected fringe '#{board.name}' to have a Home tile"
-          expect(home.predictive_board_id).to eq(cloned_root.id)
+          self_tile = board.board_images.find_by(label: board.name)
+          expect(self_tile).to be_present, "expected fringe '#{board.name}' to have a '#{board.name}' self tile"
+          expect(self_tile.predictive_board_id).to eq(cloned_root.id),
+            "expected '#{board.name}' self tile to link home to the cloned root"
+        end
+      end
+
+      it "leaves no #{slug} fringe page linking at itself" do
+        source_root = Boards::RobustSets.find_root(slug)
+        described_class.new(source_root, communicator: communicator).call
+
+        owner.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").each do |board|
+          selfies = board.board_images.where(predictive_board_id: board.id)
+          expect(selfies).to be_empty, "'#{board.name}' has a tile that opens itself"
         end
       end
     end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe VocabSets do
   end
 
   describe "cross-set isolation (#278)" do
-    it "seeds disjoint fringe boards per set, each fringe Home resolving to its own root" do
+    # Each People page's way home is its own "People" self tile; it must resolve
+    # to ITS set's root, never the other set's (the pre-namespacing bug).
+    it "seeds disjoint fringe boards per set, each fringe's self tile resolving to its own root" do
       c60_people = Board.find(@c60_root.board_images.find_by(label: "People").predictive_board_id)
       c84_people = Board.find(@c84_root.board_images.find_by(label: "People").predictive_board_id)
 
@@ -81,8 +83,8 @@ RSpec.describe VocabSets do
       expect(c60_people.obf_id).to eq("core-60:people")
       expect(c84_people.obf_id).to eq("core-84:people")
 
-      expect(c60_people.board_images.find_by(label: "Home").predictive_board_id).to eq(@c60_root.id)
-      expect(c84_people.board_images.find_by(label: "Home").predictive_board_id).to eq(@c84_root.id)
+      expect(c60_people.board_images.find_by(label: "People").predictive_board_id).to eq(@c60_root.id)
+      expect(c84_people.board_images.find_by(label: "People").predictive_board_id).to eq(@c84_root.id)
     end
 
     it "shares no fringe boards between the two seeded sets" do
@@ -235,10 +237,10 @@ RSpec.describe VocabSets do
     end
   end
 
-  # Every Core 84 fringe page matches the root's column count (12, not 10) so
-  # tiles are sized consistently across the set, and each carries its own
-  # category word as a REGULAR speaking tile (no board link) where the nav row
-  # previously left a blank self-slot — e.g. "people" on the People page.
+  # Every Core 84 fringe page matches the root's grid, and reproduces the root's
+  # nav row cell-for-cell, so a category is the same reach from any page. Each
+  # page's own tile ("People" on the People page) sits in the root's cell for it
+  # and links back home. See db/seeds/board_builder_sets/README.md.
   describe "Core 84 sub-board layout" do
     def sub_boards
       @c84_root.board_images.where.not(predictive_board_id: nil).filter_map do |bi|
@@ -253,16 +255,48 @@ RSpec.describe VocabSets do
       end
     end
 
-    it "puts each category's own word on its page as a speaking (non-folder) tile" do
+    # The nav-row rule, asserted on the SEEDED boards rather than the authored
+    # JSON (spec/db/seeds/board_builder_sets_spec.rb covers the source): each
+    # category's page carries its own tile in the SAME lg cell the root puts it
+    # in, so the reach never moves. See db/seeds/board_builder_sets/README.md.
+    it "puts each category's own tile on its page, in the root's cell, linking home" do
+      checked = 0
+
       @c84_root.board_images.where.not(predictive_board_id: nil).each do |folder_tile|
         page = Board.find_by(id: folder_tile.predictive_board_id)
         next unless page
 
-        self_tile = page.board_images.find { |bi| bi.label.to_s.casecmp?(folder_tile.label) }
-        expect(self_tile).to be_present, "#{folder_tile.label} page has no self word tile"
-        # regular word tile: speaks its label, does not navigate to another board
-        expect(self_tile.predictive_board_id).to be_nil
+        # Match the FOLDER tile, not a word of the same name — the Play page
+        # legitimately carries both a "play" word tile and its "Play" self tile.
+        self_tile = page.board_images.find do |bi|
+          bi.label.to_s.casecmp?(folder_tile.label) && bi.predictive_board_id.present?
+        end
+        expect(self_tile).to be_present, "#{folder_tile.label} page has no self tile"
         expect(self_tile.image).to be_present
+        # It's the page's way back — never a link at itself.
+        expect(self_tile.predictive_board_id).to eq(@c84_root.id),
+          "expected the '#{folder_tile.label}' self tile to link home"
+        expect(self_tile.layout["lg"].slice("x", "y")).to eq(folder_tile.layout["lg"].slice("x", "y")),
+          "expected '#{folder_tile.label}' to sit in the same cell on its own page as on the root"
+        checked += 1
+      end
+
+      expect(checked).to be > 1
+    end
+
+    it "gives each page the root's nav row, cell-for-cell" do
+      nav_y = @c84_root.large_screen_rows - 1
+      root_nav = nav_row_spec(@c84_root, nav_y)
+      expect(root_nav.compact.size).to be > 1
+
+      sub_boards.each do |page|
+        expected = root_nav.map do |tile|
+          # The tile pointing at THIS page instead links back to the root.
+          next tile if tile.nil? || tile[:predictive_board_id] != page.id
+
+          tile.merge(predictive_board_id: @c84_root.id)
+        end
+        expect(nav_row_spec(page, nav_y)).to eq(expected), "#{page.name}'s nav row does not match the root's"
       end
     end
   end
@@ -403,6 +437,19 @@ RSpec.describe VocabSets do
         "School", "Time", "Describe"
       )
     end
+  end
+
+  # [{label:, predictive_board_id:}] for the tiles in one grid row of a seeded
+  # board, indexed by lg column — nil for an empty cell.
+  def nav_row_spec(board, y)
+    row = Array.new(board.large_screen_columns)
+    board.board_images.each do |bi|
+      cell = bi.layout.is_a?(Hash) ? bi.layout["lg"] : nil
+      next unless cell && cell["y"].to_i == y
+
+      row[cell["x"].to_i] = { label: bi.label, predictive_board_id: bi.predictive_board_id }
+    end
+    row
   end
 
   def collect_set_board_ids(root)

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -24,18 +24,22 @@ RSpec.describe BuildBoardSetJob do
   end
 
   # Seeds a tiny admin-owned robust set (root + Food fringe), same shape the
-  # request spec uses, marked so Boards::RobustSets finds it.
+  # request spec uses, marked so Boards::RobustSets finds it. The Food page
+  # carries its own "Food" SELF tile linking back to the root, mirroring the
+  # authored templates (see db/seeds/board_builder_sets/README.md).
   def seed_robust_set!(slug: "core-60")
     admin = create(:admin_user)
     source_root = create(:board, user: admin, name: "Core 60", predefined: true, published: true)
     food = create(:board, user: admin, name: "Food", predefined: true, published: true)
     create(:board_image, board: source_root, label: "I",
                          image: create(:image, label: "I", user_id: admin.id))
-    food_tile = create(:board_image, board: source_root, label: "Food",
-                                     image: create(:image, label: "Food", user_id: admin.id))
+    food_image = create(:image, label: "Food", user_id: admin.id)
+    food_tile = create(:board_image, board: source_root, label: "Food", image: food_image)
     food_tile.update!(predictive_board_id: food.id)
     create(:board_image, board: food, label: "apple",
                          image: create(:image, label: "apple", user_id: admin.id))
+    self_tile = create(:board_image, board: food, label: "Food", image: food_image)
+    self_tile.update!(predictive_board_id: source_root.id)
     Boards::RobustSets.mark_root!(source_root, slug)
     source_root
   end
@@ -136,7 +140,7 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
-  describe "#perform scope classification + sub-board freeze" do
+  describe "#perform scope classification" do
     it "registers the root as in_use and a main board, not a sub-board" do
       root = precreate_root!(name: "Home")
 
@@ -150,7 +154,7 @@ RSpec.describe BuildBoardSetJob do
       expect(Board.sub_boards).not_to include(root)
     end
 
-    it "marks every child page as a sub-board and freezes it (kept out of main_boards)" do
+    it "marks every child page as a sub-board (kept out of main_boards)" do
       root = precreate_root!(name: "Home")
 
       described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"])
@@ -160,20 +164,63 @@ RSpec.describe BuildBoardSetJob do
 
       children.each do |child|
         expect(child.sub_board).to be(true), "expected child ##{child.id} #{child.name.inspect} to be a sub_board"
-        expect(child.settings["freeze_board"]).to be(true), "expected child ##{child.id} #{child.name.inspect} to be frozen"
-        expect(child.is_frozen?).to be(true)
       end
 
       expect(Board.main_boards).not_to include(*children)
       expect(Board.sub_boards).to include(*children)
     end
 
-    it "exposes the freeze on the api_view so the frontend can drop auto-return" do
+    it "leaves every child page unfrozen so it behaves like any other board" do
+      root = precreate_root!(name: "Home")
+
+      described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs", "grandma"])
+
+      children = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)")
+      expect(children).to be_present
+
+      children.each do |child|
+        expect(child.is_frozen?).to be(false), "expected child ##{child.id} #{child.name.inspect} to be unfrozen"
+      end
+    end
+
+    it "reports the children as unfrozen on the api_view" do
       root = precreate_root!(name: "Home")
       described_class.new.perform(root.id, communicator.id, "home", ["dinosaurs"])
 
       child = user.boards.where("COALESCE((settings->>'builder_child')::boolean, false)").first
-      expect(child.user_api_view[:frozen]).to be(true)
+      expect(child.user_api_view[:frozen]).to be(false)
+    end
+  end
+
+  # A page's SELF tile (the "Food" tile on the Food page, which links home) is
+  # the one folder tile that speaks — it's the you-are-here anchor. Everything
+  # else that opens a board stays muted.
+  describe "#perform self-tile muting" do
+    it "leaves the self tile unmuted while muting the other folder tiles" do
+      seed_robust_set!
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "core-60", [])
+
+      food = user.boards.find_by(name: "Food")
+      self_tile = food.board_images.find { |bi| bi.label == "Food" }
+      expect(self_tile).to be_present
+      expect(self_tile.predictive_board_id).to eq(root.id)
+      expect(self_tile.data.to_h["mute_name"]).not_to be(true)
+
+      food_folder = root.board_images.find { |bi| bi.label == "Food" }
+      expect(food_folder.data["mute_name"]).to be(true)
+    end
+
+    it "keeps word tiles unmuted" do
+      seed_robust_set!
+      root = precreate_root!(name: "Core 60")
+
+      described_class.new.perform(root.id, communicator.id, "core-60", [])
+
+      food = user.boards.find_by(name: "Food")
+      apple = food.board_images.find { |bi| bi.label == "apple" }
+      expect(apple.data.to_h["mute_name"]).not_to be(true)
     end
   end
 


### PR DESCRIPTION
Two independent Board Builder defaults.

## 1. Built pages are no longer frozen

`BuildBoardSetJob#finalize_sub_boards!` froze every child of a built set, so tapping a word kept you on that page instead of returning home. That method did double duty — its `save!` is what makes `check_is_sub_board` set `sub_board: true`, keeping children out of `main_boards` — so this drops only the freeze and keeps the save. Renamed `classify_sub_boards!`.

Freezing is untouched as a per-board option; builder sets just don't opt into it.

`rake board_builder:reclassify_builder_sets` now **clears** `freeze_board` instead of setting it, for sets built before this. Run on prod when ready (dry-run by default, `USER_ID=N` to scope).

## 2. The nav row now lines up across a whole set

A category tile must sit in the same cell on every page — that's what AAC motor planning depends on. The seed templates had drifted, more than "it's mostly right":

Core 60 root bottom row: `this · People · Feelings · Food · Drinks · Play · Places · Body · More · that`

| child | what it actually was |
|---|---|
| people | `Home · (blank) · Feelings · Food · Play · Places · Body · More · · ` |
| food | `Home · People · Feelings · (blank) · Play · Places · Body · More · · ` |
| play | `Home · People · Feelings · Food · (blank) · Places · Body · More · · ` |

`Drinks` was missing from **every** child, shifting everything after column 3 one cell left. The self slot was a blank gap — and on `play.obf` even the gap was in the wrong column. Core 84 was worse: children dropped `Drinks`/`Time`/`Describe`/`School`, added a `More` that lives on a different row on the root, and were **6 rows** against the root's **7**, so the nav row wasn't even at the same height on screen.

Now every child reproduces the root's nav row **cell-for-cell** at the root's grid dimensions. The tile for the page you're on links back to the **root** instead of at itself — it replaces the old `Home` tile, and it's the one folder tile that speaks (`mute_dynamic_tile_names!` exempts a tile whose label matches its own board's name).

### Two traps the rewrite had to respect

Both are now in `db/seeds/board_builder_sets/README.md` and guarded by the new spec:

- **Button ids are the seeder's upsert + layout key.** Existing buttons are *moved*, never renumbered — a new id forks a duplicate tile.
- **`TileDeduper` collapses same-label same-kind tiles keeping the lowest position**, which would have silently eaten the new nav-row copies. Hence `more.obf` carries `this`/`that` only in the nav row, and `food.obf`'s `Drinks` link lives there rather than duplicated in content.

### One latent seeder bug fixed to make this work

⚠️ Worth a look in review — it touches the shared seed path.

`prune_removed_tiles!` matched labels **case-insensitively**, so dropping the `Home` folder from `places.obf` left the tile behind: that page still authors the *word* `home`, which matched. `repair_layout!` then couldn't move it (its button id is gone from the source), so it kept its old cell and collided with the `this` tile now there — exactly the "84 looks like 82" overlap the code comments describe. It now matches on `obf_button_id` when one is stamped; tiles seeded before ids were stamped still fall back to labels.

## Test plan

`bundle exec rspec spec/db/seeds/board_builder_sets_spec.rb spec/sidekiq/build_board_set_job_spec.rb spec/sidekiq/build_board_set_job_grid_spec.rb spec/services/vocab_sets_spec.rb spec/services/boards/seeded_set_cloner_spec.rb spec/requests/api/v1/board_builder_spec.rb`

→ **289 examples, 0 failures.**

- New `spec/db/seeds/board_builder_sets_spec.rb` reads the `.obf` JSON directly (no DB, ~0.25s) and asserts the rule for both sets, so a future template edit fails loudly. Mutation-tested: reintroducing the off-by-one shift fails it.
- Job specs: children unfrozen but still `sub_board: true`; self tile escapes `mute_name`; other folder tiles still muted.
- Updated the specs that asserted the old `Home`-tile behavior — the invariants they guard (a working way home resolving to the *cloned* root; cross-set isolation from #278) still hold via the self tile.

### Verified end-to-end against a real DB

Seeded both sets **over the old misaligned boards** (the upgrade path a deploy takes, not a clean-DB seed) and ran `BuildBoardSetJob`:

```
root #6959 status=complete sub_board=false frozen=false
  People   frozen=false sub_board=true api_frozen=false | self="People" link=ROOT ok muted=nil
  ... (8 pages, all identical)
  root 'People' FOLDER tile muted=true   (expect true)
  root 'I' WORD tile      muted=nil    (expect nil)

  ROOT     this People Feelings Food Drinks Play Places Body More that
  People   this People Feelings Food Drinks Play Places Body More that
  ... => CLONED SET ALIGNED
```

No stale `Home` tiles left anywhere (including Places, which authors the word `home`), and no cell collisions on either set.

## Scope

- Alignment holds on the **lg** layout only — `ScreenReflow` compacts gaps on md/sm. → #520
- Built sets are **clones taken at build time**, so this reaches **new builds only**; already-built sets keep their layout. → #519

## Docs

`db/seeds/board_builder_sets/README.md` (the rule + traps), `.claude-notes/board-builder.md`, `CHANGELOG.md`, and the spec at `docs/superpowers/specs/2026-07-16-board-builder-defaults-alignment-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)