### PR TITLE
feat: writing suggestions backend (POST /api/suggestions)

### DIFF
--- a/.claude-notes/writing-suggestions.md
+++ b/.claude-notes/writing-suggestions.md
@@ -1,0 +1,52 @@
+# Writing suggestions (contextual field help)
+
+`POST /api/suggestions` returns three short starter sentences for a free-text
+field. v1 covers About Me (`profiles.bio`) only, from two frontend surfaces.
+
+## The load-bearing rule
+
+**The client names a field; the server decides what becomes context.** The
+request carries a `field_key`, an optional `subject_id`, and (only for the
+onboarding variant) an `inline_context` whose keys are themselves allow-listed.
+It never carries prompt text or arbitrary context values. Break this and the
+endpoint becomes a general OpenAI proxy anyone can bill to SpeakAnyWay.
+
+## The privacy invariant
+
+No key in `Profile::SAFETY_SENSITIVE_KEYS` may appear in any registry allow-list
+— allergies, medical conditions, medications, other conditions, emergency notes,
+and emergency contacts never reach OpenAI. This is enforced by
+`spec/services/suggestions/registry_spec.rb`, not by convention. If that spec
+blocks a change you are making, the spec is right.
+
+This is why emergency notes are NOT an AI surface: with no sensitive context
+allowed, suggestions there can't be personalized, so v2 ships them as a curated
+static list with no API call at all.
+
+## Pieces
+
+- `Suggestions::Registry` — per-field declaration. Adding a surface is one entry.
+- `Suggestions::ContextBuilder` — resolves allow-listed keys only, drops blanks.
+  AAC attributes live on `ChildAccount#details`, not on the `Profile`.
+- `Suggestions::Generator` — OpenAI in JSON mode. **Always returns an array of
+  strings, never nil, never raises.** Fixtures whenever
+  `Suggestions::Generator.use_fixtures?` (staging or test); specs exercising the
+  live path stub that to false.
+- `API::SuggestionsController` — auth, ownership via
+  `profile.profileable.editable_by?`, toggle check, 1-hour `Rails.cache`.
+
+## Deliberate choices
+
+- **Free.** No `check_credits!`, no `FEATURE_COSTS` entry; a request spec asserts
+  no `CreditTransaction` is created. Free-plan users get 25 credits/month and
+  this is onboarding help, not a power feature.
+- **Failure is invisible.** An upstream error renders 200 with `[]`. A parent
+  mid-onboarding never sees a stack trace because OpenAI was down.
+- **Toggle is opt-out.** `user.settings["ai_writing_suggestions"]`; absent means
+  on, so no backfill was needed.
+- **Own OpenAI client.** `request_timeout` is a *client* option in `ruby-openai`,
+  not a `chat` parameter — passing it in `parameters:` sends an unknown field to
+  the API. The generator builds its own client for the shorter (15s) interactive
+  timeout rather than reusing `OpenAiClient`'s 60s one.
+- Throttling rides the existing Rack::Attack `ai_generation/user` rule via
+  `ai_generation_request?` — no new rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Writing suggestions for About Me
+- `POST /api/suggestions` returns three short starter sentences for a
+  communicator's public About Me, built from their name, age range, AAC level,
+  gestalt language stage, and interests. Free — no credits are spent.
+- Emergency and medical details are never sent to OpenAI. The field registry
+  allow-lists what may become prompt context, and a spec fails the build if any
+  `Profile::SAFETY_SENSITIVE_KEYS` entry is ever added to one.
+- Users can turn the feature off account-wide via
+  `settings["ai_writing_suggestions"]`; absent means on.
+
 ### Fixed — Admin signup alerts no longer fire on upgrades
 - The "new user signed up" admin email was sent from inside three welcome-email
   methods. Because `send_plan_welcome_email_once!` routes through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,9 @@ an explicit decision, not a drive-by edit.
   and geolocation errors are rescued and logged — they can never 500 a
   request or a webhook.
 - **Safety-profile emergency info is only served by the gated `safety_view`
-  POST** — never on public page-open.
+  POST** — never on public page-open. It is also never sent to OpenAI: no
+  `Profile::SAFETY_SENSITIVE_KEYS` entry may appear in a
+  `Suggestions::Registry` context allow-list (enforced by spec).
 - **Third-party sends are env-gated to production** (Mailchimp journeys,
   PostHog captures; staging excluded via `AppEnv.staging?`) so non-prod can't
   email or track real users.
