### PR TITLE
feat: email verification for new signups

### DIFF
--- a/.claude-notes/credits.md
+++ b/.claude-notes/credits.md
@@ -57,11 +57,17 @@ topup_credits, reset_at, topup_url }`. Admins (`current_user.admin?`) bypass.
 
 Plan-credit lifecycle:
 
-- **Signup:** `User#after_create` calls `CreditService.ensure_initial_grant!`
-  to grant the tier's monthly allowance immediately. Soft-trial users
-  (`plan_type = "basic_trial"`, set by `User#set_soft_trial_plan`) get the
-  Basic-equivalent allowance with `expires_at = 14.days.from_now`. Other
-  tiers get a 30-day expiry. Idempotent — safe to call again.
+- **Email verification:** the account's initial grant is no longer made on
+  signup. `User#mark_email_verified!` — the single idempotent place an
+  account becomes verified (called from the verification-link, invitation-accept,
+  and temp-login paths) — grants legacy welcome `tokens` inside a `with_lock`,
+  then calls `User#grant_initial_plan_credits` (→
+  `CreditService.ensure_initial_grant!`) **outside** that lock/transaction, so
+  a credit-grant failure can never roll back the verification itself. An
+  unverified account holds zero tokens and zero AI credits. Soft-trial users
+  (`plan_type = "basic_trial"`) get the Basic-equivalent allowance with
+  `expires_at = 14.days.from_now`. Other tiers get a 30-day expiry.
+  Idempotent — safe to call again (no-ops once a `plan_grant` row exists).
 - **First paid period + every renewal:** `invoice.payment_succeeded` webhook
   → `CreditService.grant_plan!` with `period_end = subscription.current_period_end`.
   Reads `monthly_credits` from the subscription line's Stripe Price metadata
@@ -86,7 +92,13 @@ Plan-credit lifecycle:
   user's actual plan_type allowance (e.g. Pro = 1500). **Monthly** Stripe
   payers refresh through `invoice.payment_succeeded` instead, so they're
   excluded. Class name kept for cron stability; scope is broader than the
-  name suggests.
+  name suggests. It also requires email verification (`confirmed_at`
+  present) — but **only** for the free allowance (`plan_type` in
+  `free`/`basic_trial`). Paid tiers with no Stripe subscription (5-year
+  licenses, `clinician`, RevenueCat/App Store, `partner_pro`) bypass the
+  verification check and refresh regardless, since they've already paid and
+  this job is their only monthly re-grant path (see "No-subscription paid
+  plans ride the refresh job" below).
 - **Monthly bucket, any billing cadence:** plan credits are a monthly
   allowance, so `grant_plan!` caps `period_end` at
   `MAX_GRANT_WINDOW` (35 days). Without this, a **yearly** subscriber's
@@ -106,8 +118,8 @@ Plan-credit lifecycle:
   logs a `Rails.logger.warn` when it does. Prevents the
   "granted and expired same day" failure mode regardless of caller.
 - **Free tier allowance:** 25 credits/month
-  (`CreditService::PLAN_MONTHLY_CREDITS["free"]`). Applied on signup,
-  refresh, and post-cancellation.
+  (`CreditService::PLAN_MONTHLY_CREDITS["free"]`). Applied on email
+  verification, refresh, and post-cancellation.
 - **No-subscription paid plans ride the refresh job.** 5-Year licenses
   (`basic_5yr` 400 / `pro_5yr` 1500) and `clinician` (400) have no Stripe
   subscription, so their monthly re-grant comes from `RefreshFreeTierCreditsJob`

--- a/.claude-notes/credits.md
+++ b/.claude-notes/credits.md
@@ -68,9 +68,16 @@ Plan-credit lifecycle:
 
 - **Email verification:** the account's initial grant is no longer made on
   signup. `User#mark_email_verified!` — the single idempotent place an
-  account becomes verified (intended callers: the verification-link,
-  invitation-accept, and temp-login paths — **not yet wired**, they land in a
-  later task of this branch) — grants legacy welcome `tokens` inside a `with_lock`,
+  account becomes verified — writes `email_verified_at`, a dedicated column
+  nothing else writes (NOT `confirmed_at`, which `devise_invitable` stamps on
+  `accept_invitation!` regardless of proven inbox access, and which the
+  hand-rolled email-change flow also writes). Callers: the verification-link
+  (`GET /api/verify_email`) and temp-login (`GET /api/temp-login/:token`) —
+  both paths where the user clicked a link delivered to their inbox.
+  `set_password` / invitation-accept does **not** call it — reaching
+  `set_password` only requires the session `email_signup` already handed out,
+  with no email opened, so it is not proof of inbox ownership (see the
+  task-7r brief). It grants legacy welcome `tokens` inside a `with_lock`,
   then calls `User#grant_initial_plan_credits` (→
   `CreditService.ensure_initial_grant!`) **outside** that lock/transaction, so
   a credit-grant failure can never roll back the verification itself. An
@@ -102,7 +109,7 @@ Plan-credit lifecycle:
   user's actual plan_type allowance (e.g. Pro = 1500). **Monthly** Stripe
   payers refresh through `invoice.payment_succeeded` instead, so they're
   excluded. Class name kept for cron stability; scope is broader than the
-  name suggests. It also requires email verification (`confirmed_at`
+  name suggests. It also requires email verification (`email_verified_at`
   present) — but **only** for the free allowance (`plan_type` in
   `free`/`basic_trial`). Paid tiers with no Stripe subscription (5-year
   licenses, `clinician`, RevenueCat/App Store, `partner_pro`) bypass the

--- a/.claude-notes/credits.md
+++ b/.claude-notes/credits.md
@@ -68,8 +68,9 @@ Plan-credit lifecycle:
 
 - **Email verification:** the account's initial grant is no longer made on
   signup. `User#mark_email_verified!` — the single idempotent place an
-  account becomes verified (called from the verification-link, invitation-accept,
-  and temp-login paths) — grants legacy welcome `tokens` inside a `with_lock`,
+  account becomes verified (intended callers: the verification-link,
+  invitation-accept, and temp-login paths — **not yet wired**, they land in a
+  later task of this branch) — grants legacy welcome `tokens` inside a `with_lock`,
   then calls `User#grant_initial_plan_credits` (→
   `CreditService.ensure_initial_grant!`) **outside** that lock/transaction, so
   a credit-grant failure can never roll back the verification itself. An

--- a/.claude-notes/credits.md
+++ b/.claude-notes/credits.md
@@ -72,8 +72,9 @@ Plan-credit lifecycle:
   nothing else writes (NOT `confirmed_at`, which `devise_invitable` stamps on
   `accept_invitation!` regardless of proven inbox access, and which the
   hand-rolled email-change flow also writes). Callers: the verification-link
-  (`GET /api/verify_email`) and temp-login (`GET /api/temp-login/:token`) —
-  both paths where the user clicked a link delivered to their inbox.
+  (`GET /api/verify_email`), temp-login (`GET /api/temp-login/:token`), and
+  `confirm_email_change` (confirming a pending email-change link) — all three
+  are paths where the user clicked a link delivered to their inbox.
   `set_password` / invitation-accept does **not** call it — reaching
   `set_password` only requires the session `email_signup` already handed out,
   with no email opened, so it is not proof of inbox ownership (see the

--- a/.claude-notes/credits.md
+++ b/.claude-notes/credits.md
@@ -48,6 +48,15 @@ topup_credits, reset_at, topup_url }`. Admins (`current_user.admin?`) bypass.
   image library. Charging only applies when they're replacing/customizing an existing
   image. `regenerate_images`, `create_image_edit`, and `create_image_variation` act on
   images that already have a picture, so they keep charging unconditionally.
+  Because this path never calls `check_credits!`, it needed its own gate:
+  `#generate` requires a verified email (`require_verified_email!`, checked
+  after the `accessible_image` IDOR lookup so a non-owner's private image
+  still 404s first) — renders 403 `email_verification_required` for an
+  unverified caller, admins bypass. Without it an unverified account (zero
+  tokens, zero AI credits) could still drive free-tier OpenAI generation on
+  empty tiles at no cost to them. Board reads, board-load, and audio
+  playback are untouched by this gate — see the cross-cutting "usage must
+  never break" invariant in `CLAUDE.md`.
 - **`MonthlyFeatureLimiter` was removed** (along with `User#ai_limit_reached?`,
   `#reset_ai_limits!`, and the dead `ai_monthly_limit` plan-limit key). AI is
   gated solely by the credit ledger now; the old monthly action-counter was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Email verification for new signups
+- Both signup paths (standard signup and email-only/passwordless signup) now
+  send a confirmation email. The free welcome tokens and the initial AI credit
+  allowance are granted when the address is confirmed rather than at account
+  creation. Existing accounts are backfilled as verified and are unaffected.
+- Unverified accounts can still sign in and use the app — verification never
+  gates authentication — but hold zero welcome tokens and zero AI credits
+  until confirmed.
+- `POST /api/resend_email_verification` resends the confirmation link,
+  throttled per-account (5-minute interval).
+- Signup rate limiting (20/hour per IP on `POST /api/v1/users` and
+  `/api/v1/users/email_signup`) and rejection of disposable email domains at
+  signup.
+
+### Changed — AI image generation now requires a confirmed email address
+- Includes the previously-free first-time-fill path
+  (`POST /api/images/generate` on an image with no picture yet), which never
+  went through the credit ledger and so had no other gate. Unverified callers
+  get a generic **403 `email_verification_required`**; admins bypass.
+
+### Fixed — email-change confirmation tokens now expire
+- They previously never expired (`confirmation_sent_at` was stored but never
+  checked). Same 7-day window as signup verification.
+- Confirming an email change now grants verification (and the pending welcome
+  tokens and AI credits) to an account that had not yet been verified —
+  confirming a pending change is proof of inbox access on the new address,
+  the same as clicking the dedicated verification link.
+
 ### Changed — the category row is now the same on every page of a built board set
 - **Same reach, every page.** The row of category folders along the bottom of a
   built set's home board is now reproduced on every page of that set, in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,13 +208,24 @@ an explicit decision, not a drive-by edit.
 - **Third-party sends are env-gated to production** (Mailchimp journeys,
   PostHog captures; staging excluded via `AppEnv.staging?`) so non-prod can't
   email or track real users.
+- **Email verification is keyed on `email_verified_at`, never `confirmed_at`.**
+  `User#mark_email_verified!` is the only writer. Verified status may be
+  conferred ONLY by a path where the user clicked a link delivered to their
+  inbox: the verification link (`GET /api/verify_email`), temp-login, and
+  email-change confirmation. `set_password` / invitation-accept must never
+  confer it — `email_signup` signs the user in before any email is opened, and
+  `devise_invitable` stamps `confirmed_at` on `accept_invitation!` for any model
+  carrying that column, so `confirmed_at` cannot be a verification signal.
+  Unverified accounts hold zero welcome tokens and zero AI credits and are
+  refused image generation (403 `email_verification_required`); they can still
+  sign in and use the app — **verification never gates authentication**.
 
 ## Subsystem map (read the spoke before working in the area)
 
 | Spoke | Covers |
 |---|---|
 | `.claude-notes/billing-and-plans.md` | Stripe + RevenueCat subscription paths, webhooks + idempotency, no-card reverse trial, soft trial, Partner Program (`partner_pro`), email-only (passwordless) signup, plan-switch endpoints + error contract, `paid_plan?` details, MySpeak ID limit, downgrade rules (board read-only lock + `make_editable` cooldown, communicator fallback + `keep_signable`, sandbox→active promotion), Mission Control revenue metrics |
-| `.claude-notes/credits.md` | AI credit ledger: `CreditService`, feature costs, `check_credits!` / 402 contract, grant lifecycle + refresh/expiry cron jobs, menu image budget + refunds, free first-fill image generation, credits rake tasks, beta entitlement audit |
+| `.claude-notes/credits.md` | AI credit ledger: `CreditService`, feature costs, `check_credits!` / 402 contract, grant lifecycle + refresh/expiry cron jobs, menu image budget + refunds, free first-fill image generation, credits rake tasks, beta entitlement audit, email verification's welcome-token/credit grant |
 | `.claude-notes/marketing-integrations.md` | Mailchimp CRM sync + Customer Journeys (all journey keys + ENV wiring), dual-welcome design, plan-welcome idempotency, PostHog server-side events + `distinct_id` contract |
 | `.claude-notes/safety-profiles.md` | MySpeak safety pages: gated emergency-info reveal, view logging + parent alerts + throttling, coarse IP geolocation, random slugs + legacy-slug fallback |
 | `.claude-notes/boards-and-teams.md` | Team permissions / owner-pinning, SLP→family hand-off, board assignment deep clone (`AssignmentCloner`), non-destructive board removal, board deletion warn+confirm (409), Board Sets (BoardGroup) CRUD + limits, responsive layouts (sm/md derived from lg), OBF/OBZ import copyright policy, Make a Board From Screenshot |

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -474,8 +474,13 @@ class API::ImagesController < API::ApplicationController
     end
 
     # image_generation is free for first-time fills (no `check_credits!` call
-    # below in that case) — so email verification is the only gate standing
-    # between an unverified account and free OpenAI spend. Checked after the
+    # below in that case) — so on THIS route email verification is the only
+    # gate standing between an unverified account and free OpenAI spend. Note
+    # the communicator-side twin, API::Account::ImagesController#run_generate,
+    # has no token/credit/verification guard at all; it is only weakly
+    # reachable (a Free user's self-created communicator is forced to SANDBOX,
+    # which has no passcode and so no child token). Tracked separately.
+    # Checked after the
     # accessible_image lookup so a non-owner's private image still 404s before
     # this, same precedence as check_board_editable!'s resource-then-permission
     # ordering.

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -473,6 +473,14 @@ class API::ImagesController < API::ApplicationController
       @image = Image.find_or_create_by(label: label, user_id: @current_user.id, private: false, image_prompt: stripped_prompt, image_type: "Generated")
     end
 
+    # image_generation is free for first-time fills (no `check_credits!` call
+    # below in that case) — so email verification is the only gate standing
+    # between an unverified account and free OpenAI spend. Checked after the
+    # accessible_image lookup so a non-owner's private image still 404s before
+    # this, same precedence as check_board_editable!'s resource-then-permission
+    # ordering.
+    return unless require_verified_email!
+
     # Building the library is free: only charge when the image already has a
     # displayable picture for this user (i.e. they're replacing/customizing it).
     # First-time generation for an empty tile generates the image but isn't billed.
@@ -779,6 +787,24 @@ class API::ImagesController < API::ApplicationController
     return relation.find(id) if current_user.admin?
 
     relation.where("images.is_private IS NOT TRUE OR images.user_id = ?", current_user.id).find(id)
+  end
+
+  # Gate for #generate: image generation — including the free first-fill
+  # path — is only for verified accounts. Unverified accounts hold zero
+  # legacy tokens and zero AI credits (see User#mark_email_verified!), but
+  # the free-first-fill path never calls check_credits!, so without this an
+  # unverified account could still drive paid OpenAI generation for free.
+  # 403, not 402/429: this is a permission gate, not credit exhaustion or
+  # rate limiting. Never renders internals — generic message only.
+  def require_verified_email!
+    return true if @current_user.admin?
+    return true if @current_user.email_verified?
+
+    render json: {
+      error: "email_verification_required",
+      message: "Please verify your email address to generate images.",
+    }, status: :forbidden
+    false
   end
 
   def check_update_board_image(saved_image_url = nil)

--- a/app/controllers/api/temp_logins_controller.rb
+++ b/app/controllers/api/temp_logins_controller.rb
@@ -26,6 +26,16 @@ class API::TempLoginsController < API::ApplicationController
       temp_login_expires_at: nil,
     )
 
