### PR TITLE
feat(video-tiles): server-side duration enforcement + ffmpeg transcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Video tiles accept iPhone recordings, and the 30s limit is now enforced
+- Tile video uploads now accept **.mov / HEVC** files, so a clip recorded on an
+  iPhone can be attached directly instead of being rejected. It's converted to
+  a web-safe mp4 in the background, which is what makes it play in Chrome and
+  Firefox too.
+- The upload limit for these source files is **100 MB** (raw phone recordings
+  are large); the converted clip that gets stored and played is much smaller.
+- The **30-second limit is now enforced on the server**. Longer clips are
+  trimmed to the first 30 seconds rather than silently failing.
+- Processing happens after the upload finishes, so the editor isn't blocked —
+  the tile updates on its own once the clip is ready.
+- Requires `ffmpeg` on the server. Without it, uploads behave exactly as before
+  (mp4/webm only, 25 MB) rather than breaking.
+
 ### Changed — Board Builder pages are no longer frozen
 - Pages inside a built board set now behave like any other board: tapping a word
   returns to the home board. Previously every page of a built set was created

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,14 @@ one-off handoff/scratch files stay untracked and local.
 - **Auth:** Devise + devise-jwt
 - **Authorization:** Pundit
 - **Background jobs:** Sidekiq (v7) + Redis
