### PR TITLE
fix(billing): never downgrade an entitled account via plan_key=free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — selecting the Free plan can no longer downgrade a paying subscriber
+- `POST /api/stripe/checkout_sessions` with `plan_key: "free"` applied
+  `plan_type: "free", plan_status: "active"` to anyone who asked, with no
+  guard. That endpoint is also how the frontend's onboarding **"Maybe later"**
+  skip is wired, so it fired for people who never intended a plan change —
+  observed on staging after a Google sign-in routed an existing customer into
+  the onboarding plan picker.
+- Worse than a wrong label: it rewrote `plan_type` locally while the Stripe
+  subscription kept billing, desyncing the two.
+- Entitled accounts (`paid_plan?`, which also covers admins) are now a logged
+  no-op. Real downgrades already have a home in `subscriptions#billing_portal`
+  / `#change_plan` / `#cancel_subscription`, which cancel in Stripe properly,
+  so nobody is stranded. A cancelled subscriber still resolves to free, so
+  stranded-plan healing is unaffected.
+- Companion to #549, which closed the same hole for *unrecognized* plan keys
+  but deliberately left this explicit `"free"` branch alone.
+
+### Added — `POST /api/v1/auths/google` returns `is_new_user`
+- The endpoint both signs up and signs in, so the client could not tell a
+  brand-new account from a returning customer. That mattered: the frontend
+  sends new accounts to `/onboarding` (the plan picker) and returning
+  customers to their dashboard, and getting it wrong was the route into the
+  downgrade above. The flag is already computed internally; it is now returned
+  alongside `token` and `user`.
+
 ### Fixed — `POST /api/docs` returns the created doc instead of a 500
 - The JSON branch rendered `render :show, location: @doc`. `location: @doc`
   resolves to `doc_url`, but the route is declared inside `namespace :api`, so

--- a/app/controllers/api/stripe/checkout_sessions_controller.rb
+++ b/app/controllers/api/stripe/checkout_sessions_controller.rb
@@ -66,6 +66,28 @@ class API::Stripe::CheckoutSessionsController < API::ApplicationController
     source = params[:source].to_s.strip.presence || "web_checkout"
 
     if plan_key == "free"
+      # Selecting Free is also how the onboarding "Maybe later" skip is wired,
+      # so this fires for people who never intended a plan change at all.
+      # Applying it to someone already entitled is a silent downgrade — and
+      # worse than it looks: it rewrites plan_type locally while the Stripe
+      # subscription keeps billing, desyncing the two.
+      #
+      # A real downgrade goes through Stripe (subscriptions#billing_portal /
+      # #change_plan / #cancel_subscription), which cancels the subscription
+      # properly, so no-oping here strands nobody. paid_plan? is also true for
+      # admins, who must never be downgraded by a stray click.
+      #
+      # Companion to #549, which closed this hole for *unrecognized* plan keys
+      # but deliberately left the explicit "free" branch alone.
+      if current_user.paid_plan?
+        Rails.logger.info(
+          "[checkout_sessions#create] ignoring plan_key=free for entitled user=#{current_user.id} " \
+          "(plan_type=#{current_user.plan_type} status=#{current_user.plan_status}); " \
+          "downgrades must go through Stripe"
+        )
+        render json: { url: "#{frontend_base_url}/home" } and return
+      end
+
       current_user.update!(plan_type: "free", plan_status: "active")
       render json: { url: "#{frontend_base_url}/home" } and return
     end

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -296,7 +296,18 @@ module API
           })
         end
 
-        render json: { token: user.authentication_token, user: user.api_view }
+        # This one endpoint both signs up and signs in, so the client cannot
+        # otherwise tell a brand-new account from a returning customer — and it
+        # matters: the frontend sends new accounts to /onboarding, which is the
+        # plan picker, where selecting Free (or the "Maybe later" skip) posts
+        # plan_key: "free". Landing a returning customer there was one click
+        # from a downgrade. Without this flag the frontend has to infer it from
+        # plan/board/communicator counts.
+        render json: {
+          token: user.authentication_token,
+          user: user.api_view,
+          is_new_user: is_new_user,
+        }
       end
 
       def forgot_password

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -96,6 +96,42 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       expect(user.plan_status).to eq("active")
     end
 