+    # The temp-login link was delivered to their inbox, so reaching here proves
+    # they control that address. Idempotent — a repeat login grants nothing new.
+    # Verification must never break login: this is a login path, so a failure
+    # here is logged and swallowed rather than raised.
+    begin
+      user.mark_email_verified!
+    rescue => e
+      Rails.logger.error "temp_logins#show: mark_email_verified! failed for #{user.email}: #{e.class}: #{e.message} — continuing, sign-in must not be blocked"
+    end
+
     render json: {
       success: true,
       force_password_reset: user.force_password_reset,

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -173,18 +173,41 @@ class API::UsersController < API::ApplicationController
 
     # The whole point of this request is sending an email, so an enqueue
     # failure here can't be reported as success — that would be a lie the
-    # user discovers when nothing arrives. Wrapped in a transaction so a
-    # Redis blip on deliver_later (queue_adapter is :sidekiq, so this pushes
-    # synchronously) rolls back the token/timestamp rotation too — otherwise
-    # the cooldown would start on a send that never happened, and the user's
-    # very next retry would get throttled instead of a real second attempt.
+    # user discovers when nothing arrives, and it's why this endpoint
+    # deliberately diverges from sign_up/email_signup's best-effort verification
+    # email (those succeed regardless — account creation is the primary
+    # purpose and a missing token is recoverable from here).
+    #
+    # A DB transaction can't give this atomicity: queue_adapter is :sidekiq,
+    # so deliver_later pushes to Redis immediately, and Redis isn't a
+    # participant in any Postgres transaction wrapped around it. Wrapping one
+    # around the token write used to create two hazards instead of removing
+    # one — a worker could dequeue and render the mailer against the
+    # not-yet-committed (stale) token before commit, or the push could
+    # succeed and then the commit fail, leaving a queued job for a token that
+    # was never persisted.
+    #
+    # So: sequence instead of rolling back. Mint the token value, hand it
+    # directly to the mailer (which delivers it as-is rather than reading it
+    # back off the user — see UserMailer#verify_email), and only persist the
+    # token + email_verification_sent_at — which starts the cooldown — after
+    # the enqueue call itself has returned without raising.
+    token = SecureRandom.hex(16)
     begin
-      ActiveRecord::Base.transaction do
-        current_user.generate_email_verification_token!
-        UserMailer.verify_email(current_user).deliver_later
-      end
+      UserMailer.verify_email(current_user, token).deliver_later
     rescue => e
       Rails.logger.error "resend_email_verification: mailer enqueue failed for #{current_user.email}: #{e.class}: #{e.message}"
+      return render json: { error: "Couldn't send the verification email. Please try again in a moment." },
+                    status: :service_unavailable
+    end
+
+    begin
+      current_user.persist_email_verification_token!(token)
+    rescue => e
+      # Rare: the email is already out (with `token` embedded in its link),
+      # but we failed to save that same token to the user row, so the link
+      # would 404. Still the honest response — nothing usable was persisted.
+      Rails.logger.error "resend_email_verification: token persist failed after enqueue for #{current_user.email}: #{e.class}: #{e.message}"
       return render json: { error: "Couldn't send the verification email. Please try again in a moment." },
                     status: :service_unavailable
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -106,11 +106,28 @@ class API::UsersController < API::ApplicationController
     if user.nil? || user.confirmation_token != token
       return render json: { error: "Invalid or expired token" }, status: :unprocessable_content
     end
+
+    # Previously unchecked: confirmation_sent_at was stored but never read, so
+    # email-change tokens never expired. Same 7-day window as signup verification.
+    if user.confirmation_sent_at.blank? ||
+       user.confirmation_sent_at < User::EMAIL_VERIFICATION_VALIDITY.ago
+      return render json: { error: "Invalid or expired token" }, status: :unprocessable_content
+    end
+
     user.email = user.unconfirmed_email
     user.unconfirmed_email = nil
     user.confirmation_token = nil
     user.confirmed_at = Time.current
     if user.save
+      # Confirming a pending email change is proof of inbox access on the new
+      # address, same as clicking the dedicated verification link. Route it
+      # through mark_email_verified! so an unverified user isn't left
+      # permanently unverified after proving ownership here. Idempotent, so an
+      # already-verified user is a no-op. Must run after save: the address
+      # needs to be persisted first, and mark_email_verified!'s with_lock ->
+      # lock! raises on a dirty record, so `user` must be clean at this point
+      # (save already reset user.changed? to false; no reload needed).
+      user.mark_email_verified!
       render json: { message: "Email change confirmed", email: user.email }, status: :ok
     else
       render json: { errors: user.errors.full_messages }, status: :unprocessable_content

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -153,6 +153,45 @@ class API::UsersController < API::ApplicationController
            }, status: :ok
   end
 
+  # Resends the signup verification email. Throttled in the model layer via
+  # email_verification_sent_at so the cooldown survives across app instances
+  # (rack-attack's per-IP counters would not help a user on a shared IP).
+  def resend_email_verification
+    if current_user.email_verified?
+      return render json: { error: "Your email is already confirmed." },
+                    status: :unprocessable_content
+    end
+
+    unless current_user.can_resend_email_verification?
+      retry_after = (current_user.email_verification_sent_at +
+                     User::EMAIL_VERIFICATION_RESEND_INTERVAL - Time.current).ceil
+      return render json: {
+                      error: "We just sent one — check your inbox, then try again in a moment.",
+                      retry_after: retry_after,
+                    }, status: :too_many_requests
+    end
+
+    # The whole point of this request is sending an email, so an enqueue
+    # failure here can't be reported as success — that would be a lie the
+    # user discovers when nothing arrives. Wrapped in a transaction so a
+    # Redis blip on deliver_later (queue_adapter is :sidekiq, so this pushes
+    # synchronously) rolls back the token/timestamp rotation too — otherwise
+    # the cooldown would start on a send that never happened, and the user's
+    # very next retry would get throttled instead of a real second attempt.
+    begin
+      ActiveRecord::Base.transaction do
+        current_user.generate_email_verification_token!
+        UserMailer.verify_email(current_user).deliver_later
+      end
+    rescue => e
+      Rails.logger.error "resend_email_verification: mailer enqueue failed for #{current_user.email}: #{e.class}: #{e.message}"
+      return render json: { error: "Couldn't send the verification email. Please try again in a moment." },
+                    status: :service_unavailable
+    end
+
+    render json: { message: "Confirmation email sent to #{current_user.email}." }, status: :ok
+  end
+
   def resend_email_confirmation
     pending_email = current_user.unconfirmed_email
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,7 @@
 class API::UsersController < API::ApplicationController
+  # Clicked from an email client, which carries no bearer token.
+  skip_before_action :authenticate_token!, only: %i[verify_email]
+
   before_action :set_user, only: %i[ show update_settings destroy update ]
 
   # GET /users or /users.json
@@ -112,6 +115,42 @@ class API::UsersController < API::ApplicationController
     else
       render json: { errors: user.errors.full_messages }, status: :unprocessable_content
     end
+  end
+
+  # Signup email verification. Unauthenticated — the link arrives in an inbox.
+  # Distinct from confirm_email_change, which promotes a pending *change* to an
+  # existing account's address.
+  def verify_email
+    token = params[:token].to_s
+    user = token.present? ? User.find_by(email_verification_token: token) : nil
+
+    if user.nil?
+      return render json: { error: "That confirmation link is no longer valid. Send yourself a new one from your dashboard." },
+                    status: :unprocessable_content
+    end
+
+    # Already verified — a double-click, or an email security scanner that
+    # prefetched the link before the user got to it. Report success: the
+    # account is fine, and an error would alarm someone who did nothing wrong.
+    # Checked BEFORE expiry so a verified account never sees an error here.
+    if user.email_verified?
+      return render json: {
+                      message: "Your email is already confirmed. Your free image credits are ready to use.",
+                      email_verified: true,
+                    }, status: :ok
+    end
+
+    unless user.email_verification_token_valid?
+      return render json: { error: "That confirmation link has expired. Send yourself a new one from your dashboard." },
+                    status: :unprocessable_content
+    end
+
+    user.mark_email_verified!
+
+    render json: {
+             message: "Your email is confirmed. Your free image credits are ready to use.",
+             email_verified: true,
+           }, status: :ok
   end
 
   def resend_email_confirmation

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -126,6 +126,23 @@ module API
         user.ensure_minimum_communicator_slot!
         user.record_signup_context!(platform: platform, method: "email_only")
         user.notify_admin_of_signup!
+        # Verification email. The user is already signed in — verification
+        # gates the welcome tokens, never app access. See
+        # drafts/2026-07-26-email-verification-design.md.
+        # Best-effort: the user is already persisted (and signed in above),
+        # so a hiccup here must not 500 the request and strand a created
+        # account. queue_adapter is :sidekiq, so deliver_later enqueues to
+        # Redis synchronously in this request — a Redis blip would otherwise
+        # raise here with nothing rescuing it. A user left without a token
+        # can recover via the resend-verification endpoint, which
+        # re-generates the token — a missing token is recoverable, a 500
+        # response is not.
+        begin
+          user.generate_email_verification_token!
+          UserMailer.verify_email(user).deliver_later
+        rescue => e
+          Rails.logger.error "email_signup: email verification setup failed for #{user.email}: #{e.class}: #{e.message} — continuing; user can request a new verification email"
+        end
         # email_signup is the paid-intent path: no plan picked yet, so send a
         # plan-neutral receipt now. The real plan welcome ships from the Stripe
         # webhook once trial/active. The Mailchimp `welcome` journey is still

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -39,8 +39,20 @@ module API
           # Verification email. The user is already signed in — verification
           # gates the welcome tokens, never app access. See
           # drafts/2026-07-26-email-verification-design.md.
-          user.generate_email_verification_token!
-          UserMailer.verify_email(user).deliver_later
+          # Best-effort: the user is already persisted (and signed in above),
+          # so a hiccup here must not 500 the request and strand a created
+          # account. queue_adapter is :sidekiq, so deliver_later enqueues to
+          # Redis synchronously in this request — a Redis blip would otherwise
+          # raise here with nothing rescuing it. A user left without a token
+          # can recover via the resend-verification endpoint (later task),
+          # which re-generates the token — a missing token is recoverable, a
+          # 500 response is not.
+          begin
+            user.generate_email_verification_token!
+            UserMailer.verify_email(user).deliver_later
+          rescue => e
+            Rails.logger.error "sign_up: email verification setup failed for #{user.email}: #{e.class}: #{e.message} — continuing; user can request a new verification email"
+          end
           if user.role == "partner"
             user.send_partner_welcome_email
           end

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -13,6 +13,7 @@ module API
           render json: { error: "Email, password, and password confirmation are required" }, status: :unprocessable_content
           return
         end
+        return if reject_disposable_email(email)
 
         user = User.new(email: email, password: password, password_confirmation: password_confirmation, name: name)
         if user.save
@@ -86,6 +87,7 @@ module API
           render json: { error: "A valid email is required" }, status: :unprocessable_content
           return
         end
+        return if reject_disposable_email(email)
 
         if User.exists?(email: email)
           render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_content
@@ -290,6 +292,17 @@ module API
 
       def sign_up_params
         params.require(:user).permit(:email, :password, :password_confirmation, first_name: "", last_name: "")
+      end
+
+      # Renders the rejection and returns true when the address is disposable,
+      # so callers can `return if reject_disposable_email(email)`. Shared by
+      # both signup actions — one message, one place to change it.
+      def reject_disposable_email(email)
+        return false unless DisposableEmailDomains.disposable?(email)
+
+        render json: { error: "Please use a permanent email address — we need to be able to reach you about your account." },
+               status: :unprocessable_content
+        true
       end
     end
   end

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -36,6 +36,11 @@ module API
           user.ensure_minimum_communicator_slot!
           user.record_signup_context!(platform: platform, method: "standard")
           user.notify_admin_of_signup!
+          # Verification email. The user is already signed in — verification
+          # gates the welcome tokens, never app access. See
+          # drafts/2026-07-26-email-verification-design.md.
+          user.generate_email_verification_token!
+          UserMailer.verify_email(user).deliver_later
           if user.role == "partner"
             user.send_partner_welcome_email
           end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -57,10 +57,17 @@ class UserMailer < BaseMailer
   # `confirmation_token`; this one proves the address given at signup and
   # carries `verification_token`. They use separate DB columns so a pending
   # change and a pending signup verification can never clobber each other.
-  def verify_email(user)
+  #
+  # `token` lets a caller (resend_email_verification) hand over the exact
+  # value it wants delivered *before* persisting it to the user row — this
+  # job may run on Sidekiq before that write commits, so reading the token
+  # back off `user` here would risk rendering a stale/pre-rotation value.
+  # Falls back to the persisted column for callers (sign_up, email_signup)
+  # that write the token first and mail second.
+  def verify_email(user, token = nil)
     user.reload
     @user = user
-    @token = @user.email_verification_token
+    @token = token || @user.email_verification_token
     if @token.nil?
       Rails.logger.error "No email verification token found for user #{@user.id}"
       return

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -52,6 +52,28 @@ class UserMailer < BaseMailer
     end
   end
 
+  # Signup email verification. Distinct from confirm_update_email: that one
+  # confirms a *change* to an existing account's address and carries
+  # `confirmation_token`; this one proves the address given at signup and
+  # carries `verification_token`. They use separate DB columns so a pending
+  # change and a pending signup verification can never clobber each other.
+  def verify_email(user)
+    user.reload
+    @user = user
+    @token = @user.email_verification_token
+    if @token.nil?
+      Rails.logger.error "No email verification token found for user #{@user.id}"
+      return
+    end
+    @user_name = @user.name
+    @FRONT_END_URL = ENV["FRONT_END_URL"] || "http://localhost:8100"
+    @verification_url = @FRONT_END_URL + "/confirm-email?verification_token=#{@token}"
+
+    with_user_locale(@user) do
+      mail(to: @user.email, subject: I18n.t("user_mailer.verify_email.subject"))
+    end
+  end
+
   # Plan-neutral "your account is ready" receipt for paid-intent signups
   # (email_signup): the user hasn't reached Stripe checkout yet, so we don't
   # know which plan to welcome them onto. The real plan welcome is sent later

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,9 +185,9 @@ class User < ApplicationRecord
   # removed (drafts/drop-basic-trial-option-a.md). The `plan_type` column
   # already defaults to "free"; this callback just applies the Free-tier
   # limits in-memory on create so the account has a board slot, a communicator
-  # slot, and the AI monthly limit set from the start. The 5-credit initial
-  # grant is handled by after_create :grant_initial_plan_credits, which reads
-  # the user's plan_type ("free").
+  # slot, and the AI monthly limit set from the start. The initial AI credit
+  # grant (25 on Free) is deferred to email verification — see
+  # User#mark_email_verified!.
   before_create :setup_new_user_free_plan
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
@@ -205,11 +205,6 @@ class User < ApplicationRecord
   # already in `settings`) on every plan change. See
   # reconcile_paid_sandbox_promotions!.
   after_save :reconcile_paid_sandbox_promotions!, if: :saved_change_to_plan_type?
-
-  # Grant the user's tier's monthly AI credit allowance on signup so the
-  # very first AI call doesn't 402. Idempotent in CreditService — safe to
-  # call again if a callback runs twice.
-  after_create :grant_initial_plan_credits
 
   def grant_initial_plan_credits
     CreditService.ensure_initial_grant!(self)
@@ -600,10 +595,12 @@ class User < ApplicationRecord
     user.ensure_partner_pro_trial_subscription!(trial_end: trial_end)
 
     # Grant the Partner Pro (Pro-equivalent) credit allowance IMMEDIATELY.