+- **Video (tile clips):** `VideoTranscoder` shells out to `ffmpeg`/`ffprobe`
+  (no gem). `ProcessTileVideoJob` runs after `upload_video` to enforce the 30s
+  cap (trims, doesn't reject) and transcode .mov/HEVC → H.264 mp4, then
+  rebroadcasts the board so the editor picks up the swapped URL. **Everything
+  is gated on `VideoTranscoder.available?`** — when the binaries are missing
+  the controller narrows what it accepts (mp4/webm, 25 MB) and the job leaves
+  the original clip attached rather than destroying it. Keep that contract:
+  never accept an upload format we can't guarantee we can make web-safe.
 - **Cache:** `Rails.cache` is a **Redis cache store** in production
   (`config/environments/production.rb`, issue #474) — namespaced `ibb_cache` so
   keys can't collide with Sidekiq / Rack::Attack on the shared Redis, with a

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
   - postgresql
   - redis
   - imagemagick
-  - ffmpeg
+  - ffmpeg (`ffmpeg` + `ffprobe`) — required for tile video uploads:
+    `ProcessTileVideoJob` uses them to enforce the 30s cap and transcode
+    .mov/HEVC to web-safe mp4. If the binaries are absent the app degrades
+    gracefully (mp4/webm only, 25 MB cap, no duration enforcement) rather than
+    erroring.
 
 - Environment Variables:
 

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -4,6 +4,15 @@ class API::BoardImagesController < API::ApplicationController
   before_action :set_owned_board_image, only: %i[ update destroy create_image_variation create_image_edit set_current_audio attach_youtube_video upload_video clear_video ]
   before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation upload_audio reset_audio move destroy attach_youtube_video upload_video clear_video ]
 
+  # Extension used for the stored blob, keyed by the uploaded content type.
+  # Only covers types in BoardImage.accepted_video_content_types — anything
+  # else is rejected before this is consulted.
+  VIDEO_UPLOAD_EXTENSIONS = {
+    "video/mp4" => "mp4",
+    "video/webm" => "webm",
+    "video/quicktime" => "mov",
+  }.freeze
+
   # GET /board_images or /board_images.json
   def index
     @board_images = BoardImage.all
@@ -281,30 +290,40 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   # POST /api/board_images/:id/upload_video (multipart: video_file)
-  # mp4/webm only, 25 MB cap — both enforced here regardless of client checks.
-  # The 30s duration cap is client-side only (no ffmpeg server-side in v1).
+  #
+  # Accepted types and the size cap both depend on whether ffmpeg is present
+  # (see BoardImage.accepted_video_content_types): with it we take .mov/HEVC
+  # at up to 100 MB and hand it to ProcessTileVideoJob to convert; without it
+  # we stay on mp4/webm at 25 MB, since we'd have no way to make anything else
+  # playable. Enforced here regardless of client checks.
+  #
+  # The 30s duration cap is enforced server-side by the job, not here — the
+  # response goes out before ffmpeg runs so the editor isn't blocked on it.
   def upload_video
     file = params[:video_file]
     unless file.respond_to?(:content_type) && file.respond_to?(:size)
       render json: { error: "video_required" }, status: :unprocessable_content
       return
     end
-    unless BoardImage::ALLOWED_VIDEO_CONTENT_TYPES.include?(file.content_type)
+    unless BoardImage.accepted_video_content_types.include?(file.content_type)
       render json: { error: "invalid_video_type" }, status: :unprocessable_content
       return
     end
-    if file.size > BoardImage::MAX_VIDEO_BYTES
+    if file.size > BoardImage.max_video_upload_bytes
       render json: { error: "video_too_large" }, status: :unprocessable_content
       return
     end
 
-    extension = file.content_type == "video/webm" ? "webm" : "mp4"
+    extension = VIDEO_UPLOAD_EXTENSIONS.fetch(file.content_type, "mp4")
     filename = "board-image-#{@board_image.id}-video-#{Time.now.strftime("%m%d%y%H%M%S")}.#{extension}"
     @board_image.video_clip.purge_later if @board_image.video_clip.attached?
     @board_image.video_clip.attach(io: file, filename: filename, content_type: file.content_type)
     @board_image.reload
     @board_image.set_uploaded_video!(@board_image.video_clip_url, file.content_type)
     @board_image.board.broadcast_board_update!
+    # Enforces the duration cap and converts to web-safe mp4, then rebroadcasts
+    # the board with the processed URL.
+    ProcessTileVideoJob.perform_async(@board_image.id)
     render json: @board_image.api_view(current_user)
   end
 

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -38,8 +38,33 @@ class BoardImage < ApplicationRecord
   has_one_attached :video_clip
   attr_accessor :skip_create_voice_audio, :skip_initial_layout, :src
 
+  # Formats the web player handles as-is, so they can be stored untouched if
+  # ffmpeg isn't around to transcode.
   ALLOWED_VIDEO_CONTENT_TYPES = %w[video/mp4 video/webm].freeze
+  # Formats we only accept because ffmpeg can convert them — iPhone recordings
+  # arrive as HEVC-in-.mov, which Chrome and Firefox won't play.
+  TRANSCODABLE_VIDEO_CONTENT_TYPES = %w[video/quicktime].freeze
+
+  # Cap on what's stored and served when there's no transcode step.
   MAX_VIDEO_BYTES = 25.megabytes
+  # Cap on what's accepted for transcoding. Higher because it applies to the
+  # raw upload: a 30s iPhone .mov runs 40-80 MB and shrinks to a few MB once
+  # it's been through ffmpeg.
+  MAX_VIDEO_SOURCE_BYTES = 100.megabytes
+
+  MAX_VIDEO_DURATION_SECONDS = 30
+
+  # Content types accepted by upload_video right now. Depends on whether the
+  # binaries are present: never accept a format we can't guarantee we can make
+  # web-safe.
+  def self.accepted_video_content_types
+    return ALLOWED_VIDEO_CONTENT_TYPES unless VideoTranscoder.available?
+    ALLOWED_VIDEO_CONTENT_TYPES + TRANSCODABLE_VIDEO_CONTENT_TYPES
+  end
+
+  def self.max_video_upload_bytes
+    VideoTranscoder.available? ? MAX_VIDEO_SOURCE_BYTES : MAX_VIDEO_BYTES
+  end
 
   before_create :set_defaults
   # before_save :save_display_image_url, if: -> { display_image_url.blank? }
@@ -529,9 +554,19 @@ class BoardImage < ApplicationRecord
     save!
   end
 
-  def set_uploaded_video!(url, content_type)
-    self.data = (data || {}).merge("video" => { "source" => "upload", "url" => url, "content_type" => content_type })
+  # `processed` tracks whether ProcessTileVideoJob has run: false right after
+  # upload (the URL still points at the raw file), true once the clip is known
+  # to be within the duration cap and in a web-safe container. It also makes
+  # the job idempotent, so a Sidekiq retry can't transcode twice.
+  def set_uploaded_video!(url, content_type, duration: nil, processed: false)
+    config = { "source" => "upload", "url" => url, "content_type" => content_type, "processed" => processed }
+    config["duration"] = duration.round(2) if duration
+    self.data = (data || {}).merge("video" => config)
     save!
+  end
+
+  def video_processed?
+    video_config&.dig("processed") == true
   end
 
   def clear_video!

--- a/app/services/video_transcoder.rb
+++ b/app/services/video_transcoder.rb
@@ -1,0 +1,107 @@
+# Thin wrapper around the `ffmpeg` / `ffprobe` binaries for tile video clips.
+#
+# Shells out rather than pulling in a gem — the surface we need is two calls
+# (probe duration, transcode to web-safe mp4) and both binaries are already
+# listed as system dependencies in the README.
+#
+# Every method fails soft: a missing binary, a malformed file, or a non-zero
+# exit returns nil/false rather than raising, so a bad upload can never take
+# down the job that calls it. Callers must check `available?` before assuming
+# a transcode is possible — see ProcessTileVideoJob.
+class VideoTranscoder
+  # Container/codec the web player is guaranteed to handle.
+  OUTPUT_CONTENT_TYPE = "video/mp4".freeze
+
+  # Cap the transcode cost of a pathological upload. A 30s tile clip should
+  # take a couple of seconds; anything past this is wedged.
+  TIMEOUT_SECONDS = 120
+
+  class << self
+    # True only when both binaries are on PATH. Memoized per process — the
+    # answer can't change without a restart, and this is hit on every upload.
+    def available?
+      return @available unless @available.nil?
+      @available = binary?("ffmpeg") && binary?("ffprobe")
+    end
+
+    # Test seam: `available?` memoizes, so specs that stub the binaries need a
+    # way to clear it.
+    def reset_availability!
+      @available = nil
+    end
+
+    # Duration of the file in seconds, or nil if ffprobe can't read it.
+    def duration(path)
+      stdout, _stderr, status = run(
+        "ffprobe", "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        path.to_s
+      )
+      return nil unless status&.success?
+
+      value = stdout.to_s.strip.to_f
+      value.positive? ? value : nil
+    end
+
+    # Name of the video codec ("h264", "hevc", ...), or nil if unreadable.
+    # Used to skip re-encoding clips that are already web-safe.
+    def video_codec(path)
+      stdout, _stderr, status = run(
+        "ffprobe", "-v", "error",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=codec_name",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        path.to_s
+      )
+      return nil unless status&.success?
+
+      stdout.to_s.strip.presence
+    end
+
+    # Transcode to H.264/AAC mp4, trimming to `max_seconds`.
+    #
+    # `-movflags +faststart` moves the moov atom to the front so the clip can
+    # start playing before it has fully downloaded — without it a tile video
+    # stalls until the whole file lands. Returns true on success.
+    def transcode(input_path, output_path, max_seconds:)
+      _stdout, stderr, status = run(
+        "ffmpeg", "-y",
+        "-i", input_path.to_s,
+        "-t", max_seconds.to_s,
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-crf", "26",
+        "-pix_fmt", "yuv420p",
+        "-c:a", "aac",
+        "-b:a", "128k",
+        "-movflags", "+faststart",
+        output_path.to_s
+      )
+      return true if status&.success? && File.size?(output_path.to_s)
+
+      Rails.logger.warn("[VideoTranscoder] transcode failed: #{stderr.to_s.lines.last(3).join.strip}")
+      false
+    end
+
+    private
+
+    def binary?(name)
+      _stdout, _stderr, status = Open3.capture3("which", name)
+      status.success?
+    rescue Errno::ENOENT, StandardError
+      false
+    end
+
+    # Never raises — callers branch on the status instead.
+    def run(*args)
+      Timeout.timeout(TIMEOUT_SECONDS) { Open3.capture3(*args) }
+    rescue Timeout::Error
+      Rails.logger.warn("[VideoTranscoder] timed out after #{TIMEOUT_SECONDS}s: #{args.first}")
+      [nil, nil, nil]
+    rescue Errno::ENOENT => e
+      Rails.logger.warn("[VideoTranscoder] binary missing: #{e.message}")
+      [nil, nil, nil]
+    end
+  end
+end

--- a/app/sidekiq/process_tile_video_job.rb
+++ b/app/sidekiq/process_tile_video_job.rb
@@ -1,0 +1,117 @@
+# Post-processes an uploaded tile video: enforces the 30s cap server-side and
+# transcodes to a web-safe H.264 mp4.
+#
+# upload_video accepts the file and responds immediately with the raw URL, so
+# the editor isn't blocked on ffmpeg. This job then swaps in the processed
+# clip and broadcasts the board, which is how the open editor picks up the new
+# URL.
+#
+# Fails soft by design: if ffmpeg is missing or the transcode errors, the
+# original upload is left attached and playable rather than destroyed. That
+# only happens for mp4/webm — upload_video refuses .mov outright when the
+# binaries aren't available, so we can never be left holding an unplayable
+# clip we have no way to convert.
+class ProcessTileVideoJob
+  include Sidekiq::Job
+
+  sidekiq_options retry: 3, queue: :default
+
+  # Containers that need no re-encode when the codec and duration are already
+  # fine. webm is left alone — it plays everywhere mp4 doesn't.
+  PASSTHROUGH_CONTENT_TYPES = %w[video/mp4 video/webm].freeze
+  WEB_SAFE_CODECS = %w[h264].freeze
+
+  def perform(board_image_id)
+    board_image = BoardImage.find_by(id: board_image_id)
+    return unless board_image&.video_clip&.attached?
+
+    config = board_image.video_config
+    return unless config && config["source"] == "upload"
+    return if board_image.video_processed?
+
+    unless VideoTranscoder.available?
+      Rails.logger.warn(
+        "[ProcessTileVideoJob] ffmpeg/ffprobe unavailable; leaving board_image #{board_image_id} unprocessed",
+      )
+      return
+    end
+
+    blob = board_image.video_clip.blob
+    input = Tempfile.new(["tile_video_#{board_image_id}_in", extension_for(blob.content_type)], binmode: true)
+    output = Tempfile.new(["tile_video_#{board_image_id}_out", ".mp4"], binmode: true)
+
+    begin
+      input.write(board_image.video_clip.download)
+      input.flush
+      input.rewind
+
+      duration = VideoTranscoder.duration(input.path)
+      if duration.nil?
+        Rails.logger.warn("[ProcessTileVideoJob] could not probe board_image #{board_image_id}; leaving as-is")
+        return
+      end
+
+      if passthrough?(blob.content_type, duration, input.path)
+        # Already web-safe and within the cap — just record what we measured
+        # so we don't probe it again.
+        board_image.set_uploaded_video!(
+          config["url"], blob.content_type, duration: duration, processed: true
+        )
+        board_image.board.broadcast_board_update!
+        return
+      end
+
+      unless VideoTranscoder.transcode(
+        input.path, output.path, max_seconds: BoardImage::MAX_VIDEO_DURATION_SECONDS
+      )
+        Rails.logger.warn("[ProcessTileVideoJob] transcode failed for board_image #{board_image_id}; leaving as-is")
+        return
+      end
+
+      original_blob = blob
+      filename = "board-image-#{board_image.id}-video-#{Time.now.strftime("%m%d%y%H%M%S")}.mp4"
+
+      board_image.video_clip.attach(
+        io: File.open(output.path, "rb"),
+        filename: filename,
+        content_type: VideoTranscoder::OUTPUT_CONTENT_TYPE,
+      )
+      board_image.reload
+
+      board_image.set_uploaded_video!(
+        board_image.video_clip_url,
+        VideoTranscoder::OUTPUT_CONTENT_TYPE,
+        duration: [duration, BoardImage::MAX_VIDEO_DURATION_SECONDS].min,
+        processed: true,
+      )
+      # Purge only after the replacement is attached and the new URL is
+      # persisted, so a failure mid-way never leaves the tile pointing at a
+      # blob that no longer exists.
+      original_blob.purge_later
+      board_image.board.broadcast_board_update!
+    ensure
+      input.close!
+      output.close!
+    end
+  end
+
+  private
+
+  # Skip the re-encode when the clip is already in a container the player
+  # handles, uses a web-safe codec, and is within the duration cap.
+  def passthrough?(content_type, duration, path)
+    return false unless PASSTHROUGH_CONTENT_TYPES.include?(content_type)
+    return false if duration > BoardImage::MAX_VIDEO_DURATION_SECONDS
+    return true if content_type == "video/webm"
+
+    WEB_SAFE_CODECS.include?(VideoTranscoder.video_codec(path))
+  end
+
+  def extension_for(content_type)
+    case content_type
+    when "video/webm" then ".webm"
+    when "video/quicktime" then ".mov"
+    else ".mp4"
+    end
+  end
+end

--- a/spec/requests/api/board_images_video_spec.rb
+++ b/spec/requests/api/board_images_video_spec.rb
@@ -65,9 +65,18 @@ RSpec.describe "API::BoardImages video", type: :request do
       expect(video["url"]).to be_present
     end
 
-    it "rejects a disallowed content type with 422 and attaches nothing" do
+    it "enqueues the post-process job to enforce duration and transcode" do
       post "/api/board_images/#{board_image.id}/upload_video",
-           params: { video_file: upload_file(content_type: "video/quicktime") },
+           params: { video_file: upload_file },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(ProcessTileVideoJob.jobs.last["args"]).to eq([board_image.id])
+    end
+
+    it "rejects a content type we can never play with 422 and attaches nothing" do
+      post "/api/board_images/#{board_image.id}/upload_video",
+           params: { video_file: upload_file(content_type: "video/x-msvideo") },
            headers: auth_headers(user)
 
       expect(response).to have_http_status(:unprocessable_content)
@@ -75,7 +84,53 @@ RSpec.describe "API::BoardImages video", type: :request do
       expect(board_image.reload.video_clip).not_to be_attached
     end
 
+    # The .mov accept path is gated on the binaries: we only take a format we
+    # can guarantee we're able to convert into something browsers will play.
+    context "quicktime/.mov uploads" do
+      it "accepts them when ffmpeg is available" do
+        allow(VideoTranscoder).to receive(:available?).and_return(true)
+
+        post "/api/board_images/#{board_image.id}/upload_video",
+             params: { video_file: upload_file(content_type: "video/quicktime") },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        board_image.reload
+        expect(board_image.video_clip).to be_attached
+        expect(board_image.video_clip.blob.filename.to_s).to end_with(".mov")
+        # Not yet web-safe — the job flips this once it has converted.
+        expect(board_image.video_processed?).to be(false)
+      end
+
+      it "rejects them when ffmpeg is unavailable" do
+        allow(VideoTranscoder).to receive(:available?).and_return(false)
+
+        post "/api/board_images/#{board_image.id}/upload_video",
+             params: { video_file: upload_file(content_type: "video/quicktime") },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("invalid_video_type")
+        expect(board_image.reload.video_clip).not_to be_attached
+      end
+    end
+
+    describe "size cap" do
+      it "allows the larger source cap when ffmpeg can shrink the file" do
+        allow(VideoTranscoder).to receive(:available?).and_return(true)
+
+        expect(BoardImage.max_video_upload_bytes).to eq(BoardImage::MAX_VIDEO_SOURCE_BYTES)
+      end
+
+      it "falls back to the stored-file cap without ffmpeg" do
+        allow(VideoTranscoder).to receive(:available?).and_return(false)
+
+        expect(BoardImage.max_video_upload_bytes).to eq(BoardImage::MAX_VIDEO_BYTES)
+      end
+    end
+
     it "rejects an oversized file with 422" do
+      allow(VideoTranscoder).to receive(:available?).and_return(false)
       stub_const("BoardImage::MAX_VIDEO_BYTES", 10)
       post "/api/board_images/#{board_image.id}/upload_video",
            params: { video_file: upload_file },

--- a/spec/services/video_transcoder_spec.rb
+++ b/spec/services/video_transcoder_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+# ffmpeg/ffprobe aren't installed on CI, so every shellout is stubbed here.
+# These specs pin the contract the callers rely on: fail soft, never raise.
+RSpec.describe VideoTranscoder do
+  before { described_class.reset_availability! }
+  after { described_class.reset_availability! }
+
+  def status(success)
+    instance_double(Process::Status, success?: success)
+  end
+
+  describe ".available?" do
+    it "is true only when both binaries are on PATH" do
+      allow(Open3).to receive(:capture3).with("which", "ffmpeg").and_return(["", "", status(true)])
+      allow(Open3).to receive(:capture3).with("which", "ffprobe").and_return(["", "", status(true)])
+
+      expect(described_class).to be_available
+    end
+
+    it "is false when ffprobe is missing" do
+      allow(Open3).to receive(:capture3).with("which", "ffmpeg").and_return(["", "", status(true)])
+      allow(Open3).to receive(:capture3).with("which", "ffprobe").and_return(["", "", status(false)])
+
+      expect(described_class).not_to be_available
+    end
+
+    it "memoizes so the PATH check doesn't run on every upload" do
+      allow(Open3).to receive(:capture3).and_return(["", "", status(true)])
+
+      3.times { described_class.available? }
+
+      expect(Open3).to have_received(:capture3).twice
+    end
+  end
+
+  describe ".duration" do
+    it "parses the ffprobe output into seconds" do
+      allow(Open3).to receive(:capture3).and_return(["12.480000\n", "", status(true)])
+
+      expect(described_class.duration("/tmp/clip.mp4")).to be_within(0.01).of(12.48)
+    end
+
+    it "returns nil when ffprobe exits non-zero" do
+      allow(Open3).to receive(:capture3).and_return(["", "boom", status(false)])
+
+      expect(described_class.duration("/tmp/clip.mp4")).to be_nil
+    end
+
+    it "returns nil rather than 0.0 for unreadable output" do
+      allow(Open3).to receive(:capture3).and_return(["N/A\n", "", status(true)])
+
+      expect(described_class.duration("/tmp/clip.mp4")).to be_nil
+    end
+
+    it "returns nil instead of raising when the binary is absent" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect { described_class.duration("/tmp/clip.mp4") }.not_to raise_error
+      expect(described_class.duration("/tmp/clip.mp4")).to be_nil
+    end
+  end
+
+  describe ".video_codec" do
+    it "returns the codec name" do
+      allow(Open3).to receive(:capture3).and_return(["hevc\n", "", status(true)])
+
+      expect(described_class.video_codec("/tmp/clip.mov")).to eq("hevc")
+    end
+
+    it "returns nil on failure" do
+      allow(Open3).to receive(:capture3).and_return(["", "", status(false)])
+
+      expect(described_class.video_codec("/tmp/clip.mov")).to be_nil
+    end
+  end
+
+  describe ".transcode" do
+    let(:output) { Tempfile.new(["out", ".mp4"]) }
+    after { output.close! }
+
+    it "passes the duration cap and faststart flag to ffmpeg" do
+      output.write("x")
+      output.flush
+      allow(Open3).to receive(:capture3).and_return(["", "", status(true)])
+
+      expect(described_class.transcode("/tmp/in.mov", output.path, max_seconds: 30)).to be(true)
+      expect(Open3).to have_received(:capture3) do |*args|
+        expect(args).to include("-t", "30")
+        expect(args).to include("-movflags", "+faststart")
+        expect(args).to include("libx264")
+      end
+    end
+
+    it "returns false when ffmpeg exits non-zero" do
+      allow(Open3).to receive(:capture3).and_return(["", "error", status(false)])
+
+      expect(described_class.transcode("/tmp/in.mov", output.path, max_seconds: 30)).to be(false)
+    end
+
+    it "returns false when ffmpeg succeeds but writes an empty file" do
+      allow(Open3).to receive(:capture3).and_return(["", "", status(true)])
+
+      expect(described_class.transcode("/tmp/in.mov", output.path, max_seconds: 30)).to be(false)
+    end
+  end
+end

--- a/spec/sidekiq/process_tile_video_job_spec.rb
+++ b/spec/sidekiq/process_tile_video_job_spec.rb
@@ -1,0 +1,186 @@
+require "rails_helper"
+
+# ffmpeg isn't installed on CI, so VideoTranscoder is stubbed throughout.
+# What's pinned here is the job's decision-making: when it transcodes, when it
+# passes through, and — most importantly — that a failure never destroys the
+# user's uploaded clip.
+RSpec.describe ProcessTileVideoJob do
+  subject(:run) { described_class.new.perform(board_image.id) }
+
+  let(:user)        { create(:user) }
+  let(:board)       { create(:board, user: user) }
+  let(:board_image) { create(:board_image, board: board) }
+
+  # Stands in for an upload that already went through the controller.
+  def attach_video(content_type: "video/mp4", filename: "clip.mp4")
+    board_image.video_clip.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/tiny_video.mp4")),
+      filename: filename,
+      content_type: content_type,
+    )
+    board_image.reload
+    board_image.set_uploaded_video!(board_image.video_clip_url, content_type)
+    board_image
+  end
+
+  before do
+    allow(VideoTranscoder).to receive(:available?).and_return(true)
+    allow(board).to receive(:broadcast_board_update!)
+    allow_any_instance_of(Board).to receive(:broadcast_board_update!)
+  end
+
+  context "when ffmpeg is unavailable" do
+    it "leaves the original clip attached and playable" do
+      attach_video
+      allow(VideoTranscoder).to receive(:available?).and_return(false)
+
+      run
+
+      board_image.reload
+      expect(board_image.video_clip).to be_attached
+      expect(board_image.data["video"]["url"]).to be_present
+      expect(board_image.video_processed?).to be(false)
+    end
+
+    it "does not attempt to probe or transcode" do
+      attach_video
+      allow(VideoTranscoder).to receive(:available?).and_return(false)
+      allow(VideoTranscoder).to receive(:duration)
+      allow(VideoTranscoder).to receive(:transcode)
+
+      run
+
+      expect(VideoTranscoder).not_to have_received(:duration)
+      expect(VideoTranscoder).not_to have_received(:transcode)
+    end
+  end
+
+  context "when the clip is already web-safe and within the cap" do
+    it "marks it processed without re-encoding" do
+      attach_video
+      allow(VideoTranscoder).to receive(:duration).and_return(12.5)
+      allow(VideoTranscoder).to receive(:video_codec).and_return("h264")
+      allow(VideoTranscoder).to receive(:transcode)
+
+      run
+
+      board_image.reload
+      expect(VideoTranscoder).not_to have_received(:transcode)
+      expect(board_image.video_processed?).to be(true)
+      expect(board_image.data["video"]["duration"]).to eq(12.5)
+      expect(board_image.data["video"]["content_type"]).to eq("video/mp4")
+    end
+
+    it "re-encodes an mp4 that is not h264" do
+      attach_video
+      allow(VideoTranscoder).to receive(:duration).and_return(12.5)
+      allow(VideoTranscoder).to receive(:video_codec).and_return("hevc")
+      allow(VideoTranscoder).to receive(:transcode) do |_in, out, **|
+        File.write(out, "transcoded")
+        true
+      end
+
+      run
+
+      expect(VideoTranscoder).to have_received(:transcode)
+      expect(board_image.reload.video_processed?).to be(true)
+    end
+  end
+
+  context "when the clip exceeds the 30s cap" do
+    before do
+      attach_video(content_type: "video/quicktime", filename: "clip.mov")
+      allow(VideoTranscoder).to receive(:duration).and_return(48.0)
+      allow(VideoTranscoder).to receive(:video_codec).and_return("hevc")
+      allow(VideoTranscoder).to receive(:transcode) do |_in, out, **|
+        File.write(out, "transcoded")
+        true
+      end
+    end
+
+    it "trims to the cap and records the trimmed duration" do
+      run
+
+      board_image.reload
+      expect(VideoTranscoder).to have_received(:transcode).with(
+        anything, anything, max_seconds: BoardImage::MAX_VIDEO_DURATION_SECONDS
+      )
+      expect(board_image.data["video"]["duration"]).to eq(30.0)
+    end
+
+    it "replaces the .mov with a web-safe mp4" do
+      run
+
+      board_image.reload
+      expect(board_image.data["video"]["content_type"]).to eq("video/mp4")
+      expect(board_image.video_clip.blob.content_type).to eq("video/mp4")
+      expect(board_image.video_clip.blob.filename.to_s).to end_with(".mp4")
+      expect(board_image.data["video"]["url"]).to be_present
+    end
+  end
+
+  context "when the transcode fails" do
+    it "leaves the original clip attached rather than destroying it" do
+      attach_video(content_type: "video/quicktime", filename: "clip.mov")
+      original_key = board_image.video_clip.blob.key
+      allow(VideoTranscoder).to receive(:duration).and_return(48.0)
+      allow(VideoTranscoder).to receive(:video_codec).and_return("hevc")
+      allow(VideoTranscoder).to receive(:transcode).and_return(false)
+
+      run
+
+      board_image.reload
+      expect(board_image.video_clip).to be_attached
+      expect(board_image.video_clip.blob.key).to eq(original_key)
+      expect(board_image.video_processed?).to be(false)
+    end
+
+    it "leaves the clip alone when the duration can't be probed" do
+      attach_video
+      allow(VideoTranscoder).to receive(:duration).and_return(nil)
+      allow(VideoTranscoder).to receive(:transcode)
+
+      run
+
+      expect(VideoTranscoder).not_to have_received(:transcode)
+      expect(board_image.reload.video_processed?).to be(false)
+    end
+  end
+
+  describe "idempotency" do
+    it "does nothing on a second run, so a Sidekiq retry can't double-transcode" do
+      attach_video
+      allow(VideoTranscoder).to receive(:duration).and_return(12.5)
+      allow(VideoTranscoder).to receive(:video_codec).and_return("h264")
+      allow(VideoTranscoder).to receive(:transcode)
+
+      run
+      described_class.new.perform(board_image.id)
+
+      expect(VideoTranscoder).to have_received(:duration).once
+    end
+  end
+
+  describe "guards" do
+    it "no-ops for a missing board image" do
+      expect { described_class.new.perform(-1) }.not_to raise_error
+    end
+
+    it "no-ops when the tile has no attached clip" do
+      allow(VideoTranscoder).to receive(:duration)
+
+      described_class.new.perform(board_image.id)
+
+      expect(VideoTranscoder).not_to have_received(:duration)
+    end
+
+    it "no-ops for a youtube video config" do
+      board_image.set_youtube_video!("dQw4w9WgXcQ")
+      allow(VideoTranscoder).to receive(:duration)
+
+      run
+
+      expect(VideoTranscoder).not_to have_received(:duration)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #515. Tile video uploads now accept **.mov / HEVC** (iPhone recordings) and the **30-second cap is enforced server-side** instead of client-side only.

