### PR TITLE
fix: remove dead has_many :orders that broke User#destroy; delete set_soft_trial_plan

### DIFF
--- a/app/controllers/api/temp_logins_controller.rb
+++ b/app/controllers/api/temp_logins_controller.rb
@@ -1,6 +1,9 @@
 # app/controllers/api/temp_logins_controller.rb
 class API::TempLoginsController < API::ApplicationController
-  skip_before_action :authenticate_user!
+  # No `skip_before_action :authenticate_user!` here: no ancestor registers that
+  # callback, so skipping it raises "callback has not been defined" under eager
+  # loading. `authenticate_token!` IS registered (API::ApplicationController), so
+  # that skip stays — it's what makes this endpoint reachable without a token.
   skip_before_action :authenticate_token!
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,28 +4,8 @@ class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
 
   before_action :configure_permitted_parameters, if: :devise_controller?
-  helper_method :current_order
-
-  before_action :authenticate_user!, only: [:current_order]
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-
-  def current_order
-    return nil if current_user.nil?
-    if user_session["order_id"].nil?
-      order = current_user.orders.in_progress.last || current_user.orders.create!
-    else
-      begin
-        order = current_user.orders.in_progress.find(user_session["order_id"])
-      rescue ActiveRecord::RecordNotFound => e
-        order = current_user.orders.create!
-      rescue => e
-        puts "\n\n****Error: #{e.inspect}\n\n"
-      end
-    end
-    user_session["order_id"] = order.id unless order.nil?
-    order
-  end
 
   def token
     @open_symbol_id_token = OpenSymbol.get_token

--- a/app/controllers/service_worker_controller.rb
+++ b/app/controllers/service_worker_controller.rb
@@ -1,6 +1,8 @@
 class ServiceWorkerController < ApplicationController
   protect_from_forgery except: :service_worker
-  skip_before_action :authenticate_user!
+  # No `skip_before_action :authenticate_user!` here: no ancestor registers that
+  # callback, so skipping it raises "callback has not been defined" under eager
+  # loading. These actions are public either way.
   def service_worker
   end
 

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,8 +1,4 @@
 module IconHelper
-    def shopping_cart_nav(tooltip_text = "View Cart")
-        "<i class='fa-solid fa-cart-shopping fa-lg' data-tippy-content='#{tooltip_text}' }></i>".html_safe
-    end
-
     def contact_nav(tooltip_text = "Contact Us")
         "<i class='fa-solid fa-envelope fa-lg' data-tippy-content='#{tooltip_text}' }></i>".html_safe
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :docs, dependent: :destroy
   has_many :user_docs, dependent: :destroy
-  has_many :orders, dependent: :destroy
   has_many :openai_prompts, dependent: :destroy
   has_many :team_users, dependent: :destroy
   belongs_to :current_team, class_name: "Team", optional: true
@@ -244,25 +243,12 @@ class User < ApplicationRecord
     setup_free_limits if plan_type == "free"
   end
 
-  # DEPRECATED / DEAD: the no-CC soft trial was removed
-  # (drafts/drop-basic-trial-option-a.md). Nothing calls this — no callback,
-  # controller, job, or spec — so it can be deleted now; an existing
-  # basic_trial cohort is not a reason to keep it, since the method only ever
-  # *entered* the trial and no caller remains to do that.
-  #
-  # The cohort does still gate the rest of the basic_trial machinery, which is
-  # separate and must outlive this method: DowngradeSoftTrialJob,
+  # NOTE: `set_soft_trial_plan` was deleted here — the no-CC soft trial was
+  # removed (drafts/drop-basic-trial-option-a.md) and nothing called the method
+  # any more. It was the only way to *enter* basic_trial. The rest of the
+  # basic_trial machinery stays until the cohort ages out: DowngradeSoftTrialJob,
   # RefreshFreeTierCreditsJob, the basic_trial branches in setup_limits /
   # paid_plan?, and CreditService::PLAN_MONTHLY_CREDITS["basic_trial"].
-  def set_soft_trial_plan
-    # A non-blank paid_plan_type means the user has previously been on a paid
-    # plan (set by apply_free_plan on cancel/pause and by the soft-trial
-    # downgrade job). Don't bounce them back into basic_trial mid-trial-window.
-    return if paid_plan_type.present?
-    self.plan_type = "basic_trial" if plan_type.blank? || plan_type == "free"
-    setup_limits
-  end
-
   def setup_limits
     case plan_type
     when "free"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,8 +186,10 @@ class User < ApplicationRecord
   # already defaults to "free"; this callback just applies the Free-tier
   # limits in-memory on create so the account has a board slot, a communicator
   # slot, and the AI monthly limit set from the start. The initial AI credit