-    # The after_create :grant_initial_plan_credits hook already ran while the
-    # account was still `free` (granting the free allowance), and
-    # ensure_initial_grant! is a no-op once any plan_grant exists — so without
-    # this a partner would sit on the free allowance until a cron re-grant.
+    # The initial free-tier grant is now deferred to email verification (see
+    # User#mark_email_verified!), so unlike before, ensure_initial_grant!
+    # hasn't necessarily run yet at this point. Either way, this explicit call
+    # is what actually provisions a partner right away — without it a partner
+    # would otherwise wait on email verification (or a free allowance, if
+    # already verified) instead of getting the partner_pro amount now.
     # grant_plan! resets the plan balance to the partner_pro monthly amount now.
     begin
       CreditService.grant_plan!(
@@ -851,14 +848,28 @@ class User < ApplicationRecord
   def mark_email_verified!
     return false if email_verified?
 
-    transaction do
+    with_lock do
+      # Re-check under the row lock: a scanner prefetch racing the user's own
+      # click can put two requests past the guard above. The balance is safe
+      # either way, but callers branch on the return value to pick user-facing
+      # copy, so only one call may report true.
+      return false if email_verified?
+
       # The verification token is deliberately NOT cleared here — see
       # verify_email in API::UsersController. Email security scanners prefetch
       # links and users double-click; keeping the token lets a replay resolve
       # to this user and get "already confirmed" instead of "invalid link". It
       # grants nothing once confirmed_at is set, and expires after 7 days.
       update!(confirmed_at: Time.current)
+
+      # Both currencies are granted here, not on create: an unverified account
+      # must hold nothing spendable. `tokens` is the legacy field (still spent
+      # by images_controller#find_or_create); AI credits are what the modern
+      # endpoints bill. Both are idempotent — add_welcome_tokens is reached
+      # only once thanks to the guard above, and ensure_initial_grant! no-ops
+      # when a plan_grant already exists.
       add_welcome_tokens
+      grant_initial_plan_credits
     end
     true
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -845,9 +845,9 @@ class User < ApplicationRecord
   #
   # Returns true if this call newly verified the account, false if it was
   # already verified.
-  # `with_lock` wraps the block in `lock!` + a transaction, and `lock!`
-  # raises ActiveRecord::RecordNotSaved-ish dirty-attribute errors if the
-  # record already has unsaved changes — unlike the old
+  # `with_lock` wraps the block in `lock!` + a transaction, and `lock!` raises
+  # a plain `RuntimeError` ("Locking a record with unpersisted changes is not
+  # supported") if the record already has unsaved changes — unlike the old
   # `transaction do ... update! ... end` this replaced, which tolerated a
   # dirty object. Callers must pass a clean (unmutated) user in.
   def mark_email_verified!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -308,15 +308,21 @@ class User < ApplicationRecord
   # Free 1 / Basic 100 / Pro 300.
   # --- Email verification ---------------------------------------------------
   #
-  # `confirmed_at` is the single source of truth for "the address currently on
-  # this account is proven reachable". It is set by three paths: the signup
-  # verification link, accepting an invitation, and temp-login — all three
-  # require the user to click something delivered to that inbox.
+  # `email_verified_at` is the single source of truth for "the address
+  # currently on this account is proven reachable". It is set ONLY by paths
+  # where the user clicked a link that was delivered to their inbox: the
+  # signup verification link and temp-login. `set_password` /
+  # invitation-accept does NOT verify — email_signup hands out that session
+  # with no email opened, so reaching set_password proves nothing about inbox
+  # ownership. See the task-7r brief.
   #
-  # Deliberately NOT devise's :confirmable — this is a JSON API on JWT, and
-  # confirmable would contend with the hand-rolled email-change flow for
-  # `confirmation_token`/`confirmed_at`. See
-  # drafts/2026-07-26-email-verification-design.md.
+  # Deliberately NOT `confirmed_at` and NOT devise's :confirmable — this is a
+  # JSON API on JWT, and confirmable would contend with the hand-rolled
+  # email-change flow for `confirmation_token`/`confirmed_at`.
+  # `devise_invitable` also stamps `confirmed_at` on `accept_invitation!` for
+  # any model carrying that column, whether or not :confirmable is enabled,
+  # which is exactly the shared-column bypass `email_verified_at` exists to
+  # avoid. See drafts/2026-07-26-email-verification-design.md.
   EMAIL_VERIFICATION_VALIDITY = 7.days
   EMAIL_VERIFICATION_RESEND_INTERVAL = 5.minutes
 
@@ -831,7 +837,7 @@ class User < ApplicationRecord
   end
 
   def email_verified?
-    confirmed_at.present?
+    email_verified_at.present?
   end
 
   # Issues a fresh verification token and stamps the send time. The stamp
@@ -883,8 +889,16 @@ class User < ApplicationRecord
       # verify_email in API::UsersController. Email security scanners prefetch
       # links and users double-click; keeping the token lets a replay resolve
       # to this user and get "already confirmed" instead of "invalid link". It
-      # grants nothing once confirmed_at is set, and expires after 7 days.
-      update!(confirmed_at: Time.current)
+      # grants nothing once email_verified_at is set, and expires after 7 days.
+      #
+      # Writes email_verified_at, NOT confirmed_at, deliberately.
+      # devise_invitable stamps confirmed_at on accept_invitation! for any
+      # model carrying that column (devise_invitable/models.rb:98) — a bare
+      # set_password call (no inbox access, just the session email_signup
+      # already handed out) would otherwise confer verified status with zero
+      # proof of inbox ownership. See the task-7r brief. A future reader must
+      # NOT "simplify" this back onto confirmed_at.
+      update!(email_verified_at: Time.current)
 
       # `tokens` is the legacy field (still spent by
       # images_controller#find_or_create) — granted here, not on create, so an
@@ -898,7 +912,7 @@ class User < ApplicationRecord
     # grant_plan! runs inside a nested ActiveRecord transaction that would
     # join this one if called above — a DB error there marks the outer
     # transaction aborted, the rescue swallows it, and the COMMIT silently
-    # becomes a ROLLBACK, undoing confirmed_at and the token grant too.
+    # becomes a ROLLBACK, undoing email_verified_at and the token grant too.
     # Sitting here, a credit-grant failure can never take verification down
     # with it. Safe to call unconditionally: ensure_initial_grant! is
     # idempotent (no-ops once a plan_grant exists), and the guard above

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -859,6 +859,15 @@ class User < ApplicationRecord
       email_verification_sent_at < EMAIL_VERIFICATION_RESEND_INTERVAL.ago
   end
 
+  # Persists a token value the caller already handed to the mailer (see
+  # API::UsersController#resend_email_verification), rather than minting one
+  # itself like generate_email_verification_token! does. Used so the resend
+  # flow can enqueue the email with a token before committing anything, and
+  # only start the resend cooldown once the enqueue has actually succeeded.
+  def persist_email_verification_token!(token)
+    update!(email_verification_token: token, email_verification_sent_at: Time.current)
+  end
+
   # The ONE place an account becomes verified. Idempotent, so every path that
   # proves inbox ownership (verification link, invitation accept, temp login)
   # can call it freely without risking a double token grant.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -312,6 +312,20 @@ class User < ApplicationRecord
   # (never read on the enforcement path) and was removed — do not re-add it here.
   # Board limits match the canonical pricing table (marketing/pricing-structure.md):
   # Free 1 / Basic 100 / Pro 300.
+  # --- Email verification ---------------------------------------------------
+  #
+  # `confirmed_at` is the single source of truth for "the address currently on
+  # this account is proven reachable". It is set by three paths: the signup
+  # verification link, accepting an invitation, and temp-login — all three
+  # require the user to click something delivered to that inbox.
+  #
+  # Deliberately NOT devise's :confirmable — this is a JSON API on JWT, and
+  # confirmable would contend with the hand-rolled email-change flow for
+  # `confirmation_token`/`confirmed_at`. See
+  # drafts/2026-07-26-email-verification-design.md.
+  EMAIL_VERIFICATION_VALIDITY = 7.days
+  EMAIL_VERIFICATION_RESEND_INTERVAL = 5.minutes
+
   FREE_PLAN_LIMITS = {
     "plan_type" => "free",
     "board_limit" => ENV.fetch("FREE_BOARD_LIMIT", 1).to_i,
@@ -818,6 +832,10 @@ class User < ApplicationRecord
 
   def shared_with_me_boards
     Board.with_artifacts.where(id: team_boards.select(:board_id))
+  end
+
+  def email_verified?
+    confirmed_at.present?
   end
 
   # Token management
@@ -1894,6 +1912,9 @@ class User < ApplicationRecord
       # on invite!, but valid_password? is nil until the invitation is
       # accepted, so a pending invite is effectively passwordless.
       needs_password: invited_to_sign_up?,
+      # Drives the "verify your email" banner. Unverified accounts hold no
+      # welcome tokens until they click the link — see mark_email_verified!.
+      email_verified: email_verified?,
       profile: profile&.user_api_view,
       delete_account_token: delete_account_token,
       public_page_url: public_page_url,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -311,10 +311,10 @@ class User < ApplicationRecord
   # `email_verified_at` is the single source of truth for "the address
   # currently on this account is proven reachable". It is set ONLY by paths
   # where the user clicked a link that was delivered to their inbox: the
-  # signup verification link and temp-login. `set_password` /
-  # invitation-accept does NOT verify — email_signup hands out that session
-  # with no email opened, so reaching set_password proves nothing about inbox
-  # ownership. See the task-7r brief.
+  # signup verification link, temp-login, and confirming a pending
+  # email-change link. `set_password` / invitation-accept does NOT verify —
+  # email_signup hands out that session with no email opened, so reaching
+  # set_password proves nothing about inbox ownership. See the task-7r brief.
   #
   # Deliberately NOT `confirmed_at` and NOT devise's :confirmable — this is a
   # JSON API on JWT, and confirmable would contend with the hand-rolled

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -834,6 +834,25 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  # Issues a fresh verification token and stamps the send time. The stamp
+  # drives both expiry (EMAIL_VERIFICATION_VALIDITY) and resend cooldown
+  # (EMAIL_VERIFICATION_RESEND_INTERVAL). Returns the raw token.
+  def generate_email_verification_token!
+    token = SecureRandom.hex(16)
+    update!(email_verification_token: token, email_verification_sent_at: Time.current)
+    token
+  end
+
+  def email_verification_token_valid?
+    email_verification_sent_at.present? &&
+      email_verification_sent_at > EMAIL_VERIFICATION_VALIDITY.ago
+  end
+
+  def can_resend_email_verification?
+    email_verification_sent_at.blank? ||
+      email_verification_sent_at < EMAIL_VERIFICATION_RESEND_INTERVAL.ago
+  end
+
   # The ONE place an account becomes verified. Idempotent, so every path that
   # proves inbox ownership (verification link, invitation accept, temp login)
   # can call it freely without risking a double token grant.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -845,6 +845,11 @@ class User < ApplicationRecord
   #
   # Returns true if this call newly verified the account, false if it was
   # already verified.
+  # `with_lock` wraps the block in `lock!` + a transaction, and `lock!`
+  # raises ActiveRecord::RecordNotSaved-ish dirty-attribute errors if the
+  # record already has unsaved changes — unlike the old
+  # `transaction do ... update! ... end` this replaced, which tolerated a
+  # dirty object. Callers must pass a clean (unmutated) user in.
   def mark_email_verified!
     return false if email_verified?
 
@@ -862,15 +867,24 @@ class User < ApplicationRecord
       # grants nothing once confirmed_at is set, and expires after 7 days.
       update!(confirmed_at: Time.current)
 
-      # Both currencies are granted here, not on create: an unverified account
-      # must hold nothing spendable. `tokens` is the legacy field (still spent
-      # by images_controller#find_or_create); AI credits are what the modern
-      # endpoints bill. Both are idempotent — add_welcome_tokens is reached
-      # only once thanks to the guard above, and ensure_initial_grant! no-ops
-      # when a plan_grant already exists.
+      # `tokens` is the legacy field (still spent by
+      # images_controller#find_or_create) — granted here, not on create, so an
+      # unverified account holds nothing spendable. Idempotent: reached only
+      # once thanks to the guard above.
       add_welcome_tokens
-      grant_initial_plan_credits
     end
+
+    # AI credits are granted OUTSIDE the lock/transaction, deliberately.
+    # ensure_initial_grant! rescues its own errors and returns nil, but
+    # grant_plan! runs inside a nested ActiveRecord transaction that would
+    # join this one if called above — a DB error there marks the outer
+    # transaction aborted, the rescue swallows it, and the COMMIT silently
+    # becomes a ROLLBACK, undoing confirmed_at and the token grant too.
+    # Sitting here, a credit-grant failure can never take verification down
+    # with it. Safe to call unconditionally: ensure_initial_grant! is
+    # idempotent (no-ops once a plan_grant exists), and the guard above
+    # already guarantees only one caller reaches this line per account.
+    grant_initial_plan_credits
     true
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -869,8 +869,11 @@ class User < ApplicationRecord
   end
 
   # The ONE place an account becomes verified. Idempotent, so every path that
-  # proves inbox ownership (verification link, invitation accept, temp login)
-  # can call it freely without risking a double token grant.
+  # proves inbox ownership — the signup verification link
+  # (GET /api/verify_email), temp-login, and confirm_email_change (confirming
+  # a pending email-change link) — can call it freely without risking a
+  # double token grant. `set_password` / invitation-accept must NOT call this:
+  # see the in-body note below for why.
   #
   # Welcome tokens are granted here rather than on create: an unverified
   # account holds a zero balance, so there is no separate "can this user spend"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,7 +175,6 @@ class User < ApplicationRecord
 
   # Callbacks
   before_save :set_default_settings, unless: :settings?
-  after_create :add_welcome_tokens
   before_validation :set_uuid, on: :create
   before_save :ensure_settings, unless: :has_all_settings?
 
@@ -836,6 +835,32 @@ class User < ApplicationRecord
 
   def email_verified?
     confirmed_at.present?
+  end
+
+  # The ONE place an account becomes verified. Idempotent, so every path that
+  # proves inbox ownership (verification link, invitation accept, temp login)
+  # can call it freely without risking a double token grant.
+  #
+  # Welcome tokens are granted here rather than on create: an unverified
+  # account holds a zero balance, so there is no separate "can this user spend"
+  # gate to forget in a future AI code path. images_controller's existing
+  # `tokens > 0` check does the right thing unmodified.
+  #
+  # Returns true if this call newly verified the account, false if it was
+  # already verified.
+  def mark_email_verified!
+    return false if email_verified?
+
+    transaction do
+      # The verification token is deliberately NOT cleared here — see
+      # verify_email in API::UsersController. Email security scanners prefetch
+      # links and users double-click; keeping the token lets a replay resolve
+      # to this user and get "already confirmed" instead of "invalid link". It
+      # grants nothing once confirmed_at is set, and expires after 7 days.
+      update!(confirmed_at: Time.current)
+      add_welcome_tokens
+    end
+    true
   end
 
   # Token management

--- a/app/services/disposable_email_domains.rb
+++ b/app/services/disposable_email_domains.rb
@@ -1,0 +1,25 @@
+# Rejects throwaway addresses at signup. See config/disposable_email_domains.txt
+# for why the list is static rather than API-backed.
+class DisposableEmailDomains
+  LIST_PATH = Rails.root.join("config", "disposable_email_domains.txt")
+
+  # Loaded once per process. The list only changes on deploy.
+  def self.domains
+    @domains ||= begin
+      LIST_PATH.readlines(chomp: true)
+               .map { |line| line.strip.downcase }
+               .reject { |line| line.empty? || line.start_with?("#") }
+               .to_set
+    rescue Errno::ENOENT
+      Rails.logger.error "DisposableEmailDomains: #{LIST_PATH} missing — allowing all domains"
+      Set.new
+    end
+  end
+
+  def self.disposable?(email)
+    domain = email.to_s.strip.downcase.split("@").last
+    return false if domain.blank? || !email.to_s.include?("@")
+
+    domains.include?(domain)
+  end
+end

--- a/app/sidekiq/downgrade_soft_trial_job.rb
+++ b/app/sidekiq/downgrade_soft_trial_job.rb
@@ -16,6 +16,13 @@ class DowngradeSoftTrialJob
       # ~now) to free (25 credits/month). grant_plan! expires whatever's
       # left of the trial allowance and grants a fresh free-tier amount,
       # so the user doesn't see balance=0 the moment they're downgraded.
+      # HAZARD: this grants the free allowance with no email-verification
+      # check — same hazard class as `credits:backfill` (see
+      # lib/tasks/credits.rake). Since Task 2b, initial free-tier credits are
+      # gated on confirmed_at (see User#mark_email_verified!); this job
+      # bypasses that gate for basic_trial users expiring out of their soft
+      # trial. Do not change this behavior without an explicit decision to
+      # do so.
       CreditService.grant_plan!(
         user,
         amount: CreditService.monthly_credits_for("free"),

--- a/app/sidekiq/downgrade_soft_trial_job.rb
+++ b/app/sidekiq/downgrade_soft_trial_job.rb
@@ -19,7 +19,7 @@ class DowngradeSoftTrialJob
       # HAZARD: this grants the free allowance with no email-verification
       # check — same hazard class as `credits:backfill` (see
       # lib/tasks/credits.rake). Since Task 2b, initial free-tier credits are
-      # gated on confirmed_at (see User#mark_email_verified!); this job
+      # gated on email_verified_at (see User#mark_email_verified!); this job
       # bypasses that gate for basic_trial users expiring out of their soft
       # trial. Do not change this behavior without an explicit decision to
       # do so.

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -19,11 +19,12 @@
 #   - plan_credits_reset_at IS NULL (never granted) OR has passed
 #   - stripe_subscription_id is blank (no Stripe-driven renewal incoming)
 #   - Email is verified (confirmed_at present) — but ONLY for the free
-#     allowance (plan_type free/basic_trial). Paid tiers with no Stripe
-#     subscription (5-year licenses, clinician, RevenueCat/App Store,
-#     partner_pro) rely on THIS job for their monthly re-grant; they've
-#     already paid, so an unclicked verification email must never zero
-#     their balance.
+#     allowance (plan_type free/basic_trial). Tiers with no Stripe
+#     subscription rely on THIS job for their monthly re-grant regardless of
+#     verification: 5-year licenses, RevenueCat/App Store, and partner_pro
+#     have already paid, and clinician is a free, manually-approved comp
+#     tier (not a self-serve signup, so it isn't an abuse vector) — either
+#     way, an unclicked verification email must never zero their balance.
 #   - Skip admins
 #
 # Idempotent in practice: grant_plan! expires leftovers and sets
@@ -48,6 +49,13 @@ class RefreshFreeTierCreditsJob
     vendor
     premium
   ].freeze
+
+  # Only these plan types require a verified email before this job will
+  # refresh their allowance. Everything else in REFRESHABLE_PLAN_TYPES has
+  # already paid (5-year licenses, clinician, RevenueCat/App Store,
+  # partner_pro) and rides this job for its monthly re-grant regardless of
+  # verification — see the `eligible_users` comment below.
+  VERIFICATION_GATED_PLAN_TYPES = %w[free basic_trial].freeze
 
   def perform
     refreshed = 0
@@ -87,11 +95,13 @@ class RefreshFreeTierCreditsJob
         "stripe_subscription_id IS NULL OR stripe_subscription_id = '' " \
         "OR settings->>'billing_interval' = 'yearly'",
       )
-      # Verification gates the FREE allowance only. Paid tiers without a Stripe
-      # subscription (5-year licenses, clinician, RevenueCat/App Store,
-      # partner_pro) rely on this job for their monthly re-grant — they've paid,
-      # so an unclicked verification email must never zero their balance.
+      # Verification gates the FREE allowance only. Tiers without a Stripe
+      # subscription rely on this job for their monthly re-grant regardless of
+      # verification: 5-year licenses, RevenueCat/App Store, and partner_pro
+      # have already paid, and clinician is a free, manually-approved comp
+      # tier (not a self-serve signup, so it isn't an abuse vector) — either
+      # way, an unclicked verification email must never zero their balance.
       # See .claude-notes/credits.md ("No-subscription paid plans ride the refresh job").
-      .where("confirmed_at IS NOT NULL OR plan_type NOT IN ('free', 'basic_trial')")
+      .where("confirmed_at IS NOT NULL OR plan_type NOT IN (?)", VERIFICATION_GATED_PLAN_TYPES)
   end
 end

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -18,8 +18,12 @@
 #   - plan_type is in REFRESHABLE_PLAN_TYPES
 #   - plan_credits_reset_at IS NULL (never granted) OR has passed
 #   - stripe_subscription_id is blank (no Stripe-driven renewal incoming)
-#   - Email is verified (confirmed_at present) — an unverified account must
-#     not collect credits it was denied at signup
+#   - Email is verified (confirmed_at present) — but ONLY for the free
+#     allowance (plan_type free/basic_trial). Paid tiers with no Stripe
+#     subscription (5-year licenses, clinician, RevenueCat/App Store,
+#     partner_pro) rely on THIS job for their monthly re-grant; they've
+#     already paid, so an unclicked verification email must never zero
+#     their balance.
 #   - Skip admins
 #
 # Idempotent in practice: grant_plan! expires leftovers and sets
@@ -83,9 +87,11 @@ class RefreshFreeTierCreditsJob
         "stripe_subscription_id IS NULL OR stripe_subscription_id = '' " \
         "OR settings->>'billing_interval' = 'yearly'",
       )
