### PR TITLE
feat(leads): tag CTG booth leads with ctg-2026 in Mailchimp

### DIFF
--- a/.claude-notes/marketing-integrations.md
+++ b/.claude-notes/marketing-integrations.md
@@ -151,6 +151,26 @@ grants were already deduped on `stripe_event_id`; this extends idempotency to
 the non-credit handlers (`apply_free_plan` on delete/pause, `past_due` on
 `payment_failed`) so retries/dashboard replays don't pollute the credit ledger.
 
+**Anonymous lead capture → Mailchimp tags.** `POST /api/download_leads`
+(public, no auth) creates a `DownloadLead` from a bare email and enqueues
+`MailchimpUpsertLeadJob`, which upserts the contact via
+`MailchimpService#record_lead` and tags it. The tag comes from
+`MailchimpUpsertLeadJob::SOURCE_TAGS`, keyed on the lead's free-form `source`
+string (`"classroom_kit"` → `ClassroomKitLead`, `"ctg"` → `ctg-2026`); anything
+unlisted falls back to `DEFAULT_LEAD_TAG`. `source` is not validated against a
+whitelist — a new funnel only needs a `SOURCE_TAGS` entry to get its own
+segmentable tag, and a typo'd source degrades to the default tag rather than
+erroring. Campaign UTMs ride along in the lead's `data` jsonb.
+
+**`record_lead` only ever sends `EMAIL` + `FNAME`**, so every required merge
+field on the audience is a silent break: a permanent 4xx marks the lead
+`failed` and is deliberately *not* re-raised (it would fail identically on
+every retry), so a misconfigured audience kills capture without surfacing an
+exception. Before launching a capture funnel, confirm the audience has no
+required merge fields beyond EMAIL — as of the CTG work the production
+audience (`us2`, list `b7456c33f9`) requires none, and `ADDRESS` is present
+but optional.
+
 ## PostHog server-side analytics
 
 `PosthogService` (`app/models/posthog_service.rb`) captures events that must

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Closing the Gap booth lead attribution
+- Leads captured with `source: "ctg"` now carry the `ctg-2026` Mailchimp tag,
+  so booth signups land in the campaign's existing segment and welcome
+  automation instead of the generic lead tag.
+
 ### Added — Internal API image and board search
 - `GET`/`POST /api/internal/images/search` — find library images by label
   (single or bulk, up to 100 labels per request) and get print-resolution

--- a/app/sidekiq/mailchimp_upsert_lead_job.rb
+++ b/app/sidekiq/mailchimp_upsert_lead_job.rb
@@ -10,7 +10,12 @@ class MailchimpUpsertLeadJob
   DEFAULT_LEAD_TAG = "BoardDownloadLead".freeze
   # Source-specific Mailchimp tags so distinct lead funnels can be segmented.
   # Anything not listed here falls back to DEFAULT_LEAD_TAG (existing behavior).
-  SOURCE_TAGS = { "classroom_kit" => "ClassroomKitLead" }.freeze
+  SOURCE_TAGS = {
+    "classroom_kit" => "ClassroomKitLead",
+    # Closing the Gap 2026 booth capture. Matches the tag the ctg-2026 campaign
+    # segment and its welcome automation are already built against.
+    "ctg" => "ctg-2026",
+  }.freeze
 
   def perform(download_lead_id)
     lead = DownloadLead.find_by(id: download_lead_id)

--- a/spec/requests/api/download_leads_spec.rb
+++ b/spec/requests/api/download_leads_spec.rb
@@ -46,6 +46,47 @@ RSpec.describe "API download_leads", type: :request do
       end
     end
 