@@ -217,6 +219,7 @@ an explicit decision, not a drive-by edit.
 | `.claude-notes/ops.md` | Monitoring/alerting details, AppSignal APM config, full Rack::Attack throttle rules + ENV vars |
 | `.claude-notes/marketing-assets.md` | AAC Classroom Kit hosting: `MarketingAsset`, internal endpoints, marketing print style, QR scannability rule (do not re-add long UTMs to tag QRs) |
 | `.claude-notes/internal-api.md` | Internal `/api/internal/` surface: bearer auth + admin identity, public-CDN download path (`src` vs `original_url`), image + board search endpoints, `Images::CommercialLicense` licensing rule |
+| `.claude-notes/writing-suggestions.md` | Contextual writing suggestions (`POST /api/suggestions`): field registry + context allow-list, the no-safety-keys privacy invariant, OpenAI generator + fixtures, free/no-credit contract, user opt-out toggle |
 
 Related tracked docs: `docs/rds-migration-runbook.md`, `docs/stripe-setup.md`,
 `docs/credits-handoff.md`, `.claude-notes/artifact-generation-services.md`,

--- a/app/controllers/api/suggestions_controller.rb
+++ b/app/controllers/api/suggestions_controller.rb
@@ -32,7 +32,7 @@ module API
       context = Suggestions::ContextBuilder.build(
         entry,
         subject: subject,
-        inline: params[:inline_context]&.permit!&.to_h || {},
+        inline: permitted_inline_context(entry),
       )
 
       suggestions = fetch_suggestions(entry, context)
@@ -40,6 +40,19 @@ module API
     end
 
     private
+
+    # Permit exactly the inline keys this field's registry entry allows — never
+    # `permit!`. ContextBuilder filters again downstream, but the parameter
+    # boundary should be narrow in its own right.
+    def permitted_inline_context(entry)
+      keys = Array(entry[:inline_context])
+      return {} if keys.empty?
+
+      raw = params[:inline_context]
+      return {} unless raw.respond_to?(:permit)
+
+      raw.permit(*keys).to_h
+    end
 
     # Absent means ON — the toggle is opt-out, and no backfill was run.
     def suggestions_enabled?

--- a/app/controllers/api/suggestions_controller.rb
+++ b/app/controllers/api/suggestions_controller.rb
@@ -1,0 +1,76 @@
+module API
+  # Contextual writing suggestions for free-text fields.
+  #
+  # The client sends a `field_key` and (for persisted subjects) a `subject_id`.
+  # It never sends prompt text or context values — Suggestions::Registry decides
+  # what may become context, so this endpoint can't be turned into a general
+  # OpenAI proxy on SpeakAnyWay's bill.
+  #
+  # Free by design: NO check_credits! call. The users who most need help
+  # describing their child are on the 25-credit free plan. Cost is bounded by
+  # the explicit user tap, the response cache, and the Rack::Attack AI throttle.
+  class SuggestionsController < API::ApplicationController
+    CACHE_TTL = 1.hour
+
+    def create
+      entry = Suggestions::Registry.fetch(params[:field_key])
+      return render json: { error: "unknown_field" }, status: :unprocessable_entity if entry.nil?
+
+      unless suggestions_enabled?
+        return render json: { error: "suggestions_disabled" }, status: :forbidden
+      end
+
+      subject = nil
+      if entry[:subject].present?
+        subject = Profile.find_by(id: params[:subject_id])
+        return render json: { error: "not_found" }, status: :not_found if subject.nil?
+        unless editable?(subject)
+          return render json: { error: "not_owner" }, status: :forbidden
+        end
+      end
+
+      context = Suggestions::ContextBuilder.build(
+        entry,
+        subject: subject,
+        inline: params[:inline_context]&.permit!&.to_h || {},
+      )
+
+      suggestions = fetch_suggestions(entry, context)
+      render json: { suggestions: suggestions.map { |text| { text: text } } }
+    end
+
+    private
+
+    # Absent means ON — the toggle is opt-out, and no backfill was run.
+    def suggestions_enabled?
+      (current_user.settings || {}).fetch("ai_writing_suggestions", true) != false
+    end
+
+    # Matches API::ProfilesController#update: ownership lives on the
+    # communicator, not the profile. A profile with no communicator (a
+    # user-level page or an unclaimed placeholder) is not editable here.
+    def editable?(profile)
+      profileable = profile.profileable
+      profileable.respond_to?(:editable_by?) && profileable.editable_by?(current_user)
+    end
+
+    def fetch_suggestions(entry, context)
+      key = cache_key(entry, context)
+
+      Rails.cache.delete(key) if params[:refresh].to_s == "true"
+
+      Rails.cache.fetch(key, expires_in: CACHE_TTL) do
+        Suggestions::Generator.call(entry, context: context, locale: locale_param)
+      end
+    end
+
+    def cache_key(entry, context)
+      digest = Digest::SHA256.hexdigest(context.sort.to_h.to_json)[0, 16]
+      "suggestions:#{params[:field_key]}:#{entry[:template]}:#{locale_param}:#{digest}"
+    end
+
+    def locale_param
+      params[:locale].presence&.to_s&.first(5) || "en"
+    end
+  end
+end