-      # An unverified account was deliberately denied its initial grant at
-      # signup (see User#mark_email_verified!) — the monthly cron must not
-      # silently hand it credits before that gate is cleared.
-      .where.not(confirmed_at: nil)
+      # Verification gates the FREE allowance only. Paid tiers without a Stripe
+      # subscription (5-year licenses, clinician, RevenueCat/App Store,
+      # partner_pro) rely on this job for their monthly re-grant — they've paid,
+      # so an unclicked verification email must never zero their balance.
+      # See .claude-notes/credits.md ("No-subscription paid plans ride the refresh job").
+      .where("confirmed_at IS NOT NULL OR plan_type NOT IN ('free', 'basic_trial')")
   end
 end

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -18,7 +18,7 @@
 #   - plan_type is in REFRESHABLE_PLAN_TYPES
 #   - plan_credits_reset_at IS NULL (never granted) OR has passed
 #   - stripe_subscription_id is blank (no Stripe-driven renewal incoming)
-#   - Email is verified (confirmed_at present) — but ONLY for the free
+#   - Email is verified (email_verified_at present) — but ONLY for the free
 #     allowance (plan_type free/basic_trial). Tiers with no Stripe
 #     subscription rely on THIS job for their monthly re-grant regardless of
 #     verification: 5-year licenses, RevenueCat/App Store, and partner_pro
@@ -102,6 +102,6 @@ class RefreshFreeTierCreditsJob
       # tier (not a self-serve signup, so it isn't an abuse vector) — either
       # way, an unclicked verification email must never zero their balance.
       # See .claude-notes/credits.md ("No-subscription paid plans ride the refresh job").
-      .where("confirmed_at IS NOT NULL OR plan_type NOT IN (?)", VERIFICATION_GATED_PLAN_TYPES)
+      .where("email_verified_at IS NOT NULL OR plan_type NOT IN (?)", VERIFICATION_GATED_PLAN_TYPES)
   end
 end

--- a/app/sidekiq/refresh_free_tier_credits_job.rb
+++ b/app/sidekiq/refresh_free_tier_credits_job.rb
@@ -18,6 +18,8 @@
 #   - plan_type is in REFRESHABLE_PLAN_TYPES
 #   - plan_credits_reset_at IS NULL (never granted) OR has passed
 #   - stripe_subscription_id is blank (no Stripe-driven renewal incoming)
+#   - Email is verified (confirmed_at present) — an unverified account must
+#     not collect credits it was denied at signup
 #   - Skip admins
 #
 # Idempotent in practice: grant_plan! expires leftovers and sets
@@ -81,5 +83,9 @@ class RefreshFreeTierCreditsJob
         "stripe_subscription_id IS NULL OR stripe_subscription_id = '' " \
         "OR settings->>'billing_interval' = 'yearly'",
       )
+      # An unverified account was deliberately denied its initial grant at
+      # signup (see User#mark_email_verified!) — the monthly cron must not
+      # silently hand it credits before that gate is cleared.
+      .where.not(confirmed_at: nil)
   end
 end

--- a/app/views/user_mailer/verify_email.html.erb
+++ b/app/views/user_mailer/verify_email.html.erb
@@ -1,7 +1,6 @@
   <%= render "layouts/email_logo" %>
 <p><%= @user_name.present? ? t("user_mailer.verify_email.greeting", name: @user_name) : t("user_mailer.verify_email.greeting_no_name") %></p>
 <p><%= t("user_mailer.verify_email.intro") %></p>
-<p><%= t("user_mailer.verify_email.tokens_note") %></p>
 <p>
   <%= link_to t("user_mailer.verify_email.cta"),
               @verification_url %>

--- a/app/views/user_mailer/verify_email.html.erb
+++ b/app/views/user_mailer/verify_email.html.erb
@@ -1,0 +1,15 @@
+  <%= render "layouts/email_logo" %>
+<p><%= @user_name.present? ? t("user_mailer.verify_email.greeting", name: @user_name) : t("user_mailer.verify_email.greeting_no_name") %></p>
+<p><%= t("user_mailer.verify_email.intro") %></p>
+<p><%= t("user_mailer.verify_email.tokens_note") %></p>
+<p>
+  <%= link_to t("user_mailer.verify_email.cta"),
+              @verification_url %>
+</p>
+
+<p><%= t("user_mailer.verify_email.expiry_note") %></p>
+<p><%= t("user_mailer.verify_email.ignore") %></p>
+
+<p><%= t("user_mailer.verify_email.thanks") %></p>
+<p><%= t("user_mailer.verify_email.signature") %></p>
+<p><a href="mailto:support@speakanyway.com">support@speakanyway.com</a></p>

--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -1,0 +1,28 @@
+# Disposable / throwaway email domains rejected at signup.
+#
+# Static list on purpose: no network call in the signup hot path, no new
+# vendor, and no signup outage if a third-party API goes down. The tradeoff is
+# staleness — this is a speed bump layered behind email verification and the
+# per-IP signup throttle, not the primary defense. Refresh occasionally.
+#
+# One domain per line, lowercase. Blank lines and #-comments ignored.
+mailinator.com
+10minutemail.com
+guerrillamail.com
+guerrillamail.net
+sharklasers.com
+temp-mail.org
+tempmail.com
+throwawaymail.com
+yopmail.com
+getnada.com
+trashmail.com
+maildrop.cc
+dispostable.com
+fakeinbox.com
+mintemail.com
+mohmal.com
+emailondeck.com
+spamgourmet.com
+tempinbox.com
+mailnesia.com

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -34,6 +34,14 @@ class Rack::Attack
   PASSWORD_RESET_LIMIT  = env_int("RACK_ATTACK_PASSWORD_RESET_LIMIT", 5)
   PASSWORD_RESET_PERIOD = env_int("RACK_ATTACK_PASSWORD_RESET_PERIOD", 3600)
 
+  # Signup (per IP) — stops scripted account farming for the free welcome
+  # tokens. Set generously on purpose: schools, clinics, and libraries NAT many
+  # users behind one address, and an SLP running a group training session must
+  # not trip it. This is a backstop; email verification and the token gate
+  # carry the real load.
+  SIGNUP_LIMIT          = env_int("RACK_ATTACK_SIGNUP_LIMIT", 20)
+  SIGNUP_PERIOD         = env_int("RACK_ATTACK_SIGNUP_PERIOD", 3600)
+
   # Token-access lookups (per IP) — temp-login / communicator-claim links.
   TOKEN_LIMIT           = env_int("RACK_ATTACK_TOKEN_LIMIT", 20)
   TOKEN_PERIOD          = env_int("RACK_ATTACK_TOKEN_PERIOD", 60)
@@ -56,10 +64,18 @@ class Rack::Attack
   # POST password-reset surfaces.
   PASSWORD_RESET_PATHS = %r{\A/api/v1/(forgot_password|reset_password|reset_password_invite)(\.\w+)?\z}
 
+  # POST account-creation surfaces: standard signup and email-only signup.
+  SIGNUP_PATHS = %r{\A/api/v1/users(/email_signup)?(\.\w+)?\z}
+
   # Access-granting token lookups (enumeration-sensitive). Deliberately does
   # NOT include `GET /api/generated_boards/:token` — the frontend polls that
   # while a board renders, and throttling it could break generation.
-  TOKEN_ACCESS_PATHS = %r{\A/api/(temp-login|communicator_claims)/}
+  #
+  # temp-login/communicator_claims take their token as a path segment, hence
+  # the trailing slash; verify_email takes its token as a query param
+  # (`/api/verify_email?token=...`), so it's matched as an exact path with no
+  # trailing slash instead.
+  TOKEN_ACCESS_PATHS = %r{\A/api/(temp-login|communicator_claims)/|\A/api/verify_email\z}
 
   # AI-generation path suffixes (the issue's `/generate*` + audio generation).
   AI_GEN_SUFFIXES = %w[generate generate_audio generate_preview_image regenerate_images].freeze
@@ -142,6 +158,10 @@ class Rack::Attack
 
   throttle("password_reset/ip", limit: PASSWORD_RESET_LIMIT, period: PASSWORD_RESET_PERIOD) do |req|
     req.ip if req.post? && req.path.match?(PASSWORD_RESET_PATHS)
+  end
+
+  throttle("signup/ip", limit: SIGNUP_LIMIT, period: SIGNUP_PERIOD) do |req|
+    req.ip if req.post? && req.path.match?(SIGNUP_PATHS)
   end
 
   # --- Throttles: token-access lookups -------------------------------------

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -253,7 +253,6 @@ en:
       greeting: "Hi %{name}!"
       greeting_no_name: "Hi there!"
       intro: "Thanks for joining SpeakAnyWay. Confirm this email address so we know we can reach you — it's the address we'll use for password resets and account updates."
-      tokens_note: "Confirming also unlocks the 10 free image credits waiting on your account."
       cta: "Confirm my email"
       expiry_note: "This link works for 7 days. If it expires, you can send yourself a new one from your dashboard."
       ignore: "If you didn't create a SpeakAnyWay account, you can safely ignore this email."

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -248,6 +248,18 @@ en:
       thanks: "Thank you,"
       signature: "The SpeakAnyWay Team"
 
+    verify_email:
+      subject: "Confirm your email to finish setting up SpeakAnyWay"
+      greeting: "Hi %{name}!"
+      greeting_no_name: "Hi there!"
+      intro: "Thanks for joining SpeakAnyWay. Confirm this email address so we know we can reach you — it's the address we'll use for password resets and account updates."
+      tokens_note: "Confirming also unlocks the 10 free image credits waiting on your account."
+      cta: "Confirm my email"
+      expiry_note: "This link works for 7 days. If it expires, you can send yourself a new one from your dashboard."
+      ignore: "If you didn't create a SpeakAnyWay account, you can safely ignore this email."
+      thanks: "Thank you,"
+      signature: "The SpeakAnyWay Team"
+
     temporary_login_email:
       subject: "Your Temporary Login Link for SpeakAnyWay AAC"
       title: "Temporary login to SpeakAnyWay"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -236,6 +236,18 @@ es:
       thanks: "Gracias,"
       signature: "El equipo de SpeakAnyWay"
 
+    verify_email:
+      subject: "Confirma tu correo electrónico para terminar de configurar SpeakAnyWay"
+      greeting: "¡Hola %{name}!"
+      greeting_no_name: "¡Hola!"
+      intro: "Gracias por unirte a SpeakAnyWay. Confirma esta dirección de correo electrónico para que sepamos que podemos contactarte — es la dirección que usaremos para restablecer tu contraseña y enviarte novedades de tu cuenta."
+      tokens_note: "Al confirmar también desbloqueas los 10 créditos de imagen gratuitos que te esperan en tu cuenta."
+      cta: "Confirmar mi correo electrónico"
+      expiry_note: "Este enlace funciona durante 7 días. Si caduca, puedes enviarte uno nuevo desde tu panel."
+      ignore: "Si no creaste una cuenta de SpeakAnyWay, puedes ignorar este mensaje."
+      thanks: "Gracias,"
+      signature: "El equipo de SpeakAnyWay"
+
     temporary_login_email:
       subject: "Tu enlace de inicio de sesión temporal para SpeakAnyWay AAC"
       title: "Inicio de sesión temporal en SpeakAnyWay"

--- a/config/locales/mailer.es.yml
+++ b/config/locales/mailer.es.yml
@@ -241,7 +241,6 @@ es:
       greeting: "¡Hola %{name}!"
       greeting_no_name: "¡Hola!"
       intro: "Gracias por unirte a SpeakAnyWay. Confirma esta dirección de correo electrónico para que sepamos que podemos contactarte — es la dirección que usaremos para restablecer tu contraseña y enviarte novedades de tu cuenta."
-      tokens_note: "Al confirmar también desbloqueas los 10 créditos de imagen gratuitos que te esperan en tu cuenta."
       cta: "Confirmar mi correo electrónico"
       expiry_note: "Este enlace funciona durante 7 días. Si caduca, puedes enviarte uno nuevo desde tu panel."
       ignore: "Si no creaste una cuenta de SpeakAnyWay, puedes ignorar este mensaje."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
     post "cancel_email_change", to: "users#cancel_email_change"
     get "confirm_email_change", to: "users#confirm_email_change"
     get "verify_email", to: "users#verify_email"
+    post "resend_email_verification", to: "users#resend_email_verification"
     resources :feedback, only: [:create]
 
     get "audio/play", to: "audio#play"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
     post "resend_email_confirmation", to: "users#resend_email_confirmation"
     post "cancel_email_change", to: "users#cancel_email_change"
     get "confirm_email_change", to: "users#confirm_email_change"
+    get "verify_email", to: "users#verify_email"
     resources :feedback, only: [:create]
 
     get "audio/play", to: "audio#play"

--- a/db/migrate/20260726161949_add_email_verification.rb
+++ b/db/migrate/20260726161949_add_email_verification.rb
@@ -1,0 +1,21 @@
+class AddEmailVerification < ActiveRecord::Migration[8.0]
+  def up
+    add_column :users, :email_verification_token, :string
+    add_column :users, :email_verification_sent_at, :datetime
+    add_index :users, :email_verification_token, unique: true
+
+    # Backfill: every account that exists today is treated as verified, so no
+    # current user sees a banner or loses tokens. Raw SQL on purpose — User has
+    # `default_scope { where(deleted_at: nil) }`, and soft-deleted rows must be
+    # backfilled too (they can be restored).
+    execute <<~SQL
+      UPDATE users SET confirmed_at = created_at WHERE confirmed_at IS NULL
+    SQL
+  end
+
+  def down
+    remove_index :users, :email_verification_token
+    remove_column :users, :email_verification_token
+    remove_column :users, :email_verification_sent_at
+  end
+end

--- a/db/migrate/20260727121729_add_email_verified_at.rb
+++ b/db/migrate/20260727121729_add_email_verified_at.rb
@@ -1,0 +1,16 @@
+class AddEmailVerifiedAt < ActiveRecord::Migration[8.0]
+  def up
+    add_column :users, :email_verified_at, :datetime
+
+    # Everyone who exists today is treated as verified — nobody loses grants or
+    # sees a banner. Raw SQL because User has default_scope { where(deleted_at: nil) }
+    # and soft-deleted rows must be backfilled too.
+    execute <<~SQL
+      UPDATE users SET email_verified_at = created_at
+    SQL
+  end
+
+  def down
+    remove_column :users, :email_verified_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_23_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_26_161949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -1007,6 +1007,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_23_120000) do
     t.datetime "plan_credits_reset_at"
     t.bigint "editable_board_id"
     t.datetime "editable_board_id_set_at"
