### PR TITLE
feat: add an ASL Signs demo board, generalize the video demo seeder

### DIFF
--- a/lib/tasks/video_demo.rake
+++ b/lib/tasks/video_demo.rake
@@ -1,29 +1,83 @@
-# Seeds the predefined "Video Demo" board: one tile per curated kid-safe
-# YouTube video. Tapping a tile speaks its label and then opens the video in
-# the tile video modal (data["video"] config — see BoardImage#video_config).
+# Seeds the predefined video demo boards: one tile per curated video. Tapping
+# a tile speaks its label and then opens the video in the tile video modal
+# (data["video"] config — see BoardImage#video_config).
 module VideoDemoSeeder
-  BOARD_NAME = "Video Demo".freeze
-  COLUMNS = 3
-
-  # Curated kid-safe videos. REVIEW BEFORE SEEDING PRODUCTION: every entry
-  # must be hand-verified (plays, is the intended video, embeds allowed) —
-  # YouTube ids are not guessable and links rot. The seed task validates URL
-  # shape via YoutubeUrlParser and fails loudly on malformed entries, but it
-  # cannot verify content.
-  CURATED_VIDEOS = [
-    { label: "Baby Shark", url: "https://www.youtube.com/watch?v=XqZsoesa55w" },
-    { label: "Wheels on the Bus", url: "https://www.youtube.com/watch?v=e_04ZrNroTo" },
-    { label: "Twinkle Twinkle", url: "https://www.youtube.com/watch?v=yCjJyiqpAuU" },
-    { label: "Happy and You Know It", url: "https://www.youtube.com/watch?v=l4WNrvVjiTw" },
-    { label: "Head Shoulders Knees and Toes", url: "https://www.youtube.com/watch?v=h4eueDYPTIg" },
-    { label: "Old MacDonald", url: "https://www.youtube.com/watch?v=_6HzoUcx3eo" },
-    { label: "Itsy Bitsy Spider", url: "https://www.youtube.com/watch?v=w_lCi8U49mY" },
-    { label: "Five Little Ducks", url: "https://www.youtube.com/watch?v=pZw9veQ76fo" },
-    { label: "Row Row Row Your Boat", url: "https://www.youtube.com/watch?v=7otAJa3jui8" },
-    { label: "BINGO", url: "https://www.youtube.com/watch?v=9mmF8zOlh_g" },
-  ].freeze
+  # Curated kid-safe videos, one entry per board. REVIEW BEFORE PUBLISHING:
+  # every video must be hand-verified (plays, is the intended video, embeds
+  # allowed) — YouTube ids are not guessable and links rot. Seeding validates
+  # URL shape via YoutubeUrlParser and fails loudly on malformed entries, but
+  # it cannot judge content. Boards seed unpublished so they can be reviewed
+  # first; `video_demo:publish BOARD=<key>` makes one public.
+  BOARDS = {
+    "songs" => {
+      name: "Video Demo",
+      description: "A demo board of sing-along videos — tap a tile to hear the " \
+                   "word and watch the video.",
+      tags: ["videos", "songs", "demo"],
+      columns: 3,
+      videos: [
+        { label: "Baby Shark", url: "https://www.youtube.com/watch?v=XqZsoesa55w" },
+        { label: "Wheels on the Bus", url: "https://www.youtube.com/watch?v=e_04ZrNroTo" },
+        { label: "Twinkle Twinkle", url: "https://www.youtube.com/watch?v=yCjJyiqpAuU" },
+        { label: "Happy and You Know It", url: "https://www.youtube.com/watch?v=l4WNrvVjiTw" },
+        { label: "Head Shoulders Knees and Toes", url: "https://www.youtube.com/watch?v=h4eueDYPTIg" },
+        { label: "Old MacDonald", url: "https://www.youtube.com/watch?v=_6HzoUcx3eo" },
+        { label: "Itsy Bitsy Spider", url: "https://www.youtube.com/watch?v=w_lCi8U49mY" },
+        { label: "Five Little Ducks", url: "https://www.youtube.com/watch?v=pZw9veQ76fo" },
+        { label: "Row Row Row Your Boat", url: "https://www.youtube.com/watch?v=7otAJa3jui8" },
+        { label: "BINGO", url: "https://www.youtube.com/watch?v=9mmF8zOlh_g" },
+      ],
+    },
+    # Core words paired with the ASL sign for each. This is the clearest case
+    # for video tiles: a sign is motion, so a static symbol cannot show it.
+    # Labels are deliberately core vocabulary, so the tiles reuse the existing
+    # AAC artwork for those words instead of generating new images.
+    "asl" => {
+      name: "ASL Signs Demo",
+      description: "Core words with the ASL sign for each — tap a tile to hear " \
+                   "the word and watch how to sign it.",
+      tags: ["videos", "asl", "sign language", "demo"],
+      columns: 4,
+      videos: [
+        { label: "more", url: "https://www.youtube.com/watch?v=34CBy8zipZQ" },
+        { label: "help", url: "https://www.youtube.com/watch?v=XM1nr6IkcBE" },
+        { label: "eat", url: "https://www.youtube.com/watch?v=04FuU1RxG3E" },
+        { label: "drink", url: "https://www.youtube.com/watch?v=UqyS59psrNE" },
+        { label: "play", url: "https://www.youtube.com/watch?v=i97PA_UGApo" },
+        { label: "all done", url: "https://www.youtube.com/watch?v=YEFNwQZo7Wg" },
+        { label: "toy", url: "https://www.youtube.com/watch?v=5UdCpYcSoAc" },
+        { label: "fun", url: "https://www.youtube.com/watch?v=rByGnEU8sFM" },
+      ],
+    },
+  }.freeze
 
   module_function
