### PR TITLE
fix(boards): accept .obf file uploads and stop mis-analyzing them

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -200,6 +200,35 @@ burned — mirroring the image-generation placeholder short-circuit. (The vision
 call is **not** gated in real production.)
 
 
+## OBF/OBZ import — accepted shapes
+
+`POST /api/boards/import_obf` takes three mutually exclusive inputs, and
+**all three must keep working** — dropping one silently breaks a client:
+
+- `file` with a `.obz` extension → `ObzImporter`, synchronous, creates a
+  `BoardGroup`.
+- `file` with a `.obf` extension → parsed to a Hash and handed to
+  `ImportFromObfJob`. Anything that isn't a JSON object is a 422 at the
+  controller, never a job that fails in the background where the user can't
+  see it.
+- `data` (a JSON body) → same job, no `BoardGroup` unless `board_group_id`
+  is supplied.
+
+The app's own `download_obf` produces a bare `.obf`, so the `.obf` file
+branch is what makes export→import round-trip. It was missing until
+2026-07-31, which made every exported `.obf` un-importable by the app that
+wrote it.
+
+`ObzAnalyzer.analyze` (behind `POST /api/boards/analyze_obz`, which despite
+its name analyzes both) **detects the container from the bytes**, not the
+filename: `PK` magic → zip, otherwise a bare OBF document. It reports which
+it found in `package[:format]` (`"obz"` / `"obf"` / `"unknown"`). It never
+raises — but a report it could not produce carries an `error`
+(`unreadable_file` / `no_boards_found`). **The absence of `error` is the
+only signal a caller may treat as "this file is good."** A zeroed-out report
+without that flag is indistinguishable from a valid empty package, which is
+exactly how a garbage upload once rendered as "Looks good" in the UI.
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — importing a `.obf` file
+- **Uploading a `.obf` file now imports.** `POST /api/boards/import_obf`
+  only handled `.obz` uploads; a `.obf` fell through to
+  422 "Unsupported file format". Since the app's own export produces a bare
+  `.obf`, nothing exported from SpeakAnyWay could be imported back into it.
+  A malformed `.obf` now returns 422 up front rather than enqueuing a job
+  that fails out of sight.
+- **File analysis no longer reports a garbage file as valid.** `ObzAnalyzer`
+  read every upload as a zip, so a `.obf` (or any non-zip) raised internally,
+  got swallowed, and returned an all-zero report with HTTP 200 — which the
+  import screen rendered as "Looks good — we found everything we need."
+  The analyzer now detects the container from the bytes, reports
+  `package.format`, produces a real single-board report for a `.obf`, and
+  flags files it genuinely could not read with an `error` field.
+- Fixed a latent 500 in the JSON-body import path: passing `board_group_id`
+  alongside `data` called `merge` on an ActiveRecord model.
+
 ### Fixed — `.obf` export of ordinary boards
 - **Exporting a single board as `.obf` no longer fails on normal boards.**
   The synchronous path base64-encoded each tile's full-resolution original,

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -726,6 +726,21 @@ class API::BoardsController < API::ApplicationController
           root_board_id: result[:root_board]&.id,
           include_images: import_options[:include_images],
         }
+      elsif file_extension == ".obf"
+        json_data = parse_obf_upload(uploaded_file)
+        unless json_data
+          render json: { error: "Invalid OBF file: expected a JSON board document" },
+                 status: :unprocessable_content
+          return
+        end
+
+        # Sidekiq serializes args to JSON — pass string-keyed hash.
+        ImportFromObfJob.perform_async(json_data, current_user.id, nil, import_options.stringify_keys)
+        render json: {
+          status: "ok",
+          message: "Importing OBF file #{file_name}",
+          include_images: import_options[:include_images],
+        }
       else
         render json: { error: "Unsupported file format" }, status: :unprocessable_content
       end
@@ -733,9 +748,6 @@ class API::BoardsController < API::ApplicationController
       boardData = params[:data]&.to_json
       params[:board_group_id] = params[:board_group_id].to_i
       board_group = BoardGroup.find_by(id: params[:board_group_id]) if params[:board_group_id].present?
-      if board_group
-        boardData = board_group.merge({ board_group: board_group })
-      end
 
       json_data = JSON.parse(boardData) rescue nil
       unless json_data