+    # The CTG booth capture is email-only (no name, no board) and carries the
+    # QR/email UTMs onto the lead's data for campaign attribution.
+    context "with a ctg booth capture (email only)" do
+      let(:params) do
+        {
+          download_lead: {
+            email: "booth@example.com",
+            source: "ctg",
+            data: { utm_campaign: "ctg-2026", utm_source: "qr", utm_content: "booth" },
+          },
+        }
+      end
+
+      it "creates a ctg-sourced lead with no name and enqueues the Mailchimp job" do
+        expect {
+          post "/api/download_leads", params: params
+        }.to change(DownloadLead, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        lead = DownloadLead.last
+        expect(lead.email).to eq("booth@example.com")
+        expect(lead.name).to be_blank
+        expect(lead.board_id).to be_nil
+        expect(lead.source).to eq("ctg")
+        expect(lead.data).to eq(
+          "utm_campaign" => "ctg-2026", "utm_source" => "qr", "utm_content" => "booth"
+        )
+
+        expect(MailchimpUpsertLeadJob.jobs.size).to eq(1)
+        expect(MailchimpUpsertLeadJob.jobs.first["args"]).to eq([lead.id])
+      end
+
+      it "maps the ctg source to the ctg-2026 Mailchimp tag" do
+        post "/api/download_leads", params: params
+
+        expect(MailchimpUpsertLeadJob::SOURCE_TAGS.fetch(DownloadLead.last.source))
+          .to eq("ctg-2026")
+      end
+    end
+
     context "with an invalid / missing email" do
       it "returns 422 with errors and creates no lead (missing email)" do
         expect {

--- a/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
+++ b/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
@@ -35,6 +35,37 @@ RSpec.describe MailchimpUpsertLeadJob, type: :job do
       expect(classroom_lead.reload.mailchimp_status).to eq("synced")
     end
 
+    it "uses the ctg-2026 tag for a ctg source lead" do
+      ctg_lead = create(:download_lead, email: "booth@example.com", name: "Alex", source: "ctg")
+
+      expect(mailchimp).to receive(:record_lead).with(
+        email: "booth@example.com",
+        name: "Alex",
+        tags: ["ctg-2026"],
+      )
+
+      job.perform(ctg_lead.id)
+
+      expect(ctg_lead.reload.mailchimp_status).to eq("synced")
+    end
+
+    # Booth capture is email-only — no name, no address. record_lead must still
+    # be called (and succeed) with a nil name, since the audience has no
+    # required merge fields a bare-email lead couldn't supply.
+    it "syncs a bare-email lead that has no name" do
+      bare_lead = create(:download_lead, email: "bare@example.com", name: nil, source: "ctg")
+
+      expect(mailchimp).to receive(:record_lead).with(
+        email: "bare@example.com",
+        name: nil,
+        tags: ["ctg-2026"],
+      )
+
+      job.perform(bare_lead.id)
+
+      expect(bare_lead.reload.mailchimp_status).to eq("synced")
+    end
+
     it "marks the lead failed and re-raises on a transient (5xx) Mailchimp API error" do
       allow(mailchimp).to receive(:record_lead)
         .and_raise(MailchimpMarketing::ApiError.new(status: 500, message: "boom"))


### PR DESCRIPTION
Phase 1 backend dependency from the CTG landing plan (`conference-prep/drafts/ctg-landing-plan.md`, decision 2). Unblocks the frontend `/ctg` capture page's lead attribution.

## What changed

`MailchimpUpsertLeadJob::SOURCE_TAGS` gains `"ctg" => "ctg-2026"`, so leads captured with `source: "ctg"` carry the `ctg-2026` tag — matching the Mailchimp segment and welcome automation already built for the campaign — instead of falling back to the generic `BoardDownloadLead` tag.

No migration, no new ENV, no change to the capture endpoint. `DownloadLead#source` is free-form, so nothing else needed whitelisting.

## Verified: the flagged ADDRESS 400 does not apply

The plan flagged a known permanent 400 when the audience requires an `ADDRESS` merge field a bare-email lead can't supply. This matters because `MailchimpUpsertLeadJob` deliberately **does not re-raise** permanent 4xx errors — it marks the lead `failed` and returns, so a misconfigured audience would kill booth capture silently.

Checked both halves:

- `MailchimpService#record_lead` builds `merge_fields` from `FNAME` only (and omits it when name is blank) — it never sends `ADDRESS`.
- Read-only query of the production audience (`us2`, list `b7456c33f9`) merge fields: **zero required fields**. `ADDRESS` exists but is `required: false`, as are `PHONE`, `FNAME`, `LNAME`, and the rest.

So a bare-email booth lead upserts cleanly. Booth capture will reach Mailchimp.

Note: this is a config check plus a unit-level guard, not a live end-to-end write — actually POSTing a lead would add a real subscriber to the production audience, which I didn't do without a go-ahead.

## Tests

Added:
- job spec — `source: "ctg"` → `["ctg-2026"]` tag
- job spec — bare-email lead (`name: nil`) still syncs, guarding the email-only booth path
- request spec — email-only `ctg` capture creates the lead with UTMs on `data` and enqueues the job
- request spec — the `ctg` source resolves to the `ctg-2026` tag

## Test plan

```
bundle exec rspec spec/sidekiq/mailchimp_upsert_lead_job_spec.rb spec/requests/api/download_leads_spec.rb
```
→ **14 examples, 0 failures**

## Docs

- `CHANGELOG.md` — entry under Unreleased
- `.claude-notes/marketing-integrations.md` — documented the previously-undocumented `download_leads` → `SOURCE_TAGS` → Mailchimp tag path, plus the "required merge fields silently break capture" trap and how to check it before launching a new funnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)