+    t.string "email_verification_token"
+    t.datetime "email_verification_sent_at"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["child_lookup_key"], name: "index_users_on_child_lookup_key", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
@@ -1015,6 +1017,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_23_120000) do
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["editable_board_id"], name: "index_users_on_editable_board_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email_verification_token"], name: "index_users_on_email_verification_token", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["locked"], name: "index_users_on_locked"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_26_161949) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_121729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -1009,6 +1009,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_26_161949) do
     t.datetime "editable_board_id_set_at"
     t.string "email_verification_token"
     t.datetime "email_verification_sent_at"
+    t.datetime "email_verified_at"
     t.index ["authentication_token"], name: "index_users_on_authentication_token", unique: true
     t.index ["child_lookup_key"], name: "index_users_on_child_lookup_key", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/lib/tasks/credits.rake
+++ b/lib/tasks/credits.rake
@@ -1,5 +1,10 @@
 namespace :credits do
   desc "Backfill an initial plan credit grant for every user based on their plan_type"
+  # HAZARD: this task grants to every user lacking a plan_grant row, with no
+  # email-verification check. Since Task 2b, initial credits are gated on
+  # confirmed_at (see User#mark_email_verified!) — running this task as-is
+  # would hand credits to every unverified account and undo that gate. Do not
+  # change this behavior without an explicit decision to do so.
   task backfill: :environment do
     granted = 0
     skipped = 0

--- a/lib/tasks/credits.rake
+++ b/lib/tasks/credits.rake
@@ -2,7 +2,7 @@ namespace :credits do
   desc "Backfill an initial plan credit grant for every user based on their plan_type"
   # HAZARD: this task grants to every user lacking a plan_grant row, with no
   # email-verification check. Since Task 2b, initial credits are gated on
-  # confirmed_at (see User#mark_email_verified!) — running this task as-is
+  # email_verified_at (see User#mark_email_verified!) — running this task as-is
   # would hand credits to every unverified account and undo that gate. Do not
   # change this behavior without an explicit decision to do so.
   task backfill: :environment do

--- a/spec/lib/tasks/credits_rake_spec.rb
+++ b/spec/lib/tasks/credits_rake_spec.rb
@@ -114,13 +114,45 @@ RSpec.describe "credits rake tasks", type: :task do
     end
 
     it "does not re-grant users with a healthy non-zero plan balance" do
-      user = FactoryBot.create(:user, plan_type: "pro")
-      # User has a fresh plan_grant from after_create and a positive balance — skip them.
+      # The task's query is `User.where(id: affected_user_ids, plan_credits_balance: 0)`
+      # (lib/tasks/credits.rake:41) — so a user must both (a) show up in
+      # affected_user_ids (a "expire"/"period_ended" row, matching the stale-backfill
+      # shape) and (b) currently hold a healthy non-zero balance, to actually prove the
+      # balance filter — not just the "no plan_grant row" skip — is what excludes them.
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "pro"))
+      CreditTransaction.create!(
+        user: user,
+        amount: 1500,
+        kind: "plan_grant",
+        source: "plan",
+        expires_at: 2.months.ago,
+        metadata: { reason: "phase1_backfill", plan_type: "pro" },
+      )
+      CreditTransaction.create!(
+        user: user,
+        amount: -1500,
+        kind: "expire",
+        source: "plan",
+        metadata: { reason: "period_ended" },
+      )
+      # Give the user a healthy, non-zero balance via an explicit grant — this
+      # is the row state (plan_credits_balance != 0) the rake task's query
+      # filters on, so this user must be excluded even though they otherwise
+      # match the affected_user_ids shape.
+      CreditService.grant_plan!(
+        user,
+        amount: 1500,
+        period_end: 30.days.from_now,
+        metadata: { reason: "healthy_balance" },
+      )
+      expect(user.reload.plan_credits_balance).to eq(1500)
       grants_before = user.credit_transactions.where(kind: "plan_grant").count
+      expect(grants_before).to eq(2)
 
       task.invoke
 
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(grants_before)
+      expect(user.reload.plan_credits_balance).to eq(1500)
     end
 
     it "does not re-grant users zeroed out for unrelated reasons (no period_ended expire row)" do

--- a/spec/lib/tasks/credits_rake_spec.rb
+++ b/spec/lib/tasks/credits_rake_spec.rb
@@ -60,8 +60,13 @@ RSpec.describe "credits rake tasks", type: :task do
     end
 
     it "skips users who already have a plan_grant row" do
-      user = FactoryBot.create(:user, plan_type: "pro")
-      # ensure_initial_grant! already created a plan_grant on after_create
+      user = reset_user_credits!(FactoryBot.create(:user, plan_type: "pro"))
+      CreditService.grant_plan!(
+        user,
+        amount: 1500,
+        period_end: 30.days.from_now,
+        metadata: { reason: "pre_existing_grant" },
+      )
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
       grant_before = user.credit_transactions.find_by(kind: "plan_grant")
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -312,4 +312,34 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body.decoded).to include("Ver mensaje")
     end
   end
+
+  describe ".verify_email" do
+    let(:user) { FactoryBot.create(:user, confirmed_at: nil, name: "Sam") }
+
+    before { user.generate_email_verification_token! }
+
+    it "sends to the address being verified" do
+      mail = described_class.verify_email(user)
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "links to the frontend confirm-email page with the verification token" do
+      mail = described_class.verify_email(user)
+      # .decoded, not .encoded: the intro copy's em dash forces this
+      # single-part message to quoted-printable transfer encoding, which
+      # hard-wraps lines at 76 octets and lands a soft break inside the
+      # token when checked against the raw encoded body. Matches the same
+      # (mail.html_part || mail).body.decoded convention used above for
+      # #confirm_update_email.
+      expect((mail.html_part || mail).body.decoded).to include(
+        "/confirm-email?verification_token=#{user.reload.email_verification_token}"
+      )
+    end
+
+    it "does not send when there is no token to send" do
+      user.update!(email_verification_token: nil)
+      mail = described_class.verify_email(user)
+      expect(mail.message).to be_a(ActionMailer::Base::NullMail)
+    end
+  end
 end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -69,4 +69,42 @@ RSpec.describe User, "email verification state" do
       expect(user.reload.tokens).to eq(3)
     end
   end
+
+  describe "AI credit grant" do
+    it "does NOT grant plan credits on account creation" do
+      user = FactoryBot.create(:user)
+      expect(user.credit_transactions.where(kind: "plan_grant")).to be_empty
+      expect(CreditService.balance(user)[:total]).to eq(0)
+    end
+
+    it "grants the free-tier credit allowance on verification" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(CreditService.balance(user.reload)[:total]).to eq(
+        CreditService.monthly_credits_for("free")
+      )
+    end
+
+    it "grants both currencies in one call" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(user.reload.tokens).to eq(10)
+      expect(CreditService.balance(user)[:total]).to eq(25)
+    end
+
+    it "does not double-grant credits when called twice" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      user.mark_email_verified!
+      user.reload
+
+      user.mark_email_verified!
+
+      expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
+      expect(CreditService.balance(user.reload)[:total]).to eq(25)
+    end
+  end
 end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe User, "email verification state" do
+  describe "#email_verified?" do
+    it "is false for an account with no confirmed_at" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      expect(user.email_verified?).to be(false)
+    end
+
+    it "is true once confirmed_at is set" do
+      user = FactoryBot.create(:user, confirmed_at: Time.current)
+      expect(user.email_verified?).to be(true)
+    end
+  end
+
+  describe "#api_view" do
+    it "exposes email_verified so the frontend can render the banner" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      expect(user.api_view[:email_verified]).to be(false)
+
+      user.update!(confirmed_at: Time.current)
+      expect(user.api_view[:email_verified]).to be(true)
+    end
+  end
+end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -2,23 +2,23 @@ require "rails_helper"
 
 RSpec.describe User, "email verification state" do
   describe "#email_verified?" do
-    it "is false for an account with no confirmed_at" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+    it "is false for an account with no email_verified_at" do
+      user = FactoryBot.create(:user, email_verified_at: nil)
       expect(user.email_verified?).to be(false)
     end
 
-    it "is true once confirmed_at is set" do
-      user = FactoryBot.create(:user, confirmed_at: Time.current)
+    it "is true once email_verified_at is set" do
+      user = FactoryBot.create(:user, email_verified_at: Time.current)
       expect(user.email_verified?).to be(true)
     end
   end
 
   describe "#api_view" do
     it "exposes email_verified so the frontend can render the banner" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user, email_verified_at: nil)
       expect(user.api_view[:email_verified]).to be(false)
 
-      user.update!(confirmed_at: Time.current)
+      user.update!(email_verified_at: Time.current)
       expect(user.api_view[:email_verified]).to be(true)
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe User, "email verification state" do
     # Mimecast) prefetch links, and users double-click. Keeping the token lets
     # a replay still resolve to this user so the endpoint can answer "already
     # confirmed" instead of a scary "invalid link". It grants nothing once
-    # confirmed_at is set, and expires on its own after 7 days.
+    # email_verified_at is set, and expires on its own after 7 days.
     it "retains the verification token so a replayed link can still be resolved" do
       user = FactoryBot.create(:user, confirmed_at: nil,
                                       email_verification_token: "abc123",
@@ -62,7 +62,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "leaves an already-verified user's balance untouched" do
-      user = FactoryBot.create(:user, confirmed_at: 1.day.ago)
+      user = FactoryBot.create(:user, email_verified_at: 1.day.ago)
       user.update!(tokens: 3)
 
       expect(user.mark_email_verified!).to be(false)
@@ -140,6 +140,22 @@ RSpec.describe User, "email verification state" do
     it "allows a resend when nothing has ever been sent" do
       user = FactoryBot.create(:user, confirmed_at: nil, email_verification_sent_at: nil)
       expect(user.can_resend_email_verification?).to be(true)
+    end
+  end
+
+  describe "email_verified_at ownership" do
+    # Regression guard. devise_invitable stamps confirmed_at on accept_invitation!
+    # for any model with that column, so confirmed_at can never be our source of
+    # truth — see the task-7r brief.
+    it "is not verified merely because confirmed_at is set" do
+      user = FactoryBot.create(:user, confirmed_at: Time.current, email_verified_at: nil)
+      expect(user.email_verified?).to be(false)
+    end
+
+    it "reads email_verified_at, not confirmed_at" do
+      user = FactoryBot.create(:user, email_verified_at: nil)
+      user.mark_email_verified!
+      expect(user.reload.email_verified_at).to be_present
     end
   end
 end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "grants tokens when the address is verified" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
 
       expect(user.mark_email_verified!).to be(true)
 
@@ -44,9 +44,9 @@ RSpec.describe User, "email verification state" do
     # confirmed" instead of a scary "invalid link". It grants nothing once
     # email_verified_at is set, and expires on its own after 7 days.
     it "retains the verification token so a replayed link can still be resolved" do
-      user = FactoryBot.create(:user, confirmed_at: nil,
-                                      email_verification_token: "abc123",
-                                      email_verification_sent_at: Time.current)
+      user = FactoryBot.create(:user,
+                                email_verification_token: "abc123",
+                                email_verification_sent_at: Time.current)
 
       user.mark_email_verified!
 
@@ -54,7 +54,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "is idempotent — a second call never double-grants" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
       user.mark_email_verified!
 
       expect(user.mark_email_verified!).to be(false)
@@ -78,7 +78,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "grants the free-tier credit allowance on verification" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
 
       user.mark_email_verified!
 
@@ -88,7 +88,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "grants both currencies in one call" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
 
       user.mark_email_verified!
 
@@ -97,7 +97,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "does not double-grant credits when called twice" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
       user.mark_email_verified!
       user.reload
 
@@ -110,7 +110,7 @@ RSpec.describe User, "email verification state" do
 
   describe "verification tokens" do
     it "generates a token and stamps the send time" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
 
       token = user.generate_email_verification_token!
 
@@ -120,7 +120,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "treats a fresh token as valid and a 8-day-old one as expired" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
       user.generate_email_verification_token!
       expect(user.email_verification_token_valid?).to be(true)
 
@@ -129,7 +129,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "blocks a resend inside the cooldown and allows one after" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user)
       user.generate_email_verification_token!
       expect(user.can_resend_email_verification?).to be(false)
 
@@ -138,7 +138,7 @@ RSpec.describe User, "email verification state" do
     end
 
     it "allows a resend when nothing has ever been sent" do
-      user = FactoryBot.create(:user, confirmed_at: nil, email_verification_sent_at: nil)
+      user = FactoryBot.create(:user, email_verification_sent_at: nil)
       expect(user.can_resend_email_verification?).to be(true)
     end
   end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -107,4 +107,39 @@ RSpec.describe User, "email verification state" do
       expect(CreditService.balance(user.reload)[:total]).to eq(25)
     end
   end
+
+  describe "verification tokens" do
+    it "generates a token and stamps the send time" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      token = user.generate_email_verification_token!
+
+      expect(token).to be_present
+      expect(user.reload.email_verification_token).to eq(token)
+      expect(user.email_verification_sent_at).to be_within(5.seconds).of(Time.current)
+    end
+
+    it "treats a fresh token as valid and a 8-day-old one as expired" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      user.generate_email_verification_token!
+      expect(user.email_verification_token_valid?).to be(true)
+
+      user.update!(email_verification_sent_at: 8.days.ago)
+      expect(user.email_verification_token_valid?).to be(false)
+    end
+
+    it "blocks a resend inside the cooldown and allows one after" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      user.generate_email_verification_token!
+      expect(user.can_resend_email_verification?).to be(false)
+
+      user.update!(email_verification_sent_at: 6.minutes.ago)
+      expect(user.can_resend_email_verification?).to be(true)
+    end
+
+    it "allows a resend when nothing has ever been sent" do
+      user = FactoryBot.create(:user, confirmed_at: nil, email_verification_sent_at: nil)
+      expect(user.can_resend_email_verification?).to be(true)
+    end
+  end
 end

--- a/spec/models/user_email_verification_spec.rb
+++ b/spec/models/user_email_verification_spec.rb
@@ -22,4 +22,51 @@ RSpec.describe User, "email verification state" do
       expect(user.api_view[:email_verified]).to be(true)
     end
   end
+
+  describe "welcome tokens" do
+    it "does NOT grant tokens on account creation" do
+      user = FactoryBot.create(:user)
+      expect(user.tokens).to eq(0)
+    end
+
+    it "grants tokens when the address is verified" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      expect(user.mark_email_verified!).to be(true)
+
+      expect(user.reload.tokens).to eq(10)
+      expect(user.email_verified?).to be(true)
+    end
+
+    # Deliberately NOT cleared. Email security scanners (Outlook Safe Links,
+    # Mimecast) prefetch links, and users double-click. Keeping the token lets
+    # a replay still resolve to this user so the endpoint can answer "already
+    # confirmed" instead of a scary "invalid link". It grants nothing once
+    # confirmed_at is set, and expires on its own after 7 days.
+    it "retains the verification token so a replayed link can still be resolved" do
+      user = FactoryBot.create(:user, confirmed_at: nil,
+                                      email_verification_token: "abc123",
+                                      email_verification_sent_at: Time.current)
+
+      user.mark_email_verified!
+
+      expect(user.reload.email_verification_token).to eq("abc123")
+    end
+
+    it "is idempotent — a second call never double-grants" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+      user.mark_email_verified!
+
+      expect(user.mark_email_verified!).to be(false)
+      expect(user.reload.tokens).to eq(10)
+    end
+
+    it "leaves an already-verified user's balance untouched" do
+      user = FactoryBot.create(:user, confirmed_at: 1.day.ago)
+      user.update!(tokens: 3)
+
+      expect(user.mark_email_verified!).to be(false)
+      expect(user.reload.tokens).to eq(3)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -271,42 +271,69 @@ RSpec.describe User, type: :model do
     end
   end
 
-  context "initial plan-credit grant on signup" do
-    it "grants the free allowance (25) by default since new users land on free" do
+  # The initial grant used to fire on signup; it's now deferred to email
+  # verification (see User#mark_email_verified! / task-2b) so an unverified
+  # account holds zero spendable credits. These specs cover the per-plan
+  # amounts and reset window at the new trigger point.
+  context "initial plan-credit grant on verification" do
+    it "does NOT grant plan credits on account creation" do
       user = FactoryBot.create(:user)
       expect(user.plan_type).to eq("free")
-      expect(user.plan_credits_balance).to eq(25)
+      expect(user.plan_credits_balance).to eq(0)
+      expect(user.credit_transactions.where(kind: "plan_grant")).to be_empty
+    end
+
+    it "grants the free allowance (25) by default since new users land on free" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(user.reload.plan_credits_balance).to eq(25)
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
 
     it "grants the basic allowance (400) when plan_type is explicitly basic" do