-  # grant (25 on Free) is deferred to email verification — see
-  # User#mark_email_verified!.
+  # grant is deferred to email verification — see User#mark_email_verified!.
+  # Its size is the plan's monthly allowance, read from
+  # CreditService::PLAN_MONTHLY_CREDITS for the user's plan_type; don't
+  # restate the number here, it drifts.
   before_create :setup_new_user_free_plan
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
@@ -242,10 +244,16 @@ class User < ApplicationRecord
     setup_free_limits if plan_type == "free"
   end
 
-  # DEPRECATED: the no-CC soft trial was removed
-  # (drafts/drop-basic-trial-option-a.md). No longer wired to any callback or
-  # controller — kept defined as harmless fallback during the cutover. Safe to
-  # delete once the basic_trial cohort is confirmed empty.
+  # DEPRECATED / DEAD: the no-CC soft trial was removed
+  # (drafts/drop-basic-trial-option-a.md). Nothing calls this — no callback,
+  # controller, job, or spec — so it can be deleted now; an existing
+  # basic_trial cohort is not a reason to keep it, since the method only ever
+  # *entered* the trial and no caller remains to do that.
+  #
+  # The cohort does still gate the rest of the basic_trial machinery, which is
+  # separate and must outlive this method: DowngradeSoftTrialJob,
+  # RefreshFreeTierCreditsJob, the basic_trial branches in setup_limits /
+  # paid_plan?, and CreditService::PLAN_MONTHLY_CREDITS["basic_trial"].
   def set_soft_trial_plan
     # A non-blank paid_plan_type means the user has previously been on a paid
     # plan (set by apply_free_plan on cancel/pause and by the soft-trial

