### PR TITLE
fix(export): bundle display-size tile variants in the sync .obf export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — `.obf` export of ordinary boards
+- **Exporting a single board as `.obf` no longer fails on normal boards.**
+  The synchronous path base64-encoded each tile's full-resolution original,
+  so a routine 60-tile board ran to tens of MB and tripped the 20MB cap with
+  a generic "Export failed". It now bundles the same 288px webp tile variant
+  the app displays (falling back to the original when that variant hasn't
+  been generated yet, and never generating one mid-request). `.obz` packages
+  are unchanged and still carry full-resolution originals.
+- Inline export now dedupes by doc, so two tiles sharing one image encode
+  and count those bytes once rather than once per tile.
+- The `download_obf` 422 now carries an `error_code` (`too_many_tiles` vs
+  `export_too_large`) so clients and logs can tell the two caps apart.
+
 ### Added — OBF/OBZ export hardening
 - Tile audio is now bundled into `.obz` packages (previously silent on
   export — only images were included). No change to `.obf` structure for

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -650,9 +650,14 @@ class API::BoardsController < API::ApplicationController
 
     send_data result.obf.to_json, filename: filename,
                                   type: "application/json", disposition: "attachment"
-  rescue Boards::ObfExporter::TooLarge
+  rescue Boards::ObfExporter::TooLarge => e
+    # error_code (not the exception message, which stays internal) is what
+    # lets a client distinguish "too many tiles" from "too many bytes" — and
+    # what makes the cause visible in logs when a user reports a failed
+    # export.
     render json: {
       error: "Board is too large to export synchronously",
+      error_code: e.code,
       export_package_url: export_package_api_board_path(@board),
     }, status: :unprocessable_content
   end

--- a/app/services/boards/obf_exporter.rb
+++ b/app/services/boards/obf_exporter.rb
@@ -11,7 +11,20 @@ module Boards
   # because SpeakAnyWay has no standing to license a user's family photos
   # under an open license on their behalf.
   class ObfExporter
-    class TooLarge < StandardError; end
+    # Carries a stable machine-readable code so a client can tell the two
+    # inline caps apart (the rendered 422 is otherwise identical for both) —
+    # and so neither cap has to leak the exception message to the API.
+    class TooLarge < StandardError
+      TILE_LIMIT = "too_many_tiles".freeze
+      SIZE_LIMIT = "export_too_large".freeze
+
+      attr_reader :code
+
+      def initialize(message = nil, code: SIZE_LIMIT)
+        super(message)
+        @code = code
+      end
+    end
 
     FORMAT = "open-board-0.1".freeze
     OPEN_LICENSE = { "type" => "CC BY-SA 4.0",
@@ -23,6 +36,11 @@ module Boards
     # inside a Puma worker). :package and :url modes are unaffected — :package
     # goes through the async ExportBoardPackageJob + Boards::ObzPackager,
     # which has its own MAX_BYTES cap on the whole .obz.
+    #
+    # These bound the DISPLAY-SIZE bytes inline mode actually bundles (see
+    # #inline_bytes_for), not the originals. Against originals a wholly
+    # ordinary 60-tile board ran to tens of MB and 422'd here, which made the
+    # sync .obf path unusable for real boards rather than only for outliers.
     MAX_INLINE_TILES = 200
     MAX_INLINE_BYTES = 20 * 1024 * 1024
 
@@ -63,7 +81,10 @@ module Boards
       ).to_a
 
       if asset_mode == :inline && tiles.size > MAX_INLINE_TILES
-        raise TooLarge, "Board has #{tiles.size} tiles, over the #{MAX_INLINE_TILES}-tile sync export limit"
+        raise TooLarge.new(
+          "Board has #{tiles.size} tiles, over the #{MAX_INLINE_TILES}-tile sync export limit",
+          code: TooLarge::TILE_LIMIT,
+        )
       end
 
       predictive_ids = tiles.filter_map(&:predictive_board_id).uniq
