### PR TITLE
feat(billing): expose trial state + card-on-file so the app can ask for a payment method

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -138,6 +138,34 @@ The `trial_started` AnalyticsEvent is likewise gated on `apply_trial`, so promo
 conversions don't pollute the trial→paid metric. Non-promo checkouts are
 unchanged (full no-card reverse trial).
 
+**Client-facing trial state.** `User#api_view` carries a computed `trial`
+block — `{ active, status, ends_at, provider, needs_payment_method,
+plan_label }` — so the frontend never re-derives billing rules. `provider` is
+`"stripe"` when `stripe_subscription_id` is present, else `"revenuecat"`.
+`active` is false for `partner_pro` (the 3-month pilot trial is managed
+outside the app, so no countdown UI). `needs_payment_method` is true only for
+a Stripe trial with no card on file — that is the reverse-trial cohort that
+drops to Free at trial end.
+
+The card-on-file signal is `settings["has_payment_method"]`, written by
+`handle_subscription_upsert` (subscription default payment method, falling
+back to the customer's `invoice_settings.default_payment_method`, which is
+where the Customer Portal writes it) and by a `payment_method.attached`
+handler so a portal-added card registers mid-trial. Both fail soft: a Stripe
+error keeps the previous value rather than raising. Both webhook paths and
+`SubscriptionsController#customer_has_payment_method?` share the same lookup,
+`Billing::PaymentMethods.on_file?` (`app/services/billing/payment_methods.rb`).
+
+**Payment-method portal CTA.** `POST /api/subscriptions/billing_portal`
+accepts an optional `flow` param; `flow=payment_method_update` adds
+`flow_data: { type: "payment_method_update" }` to the Stripe session so the
+portal opens directly on "add a card" instead of its home screen — the
+destination for the trial banner's payment-method CTA. Allowed flow values
+are allow-listed (`API::SubscriptionsController::PORTAL_FLOWS`) rather than
+passed through, so a client can never drive an arbitrary Stripe portal flow;
+an unrecognized value is silently ignored and the portal opens on its normal
+home screen.
+
 ### Partner Program (`partner_pro`)
 
 The `/sign-up/partner` flow (frontend `viewType="partner"`) posts to the normal

--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -147,15 +147,29 @@ outside the app, so no countdown UI). `needs_payment_method` is true only for
 a Stripe trial with no card on file — that is the reverse-trial cohort that
 drops to Free at trial end.
 
-The card-on-file signal is `settings["has_payment_method"]`, written by
-`handle_subscription_upsert` (subscription default payment method, falling
-back to the customer's `invoice_settings.default_payment_method`, which is
-where the Customer Portal writes it) and by a `payment_method.attached`
-handler so a portal-added card registers mid-trial. Both fail soft: a Stripe
-error keeps the previous value rather than raising. `handle_subscription_upsert`'s
-lookup and `SubscriptionsController#customer_has_payment_method?` share
-`Billing::PaymentMethods.on_file?`; the `payment_method.attached` handler sets
-the flag directly from the webhook event without re-querying Stripe.
+The card-on-file signal is `settings["has_payment_method"]`, written by two
+webhook paths.
+
+`handle_subscription_upsert` computes it **only when
+`subscription.status == "trialing"`** — the flag is read nowhere else, so
+non-trial upserts skip the lookup entirely rather than spend a Stripe call on
+every routine subscription event. It shares `Billing::PaymentMethods.on_file?`
+with `SubscriptionsController#customer_has_payment_method?`; that lookup checks
+the subscription's `default_payment_method`, then the customer's
+`invoice_settings.default_payment_method` (where the Customer Portal writes
+it), then the legacy `default_source`. The shared lookup deliberately does
+**not** rescue — each caller keeps its own fallback, because they want opposite
+answers on an inconclusive lookup: the webhook keeps the previous value (don't
+flip the flag on a blip), while `customer_has_payment_method?` assumes `true`
+(never block a plan change).
+
+The `payment_method.attached` handler sets the flag directly from the event
+without re-querying Stripe, so a portal-added card registers mid-trial rather
+than waiting for the next subscription event. **That event must be enabled on
+the Stripe webhook endpoint** (see `docs/stripe-setup.md` §3) or the handler
+never fires. There is no `payment_method.detached` counterpart: a card removed
+mid-trial leaves the flag stale-true until the next `trialing` upsert
+recomputes it.
 
 **Payment-method portal CTA.** `POST /api/subscriptions/billing_portal`
 accepts an optional `flow` param; `flow=payment_method_update` adds

--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -152,9 +152,10 @@ The card-on-file signal is `settings["has_payment_method"]`, written by
 back to the customer's `invoice_settings.default_payment_method`, which is
 where the Customer Portal writes it) and by a `payment_method.attached`
 handler so a portal-added card registers mid-trial. Both fail soft: a Stripe
-error keeps the previous value rather than raising. Both webhook paths and
-`SubscriptionsController#customer_has_payment_method?` share the same lookup,
-`Billing::PaymentMethods.on_file?` (`app/services/billing/payment_methods.rb`).
+error keeps the previous value rather than raising. `handle_subscription_upsert`'s
+lookup and `SubscriptionsController#customer_has_payment_method?` share
+`Billing::PaymentMethods.on_file?`; the `payment_method.attached` handler sets
+the flag directly from the webhook event without re-querying Stripe.
 
 **Payment-method portal CTA.** `POST /api/subscriptions/billing_portal`
 accepts an optional `flow` param; `flow=payment_method_update` adds

--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -141,11 +141,21 @@ unchanged (full no-card reverse trial).
 **Client-facing trial state.** `User#api_view` carries a computed `trial`
 block — `{ active, status, ends_at, provider, needs_payment_method,
 plan_label }` — so the frontend never re-derives billing rules. `provider` is
-`"stripe"` when `stripe_subscription_id` is present, else `"revenuecat"`.
-`active` is false for `partner_pro` (the 3-month pilot trial is managed
-outside the app, so no countdown UI). `needs_payment_method` is true only for
-a Stripe trial with no card on file — that is the reverse-trial cohort that
-drops to Free at trial end.
+`nil` when the user isn't on a suppressed-or-active trial (`show_trial_ui?`
+false — the value most users produce, including a plain non-trialing account
+or a `partner_pro` pilot); otherwise `"stripe"` when `stripe_subscription_id`
+is present, else `"revenuecat"`. A strict TypeScript consumer must handle the
+`nil` case. `active` is false for `partner_pro` regardless of whether a Stripe
+trial exists — `show_trial_ui?` suppresses the countdown UI for the pilot
+outright. The 3-month pilot length itself is `plan_expires_at`, set by
+`handle_new_partner_pro_subscription` (`now + PARTNER_PILOT_TRIAL_MONTHS.months`),
+**not** a Stripe trial: Partner checkout auto-applies the `PARTNERPILOT26`
+promo code, and `apply_trial = promo.blank?`, so partners normally get **no**
+Stripe trial period from checkout at all — see "Partner Program" below for the
+separate `/sign-up/partner` path that does create a real no-card Stripe trial
+subscription. `needs_payment_method` is true only for a Stripe trial with no
+card on file — that is the reverse-trial cohort that drops to Free at trial
+end.
 
 The card-on-file signal is `settings["has_payment_method"]`, written by two
 webhook paths.
