### PR TITLE
feat: seed the Video Demo board unpublished, with publish/unpublish tasks

### DIFF
--- a/lib/tasks/video_demo.rake
+++ b/lib/tasks/video_demo.rake
@@ -38,12 +38,17 @@ module VideoDemoSeeder
       end
   end
 
+  # Seeds unpublished on purpose: `published` is what makes a predefined admin
+  # board public (Board.public_boards, Board#viewable_by?), so leaving it false
+  # keeps the board reviewable by the admin owner while invisible to everyone
+  # else. Publish with `video_demo:publish` once the videos have been watched.
+  # Only set on create, so re-running the seed never un-publishes a reviewed
+  # board.
   def configure_board!(board, admin)
     board.assign_attributes(
       description: "A demo board of sing-along videos — tap a tile to hear the " \
                    "word and watch the video.",
       predefined: true,
-      published: true,
       board_type: "default",
       number_of_columns: COLUMNS,
       small_screen_columns: COLUMNS,
@@ -51,6 +56,7 @@ module VideoDemoSeeder
       large_screen_columns: COLUMNS,
       tags: ["videos", "songs", "demo"],
     )
+    board.published = false if board.new_record?
     board.parent = admin
     board.layout ||= {}
     board.generate_unique_slug if board.slug.blank?
@@ -109,5 +115,49 @@ namespace :video_demo do
     board.save!
 
     puts "  Done: board id=#{board.id}, slug=#{board.slug}, #{board.board_images.count} tiles."
+    puts ""
+    puts "  UNPUBLISHED — visible to you as the admin owner, not to anyone else."
+    puts "  Review it, then publish with:"
+    puts "    bin/rails video_demo:publish"
+  end
+
+  desc "Publish the 'Video Demo' board after review — this makes it public. " \
+       "Usage: bin/rails video_demo:publish"
+  task publish: :environment do
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+    board = Board.find_by(
+      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
+    )
+    if board.nil?
+      puts "No '#{VideoDemoSeeder::BOARD_NAME}' board found — run video_demo:seed first."
+      next
+    end
+    if board.published?
+      puts "'#{board.name}' (id=#{board.id}) is already published."
+      next
+    end
+    if board.board_images.empty?
+      puts "'#{board.name}' (id=#{board.id}) has no tiles — refusing to publish an empty board."
+      next
+    end
+
+    board.update!(published: true)
+    puts "Published '#{board.name}' (id=#{board.id}, slug=#{board.slug}) — it is now public."
+  end
+
+  desc "Unpublish the 'Video Demo' board (reverses video_demo:publish). " \
+       "Usage: bin/rails video_demo:unpublish"
+  task unpublish: :environment do
+    admin = User.find(User::DEFAULT_ADMIN_ID)
+    board = Board.find_by(
+      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
+    )
+    if board.nil?
+      puts "No '#{VideoDemoSeeder::BOARD_NAME}' board found."
+      next
+    end
+
+    board.update!(published: false)
+    puts "Unpublished '#{board.name}' (id=#{board.id}) — no longer public."
   end
 end