`upload_video` still responds immediately with the raw upload URL so the editor isn't blocked on ffmpeg. `ProcessTileVideoJob` then probes the clip, trims it to 30s, transcodes to H.264 mp4, swaps the blob, and calls `broadcast_board_update!` — the open editor picks up the new URL over the existing realtime channel.

**No new gem.** `VideoTranscoder` shells out to `ffmpeg`/`ffprobe` via `Open3`.

### ffmpeg is already installed in production

The issue assumed this needed a new system dependency and explicit approval. It doesn't — production (`ip-10-0-1-165`) already has **ffmpeg 4.4.2** with both `ffmpeg` and `ffprobe` at `/usr/bin`, and 26 GB free. Staging shares that box, so both environments are covered. Nothing to install.

Consequence worth knowing before merge: `VideoTranscoder.available?` will return `true` the moment this deploys, so **production goes straight to the transcoding path** — the degradation fallback below is exercised only in local dev and CI, where the binaries genuinely are absent.

### Graceful degradation

Everything keys off `VideoTranscoder.available?`:

| | ffmpeg present (prod, staging) | ffmpeg absent (CI) |
|---|---|---|
| Accepted types | mp4, webm, **quicktime** | mp4, webm (today's behavior) |
| Size cap | 100 MB source | 25 MB |
| Duration cap | enforced (trimmed) | not enforced |
| Job behavior | transcodes | logs, leaves original attached |

Two invariants worth preserving in future changes:
- **Never accept an upload format we can't guarantee we can make web-safe.** `.mov` is only accepted because ffmpeg is there to convert it — so we can never be left holding an unplayable clip with no way to fix it.
- **A failure never destroys the user's clip.** Probe failure, transcode failure, and missing binaries all leave the original attached and playable. The original blob is purged only *after* the replacement is attached and the new URL is persisted.

### Other details
- Idempotent via `data["video"]["processed"]`, so a Sidekiq retry can't double-transcode.
- Skips re-encoding when the clip is already H.264 mp4 (or webm) and within the cap — just stamps the measured duration.
- `-movflags +faststart` so a tile clip starts playing before it has fully downloaded.
- 100 MB applies to the *source* upload; the transcoded mp4 that gets stored and served is a few MB.

## Test plan

### Real ffmpeg validation (not stubbed)

ffmpeg was installed locally and the **actual `VideoTranscoder` code** was run against generated HEVC-in-`.mov` sources that stand in for iPhone recordings. This is the integration gap the unit specs can't cover, since they stub every shellout.

| Source | Result |
|---|---|
| 45s HEVC 1080p + AAC | → **30.0s**, `h264`, `yuv420p`, `aac`, 1.8s to encode |
| 40s HEVC, **no audio track** | → **30.0s**, `h264` — `-c:a aac` against a source with no audio stream is a no-op, not an error |
| 8s HEVC (under the cap) | → **8.0s**, `h264` — `-t 30` on a shorter input doesn't pad |

`+faststart` verified structurally on the output: `moov` at byte 36, `mdat` at 33960, so the moov atom precedes the media data and playback can begin before the full download.

**Version skew — checked, not assumed.** Local validation ran on ffmpeg **8.1.2**; production is **4.4.2**. The same flag set was executed directly on the prod box against a 40s HEVC source and produced `codec_name=h264`, `duration=30.000000` — trim, H.264 conversion, and `+faststart` all accepted on 4.4.2. Prod's build was also confirmed to carry both required encoders (`libx264`, `aac`), since a build missing either would fail only on real uploads.

### Specs

- `bundle exec rspec spec/services/video_transcoder_spec.rb spec/sidekiq/process_tile_video_job_spec.rb spec/requests/api/board_images_video_spec.rb` — **42 examples, 0 failures**
  - transcoder: availability memoization, duration/codec parsing, `nil` (not `0.0`) on unreadable output, no raise when the binary is absent, correct ffmpeg flags, false on empty output
  - job: missing-binary path, over-30s trim, already-compliant skip, transcode-failure preserves the original blob key, idempotency, guards (missing record, no clip, youtube config)
  - requests: quicktime accepted with ffmpeg / rejected without, cap switching, job enqueue
- `bundle exec rspec spec/models/board_image_spec.rb spec/requests/api/board_images_idor_spec.rb spec/services/youtube_url_parser_spec.rb spec/lib/tasks/video_demo_rake_spec.rb` — **58 examples, 0 failures** (no regressions in the #515 surface)

### Remaining manual check

One end-to-end upload of a real >30s iPhone `.mov` on staging.

Everything above validates the ffmpeg invocation **in isolation**. What no test here covers is the full path: upload → Sidekiq → blob swap → `broadcast_board_update!` → frontend picking up the swapped URL. That last hop has the least evidence behind it and is worth eyes before merge.

Docs updated in the same PR: README system deps, CLAUDE.md architecture note, CHANGELOG entry.

## Not in scope
- OBF import round-trip (still open from #515)
- User-facing notification when a transcode fails — it currently only logs, and the tile keeps the original clip
- Poster/thumbnail extraction

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
