### PR TITLE
fix(billing): never silently downgrade a user on an unrecognized checkout plan_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — An unrecognized checkout plan_key no longer downgrades the user to Free
+- `POST /api/stripe/checkout_sessions` treated *any* plan_key it didn't
+  recognize (a typo, plan-key drift between frontend and backend, a missing
+  `STRIPE_PRICE_*` env var) the same as an explicit `plan_key=free` request:
+  it silently reset the user's `plan_type` to `"free"` and redirected to
+  `/home` with no Stripe session and no error. That's how a paired frontend
+  bug (5-Year License buttons posting an unhandled plan_key here) was able
+  to bounce users to the dashboard.
+- Unrecognized/misconfigured plan keys now get a 400 `Unknown or
+  unconfigured plan_key` response and never touch the user's plan record.
+  Only an explicit `plan_key=free` still short-circuits to the free plan.
+
 ### Fixed — Promo codes are redeemable on annual plans at Stripe Checkout
 - Picking a yearly plan from /pricing and typing a promotion code into Stripe's
   own code box failed with "does not meet the minimum amount requirement". The

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -65,9 +65,17 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     # `source` the (best-effort) client event does; defaulted so it's never nil.
     source = params[:source].to_s.strip.presence || "web_checkout"
 
-    if plan_key == "free" || price_id.blank?
+    if plan_key == "free"
       current_user.update!(plan_type: "free", plan_status: "active")
       render json: { url: "#{frontend_base_url}/home" } and return
+    end
+
+    # An unrecognized/misconfigured plan_key (frontend/backend plan-key
+    # drift, a missing STRIPE_PRICE_* env var) must never silently downgrade
+    # an existing plan — it used to fall into the free short-circuit above,
+    # resetting plan_type to "free" with no Stripe session and no error.
+    if price_id.blank?
+      render json: { error: "Unknown or unconfigured plan_key" }, status: :bad_request and return
     end
     is_partner = plan_key == "partner_pro"
 

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       expect(user.plan_status).to eq("active")
     end
 
+    it "rejects an unrecognized plan_key with a 400 instead of downgrading the user to free" do
+      user.update!(plan_type: "pro", plan_status: "active")
+      expect(Stripe::Checkout::Session).not_to receive(:create)
+
+      do_post.call({ plan_key: "basic_5yr" })
+
+      expect(response).to have_http_status(:bad_request)
+      expect(user.reload.plan_type).to eq("pro")
+      expect(user.plan_status).to eq("active")
+    end
+
     it "auto-applies the partner pilot promo code for plan_key=partner_pro" do
       user.update!(stripe_customer_id: "cus_partner")
       promo = OpenStruct.new(id: "promo_partner_id")


### PR DESCRIPTION
## Summary

- `POST /api/stripe/checkout_sessions` treated **any** unrecognized `plan_key` — a typo, plan-key drift between frontend and backend, a missing `STRIPE_PRICE_*` env var — the same as an explicit `plan_key=free` request: it silently reset the user's `plan_type` to `"free"` and redirected to `/home`, with no Stripe session and no visible error.
- This is exactly how the 5-Year License frontend bug ([itty-bitty-frontend#596](https://github.com/brittanyjohns/itty-bitty-frontend/pull/596)) was able to bounce users straight to the dashboard: it posted `basic_5yr`/`pro_5yr` to this endpoint, which doesn't know those keys.
- Companion/follow-up to that frontend fix, closing the underlying safety gap so a *future* unrecognized plan_key (bad deploy, new plan added to one repo but not the other, etc.) fails loud instead of silently mutating billing state.

## Change

- Split the short-circuit: only an explicit `plan_key=free` still resets the user to Free and redirects to `/home`.
- Any other `plan_key` with no matching price ID now returns `400 { error: "Unknown or unconfigured plan_key" }` and never touches the user's plan record.

## Test plan

- [x] `bundle exec rspec spec/requests/api/stripe/checkout_sessions_spec.rb` — 31/31 passing, including new coverage that an unrecognized plan_key 400s and leaves an existing paid user's `plan_type`/`plan_status` untouched
- [x] `bundle exec rspec spec/requests/api/stripe/checkout_sessions_license_spec.rb spec/requests/api/stripe/checkout_sessions_topup_spec.rb` — 21/21 passing (sibling endpoints unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)