@@ -754,6 +766,18 @@ class API::BoardsController < API::ApplicationController
     else
       render json: { error: "No file or data provided" }, status: :unprocessable_content
     end
+  end
+
+  # A bare .obf upload is a single JSON board document (an .obz is a zip of
+  # them). Returns the parsed Hash, or nil if the upload isn't one — the
+  # caller turns nil into a 422 rather than letting the job fail silently in
+  # the background.
+  def parse_obf_upload(uploaded_file)
+    parsed = JSON.parse(uploaded_file.read)
+    parsed.is_a?(Hash) ? parsed : nil
+  rescue JSON::ParserError => e
+    Rails.logger.error "OBF import: unparseable upload: #{e.message}"
+    nil
   end
 
   # Pulls the three opt-in params off the request and validates that

--- a/app/services/obz_analyzer.rb
+++ b/app/services/obz_analyzer.rb
@@ -16,19 +16,37 @@ module ObzAnalyzer
   #
   # file_or_bytes: Pathname | IO | StringIO | String (raw bytes; never probed as a path)
   #
+  # Handles BOTH container formats, dispatching on the bytes rather than on a
+  # filename: an .obz is a zip of .obf documents, a bare .obf is one JSON
+  # document. `package[:format]` tells the caller which it got.
+  #
   # Returns a Hash:
   # {
-  #   package: {...},        # package-level overview and checks
+  #   package: {...},        # package-level overview and checks (incl. :format)
   #   manifest: {...},       # manifest presence and resolution results
   #   root_board: {...},     # how root was determined
   #   totals: {...},         # aggregate counts across all boards
   #   boards: [ {...}, ...], # per-board stats
-  #   warnings: [ ... ]      # any non-fatal issues
+  #   warnings: [ ... ],     # any non-fatal issues
+  #   error: "..."           # present ONLY when the file could not be read
   # }
   #
+  # A report without :error is a report we stand behind — callers may treat
+  # its absence as "this file is importable". Never return a zeroed-out
+  # report for an unreadable file; that reads as "valid but empty".
   def analyze(file_or_bytes)
+    bytes = to_bytes(file_or_bytes)
+    zip_bytes?(bytes) ? analyze_obz(bytes) : analyze_obf(bytes)
+  rescue => e
+    Rails.logger.error "[ObzAnalyzer] analyze error: #{e.class}: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    unreadable_report
+  end
+
+  # An OBZ (zip) package: many .obf documents plus an optional manifest.
+  def analyze_obz(bytes)
     # --- Read ZIP into memory (bytes), build path index (normalized) ---
-    entries, index = read_zip_to_hash(file_or_bytes) # {orig_path => bytes}, {norm => orig}
+    entries, index = read_zip_to_hash(bytes) # {orig_path => bytes}, {norm => orig}
 
     # --- Find manifest anywhere (prefer root-level) ---
     manifest_raw, manifest_path = find_manifest(entries)
@@ -63,6 +81,7 @@ module ObzAnalyzer
                root_board: { resolved: false, method: nil, path: nil },
                totals: empty_totals,
                boards: [],
+               error: "no_boards_found",
                warnings: warnings + ["No .obf files found in archive"],
              }
     end
@@ -111,42 +130,7 @@ module ObzAnalyzer
       # Merge into aggregate
       merge_aggregate!(aggregate, board_stats, asset_stats, non_string_ids)
 
