### PR TITLE
fix(billing): let promo codes redeem on annual Stripe checkouts

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -135,8 +135,18 @@ purchase does not meet the minimum amount requirement"* (prod 400s on the beta-
 end Founding Family launch, 2026-07-07). Without the trial the checkout carries
 the plan's real price (yearly `$80`/`$200` ≥ `$50`) and the discount applies.
 The `trial_started` AnalyticsEvent is likewise gated on `apply_trial`, so promo
-conversions don't pollute the trial→paid metric. Non-promo checkouts are
-unchanged (full no-card reverse trial).
+conversions don't pollute the trial→paid metric.
+
+**Yearly checkouts skip the trial too, promo or not
+(`apply_trial = promo.blank? && !yearly_plan?(plan_key)`).** A checkout created
+without a `promo_code` sets `allow_promotion_codes`, which renders Stripe's own
+code box on the Checkout page — and that box validates against the same $0
+amount-due, so a buyer who reached an annual plan through /pricing rather than
+the campaign link could never redeem FOUNDING there. Charging the annual price
+up front keeps the box usable. **Monthly is unchanged** (full no-card reverse
+trial), and monthly still can't redeem a $50-minimum code — which is the
+restriction doing its job, not a bug. The durable fix for the confusing Stripe
+error on monthly is a promo field we own, pre-checkout; not built yet.
 
 **Client-facing trial state.** `User#api_view` carries a computed `trial`
 block — `{ active, status, ends_at, provider, needs_payment_method,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — Promo codes are redeemable on annual plans at Stripe Checkout
+- Picking a yearly plan from /pricing and typing a promotion code into Stripe's
+  own code box failed with "does not meet the minimum amount requirement". The
+  14-day no-card trial set the amount due today to $0, and a minimum-restricted
+  coupon (the FOUNDING code's $50 floor, which is what limits it to annual
+  plans) is validated against that amount. Only the campaign link
+  (`/pricing?promo=FOUNDING`) worked, because that path already skipped the
+  trial.
+- Yearly checkouts now skip the trial whether or not a promo code was passed in,
+  so the annual price is due at checkout and the code validates. Monthly
+  checkouts are unchanged and keep the full no-card reverse trial.
+
 ### Added — Referral attribution on signup links
 - Signup now captures a `ref` query param (e.g. `/sign-up/partner?ref=emilydiaz`)
   into `settings["signup_ref"]`, sanitized (trimmed, lowercased, capped at 64

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -150,7 +150,15 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     # requirement" (prod 400s, 2026-07-07). Without the trial the checkout
     # carries the plan's real price (yearly $80/$200 ≥ $50), the minimum is
     # satisfied, and the discount applies to the subscription.
-    apply_trial = promo.blank?
+    #
+    # Yearly plans skip the trial for the same reason even WITHOUT a promo
+    # param: `allow_promotion_codes` renders Stripe's own code box on the
+    # Checkout page, and a trialing session's $0 amount-due makes that box
+    # reject any minimum-restricted code. Someone who picks an annual plan from
+    # /pricing and types FOUNDING into Stripe is otherwise guaranteed a
+    # "minimum amount" error. Charging the annual price up front keeps that box
+    # working; monthly keeps the reverse trial.
+    apply_trial = promo.blank? && !yearly_plan?(plan_key)
     if apply_trial
       session_params[:subscription_data] = {
         trial_period_days: trial_days,
@@ -475,7 +483,13 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
   # `billing_interval_from_price` in the webhook, but derived from the plan_key
   # we already have at session-create time (no Stripe round-trip).
   def billing_interval_for(plan_key)
-    plan_key.to_s.end_with?("_yearly") ? "yearly" : "monthly"
+    yearly_plan?(plan_key) ? "yearly" : "monthly"
+  end
+
+  # Annual self-serve plans (`basic_yearly` / `pro_yearly`). These never carry
+  # the no-card reverse trial — see the `apply_trial` note in #create.
+  def yearly_plan?(plan_key)
+    plan_key.to_s.end_with?("_yearly")
   end
 
   # Prefer the request's Origin (then Referer) when it points at a trusted

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -177,14 +177,43 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       do_post.call({ plan_key: "basic_yearly", promo_code: "FOUNDING" })
     end
 
-    it "keeps the 14-day no-card trial when no promo is applied" do
-      do_post.call({ plan_key: "basic_yearly" })
+    it "keeps the 14-day no-card trial on a monthly plan when no promo is applied" do
+      do_post.call({ plan_key: "basic" })
 
       expect(captured[:subscription_data][:trial_period_days]).to eq(14)
       expect(captured[:subscription_data][:trial_settings]).to eq(
         end_behavior: { missing_payment_method: "cancel" },
       )
       expect(captured[:allow_promotion_codes]).to eq(true)
+    end
+
+    # Second half of the same bug: a buyer who picks an annual plan from
+    # /pricing WITHOUT the campaign link gets Stripe's own promo-code box
+    # (allow_promotion_codes), and a trialing session's $0 amount-due makes
+    # that box reject FOUNDING for not meeting the $50 minimum. Yearly
+    # checkouts therefore skip the trial entirely.
+    %w[basic_yearly pro_yearly].each do |plan_key|
+      it "omits the trial for #{plan_key} even without a promo, so Stripe's promo box works" do
+        do_post.call({ plan_key: plan_key })
+
+        expect(response).to have_http_status(:ok)
+        expect(captured).not_to have_key(:subscription_data)
+        # Stripe's code box stays on — with the real annual price due today,
+        # a minimum-restricted coupon now validates.
+        expect(captured[:allow_promotion_codes]).to eq(true)
+      end
+    end
+
+    it "does not record trial_started for a yearly checkout (no trial began)" do
+      expect {
+        do_post.call({ plan_key: "pro_yearly" })
+      }.not_to change { AnalyticsEvent.for_event("trial_started").count }
+    end
+
+    it "still records trial_started for a monthly checkout" do
+      expect {
+        do_post.call({ plan_key: "basic" })
+      }.to change { AnalyticsEvent.for_event("trial_started").count }.by(1)
     end
   end
 


### PR DESCRIPTION
## Summary
- Yearly checkouts (`basic_yearly` / `pro_yearly`) now skip the 14-day no-card reverse trial regardless of whether a `promo_code` param is passed, so the annual price is due today.
- Fixes: a buyer who reached an annual plan via /pricing (no campaign link) and typed a promotion code into Stripe's own promo box got "does not meet the minimum amount requirement" — because the trial zeroed the amount due to $0, and the FOUNDING coupon's $50 minimum (the mechanism gating it to yearly plans) validates against that amount.
- Monthly checkouts are unchanged — full reverse trial, `trial_started` still fires, and a $50-minimum code still correctly won't apply there (that's the restriction working, not a bug).
- Docs: updated `.claude-notes/billing-and-plans.md` reverse-trial section and added a `CHANGELOG.md` entry.

Known follow-up (not in this PR): monthly + FOUNDING still surfaces Stripe's generic minimum-amount error rather than friendlier copy. A promo-code field we own on /pricing would fix that — separate piece of work.

## Test plan
- `bundle exec rspec spec/requests/api/stripe/checkout_sessions_spec.rb` — 30 examples, 0 failures (added coverage: yearly omits trial with/without promo, `trial_started` gated correctly for both plan types)
- `bundle exec rspec spec/requests/api/subscriptions_change_plan_spec.rb spec/requests/api/subscriptions_change_plan_portal_session_spec.rb` — 24 examples, 0 failures
- `bin/rails zeitwerk:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)