--- a/app/services/suggestions/context_builder.rb
+++ b/app/services/suggestions/context_builder.rb
@@ -1,0 +1,60 @@
+module Suggestions
+  # Turns a registry entry + subject record into the plain hash that becomes
+  # prompt context. Only allow-listed keys can be produced, by construction:
+  # #build iterates the entry's allow-list, never the record's attributes.
+  #
+  # Blank values are dropped so the prompt never carries empty fields (an empty
+  # "interests:" line makes the model invent interests).
+  class ContextBuilder
+    def self.build(entry, subject: nil, inline: {})
+      new(entry, subject: subject, inline: inline).build
+    end
+
+    def initialize(entry, subject: nil, inline: {})
+      @entry = entry
+      @subject = subject
+      @inline = (inline || {}).symbolize_keys
+    end
+
+    def build
+      from_record.merge(from_inline)
+    end
+
+    private
+
+    def from_record
+      Array(@entry[:context]).each_with_object({}) do |key, acc|
+        value = resolve(key)
+        acc[key] = value if value.present?
+      end
+    end
+
+    def from_inline
+      Array(@entry[:inline_context]).each_with_object({}) do |key, acc|
+        value = @inline[key].to_s.strip.first(Registry::INLINE_VALUE_MAX_CHARS)
+        acc[key] = value if value.present?
+      end
+    end
+
+    # AAC attributes live on ChildAccount#details (jsonb), not on the Profile.
+    # `profileable` is the communicator for a MySpeak profile; it can be a User
+    # (a user-level public page) or nil (an unclaimed placeholder), and neither
+    # carries communicator context.
+    def communicator
+      return @communicator if defined?(@communicator)
+
+      profileable = @subject.respond_to?(:profileable) ? @subject.profileable : nil
+      @communicator = profileable.is_a?(ChildAccount) ? profileable : nil
+    end
+
+    def resolve(key)
+      case key
+      when :name      then communicator&.name
+      when :age_band  then communicator&.age_band
+      when :aac_level then communicator&.aac_level
+      when :glp_stage then communicator&.glp_stage
+      when :interests then Array(communicator&.details&.dig("interests")).join(", ")
+      end
+    end
+  end
+end