-      user = FactoryBot.create(:user, plan_type: "basic")
-      expect(user.plan_credits_balance).to eq(400)
+      user = FactoryBot.create(:user, plan_type: "basic", confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(user.reload.plan_credits_balance).to eq(400)
     end
 
     it "grants the pro allowance (1500) when plan_type is explicitly pro" do
-      user = FactoryBot.create(:user, plan_type: "pro")
-      expect(user.plan_credits_balance).to eq(1500)
+      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(user.reload.plan_credits_balance).to eq(1500)
     end
 
     it "sets plan_credits_reset_at = 30 days from now for free users (default)" do
-      user = FactoryBot.create(:user)
-      expect(user.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      user.mark_email_verified!
+
+      expect(user.reload.plan_credits_reset_at).to be_within(5.seconds).of(30.days.from_now)
     end
 
     it "does not grant credits to admins" do
-      admin = FactoryBot.create(:admin_user)
-      expect(admin.plan_credits_balance).to eq(0)
+      admin = FactoryBot.create(:admin_user, confirmed_at: nil)
+
+      admin.mark_email_verified!
+
+      expect(admin.reload.plan_credits_balance).to eq(0)
       expect(admin.credit_transactions.where(kind: "plan_grant")).to be_empty
     end
   end
 
   # Regression guard for drafts/drop-basic-trial-option-a.md: the no-CC
   # basic_trial soft trial was removed, so every brand-new signup must land on
-  # Free with Free limits and the 25-credit initial grant — no 400-credit trial.
+  # Free with Free limits — no 400-credit trial. The 25-credit grant itself
+  # is deferred to email verification (task-2b), so it's exercised here via
+  # an explicit mark_email_verified! rather than being present at create.
   context "fresh signup (no-CC soft trial removed)" do
-    it "lands on free with Free limits, a communicator slot, and a 25-credit grant" do
-      user = FactoryBot.create(:user)
+    it "lands on free with Free limits, a communicator slot, and a 25-credit grant on verification" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
 
       expect(user.plan_type).to eq("free")
       expect(user.settings["board_limit"]).to eq(User::FREE_PLAN_LIMITS["board_limit"])
@@ -316,7 +343,12 @@ RSpec.describe User, type: :model do
         .to eq(User::FREE_PLAN_LIMITS["paid_communicator_limit"])
       expect(user.settings["paid_communicator_limit"].to_i).to be >= 1
 
-      expect(user.plan_credits_balance).to eq(25)
+      # Not yet granted before verification.
+      expect(user.plan_credits_balance).to eq(0)
+
+      user.mark_email_verified!
+
+      expect(user.reload.plan_credits_balance).to eq(25)
       expect(user.credit_transactions.where(kind: "plan_grant").count).to eq(1)
     end
   end
@@ -413,7 +445,12 @@ RSpec.describe User, type: :model do
   context "admin views expose ai_credits" do
     it "includes the credit balance in admin_api_view" do
       user = FactoryBot.create(:user, plan_type: "pro")
-      credits = user.admin_api_view["ai_credits"]
+      # The initial grant is deferred to email verification (task-2b) — grant
+      # explicitly here since this spec is about admin-view formatting, not
+      # the grant path itself.
+      CreditService.grant_plan!(user, amount: 1500, period_end: 1.month.from_now,
+                                       metadata: { source: "spec" })
+      credits = user.reload.admin_api_view["ai_credits"]
       expect(credits[:total]).to eq(1500)
       expect(credits[:plan]).to eq(1500)
       expect(credits[:topup]).to eq(0)
@@ -421,7 +458,9 @@ RSpec.describe User, type: :model do
 
     it "includes the credit balance in admin_index_view" do
       user = FactoryBot.create(:user, plan_type: "pro")
-      expect(user.admin_index_view["ai_credits"][:total]).to eq(1500)
+      CreditService.grant_plan!(user, amount: 1500, period_end: 1.month.from_now,
+                                       metadata: { source: "spec" })
+      expect(user.reload.admin_index_view["ai_credits"][:total]).to eq(1500)
     end
 
     it "reflects topup credits in the total" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -465,8 +465,13 @@ RSpec.describe User, type: :model do
 
     it "reflects topup credits in the total" do
       user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      # Give the user a non-zero plan balance too, so this actually proves the
+      # two buckets are summed rather than degenerating to `25 == 0 + 25`.
+      CreditService.grant_plan!(user, amount: 25, period_end: 1.month.from_now,
+                                       metadata: { source: "spec" })
       CreditService.grant_topup!(user, amount: 25)
       credits = user.reload.admin_api_view["ai_credits"]
+      expect(credits[:plan]).to eq(25)
       expect(credits[:topup]).to eq(25)
       expect(credits[:total]).to eq(credits[:plan] + 25)
     end

--- a/spec/requests/api/board_screenshot_imports_spec.rb
+++ b/spec/requests/api/board_screenshot_imports_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe "API::BoardScreenshotImports", type: :request do
   end
 
   describe "POST /api/board_screenshot_imports (create)" do
+    # The initial credit grant is deferred to email verification (task-2b),
+    # so a bare `create(:user)` now starts at 0 credits. Grant explicitly —
+    # these specs are about the screenshot-import spend flow, not the grant
+    # path itself. The "out of credits" spec below overrides this back to 0.
+    before do
+      CreditService.grant_plan!(user, amount: 100, period_end: 1.month.from_now,
+                                       metadata: { source: "spec" })
+    end
+
     it "rejects anonymous callers with 401" do
       post "/api/board_screenshot_imports", params: { cropped_image: data_url }
       expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -4,7 +4,11 @@ require "rails_helper"
 # and return 402 insufficient_credits when the balance is too low. Each AI
 # endpoint is covered, plus the shape of the 402 body and admin bypass.
 RSpec.describe "Credit enforcement on AI endpoints", type: :request do
-  let(:user) { FactoryBot.create(:user) }
+  # confirmed_at set: image_generation now requires a verified email (even on
+  # its free first-fill path — see images_email_verification_spec.rb), and
+  # this file's `/api/images/generate` examples are about credit gating, not
+  # verification, so the fixture stays verified by default.
+  let(:user) { FactoryBot.create(:user, confirmed_at: Time.current) }
 
   # Most tests below dictate exact balances; clear the after_create grant
   # so we're not fighting it. The grant_plan! calls in inner `before`

--- a/spec/requests/api/credit_enforcement_spec.rb
+++ b/spec/requests/api/credit_enforcement_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 # and return 402 insufficient_credits when the balance is too low. Each AI
 # endpoint is covered, plus the shape of the 402 body and admin bypass.
 RSpec.describe "Credit enforcement on AI endpoints", type: :request do
-  # confirmed_at set: image_generation now requires a verified email (even on
-  # its free first-fill path — see images_email_verification_spec.rb), and
-  # this file's `/api/images/generate` examples are about credit gating, not
-  # verification, so the fixture stays verified by default.
-  let(:user) { FactoryBot.create(:user, confirmed_at: Time.current) }
+  # email_verified_at set: image_generation now requires a verified email
+  # (even on its free first-fill path — see images_email_verification_spec.rb),
+  # and this file's `/api/images/generate` examples are about credit gating,
+  # not verification, so the fixture stays verified by default.
+  let(:user) { FactoryBot.create(:user, email_verified_at: Time.current) }
 
   # Most tests below dictate exact balances; clear the after_create grant
   # so we're not fighting it. The grant_plan! calls in inner `before`

--- a/spec/requests/api/images_email_verification_spec.rb
+++ b/spec/requests/api/images_email_verification_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+# Part B (email-verification gap): image_generation is deliberately free for
+# first-time fills (API::ImagesController#generate only calls check_credits!
+# when the image already has a displayable picture — see .claude-notes/credits.md
+# "image_generation is free for first-time fills"). That free path never
+# touches CreditService, so an unverified account holding zero tokens and
+# zero AI credits could still drive paid OpenAI generation for empty tiles.
+# require_verified_email! closes that hole.
+RSpec.describe "API::Images#generate email verification gate", type: :request do
+  def auth(user)
+    auth_headers(user)
+  end
+
+  describe "unverified user" do
+    let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+
+    it "gets 403 with the email_verification_required error code on the free first-fill path" do
+      expect {
+        post "/api/images/generate",
+             params: { image: { label: "cat", image_prompt: "cat" } },
+             headers: auth(user)
+      }.not_to change(GenerateImageJob.jobs, :size)
+
+      expect(response).to have_http_status(:forbidden)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("email_verification_required")
+      # Generic, user-facing only — no internals leaked.
+      expect(body["message"]).to be_a(String)
+      expect(body).not_to have_key("backtrace")
+    end
+
+    it "gets the same 403 even when replacing an existing image (billed path never reached)" do
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
+
+      expect {
+        post "/api/images/generate",
+             params: { image: { label: "cat", image_prompt: "cat" } },
+             headers: auth(user)
+      }.not_to change(GenerateImageJob.jobs, :size)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)["error"]).to eq("email_verification_required")
+    end
+  end
+
+  describe "verified user" do
+    let(:user) { FactoryBot.create(:user, confirmed_at: Time.current) }
+
+    before { reset_user_credits!(user) }
+
+    it "can generate a first-time fill for free (no existing image, zero credit balance)" do
+      expect(user.reload.plan_credits_balance).to eq(0)
+
+      expect {
+        post "/api/images/generate",
+             params: { image: { label: "cat", image_prompt: "cat" } },
+             headers: auth(user)
+      }.to change(GenerateImageJob.jobs, :size).by(1)
+
+      expect(response).not_to have_http_status(:forbidden)
+      expect(response).not_to have_http_status(402)
+      expect(user.reload.plan_credits_balance).to eq(0) # first fill is not billed
+    end
+
+    it "still enforces check_credits! unchanged when replacing an existing image (already-billed path)" do
+      # No credits granted — the billed (replace/customize) path must still 402
+      # exactly as it did before this change, since the user is verified.
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
+
+      expect {
+        post "/api/images/generate",
+             params: { image: { label: "cat", image_prompt: "cat" } },
+             headers: auth(user)
+      }.not_to change(GenerateImageJob.jobs, :size)
+
+      expect(response).to have_http_status(402)
+      expect(JSON.parse(response.body)["error"]).to eq("insufficient_credits")
+    end
+
+    it "spends credits and generates when replacing an existing image with a healthy balance" do
+      CreditService.grant_plan!(user, amount: 1000, period_end: 30.days.from_now)
+      allow_any_instance_of(Image).to receive(:display_image_url).and_return("https://example.com/cat.png")
+
+      expect {
+        post "/api/images/generate",
+             params: { image: { label: "cat", image_prompt: "cat" } },
+             headers: auth(user)
+      }.to change { user.reload.plan_credits_balance }.by(-3)
+       .and change(GenerateImageJob.jobs, :size).by(1)
+
+      expect(response).not_to have_http_status(:forbidden)
+      expect(response).not_to have_http_status(402)
+    end
+  end
+end

--- a/spec/requests/api/images_email_verification_spec.rb
+++ b/spec/requests/api/images_email_verification_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "API::Images#generate email verification gate", type: :request do
   end
 
   describe "unverified user" do
-    let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+    let(:user) { FactoryBot.create(:user, email_verified_at: nil) }
 
     it "gets 403 with the email_verification_required error code on the free first-fill path" do
       expect {
@@ -45,7 +45,7 @@ RSpec.describe "API::Images#generate email verification gate", type: :request do
   end
 
   describe "verified user" do
-    let(:user) { FactoryBot.create(:user, confirmed_at: Time.current) }
+    let(:user) { FactoryBot.create(:user, email_verified_at: Time.current) }
 
     before { reset_user_credits!(user) }
 

--- a/spec/requests/api/users_confirm_email_change_spec.rb
+++ b/spec/requests/api/users_confirm_email_change_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/confirm_email_change", type: :request do
+  let(:user) do
+    FactoryBot.create(:user, email: "old@example.com").tap do |u|
+      u.update!(unconfirmed_email: "new@example.com",
+                confirmation_token: "changetoken123",
+                confirmation_sent_at: Time.current)
+    end
+  end
+
+  # confirm_email_change requires auth: the mailer link points at the
+  # frontend route (/confirm-email?confirmation_token=...), which is loaded
+  # by the already-signed-in SPA and calls this API with the user's existing
+  # bearer token attached — unlike verify_email, which is hit unauthenticated
+  # straight from an inbox before any session exists.
+  it "promotes the pending address with a fresh token" do
+    get "/api/confirm_email_change", params: { confirmation_token: user.confirmation_token },
+                                      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.email).to eq("new@example.com")
+    expect(user.unconfirmed_email).to be_nil
+  end
+
+  it "rejects a token older than the validity window and leaves the address alone" do
+    user.update!(confirmation_sent_at: 8.days.ago)
+
+    get "/api/confirm_email_change", params: { confirmation_token: user.confirmation_token },
+                                      headers: auth_headers(user)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(user.reload.email).to eq("old@example.com")
+    expect(user.unconfirmed_email).to eq("new@example.com")
+  end
+
+  # Part 2: confirming an email change is proof of inbox access on the new
+  # address, so it should route through mark_email_verified! the same as the
+  # dedicated verification link — an unverified user who changes their email
+  # should not be stuck unverified forever with no welcome tokens/credits.
+  describe "verification side effect" do
+    let(:unverified_user) do
+      FactoryBot.create(:user, email: "old@example.com", email_verified_at: nil).tap do |u|
+        u.update!(unconfirmed_email: "new@example.com",
+                  confirmation_token: "changetoken456",
+                  confirmation_sent_at: Time.current)
+      end
+    end
+
+    it "verifies an unverified user and grants welcome tokens + AI credits" do
+      get "/api/confirm_email_change", params: { confirmation_token: unverified_user.confirmation_token },
+                                        headers: auth_headers(unverified_user)
+
+      expect(response).to have_http_status(:ok)
+      unverified_user.reload
+      expect(unverified_user.email).to eq("new@example.com")
+      expect(unverified_user.email_verified?).to be(true)
+      expect(unverified_user.tokens).to eq(10)
+      expect(CreditService.balance(unverified_user)[:total]).to eq(
+        CreditService.monthly_credits_for("free")
+      )
+    end
+
+    it "leaves an already-verified user verified and does not double-grant" do
+      verified_user = FactoryBot.create(:user, email: "old2@example.com", email_verified_at: 1.day.ago).tap do |u|
+        u.update!(unconfirmed_email: "new2@example.com",
+                  confirmation_token: "changetoken789",
+                  confirmation_sent_at: Time.current)
+      end
+      verified_user.update!(tokens: 3)
+      previous_balance = CreditService.balance(verified_user)[:total]
+
+      get "/api/confirm_email_change", params: { confirmation_token: verified_user.confirmation_token },
+                                        headers: auth_headers(verified_user)
+
+      expect(response).to have_http_status(:ok)
+      verified_user.reload
+      expect(verified_user.email).to eq("new2@example.com")
+      expect(verified_user.email_verified?).to be(true)
+      expect(verified_user.tokens).to eq(3)
+      expect(CreditService.balance(verified_user)[:total]).to eq(previous_balance)
+    end
+  end
+end

--- a/spec/requests/api/users_verify_email_spec.rb
+++ b/spec/requests/api/users_verify_email_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "POST /api/resend_email_verification", type: :request do
   end
 
   it "refuses when the account is already verified" do
-    user.update!(confirmed_at: Time.current)
+    user.update!(email_verified_at: Time.current)
 
     expect { resend }.not_to have_enqueued_mail(UserMailer, :verify_email)
     expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/api/users_verify_email_spec.rb
+++ b/spec/requests/api/users_verify_email_spec.rb
@@ -116,7 +116,12 @@ RSpec.describe "POST /api/resend_email_verification", type: :request do
     original_token = user.email_verification_token
     original_sent_at = user.email_verification_sent_at
 
-    allow(UserMailer).to receive(:verify_email).and_raise(Redis::BaseConnectionError, "connection refused")
+    # Stub deliver_later itself (not UserMailer.verify_email) so the failure
+    # happens exactly where it would in production — the Redis push inside
+    # deliver_later — rather than before the mailer is ever touched.
+    delivery = instance_double(ActionMailer::MessageDelivery)
+    allow(UserMailer).to receive(:verify_email).and_return(delivery)
+    allow(delivery).to receive(:deliver_later).and_raise(Redis::BaseConnectionError, "connection refused")
 
     resend
 