-      # Missing image/sound references (by id) within this OBF
-      missing = find_missing_media_refs(obj)
-
-      boards << {
-        path: p,
-        id: safe_s(obj["id"]),
-        name: safe_s(obj["name"]),
-        grid: board_stats[:grid],
-        counts: {
-          buttons: board_stats[:buttons],
-          dynamic_buttons: board_stats[:dynamic_buttons],
-          actions_total: board_stats[:actions_total],
-          actions_breakdown: board_stats[:actions_breakdown],
-          vocalizations: board_stats[:vocalizations],
-          absolute_positioned_buttons: board_stats[:absolute_buttons],
-        },
-        strings_locales: board_stats[:strings_locales],
-        license_present: !!obj["license"],
-        media: {
-          images_defined: asset_stats[:images_defined],
-          images_referenced: asset_stats[:images_referenced],
-          images_inline_data: asset_stats[:images_inline],
-          images_path: asset_stats[:images_path],
-          images_url: asset_stats[:images_url],
-          images_symbol: asset_stats[:images_symbol],
-          image_content_types: asset_stats[:image_content_types].to_a.sort,
-          sounds_defined: asset_stats[:sounds_defined],
-          sounds_referenced: asset_stats[:sounds_referenced],
-          sounds_inline_data: asset_stats[:sounds_inline],
-          sounds_path: asset_stats[:sounds_path],
-          sounds_url: asset_stats[:sounds_url],
-          sound_content_types: asset_stats[:sound_content_types].to_a.sort,
-        },
-        missing_media_refs: missing,
-        non_string_ids_detected: non_string_ids, # true/false
-      }
+      boards << build_board_entry(p, obj, board_stats, asset_stats, non_string_ids)
     end
 
     # Package-level checks: duplicates across package (images/sounds ids in OBZ must be unique)
@@ -169,17 +153,104 @@ module ObzAnalyzer
       boards: boards,
       warnings: warnings + pkg_dups,
     }
-  rescue => e
-    Rails.logger.error "[ObzAnalyzer] analyze error: #{e.class}: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
+  end
+
+  # A bare .obf document: exactly one board, no manifest, no zip entries.
+  # Shares the per-board and totals machinery with the OBZ path so the two
+  # reports stay comparable field for field.
+  def analyze_obf(bytes)
+    obj, warnings, non_string_ids = parse_obf_with_checks(bytes)
+    return unreadable_report unless obj.is_a?(Hash) && obj.any?
+
+    board_stats = per_board_stats(obj)
+    asset_stats = per_board_asset_stats(obj)
+
+    aggregate = init_aggregate
+    merge_aggregate!(aggregate, board_stats, asset_stats, non_string_ids)
+
     {
-      package: {},
+      package: { format: "obf", zip_entries: 0, total_bytes: bytes.bytesize },
+      manifest: {
+        found: false,
+        path: nil,
+        dir: "",
+        declared_board_count: 0,
+        unresolved_manifest_board_paths: [],
+        resolved_board_paths: [],
+        total_boards_listed_or_found: 1,
+      },
+      root_board: { resolved: true, method: "single_obf", manifest_root: nil, path: nil },
+      totals: finalize_totals(aggregate).merge({ dynamic_target_boards: 0 }),
+      boards: [build_board_entry(nil, obj, board_stats, asset_stats, non_string_ids)],
+      warnings: warnings,
+    }
+  end
+
+  def build_board_entry(path, obj, board_stats, asset_stats, non_string_ids)
+    {
+      path: path,
+      id: safe_s(obj["id"]),
+      name: safe_s(obj["name"]),
+      grid: board_stats[:grid],
+      counts: {
+        buttons: board_stats[:buttons],
+        dynamic_buttons: board_stats[:dynamic_buttons],
+        actions_total: board_stats[:actions_total],
+        actions_breakdown: board_stats[:actions_breakdown],
+        vocalizations: board_stats[:vocalizations],
+        absolute_positioned_buttons: board_stats[:absolute_buttons],
+      },
+      strings_locales: board_stats[:strings_locales],
+      license_present: !!obj["license"],
+      media: {
+        images_defined: asset_stats[:images_defined],
+        images_referenced: asset_stats[:images_referenced],
+        images_inline_data: asset_stats[:images_inline],
+        images_path: asset_stats[:images_path],
+        images_url: asset_stats[:images_url],
+        images_symbol: asset_stats[:images_symbol],
+        image_content_types: asset_stats[:image_content_types].to_a.sort,
+        sounds_defined: asset_stats[:sounds_defined],
+        sounds_referenced: asset_stats[:sounds_referenced],
+        sounds_inline_data: asset_stats[:sounds_inline],
+        sounds_path: asset_stats[:sounds_path],
+        sounds_url: asset_stats[:sounds_url],
+        sound_content_types: asset_stats[:sound_content_types].to_a.sort,
+      },
+      missing_media_refs: find_missing_media_refs(obj),
+      non_string_ids_detected: non_string_ids, # true/false
+    }
+  end
+
+  # The file is neither a readable zip nor a parseable OBF document. Carries
+  # an :error so callers can tell this apart from a valid-but-empty package;
+  # the underlying exception stays in the log, never in the response.
+  def unreadable_report
+    {
+      package: { format: "unknown", zip_entries: 0, total_bytes: 0 },
       manifest: { found: false },
       root_board: { resolved: false },
       totals: empty_totals,
       boards: [],
-      warnings: ["Analyzer error: #{e.class}: #{e.message}"],
+      error: "unreadable_file",
+      warnings: ["This file could not be read as an OBF or OBZ document."],
     }