--- a/app/services/suggestions/generator.rb
+++ b/app/services/suggestions/generator.rb
@@ -1,0 +1,142 @@
+require "json"
+
+module Suggestions
+  # Builds the prompt, calls OpenAI in JSON mode, and normalizes the result.
+  #
+  # Contract: ALWAYS returns an array of plain strings. Never nil, never raises.
+  # A parent mid-onboarding must never see an error because OpenAI hiccuped —
+  # the caller renders 200 with an empty array and the UI degrades quietly.
+  #
+  # Mirrors CoachingPromptGenerator's shape (JSON mode, staging fallback, broad
+  # rescue), which is the established pattern for non-critical AI in this app.
+  class Generator
+    MODEL = ENV.fetch("OPENAI_SUGGESTIONS_MODEL", OpenAiClient::GTP_MODEL)
+
+    # Deliberately shorter than OpenAiClient's 60s default: this is interactive,
+    # and a parent staring at a spinner would rather be told "not right now".
+    # NOTE: request_timeout is a CLIENT option in ruby-openai, not a chat
+    # parameter — hence our own client below rather than OpenAiClient's.
+    TIMEOUT_SECONDS = Integer(ENV.fetch("OPENAI_SUGGESTIONS_TIMEOUT", 15))
+
+    # Used in staging and test so neither burns paid OpenAI calls. Matches the
+    # AppEnv.staging? stub pattern documented in the backend CLAUDE.md.
+    FIXTURES = {
+      about_me: [
+        "Loves trains and will show you every single one that goes past.",
+        "Says hello with a big wave, and a high five if you offer one.",
+        "Happiest with music on and a bit of room to move.",
+      ],
+    }.freeze
+
+    def self.call(entry, context:, locale: "en")
+      new(entry, context: context, locale: locale).call
+    end
+
+    # Neither staging nor the test suite may make paid OpenAI calls. Public so
+    # specs exercising the live path can stub it to false.
+    def self.use_fixtures?
+      AppEnv.staging? || Rails.env.test?
+    end
+
+    # Our own client rather than OpenAiClient's, purely for the shorter
+    # interactive timeout — request_timeout is a client option in ruby-openai.
+    def self.openai_client
+      @openai_client ||= OpenAI::Client.new(
+        access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
+        log_errors: true,
+        request_timeout: TIMEOUT_SECONDS,
+      )
+    end
+
+    def initialize(entry, context:, locale: "en")
+      @entry = entry
+      @context = context || {}
+      @locale = locale.presence || "en"
+    end
+
+    def call
+      return fixtures if self.class.use_fixtures?
+
+      normalize(request_suggestions)
+    rescue => e
+      Rails.logger.error "[Suggestions::Generator] #{e.class}: #{e.message}"
+      []
+    end
+
+    private
+
+    def fixtures
+      normalize(FIXTURES.fetch(@entry[:template], []))
+    end
+
+    def request_suggestions
+      response = self.class.openai_client.chat(
+        parameters: {
+          model: MODEL,
+          messages: [
+            { role: "system", content: system_prompt },
+            { role: "user", content: user_prompt },
+          ],
+          response_format: { type: "json_object" },
+        },
+      )
+
+      content = response.dig("choices", 0, "message", "content")
+      return [] if content.blank?
+
+      parsed = JSON.parse(content)
+      Array(parsed["suggestions"])
+    rescue JSON::ParserError => e
+      Rails.logger.warn "[Suggestions::Generator] bad JSON: #{e.message}"
+      []
+    end
+
+    def normalize(raw)
+      Array(raw)
+        .select { |s| s.is_a?(String) }
+        .map { |s| s.strip.first(@entry[:max_chars]) }
+        .reject(&:blank?)
+        .first(@entry[:count])
+    end
+
+    # Voice rules come from marketing/.claude-notes/brand-voice.md. The
+    # prohibitions are not stylistic — About Me is published publicly on a
+    # child's MySpeak page, so an invented "fact" becomes a public claim about
+    # a real child.
+    def system_prompt
+      <<~PROMPT
+        You help a parent or teacher write a short public "About Me" blurb for a
+        nonspeaking communicator who uses SpeakAnyWay, an AAC (augmentative and
+        alternative communication) app.
+
+        Write in the warm, plain voice of a parent introducing their child to a
+        friendly stranger. Be concrete and specific, never generic. Prefer
+        "Loves trains and will show you every one that goes past" over "is a
+        happy child who enjoys activities".
+
+        Rules you must follow:
+        - Respond in this language: #{@locale}
+        - Exactly #{@entry[:count]} suggestions, 1-2 sentences each, under #{@entry[:max_chars]} characters each.
+        - NEVER invent a fact about the child. Use only the details provided.
+          Where you have few details, write a warm opening the parent can finish
+          themselves rather than guessing.
+        - Never diagnose, imply a diagnosis, or mention any medical condition.
+        - Never use the word "autism".
+        - Say "nonspeaking", never "nonverbal". Say "communicator", never "AAC user".
+        - No inspiration porn, no "look how amazing", no toxic positivity, and
+          never frame anyone as fixing or rescuing the child.
+        - If you name the product, it is always written "SpeakAnyWay".
+
+        Respond with JSON only, in exactly this shape:
+        {"suggestions": ["...", "...", "..."]}
+      PROMPT
+    end
+
+    def user_prompt
+      return "No details are known yet. Write warm, general openings." if @context.blank?
+
+      lines = @context.map { |key, value| "#{key.to_s.humanize}: #{value}" }
+      "What we know about this communicator:\n#{lines.join("\n")}"
+    end
+  end
+end