@@ -167,9 +177,28 @@ The `payment_method.attached` handler sets the flag directly from the event
 without re-querying Stripe, so a portal-added card registers mid-trial rather
 than waiting for the next subscription event. **That event must be enabled on
 the Stripe webhook endpoint** (see `docs/stripe-setup.md` §3) or the handler
-never fires. There is no `payment_method.detached` counterpart: a card removed
-mid-trial leaves the flag stale-true until the next `trialing` upsert
-recomputes it.
+never fires. It only writes for a `trialing` user — the flag means nothing
+for anyone else, and gating it stops an unrelated attach (e.g. a credit
+top-up purchase's payment method, which is never a subscription/customer
+default anywhere) from masking a trialist's missing card.
+
+**Optimistic at attach, authoritative at `trial_will_end` — the split is
+deliberate.** `payment_method.attached` always writes `true` for any attach
+without an authoritative `Billing::PaymentMethods.on_file?` check, because the
+event can arrive before Stripe has updated `customer.invoice_settings` — an
+authoritative lookup right then could read stale state and write `false`,
+strictly worse than the optimistic write. There is no `payment_method.detached`
+counterpart, so between trial start and the next signal the flag can only be
+corrected in one direction from this handler. Stripe fires nothing else during
+a quiet trial (no card added, no card removed, no plan change) between
+`customer.subscription.created` and the terminal event, so a card removed
+mid-trial via the portal would otherwise stay stale-true for the whole
+14-day window — `handle_trial_will_end` (fired ~3 days before trial end, the
+same moment the frontend CTA turns on) is what authoritatively recomputes the
+flag via `payment_method_on_file?` before the banner is ever shown, correcting
+both a stale-true removed card and a trial already in flight at deploy time
+with no flag set at all. There is no quiet-trial upsert to "self-heal" on —
+`trial_will_end` is the only correction point.
 
 **Payment-method portal CTA.** `POST /api/subscriptions/billing_portal`
 accepts an optional `flow` param; `flow=payment_method_update` adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - `POST /api/subscriptions/billing_portal` accepts `flow=payment_method_update`
   to open Stripe's focused "add a card" flow.
 
+### Fixed — stale `has_payment_method` flag during a quiet trial
+- Stripe fires no subscription event between trial start and the trial-ending
+  reminder, so `has_payment_method` could sit wrong (or entirely unset) for a
+  trial's full 14 days — missing the "add a payment method" nudge for anyone
+  whose card was removed mid-trial, or wrongly nudging a card-required trialist
+  who already had one on file. `customer.subscription.trial_will_end` now
+  recomputes the flag authoritatively right before the frontend CTA turns on.
+- `payment_method.attached` now only writes the flag for a `trialing` user —
+  a payment method attached for an unrelated purchase (e.g. a credit top-up)
+  no longer masks a trialist's missing card.
+- `trial_provider` now honors the same partner_pro trial-UI suppression as
+  `show_trial_ui?` / `trial_plan_label`.
+- Downgrading to Free now clears `has_payment_method` alongside `trial_ends_at`.
+
 ### Added — Email verification for new signups
 - Both signup paths (standard signup and email-only/passwordless signup) now
   send a confirmation email. The free welcome tokens and the initial AI credit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Payment-method prompt for no-card reverse trials
+- `api_view` now returns a computed `trial` block (`active`, `status`,
+  `ends_at`, `provider`, `needs_payment_method`, `plan_label`) so the app can
+  ask card-less trialists for a payment method instead of a plan they already
+  chose.
+- `settings["has_payment_method"]` tracks whether Stripe has a chargeable card,
+  updated on subscription upsert and on `payment_method.attached`.
+- `POST /api/subscriptions/billing_portal` accepts `flow=payment_method_update`
+  to open Stripe's focused "add a card" flow.
+
 ### Added — Email verification for new signups
 - Both signup paths (standard signup and email-only/passwordless signup) now
   send a confirmation email. The free welcome tokens and the initial AI credit

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -13,6 +13,10 @@ class API::SubscriptionsController < API::ApplicationController
     render json: { error: "Failed to load subscriptions" }, status: :bad_request
   end
 
+  # Flows the client may request. Allow-listed rather than passed through so a
+  # client can't drive arbitrary Stripe portal flows.
+  PORTAL_FLOWS = %w[payment_method_update].freeze
+
   def billing_portal
     # Free accounts (mobile signups, legacy users) may not have a Stripe
     # customer yet — create one lazily so the portal works for everyone.
@@ -21,6 +25,12 @@ class API::SubscriptionsController < API::ApplicationController
       customer: customer_id,
       return_url: "#{DOMAIN}/dashboard",
     }
+    # Focused "add a card" flow for the trial banner's payment-method CTA.
+    # Without it the portal opens on its home screen and a trialist with no
+    # card has to hunt for the payment-method section.
+    if PORTAL_FLOWS.include?(params[:flow].to_s)
+      portal_params[:flow_data] = { type: params[:flow].to_s }
+    end
     portal_params[:configuration] = ENV["STRIPE_PORTAL_CONFIG_ID"] if ENV["STRIPE_PORTAL_CONFIG_ID"].present?
     session = Stripe::BillingPortal::Session.create(portal_params)
     render json: { url: session&.url }, status: 200

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -383,15 +383,17 @@ class API::SubscriptionsController < API::ApplicationController
   end
 
   # Does the customer have a usable payment method for an immediate charge?
-  # Checks the subscription's own default first, then the customer's default
-  # payment method / legacy default source. On any Stripe error we assume "yes"
-  # so we never block a plan change on an inconclusive lookup — the actual
-  # change attempt surfaces the real error reactively.
+  # Delegates the actual lookup (subscription default -> customer
+  # invoice_settings default -> legacy default_source) to the shared
+  # Billing::PaymentMethods, also used by
+  # WebhooksController#payment_method_on_file?. On any Stripe error we assume
+  # "yes" so we never block a plan change on an inconclusive lookup — the
+  # actual change attempt surfaces the real error reactively. This rescue is
+  # deliberately kept local rather than folded into the shared lookup — see
+  # that module's comment for why the two callers' fallbacks must stay
+  # independent.
   def customer_has_payment_method?(customer_id, subscription = nil)