@@ -130,14 +151,28 @@ module Boards
       path = "images/#{doc.id}.#{asset_extension(doc)}"
 
       if asset_mode == :inline
-        bytes = doc.image.download
-        @inline_bytes_total = (@inline_bytes_total || 0) + bytes.bytesize
-        if @inline_bytes_total > MAX_INLINE_BYTES
-          raise TooLarge, "Inline export exceeds #{MAX_INLINE_BYTES / 1024 / 1024}MB, over the sync export size limit"
+        # Two tiles can point at the same doc (the same symbol used twice on a
+        # board, or a shared Image resolving to one doc for both). :package
+        # dedupes those downstream by zip path; inline mode has no such
+        # downstream, so it dedupes here — otherwise identical bytes are
+        # downloaded, encoded, and counted against MAX_INLINE_BYTES once per
+        # referencing tile.
+        cached = inline_cache[doc.id]
+        unless cached
+          bytes, content_type = inline_bytes_for(doc)
+          @inline_bytes_total = (@inline_bytes_total || 0) + bytes.bytesize
+          if @inline_bytes_total > MAX_INLINE_BYTES
+            raise TooLarge.new(
+              "Inline export exceeds #{MAX_INLINE_BYTES / 1024 / 1024}MB, over the sync export size limit",
+              code: TooLarge::SIZE_LIMIT,
+            )
+          end
+
+          cached = inline_cache[doc.id] = { data: Base64.strict_encode64(bytes), content_type: content_type }
         end
 
-        data = Base64.strict_encode64(bytes)
-        return tile.to_obf_image_format(exporting_user, mode: :inline, data: data, content_type: doc.image.content_type)
+        return tile.to_obf_image_format(exporting_user, mode: :inline,
+                                                        data: cached[:data], content_type: cached[:content_type])
       end
 
       assets << Asset.new(:image, doc.id.to_s, path, doc)
@@ -148,6 +183,47 @@ module Boards
       Rails.logger.warn "[ObfExporter] asset unreadable for doc #{doc.id}: #{e.class}: #{e.message}"
       skipped_assets << { board_image_id: tile.id, label: tile.label, reason: "image could not be read" }
       tile.to_obf_image_format(exporting_user)
+    end
+
+    def inline_cache
+      @inline_cache ||= {}
+    end
+
+    # The bytes inline mode bundles, and the content_type describing THEM.
+    #
+    # Prefers the 288px webp tile variant — the same rendition the app itself
+    # displays — over the full-resolution original. An original is routinely
+    # 30-50x the variant's size, so bundling originals meant an ordinary board
+    # blew MAX_INLINE_BYTES and had no working sync export at all. A single
+    # .obf is a display-fidelity artifact; the async .obz path (asset_mode:
+    # :package) is the one that still carries originals.
+    #
+    # Only an ALREADY-PROCESSED variant is used. Calling #processed on an
+    # unprocessed variant would transcode it right here inside the Puma
+    # worker, once per tile — exactly the kind of in-request work the caps
+    # exist to prevent. Unprocessed (and non-variable blobs, e.g. SVG) fall
+    # back to the original, which is correct if larger.
+    def inline_bytes_for(doc)
+      variant = doc.tile_variant if doc.tile_variant_processed?
+      if variant
+        return [variant.processed.download, variant_content_type]
+      end
+
+      [doc.image.download, doc.image.content_type]
+    rescue StandardError => e
+      # A missing/corrupt variant record must not cost the tile its bytes —
+      # the original is still right here. A failure reading the ORIGINAL is a
+      # real read failure and propagates to attach_asset's rescue, which
+      # degrades the tile to a url reference.
+      Rails.logger.warn "[ObfExporter] tile variant unreadable for doc #{doc.id}: #{e.class}: #{e.message}"
+      [doc.image.download, doc.image.content_type]
+    end
+
+    # Derived from the transformation Doc#tile_variant actually applies rather
+    # than hardcoded, so an OBF can never describe variant bytes with a format
+    # they stopped being written in.
+    def variant_content_type
+      "image/#{Doc::TILE_VARIANT_TRANSFORMATIONS.fetch(:format)}"
     end
 
     # Sound bundling mirrors image bundling's shape but skips

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -153,7 +153,21 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       expect(response).to have_http_status(:unprocessable_content)
       body = JSON.parse(response.body)
       expect(body["error"]).to match(/too large/i)