--- a/app/services/suggestions/registry.rb
+++ b/app/services/suggestions/registry.rb
@@ -1,0 +1,45 @@
+module Suggestions
+  # Declarative allow-list for every field that can ask for writing suggestions.
+  #
+  # The client sends a `field_key` and nothing else that reaches OpenAI — the
+  # SERVER decides which attributes become prompt context. Adding a new surface
+  # is one entry here, not a new subsystem.
+  #
+  # INVARIANT: `context` and `inline_context` may never name anything in
+  # Profile::SAFETY_SENSITIVE_KEYS. A child's allergies, medical conditions,
+  # emergency notes, and emergency contacts do not go to OpenAI. This is
+  # enforced by spec/services/suggestions/registry_spec.rb — if you are here to
+  # add a key and that spec is in your way, the spec is right and you are wrong.
+  module Registry
+    # Inline context values come from the client (used only where the record
+    # doesn't exist yet, e.g. mid-onboarding). The server still decides WHICH
+    # keys are legal; this caps how long each value may be.
+    INLINE_VALUE_MAX_CHARS = 60
+
+    FIELDS = {
+      # About Me on a saved communicator profile — profiles.bio, public.
+      "profile_about_me" => {
+        subject: "Profile",
+        context: %i[name age_band aac_level glp_stage interests],
+        inline_context: [],
+        template: :about_me,
+        count: 3,
+        max_chars: 180,
+      },
+      # Same field during the MySpeak wizard, where no Profile exists yet. Only
+      # the name is available, so suggestions are thinner here by design.
+      "onboarding_about_me" => {
+        subject: nil,
+        context: [],
+        inline_context: %i[name],
+        template: :about_me,
+        count: 3,
+        max_chars: 180,
+      },
+    }.freeze
+
+    def self.fetch(field_key)
+      FIELDS[field_key.to_s]
+    end
+  end
+end

--- a/app/views/main/privacy.html.erb
+++ b/app/views/main/privacy.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4">
     <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 mt-4">
         <h1 class="text-xl font-bold mb-4">Privacy Policy for SpeakAnyWay</h1>
-        <p class="my-3">Last Updated: 04/06/2024</p>
+        <p class="my-3">Last Updated: 07/24/2026</p>
         <hr>
         <p>At SpeakAnyWay, accessible from https://www.speakanyway.com/, one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by SpeakAnyWay and how we use it.</p>
         <p>If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us.</p>
@@ -24,6 +24,12 @@
             <li>Send you emails</li>
             <li>Find and prevent fraud</li>
         </ul>
+
+        <h2 class="mt-6 mb-2 font-semibold">AI-assisted writing suggestions</h2>
+        <p>Some text fields in SpeakAnyWay offer optional writing suggestions. These only run when you ask for them by tapping "Give me ideas" — they never run on their own, and they are never generated in the background.</p>
+        <p>When you tap it, we send a small amount of context about that communicator to our AI provider, OpenAI, so the suggestions are relevant: their name, age range, AAC level, gestalt language stage, and interests.</p>
+        <p><strong>We never send emergency or medical information to OpenAI.</strong> Allergies, medical conditions, medications, other health conditions, emergency notes, and emergency contacts are excluded from these requests entirely.</p>
+        <p>You can turn writing suggestions off for your whole account at any time in Settings. Turning them off stops these requests completely.</p>
 
         <h2 class="mt-6 mb-2 font-semibold">Log Files</h2>
         <p>SpeakAnyWay follows a standard procedure of using log files.</p>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,6 +116,10 @@ class Rack::Attack
 
     return true if path == "/api/generated_boards"
 
+    # Writing suggestions — free (no credit gate), so the frequency ceiling is
+    # the only thing bounding abuse here.
+    return true if path == "/api/suggestions"
+
     AI_GEN_SUFFIXES.any? { |suffix| path.end_with?("/#{suffix}") }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,8 @@ Rails.application.routes.draw do
   #  API routes
   namespace :api, defaults: { format: :json } do
     get "stats", to: "stats#index"
+    # Contextual writing suggestions (About Me in v1). Free — no credit gate.
+    post "suggestions", to: "suggestions#create"
     namespace :stripe do
       resources :checkout_sessions, only: :create do
         collection do