-    return true if subscription.respond_to?(:default_payment_method) && subscription.default_payment_method.present?
-
-    customer = Stripe::Customer.retrieve(customer_id)
-    customer.invoice_settings&.default_payment_method.present? || customer.default_source.present?
+    Billing::PaymentMethods.on_file?(customer_id, subscription: subscription)
   rescue Stripe::StripeError => e
     Rails.logger.warn "customer_has_payment_method? lookup failed: #{e.message} (user #{current_user.id})"
     true

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -70,6 +70,8 @@ class API::WebhooksController < API::ApplicationController
       handle_subscription_deleted(event.data.object)
     when "customer.subscription.paused"
       handle_subscription_paused(event.data.object)
+    when "payment_method.attached"
+      handle_payment_method_attached(event.data.object)
     when "invoice.payment_succeeded"
       handle_invoice_payment_succeeded(event.data.object, event.id)
     when "invoice.payment_failed"
@@ -875,6 +877,26 @@ class API::WebhooksController < API::ApplicationController
     Rails.logger.info "[StripeWebhook] subscription paused: user=#{user.id} status=paused"
   rescue => e
     Rails.logger.error "[StripeWebhook] handle_subscription_paused error: #{e.class} - #{e.message}"
+  end
+
+  # A card added through the Customer Portal attaches to the customer and may
+  # never touch the subscription, so handle_subscription_upsert can miss it.
+  # Flip the flag here so the "add a payment method" nudge stops immediately
+  # rather than waiting for the next subscription event.
+  def handle_payment_method_attached(payment_method)
+    raw_customer = payment_method.customer
+    customer_id = raw_customer.respond_to?(:id) ? raw_customer.id : raw_customer
+    user = User.find_by(stripe_customer_id: customer_id)
+    unless user
+      Rails.logger.info "[StripeWebhook] payment_method.attached: no user for customer #{customer_id}"
+      return
+    end
+
+    user.settings["has_payment_method"] = true
+    user.save!
+    Rails.logger.info "[StripeWebhook] payment_method.attached: user=#{user.id}"
+  rescue => e
+    Rails.logger.error "[StripeWebhook] payment_method.attached failed: #{e.class} - #{e.message}"
   end
 
   # ========== Helper methods ==========

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -130,6 +130,27 @@ class API::WebhooksController < API::ApplicationController
       return
     end
 
