### PR TITLE
feat(leads): capture Words Within Reach playground nominations

### DIFF
--- a/app/controllers/api/download_leads_controller.rb
+++ b/app/controllers/api/download_leads_controller.rb
@@ -2,6 +2,11 @@ module API
   # Public (no-auth) capture endpoint for anonymous free-board-download leads.
   # An unsigned-in visitor enters their email to download a board PDF; the email
   # becomes a Mailchimp marketing lead (synced async via MailchimpUpsertLeadJob).
+  #
+  # Also carries Words Within Reach playground nominations (source
+  # "playground_nomination"), which are the same shape of anonymous, email-keyed
+  # capture. Those only sync to Mailchimp when the nominator explicitly opted in
+  # — see DownloadLead#sync_to_mailchimp?.
   class DownloadLeadsController < API::ApplicationController
     skip_before_action :authenticate_token!, only: %i[create]
 
@@ -9,7 +14,7 @@ module API
       lead = DownloadLead.new(download_lead_params)
 
       if lead.save
-        MailchimpUpsertLeadJob.perform_async(lead.id)
+        enqueue_or_skip_mailchimp(lead)
         render json: { success: true }, status: :created
       else
         render json: { success: false, errors: lead.errors.full_messages }, status: :unprocessable_content
@@ -17,6 +22,17 @@ module API
     end
 
     private
+
+    # A lead with no marketing consent is marked "skipped" rather than left at
+    # "pending", so it doesn't linger in the mailchimp_pending scope and read as
+    # a stuck sync.
+    def enqueue_or_skip_mailchimp(lead)
+      if lead.sync_to_mailchimp?
+        MailchimpUpsertLeadJob.perform_async(lead.id)
+      else
+        lead.update_column(:mailchimp_status, DownloadLead::MAILCHIMP_SKIPPED)
+      end
+    end
 
     def download_lead_params
       params.require(:download_lead).permit(:email, :name, :board_id, :source, data: {})

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -21,6 +21,18 @@ class AdminMailer < BaseMailer
     mail(to: to_email, subject: subject, from: "noreply@speakanyway.com")
   end
 
