### PR TITLE
feat(signup): capture a sanitized ref param for partner attribution

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -221,6 +221,16 @@ only if nil), tags Mailchimp, and sends `PartnerMailer.welcome_email` (the free
 welcome + welcome journey are skipped). Entitlements equal Pro
 (`setup_partner_pro_plan` → 300 boards / 5 communicators / 1500 credits).
 
+**Attribution:** `/sign-up/partner` is deliberately ungated (no invite codes, no
+approval step), so who referred a partner is tracked by a `?ref=` query param
+alone. `sign_up` and `email_signup` pass `params[:ref]` into
+`User#record_signup_context!`, which sanitizes it via `User.sanitize_signup_ref`
+(strip, downcase, cap at `SIGNUP_REF_MAX_LENGTH`) and writes
+`settings["signup_ref"]` **only when it survives** — an absent ref leaves no key,
+so "unattributed" and "attributed to blank" stay distinguishable. It also rides
+the `user_signed_up` PostHog event and surfaces on `admin_api_view` plus the
+admin user show page.
+
 **A real no-card Stripe trial backs the pilot (Phase 2, built).**
 `handle_new_partner_pro_subscription` calls
 `user.ensure_partner_pro_trial_subscription!(trial_end:)`, which creates a

--- a/.claude-notes/marketing-integrations.md
+++ b/.claude-notes/marketing-integrations.md
@@ -181,11 +181,12 @@ PostHog events; the backend ensures the full funnel is always captured
 
 **Auth events** — fired from `API::V1::AuthsController`:
 
-- **`user_signed_up`** `{ signup_method, plan_type, platform }` — on successful
-  `sign_up` (`signup_method: "standard"`) or `email_signup`
+- **`user_signed_up`** `{ signup_method, plan_type, platform, signup_ref }` — on
+  successful `sign_up` (`signup_method: "standard"`) or `email_signup`
   (`signup_method: "email_only"`). `platform` is `"web"`, `"ios"`, or
-  `"android"`. Ensures signups are tracked even when the frontend PostHog JS is
-  blocked by ad blockers.
+  `"android"`. `signup_ref` is the sanitized `?ref=` attribution and is `nil`
+  for unattributed signups. Ensures signups are tracked even when the frontend
+  PostHog JS is blocked by ad blockers.
 - **`user_signed_in`** `{ plan_type }` — on successful password login
   (`#create`). Same ad-blocker-resilience rationale.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added — Referral attribution on signup links
+- Signup now captures a `ref` query param (e.g. `/sign-up/partner?ref=emilydiaz`)
+  into `settings["signup_ref"]`, sanitized (trimmed, lowercased, capped at 64
+  characters) and only written when non-blank. Applies to both the standard and
+  email-only signup paths.
+- The ref rides the `user_signed_up` PostHog event and is shown on the admin
+  user page, so it's clear which creator referred a partner without opening the
+  console.
+
 ### Fixed — Welcome emails no longer promise a Supporter limit
 - The Basic welcome email said "Invite up to 2 Supporter accounts" and the
   MySpeak claim-link email said "2 included". No such limit exists: the invite

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -35,7 +35,7 @@ module API
           sign_in user
           user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
           user.ensure_minimum_communicator_slot!
-          user.record_signup_context!(platform: platform, method: "standard")
+          user.record_signup_context!(platform: platform, method: "standard", ref: params[:ref])
           user.notify_admin_of_signup!
           # Verification email. The user is already signed in — verification
           # gates the welcome tokens, never app access. See
@@ -66,6 +66,7 @@ module API
             signup_method: "standard",
             plan_type: user.plan_type,
             platform: platform.presence || "web",
+            signup_ref: user.settings&.dig("signup_ref"),
           })
           render json: { token: user.authentication_token, user: user.api_view }
         else
@@ -126,7 +127,7 @@ module API
         sign_in user
         user.update(last_sign_in_at: Time.now, last_sign_in_ip: request.remote_ip)
         user.ensure_minimum_communicator_slot!