+    # Authoritative has_payment_method recompute — this is the ONE quiet-trial
+    # correction point. Stripe fires nothing between customer.subscription.created
+    # and this event (~3 days before trial end), so the flag written at trial
+    # start is otherwise stale for the entire 14 days: a trial already in flight
+    # when this feature deployed has no key at all (`!nil` -> needs_payment_method
+    # true, wrong for anyone who already has a card), and a card removed mid-trial
+    # via the portal leaves the flag stale-true (never nudged, cancels silently).
+    # trial_will_end fires exactly when the frontend CTA turns on, so recomputing
+    # here corrects both cohorts before the banner is ever shown. Wrapped in its
+    # own begin/rescue so a Stripe hiccup can never skip the analytics event or
+    # the Mailchimp enqueue below (external-service failures fail soft).
+    if user.plan_status == "trialing"
+      begin
+        user.settings["has_payment_method"] =
+          payment_method_on_file?(subscription, user.settings["has_payment_method"])
+        user.save!
+      rescue => e
+        Rails.logger.error "[StripeWebhook] trial_will_end: has_payment_method recompute failed for user=#{user.id}: #{e.class} - #{e.message}"
+      end
+    end
+
     trial_end = subscription.respond_to?(:trial_end) ? subscription.trial_end : nil
     AnalyticsEvent.track(
       "trial_will_end",
@@ -897,6 +918,24 @@ class API::WebhooksController < API::ApplicationController
       return
     end
 
+    # The flag only means anything for a trialist (it drives the trial banner's
+    # CTA) — gate the write so a non-trial attach (e.g. a credit top-up
+    # purchase's PM) writes nothing at all.
+    unless user.plan_status == "trialing"
+      Rails.logger.info "[StripeWebhook] payment_method.attached: user=#{user.id} not trialing; skipping"
+      return
+    end
+
+    # Deliberately optimistic: write `true` for ANY attach rather than calling
+    # Billing::PaymentMethods.on_file? (the narrower "is this actually a
+    # default somewhere" definition). This event can arrive before Stripe has
+    # updated customer.invoice_settings, so an authoritative lookup here could
+    # read stale state and write `false` — strictly worse than doing nothing.
+    # A PM attached-but-never-defaulted (e.g. a credit top-up purchase) is
+    # exactly the gap this optimistic write can't close; that's fine, because
+    # handle_trial_will_end (Fix A) is the authoritative recompute ~3 days
+    # before trial end, before the CTA is ever shown. Design: optimistic at
+    # attach, authoritative at trial_will_end.
     user.settings["has_payment_method"] = true
     user.save!
     Rails.logger.info "[StripeWebhook] payment_method.attached: user=#{user.id}"

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -886,6 +886,11 @@ class API::WebhooksController < API::ApplicationController
   def handle_payment_method_attached(payment_method)
     raw_customer = payment_method.customer
     customer_id = raw_customer.respond_to?(:id) ? raw_customer.id : raw_customer
+    if customer_id.blank?
+      Rails.logger.info "[StripeWebhook] payment_method.attached: blank customer id; skipping"
+      return
+    end
+
     user = User.find_by(stripe_customer_id: customer_id)
     unless user
       Rails.logger.info "[StripeWebhook] payment_method.attached: no user for customer #{customer_id}"

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -497,9 +497,16 @@ class API::WebhooksController < API::ApplicationController
 
     # Does Stripe have a card it can actually charge? Drives the trial banner's
     # "add a payment method" CTA — the no-card reverse trial (#264) cancels to
-    # Free at trial end when this stays false.
-    user.settings["has_payment_method"] =
-      payment_method_on_file?(subscription, user.settings["has_payment_method"])
+    # Free at trial end when this stays false. Only ever read for trialists
+    # (see `payment_method_on_file?`'s consumer), so only compute it while
+    # trialing — every other status (routine active-subscription updates like
+    # extra-communicator quantity changes) would otherwise pay for a synchronous
+    # `Stripe::Customer.retrieve` on a value nobody reads. Leave the existing
+    # value untouched for non-trialing statuses.
+    if subscription.status == "trialing"
+      user.settings["has_payment_method"] =
+        payment_method_on_file?(subscription, user.settings["has_payment_method"])
+    end
 
     user.setup_limits
 
@@ -910,23 +917,19 @@ class API::WebhooksController < API::ApplicationController
     (plan_item || items.first).price
   end
 
-  # True when Stripe has a chargeable card for this subscription. The
-  # subscription's own default_payment_method wins; the Customer Portal writes
-  # the card onto the *customer* instead, so fall back to that.
+  # True when Stripe has a chargeable card for this subscription. Delegates the
+  # actual lookup (subscription default -> customer invoice_settings default ->
+  # legacy default_source) to the shared Billing::PaymentMethods, also used by
+  # SubscriptionsController#customer_has_payment_method?.
   #
   # Fail-soft per the cross-cutting invariant: a Stripe error returns the value
   # we already had rather than raising — an external blip must never 500 a
   # webhook. Stale-false is a soft failure (we nudge someone who has a card);
-  # the next subscription event corrects it.
+  # the next subscription event corrects it. This rescue is deliberately kept
+  # local rather than folded into the shared lookup — see that module's
+  # comment for why the two callers' fallbacks must stay independent.
   def payment_method_on_file?(subscription, previous = false)
-    return true if subscription.try(:default_payment_method).present?
-
-    raw_customer = subscription.customer
-    customer_id = raw_customer.respond_to?(:id) ? raw_customer.id : raw_customer
-    return !!previous if customer_id.blank?
-
-    customer = Stripe::Customer.retrieve(customer_id)
-    customer.try(:invoice_settings).try(:default_payment_method).present?
+    Billing::PaymentMethods.on_file?(subscription.customer, subscription: subscription)
   rescue => e
     Rails.logger.error "[StripeWebhook] payment_method_on_file? failed for sub=#{subscription.try(:id)}: #{e.class} - #{e.message}"
     !!previous

--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -495,6 +495,12 @@ class API::WebhooksController < API::ApplicationController
       user.settings.delete("trial_ends_at")
     end
 
+    # Does Stripe have a card it can actually charge? Drives the trial banner's
+    # "add a payment method" CTA — the no-card reverse trial (#264) cancels to
+    # Free at trial end when this stays false.
+    user.settings["has_payment_method"] =
+      payment_method_on_file?(subscription, user.settings["has_payment_method"])
+
     user.setup_limits
 
     user.save!
@@ -902,6 +908,28 @@ class API::WebhooksController < API::ApplicationController
     end
     plan_item ||= items.find { |item| !Billing::ExtraCommunicators.extra_comm_item?(item) }
     (plan_item || items.first).price
+  end
+
+  # True when Stripe has a chargeable card for this subscription. The
+  # subscription's own default_payment_method wins; the Customer Portal writes
+  # the card onto the *customer* instead, so fall back to that.
+  #
+  # Fail-soft per the cross-cutting invariant: a Stripe error returns the value
+  # we already had rather than raising — an external blip must never 500 a
+  # webhook. Stale-false is a soft failure (we nudge someone who has a card);
+  # the next subscription event corrects it.
+  def payment_method_on_file?(subscription, previous = false)
+    return true if subscription.try(:default_payment_method).present?
+
+    raw_customer = subscription.customer
+    customer_id = raw_customer.respond_to?(:id) ? raw_customer.id : raw_customer
+    return !!previous if customer_id.blank?
+
+    customer = Stripe::Customer.retrieve(customer_id)
+    customer.try(:invoice_settings).try(:default_payment_method).present?
+  rescue => e
+    Rails.logger.error "[StripeWebhook] payment_method_on_file? failed for sub=#{subscription.try(:id)}: #{e.class} - #{e.message}"
+    !!previous
   end
 
   # Map a Stripe Price's recurring interval to the frontend's billing_interval

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1560,7 +1560,7 @@ class User < ApplicationRecord
   # Which provider runs the current trial. Stripe trials always carry a
   # stripe_subscription_id; RevenueCat (IAP) trials never do.
   def trial_provider
-    return nil unless plan_status == "trialing"
+    return nil unless show_trial_ui?
 
     stripe_subscription_id.present? ? "stripe" : "revenuecat"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1549,6 +1549,59 @@ class User < ApplicationRecord
     (trial_expired_at - Time.now).to_i / 1.day
   end
 
+  # --- Provider-trial surface for the client -----------------------------
+  # The client must not re-derive billing rules; the server owns them. See
+  # drafts/2026-07-27-trial-banner-payment-method-design.md.
+  #
+  # Deliberately separate from free_trial? / trial_days_left, which describe
+  # the 14-day-from-signup window for Free accounts. That window is unrelated
+  # to a provider trial and keeps its own client behavior.
+
+  # Which provider runs the current trial. Stripe trials always carry a
+  # stripe_subscription_id; RevenueCat (IAP) trials never do.
+  def trial_provider
+    return nil unless plan_status == "trialing"
+
+    stripe_subscription_id.present? ? "stripe" : "revenuecat"
+  end
+
+  # Should the client show trial UI at all? partner_pro pilots ride a 3-month
+  # no-card trial managed outside the app, so a persistent 90-day countdown
+  # strip is noise for them.
+  def show_trial_ui?
+    plan_status == "trialing" && plan_type != "partner_pro"
+  end
+
+  # True only when adding a card is the action that keeps the user's plan: a
+  # Stripe reverse trial (#264) with nothing on file. RevenueCat trialists
+  # already pay through Apple/Google and cannot add a card here at all.
+  def trial_needs_payment_method?
+    show_trial_ui? &&
+      trial_provider == "stripe" &&
+      !(settings || {})["has_payment_method"]
+  end
+
+  # Display name of the plan being trialed, for banner copy. nil for tiers
+  # without a consumer-facing label — the client falls back to generic copy.
+  def trial_plan_label
+    return nil unless show_trial_ui?
+    return "Pro" if pro?
+    return "Basic" if basic?
+
+    nil
+  end
+
+  def trial_api_view
+    {
+      active: show_trial_ui?,
+      status: plan_status,
+      ends_at: (settings || {})["trial_ends_at"],
+      provider: trial_provider,
+      needs_payment_method: trial_needs_payment_method?,
+      plan_label: trial_plan_label,
+    }
+  end
+
   def startup_board_group
     startup_board_group_id = settings["startup_board_group_id"]
     board_group = BoardGroup.includes(board_group_boards: :board).find_by(id: startup_board_group_id) if startup_board_group_id
@@ -2060,6 +2113,7 @@ class User < ApplicationRecord
       free_trial: free_trial?,
       trial_expired: trial_expired?,
       trial_days_left: trial_days_left,
+      trial: trial_api_view,
       comm_account_limit_reached: comm_account_limit_reached,
 
       # Communicators (REAL)

--- a/app/services/billing/payment_methods.rb
+++ b/app/services/billing/payment_methods.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Billing
+  # Single lookup for "does Stripe have a chargeable payment method for this
+  # customer?" — shared by the webhook's has_payment_method flag
+  # (WebhooksController#payment_method_on_file?, the no-card reverse trial's
+  # trial-banner CTA) and the plan-change immediate-charge guard
+  # (SubscriptionsController#customer_has_payment_method?).
+  #
+  # Checks, in order: the subscription's own `default_payment_method` (no API
+  # call needed), then the customer's `invoice_settings.default_payment_method`
+  # (where the Customer Portal writes a new card), then the legacy Stripe
+  # Sources API `default_source` field (older cards some customers still carry).
+  #
+  # Deliberately does NOT rescue Stripe errors — the two callers have
+  # different, intentional fallback policies on a lookup failure and must keep
+  # rescuing at their own call site:
+  #   - SubscriptionsController#customer_has_payment_method? assumes "yes" on
+  #     error, so an inconclusive lookup never blocks a plan change.
+  #   - WebhooksController#payment_method_on_file? keeps the previously stored
+  #     value on error, so a Stripe blip never flips the flag.
+  # Collapsing those into one fallback here would break one of the two.
+  module PaymentMethods
+    module_function
+
+    # `customer_id` may be a bare Stripe customer id string or an expanded
+    # Stripe::Customer-like object (anything responding to `:id`).
+    def on_file?(customer_id, subscription: nil)
+      return true if subscription.respond_to?(:default_payment_method) && subscription.default_payment_method.present?
+
+      raw_id = customer_id.respond_to?(:id) ? customer_id.id : customer_id
+      return false if raw_id.blank?
+
+      customer = Stripe::Customer.retrieve(raw_id)
+      customer.invoice_settings&.default_payment_method.present? || customer.default_source.present?
+    end
+  end
+end

--- a/app/services/billing/plan_transitions.rb
+++ b/app/services/billing/plan_transitions.rb
@@ -23,6 +23,7 @@ module Billing
       user.setup_free_limits
       user.stripe_subscription_id = nil
       user.settings.delete("trial_ends_at")
+      user.settings.delete("has_payment_method")
       # Pro-only extra-communicator add-on slots don't survive a downgrade: a
       # cancelled subscription or an expired license takes its extras with it.
       # (Over-limit communicators are retained in fallback by the reconciler.)

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -138,7 +138,11 @@ Checklist (Settings → Billing → Customer portal, each mode):
 
 - Invoice history: **ON** (receipts are the main value for free users)
 - Customer information update: **ON**
-- Payment method update: **ON**
+- Payment method update: **ON** — required for the trial banner's
+  `flow=payment_method_update` CTA (§3 `payment_method.attached`, and see
+  `.claude-notes/billing-and-plans.md` → "Payment-method portal CTA"): with
+  this off, the portal session Stripe returns for that flow errors instead of
+  opening on "add a card".
 - Don't regress paid users' cancel/update-subscription settings — the
   portal config is shared by free and paid customers.
 

--- a/docs/stripe-setup.md
+++ b/docs/stripe-setup.md
@@ -100,6 +100,7 @@ There's already a Stripe webhook configured at `/api/webhooks` that uses
 - `customer.subscription.paused`
 - `customer.created`
 - `invoice.payment_succeeded` *(triggers plan-credit grants on first paid period and every renewal — Phase 4)*
+- `payment_method.attached` *(flips `settings["has_payment_method"]` on mid-trial so a card added via the Customer Portal registers immediately, instead of waiting for the next subscription-upsert webhook)*
 
 ## 4. Redirect URLs (success_url / cancel_url)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -550,6 +550,7 @@ RSpec.describe User, type: :model do
 
       expect(user.api_view[:trial]).to include(
         active: false,
+        provider: nil,
         needs_payment_method: false,
       )
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -490,6 +490,81 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#api_view trial block" do
+    it "describes a card-less Stripe trial as needing a payment method" do
+      user = FactoryBot.create(:user,
+        plan_type: "basic",
+        plan_status: "trialing",
+        stripe_subscription_id: "sub_123")
+      user.settings["trial_ends_at"] = "2026-08-10T12:00:00Z"
+      user.settings["has_payment_method"] = false
+      user.save!
+
+      expect(user.api_view[:trial]).to include(
+        active: true,
+        provider: "stripe",
+        needs_payment_method: true,
+        plan_label: "Basic",
+        ends_at: "2026-08-10T12:00:00Z",
+      )
+    end
+
+    it "does not ask a Stripe trialist who already has a card" do
+      user = FactoryBot.create(:user,
+        plan_type: "pro",
+        plan_status: "trialing",
+        stripe_subscription_id: "sub_456")
+      user.settings["has_payment_method"] = true
+      user.save!
+
+      expect(user.api_view[:trial]).to include(
+        active: true,
+        provider: "stripe",
+        needs_payment_method: false,
+        plan_label: "Pro",
+      )
+    end
+
+    it "never asks a RevenueCat trialist for a card" do
+      user = FactoryBot.create(:user,
+        plan_type: "pro",
+        plan_status: "trialing",
+        stripe_subscription_id: nil)
+      user.settings["trial_ends_at"] = "2026-08-10T12:00:00Z"
+      user.save!
+
+      expect(user.api_view[:trial]).to include(
+        active: true,
+        provider: "revenuecat",
+        needs_payment_method: false,
+      )
+    end
+
+    it "suppresses trial UI for partner_pro pilots" do
+      user = FactoryBot.create(:user,
+        plan_type: "partner_pro",
+        plan_status: "trialing",
+        stripe_subscription_id: "sub_partner")
+      user.settings["trial_ends_at"] = "2026-10-10T12:00:00Z"
+      user.save!
+
+      expect(user.api_view[:trial]).to include(
+        active: false,
+        needs_payment_method: false,
+      )
+    end
+
+    it "is inactive for a user who is not on a provider trial" do
+      user = FactoryBot.create(:user, plan_type: "free", plan_status: nil)
+
+      expect(user.api_view[:trial]).to include(
+        active: false,
+        provider: nil,
+        needs_payment_method: false,
+      )
+    end
+  end
+
   describe "#api_view has_boards flag" do
     it "is false when the user has no boards" do
       user = FactoryBot.create(:free_user)

--- a/spec/requests/api/subscriptions_billing_portal_spec.rb
+++ b/spec/requests/api/subscriptions_billing_portal_spec.rb
@@ -87,4 +87,50 @@ RSpec.describe "POST /api/subscriptions/billing_portal", type: :request do
       expect(captured[:configuration]).to eq("bpc_test_config")
     end
   end
+
+  context "when a focused payment-method flow is requested" do
+    let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+    it "passes flow_data so the portal opens on 'add a card'" do
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      post "/api/subscriptions/billing_portal",
+           params: { flow: "payment_method_update" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:flow_data]).to eq(type: "payment_method_update")
+    end
+
+    it "omits flow_data for a plain portal request" do
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      post "/api/subscriptions/billing_portal", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(captured).not_to have_key(:flow_data)
+    end
+
+    it "ignores an unrecognized flow value" do
+      captured = nil
+      expect(Stripe::BillingPortal::Session).to receive(:create) do |params|
+        captured = params
+        portal_session
+      end
+
+      post "/api/subscriptions/billing_portal",
+           params: { flow: "something_else" },
+           headers: auth_headers(user)
+
+      expect(captured).not_to have_key(:flow_data)
+    end
+  end
 end