+
+  def board_keys
+    BOARDS.keys
+  end
+
+  # Resolves the BOARD env var to one key or all of them. Raises on an unknown
+  # key rather than silently seeding nothing.
+  def resolve_keys(raw)
+    return board_keys if raw.blank?
+
+    key = raw.to_s.strip.downcase
+    unless BOARDS.key?(key)
+      raise "video_demo: unknown BOARD #{raw.inspect} — valid keys: #{board_keys.join(", ")}"
+    end
+    [key]
+  end
+
+  def config_for(key)
+    BOARDS.fetch(key)
+  end
+
+  def board_for(key, admin)
+    Board.find_or_initialize_by(
+      name: config_for(key)[:name], user_id: admin.id, predefined: true,
+    )
+  end
 
   # Same reuse-don't-generate policy as core_boards: prefer an existing public
   # image with artwork, else create one without queuing generation.
@@ -41,20 +95,18 @@ module VideoDemoSeeder
   # Seeds unpublished on purpose: `published` is what makes a predefined admin
   # board public (Board.public_boards, Board#viewable_by?), so leaving it false
   # keeps the board reviewable by the admin owner while invisible to everyone
-  # else. Publish with `video_demo:publish` once the videos have been watched.
-  # Only set on create, so re-running the seed never un-publishes a reviewed
-  # board.
-  def configure_board!(board, admin)
+  # else. Only set on create, so re-running never un-publishes a reviewed board.
+  def configure_board!(board, admin, cfg)
+    columns = cfg[:columns]
     board.assign_attributes(
-      description: "A demo board of sing-along videos — tap a tile to hear the " \
-                   "word and watch the video.",
+      description: cfg[:description],
       predefined: true,
       board_type: "default",
-      number_of_columns: COLUMNS,
-      small_screen_columns: COLUMNS,
-      medium_screen_columns: COLUMNS,
-      large_screen_columns: COLUMNS,
-      tags: ["videos", "songs", "demo"],
+      number_of_columns: columns,
+      small_screen_columns: columns,
+      medium_screen_columns: columns,
+      large_screen_columns: columns,
+      tags: cfg[:tags],
     )
     board.published = false if board.new_record?
     board.parent = admin
@@ -63,73 +115,93 @@ module VideoDemoSeeder
     board.save!
     board
   end
+
+  # Parses every curated URL up front so a typo fails before any writes.
+  def parse_videos!(cfg)
+    cfg[:videos].map do |entry|
+      youtube_id = YoutubeUrlParser.video_id(entry[:url])
+      raise "video_demo: unparseable YouTube URL for #{entry[:label].inspect}: #{entry[:url]}" unless youtube_id
+      entry.merge(youtube_id: youtube_id)
+    end
+  end
 end
 
 namespace :video_demo do