-        user.record_signup_context!(platform: platform, method: "email_only")
+        user.record_signup_context!(platform: platform, method: "email_only", ref: params[:ref])
         user.notify_admin_of_signup!
         # Verification email. The user is already signed in — verification
         # gates the welcome tokens, never app access. See
@@ -158,6 +159,7 @@ module API
           signup_method: "email_only",
           plan_type: user.plan_type,
           platform: platform.presence || "web",
+          signup_ref: user.settings&.dig("signup_ref"),
         })
         render json: { token: user.authentication_token, user: user.api_view }
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1116,11 +1116,27 @@ class User < ApplicationRecord
   # can report it. Stored in `settings` rather than columns: nothing queries
   # it, so a jsonb key avoids a migration and a backfill decision. Accounts
   # created before this shipped have neither key and render as "unknown".
-  def record_signup_context!(platform: nil, method: nil)
+  # `ref` is the creator/partner attribution from the signup link's `?ref=`
+  # query param. Written only when it survives sanitizing, so an absent ref
+  # leaves no key at all — "no attribution" and "attributed to blank" must not
+  # be indistinguishable in the admin view.
+  def record_signup_context!(platform: nil, method: nil, ref: nil)
     self.settings ||= {}
     settings["signup_platform"] = platform.presence || "web"
     settings["signup_method"] = method
+    sanitized_ref = self.class.sanitize_signup_ref(ref)
+    settings["signup_ref"] = sanitized_ref if sanitized_ref
     save
+  end
+
+  SIGNUP_REF_MAX_LENGTH = 64
+
+  # Attribution refs come straight off a public query param, so they are
+  # normalized (a link shared as `?ref=EmilyDiaz` must match `?ref=emilydiaz`)
+  # and length-capped. Returns nil for anything blank so callers can decide
+  # not to write the key.
+  def self.sanitize_signup_ref(value)
+    value.to_s.strip.downcase.first(SIGNUP_REF_MAX_LENGTH).presence
   end
 
   # Single entry point for the admin "new signup" alert. Deliberately NOT
@@ -1665,6 +1681,7 @@ class User < ApplicationRecord
     view["can_create_boards"] = can_create_boards
     view["settings"] = settings
     view["settings"]["plan_type"] = plan_type
+    view["signup_ref"] = settings["signup_ref"]
     view["partner_pro"] = partner_pro?
     view["plan_status"] = plan_status
     view["paid_plan_type"] = paid_plan_type

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -323,6 +323,7 @@
         ["Stripe sub",       @user.stripe_subscription_id.present? ?
           link_to(@user.stripe_subscription_id, "https://dashboard.stripe.com/subscriptions/#{@user.stripe_subscription_id}",
                   target: "_blank", rel: "noopener", class: "text-accent hover:underline") : "—"],
+        ["Signup ref",       @user.settings&.dig("signup_ref").presence || "—"],
         ["Created",          @user.created_at.strftime("%b %-d, %Y %H:%M %Z")],
         ["Last sign-in",     @user.last_sign_in_at&.strftime("%b %-d, %Y %H:%M %Z") || "Never"],
         ["Last sign-in IP",  @user.last_sign_in_ip.presence || "—"],

--- a/spec/models/user_admin_notification_spec.rb
+++ b/spec/models/user_admin_notification_spec.rb
@@ -21,6 +21,42 @@ RSpec.describe "User admin signup notification" do
       user.record_signup_context!(platform: "android", method: "standard")
       expect(User.find(user.id).settings["signup_platform"]).to eq("android")
     end