--- a/spec/requests/api/suggestions_spec.rb
+++ b/spec/requests/api/suggestions_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe "API::Suggestions", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user, name: "Sam") }
+  let(:profile) { create(:profile, profileable: communicator) }
+  let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
+
+  def post_suggestions(body, request_headers = headers)
+    post "/api/suggestions", params: body.to_json, headers: request_headers
+  end
+
+  before do
+    allow(Suggestions::Generator).to receive(:call)
+      .and_return(["Loves trains.", "Waves hello.", "Draws daily."])
+  end
+
+  describe "POST /api/suggestions" do
+    it "returns suggestions for a profile the user owns" do
+      post_suggestions(field_key: "profile_about_me", subject_id: profile.id)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["suggestions"]).to eq([
+        { "text" => "Loves trains." },
+        { "text" => "Waves hello." },
+        { "text" => "Draws daily." },
+      ])
+    end
+
+    it "returns 401 without a token" do
+      post_suggestions({ field_key: "profile_about_me", subject_id: profile.id },
+                       { "Content-Type" => "application/json" })
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns 403 not_owner for a profile the user cannot edit" do
+      post_suggestions(
+        { field_key: "profile_about_me", subject_id: profile.id },
+        auth_headers(other_user).merge("Content-Type" => "application/json"),
+      )
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+    end
+
+    it "returns 403 suggestions_disabled when the user turned the feature off" do
+      user.update!(settings: (user.settings || {}).merge("ai_writing_suggestions" => false))
+
+      post_suggestions(field_key: "profile_about_me", subject_id: profile.id)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("suggestions_disabled")
+    end
+
+    it "treats an absent toggle as enabled" do
+      user.update!(settings: (user.settings || {}).except("ai_writing_suggestions"))
+
+      post_suggestions(field_key: "profile_about_me", subject_id: profile.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 422 for an unknown field_key" do
+      post_suggestions(field_key: "nope", subject_id: profile.id)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)["error"]).to eq("unknown_field")
+    end
+
+    it "returns 200 with an empty array when the generator fails" do
+      allow(Suggestions::Generator).to receive(:call).and_return([])
+
+      post_suggestions(field_key: "profile_about_me", subject_id: profile.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["suggestions"]).to eq([])
+    end
+
+    it "passes the requested locale through to the generator" do
+      expect(Suggestions::Generator).to receive(:call)
+        .with(anything, hash_including(locale: "es")).and_return([])
+
+      post_suggestions(field_key: "profile_about_me", subject_id: profile.id, locale: "es")
+    end
+
+    it "accepts the onboarding variant with inline context and no subject" do
+      expect(Suggestions::Generator).to receive(:call)
+        .with(anything, hash_including(context: { name: "Sam" })).and_return([])
+
+      post_suggestions(
+        field_key: "onboarding_about_me",
+        inline_context: { name: "Sam", emergency_notes: "has seizures" },
+      )
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # This feature is free. If someone adds check_credits! later, this fails.
+    it "never spends credits" do
+      # Realize the lazy lets first: User#after_create makes an initial grant
+      # transaction, which would otherwise land inside the expect block and
+      # mask what we're actually measuring.
+      profile
+
+      expect {
+        post_suggestions(field_key: "profile_about_me", subject_id: profile.id)
+      }.not_to change(CreditTransaction, :count)
+    end
+  end
+end

--- a/spec/services/suggestions/context_builder_spec.rb
+++ b/spec/services/suggestions/context_builder_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+RSpec.describe Suggestions::ContextBuilder do
+  let(:user) { create(:user) }
+  let(:communicator) do
+    create(:child_account, user: user, name: "Sam").tap do |c|
+      c.update!(details: {
+        "age_band" => "7-10",
+        "aac_level" => "emerging",
+        "glp_stage" => 2,
+        "interests" => %w[trains drawing],
+        "allergies" => "peanuts",
+      })
+    end
+  end
+  let(:profile) { create(:profile, profileable: communicator) }
+  let(:entry) { Suggestions::Registry.fetch("profile_about_me") }
+
+  describe ".build" do
+    it "resolves every allow-listed key off the communicator" do
+      result = described_class.build(entry, subject: profile)
+
+      expect(result).to eq(
+        name: "Sam",
+        age_band: "7-10",
+        aac_level: "emerging",
+        glp_stage: 2,
+        interests: "trains, drawing",
+      )
+    end
+
+    it "drops keys whose values are blank rather than sending empty strings" do
+      communicator.update!(details: { "age_band" => "7-10" })
+
+      result = described_class.build(entry, subject: profile)
+
+      expect(result.keys).to contain_exactly(:name, :age_band)
+    end
+
+    # The allow-list is the whole security model — a value present on the
+    # record but absent from `context` must not appear in the output.
+    it "cannot produce a key that is not allow-listed" do
+      result = described_class.build(entry, subject: profile)
+
+      expect(result).not_to have_key(:allergies)
+      expect(result).not_to have_key(:vocab_type)
+    end
+
+    it "accepts allow-listed inline values and caps their length" do
+      onboarding = Suggestions::Registry.fetch("onboarding_about_me")
+
+      result = described_class.build(onboarding, inline: { name: "A" * 200 })
+
+      expect(result[:name].length).to eq(Suggestions::Registry::INLINE_VALUE_MAX_CHARS)
+    end
+
+    it "ignores inline keys that are not allow-listed" do
+      onboarding = Suggestions::Registry.fetch("onboarding_about_me")
+
+      result = described_class.build(
+        onboarding,
+        inline: { name: "Sam", emergency_notes: "has seizures" },
+      )
+
+      expect(result).to eq(name: "Sam")
+    end
+
+    it "returns an empty hash when the profile has no communicator" do
+      orphan = create(:profile, profileable: nil)
+
+      expect(described_class.build(entry, subject: orphan)).to eq({})
+    end
+  end
+end