--- a/spec/requests/api/subscriptions_billing_portal_spec.rb
+++ b/spec/requests/api/subscriptions_billing_portal_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "POST /api/subscriptions/billing_portal", type: :request do
         portal_session
       end
 
-      post "/api/subscriptions/billing_portal", headers: auth_headers(user)
+      do_post(user)
 
       expect(response).to have_http_status(:ok)
       expect(captured).not_to have_key(:flow_data)

--- a/spec/requests/api/webhooks_payment_method_spec.rb
+++ b/spec/requests/api/webhooks_payment_method_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+# Covers settings["has_payment_method"] — the flag behind the trial banner's
+# "add a payment method" CTA (see drafts/2026-07-27-trial-banner-payment-method-design.md).
+RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
+  include StripeHelpers
+
+  let_it_be(:user, reload: true) do
+    FactoryBot.create(:user,
+      stripe_customer_id: "cus_pm_user",
+      plan_type: "basic",
+      plan_status: "trialing")
+  end
+
+  before { ENV["STRIPE_WEBHOOK_SECRET"] ||= "whsec_test_dummy" }
+
+  def stub_event(object, type:, event_id: "evt_#{SecureRandom.hex(4)}")
+    event = OpenStruct.new(id: event_id, type: type, data: OpenStruct.new(object: object))
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+    event
+  end
+
+  def build_metadata(hash)
+    Class.new do
+      def initialize(h) = @h = h.transform_keys(&:to_s)
+      def [](k) = @h[k.to_s]
+      def presence = @h.presence
+      def to_h = @h
+    end.new(hash)
+  end
+
+  def build_price(plan_type: "basic", monthly_credits: 400, id: "price_basic")
+    OpenStruct.new(
+      id: id,
+      metadata: build_metadata("plan_type" => plan_type, "monthly_credits" => monthly_credits.to_s),
+    )
+  end
+
+  def build_subscription(default_payment_method: nil, status: "trialing")
+    OpenStruct.new(
+      id: "sub_#{SecureRandom.hex(3)}",
+      customer: user.stripe_customer_id,
+      status: status,
+      current_period_end: 14.days.from_now.to_i,
+      trial_end: 14.days.from_now.to_i,
+      default_payment_method: default_payment_method,
+      items: OpenStruct.new(data: [OpenStruct.new(price: build_price, quantity: 1)]),
+    )
+  end
+
+  def stub_customer(default_payment_method:)
+    allow(Stripe::Customer).to receive(:retrieve).and_return(
+      OpenStruct.new(invoice_settings: OpenStruct.new(default_payment_method: default_payment_method)),
+    )
+  end
+
+  it "records false for a no-card reverse trial" do
+    stub_customer(default_payment_method: nil)
+    stub_event(build_subscription, type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.settings["has_payment_method"]).to eq(false)
+  end
+
+  it "records true when the subscription carries a default payment method" do
+    stub_event(build_subscription(default_payment_method: "pm_card_123"),
+               type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.settings["has_payment_method"]).to eq(true)
+  end
+
+  it "falls back to the customer's default payment method (portal writes it there)" do
+    stub_customer(default_payment_method: "pm_from_portal")
+    stub_event(build_subscription, type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.settings["has_payment_method"]).to eq(true)
+  end
+
+  it "keeps the previous value and does not 500 when Stripe raises" do
+    user.update!(settings: user.settings.merge("has_payment_method" => true))
+    allow(Stripe::Customer).to receive(:retrieve).and_raise(Stripe::APIError.new("boom"))
+    stub_event(build_subscription, type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.settings["has_payment_method"]).to eq(true)
+  end
+end