-  desc "Create the public 'Video Demo' board (curated kid-safe YouTube tiles). " \
-       "Idempotent — skips when the board already has tiles. ENV: DRY_RUN=1. " \
+  desc "Create the unpublished video demo boards (curated kid-safe YouTube tiles). " \
+       "Idempotent — skips a board that already has tiles. " \
+       "ENV: BOARD=#{VideoDemoSeeder.board_keys.join("|")} (default: all), DRY_RUN=1. " \
        "Usage: bin/rails video_demo:seed"
   task seed: :environment do
     ActiveRecord::Base.logger.level = Logger::WARN
     admin = User.find(User::DEFAULT_ADMIN_ID)
     dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase)
-
-    # Fail loudly on a malformed curated entry before touching the database.
-    parsed = VideoDemoSeeder::CURATED_VIDEOS.map do |entry|
-      youtube_id = YoutubeUrlParser.video_id(entry[:url])
-      raise "video_demo: unparseable YouTube URL for #{entry[:label].inspect}: #{entry[:url]}" unless youtube_id
-      entry.merge(youtube_id: youtube_id)
-    end
+    keys = VideoDemoSeeder.resolve_keys(ENV["BOARD"])
 
     puts ""
     puts "=" * 60
-    puts "Video Demo board seeding#{dry_run ? " (DRY RUN)" : ""}"
+    puts "Video demo board seeding#{dry_run ? " (DRY RUN)" : ""}"
     puts "=" * 60
     puts "  Admin user: #{admin.email} (id=#{admin.id})"
-    puts "  Videos (#{parsed.size}): #{parsed.map { |v| v[:label] }.join(", ")}"
 
-    board = Board.find_or_initialize_by(
-      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
-    )
-    if board.persisted? && board.board_images.exists?
-      puts "  Board already seeded (id=#{board.id}, #{board.board_images.count} tiles) — skipping."
-      next
-    end
-    next if dry_run
+    seeded = []
+    keys.each do |key|
+      cfg = VideoDemoSeeder.config_for(key)
+      parsed = VideoDemoSeeder.parse_videos!(cfg)
 
-    VideoDemoSeeder.configure_board!(board, admin)
-    parsed.each do |entry|
-      image = VideoDemoSeeder.find_or_build_image(entry[:label])
-      board_image = board.add_image(image.id)
-      unless board_image
-        puts "  ! could not add tile for #{entry[:label].inspect} — skipped"
+      puts ""
+      puts "  [#{key}] #{cfg[:name]} — #{parsed.size} videos"
+
+      board = VideoDemoSeeder.board_for(key, admin)
+      if board.persisted? && board.board_images.exists?
+        puts "    Already seeded (id=#{board.id}, #{board.board_images.count} tiles) — skipping."
         next
       end
-      board_image.set_youtube_video!(entry[:youtube_id])
-      puts "  + #{entry[:label]} (#{entry[:youtube_id]})"
+      next if dry_run
+
+      VideoDemoSeeder.configure_board!(board, admin, cfg)
+      parsed.each do |entry|
+        image = VideoDemoSeeder.find_or_build_image(entry[:label])
+        board_image = board.add_image(image.id)
+        unless board_image
+          puts "    ! could not add tile for #{entry[:label].inspect} — skipped"
+          next
+        end
+        board_image.set_youtube_video!(entry[:youtube_id])
+        puts "    + #{entry[:label]} (#{entry[:youtube_id]})"
+      end
+
+      board.update_column(:layout, {}) if board.layout.nil?
+      %w[lg md sm].each { |screen| board.calculate_grid_layout_for_screen_size(screen, true) }
+      board.set_current_word_list
+      board.save!
+      seeded << key
+      puts "    Done: board id=#{board.id}, slug=#{board.slug}, #{board.board_images.count} tiles."
     end
 
-    board.update_column(:layout, {}) if board.layout.nil?
-    %w[lg md sm].each { |screen| board.calculate_grid_layout_for_screen_size(screen, true) }
-    board.set_current_word_list
-    board.save!
+    next if dry_run || seeded.empty?
 
-    puts "  Done: board id=#{board.id}, slug=#{board.slug}, #{board.board_images.count} tiles."
     puts ""
     puts "  UNPUBLISHED — visible to you as the admin owner, not to anyone else."
-    puts "  Review it, then publish with:"
-    puts "    bin/rails video_demo:publish"
+    puts "  Review, then publish each with:"
+    seeded.each { |key| puts "    bin/rails video_demo:publish BOARD=#{key}" }
   end
 