+
+    it "stores a sanitized signup ref when one is given" do
+      user.record_signup_context!(platform: "web", method: "standard", ref: "  EmilyDiaz ")
+      expect(user.reload.settings["signup_ref"]).to eq("emilydiaz")
+    end
+
+    it "leaves the key absent when no ref is given" do
+      user.record_signup_context!(platform: "web", method: "standard")
+      expect(user.reload.settings).not_to have_key("signup_ref")
+    end
+
+    it "leaves the key absent for a whitespace-only ref" do
+      user.record_signup_context!(platform: "web", method: "standard", ref: "   ")
+      expect(user.reload.settings).not_to have_key("signup_ref")
+    end
+
+    it "truncates an overlong ref" do
+      user.record_signup_context!(platform: "web", method: "standard", ref: "a" * 200)
+      expect(user.reload.settings["signup_ref"]).to eq("a" * User::SIGNUP_REF_MAX_LENGTH)
+    end
+  end
+
+  describe ".sanitize_signup_ref" do
+    it "strips and downcases" do
+      expect(User.sanitize_signup_ref(" EmilyDiaz\n")).to eq("emilydiaz")
+    end
+
+    it "caps the length at SIGNUP_REF_MAX_LENGTH" do
+      expect(User.sanitize_signup_ref("z" * 100).length).to eq(User::SIGNUP_REF_MAX_LENGTH)
+    end
+
+    it "returns nil for blank input" do
+      expect(User.sanitize_signup_ref(nil)).to be_nil
+      expect(User.sanitize_signup_ref("")).to be_nil
+      expect(User.sanitize_signup_ref("  ")).to be_nil
+    end
   end
 
   describe "#notify_admin_of_signup!" do

