### PR TITLE
feat(video-tiles): YouTube search endpoint for the Video tab

### DIFF
--- a/app/controllers/api/youtube_search_controller.rb
+++ b/app/controllers/api/youtube_search_controller.rb
@@ -1,0 +1,20 @@
+class API::YoutubeSearchController < API::ApplicationController
+  # Signed-in only (inherited authenticate_token!), same posture as
+  # attach_youtube_video — the admin gate lives on the Video tab UI.
+  def search
+    query = params[:q].to_s.strip
+    if query.blank?
+      return render json: { error: "Query parameter is required" }, status: :bad_request
+    end
+    unless YoutubeSearchService.enabled?
+      return render json: { error: "search_unavailable" }, status: :service_unavailable
+    end
+
+    results = YoutubeSearchService.new(query).search
+    if results
+      render json: { videos: results }
+    else
+      render json: { error: "Failed to fetch search results" }, status: :internal_server_error
+    end
+  end
+end

--- a/app/services/youtube_search_service.rb
+++ b/app/services/youtube_search_service.rb
@@ -1,0 +1,64 @@
+require "net/http"
+require "json"
+
+# Proxies YouTube Data API v3 search so the API key never reaches the client.
+# Results are restricted to safe-search strict, embeddable videos — tiles play
+# in an iframe, so a non-embeddable result would attach but never play.
+#
+# Returns nil on any failure (missing key, HTTP error, malformed body) — the
+# controller maps that to a generic error response.
+class YoutubeSearchService
+  BASE_URL = "https://www.googleapis.com/youtube/v3/search"
+  MAX_RESULTS = 12
+
+  def self.enabled?
+    ENV["YOUTUBE_API_KEY"].present?
+  end
+
+  def initialize(query)
+    @query = query.to_s.strip
+  end
+
+  def search
+    return nil unless self.class.enabled?
+
+    uri = URI(BASE_URL)
+    uri.query = URI.encode_www_form(
+      key: ENV["YOUTUBE_API_KEY"],
+      part: "snippet",
+      type: "video",
+      safeSearch: "strict",
+      videoEmbeddable: "true",
+      maxResults: MAX_RESULTS,
+      q: @query,
+    )
+    response = Net::HTTP.get_response(uri)
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    parse(JSON.parse(response.body))
+  rescue StandardError => e
+    Rails.logger.error "YoutubeSearchService error: #{e.message}"
+    nil
+  end
+
+  private
+
+  # Only ids that pass the same validation as user-pasted URLs are returned,
+  # so search results can never smuggle a value the attach endpoint would
+  # reject (or worse, accept unvalidated).
+  def parse(body)
+    Array(body["items"]).filter_map do |item|
+      id = item.dig("id", "videoId")
+      next unless id.to_s.match?(YoutubeUrlParser::VIDEO_ID_RE)
+
+      snippet = item["snippet"] || {}
+      {
+        youtube_id: id,
+        title: snippet["title"],
+        channel_title: snippet["channelTitle"],
+        thumbnail_url: snippet.dig("thumbnails", "medium", "url") ||
+          snippet.dig("thumbnails", "default", "url"),
+      }.with_indifferent_access
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
     get "free_download_boards", to: "boards#free_download_boards"
     post "download_leads", to: "download_leads#create"
     post "google_images", to: "google_search_results#image_search"
+    post "youtube_search", to: "youtube_search#search"
 
     resources :board_screenshot_imports
     post "board_screenshot_imports/:id/commit", to: "board_screenshot_imports#commit"