--- a/spec/requests/api/users_verify_email_spec.rb
+++ b/spec/requests/api/users_verify_email_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/verify_email", type: :request do
+  let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+
+  def verify(token)
+    get "/api/verify_email", params: { token: token }
+  end
+
+  it "verifies the account and grants the welcome tokens" do
+    token = user.generate_email_verification_token!
+
+    verify(token)
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["email_verified"]).to be(true)
+    expect(user.reload.email_verified?).to be(true)
+    expect(user.tokens).to eq(10)
+  end
+
+  it "works without authentication — the link is clicked from an inbox" do
+    token = user.generate_email_verification_token!
+    verify(token) # no auth_headers
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "rejects an unknown token" do
+    verify("not-a-real-token")
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body)["error"]).to be_present
+  end
+
+  it "rejects an expired token without verifying the account" do
+    token = user.generate_email_verification_token!
+    user.update!(email_verification_sent_at: 8.days.ago)
+
+    verify(token)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(user.reload.email_verified?).to be(false)
+    expect(user.tokens).to eq(0)
+  end
+
+  # Double-clicks and email security scanners (Outlook Safe Links, Mimecast)
+  # that prefetch links must not produce an error on an account that verified
+  # fine — schools and clinics run exactly those scanners.
+  it "reports success on a replayed link without double-granting" do
+    token = user.generate_email_verification_token!
+    verify(token)
+    expect(user.reload.tokens).to eq(10)
+
+    verify(token)
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["email_verified"]).to be(true)
+    expect(user.reload.tokens).to eq(10)
+  end
+
+  it "still reports success for an already-verified user past the expiry window" do
+    token = user.generate_email_verification_token!
+    verify(token)
+    user.update!(email_verification_sent_at: 8.days.ago)
+
+    verify(token)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.tokens).to eq(10)
+  end
+end

--- a/spec/requests/api/users_verify_email_spec.rb
+++ b/spec/requests/api/users_verify_email_spec.rb
@@ -68,3 +68,61 @@ RSpec.describe "GET /api/verify_email", type: :request do
     expect(user.reload.tokens).to eq(10)
   end
 end
+
+RSpec.describe "POST /api/resend_email_verification", type: :request do
+  let(:user) { FactoryBot.create(:user, confirmed_at: nil) }
+
+  def resend(as_user: user)
+    post "/api/resend_email_verification", headers: auth_headers(as_user), as: :json
+  end
+
+  it "sends a fresh verification email and rotates the token" do
+    original = user.generate_email_verification_token!
+    user.update!(email_verification_sent_at: 6.minutes.ago)
+
+    expect { resend }.to have_enqueued_mail(UserMailer, :verify_email)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.email_verification_token).not_to eq(original)
+  end
+
+  it "sends when nothing has been sent yet" do
+    expect { resend }.to have_enqueued_mail(UserMailer, :verify_email)
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "throttles a second request inside the cooldown" do
+    user.generate_email_verification_token!
+
+    expect { resend }.not_to have_enqueued_mail(UserMailer, :verify_email)
+
+    expect(response).to have_http_status(:too_many_requests)
+    expect(JSON.parse(response.body)["retry_after"]).to be > 0
+  end
+
+  it "refuses when the account is already verified" do
+    user.update!(confirmed_at: Time.current)
+
+    expect { resend }.not_to have_enqueued_mail(UserMailer, :verify_email)
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it "requires authentication" do
+    post "/api/resend_email_verification", as: :json
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "responds honestly when the mailer enqueue fails, without rotating the token or starting the cooldown" do
+    original_token = user.email_verification_token
+    original_sent_at = user.email_verification_sent_at
+
+    allow(UserMailer).to receive(:verify_email).and_raise(Redis::BaseConnectionError, "connection refused")
+
+    resend
+
+    expect(response).to have_http_status(:service_unavailable)
+    expect(JSON.parse(response.body)["error"]).to be_present
+    expect(user.reload.email_verification_token).to eq(original_token)
+    expect(user.reload.email_verification_sent_at).to eq(original_sent_at)
+  end
+end

--- a/spec/requests/api/v1/auths_disposable_email_spec.rb
+++ b/spec/requests/api/v1/auths_disposable_email_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "disposable email rejection", type: :request do
+  it "rejects a disposable address at standard signup" do
+    post "/api/v1/users",
+         params: { email: "throwaway@mailinator.com", password: "password123",
+                   password_confirmation: "password123" },
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body)["error"]).to be_present
+    expect(User.find_by(email: "throwaway@mailinator.com")).to be_nil
+  end
+
+  it "rejects a disposable address at email signup" do
+    post "/api/v1/users/email_signup", params: { email: "throwaway@mailinator.com" }, as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(User.find_by(email: "throwaway@mailinator.com")).to be_nil
+  end
+end

--- a/spec/requests/api/v1/auths_email_verification_spec.rb
+++ b/spec/requests/api/v1/auths_email_verification_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe "signup email verification", type: :request do
 
       expect(User.find_by(email: "new@example.com").email_verification_token).to be_present
     end
+
+    it "still succeeds and returns a token when the verification mail enqueue raises (e.g. Redis is down)" do
+      allow(UserMailer).to receive(:verify_email).and_raise(Redis::CannotConnectError, "Error connecting to Redis")
+
+      sign_up
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["token"]).to be_present
+
+      user = User.find_by(email: "new@example.com")
+      expect(user).to be_present
+      # Token generation runs before the mailer call, so it still lands even
+      # though the enqueue itself blew up.
+      expect(user.email_verification_token).to be_present
+    end
   end
 
   describe "POST /api/v1/users/email_signup (paid-intent signup)" do

--- a/spec/requests/api/v1/auths_email_verification_spec.rb
+++ b/spec/requests/api/v1/auths_email_verification_spec.rb
@@ -8,6 +8,11 @@ require "rails_helper"
 # inbox ownership — see the task-7r brief), so email_signup's welcome receipt
 # alone can no longer be relied on to verify the address.
 RSpec.describe "signup email verification", type: :request do
+  # The Stripe gem raises Stripe::AuthenticationError client-side when no API
+  # key is configured, before any request is made — so the WebMock stub for
+  # api.stripe.com never sees it. CI has no key. Same stub as auth_spec.rb.
+  before { allow(User).to receive(:create_stripe_customer).and_return("cus_test") }
+
   describe "POST /api/v1/users (standard signup)" do
     def sign_up(email: "new@example.com")
       post "/api/v1/users",
@@ -96,6 +101,8 @@ RSpec.describe "signup email verification", type: :request do
 end
 
 RSpec.describe "verification is earned only by an emailed link", type: :request do
+  before { allow(User).to receive(:create_stripe_customer).and_return("cus_test") }
+
   # THE security regression test for this task. Reaching set_password requires
   # only the session email_signup already handed out — no inbox access — so it
   # must not confer verified status, even though devise_invitable's

--- a/spec/requests/api/v1/auths_email_verification_spec.rb
+++ b/spec/requests/api/v1/auths_email_verification_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 # Signup no longer grants tokens up front — see
-# drafts/2026-07-26-email-verification-design.md. `sign_up` sends a
-# verification email; `email_signup` does not, because its welcome receipt
-# already carries a magic login link that proves inbox ownership.
+# drafts/2026-07-26-email-verification-design.md. Both `sign_up` and
+# `email_signup` send a verification email now (task-7r): `set_password` /
+# invitation-accept no longer confers verified status (devise_invitable
+# stamps confirmed_at on accept_invitation! regardless, which is not proof of
+# inbox ownership — see the task-7r brief), so email_signup's welcome receipt
+# alone can no longer be relied on to verify the address.
 RSpec.describe "signup email verification", type: :request do
   describe "POST /api/v1/users (standard signup)" do
     def sign_up(email: "new@example.com")
@@ -52,10 +55,16 @@ RSpec.describe "signup email verification", type: :request do
   end
 
   describe "POST /api/v1/users/email_signup (paid-intent signup)" do
-    it "does NOT send a verification email — the welcome receipt's magic link covers it" do
+    # Was "does NOT send" prior to task-7r: the welcome receipt's magic link
+    # was assumed to prove inbox ownership via set_password, but set_password
+    # doesn't prove that (see the task-7r brief) — so email_signup now sends
+    # its own verification email, same as sign_up.
+    it "sends a verification email" do
       expect {
         post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
-      }.not_to have_enqueued_mail(UserMailer, :verify_email)
+      }.to have_enqueued_mail(UserMailer, :verify_email)
+
+      expect(User.find_by(email: "paid@example.com").email_verification_token).to be_present
     end
 
     it "creates the account unverified with a zero balance" do
@@ -65,5 +74,53 @@ RSpec.describe "signup email verification", type: :request do
       expect(user.email_verified?).to be(false)
       expect(user.tokens).to eq(0)
     end
+  end
+end
+
+RSpec.describe "verification is earned only by an emailed link", type: :request do
+  # THE security regression test for this task. Reaching set_password requires
+  # only the session email_signup already handed out — no inbox access — so it
+  # must not confer verified status, even though devise_invitable's
+  # accept_invitation! stamps confirmed_at underneath us.
+  it "does NOT verify a user who sets a password without clicking an emailed link" do
+    post "/api/v1/users/email_signup", params: { email: "nobody@example.com" }, as: :json
+    user = User.find_by(email: "nobody@example.com")
+
+    post "/api/v1/users/set_password",
+         params: { password: "password123", password_confirmation: "password123" },
+         headers: auth_headers(user), as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.email_verified?).to be(false)
+    expect(user.tokens).to eq(0)
+    expect(CreditService.balance(user)[:total]).to eq(0)
+  end
+
+  it "sends a verification email on email_signup" do
+    expect {
+      post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
+    }.to have_enqueued_mail(UserMailer, :verify_email)
+
+    expect(User.find_by(email: "paid@example.com").email_verification_token).to be_present
+  end
+
+  it "verifies and grants on a successful temp login" do
+    user = FactoryBot.create(:user, email_verified_at: nil)
+    user.update!(temp_login_token: "temptoken123", temp_login_expires_at: 1.hour.from_now)
+
+    get "/api/temp-login/temptoken123"
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.email_verified?).to be(true)
+    expect(user.tokens).to eq(10)
+  end
+
+  it "does not double-grant when an already-verified user uses a temp login" do
+    user = FactoryBot.create(:user, email_verified_at: 1.day.ago)
+    user.update!(tokens: 2, temp_login_token: "temptoken456", temp_login_expires_at: 1.hour.from_now)
+
+    get "/api/temp-login/temptoken456"
+
+    expect(user.reload.tokens).to eq(2)
   end
 end

--- a/spec/requests/api/v1/auths_email_verification_spec.rb
+++ b/spec/requests/api/v1/auths_email_verification_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe "signup email verification", type: :request do
       expect(user.email_verified?).to be(false)
       expect(user.tokens).to eq(0)
     end
+
+    it "still succeeds and returns a token when the verification mail enqueue raises (e.g. Redis is down)" do
+      allow(UserMailer).to receive(:verify_email).and_raise(Redis::CannotConnectError, "Error connecting to Redis")
+
+      expect {
+        post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
+      }.to have_enqueued_mail(UserMailer, :welcome_email_receipt)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["token"]).to be_present
+
+      user = User.find_by(email: "paid@example.com")
+      expect(user).to be_present
+      # By this point the account exists, is signed in, and has a Stripe
+      # customer — the verification-mail rescue must not strand any of that,
+      # and the welcome receipt still has to go out despite the failure.
+    end
   end
 end
 
@@ -96,14 +114,6 @@ RSpec.describe "verification is earned only by an emailed link", type: :request 
     expect(CreditService.balance(user)[:total]).to eq(0)
   end
 
-  it "sends a verification email on email_signup" do
-    expect {
-      post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
-    }.to have_enqueued_mail(UserMailer, :verify_email)
-
-    expect(User.find_by(email: "paid@example.com").email_verification_token).to be_present
-  end
-
   it "verifies and grants on a successful temp login" do
     user = FactoryBot.create(:user, email_verified_at: nil)
     user.update!(temp_login_token: "temptoken123", temp_login_expires_at: 1.hour.from_now)
@@ -121,6 +131,7 @@ RSpec.describe "verification is earned only by an emailed link", type: :request 
 
     get "/api/temp-login/temptoken456"
 
+    expect(response).to have_http_status(:ok)
     expect(user.reload.tokens).to eq(2)
   end
 end

--- a/spec/requests/api/v1/auths_email_verification_spec.rb
+++ b/spec/requests/api/v1/auths_email_verification_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+# Signup no longer grants tokens up front — see
+# drafts/2026-07-26-email-verification-design.md. `sign_up` sends a
+# verification email; `email_signup` does not, because its welcome receipt
+# already carries a magic login link that proves inbox ownership.
+RSpec.describe "signup email verification", type: :request do
+  describe "POST /api/v1/users (standard signup)" do
+    def sign_up(email: "new@example.com")
+      post "/api/v1/users",
+           params: { email: email, password: "password123",
+                     password_confirmation: "password123", name: "Sam" },
+           as: :json
+    end
+
+    it "still signs the user in and returns a token" do
+      sign_up
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["token"]).to be_present
+    end
+
+    it "creates the account unverified with a zero token balance" do
+      sign_up
+      user = User.find_by(email: "new@example.com")
+      expect(user.email_verified?).to be(false)
+      expect(user.tokens).to eq(0)
+    end
+
+    it "issues a verification token and sends the email" do
+      expect {
+        sign_up
+      }.to have_enqueued_mail(UserMailer, :verify_email)
+
+      expect(User.find_by(email: "new@example.com").email_verification_token).to be_present
+    end
+  end
+
+  describe "POST /api/v1/users/email_signup (paid-intent signup)" do
+    it "does NOT send a verification email — the welcome receipt's magic link covers it" do
+      expect {
+        post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
+      }.not_to have_enqueued_mail(UserMailer, :verify_email)
+    end
+
+    it "creates the account unverified with a zero balance" do
+      post "/api/v1/users/email_signup", params: { email: "paid@example.com" }, as: :json
+
+      user = User.find_by(email: "paid@example.com")
+      expect(user.email_verified?).to be(false)
+      expect(user.tokens).to eq(0)
+    end
+  end
+end

--- a/spec/requests/api/v1/email_signup_spec.rb
+++ b/spec/requests/api/v1/email_signup_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
   end
 
   describe "happy path" do
-    it "creates a passwordless invited user on the free plan with initial credits" do
+    it "creates a passwordless invited user on the free plan with zero credits until verified" do
       expect {
         do_post(email: "buyer@example.com")
       }.to change(User, :count).by(1)
@@ -27,7 +27,10 @@ RSpec.describe "POST /api/v1/users/email_signup", type: :request do
       expect(user.invitation_accepted_at).to be_nil
       expect(user.valid_password?("anything")).to be_falsey
       expect(user.plan_type).to eq("free")
-      expect(user.plan_credits_balance.to_i).to be > 0
+      # The initial credit grant is deferred to email verification (task-2b).
+      # Wiring the invitation-accept flow to verification is a later task
+      # (Task 7) — until then an invited-but-unaccepted user holds nothing.
+      expect(user.plan_credits_balance.to_i).to eq(0)
     end
 
     it "returns the same envelope as sign_up, with needs_password true" do

--- a/spec/requests/lifecycle_integration_spec.rb
+++ b/spec/requests/lifecycle_integration_spec.rb
@@ -49,10 +49,13 @@ RSpec.describe "Subscription lifecycle (end-to-end)", type: :request do
     # ----- Step 1: legacy basic_trial account -----
     # New signups now land on free (the no-CC soft trial was removed,
     # drafts/drop-basic-trial-option-a.md), but basic_trial remains a valid
-    # fallback state we must keep handling. Construct one explicitly: it gets
-    # the 400-credit grant (User#after_create → CreditService.ensure_initial_grant!)
-    # and no Stripe customer yet.
+    # fallback state we must keep handling. Construct one explicitly, then
+    # verify: the 400-credit grant is deferred to email verification
+    # (User#mark_email_verified! → CreditService.ensure_initial_grant!,
+    # task-2b) rather than firing on create.
     user = FactoryBot.create(:user, stripe_customer_id: "cus_lifecycle", plan_type: "basic_trial")
+    user.mark_email_verified!
+    user.reload
     expect(user.plan_type).to eq("basic_trial")
     expect(user.plan_credits_balance).to eq(400)
     expect(user.paid_plan?).to be true # basic_trial.include?("basic") → true
@@ -154,8 +157,9 @@ RSpec.describe "Subscription lifecycle (end-to-end)", type: :request do
       stripe_customer_id: "cus_soft_only",
       plan_type: "basic_trial",
       paid_plan_type: nil)
+    user.mark_email_verified! # initial grant is deferred to verification (task-2b)
     user.update_column(:created_at, 20.days.ago)
-    expect(user.plan_credits_balance).to eq(400) # initial grant
+    expect(user.reload.plan_credits_balance).to eq(400) # initial grant
     user.update_columns(plan_credits_balance: 12, plan_credits_reset_at: 1.day.ago)
 
     DowngradeSoftTrialJob.new.perform

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -133,6 +133,11 @@ RSpec.describe "Rack::Attack rate limiting", type: :request do
   describe "signup throttle (per IP)" do
     let(:limit) { Rack::Attack::SIGNUP_LIMIT }
 
