### PR TITLE
fix(api): return 201 JSON from POST /api/docs instead of 500ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — `POST /api/docs` returns the created doc instead of a 500
+- The JSON branch rendered `render :show, location: @doc`. `location: @doc`
+  resolves to `doc_url`, but the route is declared inside `namespace :api`, so
+  the helper is `api_doc_url` — and there is no `app/views/api/docs/show`
+  template for `render :show` to find either. Both faults fired *after* the
+  Doc was saved, so the record was created and the caller still got a 500.
+- The endpoint now responds `201` with the doc's `api_view` (the same shape
+  `PATCH /api/docs/:id` returns) and a `Location` header built from
+  `api_doc_url`. The same `doc_url` typo in `#update`'s HTML redirect is fixed
+  too. No frontend change: the app only calls `docs/:id/mark_as_current`.
+
 ### Fixed — The SpeakAnyWay logo no longer shows up as an email attachment
 - Every transactional email attached the logo as an inline (`cid`) image.
   Referencing an inline part from the HTML is legal MIME, but mail clients

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -74,7 +74,16 @@ class API::DocsController < API::ApplicationController
           UserDoc.create(user_id: current_user.id, doc_id: @doc.id, image_id: @image.id)
         end
         format.html { redirect_to @doc.documentable, notice: "Doc was successfully created." }
-        format.json { render :show, status: :created, location: @doc }
+        # `location: @doc` would resolve to `doc_url`, but the route lives under
+        # `namespace :api`, so the helper is `api_doc_url`. There is also no
+        # app/views/api/docs/show template — `render :show` raises. Both faults
+        # fired only after the Doc was saved, so the record was created and the
+        # client still got a 500. Render the same api_view #update does.
+        format.json do
+          render json: @doc.api_view(current_user),
+                 status: :created,
+                 location: api_doc_url(@doc)
+        end
       else
         format.html { render :new, status: :unprocessable_content }
         format.json { render json: @doc.errors, status: :unprocessable_content }
@@ -96,7 +105,7 @@ class API::DocsController < API::ApplicationController
 
     respond_to do |format|
       if @doc.update(doc_params)
-        format.html { redirect_to doc_url(@doc), notice: "Doc was successfully updated." }
+        format.html { redirect_to api_doc_url(@doc), notice: "Doc was successfully updated." }
         format.json { render json: @doc.api_view(current_user), status: :ok }
       else
         format.html { render :edit, status: :unprocessable_content }

--- a/spec/requests/api/docs_create_spec.rb
+++ b/spec/requests/api/docs_create_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+# API::DocsController#create's JSON branch was `render :show, location: @doc`.
+# Two faults, both firing only AFTER the Doc was saved: `location: @doc` resolves
+# to `doc_url`, but the route is declared inside `namespace :api` so the helper is
+# `api_doc_url`; and there is no app/views/api/docs/show template for `render :show`
+# to find. The record was created and the client got a 500. These specs pin the
+# JSON create path to a real 201 + api_view body.
+RSpec.describe "API::Docs#create", type: :request do
+  let!(:user)  { create(:user) }
+  let!(:image) { create(:image) }
+
+  let(:upload) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join("spec/fixtures/files/sample.png"), "image/png"
+    )
+  end
+
+  def create_doc(params, headers = auth_headers(user))
+    post "/api/docs", params: { doc: params }, headers: headers
+  end
+
+  it "returns 201 with the doc's api_view instead of 500ing" do
+    expect {
+      create_doc(documentable_id: image.id, documentable_type: "Image", image: upload)
+    }.to change(Doc, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+
+    body = JSON.parse(response.body)
+    doc  = Doc.last
+    expect(body["id"]).to eq(doc.id)
+    expect(body["documentable_id"]).to eq(image.id)
+    expect(body["documentable_type"]).to eq("Image")
+    expect(body["user_id"]).to eq(user.id)
+  end
+
+  it "sets a Location header built from the api-namespaced route helper" do
+    create_doc(documentable_id: image.id, documentable_type: "Image", image: upload)
+
+    expect(response).to have_http_status(:created)
+    expect(response.headers["Location"]).to end_with("/api/docs/#{Doc.last.id}")
+  end
+
+  it "assigns the doc to the current user and links a UserDoc" do
+    create_doc(documentable_id: image.id, documentable_type: "Image", image: upload)
+
+    doc = Doc.last
+    expect(doc.user).to eq(user)
+    expect(UserDoc.find_by(doc_id: doc.id, user_id: user.id, image_id: image.id)).to be_present
+  end
+
+  it "carries source_type through when supplied" do
+    create_doc(
+      documentable_id: image.id,
+      documentable_type: "Image",
+      image: upload,
+      source_type: "OpenSymbol",
+    )
+
+    expect(response).to have_http_status(:created)
+    expect(JSON.parse(response.body)["source_type"]).to eq("OpenSymbol")
+  end
+
+  it "rejects an unauthenticated request without creating a doc" do
+    expect {
+      post "/api/docs",
+           params: { doc: { documentable_id: image.id, documentable_type: "Image", image: upload } }
+    }.not_to change(Doc, :count)
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
## Summary

`POST /api/docs` created the Doc and then raised, so the record was saved and the caller got a 500.

The JSON branch was `render :show, status: :created, location: @doc`. Two separate faults, both firing *after* `@doc.save`:

1. **`location: @doc` resolves to `doc_url(@doc)`** — but the route is declared inside `namespace :api` (`config/routes.rb`), so the helper is `api_doc_url`. `NoMethodError: undefined method 'doc_url'`.
2. **`render :show` has no template.** There is no `app/views/api/docs/` directory — no `docs` view directory anywhere under `app/views/` — so this would have raised next even with the helper fixed.

The endpoint now renders `@doc.api_view(current_user)` with `status: :created` and a `Location` header built from `api_doc_url`. That's the same body shape `PATCH /api/docs/:id` already returns, so no new view file is introduced.

Also fixes the **identical `doc_url` typo in `#update`'s HTML redirect** (`app/controllers/api/docs_controller.rb:99`) — same bug class, same file.

**No frontend change needed.** The app never calls `POST /api/docs`; it only uses `docs/:id/mark_as_current`. This was a latent 500 on a public authenticated endpoint, found while adding `source_type` provenance to the doc-upload paths.

### Known, out of scope

`GET /api/docs/:id` (`#show`) is still broken for the same missing-template reason (`def show; end` with no view), as are the `render :new` / `render :edit` HTML failure branches in this controller. Fixing the controller's whole HTML/view surface is a separate change from the create path.

## Test plan

New `spec/requests/api/docs_create_spec.rb` covers the JSON create path:

- 201 + `api_view` body (id, documentable, user_id)
- `Location` header built from the api-namespaced helper
- owner assigned server-side + `UserDoc` link created
- `source_type` passthrough
- 401 when unauthenticated, with no Doc created

**Ran:**

```
bundle exec rspec spec/requests/api/docs_create_spec.rb spec/requests/api/docs_update_authorization_spec.rb
# 9 examples, 0 failures
```

`bin/rails zeitwerk:check` — clean.

**Regression check:** reverted the controller line and reran the new spec to confirm it catches the original bug, then restored:

```
NoMethodError: undefined method `doc_url' for an instance of API::DocsController
5 examples, 4 failures
```

## Docs

CHANGELOG entry added. No `.claude-notes/` spoke covers the `/api/docs` surface (`internal-api.md` is the separate `/api/internal/` one), and no convention or architecture changed — this is a bug fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)