--- a/spec/lib/tasks/video_demo_rake_spec.rb
+++ b/spec/lib/tasks/video_demo_rake_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "video_demo rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  def run(name)
+    task = Rake::Task["video_demo:#{name}"]
+    task.reenable
+    task.invoke
+  end
+
+  before do
+    FactoryBot.create(:user, id: User::DEFAULT_ADMIN_ID) unless User.exists?(User::DEFAULT_ADMIN_ID)
+    allow(AacWordCategorizer).to receive(:categorize).and_return("noun")
+    allow(SaveAudioJob).to receive(:perform_async)
+  end
+
+  after do
+    ENV.delete("DRY_RUN")
+    %w[seed publish unpublish].each { |t| Rake::Task["video_demo:#{t}"].reenable }
+  end
+
+  let(:board) { Board.find_by(name: VideoDemoSeeder::BOARD_NAME) }
+
+  describe "seed" do
+    before { run(:seed) }
+
+    # published is what makes a predefined admin board public, so seeding it
+    # false is what keeps the board reviewable-but-private.
+    it "creates the board unpublished so it is not yet public" do
+      expect(board).to be_present
+      expect(board.published).to be(false)
+      expect(board.predefined).to be(true)
+      expect(board.user_id).to eq(User::DEFAULT_ADMIN_ID)
+      expect(Board.public_boards).not_to include(board)
+    end
+
+    it "is viewable by the admin owner but not by a logged-out visitor" do
+      admin = User.find(User::DEFAULT_ADMIN_ID)
+      expect(board.viewable_by?(admin)).to be(true)
+      expect(board.viewable_by?(nil)).to be(false)
+    end
+
+    it "adds a tile per curated video, each carrying its youtube config" do
+      expect(board.board_images.count).to eq(VideoDemoSeeder::CURATED_VIDEOS.size)
+      video = board.board_images.first.data["video"]
+      expect(video["source"]).to eq("youtube")
+      expect(video["youtube_id"]).to match(/\A[A-Za-z0-9_-]{11}\z/)
+    end
+
+    it "does not duplicate the board or its tiles on a second run" do
+      run(:seed)
+
+      expect(Board.where(name: VideoDemoSeeder::BOARD_NAME).count).to eq(1)
+      expect(board.board_images.count).to eq(VideoDemoSeeder::CURATED_VIDEOS.size)
+    end
+
+    it "leaves an already-published board published when re-seeded" do
+      board.update!(published: true)
+      run(:seed)
+
+      expect(board.reload.published).to be(true)
+    end
+  end
+
+  describe "publish" do
+    it "makes a seeded board public" do
+      run(:seed)
+      expect(board.published).to be(false)
+
+      run(:publish)
+
+      expect(board.reload.published).to be(true)
+      expect(Board.public_boards).to include(board)
+    end
+
+    it "refuses to publish a board with no tiles" do
+      Board.create!(
+        name: VideoDemoSeeder::BOARD_NAME,
+        user_id: User::DEFAULT_ADMIN_ID,
+        predefined: true,
+        published: false,
+      )
+
+      run(:publish)
+
+      expect(board.reload.published).to be(false)
+    end
+
+    it "does nothing when no board has been seeded" do
+      expect { run(:publish) }.not_to raise_error
+      expect(board).to be_nil
+    end
+  end
+
+  describe "unpublish" do
+    it "takes a published board back out of public view" do
+      run(:seed)
+      run(:publish)
+
+      run(:unpublish)
+
+      expect(board.reload.published).to be(false)
+      expect(Board.public_boards).not_to include(board)
+    end
+  end
+
+  describe "DRY_RUN" do
+    it "writes nothing to the database" do
+      ENV["DRY_RUN"] = "1"
+      run(:seed)
+
+      expect(Board.where(name: VideoDemoSeeder::BOARD_NAME)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
So the demo board can be reviewed as the admin owner before it's public.

## What changed

`published` is what makes a predefined admin-owned board public — `Board.public_boards` filters on it, and `Board#viewable_by?` returns true for anyone when it's set. So seeding it `false` gives exactly the reviewable-but-private state:

- **Admin owner** can open and review the board normally.
- **Logged-out visitors and other users** can't see it, and it doesn't appear in the public boards library.

It's only assigned on create, so re-running the seed can never un-publish a board you've already reviewed and published.

Also adds two small tasks to close the loop (there's no admin UI toggle for this today):

```
bin/rails video_demo:seed       # creates it unpublished, prints the next step
bin/rails video_demo:publish    # makes it public after review
bin/rails video_demo:unpublish  # reverses that
```

`publish` refuses to publish a board with no tiles, and both tasks no-op with a clear message when the board doesn't exist.

Relates to #517 — the curated links are verified as real and embeddable; this makes the "one human viewing pass" step safe to do in production.

## Test plan

New `spec/lib/tasks/video_demo_rake_spec.rb` (follows the existing `core_boards_rake_spec.rb` pattern) — **10 examples, 0 failures**:

- seeds unpublished and stays out of `Board.public_boards`
- viewable by the admin owner, **not** viewable by a logged-out visitor
- one tile per curated video, each carrying a valid 11-char `youtube_id`
- idempotent: no duplicate board or tiles on a second run
- re-seeding leaves an already-published board published
- `publish` makes it public; refuses an empty board; no-ops with no board
- `unpublish` reverses it
- `DRY_RUN=1` writes nothing

Also smoke-tested `DRY_RUN=1 video_demo:seed` and `video_demo:publish` against dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)