+    # The Stripe gem raises Stripe::AuthenticationError client-side when no API
+    # key is configured, before any request is made — so the WebMock stub for
+    # api.stripe.com never sees it. CI has no key. Same stub as auth_spec.rb.
+    before { allow(User).to receive(:create_stripe_customer).and_return("cus_test") }
+
     # Distinct emails so failures come from the throttle, not uniqueness.
     def signup(n)
       post "/api/v1/users",

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -97,6 +97,69 @@ RSpec.describe "Rack::Attack rate limiting", type: :request do
       get "/api/temp-login/deadbeef"
       expect(response).to have_http_status(:too_many_requests)
     end
+
+    # verify_email takes its token as a query param, not a path segment, so
+    # the path has no trailing slash — unlike temp-login/communicator_claims.
+    # A regex that forgot this would silently never match and leave the
+    # endpoint unprotected while looking protected.
+    it "throttles GET /api/verify_email (query-string token, no trailing slash) past the limit" do
+      limit = Rack::Attack::TOKEN_LIMIT
+
+      limit.times { get "/api/verify_email", params: { token: "deadbeef" } }
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      get "/api/verify_email", params: { token: "deadbeef" }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "TOKEN_ACCESS_PATHS regex" do
+    it "matches /api/verify_email even though it has no trailing slash" do
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).to match("/api/verify_email")
+    end
+
+    it "still matches the path-segment token endpoints" do
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).to match("/api/temp-login/abc123")
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).to match("/api/communicator_claims/abc123")
+    end
+
+    it "does not match unrelated or lookalike paths" do
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).not_to match("/api/verify_emailxxx")
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).not_to match("/api/verify_email/")
+      expect(Rack::Attack::TOKEN_ACCESS_PATHS).not_to match("/api/resend_email_verification")
+    end
+  end
+
+  describe "signup throttle (per IP)" do
+    let(:limit) { Rack::Attack::SIGNUP_LIMIT }
+
+    # Distinct emails so failures come from the throttle, not uniqueness.
+    def signup(n)
+      post "/api/v1/users",
+        params: { email: "signup#{n}@example.com", password: "password123",
+                  password_confirmation: "password123" },
+        as: :json
+    end
+
+    it "lets a normal signup rate through" do
+      3.times { |i| signup(i) }
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 once the burst passes the limit" do
+      limit.times { |i| signup(i) }
+      expect(response).not_to have_http_status(:too_many_requests)
+
+      signup(limit) # one over
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "throttles the email-only signup path on the same counter" do
+      limit.times { |i| signup(i) }
+
+      post "/api/v1/users/email_signup", params: { email: "over@example.com" }, as: :json
+      expect(response).to have_http_status(:too_many_requests)
+    end
   end
 
   describe "AI / audio generation throttle" do

--- a/spec/services/disposable_email_domains_spec.rb
+++ b/spec/services/disposable_email_domains_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe DisposableEmailDomains do
+  it "flags a known disposable domain" do
+    expect(described_class.disposable?("someone@mailinator.com")).to be(true)
+  end
+
+  it "is case-insensitive" do
+    expect(described_class.disposable?("Someone@MAILINATOR.com")).to be(true)
+  end
+
+  it "allows ordinary providers" do
+    expect(described_class.disposable?("parent@gmail.com")).to be(false)
+    expect(described_class.disposable?("slp@schooldistrict.org")).to be(false)
+  end
+
+  it "is nil- and garbage-safe" do
+    expect(described_class.disposable?(nil)).to be(false)
+    expect(described_class.disposable?("")).to be(false)
+    expect(described_class.disposable?("no-at-sign")).to be(false)
+  end
+
+  it "matches only the domain, never the local part" do
+    expect(described_class.disposable?("mailinator.com@gmail.com")).to be(false)
+  end
+end

--- a/spec/sidekiq/board_screenshot_import_job_spec.rb
+++ b/spec/sidekiq/board_screenshot_import_job_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe BoardScreenshotImportJob, type: :job do
     before { allow(vision).to receive(:parse_board).and_raise(StandardError, "vision boom") }
 
     it "marks the import failed and refunds the exact source split, idempotently" do
+      # The initial credit grant is deferred to email verification (task-2b),
+      # so a bare `create(:user)` starts at 0 credits — grant explicitly so
+      # there's a balance to spend from and later refund.
+      CreditService.grant_plan!(user, amount: 100, period_end: 1.month.from_now,
+                                       metadata: { source: "spec" })
       spend = CreditService.spend!(user, feature_key: "screenshot_import")
       import.update!(metadata: { "credit_txn_id" => spend.id })
       balance_after_spend = user.reload.plan_credits_balance

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves users whose reset_at is in the future alone" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: Time.current)
       user.update_columns(plan_credits_balance: 5, plan_credits_reset_at: 5.days.from_now, stripe_subscription_id: nil)
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
@@ -29,6 +29,24 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
     it "refreshes a non-Stripe Pro user (App Store / RevenueCat / admin-set) with the Pro allowance" do
       user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
+      user.update_columns(
+        plan_credits_balance: 0,
+        plan_credits_reset_at: 2.days.ago,
+        stripe_subscription_id: nil,
+      )
+
+      expect {
+        described_class.new.perform
+      }.to change { user.reload.plan_credits_balance }.from(0).to(1500)
+    end
+
+    it "refreshes an UNVERIFIED pro_5yr user (paid tiers ride this job regardless of verification)" do
+      # 5-Year licenses have no Stripe subscription, so this job is their only
+      # monthly re-grant path. Verification gates the FREE allowance only —
+      # a paying customer who never clicks the verification email must not
+      # be stuck at zero credits once ExpirePlanCreditsJob zeroes their
+      # initial grant.
+      user = FactoryBot.create(:user, plan_type: "pro_5yr", confirmed_at: nil)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -49,7 +67,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves MONTHLY Stripe-driven paid users alone (refresh comes from invoice.payment_succeeded)" do
-      user = FactoryBot.create(:user, plan_type: "pro")
+      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -75,7 +93,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
     it "skips admins" do
       admin = FactoryBot.create(:admin_user)
-      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
+      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil, confirmed_at: Time.current)
 
       expect { described_class.new.perform }.not_to change { admin.reload.plan_credits_balance }
     end
@@ -91,7 +109,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves top-up credits untouched" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: Time.current)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50, stripe_subscription_id: nil)
 
       described_class.new.perform

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
   describe "#perform" do
     it "refreshes a free user whose plan_credits_reset_at has passed" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, email_verified_at: 30.days.ago)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       expect {
@@ -13,7 +13,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a basic_trial user whose reset_at has passed" do
-      user = FactoryBot.create(:user, plan_type: "basic_trial", confirmed_at: Time.current) # legacy fallback tier
+      user = FactoryBot.create(:user, plan_type: "basic_trial", email_verified_at: Time.current) # legacy fallback tier
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -21,14 +21,14 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves users whose reset_at is in the future alone" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, email_verified_at: Time.current)
       user.update_columns(plan_credits_balance: 5, plan_credits_reset_at: 5.days.from_now, stripe_subscription_id: nil)
 
       expect { described_class.new.perform }.not_to change { user.reload.plan_credits_balance }
     end
 
     it "refreshes a non-Stripe Pro user (App Store / RevenueCat / admin-set) with the Pro allowance" do
-      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "pro", email_verified_at: Time.current)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -46,7 +46,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
       # a paying customer who never clicks the verification email must not
       # be stuck at zero credits once ExpirePlanCreditsJob zeroes their
       # initial grant.
-      user = FactoryBot.create(:user, plan_type: "pro_5yr", confirmed_at: nil)
+      user = FactoryBot.create(:user, plan_type: "pro_5yr", email_verified_at: nil)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -59,7 +59,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a non-Stripe Basic user with the Basic allowance" do
-      user = FactoryBot.create(:user, plan_type: "basic", confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "basic", email_verified_at: Time.current)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -67,7 +67,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves MONTHLY Stripe-driven paid users alone (refresh comes from invoice.payment_succeeded)" do
-      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "pro", email_verified_at: Time.current)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -78,7 +78,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a YEARLY Stripe subscriber (their invoice only fires once a year)" do
-      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "pro", email_verified_at: Time.current)
       user.update!(settings: user.settings.merge("billing_interval" => "yearly"))
       user.update_columns(
         plan_credits_balance: 0,
@@ -93,13 +93,13 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
     it "skips admins" do
       admin = FactoryBot.create(:admin_user)
-      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil, confirmed_at: Time.current)
+      admin.update_columns(plan_type: "free", plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil, email_verified_at: Time.current)
 
       expect { described_class.new.perform }.not_to change { admin.reload.plan_credits_balance }
     end
 
     it "expires leftover credits before granting (no rollover for plan credits)" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, email_verified_at: 30.days.ago)
       user.update_columns(plan_credits_balance: 7, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -109,7 +109,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "leaves top-up credits untouched" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: Time.current)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, email_verified_at: Time.current)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -124,7 +124,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
   describe "email verification gating" do
     it "refreshes credits for a verified free user" do
-      user = FactoryBot.create(:user, confirmed_at: Time.current)
+      user = FactoryBot.create(:user, email_verified_at: Time.current)
 
       described_class.new.perform
 
@@ -134,7 +134,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     # Without this the monthly cron would hand 25 credits to every unverified
     # account, silently undoing the signup gate a month later.
     it "skips an unverified user" do
-      user = FactoryBot.create(:user, confirmed_at: nil)
+      user = FactoryBot.create(:user, email_verified_at: nil)
 
       described_class.new.perform
 

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
   describe "#perform" do
     it "refreshes a free user whose plan_credits_reset_at has passed" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: 30.days.ago)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       expect {
@@ -13,7 +13,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a basic_trial user whose reset_at has passed" do
-      user = FactoryBot.create(:user, plan_type: "basic_trial") # legacy fallback tier
+      user = FactoryBot.create(:user, plan_type: "basic_trial", confirmed_at: Time.current) # legacy fallback tier
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 1.minute.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -28,7 +28,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a non-Stripe Pro user (App Store / RevenueCat / admin-set) with the Pro allowance" do
-      user = FactoryBot.create(:user, plan_type: "pro")
+      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
       user.update_columns(
         plan_credits_balance: 0,
         plan_credits_reset_at: 2.days.ago,
@@ -41,7 +41,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a non-Stripe Basic user with the Basic allowance" do
-      user = FactoryBot.create(:user, plan_type: "basic")
+      user = FactoryBot.create(:user, plan_type: "basic", confirmed_at: Time.current)
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -60,7 +60,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "refreshes a YEARLY Stripe subscriber (their invoice only fires once a year)" do
-      user = FactoryBot.create(:user, plan_type: "pro")
+      user = FactoryBot.create(:user, plan_type: "pro", confirmed_at: Time.current)
       user.update!(settings: user.settings.merge("billing_interval" => "yearly"))
       user.update_columns(
         plan_credits_balance: 0,
@@ -81,7 +81,7 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
     end
 
     it "expires leftover credits before granting (no rollover for plan credits)" do
-      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago)
+      user = FactoryBot.create(:user, plan_type: "free", created_at: 30.days.ago, confirmed_at: 30.days.ago)
       user.update_columns(plan_credits_balance: 7, plan_credits_reset_at: 2.days.ago, stripe_subscription_id: nil)
 
       described_class.new.perform
@@ -96,6 +96,26 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
 
       described_class.new.perform
       expect(user.reload.topup_credits_balance).to eq(50)
+    end
+  end
+
+  describe "email verification gating" do
+    it "refreshes credits for a verified free user" do
+      user = FactoryBot.create(:user, confirmed_at: Time.current)
+
+      described_class.new.perform
+
+      expect(CreditService.balance(user.reload)[:total]).to be > 0
+    end
+
+    # Without this the monthly cron would hand 25 credits to every unverified
+    # account, silently undoing the signup gate a month later.
+    it "skips an unverified user" do
+      user = FactoryBot.create(:user, confirmed_at: nil)
+
+      described_class.new.perform
+
+      expect(CreditService.balance(user.reload)[:total]).to eq(0)
     end
   end
 end

--- a/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
+++ b/spec/sidekiq/refresh_free_tier_credits_job_spec.rb
@@ -113,6 +113,11 @@ RSpec.describe RefreshFreeTierCreditsJob, type: :sidekiq do
       user.update_columns(plan_credits_balance: 0, plan_credits_reset_at: 2.days.ago, topup_credits_balance: 50, stripe_subscription_id: nil)
 
       described_class.new.perform
+      # Assert the user was actually processed (plan credits refreshed), not
+      # just excluded from the run — an excluded user would also leave
+      # topup_credits_balance untouched, which would let this example pass
+      # vacuously.
+      expect(user.reload.plan_credits_balance).to eq(25)
       expect(user.reload.topup_credits_balance).to eq(50)
     end
   end


### PR DESCRIPTION
## Summary

Adds email verification for new signups, so fake addresses can't farm free AI generation and typo'd addresses surface themselves.

**Verification never gates authentication.** Unverified users sign in and use the app normally — they just hold no welcome tokens and no AI credits, see a persistent banner (frontend PR to follow), and can't trigger AI image generation. Every existing account is backfilled as verified and is completely unaffected.

Design + plan: `drafts/2026-07-26-email-verification-design.md`, `drafts/2026-07-26-email-verification-plan.md`.

## How it works

`email_verified_at` is the single source of truth, written **only** by `User#mark_email_verified!`. Verified status is conferred only by paths where the user clicked a link delivered to their inbox:

- the verification link (`GET /api/verify_email`)
- temp-login (`GET /api/temp-login/:token`)
- email-change confirmation (`GET /api/confirm_email_change`)

Both grants (10 legacy `tokens`, 25 AI credits) moved off `after_create` onto that method, so an unverified account simply holds nothing spendable — there's no per-endpoint permission check to forget in a future code path.

New endpoints: `GET /api/verify_email`, `POST /api/resend_email_verification` (throttled per-account, 5 min).

## Scope grew during implementation — four real holes the original plan missed

The plan closed one hole. Code review found three more, plus a bypass. Flagging these because they explain the diff size:

1. **AI credits were the real leak.** A second `after_create` granted 25 credits — the currency the modern AI endpoints actually bill (image generation = 3). That's ~8 free images per throwaway address, *more* value than the 10 legacy tokens the plan was blocking.
2. **`RefreshFreeTierCreditsJob` would have undone the gate** a month later by re-granting to unverified accounts. Now gated — but **only for `free`/`basic_trial`**: this job is the sole monthly re-grant path for 5-Year licenses, clinician comps, and RevenueCat subscribers, so a blanket filter would have zeroed out paying customers from month 2.
3. **Free first-fill image generation was entirely unbilled**, so a zero-balance account could still drive OpenAI spend. Now returns 403 `email_verification_required`.
4. **The gate was bypassable.** Verification originally keyed on `confirmed_at` — but `devise_invitable` stamps that column on `accept_invitation!` for any model that has it, and `set_password` is reachable from the session `email_signup` hands out *before any email is opened*. Anyone could reach verified status with no inbox access. Hence the dedicated `email_verified_at` column.

Also fixed in passing: email-change confirmation tokens never expired (`confirmation_sent_at` was stored but never read).

## Abuse controls

- `signup/ip` rack-attack throttle, **20/hour** — deliberately generous, since schools/clinics/libraries NAT many users behind one IP.
- `/api/verify_email` added to `TOKEN_ACCESS_PATHS` (it previously matched no rule at all).
- Static disposable-domain rejection at both signup endpoints — no network call in the signup path, no new vendor.

## Test plan

- `bundle exec rspec` — **3288 examples, 0 failures, 8 pending** (full suite, clean test DB).
- Every task was TDD'd (failing test first) and independently code-reviewed; several went through fix passes.
- Security regression spec pins the bypass closed: a user who sets a password without clicking an emailed link is **not** verified and receives no grants.

## Notes for review

- Fail-soft: verification mail enqueues are rescued (`deliver_later` pushes to Redis synchronously, and a blip must never 500 a signup that already created and signed in a user).
- The AAC invariant holds — board reads, board-load, and audio playback are untouched by every gate here.
- Docs updated: `CLAUDE.md` invariant, `.claude-notes/credits.md`, `CHANGELOG.md`.

## Follow-ups (not in this PR)

- Unverified accounts still squat the email namespace; a reaper job would close it.
- `API::Account::ImagesController#run_generate` has no token/credit/verification guard (weakly reachable — SANDBOX communicators have no child token).
- **Pre-existing, unrelated:** `User has_many :orders, dependent: :destroy` but no `Order` model exists. Admin hard-delete (`DELETE /api/users/:id`) would raise, and it poisons the test DB via `spec/models/user_spec.rb`'s `after(:context)` hook. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