+      expect(body["error_code"]).to eq("too_many_tiles")
       expect(body["export_package_url"]).to be_present
+    end
+
+    # Which cap raises which code is the exporter spec's job; this asserts the
+    # controller surfaces whatever code it was handed rather than a constant.
+    it "reports the size cap with its own error_code" do
+      allow_any_instance_of(Boards::ObfExporter).to receive(:call).and_raise(
+        Boards::ObfExporter::TooLarge.new("too big", code: Boards::ObfExporter::TooLarge::SIZE_LIMIT),
+      )
+
+      get "/api/boards/#{board.id}/download_obf", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error_code"]).to eq("export_too_large")
     end
   end
 end

--- a/spec/services/boards/obf_exporter_spec.rb
+++ b/spec/services/boards/obf_exporter_spec.rb
@@ -458,5 +458,103 @@ RSpec.describe Boards::ObfExporter do
         described_class.new(board.reload, exporting_user: user, asset_mode: :inline).call
       }.to raise_error(Boards::ObfExporter::TooLarge, /size/i)
     end
+
+    # The rendered 422 is identical for both caps, so the code is the only
+    # thing that says which one fired.
+    it "codes the two caps distinctly" do
+      stub_const("Boards::ObfExporter::MAX_INLINE_TILES", 0)
+      add_tile("apple")
+
+      expect {
+        described_class.new(board.reload, exporting_user: user, asset_mode: :inline).call
+      }.to raise_error(an_object_having_attributes(code: "too_many_tiles"))
+
+      stub_const("Boards::ObfExporter::MAX_INLINE_TILES", 200)
+      stub_const("Boards::ObfExporter::MAX_INLINE_BYTES", 10)
+
+      expect {
+        described_class.new(board.reload, exporting_user: user, asset_mode: :inline).call
+      }.to raise_error(an_object_having_attributes(code: "export_too_large"))
+    end
+  end
+
+  describe "inline mode bundles display-size bytes" do
+    def doc_for(label)
+      Image.find_by(label: label).docs.last
+    end
+
+    def inline_images(exporter_user = user)
+      described_class.new(board.reload, exporting_user: exporter_user, asset_mode: :inline).call.obf["images"]
+    end
+
+    it "bundles the processed tile variant rather than the full-resolution original" do
+      add_tile("apple")
+      doc = doc_for("apple")
+      doc.tile_variant.processed
+
+      entry = inline_images.first
+
+      expect(entry[:content_type]).to eq("image/webp")
+      expect(Base64.strict_decode64(entry[:data]).bytesize).to be < doc.image.download.bytesize
+    end
+
+    # Processing on demand would transcode inside the Puma worker, once per
+    # tile — the original is the cheaper honest answer until the variant
+    # exists.
+    it "falls back to the original when the variant has not been processed yet" do
+      add_tile("apple")
+      doc = doc_for("apple")
+
+      entry = inline_images.first
+
+      expect(entry[:content_type]).to eq("image/png")
+      expect(Base64.strict_decode64(entry[:data]).bytesize).to eq(doc.image.download.bytesize)
+    end
+
+    it "does not process the variant as a side effect of exporting" do
+      add_tile("apple")
+
+      expect { inline_images }.not_to change { doc_for("apple").tile_variant_processed? }.from(false)
+    end
+
+    it "still bundles the original when the variant record is unreadable" do
+      add_tile("apple")
+      allow_any_instance_of(Doc).to receive(:tile_variant_processed?).and_return(true)
+      allow_any_instance_of(Doc).to receive(:tile_variant).and_raise(StandardError, "boom")
+
+      entry = inline_images.first
+
+      expect(entry[:content_type]).to eq("image/png")
+      expect(entry[:data]).to be_present
+    end
+
+    context "when two tiles share one doc" do
+      let!(:shared_doc) do
+        image = create(:image, label: "apple", user: user)
+        doc = create(:doc, documentable: image, user: user, source_type: Doc::SOURCE_TYPE_USER, current: true)
+        doc.image.attach(io: File.open(Rails.root.join("public", "logo_bubble.png")),
+                         filename: "tile.png", content_type: "image/png")
+        2.times do |i|
+          board.board_images.create!(image_id: image.id, position: i, skip_create_voice_audio: true)
+        end
+        doc
+      end
+
+      it "counts the shared bytes once against the size cap" do
+        # Room for exactly one copy: without the dedupe the second tile's
+        # identical bytes push the running total past the cap and 422 a board
+        # that is well inside it.
+        stub_const("Boards::ObfExporter::MAX_INLINE_BYTES", shared_doc.image.download.bytesize + 10)
+
+        expect { inline_images }.not_to raise_error
+      end
+
+      it "encodes the shared bytes once and reuses them for both tiles" do
+        entries = inline_images
+
+        expect(entries.size).to eq(2)
+        expect(entries.first[:data]).to eq(entries.last[:data])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Exporting a single board as `.obf` failed on ordinary boards — a plain 60-tile Core 60 board returned 422 `"Board is too large to export synchronously"`.