+  end
+
+  def to_bytes(file_or_bytes)
+    bytes = case file_or_bytes
+      when Pathname then File.binread(file_or_bytes.to_s)
+      when IO, StringIO then file_or_bytes.read
+      when String then file_or_bytes # treat as raw bytes
+      else file_or_bytes.to_s
+      end
+    bytes.dup.force_encoding(Encoding::BINARY)
+  end
+
+  # Local-file-header / central-directory / end-of-central-directory magic.
+  # An empty zip has no local header, so all three are worth accepting.
+  def zip_bytes?(bytes)
+    bytes.start_with?("PK\x03\x04".b, "PK\x05\x06".b, "PK\x07\x08".b)
   end
 
   # Convenience: a quick high-level count (compat with your earlier helper)
@@ -192,17 +263,7 @@ module ObzAnalyzer
   # ----------------------------------------------------------------------------
 
   def read_zip_to_hash(file_or_bytes)
-    bytes = case file_or_bytes
-      when Pathname
-        File.binread(file_or_bytes.to_s)
-      when IO, StringIO
-        file_or_bytes.read
-      when String
-        file_or_bytes # treat as raw bytes
-      else
-        file_or_bytes.to_s
-      end
-    bytes = bytes.dup.force_encoding(Encoding::BINARY)
+    bytes = to_bytes(file_or_bytes)
 
     entries = {}
     index = {} # normalized_path => original_path
@@ -489,6 +550,7 @@ module ObzAnalyzer
 
   def package_meta(entries)
     {
+      format: "obz",
       zip_entries: entries.size,
       total_bytes: entries.values.map(&:bytesize).sum,
     }

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -24,6 +24,94 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       expect(body["root_board_id"]).to be_present
     end
 