--- a/spec/requests/api/webhooks_payment_method_spec.rb
+++ b/spec/requests/api/webhooks_payment_method_spec.rb
@@ -48,9 +48,12 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
     )
   end
 
-  def stub_customer(default_payment_method:)
+  def stub_customer(default_payment_method:, default_source: nil)
     allow(Stripe::Customer).to receive(:retrieve).and_return(
-      OpenStruct.new(invoice_settings: OpenStruct.new(default_payment_method: default_payment_method)),
+      OpenStruct.new(
+        invoice_settings: OpenStruct.new(default_payment_method: default_payment_method),
+        default_source: default_source,
+      ),
     )
   end
 
@@ -85,6 +88,26 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
     user.update!(settings: user.settings.merge("has_payment_method" => true))
     allow(Stripe::Customer).to receive(:retrieve).and_raise(Stripe::APIError.new("boom"))
     stub_event(build_subscription, type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.settings["has_payment_method"]).to eq(true)
+  end
+
+  it "records true for a customer whose only card is a legacy default_source" do
+    stub_customer(default_payment_method: nil, default_source: "card_legacy")
+    stub_event(build_subscription, type: "customer.subscription.updated")
+
+    post_webhook("{}", header_with_signature)
+
+    expect(user.reload.settings["has_payment_method"]).to eq(true)
+  end
+
+  it "does not call Stripe::Customer.retrieve and leaves has_payment_method unchanged for a non-trialing upsert" do
+    user.update!(settings: user.settings.merge("has_payment_method" => true))
+    expect(Stripe::Customer).not_to receive(:retrieve)
+    stub_event(build_subscription(status: "active"), type: "customer.subscription.updated")
 
     post_webhook("{}", header_with_signature)
 

--- a/spec/requests/api/webhooks_payment_method_spec.rb
+++ b/spec/requests/api/webhooks_payment_method_spec.rb
@@ -114,4 +114,28 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
     expect(response).to have_http_status(:ok)
     expect(user.reload.settings["has_payment_method"]).to eq(true)
   end