-  desc "Publish the 'Video Demo' board after review — this makes it public. " \
-       "Usage: bin/rails video_demo:publish"
+  desc "Publish a demo board after review — this makes it public. " \
+       "ENV: BOARD=#{VideoDemoSeeder.board_keys.join("|")} (required). " \
+       "Usage: bin/rails video_demo:publish BOARD=asl"
   task publish: :environment do
+    # BOARD is required here, unlike seed: publishing is public-facing, so it
+    # must never happen to a board the caller didn't name.
+    if ENV["BOARD"].blank?
+      puts "BOARD is required. Usage: bin/rails video_demo:publish BOARD=<#{VideoDemoSeeder.board_keys.join("|")}>"
+      next
+    end
     admin = User.find(User::DEFAULT_ADMIN_ID)
-    board = Board.find_by(
-      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
-    )
-    if board.nil?
-      puts "No '#{VideoDemoSeeder::BOARD_NAME}' board found — run video_demo:seed first."
+    key = VideoDemoSeeder.resolve_keys(ENV["BOARD"]).first
+    board = VideoDemoSeeder.board_for(key, admin)
+
+    if board.new_record?
+      puts "No '#{VideoDemoSeeder.config_for(key)[:name]}' board found — run video_demo:seed BOARD=#{key} first."
       next
     end
     if board.published?
@@ -145,15 +217,20 @@ namespace :video_demo do
     puts "Published '#{board.name}' (id=#{board.id}, slug=#{board.slug}) — it is now public."
   end
 
-  desc "Unpublish the 'Video Demo' board (reverses video_demo:publish). " \
-       "Usage: bin/rails video_demo:unpublish"
+  desc "Unpublish a demo board (reverses video_demo:publish). " \
+       "ENV: BOARD=#{VideoDemoSeeder.board_keys.join("|")} (required). " \
+       "Usage: bin/rails video_demo:unpublish BOARD=asl"
   task unpublish: :environment do
+    if ENV["BOARD"].blank?
+      puts "BOARD is required. Usage: bin/rails video_demo:unpublish BOARD=<#{VideoDemoSeeder.board_keys.join("|")}>"
+      next
+    end
     admin = User.find(User::DEFAULT_ADMIN_ID)
-    board = Board.find_by(
-      name: VideoDemoSeeder::BOARD_NAME, user_id: admin.id, predefined: true,
-    )
-    if board.nil?
-      puts "No '#{VideoDemoSeeder::BOARD_NAME}' board found."
+    key = VideoDemoSeeder.resolve_keys(ENV["BOARD"]).first
+    board = VideoDemoSeeder.board_for(key, admin)
+
+    if board.new_record?
+      puts "No '#{VideoDemoSeeder.config_for(key)[:name]}' board found."
       next
     end
 

--- a/spec/lib/tasks/video_demo_rake_spec.rb
+++ b/spec/lib/tasks/video_demo_rake_spec.rb
@@ -19,101 +19,141 @@ RSpec.describe "video_demo rake tasks", type: :task do
   end
 
   after do
-    ENV.delete("DRY_RUN")
+    %w[BOARD DRY_RUN].each { |k| ENV.delete(k) }
     %w[seed publish unpublish].each { |t| Rake::Task["video_demo:#{t}"].reenable }
   end
 
-  let(:board) { Board.find_by(name: VideoDemoSeeder::BOARD_NAME) }
+  def board_for(key)
+    Board.find_by(name: VideoDemoSeeder.config_for(key)[:name])
+  end
 
   describe "seed" do
-    before { run(:seed) }
-
-    # published is what makes a predefined admin board public, so seeding it
-    # false is what keeps the board reviewable-but-private.
-    it "creates the board unpublished so it is not yet public" do
-      expect(board).to be_present
-      expect(board.published).to be(false)
-      expect(board.predefined).to be(true)
-      expect(board.user_id).to eq(User::DEFAULT_ADMIN_ID)
-      expect(Board.public_boards).not_to include(board)
-    end
-
-    it "is viewable by the admin owner but not by a logged-out visitor" do
-      admin = User.find(User::DEFAULT_ADMIN_ID)
-      expect(board.viewable_by?(admin)).to be(true)
-      expect(board.viewable_by?(nil)).to be(false)
-    end
-
-    it "adds a tile per curated video, each carrying its youtube config" do
-      expect(board.board_images.count).to eq(VideoDemoSeeder::CURATED_VIDEOS.size)
-      video = board.board_images.first.data["video"]
-      expect(video["source"]).to eq("youtube")
-      expect(video["youtube_id"]).to match(/\A[A-Za-z0-9_-]{11}\z/)
-    end
-
-    it "does not duplicate the board or its tiles on a second run" do
+    it "seeds every configured board when BOARD is not given" do
       run(:seed)
 