+    # A bare .obf is a single JSON board document. It used to fall through to
+    # the "unsupported format" branch, which made every .obf export in the
+    # app un-importable by the app itself.
+    context "with a bare .obf upload" do
+      let(:obf_path) { Rails.root.join("spec/data/test_internal.obf") }
+
+      def obf_upload
+        Rack::Test::UploadedFile.new(obf_path, "application/json")
+      end
+
+      # Sidekiq::Testing.fake! queues are process-global and nothing in the
+      # suite clears them between examples, so a job enqueued by a previous
+      # example would otherwise drain into this one's assertions.
+      before { ImportFromObfJob.jobs.clear }
+
+      it "accepts the file and queues the import" do
+        expect {
+          post "/api/boards/import_obf",
+               params: { file: obf_upload },
+               headers: auth_headers(user)
+        }.to change { ImportFromObfJob.jobs.size }.by(1)
+
+        expect(response).to have_http_status(:ok)
+        body = JSON.parse(response.body)
+        expect(body["status"]).to eq("ok")
+        expect(body["include_images"]).to eq(false)
+      end
+
+      it "creates the board once the queued job runs" do
+        post "/api/boards/import_obf",
+             params: { file: obf_upload },
+             headers: auth_headers(user)
+
+        expect { ImportFromObfJob.drain }.to change { user.boards.count }.by(1)
+        expect(user.boards.last.status).to eq("active")
+      end
+
+      it "passes the image opt-in through to the job" do
+        post "/api/boards/import_obf",
+             params: {
+               file: obf_upload,
+               include_images: "true",
+               image_license_acknowledged: "true",
+             },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["include_images"]).to eq(true)
+        options = ImportFromObfJob.jobs.last["args"].last
+        expect(options).to include("include_images" => true, "license_acknowledged" => true)
+      end
+
+      it "returns 400 image_license_required when include_images=true without ack" do
+        post "/api/boards/import_obf",
+             params: { file: obf_upload, include_images: "true" },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)["error"]).to eq("image_license_required")
+      end
+
+      it "returns 422 without queuing anything when the .obf is not valid JSON" do
+        garbage = Rack::Test::UploadedFile.new(
+          StringIO.new("{ not json"), "application/json",
+          original_filename: "broken.obf",
+        )
+
+        expect {
+          post "/api/boards/import_obf",
+               params: { file: garbage },
+               headers: auth_headers(user)
+        }.not_to change { ImportFromObfJob.jobs.size }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to match(/invalid obf/i)
+      end
+
+      it "returns 422 when the .obf parses but isn't a board document" do
+        array_doc = Rack::Test::UploadedFile.new(
+          StringIO.new("[1, 2, 3]"), "application/json",
+          original_filename: "array.obf",
+        )
+        post "/api/boards/import_obf",
+             params: { file: array_doc },
+             headers: auth_headers(user)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
     it "returns 422 for an unsupported extension" do
       txt = Rack::Test::UploadedFile.new(
         StringIO.new("not a board"), "text/plain",

--- a/spec/services/obz_analyzer_spec.rb
+++ b/spec/services/obz_analyzer_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe ObzAnalyzer do
+  def analyze_fixture(name)
+    described_class.analyze(File.binread(Rails.root.join("spec/data", name)))
+  end
+
+  describe ".analyze" do
+    context "with an .obz package" do
+      subject(:report) { analyze_fixture("simple.obz") }
+
+      it "reports the obz format and finds the boards inside" do
+        expect(report.dig(:package, :format)).to eq("obz")
+        expect(report[:boards].size).to eq(1)
+        expect(report.dig(:totals, :boards)).to eq(1)
+      end
+
+      it "counts the zip entries" do
+        expect(report.dig(:package, :zip_entries)).to be > 0
+        expect(report.dig(:package, :total_bytes)).to be > 0
+      end
+
+      it "carries no error" do
+        expect(report[:error]).to be_nil
+      end
+    end
+
+    # The bug this guards: a bare .obf isn't a zip, so the analyzer used to
+    # raise, get swallowed, and return a zeroed-out report that the UI read
+    # as "valid file, nothing in it".
+    context "with a bare .obf document" do
+      subject(:report) { analyze_fixture("test_internal.obf") }
+
+      it "reports the obf format" do
+        expect(report.dig(:package, :format)).to eq("obf")
+        expect(report.dig(:package, :zip_entries)).to eq(0)
+        expect(report.dig(:package, :total_bytes)).to be > 0
+      end
+
+      it "reports exactly one board with its real counts" do
+        expect(report[:boards].size).to eq(1)
+        expect(report.dig(:totals, :boards)).to eq(1)
+        expect(report.dig(:totals, :buttons)).to eq(5)
+        expect(report.dig(:totals, :images_defined)).to eq(5)
+        expect(report.dig(:totals, :sounds_defined)).to eq(5)
+      end
+
+      it "describes the board itself, not a zip path" do
+        board = report[:boards].first
+        expect(board[:path]).to be_nil
+        expect(board[:name]).to be_present
+        expect(board.dig(:counts, :buttons)).to eq(5)
+        expect(board.dig(:grid, :columns)).to eq(5)
+      end
+
+      it "resolves the single board as the root" do
+        expect(report.dig(:root_board, :resolved)).to be true
+        expect(report.dig(:root_board, :method)).to eq("single_obf")
+      end
+
+      it "reports no manifest without treating that as a failure" do
+        expect(report.dig(:manifest, :found)).to be false
+        expect(report.dig(:manifest, :total_boards_listed_or_found)).to eq(1)
+        expect(report[:error]).to be_nil
+      end
+
+      it "counts inline image data when the file bundles it" do
+        inline = analyze_fixture("lots_of_stuff.obf")
+        expect(inline.dig(:package, :format)).to eq("obf")
+        expect(inline.dig(:totals, :buttons)).to eq(5)
+      end
+    end
+
+    context "with a file that is neither" do
+      it "flags an unreadable file rather than reporting an empty package" do
+        report = described_class.analyze("this is not a board")
+
+        expect(report[:error]).to eq("unreadable_file")
+        expect(report.dig(:package, :format)).to eq("unknown")
+        expect(report[:boards]).to be_empty
+      end
+
+      it "does not leak the underlying exception to the caller" do
+        report = described_class.analyze("this is not a board")
+        expect(report[:warnings].join).not_to match(/Zip::Error|NoMethodError|backtrace/)
+      end
+
+      it "flags an empty JSON object as unreadable" do
+        expect(described_class.analyze("{}")[:error]).to eq("unreadable_file")
+      end
+
+      it "flags a valid JSON array as unreadable" do
+        expect(described_class.analyze("[1,2,3]")[:error]).to eq("unreadable_file")
+      end
+    end
+
+    context "with a zip containing no boards" do
+      it "reports no_boards_found" do
+        buffer = Zip::OutputStream.write_buffer do |zos|
+          zos.put_next_entry("readme.txt")
+          zos.write("nothing to see here")
+        end
+        report = described_class.analyze(buffer.string)
+
+        expect(report[:error]).to eq("no_boards_found")
+        expect(report.dig(:package, :format)).to eq("obz")
+      end
+    end
+  end
+
+  describe ".count_boards" do
+    it "counts a single bare .obf as one board" do
+      bytes = File.binread(Rails.root.join("spec/data/test_internal.obf"))
+      expect(described_class.count_boards(bytes)).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Exporting a board as `.obf` and importing it back failed with **422 "Unsupported file format"**. Three defects, all on this path:

1. **`import_obf` had no `.obf` file branch.** Only `.obz` uploads were handled; a `.obf` fell to the `else` → 422. The OBF importer existed but only ran on the JSON `data` param, which the frontend never uses. Since `download_obf` emits a bare `.obf`, nothing exported from SpeakAnyWay could be imported back into it.
2. **`ObzAnalyzer` read every upload as a zip.** A `.obf` raised `Zip::Error` internally, got swallowed by the blanket `rescue`, and returned an all-zero report with **HTTP 200** — which the import screen renders as *"Looks good — we found everything we need."* Step 1 said fine, step 2 hard-failed.
3. **Latent 500:** passing `board_group_id` alongside `data` called `merge` on an ActiveRecord model. The board group was already passed to the job separately, so the line was dead — removed.

## Changes

- `import_obf` accepts `.obf`, parses it, and enqueues `ImportFromObfJob`. A malformed `.obf` returns 422 at the controller rather than enqueuing a job that fails out of sight.
- `ObzAnalyzer.analyze` detects the container **from the bytes** (`PK` magic), not the filename, and reports `package.format` (`obz`/`obf`/`unknown`). A bare `.obf` gets a real single-board report sharing the same per-board and totals machinery as the OBZ path.
- Reports the analyzer could not produce now carry an `error` (`unreadable_file` / `no_boards_found`). **Absence of `error` is the only signal a caller may treat as "this file is good"** — a zeroed report is otherwise indistinguishable from a valid empty package. The exception detail stays in the log, not the response.

Frontend counterpart: https://github.com/brittanyjohns/itty-bitty-frontend/pull/602 (consumes `package.format` and `error`). The backend is backward-compatible — an older frontend just ignores the new fields.

## Test plan

- `spec/services/obz_analyzer_spec.rb` (new, 15 examples): obz unchanged, bare `.obf` reports one board with real counts, garbage/`{}`/JSON-array → `unreadable_file`, board-less zip → `no_boards_found`, no exception detail leaked.
- `spec/requests/api/boards/import_export_spec.rb`: `.obf` queues the job, drains to a real board, carries the image opt-in through, 400 without the license ack, 422 for malformed and non-object `.obf`.
- `bundle exec rspec spec/models/obz_importer_spec.rb spec/requests/api/boards spec/services/obz_analyzer_spec.rb spec/sidekiq/` → **305 examples, 0 failures**.
- Verified against the real file that triggered this report: analyze → `format=obf, error=nil, boards=1, buttons=36`; import → `200 ok`; job drain → board "zoo animals", status `active`, **36 tiles**.

### Note for reviewers
The new `.obf` context clears `ImportFromObfJob.jobs` in a `before` hook. `Sidekiq::Testing.fake!` queues are process-global and nothing in the suite clears them between examples, so a job enqueued by a previous example drains into a later one's assertions. Worth fixing suite-wide separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)