The cap added in #557 was doing its job; the input was the problem. `ObfExporter#attach_asset` base64-encoded `doc.image` — the **full-resolution original** — for every tile, while the app itself only ever displays the 288px webp tile variant. At roughly 0.5–1.5MB per original, a routine board ran to tens of MB against `MAX_INLINE_BYTES` (20MB), which made the sync `.obf` path unusable for real boards rather than only for outliers.

- Inline mode now reads the processed tile variant and reports **its** `content_type`, not the original's.
- Only an **already-processed** variant is used. Calling `#processed` on an unprocessed one would transcode inside the Puma worker, once per tile — exactly what the caps exist to prevent. Unprocessed variants and non-variable blobs (SVG) fall back to the original.
- `asset_mode: :package` (the async `.obz` path) is untouched and still bundles full-resolution originals. The two formats now differ in image fidelity; the frontend PR says so in the format picker.
- Inline assets are deduped by doc id. `:package` dedupes shared bytes downstream by zip path, but inline has no downstream — a doc referenced by two tiles was downloaded, encoded, and counted twice.
- `TooLarge` carries a code, surfaced as `error_code` in the 422 (`too_many_tiles` vs `export_too_large`). Both caps rendered identical JSON before, so neither a client nor a log could tell which fired.

Pairs with itty-bitty-frontend #600, which stops a genuinely oversized board from dead-ending. Each stands alone.

## Test plan

- `bundle exec rspec spec/services/boards/obf_exporter_spec.rb` — 33 passed. New coverage: bundles the processed variant over the original, falls back when unprocessed, doesn't process as a side effect, falls back when the variant record is unreadable, counts shared bytes once against the cap, reuses the encoded bytes for both tiles, and codes the two caps distinctly.
- `bundle exec rspec spec/requests/api/boards/import_export_spec.rb spec/requests/api/board_exports_spec.rb spec/services/boards/obz_packager_spec.rb spec/services/boards/obz_round_trip_spec.rb` — 47 passed.
- `bundle exec rspec spec/models/board_export_spec.rb spec/services/boards/export_scope_spec.rb spec/models/board_image_obf_format_spec.rb spec/sidekiq` — 280 passed, 1 pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)