--- a/spec/services/suggestions/generator_spec.rb
+++ b/spec/services/suggestions/generator_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe Suggestions::Generator do
+  let(:entry) { Suggestions::Registry.fetch("profile_about_me") }
+  let(:context) { { name: "Sam", age_band: "7-10", interests: "trains, drawing" } }
+  let(:client) { instance_double(OpenAI::Client) }
+
+  def openai_returning(content)
+    allow(described_class).to receive(:openai_client).and_return(client)
+    allow(client).to receive(:chat).and_return(
+      { "choices" => [{ "message" => { "content" => content } }] },
+    )
+  end
+
+  # The generator serves fixtures in test so no spec can accidentally bill a
+  # real OpenAI call. These examples exercise the live path against a stubbed
+  # client, so they opt in explicitly.
+  before { allow(described_class).to receive(:use_fixtures?).and_return(false) }
+
+  describe ".use_fixtures?" do
+    it "is true in the test environment" do
+      allow(described_class).to receive(:use_fixtures?).and_call_original
+
+      expect(described_class.use_fixtures?).to be(true)
+    end
+
+    it "is true in staging" do
+      allow(described_class).to receive(:use_fixtures?).and_call_original
+      allow(AppEnv).to receive(:staging?).and_return(true)
+
+      expect(described_class.use_fixtures?).to be(true)
+    end
+  end
+
+  describe ".call" do
+    it "returns the parsed suggestions" do
+      openai_returning({ suggestions: ["Loves trains.", "Waves hello.", "Draws daily."] }.to_json)
+
+      expect(described_class.call(entry, context: context, locale: "en"))
+        .to eq(["Loves trains.", "Waves hello.", "Draws daily."])
+    end
+
+    it "truncates to the entry's count" do
+      openai_returning({ suggestions: %w[one two three four five] }.to_json)
+
+      expect(described_class.call(entry, context: context, locale: "en").length).to eq(3)
+    end
+
+    it "caps each suggestion at the entry's max_chars" do
+      openai_returning({ suggestions: ["x" * 500] }.to_json)
+
+      result = described_class.call(entry, context: context, locale: "en")
+      expect(result.first.length).to eq(entry[:max_chars])
+    end
+
+    it "drops blank and non-string entries" do
+      openai_returning({ suggestions: ["Loves trains.", "", nil, 42] }.to_json)
+
+      expect(described_class.call(entry, context: context, locale: "en"))
+        .to eq(["Loves trains."])
+    end
+
+    it "returns an empty array when the model returns malformed JSON" do
+      openai_returning("not json at all")
+
+      expect(described_class.call(entry, context: context, locale: "en")).to eq([])
+    end
+
+    it "returns an empty array when the API raises" do
+      allow(described_class).to receive(:openai_client).and_return(client)
+      allow(client).to receive(:chat).and_raise(StandardError, "upstream is down")
+
+      expect(described_class.call(entry, context: context, locale: "en")).to eq([])
+    end
+
+    it "serves fixtures without touching OpenAI when fixtures are in force" do
+      allow(described_class).to receive(:use_fixtures?).and_return(true)
+      expect(described_class).not_to receive(:openai_client)
+
+      result = described_class.call(entry, context: context, locale: "en")
+      expect(result.length).to eq(3)
+    end
+
+    it "sends the locale and the context to the model" do
+      allow(described_class).to receive(:openai_client).and_return(client)
+      captured = nil
+      allow(client).to receive(:chat) do |parameters:|
+        captured = parameters
+        { "choices" => [{ "message" => { "content" => { suggestions: ["a"] }.to_json } }] }
+      end
+
+      described_class.call(entry, context: context, locale: "es")
+
+      expect(captured[:messages].last[:content]).to include("Sam").and include("trains, drawing")
+      expect(captured[:messages].first[:content]).to include("es")
+      expect(captured[:response_format]).to eq({ type: "json_object" })
+      # request_timeout is a client option, not a chat parameter.
+      expect(captured).not_to have_key(:request_timeout)
+    end
+  end
+end