--- a/app/services/credit_service.rb
+++ b/app/services/credit_service.rb
@@ -38,7 +38,7 @@ class CreditService
   # Default monthly grant by plan_type. Stripe Price metadata overrides at grant time.
   PLAN_MONTHLY_CREDITS = {
     "free" => 25,
-    "basic_trial" => 400, # Soft 14-day Basic trial set by User#set_soft_trial_plan
+    "basic_trial" => 400, # Retired soft 14-day Basic trial; kept for the existing cohort
     "basic" => 400,
     "basic_5yr" => 400,   # 5-Year Basic license — Basic-equivalent monthly credits
     "pro" => 1500,

--- a/app/views/layouts/_mobile_nav.html.erb
+++ b/app/views/layouts/_mobile_nav.html.erb
@@ -18,7 +18,6 @@
                         <%= link_to new_menu_nav, new_menu_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
                         <%= link_to new_image_nav, new_image_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
                         <!-- User tokens and logout -->
-                        <%= link_to shopping_cart_nav, carts_show_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm"  unless current_order && current_order.order_items.empty? %>
                         <%= link_to tokens_nav, products_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
                         <%= button_to logout_nav, destroy_user_session_path, method: :delete, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
                     <% else %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,6 @@
           <%= link_to board_nav, boards_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
           <%= link_to menu_nav, menus_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
           <%= link_to image_nav, images_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
-          <%= link_to shopping_cart_nav, carts_show_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" unless current_order && current_order.order_items.empty? %>
           <%= link_to tokens_nav, products_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm", data: { tippy_content: "Buy more tokens. You currently have #{current_user.tokens}." } %>
           <%= link_to user_nav, current_user, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-xs", data: { tippy_content: "Your Account: #{current_user}" } %>
           <%= link_to team_nav, team_path(current_user.current_team_id), class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm", data: { tippy_content: "Current Team: #{current_user.current_team&.name&.upcase}" } if current_user.current_team_id %>
@@ -67,7 +66,6 @@
               <%= link_to new_menu_nav, new_menu_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
               <%= link_to new_image_nav, new_image_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
               <!-- User tokens and logout -->
-              <%= link_to shopping_cart_nav, carts_show_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" unless current_order && current_order.order_items.empty? %>
               <%= link_to tokens_nav, products_path, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
               <%= button_to logout_nav, destroy_user_session_path, method: :delete, class: "text-blue-200 hover:text-white px-3 py-2 rounded-md text-sm" %>
             <% else %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -653,4 +653,37 @@ RSpec.describe User, type: :model do
       expect(user.free_trial?).to be(false)
     end
   end
+
+  describe "#destroy" do
+    # Regression: `has_many :orders, dependent: :destroy` outlived the Order
+    # model (deleted in #25). Rails resolves the class name when the dependent
+    # callback runs, so EVERY User#destroy raised
+    # "NameError: Missing model class Order for the User#orders association",
+    # regardless of whether the user had any orders rows. Account deletion was
+    # broken for all users. Guard against re-adding an association whose model
+    # doesn't exist.
+    it "destroys a user without raising" do
+      user = FactoryBot.create(:user)
+
+      expect { user.destroy! }.not_to raise_error
+      expect(User.exists?(user.id)).to be(false)
+    end
+
+    it "has no association pointing at a missing model class" do
+      # Polymorphic associations resolve their class per-row, so there is no
+      # single klass to check — skip them rather than treating them as missing.
+      resolvable = User.reflect_on_all_associations.reject(&:polymorphic?)
+
+      missing = resolvable.reject do |assoc|
+        begin
+          assoc.klass
+          true
+        rescue NameError
+          false
+        end
+      end
+
+      expect(missing.map(&:name)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Started as a comment fix, turned up a real bug.

### 1. `has_many :orders, dependent: :destroy` was breaking `User#destroy` — for everyone

`Order` and `OrderItem` were deleted in #25, but the association stayed on `User`. Rails resolves the association's class name when the dependent-destroy callback runs, so **every** `User#destroy` raised:

```
NameError: Missing model class Order for the User#orders association
```

This fired whether or not the user had rows in `orders` — the callback resolves `Order` before it queries. Account deletion has been broken for all users since #25.

Verified both directions against the test DB with `rails runner`:

| | Result |
|---|---|
| With the association (reproduces pre-change) | `NameError: Missing model class Order…` |
| With it removed | destroys cleanly |

The `orders` table still exists in `db/schema.rb` (with an `order_items` FK), so no data is touched — only the dangling association.

### 2. Removed the rest of the dead shopping-cart path

The last consumers of that association:

- `ApplicationController#current_order`, its `helper_method`, and `before_action :authenticate_user!, only: [:current_order]` (which never matched an action)
- the three navbar cart links in `layouts/_navbar` and `layouts/_mobile_nav`
- `IconHelper#shopping_cart_nav`

All pre-React HTML-app leftovers. The links pointed at `carts_show_path`, which has no route.

### 3. Deleted `set_soft_trial_plan`

The no-CC soft trial was removed (`drafts/drop-basic-trial-option-a.md`) and nothing called the method — no callback, controller, job, or spec. It was the only way to *enter* `basic_trial`, so an existing cohort was never a reason to keep it.

The rest of the basic_trial machinery **stays** until the cohort ages out — `DowngradeSoftTrialJob`, `RefreshFreeTierCreditsJob`, the `basic_trial` branches in `setup_limits` / `paid_plan?`, and `CreditService::PLAN_MONTHLY_CREDITS["basic_trial"]`. A note in the method's place spells that out so a future cleanup doesn't remove the wrong thing. Also fixed the now-dangling reference to the method in `CreditService`.

### 4. Drift-proofed the initial-credit-grant comment

The original report was that this comment said "the 5-credit initial grant" while the value is 25. #538 had already corrected the number and moved the grant to email verification, so the factual error was gone before this branch — but the comment still restated the number inline, which is how it drifted in the first place. It now points at `CreditService::PLAN_MONTHLY_CREDITS`.

## Test plan

`bundle exec rspec spec/models/user_spec.rb spec/services/credit_service_spec.rb spec/sidekiq/downgrade_soft_trial_job_spec.rb spec/sidekiq/refresh_free_tier_credits_job_spec.rb`

→ **138 examples, 0 failures** (118 for the two core files after the cart removal; the job specs were run against the same tree)

New specs in `spec/models/user_spec.rb`:
- `#destroy` succeeds and actually removes the row — fails on `main` with the `NameError` above
- a guard that no `User` association points at a missing model class, so this can't be reintroduced; skips polymorphic associations, which resolve per-row and have no single `klass`

**No test for the cart/ERB removal, deliberately.** The signed-in branch of `layouts/_navbar` is dead independently of the cart: it references nine route helpers that no longer exist — `boards_path`, `menus_path`, `images_path`, `products_path`, `new_board_path`, `new_menu_path`, `new_image_path`, `docs_path`, `carts_show_path`. It cannot render regardless of this change, so a spec asserting it renders would be fiction. Verified with a `rails runner` audit of `Rails.application.routes.url_helpers`.

## Not included

- The `orders` / `order_items` tables are still in the schema. Dropping them is a migration and a separate call.
- The wider dead HTML/ERB surface (`layouts/application` and its navbar, the pre-React pages behind those missing route helpers) is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)