-      expect(Board.where(name: VideoDemoSeeder::BOARD_NAME).count).to eq(1)
-      expect(board.board_images.count).to eq(VideoDemoSeeder::CURATED_VIDEOS.size)
+      VideoDemoSeeder.board_keys.each do |key|
+        cfg = VideoDemoSeeder.config_for(key)
+        board = board_for(key)
+        expect(board).to be_present, "expected the #{key} board to exist"
+        expect(board.board_images.count).to eq(cfg[:videos].size)
+      end
+    end
+
+    it "seeds only the named board when BOARD is given" do
+      ENV["BOARD"] = "asl"
+      run(:seed)
+
+      expect(board_for("asl")).to be_present
+      expect(board_for("songs")).to be_nil
+    end
+
+    it "raises on an unknown BOARD rather than silently seeding nothing" do
+      ENV["BOARD"] = "nope"
+
+      expect { run(:seed) }.to raise_error(/unknown BOARD/)
+      expect(Board.count).to eq(0)
+    end
+
+    # published is what makes a predefined admin board public, so seeding it
+    # false is what keeps these boards reviewable-but-private.
+    it "creates every board unpublished and out of public view" do
+      run(:seed)
+
+      VideoDemoSeeder.board_keys.each do |key|
+        board = board_for(key)
+        expect(board.published).to be(false)
+        expect(Board.public_boards).not_to include(board)
+        expect(board.viewable_by?(nil)).to be(false)
+        expect(board.viewable_by?(User.find(User::DEFAULT_ADMIN_ID))).to be(true)
+      end
+    end
+
+    it "gives every tile a valid youtube video config" do
+      run(:seed)
+
+      VideoDemoSeeder.board_keys.each do |key|
+        board_for(key).board_images.each do |bi|
+          video = bi.data["video"]
+          expect(video["source"]).to eq("youtube")
+          expect(video["youtube_id"]).to match(/\A[A-Za-z0-9_-]{11}\z/)
+        end
+      end
+    end
+
+    it "does not duplicate boards or tiles on a second run" do
+      run(:seed)
+      run(:seed)
+
+      VideoDemoSeeder.board_keys.each do |key|
+        cfg = VideoDemoSeeder.config_for(key)
+        expect(Board.where(name: cfg[:name]).count).to eq(1)
+        expect(board_for(key).board_images.count).to eq(cfg[:videos].size)
+      end
     end
 
     it "leaves an already-published board published when re-seeded" do
-      board.update!(published: true)
+      run(:seed)
+      board_for("asl").update!(published: true)
       run(:seed)
 
-      expect(board.reload.published).to be(true)
+      expect(board_for("asl").reload.published).to be(true)
+    end
+
+    it "writes nothing under DRY_RUN" do
+      ENV["DRY_RUN"] = "1"
+      run(:seed)
+
+      expect(Board.count).to eq(0)
     end
   end
 
   describe "publish" do
-    it "makes a seeded board public" do
-      run(:seed)
-      expect(board.published).to be(false)
+    before { run(:seed) }
 
+    it "makes the named board public and leaves the others alone" do
+      ENV["BOARD"] = "asl"
       run(:publish)
 
-      expect(board.reload.published).to be(true)
-      expect(Board.public_boards).to include(board)
+      expect(board_for("asl").reload.published).to be(true)
+      expect(Board.public_boards).to include(board_for("asl"))
+      expect(board_for("songs").reload.published).to be(false)
+    end
+
+    # Publishing is public-facing, so it must never happen to an unnamed board.
+    it "refuses to publish anything when BOARD is omitted" do
+      run(:publish)
+
+      VideoDemoSeeder.board_keys.each do |key|
+        expect(board_for(key).reload.published).to be(false)
+      end
     end
 
     it "refuses to publish a board with no tiles" do
-      Board.create!(
-        name: VideoDemoSeeder::BOARD_NAME,
-        user_id: User::DEFAULT_ADMIN_ID,
-        predefined: true,
-        published: false,
-      )
-
+      board_for("asl").board_images.destroy_all
+      ENV["BOARD"] = "asl"
       run(:publish)
 