+
+  describe "payment_method.attached" do
+    def build_payment_method(customer: user.stripe_customer_id)
+      OpenStruct.new(id: "pm_#{SecureRandom.hex(3)}", customer: customer)
+    end
+
+    it "flips has_payment_method to true for the matching user" do
+      user.update!(settings: user.settings.merge("has_payment_method" => false))
+      stub_event(build_payment_method, type: "payment_method.attached")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.settings["has_payment_method"]).to eq(true)
+    end
+
+    it "is a no-op for an unknown customer and still returns 200" do
+      stub_event(build_payment_method(customer: "cus_nobody"), type: "payment_method.attached")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/api/webhooks_payment_method_spec.rb
+++ b/spec/requests/api/webhooks_payment_method_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(user.reload.settings["has_payment_method"]).to eq(true)
+    # Pins that the Stripe error was swallowed by payment_method_on_file?'s own
+    # local rescue, not by handle_subscription_upsert's outer rescue. If the
+    # local rescue were removed, the error would propagate to the outer rescue,
+    # user.save! would never run, and this would fail (trial_ends_at would be
+    # nil) even though has_payment_method and the 200 response above would
+    # still look correct.
+    expect(user.reload.settings["trial_ends_at"]).to be_present
   end
 
   it "records true for a customer whose only card is a legacy default_source" do
@@ -158,6 +165,25 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(stranger.reload.settings["has_payment_method"]).to eq(false)
+    end
+
+    # Fix B: the flag is only meaningful for a trialist (it drives the trial
+    # banner's CTA), so a non-trial attach — e.g. a credit top-up purchase's
+    # payment method, which is never a subscription/customer default anywhere
+    # — must write nothing. Writing `true` here would silently disable the
+    # nudge for the exact reverse-trial cohort this feature exists to catch.
+    it "does not write has_payment_method for a non-trialing user" do
+      non_trialist = FactoryBot.create(:user,
+        stripe_customer_id: "cus_pm_non_trial",
+        plan_type: "basic",
+        plan_status: "active")
+      non_trialist.update!(settings: non_trialist.settings.merge("has_payment_method" => false))
+      stub_event(build_payment_method(customer: "cus_pm_non_trial"), type: "payment_method.attached")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(non_trialist.reload.settings["has_payment_method"]).to eq(false)
     end
   end
 end

--- a/spec/requests/api/webhooks_payment_method_spec.rb
+++ b/spec/requests/api/webhooks_payment_method_spec.rb
@@ -137,5 +137,27 @@ RSpec.describe "POST /api/webhooks (has_payment_method)", type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "resolves the customer id from an expanded customer object" do
+      user.update!(settings: user.settings.merge("has_payment_method" => false))
+      expanded_customer = OpenStruct.new(id: user.stripe_customer_id)
+      stub_event(build_payment_method(customer: expanded_customer), type: "payment_method.attached")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.settings["has_payment_method"]).to eq(true)
+    end
+
+    it "is a no-op and does not flip an unrelated user's flag when the customer id is blank" do
+      stranger = FactoryBot.create(:user, stripe_customer_id: nil)
+      stranger.update!(settings: stranger.settings.merge("has_payment_method" => false))
+      stub_event(build_payment_method(customer: nil), type: "payment_method.attached")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(stranger.reload.settings["has_payment_method"]).to eq(false)
+    end
   end
 end

--- a/spec/requests/api/webhooks_plan_type_spec.rb
+++ b/spec/requests/api/webhooks_plan_type_spec.rb
@@ -294,6 +294,16 @@ RSpec.describe "POST /api/webhooks (plan_type)", type: :request do
 
       expect(user.reload.settings["trial_ends_at"]).to be_nil
     end
+
+    it "clears has_payment_method alongside trial_ends_at on cancellation" do
+      user.update!(plan_type: "pro", settings: { "trial_ends_at" => 7.days.from_now.iso8601, "has_payment_method" => true })
+      sub = build_subscription
+      stub_event(sub, type: "customer.subscription.deleted")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(user.reload.settings["has_payment_method"]).to be_nil
+    end
   end
 
   describe "customer.subscription.paused" do

--- a/spec/requests/api/webhooks_trial_wrap_spec.rb
+++ b/spec/requests/api/webhooks_trial_wrap_spec.rb
@@ -36,4 +36,58 @@ RSpec.describe "POST /api/webhooks (trial_wrap enqueue)", type: :request do
 
     expect(MailchimpTrialWrapJob.jobs.last["args"]).to eq([user.id, trial_end])
   end
+
+  # Fix A: nothing else recomputes has_payment_method during a quiet trial, so
+  # trial_will_end (fired ~3 days before end, exactly when the frontend CTA
+  # turns on) is the sole authoritative correction point. See
+  # API::WebhooksController#handle_trial_will_end.
+  describe "has_payment_method recompute" do
+    def build_sub(default_payment_method: nil)
+      OpenStruct.new(
+        id: "sub_recompute",
+        customer: user.stripe_customer_id,
+        status: "trialing",
+        trial_end: 1_781_000_000,
+        default_payment_method: default_payment_method,
+      )
+    end
+
+    it "recomputes the flag for a trialing user from the live subscription" do
+      user.update!(settings: user.settings.merge("has_payment_method" => nil))
+      stub_event(build_sub(default_payment_method: "pm_card_123"), type: "customer.subscription.trial_will_end")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.settings["has_payment_method"]).to eq(true)
+    end
+
+    it "does not write has_payment_method for a non-trialing user" do
+      user.update!(plan_status: "active", settings: user.settings.merge("has_payment_method" => true))
+      expect(Stripe::Customer).not_to receive(:retrieve)
+      stub_event(build_sub, type: "customer.subscription.trial_will_end")
+
+      post_webhook("{}", header_with_signature)
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.settings["has_payment_method"]).to eq(true)
+    end
+
+    it "still fires analytics and enqueues the Mailchimp job when the Stripe recompute fails" do
+      user.update!(settings: user.settings.merge("has_payment_method" => false))
+      allow(Stripe::Customer).to receive(:retrieve).and_raise(Stripe::APIError.new("boom"))
+      trial_end = 1_781_000_000
+      stub_event(build_sub, type: "customer.subscription.trial_will_end")
+
+      expect {
+        expect { post_webhook("{}", header_with_signature) }
+          .to change(MailchimpTrialWrapJob.jobs, :size).by(1)
+      }.to change { AnalyticsEvent.for_event("trial_will_end").count }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(MailchimpTrialWrapJob.jobs.last["args"]).to eq([user.id, trial_end])
+      # The flag itself is untouched by the failed recompute (previous value kept).
+      expect(user.reload.settings["has_payment_method"]).to eq(false)
+    end
+  end
 end

