### PR TITLE
fix(export): serve .obz downloads via a JSON storage URL, not a cross-origin redirect

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -467,11 +467,27 @@ Board Set) create a `BoardExport` and run `ExportBoardPackageJob` async;
   low-consequence race (worst case: two exports run instead of one),
   bounded by the rate limit above and accepted rather than fixed.
 - **`GET /api/board_exports/:id/download` redirects instead of buffering.**
-  It now `redirect_to`s the attachment's storage URL
+  It `redirect_to`s the attachment's storage URL
   (`@board_export.file.url(disposition: "attachment", filename: ...)`,
   `allow_other_host: true`) rather than streaming the whole `.obz` (up to
   `ObzPackager::MAX_BYTES`, 200MB) through the Puma worker via `send_data`.
   `#show` and the 404-for-unowned-or-missing-export behavior are unchanged.
+- **A browser must never `fetch()` `#download` — that redirect is
+  unreachable cross-origin.** The frontend's API calls carry an
+  `Authorization` header, which makes every one of them a *preflighted* CORS
+  request, and a preflighted request that redirects to another origin forces
+  a **second preflight against that origin**. In production the redirect
+  target is S3, which has no CORS rule for our origins and answers the
+  `OPTIONS` with 403 — so the download failed for every user while looking
+  like a failed export. This is invisible in dev/test, where the Disk
+  service's `file.url` is a *same-origin* Rails path and the redirect never
+  crosses an origin. `GET /api/board_exports/:id/download_url` exists for
+  browsers: same owner scoping and completed/attached guard, but it returns
+  `{ url: <storage URL> }` as JSON so the client can **navigate** to it
+  (navigation isn't a CORS request at all). Keep `#download` for
+  non-browser callers. The presigned URL's own attachment disposition
+  supplies the filename, which `ExportBoardPackageJob` already sets to
+  `<board-name>.obz`.
 - **`BoardExport#file` uses a dedicated private storage service in
   production.** `has_one_attached :file, service: Rails.env.production? ?
   :amazon_private : Rails.application.config.active_storage.service`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - The `download_obf` 422 now carries an `error_code` (`too_many_tiles` vs
   `export_too_large`) so clients and logs can tell the two caps apart.
 
+### Fixed — `.obz` downloads were blocked in production
+- Added `GET /api/board_exports/:id/download_url`, which returns the export's
+  storage URL as JSON instead of redirecting to it. The existing `#download`
+  redirect can't serve a browser: the web app's requests carry an
+  `Authorization` header, so they're preflighted, and a preflighted request
+  that redirects cross-origin re-preflights against the new origin — S3,
+  which has no CORS rule for our origins and answers 403. Every `.obz`
+  download failed in production (single boards and Board Sets alike) while
+  the modal reported it as a failed *export*. Only reproducible against S3;
+  dev/test use the Disk service, whose URL is same-origin. `#download` is
+  unchanged and still serves non-browser callers.
+
 ### Added — OBF/OBZ export hardening
 - Tile audio is now bundled into `.obz` packages (previously silent on
   export — only images were included). No change to `.obf` structure for

--- a/app/controllers/api/board_exports_controller.rb
+++ b/app/controllers/api/board_exports_controller.rb
@@ -6,18 +6,42 @@ class API::BoardExportsController < API::ApplicationController
   end
 
   def download
-    unless @board_export.completed? && @board_export.file.attached?
-      render json: { error: "Export not ready" }, status: :not_found
-      return
-    end
+    return unless ready_to_download?
 
     # Redirect to the storage URL instead of buffering the whole (up to
     # 200MB) .obz through this Puma worker via send_data.
-    redirect_to @board_export.file.url(disposition: "attachment", filename: @board_export.file.filename.to_s),
-                allow_other_host: true
+    redirect_to storage_url, allow_other_host: true
+  end
+
+  # Hands the caller the storage URL as JSON so the browser can *navigate* to
+  # it rather than fetch() it. #download can't serve the web app directly: the
+  # frontend's fetch carries an Authorization header, which makes it a
+  # preflighted CORS request, and a preflighted request that redirects
+  # cross-origin forces a second preflight — against S3, which has no CORS
+  # rule for our origins and answers 403. Navigation isn't a CORS request at
+  # all, and the presigned URL already carries an attachment disposition, so
+  # the file downloads with the right name.
+  #
+  # #download stays as-is for non-browser callers (curl, native).
+  def download_url
+    return unless ready_to_download?
+
+    render json: { url: storage_url }
   end
 
   private
+
+  # Renders the not-ready 404 and returns false, so actions can `return unless`.
+  def ready_to_download?
+    return true if @board_export.completed? && @board_export.file.attached?
+
+    render json: { error: "Export not ready" }, status: :not_found
+    false
+  end
+
+  def storage_url
+    @board_export.file.url(disposition: "attachment", filename: @board_export.file.filename.to_s)
+  end
 
   # Scoped to the current user, so another user's export is a plain 404 rather
   # than a 403 that confirms it exists.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -314,6 +314,7 @@ Rails.application.routes.draw do
     resources :board_exports, only: [:show] do
       member do
         get "download"
+        get "download_url"
       end
     end
     resources :board_images do

--- a/spec/requests/api/board_exports_spec.rb
+++ b/spec/requests/api/board_exports_spec.rb
@@ -189,4 +189,41 @@ RSpec.describe "API::BoardExports", type: :request do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  describe "GET /api/board_exports/:id/download_url" do
+    it "404s a queued (not yet completed) export" do
+      record = BoardExport.create!(user: user, exportable: board)
+      get "/api/board_exports/#{record.id}/download_url", headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s a completed export with no file attached" do
+      record = BoardExport.create!(user: user, exportable: board, status: "completed")
+      get "/api/board_exports/#{record.id}/download_url", headers: auth_headers(user)
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # The whole point of this action: the browser gets a URL to navigate to,
+    # so no cross-origin redirect (and no S3 preflight) is ever involved.
+    it "returns the storage URL as JSON for a completed, attached export" do
+      record = BoardExport.create!(user: user, exportable: board)
+      ExportBoardPackageJob.new.perform(record.id)
+      record.reload
+
+      get "/api/board_exports/#{record.id}/download_url", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["url"]).to be_present
+    end
+
+    it "404s a stranger's attempt to read someone else's download URL" do
+      record = BoardExport.create!(user: user, exportable: board)
+      ExportBoardPackageJob.new.perform(record.id)
+      record.reload
+
+      get "/api/board_exports/#{record.id}/download_url", headers: auth_headers(stranger)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Every `.obz` export download failed in production — for single boards and Board Sets alike — while the UI reported it as a failed *export*. The package built fine; the download step was unreachable.