--- a/spec/services/suggestions/registry_spec.rb
+++ b/spec/services/suggestions/registry_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Suggestions::Registry do
+  describe "FIELDS" do
+    it "registers the two v1 About Me surfaces" do
+      expect(described_class::FIELDS.keys).to contain_exactly(
+        "profile_about_me", "onboarding_about_me"
+      )
+    end
+
+    # THE PRIVACY INVARIANT. A context allow-list may never name a safety key.
+    # If this fails, someone is about to send a child's medical data to OpenAI.
+    it "never allow-lists a safety-sensitive key" do
+      sensitive = Profile::SAFETY_SENSITIVE_KEYS.map(&:to_sym)
+
+      described_class::FIELDS.each do |field_key, entry|
+        allow_listed = Array(entry[:context]) + Array(entry[:inline_context])
+        expect(allow_listed & sensitive).to be_empty,
+          "#{field_key} allow-lists sensitive keys: #{(allow_listed & sensitive).inspect}"
+      end
+    end
+
+    it "gives every entry a template, a count, and a character cap" do
+      described_class::FIELDS.each do |field_key, entry|
+        expect(entry[:template]).to be_present, "#{field_key} has no template"
+        expect(entry[:count]).to be > 0
+        expect(entry[:max_chars]).to be > 0
+      end
+    end
+  end
+
+  describe ".fetch" do
+    it "returns the entry for a known key" do
+      expect(described_class.fetch("profile_about_me")).to include(template: :about_me)
+    end
+
+    it "returns nil for an unknown key" do
+      expect(described_class.fetch("not_a_field")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `POST /api/suggestions` — the backend for contextual "Give me ideas" writing
help on free-text fields. v1 serves About Me (`profiles.bio`) only.

**Nothing calls this endpoint yet**, so it ships and deploys safely on its own.
The frontend follows in a separate PR.

### How it works

The client sends a `field_key` and (for saved records) a `subject_id`. It never
sends prompt text or context values — `Suggestions::Registry` declares, per
field, exactly which attributes may become OpenAI context. Without that, this
endpoint would be a general OpenAI proxy anyone could bill to SpeakAnyWay.

- `Suggestions::Registry` — per-field allow-list. Adding a surface is one entry.
- `Suggestions::ContextBuilder` — resolves allow-listed keys only, drops blanks.
- `Suggestions::Generator` — OpenAI in JSON mode; always returns an array of
  strings, never nil, never raises. Fixtures in staging and test.
- `API::SuggestionsController` — auth, ownership, toggle, 1-hour cache.

### Deliberate choices

- **Free.** No `check_credits!`, no `FEATURE_COSTS` entry. A spec asserts no
  `CreditTransaction` is created. Free-plan users have 25 credits/month and this
  is onboarding help, not a power feature.
- **Failure is invisible.** An OpenAI error renders `200` with `[]`. A parent
  mid-onboarding never sees an error because an upstream call failed.
- **Opt-out toggle.** `user.settings["ai_writing_suggestions"]`; absent means on,
  so no backfill was needed.
- Throttling rides the existing Rack::Attack `ai_generation/user` rule.

### The privacy invariant

No key in `Profile::SAFETY_SENSITIVE_KEYS` may appear in any registry allow-list
— allergies, medical conditions, medications, other conditions, emergency notes,
and emergency contacts never reach OpenAI. This is enforced by a spec, not a
comment: adding one to a context list fails the build.

This is also why emergency notes are *not* an AI surface. With no sensitive
context permitted, suggestions there can't be personalized, so v2 ships them as
a curated static list with no API call at all.

## ⚠️ Needs your sign-off before merge

`app/views/main/privacy.html.erb` gains an "AI-assisted writing suggestions"
section and the Last Updated date moves to 07/24/2026. This is legal-adjacent
copy — please read the wording rather than rubber-stamping it.

Note: this backend view is a stub (it ends in "More content here"). The
substantive policy users actually read is the frontend `PrivacyPolicy.tsx`,
which contains a "we do not share your personal information with third parties"
line that has to be qualified. **That change lands in the frontend PR**, and the
two copies must end up saying the same thing.

## Test plan

```
bundle exec rspec spec/services/suggestions spec/requests/api/suggestions_spec.rb \
  spec/requests/api/profiles_spec.rb spec/requests/api/profiles_owner_protection_spec.rb \
  spec/requests/api/child_accounts_aac_profile_spec.rb
```

**69 examples, 0 failures.** That covers the 31 new examples (registry incl. the
privacy invariant, context builder, generator, and the request spec: 401 / 403
not-owner / 403 disabled / 422 unknown field / 200 shape / 200-with-empty on
upstream failure / locale passthrough / onboarding inline variant / no credits
spent) plus the neighbouring profile specs as a regression check.

Throttle matcher verified directly:

```
bundle exec rails runner '...ai_generation_request?(req)'
# /api/suggestions POST => true
# /api/boards   GET     => false   (reads stay unthrottled)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