+  # Words Within Reach playground nomination, fired by
+  # DownloadLead#notify_admin_of_nomination. There is no admin UI for
+  # nominations yet, so this email IS the inbox for the campaign — it has to
+  # carry every field somebody would need to follow up without opening a console.
+  def new_nomination_email(lead)
+    @lead = lead
+    park = lead.nomination_field(:park) || "Unnamed playground"
+    city = lead.nomination_field(:city)
+    subject = admin_subject("Playground nomination: #{park}#{" (#{city})" if city}")
+    mail(to: admin_recipient, subject: subject, from: "noreply@speakanyway.com")
+  end
+
   # Partner-pilot review digest, sent by PartnerPilotEndingJob when there are
   # partners ending soon and/or newly past their 3-month window. Gives Brittany
   # a single actionable list — nobody is auto-downgraded, so this is the signal

--- a/app/models/download_lead.rb
+++ b/app/models/download_lead.rb
@@ -2,15 +2,31 @@
 # their email to download a free board PDF. The email is synced to Mailchimp as
 # a marketing lead (see MailchimpUpsertLeadJob). board_id is a soft reference
 # (belongs_to optional, no DB FK) so a lead survives the board being deleted.
+#
+# The same public endpoint also carries the Words Within Reach playground
+# nomination form (source "playground_nomination"). A nomination is a lead in
+# every structural sense — anonymous, email-keyed, arriving with campaign
+# metadata — so it reuses this table rather than adding a parallel one. The
+# nomination-specific fields (park, city, role, why, sponsor interest) live in
+# the schema-free `data` jsonb column, so no migration is involved.
 class DownloadLead < ApplicationRecord
   # Default capture source when the client doesn't send one.
   DEFAULT_SOURCE = "free_download".freeze
 
+  # Words Within Reach playground nomination. Discriminates nominations from the
+  # free-download funnel everywhere `source` is read.
+  NOMINATION_SOURCE = "playground_nomination".freeze
+
   # Mailchimp sync lifecycle (mailchimp_status column). Set by
   # MailchimpUpsertLeadJob: starts "pending", → "synced" on success / "failed".
+  # "skipped" is terminal and set without ever enqueuing the job — it means the
+  # lead never consented to marketing, so there is nothing to retry or fix. It
+  # exists so consent-less leads don't sit in mailchimp_pending forever and read
+  # as a broken sync in Mission Control.
   MAILCHIMP_PENDING = "pending".freeze
   MAILCHIMP_SYNCED  = "synced".freeze
   MAILCHIMP_FAILED  = "failed".freeze
+  MAILCHIMP_SKIPPED = "skipped".freeze
 
   belongs_to :board, optional: true
 
@@ -18,14 +34,57 @@ class DownloadLead < ApplicationRecord
 
   before_validation :default_source
 
+  after_create :notify_admin_of_nomination, if: :nomination?
+
   scope :for_source, ->(source) { where(source: source) }
+  scope :nominations, -> { where(source: NOMINATION_SOURCE) }
   scope :mailchimp_pending, -> { where(mailchimp_status: MAILCHIMP_PENDING) }
   scope :mailchimp_synced,  -> { where(mailchimp_status: MAILCHIMP_SYNCED) }
   scope :mailchimp_failed,  -> { where(mailchimp_status: MAILCHIMP_FAILED) }
+  scope :mailchimp_skipped, -> { where(mailchimp_status: MAILCHIMP_SKIPPED) }
+
+  def nomination?
+    source == NOMINATION_SOURCE
+  end
+
+  # Explicit marketing consent, captured as an opt-in checkbox on the landing
+  # page and stored in `data`. Absent, blank, or unparseable means no consent —
+  # this deliberately fails closed.
+  def marketing_opt_in?
+    ActiveModel::Type::Boolean.new.cast(nomination_field(:marketing_opt_in)) || false
+  end
+
+  # Nominating a playground is not subscribing to a newsletter, so a nomination
+  # only reaches Mailchimp when the nominator ticked the box. Every pre-existing
+  # funnel (free_download, classroom_kit, ctg) is unchanged: those visitors
+  # entered an email specifically to be sent something, and they still sync.
+  def sync_to_mailchimp?
+    return marketing_opt_in? if nomination?
+
+    true
+  end
+
+  # Nil-safe reader for the jsonb payload, so a mailer or admin view can render a
+  # partially filled nomination without guarding every field.
+  def nomination_field(key)
+    return nil unless data.is_a?(Hash)
+
+    data[key.to_s].presence
+  end
 
   private
 
   def default_source
     self.source = DEFAULT_SOURCE if source.blank?
+  end
+
+  # Mirrors FeedbackItem#send_admin_notification — a nomination nobody sees is
+  # worthless, and there is no admin UI for these yet. deliver_later keeps the
+  # mail off the request path; a mail failure must never lose the record, which
+  # is why this rescues rather than letting the after_create roll the row back.
+  def notify_admin_of_nomination
+    AdminMailer.new_nomination_email(self).deliver_later
+  rescue StandardError => e
+    Rails.logger.error("[Nomination] admin notification failed for lead #{id}: #{e.message}")
   end
 end

--- a/app/sidekiq/mailchimp_upsert_lead_job.rb
+++ b/app/sidekiq/mailchimp_upsert_lead_job.rb
@@ -15,11 +15,22 @@ class MailchimpUpsertLeadJob
     # Closing the Gap 2026 booth capture. Matches the tag the ctg-2026 campaign
     # segment and its welcome automation are already built against.
     "ctg" => "ctg-2026",
+    # Words Within Reach playground nominations, so opted-in nominators are a
+    # segment of their own rather than mixed into the download list.
+    "playground_nomination" => "PlaygroundNomination",
   }.freeze
 
   def perform(download_lead_id)
     lead = DownloadLead.find_by(id: download_lead_id)
     return unless lead
+
+    # The controller already gates this, but a lead can also be re-enqueued by
+    # hand or by a backfill task. Consent is checked at the point of sending so
+    # there is exactly one answer to "does this email belong in Mailchimp".
+    unless lead.sync_to_mailchimp?
+      lead.update(mailchimp_status: DownloadLead::MAILCHIMP_SKIPPED)
+      return
+    end
 
     MailchimpService.new.record_lead(
       email: lead.email,

--- a/app/views/admin_mailer/new_nomination_email.html.erb
+++ b/app/views/admin_mailer/new_nomination_email.html.erb
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>New playground nomination</title>
+  </head>
+  <body style="margin:0; padding:0; background-color:#f7f7fb; font-family: Arial, Helvetica, sans-serif;">
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f7f7fb; padding:20px;">
+      <tr>
+        <td align="center">
+          <table width="640" cellpadding="0" cellspacing="0" style="background-color:#ffffff; border-radius:8px; padding:24px;">
+            <tr>
+              <td><%= render "layouts/email_logo" %></td>
+            </tr>
+            <tr>
+              <td style="color:#333333; font-size:15px; line-height:1.5;">
+                <h2 style="margin-top:0;">New playground nomination</h2>
+                <p style="color:#666666; margin-top:0;">Words Within Reach — A SpeakAnyWay Community Initiative</p>
+
+                <% if @lead.nomination_field(:sponsor_interest).to_s.casecmp("yes").zero? %>
+                  <p style="background:#f0fbf6; border-left:4px solid #56B58C; padding:10px 12px; margin:16px 0; font-weight:bold;">
+                    This nominator said they're interested in sponsoring or helping fund it.
+                  </p>
+                <% end %>
+
+                <table width="100%" cellpadding="6" cellspacing="0" style="border-collapse:collapse; font-size:14px;">
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666; width:150px;">Playground</td>
+                    <td style="padding:6px;"><%= @lead.nomination_field(:park) || "—" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">City / state</td>
+                    <td style="padding:6px;"><%= @lead.nomination_field(:city) || "—" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Nominated by</td>
+                    <td style="padding:6px;"><%= @lead.name.presence || "—" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Email</td>
+                    <td style="padding:6px;"><a href="mailto:<%= @lead.email %>" style="color:#6a4cf0;"><%= @lead.email %></a></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Their role</td>
+                    <td style="padding:6px;"><%= @lead.nomination_field(:role) || "—" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Sponsor interest</td>
+                    <td style="padding:6px;"><%= @lead.nomination_field(:sponsor_interest) || "No" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Marketing opt-in</td>
+                    <td style="padding:6px;"><%= @lead.marketing_opt_in? ? "Yes — added to Mailchimp" : "No — not added to any list" %></td>
+                  </tr>
+                  <tr style="border-bottom:1px solid #eeeeee;">
+                    <td style="padding:6px; color:#666666;">Submitted</td>
+                    <td style="padding:6px;"><%= @lead.created_at&.strftime("%b %d, %Y at %l:%M %p %Z") %></td>
+                  </tr>
+                </table>
+
+                <% if @lead.nomination_field(:why).present? %>
+                  <h3 style="margin-bottom:6px;">Why this playground</h3>
+                  <p style="background:#faf9ff; border-radius:6px; padding:12px; margin-top:0; white-space:pre-wrap;"><%= @lead.nomination_field(:why) %></p>
+                <% end %>
+
+                <hr style="border:none; border-top:1px solid #eeeeee; margin:24px 0;" />
+                <p style="color:#666666; font-size:13px;">
+                  Reply straight to <a href="mailto:<%= @lead.email %>" style="color:#6a4cf0;"><%= @lead.email %></a> to follow up.
+                  Lead #<%= @lead.id %>, source <code><%= @lead.source %></code>.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -19,6 +19,72 @@ RSpec.describe AdminMailer, type: :mailer do
     end
   end
 
+  describe "#new_nomination_email" do
+    # There is no admin UI for nominations yet, so this email is the only place
+    # the details show up — every field has to survive into the body.
+    def nomination(data = {})
+      FactoryBot.create(
+        :download_lead,
+        email: "nominator@example.com",
+        name: "Jane Doe",
+        source: DownloadLead::NOMINATION_SOURCE,
+        data: {
+          "park" => "LaGrange Community Park",
+          "city" => "LaGrange, OH",
+          "role" => "Parent / caregiver",
+          "why" => "Our son swings here every day and there are no words on the swings.",
+          "sponsor_interest" => "No",
+        }.merge(data),
+      )
+    end
+
+    def body_of(mail)
+      (mail.html_part || mail).body.decoded
+    end
+
+    it "addresses the admin, names the park in the subject, and renders the details" do
+      mail = described_class.new_nomination_email(nomination).deliver_now
+
+      expect(mail.to).to eq([ENV["ADMIN_EMAIL"] || "brittany@speakanyway.com"])
+      expect(mail.subject).to eq("Playground nomination: LaGrange Community Park (LaGrange, OH)")
+
+      body = body_of(mail)
+      expect(body).to include("LaGrange Community Park")
+      expect(body).to include("nominator@example.com")
+      expect(body).to include("Jane Doe")
+      expect(body).to include("Parent / caregiver")
+      expect(body).to include("there are no words on the swings")
+    end
+
+    it "calls out a nominator who is interested in sponsoring" do
+      mail = described_class.new_nomination_email(nomination("sponsor_interest" => "Yes")).deliver_now
+      expect(body_of(mail)).to include("interested in sponsoring")
+    end
+
+    it "does not call out sponsorship when they said no" do
+      mail = described_class.new_nomination_email(nomination).deliver_now
+      expect(body_of(mail)).not_to include("interested in sponsoring")
+    end
+
+    it "states plainly whether the nominator opted into marketing" do
+      opted_out = body_of(described_class.new_nomination_email(nomination).deliver_now)
+      expect(opted_out).to include("not added to any list")
+
+      opted_in = body_of(
+        described_class.new_nomination_email(nomination("marketing_opt_in" => true)).deliver_now,
+      )
+      expect(opted_in).to include("added to Mailchimp")
+    end
+
+    it "renders a sparse nomination without blowing up" do
+      lead = FactoryBot.create(:download_lead, source: DownloadLead::NOMINATION_SOURCE, data: {})
+      mail = described_class.new_nomination_email(lead).deliver_now
+
+      expect(mail.subject).to eq("Playground nomination: Unnamed playground")
+      expect(body_of(mail)).to include(lead.email)
+    end
+  end
+
   describe "#partner_pilot_review" do
     it "addresses the admin, summarizes counts, and lists both groups" do
       expiring = FactoryBot.create(:user, name: "Soon", email: "soon@example.com", plan_type: "partner_pro")

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -8,7 +8,31 @@ class AdminMailerPreview < ActionMailer::Preview
     AdminMailer.plan_change_email(preview_user, from_plan: "free", to_plan: "pro", source: "stripe")
   end
 
+  def new_nomination_email
+    AdminMailer.new_nomination_email(preview_nomination)
+  end
+
   private
+
+  # Uses a real nomination when one exists, otherwise an unsaved stand-in so the
+  # preview renders on a fresh database.
+  def preview_nomination
+    DownloadLead.nominations.order(created_at: :desc).first || DownloadLead.new(
+      id: 0,
+      email: "nominator@example.com",
+      name: "Jane Doe",
+      source: DownloadLead::NOMINATION_SOURCE,
+      created_at: Time.current,
+      data: {
+        "park" => "LaGrange Community Park",
+        "city" => "LaGrange, OH",
+        "role" => "Parent / caregiver",
+        "why" => "Our son swings here every day and there are no words on the swings.",
+        "sponsor_interest" => "Yes",
+        "marketing_opt_in" => true,
+      },
+    )
+  end
 
   def preview_user
     User.non_admin.order(created_at: :desc).first || User.first

--- a/spec/models/download_lead_spec.rb
+++ b/spec/models/download_lead_spec.rb
@@ -34,6 +34,119 @@ RSpec.describe DownloadLead, type: :model do
     end
   end
 
+  # Words Within Reach playground nominations ride the same table as download
+  # leads, discriminated by source, with the campaign fields in `data`.
+  describe "playground nominations" do
+    include ActiveJob::TestHelper
+
+    let(:nomination_data) do
+      {
+        "park" => "LaGrange Community Park",
+        "city" => "LaGrange, OH",
+        "role" => "Parent / caregiver",
+        "why" => "Our son swings here every day.",
+        "sponsor_interest" => "Yes",
+      }
+    end
+
+    it "identifies a nomination by source" do
+      expect(build(:download_lead, source: DownloadLead::NOMINATION_SOURCE)).to be_nomination
+      expect(build(:download_lead, source: "free_download")).not_to be_nomination
+    end
+
+    it "scopes nominations away from other lead sources" do
+      nomination = create(:download_lead, source: DownloadLead::NOMINATION_SOURCE, data: nomination_data)
+      create(:download_lead, source: "free_download")
+
+      expect(DownloadLead.nominations).to contain_exactly(nomination)
+    end
+
+    describe "#marketing_opt_in?" do
+      it "is false when data carries no opt-in key" do
+        expect(build(:download_lead, data: nomination_data)).not_to be_marketing_opt_in
+      end
+
+      it "is false when data is nil" do
+        expect(build(:download_lead, data: nil)).not_to be_marketing_opt_in
+      end
+
+      it "reads falsey values as no consent" do
+        ["false", "0", "", nil].each do |value|
+          lead = build(:download_lead, data: nomination_data.merge("marketing_opt_in" => value))
+          expect(lead.marketing_opt_in?).to eq(false), "expected #{value.inspect} to read as no consent"
+        end
+      end
+
+      it "reads the values a checkbox actually sends as consent" do
+        [true, "true", "1"].each do |value|
+          lead = build(:download_lead, data: nomination_data.merge("marketing_opt_in" => value))
+          expect(lead.marketing_opt_in?).to eq(true), "expected #{value.inspect} to read as consent"
+        end
+      end
+    end
+
+    describe "#sync_to_mailchimp?" do
+      it "is false for a nomination without an opt-in" do
+        lead = build(:download_lead, source: DownloadLead::NOMINATION_SOURCE, data: nomination_data)
+        expect(lead.sync_to_mailchimp?).to eq(false)
+      end
+
+      it "is true for a nomination with an opt-in" do
+        lead = build(
+          :download_lead,
+          source: DownloadLead::NOMINATION_SOURCE,
+          data: nomination_data.merge("marketing_opt_in" => true),
+        )
+        expect(lead.sync_to_mailchimp?).to eq(true)
+      end
+
+      # Nominations are the only source that requires consent. Every funnel that
+      # existed before this change must behave exactly as it did.
+      it "is true for every non-nomination source, opt-in or not" do
+        %w[free_download classroom_kit ctg etsy_landing].each do |source|
+          expect(build(:download_lead, source: source).sync_to_mailchimp?).to eq(true)
+        end
+      end
+    end
+
+    describe "#nomination_field" do
+      it "reads a string key from data given a symbol" do
+        lead = build(:download_lead, data: nomination_data)
+        expect(lead.nomination_field(:park)).to eq("LaGrange Community Park")
+      end
+
+      it "returns nil for a blank value, a missing key, or nil data" do
+        lead = build(:download_lead, data: nomination_data.merge("city" => ""))
+        expect(lead.nomination_field(:city)).to be_nil
+        expect(lead.nomination_field(:nope)).to be_nil
+        expect(build(:download_lead, data: nil).nomination_field(:park)).to be_nil
+      end
+    end
+
+    describe "admin notification" do
+      it "emails the admin when a nomination is created" do
+        expect {
+          create(:download_lead, source: DownloadLead::NOMINATION_SOURCE, data: nomination_data)
+        }.to have_enqueued_mail(AdminMailer, :new_nomination_email)
+      end
+
+      it "does not email the admin for an ordinary download lead" do
+        expect {
+          create(:download_lead, source: "free_download")
+        }.not_to have_enqueued_mail(AdminMailer, :new_nomination_email)
+      end
+
+      # A mail failure must never cost us the nomination itself.
+      it "still saves the lead when the mailer raises" do
+        allow(AdminMailer).to receive(:new_nomination_email).and_raise(StandardError, "smtp down")
+
+        expect {
+          create(:download_lead, source: DownloadLead::NOMINATION_SOURCE, data: nomination_data)
+        }.to change(DownloadLead, :count).by(1)
+      end
+    end
+  end
+
   describe "board association" do
     it "is valid without a board (board_id can be nil)" do
       lead = build(:download_lead, board: nil)

--- a/spec/requests/api/download_leads_spec.rb
+++ b/spec/requests/api/download_leads_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 # POST /api/download_leads is PUBLIC (no auth). It captures an anonymous
 # visitor's email as a DownloadLead and enqueues the Mailchimp sync job.
 RSpec.describe "API download_leads", type: :request do
+  include ActiveJob::TestHelper
+
   before { MailchimpUpsertLeadJob.jobs.clear }
 
   describe "POST /api/download_leads" do
@@ -84,6 +86,68 @@ RSpec.describe "API download_leads", type: :request do
 
         expect(MailchimpUpsertLeadJob::SOURCE_TAGS.fetch(DownloadLead.last.source))
           .to eq("ctg-2026")
+      end
+    end
+
+    # Words Within Reach playground nominations post to this same endpoint with
+    # source "playground_nomination" and the campaign fields in `data`.
+    context "with a playground nomination" do
+      def nomination_params(extra_data = {})
+        {
+          download_lead: {
+            email: "nominator@example.com",
+            name: "Jane Doe",
+            source: "playground_nomination",
+            data: {
+              park: "LaGrange Community Park",
+              city: "LaGrange, OH",
+              role: "Parent / caregiver",
+              why: "Our son swings here every day.",
+              sponsor_interest: "Yes",
+            }.merge(extra_data),
+          },
+        }
+      end
+
+      it "stores the nomination fields in data and returns 201" do
+        expect {
+          post "/api/download_leads", params: nomination_params
+        }.to change(DownloadLead, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+
+        lead = DownloadLead.last
+        expect(lead).to be_nomination
+        expect(lead.email).to eq("nominator@example.com")
+        expect(lead.nomination_field(:park)).to eq("LaGrange Community Park")
+        expect(lead.nomination_field(:sponsor_interest)).to eq("Yes")
+      end
+
+      it "does not sync to Mailchimp without an explicit opt-in" do
+        post "/api/download_leads", params: nomination_params
+
+        expect(MailchimpUpsertLeadJob.jobs.size).to eq(0)
+        expect(DownloadLead.last.mailchimp_status).to eq(DownloadLead::MAILCHIMP_SKIPPED)
+      end
+
+      it "syncs to Mailchimp when the nominator opted in" do
+        post "/api/download_leads", params: nomination_params(marketing_opt_in: "true")
+
+        lead = DownloadLead.last
+        expect(lead).to be_marketing_opt_in
+        expect(MailchimpUpsertLeadJob.jobs.size).to eq(1)
+        expect(MailchimpUpsertLeadJob.jobs.first["args"]).to eq([lead.id])
+      end
+
+      it "maps the nomination source to its own Mailchimp tag" do
+        expect(MailchimpUpsertLeadJob::SOURCE_TAGS.fetch("playground_nomination"))
+          .to eq("PlaygroundNomination")
+      end
+
+      it "notifies the admin" do
+        expect {
+          post "/api/download_leads", params: nomination_params
+        }.to have_enqueued_mail(AdminMailer, :new_nomination_email)
       end
     end
 


### PR DESCRIPTION
## What this does

The Words Within Reach landing page has a "nominate a playground" form. This gives it somewhere to post.

Nominations reuse `DownloadLead` rather than getting their own table. A nomination is the same shape as a download lead — anonymous, email-keyed, arriving with campaign metadata — and `POST /api/download_leads` is already public (`skip_before_action :authenticate_token!`). The campaign fields (park, city, role, why, sponsor interest, opt-in) go into the existing `data` jsonb column, so **there is no migration in this PR**.

`FeedbackItem` was the other candidate and it doesn't fit: it's `belongs_to :user` with `user_id null: false` and an authenticated controller. Nominators are parks directors and strangers who will never have an account.

### Behavior

1. **Every nomination emails the admin.** `AdminMailer#new_nomination_email`, fired from an `after_create` on the model (same pattern as `FeedbackItem#send_admin_notification`). There's no admin UI for nominations yet, so this email *is* the inbox: it carries every field, flags a nominator who offered to sponsor, and links a reply-to. The callback rescues — a mail failure must never roll back the nomination.

2. **Mailchimp sync is gated on an explicit opt-in.** The landing page now has a checkbox: *"Keep me posted on SpeakAnyWay news and new boards."* Only a ticked box syncs. Nominating a playground isn't subscribing to a newsletter, and the page says so in plain words, so the code has to match the promise.

3. **Nothing else changes.** `sync_to_mailchimp?` returns `true` for anything that isn't a nomination — `free_download`, `classroom_kit`, `ctg`, everything. There's a spec that asserts exactly that so the consent gate can't quietly widen later.

4. **New `mailchimp_status` value: `"skipped"`.** A consent-less lead is marked skipped instead of being left at `pending`. Otherwise it sits in the `mailchimp_pending` scope forever and reads as a stuck sync in Mission Control.

5. **New Mailchimp tag `PlaygroundNomination`** so opted-in nominators are their own segment.

The job also re-checks consent before sending, not just the controller — a lead can be re-enqueued by hand or by a backfill, and there should be exactly one answer to "does this email belong in Mailchimp."

## Test plan

**I could not run the suite** — this session ran in a cloud container with no copy of the repo, no gems, and no Postgres, and the machine-side shell had no Ruby toolchain. What I did verify: every Ruby file passes `ruby -c`, the ERB template compiles, and the landing page form was driven end-to-end with Playwright against a stubbed endpoint (opt-in checked, opt-in unchecked, and request blocked → mailto fallback), confirming the exact payload shape the request spec asserts.

Please run:

```
bundle exec rspec spec/models/download_lead_spec.rb spec/requests/api/download_leads_spec.rb spec/mailers/admin_mailer_spec.rb
```

Coverage added: `nomination?`, the `nominations` scope, `marketing_opt_in?` across the values a checkbox actually sends (`true`/`"true"`/`"1"` vs `"false"`/`"0"`/`""`/`nil`/missing key/nil data), `sync_to_mailchimp?` both ways plus the every-other-source guard, `nomination_field`, the admin notification firing (and *not* firing for ordinary leads, and not losing the record when the mailer raises), the full request path including `mailchimp_status == "skipped"`, and the mailer's subject, sponsor callout, opt-in wording, and a sparse nomination.

There's also a mailer preview at `/rails/mailers/admin_mailer/new_nomination_email` — worth eyeballing before merge since I couldn't render it.

## Two things to know before this goes live

**CORS decides where the landing page can be hosted.** `config/initializers/cors.rb` allows `speakanyway.com`, `www.speakanyway.com`, `app.speakanyway.com`, `*.speakanyway.netlify.app`, and localhost. A random Netlify Drop domain is **blocked** — the POST fails and the page silently degrades to its mailto fallback, which looks like it worked. The page has to live on one of those hosts.

**`MissionControl::DownloadLeadMetrics` is unscoped by source.** Nominations will show up in `total_leads`, `leads_by_source`, and the Mailchimp-health counts. Not wrong exactly, but the numbers will move. Worth a follow-up to either exclude nominations or break them out — happy to do it, just didn't want to widen this PR.