--- a/spec/services/billing/payment_methods_spec.rb
+++ b/spec/services/billing/payment_methods_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Billing::PaymentMethods do
+  def customer(default_payment_method: nil, default_source: nil)
+    OpenStruct.new(
+      invoice_settings: OpenStruct.new(default_payment_method: default_payment_method),
+      default_source: default_source,
+    )
+  end
+
+  def subscription(default_payment_method: nil, customer: "cus_123")
+    OpenStruct.new(default_payment_method: default_payment_method, customer: customer)
+  end
+
+  describe ".on_file?" do
+    it "short-circuits true on the subscription-level default without calling Stripe" do
+      expect(Stripe::Customer).not_to receive(:retrieve)
+
+      result = described_class.on_file?("cus_123", subscription: subscription(default_payment_method: "pm_sub"))
+
+      expect(result).to be(true)
+    end
+
+    it "is true when the customer's invoice_settings default is set" do
+      allow(Stripe::Customer).to receive(:retrieve).with("cus_123").and_return(
+        customer(default_payment_method: "pm_cust"),
+      )
+
+      result = described_class.on_file?("cus_123", subscription: subscription)
+
+      expect(result).to be(true)
+    end
+
+    it "is true when only the legacy default_source is set" do
+      allow(Stripe::Customer).to receive(:retrieve).with("cus_123").and_return(
+        customer(default_source: "card_legacy"),
+      )
+
+      result = described_class.on_file?("cus_123", subscription: subscription)
+
+      expect(result).to be(true)
+    end
+
+    it "is false when neither the subscription, invoice_settings default, nor default_source is set" do
+      allow(Stripe::Customer).to receive(:retrieve).with("cus_123").and_return(customer)
+
+      result = described_class.on_file?("cus_123", subscription: subscription)
+
+      expect(result).to be(false)
+    end
+
+    it "accepts an expanded customer object as well as a bare id" do
+      allow(Stripe::Customer).to receive(:retrieve).with("cus_expanded").and_return(
+        customer(default_payment_method: "pm_cust"),
+      )
+      expanded_customer = OpenStruct.new(id: "cus_expanded")
+
+      result = described_class.on_file?(expanded_customer, subscription: subscription)
+
+      expect(result).to be(true)
+    end
+
+    it "lets a Stripe error propagate instead of swallowing it, so each caller keeps its own fallback" do
+      allow(Stripe::Customer).to receive(:retrieve).and_raise(Stripe::APIError.new("boom"))
+
+      expect {
+        described_class.on_file?("cus_123", subscription: subscription)
+      }.to raise_error(Stripe::APIError, "boom")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The trial banner tells everyone "Choose a plan" — including people who already chose one. On the default web checkout a user picks Basic or Pro and starts a real 14-day Stripe trial with **no card** (the no-card reverse trial, #264); if none is added by day 14 Stripe cancels them cleanly to Free. They didn't fail to pick a plan. They're missing a payment method.

This is the backend half: it computes that answer server-side so the app never re-derives billing rules. Additive only — nothing reads the new field until the companion frontend PR ships.

### Changes

1. **`settings["has_payment_method"]`** — written by `handle_subscription_upsert`, but **only when `subscription.status == "trialing"`**, since the flag is read nowhere else. Non-trial upserts skip the lookup entirely rather than spend a Stripe call on every routine subscription event.
2. **`Billing::PaymentMethods.on_file?`** (`app/services/billing/`) — one shared lookup, now used by both the webhook and `SubscriptionsController#customer_has_payment_method?`. Checks the subscription's `default_payment_method`, then the customer's `invoice_settings.default_payment_method`, then the legacy `default_source`. It deliberately does **not** rescue: the two callers want opposite answers on an inconclusive lookup, so each keeps its own fallback (the webhook keeps the previous value; the plan-change guard assumes `true` so a switch is never blocked).
3. **`payment_method.attached` handler** — a card added through the Customer Portal attaches to the *customer* and may never touch the subscription, so without this a user who adds a card on day 12 keeps getting nudged.
4. **Authoritative recompute in `handle_trial_will_end`** — Stripe fires nothing between `subscription.created` and the terminal event, so a flag written at trial start is stale for the whole 14 days. `trial_will_end` fires ~3 days out, which is exactly when the frontend CTA turns on. This corrects both trials already in flight at deploy (no key → would have read as "needs a card") and cards removed mid-trial. Wrapped in its own rescue so a Stripe hiccup can't skip the analytics event or the Mailchimp enqueue.
5. **`api_view[:trial]`** — `{ active, status, ends_at, provider, needs_payment_method, plan_label }`. `active` is false for `partner_pro` (3-month pilot, managed outside the app). `needs_payment_method` is true only for a Stripe trial with no card — never RevenueCat, who pay through Apple/Google and can't add a card here. Pure in-memory: no Stripe calls, no new queries on this hot read path.
6. **`billing_portal` accepts `flow=payment_method_update`** — allow-listed, not pass-through — so the CTA lands on "add a card" instead of the portal home.
7. **`docs/stripe-setup.md`** — `payment_method.attached` was missing from the required-events list, so the new handler would never have fired in production.

Design doc: `drafts/2026-07-27-trial-banner-payment-method-design.md`

## Test plan

```
bundle exec rspec spec/models/user_spec.rb spec/services/billing \
  spec/requests/api/webhooks_payment_method_spec.rb spec/requests/api/webhooks_trial_wrap_spec.rb \
  spec/requests/api/subscriptions_billing_portal_spec.rb spec/requests/api/webhooks_plan_type_spec.rb \
  spec/requests/api/webhooks_idempotency_spec.rb spec/requests/api/subscriptions_change_plan_spec.rb \
  spec/requests/api/subscriptions_preview_plan_change_spec.rb
```
**169 examples, 0 failures.**

Covers all five cohorts through `api_view` (Stripe no-card, Stripe card-on-file, RevenueCat, `partner_pro`, not-trialing), the flag's write/clear paths including the trialing gate and the `trial_will_end` recompute, the shared lookup's error propagation, and the portal allow-list.

## Deploy note

`payment_method.attached` must be enabled on the Stripe webhook endpoint (done). Also worth confirming `STRIPE_PRICE_PARTNER_PRO`'s Price metadata says `plan_type=partner_pro` — the webhook overwrites `plan_type` from that metadata, so if it says `pro` the partner banner suppression silently stops working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