--- a/spec/requests/api/youtube_search_spec.rb
+++ b/spec/requests/api/youtube_search_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "API::YoutubeSearch", type: :request do
+  let!(:user) { create(:user) }
+
+  describe "POST /api/youtube_search" do
+    it "requires authentication" do
+      post "/api/youtube_search", params: { q: "wheels on the bus" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "requires a query" do
+      post "/api/youtube_search", params: { q: "" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns videos from the search service" do
+      results = [{ "youtube_id" => "dQw4w9WgXcQ", "title" => "A Song" }]
+      service = instance_double(YoutubeSearchService, search: results)
+      allow(YoutubeSearchService).to receive(:enabled?).and_return(true)
+      allow(YoutubeSearchService).to receive(:new).with("wheels on the bus").and_return(service)
+
+      post "/api/youtube_search", params: { q: "wheels on the bus" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["videos"]).to eq(results)
+    end
+
+    it "returns 503 search_unavailable when no API key is configured" do
+      allow(YoutubeSearchService).to receive(:enabled?).and_return(false)
+
+      post "/api/youtube_search", params: { q: "wheels on the bus" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(JSON.parse(response.body)["error"]).to eq("search_unavailable")
+    end
+
+    it "returns a generic error when the search fails" do
+      service = instance_double(YoutubeSearchService, search: nil)
+      allow(YoutubeSearchService).to receive(:enabled?).and_return(true)
+      allow(YoutubeSearchService).to receive(:new).and_return(service)
+
+      post "/api/youtube_search", params: { q: "wheels on the bus" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:internal_server_error)
+      expect(JSON.parse(response.body)["error"]).to eq("Failed to fetch search results")
+    end
+  end
+end

--- a/spec/services/youtube_search_service_spec.rb
+++ b/spec/services/youtube_search_service_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe YoutubeSearchService do
+  let(:api_key) { "test-key" }
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("YOUTUBE_API_KEY").and_return(api_key)
+  end
+
+  def stub_youtube(status:, body:)
+    stub_request(:get, YoutubeSearchService::BASE_URL)
+      .with(query: hash_including(
+        "q" => "wheels on the bus",
+        "safeSearch" => "strict",
+        "videoEmbeddable" => "true",
+        "type" => "video",
+      ))
+      .to_return(status: status, body: body.to_json, headers: { "Content-Type" => "application/json" })
+  end
+
+  def item(video_id, title: "A Song", channel: "Kids Channel")
+    {
+      id: { videoId: video_id },
+      snippet: {
+        title: title,
+        channelTitle: channel,
+        thumbnails: {
+          default: { url: "https://i.ytimg.com/vi/#{video_id}/default.jpg" },
+          medium: { url: "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg" },
+        },
+      },
+    }
+  end
+
+  describe "#search" do
+    it "returns parsed results with validated ids" do
+      stub_youtube(status: 200, body: { items: [item("dQw4w9WgXcQ")] })
+
+      results = described_class.new("wheels on the bus").search
+
+      expect(results).to eq([{
+        "youtube_id" => "dQw4w9WgXcQ",
+        "title" => "A Song",
+        "channel_title" => "Kids Channel",
+        "thumbnail_url" => "https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
+      }])
+    end
+
+    it "drops items whose video id fails validation" do
+      stub_youtube(status: 200, body: {
+        items: [item("bad id!"), item(""), item("dQw4w9WgXcQ")],
+      })
+
+      results = described_class.new("wheels on the bus").search
+
+      expect(results.map { |r| r["youtube_id"] }).to eq(["dQw4w9WgXcQ"])
+    end
+
+    it "falls back to the default thumbnail when medium is missing" do
+      no_medium = item("dQw4w9WgXcQ")
+      no_medium[:snippet][:thumbnails].delete(:medium)
+      stub_youtube(status: 200, body: { items: [no_medium] })
+
+      results = described_class.new("wheels on the bus").search
+
+      expect(results.first["thumbnail_url"])
+        .to eq("https://i.ytimg.com/vi/dQw4w9WgXcQ/default.jpg")
+    end
+
+    it "returns an empty array when the API returns no items" do
+      stub_youtube(status: 200, body: { items: [] })
+
+      expect(described_class.new("wheels on the bus").search).to eq([])
+    end
+
+    it "returns nil on an API error response" do
+      stub_youtube(status: 403, body: { error: { message: "quota" } })
+
+      expect(described_class.new("wheels on the bus").search).to be_nil
+    end
+
+    it "returns nil on a network failure" do
+      stub_request(:get, YoutubeSearchService::BASE_URL)
+        .with(query: hash_including("q" => "wheels on the bus"))
+        .to_timeout
+
+      expect(described_class.new("wheels on the bus").search).to be_nil
+    end
+
+    context "when the API key is not configured" do
+      let(:api_key) { nil }
+
+      it "returns nil without making a request" do
+        expect(described_class.new("wheels on the bus").search).to be_nil
+        expect(a_request(:get, /googleapis/)).not_to have_been_made
+      end
+    end
+  end
+
+  describe ".enabled?" do
+    it "is true with a key and false without" do
+      expect(described_class.enabled?).to be(true)
+      allow(ENV).to receive(:[]).with("YOUTUBE_API_KEY").and_return(nil)
+      expect(described_class.enabled?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `POST /api/youtube_search` (signed-in users) returning up to 12 YouTube results `{ youtube_id, title, channel_title, thumbnail_url }` for the Video tab's upcoming search UI (frontend PR to follow in `itty-bitty-frontend`).
- `YoutubeSearchService` proxies the YouTube Data API v3 with `safeSearch=strict` and `videoEmbeddable=true`, keyed by a new server-side `YOUTUBE_API_KEY` env var — the key never reaches the client.
- Result ids are re-validated against `YoutubeUrlParser::VIDEO_ID_RE`; attaching remains exclusively through the existing validated `attach_youtube_video` endpoint, so no new attach/security surface.
- Fails soft per API error conventions: missing key → 503 `search_unavailable`; API/network failure → generic 500 message, details only logged.

## Deploy note
Requires `YOUTUBE_API_KEY` set in Hatchbox env (prod + staging) — YouTube Data API v3 enabled key. Until it's set, the endpoint returns 503 and the frontend will show search as unavailable. Quota: 100 units/search, 10k/day default (~100 searches/day) — fine while the Video tab is admin-only.

## Test plan
- `bundle exec rspec spec/services/youtube_search_service_spec.rb spec/requests/api/youtube_search_spec.rb` — **13 examples, 0 failures** (service: parsing, id validation, thumbnail fallback, API error, timeout, missing key; request: auth required, blank query 400, happy path, 503, generic 500).
- `bin/rails zeitwerk:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)