--- a/spec/requests/api/v1/signup_ref_spec.rb
+++ b/spec/requests/api/v1/signup_ref_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+# Attribution for the ungated partner signup link (/sign-up/partner?ref=...).
+# The ref is captured into settings["signup_ref"] and mirrored onto the
+# user_signed_up PostHog event.
+RSpec.describe "Signup ref attribution", type: :request do
+  before do
+    allow(User).to receive(:create_stripe_customer).and_return("cus_test_ref")
+    allow(MailchimpEventJob).to receive(:perform_async)
+    allow(PosthogService).to receive(:capture_for_user)
+  end
+
+  let(:params) do
+    {
+      email: "referred@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Referred Signup",
+    }
+  end
+
+  def referred_user
+    User.find_by(email: "referred@example.com")
+  end
+
+  describe "POST /api/v1/users" do
+    it "stores the ref" do
+      post "/api/v1/users", params: params.merge(ref: "emilydiaz")
+
+      expect(response).to have_http_status(:ok)
+      expect(referred_user.settings["signup_ref"]).to eq("emilydiaz")
+    end
+
+    it "normalizes case and surrounding whitespace" do
+      post "/api/v1/users", params: params.merge(ref: "  EmilyDiaz ")
+
+      expect(referred_user.settings["signup_ref"]).to eq("emilydiaz")
+    end
+
+    it "leaves the key absent when no ref is sent" do
+      post "/api/v1/users", params: params
+
+      expect(referred_user.settings).not_to have_key("signup_ref")
+    end
+
+    it "leaves the key absent for a whitespace-only ref" do
+      post "/api/v1/users", params: params.merge(ref: "   ")
+
+      expect(referred_user.settings).not_to have_key("signup_ref")
+    end
+
+    it "truncates an overlong ref" do
+      post "/api/v1/users", params: params.merge(ref: "x" * 200)
+
+      expect(referred_user.settings["signup_ref"]).to eq("x" * User::SIGNUP_REF_MAX_LENGTH)
+    end
+
+    it "sends the ref on the user_signed_up event" do
+      post "/api/v1/users", params: params.merge(ref: "emilydiaz")
+
+      expect(PosthogService).to have_received(:capture_for_user).with(
+        referred_user, "user_signed_up",
+        properties: hash_including(signup_ref: "emilydiaz")
+      )
+    end
+
+    it "sends a nil ref on the event when none was given" do
+      post "/api/v1/users", params: params
+
+      expect(PosthogService).to have_received(:capture_for_user).with(
+        referred_user, "user_signed_up",
+        properties: hash_including(signup_ref: nil)
+      )
+    end
+
+    context "with a partner_pro signup" do
+      before do
+        allow(MailchimpService).to receive(:new).and_return(
+          instance_double(MailchimpService, record_new_subscriber: true)
+        )
+        allow_any_instance_of(User).to receive(:send_partner_welcome_email)
+      end
+
+      it "stores the ref without disturbing partner provisioning" do
+        post "/api/v1/users", params: params.merge(plan_type: "partner_pro", ref: "emilydiaz")
+
+        expect(response).to have_http_status(:ok)
+        user = referred_user
+        expect(user.settings["signup_ref"]).to eq("emilydiaz")
+        expect(user.role).to eq("partner")
+        expect(user.plan_type).to eq("partner_pro")
+        expect(user.plan_status).to eq("active")
+        expect(user.paid_plan?).to be(true)
+      end
+    end
+  end
+
+  describe "POST /api/v1/users/email_signup" do
+    it "stores the ref" do
+      post "/api/v1/users/email_signup", params: { email: "referred@example.com", ref: "EmilyDiaz" }
+
+      expect(response).to have_http_status(:ok)
+      expect(referred_user.settings["signup_ref"]).to eq("emilydiaz")
+    end
+
+    it "leaves the key absent when no ref is sent" do
+      post "/api/v1/users/email_signup", params: { email: "referred@example.com" }
+
+      expect(referred_user.settings).not_to have_key("signup_ref")
+    end
+  end
+
+  describe "admin_api_view" do
+    it "exposes the ref at the top level" do
+      user = create(:user)
+      user.record_signup_context!(platform: "web", method: "standard", ref: "emilydiaz")
+
+      expect(user.admin_api_view["signup_ref"]).to eq("emilydiaz")
+    end
+
+    it "is nil when the user has no ref" do
+      expect(create(:user).admin_api_view["signup_ref"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Implements `.claude-notes/partner-signup-link-handoff.md`.

`/sign-up/partner` stays ungated, so attribution rides a `ref` query param on the signup link (e.g. `?ref=emilydiaz`). Ships alone safely — the frontend not sending `ref` yet is a no-op. No migrations, no ENV vars.

## What changed

- **Capture** — `sign_up` and `email_signup` pass `params[:ref]` into `User#record_signup_context!(ref:)`. A new `User.sanitize_signup_ref` strips, downcases, and caps at `SIGNUP_REF_MAX_LENGTH` (64). `settings["signup_ref"]` is written **only when the ref survives sanitizing**, so an absent ref leaves no key — "unattributed" and "attributed to blank" stay distinguishable.
- **PostHog** — `signup_ref` added to the `user_signed_up` properties on both paths, nil-safe.
- **Admin visibility** — `signup_ref` on `User#admin_api_view` (top level, not just nested in `settings`) and a "Signup ref" row on the admin user show page.
- Partner provisioning (`handle_new_partner_pro_subscription`) is untouched.
- Docs: `.claude-notes/billing-and-plans.md` (Partner Program), `.claude-notes/marketing-integrations.md` (event schema), `CHANGELOG.md`.

## Test plan

New `spec/requests/api/v1/signup_ref_spec.rb` covers the handoff's table: ref stored, no-ref key absent, whitespace-only absent, 200-char ref truncated to 64, case/whitespace normalized, PostHog property present (and nil when unattributed), partner signup storing the ref with role/plan/status/`paid_plan?` unchanged, `email_signup` capture, and `admin_api_view` exposure. Model-level sanitizer cases added to `spec/models/user_admin_notification_spec.rb`.

Ran locally, all green:

- `spec/requests/api/v1/signup_ref_spec.rb` + `spec/models/user_admin_notification_spec.rb` — **36 examples, 0 failures**
- Auths controller specs (`auths_current`, `auths_disposable_email`, `auths_email_verification`, `auths_posthog`, `email_signup`, `set_password`, `signup_admin_notification`, `api/auth_spec`) + full `spec/models/user_spec.rb` — **147 examples, 0 failures**
- `spec/requests/admin/users_spec.rb` (touched `admin_api_view` + show view) — **50 examples, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)