+    # plan_key=free is also how the onboarding "Maybe later" skip is wired, so
+    # it fires for people who never intended a plan change at all. Applying it
+    # to an entitled account downgrades plan_type locally while the Stripe
+    # subscription keeps billing. Real downgrades go through
+    # subscriptions#cancel_subscription / #billing_portal.
+    it "does not downgrade an active paid subscriber who lands on plan_key=free" do
+      user.update!(plan_type: "pro", plan_status: "active")
+      expect(Stripe::Checkout::Session).not_to receive(:create)
+
+      do_post.call({ plan_key: "free" })
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["url"]).to end_with("/home")
+      expect(user.reload.plan_type).to eq("pro")
+      expect(user.plan_status).to eq("active")
+    end
+
+    it "does not downgrade an admin who lands on plan_key=free" do
+      user.update!(role: "admin", plan_type: "pro", plan_status: "active")
+
+      do_post.call({ plan_key: "free" })
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.plan_type).to eq("pro")
+    end
+
+    it "still applies free for a cancelled subscriber, so stranded accounts heal" do
+      user.update!(plan_type: "pro", plan_status: "canceled")
+
+      do_post.call({ plan_key: "free" })
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.plan_type).to eq("free")
+      expect(user.plan_status).to eq("active")
+    end
+
     it "rejects an unrecognized plan_key with a 400 instead of downgrading the user to free" do
       user.update!(plan_type: "pro", plan_status: "active")
       expect(Stripe::Checkout::Session).not_to receive(:create)

--- a/spec/requests/api/v1/auths_google_spec.rb
+++ b/spec/requests/api/v1/auths_google_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "POST /api/v1/auths/google", type: :request do
       body = JSON.parse(response.body)
       expect(body["token"]).to eq(user.authentication_token)
       expect(body["user"]["id"]).to eq(user.id)
+      # The frontend routes new accounts to /onboarding (the plan picker) and
+      # returning customers to their dashboard. Sending a returning customer to
+      # the picker was one click from a downgrade, so this flag is load-bearing.
+      expect(body["is_new_user"]).to be(true)
     end
 
     it "runs signup side effects (Stripe customer, Mailchimp, PostHog)" do
@@ -83,6 +87,17 @@ RSpec.describe "POST /api/v1/auths/google", type: :request do
 
       body = JSON.parse(response.body)
       expect(body["token"]).to eq(existing.authentication_token)
+      # Auto-linked an account that already existed — not a signup.
+      expect(body["is_new_user"]).to be(false)
+    end
+
+    it "does not touch the plan of the account it links to" do
+      existing.update!(plan_type: "pro", plan_status: "active")
+
+      do_post(id_token: "valid-id-token")
+
+      expect(existing.reload.plan_type).to eq("pro")
+      expect(existing.plan_status).to eq("active")
     end
 
     it "does not run signup side effects for an auto-linked account" do
@@ -109,6 +124,7 @@ RSpec.describe "POST /api/v1/auths/google", type: :request do
 
       body = JSON.parse(response.body)
       expect(body["token"]).to eq(existing.reload.authentication_token)
+      expect(body["is_new_user"]).to be(false)
     end
   end
 


### PR DESCRIPTION
## Summary

Two backend fixes behind the staging bug where signing in with Google left an existing account on the Free plan.

### 1. `plan_key: "free"` could silently downgrade a paying subscriber

`POST /api/stripe/checkout_sessions` applied `plan_type: "free", plan_status: "active"` to anyone who asked. That endpoint is also how the frontend's onboarding **"Maybe later"** skip is wired, so it fired for people who never intended a plan change at all.

Worse than a wrong label: it rewrote `plan_type` locally while the Stripe subscription kept billing, desyncing the two.

Entitled accounts (`paid_plan?`, which also covers admins) are now a logged no-op. Real downgrades already have a home in `subscriptions#billing_portal` / `#change_plan` / `#cancel_subscription`, which cancel in Stripe properly — I checked before making this a no-op, so nobody is stranded. A cancelled subscriber still resolves to free, so stranded-plan healing is unaffected.

Companion to #549, which closed this hole for *unrecognized* plan keys but deliberately left the explicit `"free"` branch alone.

### 2. `POST /api/v1/auths/google` now returns `is_new_user`

That endpoint both signs up and signs in, so the client couldn't tell a brand-new account from a returning customer — which is exactly what decides whether the frontend sends someone to `/onboarding` (the plan picker). The flag was already computed internally; it's now returned alongside `token` and `user`. Additive, so it can deploy in either order relative to the frontend.

## How this was hit

Frontend PR brittanyjohns/itty-bitty-frontend#598 added Google sign-in. Because Google is one sign-up-or-sign-in endpoint, the signup screen treated every success as a new signup and sent the user to `/onboarding` — one click from the downgrade above. That frontend routing is already fixed there; this PR removes the underlying footgun and gives the frontend the real signal instead of an inference.

## Test plan

- [x] `spec/requests/api/v1/auths_google_spec.rb` — **11 examples, 0 failures**. New: `is_new_user` true for a new account and false for both returning paths, plus an explicit assertion that auto-linking does not touch the linked account's plan.
- [x] `spec/requests/api/stripe/checkout_sessions_spec.rb` — **34 examples, 0 failures**. New: no downgrade for an active paid subscriber, none for an admin, and free still applies for a cancelled subscriber.
- [x] Verified the new guard specs **fail without the fix** (temporarily neutralized the `paid_plan?` check → the 2 downgrade specs fail), so they'd catch a regression.
- [x] Full `spec/requests/api/v1/` + `spec/requests/api/stripe/` — **219 examples, 0 failures**.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)