-      expect(board.reload.published).to be(false)
-    end
-
-    it "does nothing when no board has been seeded" do
-      expect { run(:publish) }.not_to raise_error
-      expect(board).to be_nil
+      expect(board_for("asl").reload.published).to be(false)
     end
   end
 
   describe "unpublish" do
     it "takes a published board back out of public view" do
       run(:seed)
+      ENV["BOARD"] = "asl"
       run(:publish)
-
       run(:unpublish)
 
-      expect(board.reload.published).to be(false)
-      expect(Board.public_boards).not_to include(board)
+      expect(board_for("asl").reload.published).to be(false)
+      expect(Board.public_boards).not_to include(board_for("asl"))
     end
-  end
 
-  describe "DRY_RUN" do
-    it "writes nothing to the database" do
-      ENV["DRY_RUN"] = "1"
+    it "refuses to act when BOARD is omitted" do
       run(:seed)
+      board_for("asl").update!(published: true)
+      run(:unpublish)
 
-      expect(Board.where(name: VideoDemoSeeder::BOARD_NAME)).to be_empty
+      expect(board_for("asl").reload.published).to be(true)
     end
   end
 end


### PR DESCRIPTION
Adds a second video demo board and makes it easy to add more.

## The ASL board

Core words paired with the ASL sign for each — 8 tiles: more, help, eat, drink, play, all done, toy, fun.

This is the strongest possible demo of video tiles: **a sign is motion, so a static symbol physically cannot show it.** The labels are deliberately core vocabulary, which means the tiles reuse the existing AAC artwork for those words rather than generating new images — so each tile shows the familiar symbol *and* plays the sign.

All 8 videos verified via YouTube's oEmbed endpoint (exist, allow embedding, titles match their labels) and all come from a single channel ("Sign 'n Grow") for a consistent format:

| Tile | ID | Tile | ID |
|---|---|---|---|
| more | `34CBy8zipZQ` | all done | `YEFNwQZo7Wg` |
| help | `XM1nr6IkcBE` | toy | `5UdCpYcSoAc` |
| eat | `04FuU1RxG3E` | fun | `rByGnEU8sFM` |
| drink | `UqyS59psrNE` | play | `i97PA_UGApo` |

## Why only ASL, and not animals / action words / routines

Those were also requested, but per-tile YouTube content for them doesn't really exist. Searching turns up either **compilations** ("50 Animal Sounds", "38 MINUTES of mooing cows") — wrong for a tile labeled "cow" — or **songs** ("Brush Your Teeth Song", "Action Verbs Song"), which lands right back at another songs board. A "jump" tile that opens a 12-minute verb compilation is a worse demo than no board at all.

Those three are better served by **our own short uploaded clips** (a 2-second clip of someone jumping is exactly what the upload path is for, and now that #523 shipped ffmpeg transcoding, that path is solid). Tracked separately.

## Seeder changes

`VideoDemoSeeder` went from one hardcoded board to a `BOARDS` map, so future boards are a data change rather than a copy-pasted task.

```
bin/rails video_demo:seed                  # all boards, idempotent
bin/rails video_demo:seed BOARD=asl        # just one
bin/rails video_demo:publish BOARD=asl     # public, after review
bin/rails video_demo:unpublish BOARD=asl
```

**Behavior change worth noting:** `publish`/`unpublish` now **require** `BOARD`. Publishing is public-facing, so it should never happen to a board the caller didn't explicitly name. Running them bare prints usage and exits without touching anything. (`seed` still defaults to all boards — it's safe, since everything seeds unpublished.)

An unknown `BOARD` raises instead of silently seeding nothing.

## Test plan

`spec/lib/tasks/video_demo_rake_spec.rb` rewritten for the multi-board shape — **13 examples, 0 failures**:

- seeds all boards by default; only the named one with `BOARD=`; raises on an unknown key
- every board seeds **unpublished**, stays out of `Board.public_boards`, is **not** viewable logged-out, **is** viewable by the admin owner
- every tile carries a valid 11-char youtube config
- idempotent across runs; re-seeding never un-publishes a reviewed board
- `publish BOARD=asl` publishes only that board and leaves songs alone
- `publish`/`unpublish` refuse to act with no `BOARD`
- refuses to publish an empty board
- `DRY_RUN=1` writes nothing

Also dry-ran locally against both boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)