`GET /api/board_exports/:id/download` redirects to the attachment's storage URL, which in production is S3 (`amazon_private`). A browser can't follow that redirect:

1. The web app's API calls carry an `Authorization` header, so **every one is a preflighted CORS request**.
2. A preflighted request that redirects cross-origin **re-preflights against the new origin**.
3. S3 has no CORS rule for our origins and answers the `OPTIONS` with **403** — no `Access-Control-Allow-Origin`, so the fetch dies.

This is invisible in dev/test: the Disk service's `file.url` is a *same-origin* Rails path, so the redirect never crosses an origin and the existing spec passes.

## What changed

- New `GET /api/board_exports/:id/download_url` returning `{ url: <storage URL> }` as JSON, so the client can **navigate** to it — navigation isn't a CORS request at all. Same owner scoping and completed/attached guard as `#download`, extracted into `ready_to_download?` / `storage_url` so both actions share one path.
- `#download` is unchanged and still serves non-browser callers (curl, native).
- The presigned URL's own attachment disposition supplies the filename, which `ExportBoardPackageJob` already sets to `<board-name>.obz` — so the saved filename is identical to before.

Not chosen: buffering the file through Puma (the redirect exists specifically to avoid holding up to 200MB in a worker), or adding a bucket CORS rule (relies on the redirect + re-preflight dance working in every browser, and on a header the presigned request doesn't expect).

## Test plan

- 4 new request specs on `download_url`: owner gets a URL, queued export 404s, completed-but-unattached 404s, stranger 404s.
- `bundle exec rspec spec/requests/api/board_exports_spec.rb spec/models/board_export_spec.rb spec/services/boards/obf_exporter_spec.rb spec/requests/api/boards/import_export_spec.rb` → **80 examples, 0 failures** (run after rebasing onto #558).

## Deploy order

**Ship this before the frontend PR** (brittanyjohns/itty-bitty-frontend#601) — that branch calls `download_url`, which 404s until this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
