### PR TITLE
fix(billing): recreate a stale Stripe customer instead of blocking checkout

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -392,6 +392,14 @@ demo/myspeak signups keep using `sign_up`. Key invariants:
   → 400 generic message. Requires a saved Customer-portal default config in
   the Stripe dashboard (test + live) — see `docs/stripe-setup.md` §4b.
   Optional `STRIPE_PORTAL_CONFIG_ID` pins a dedicated config.
+- **A stored `stripe_customer_id` is verified, not trusted.**
+  `ensure_stripe_customer!` retrieves the customer and recreates it when Stripe
+  answers `resource_missing` or `deleted` — a customer removed from the
+  dashboard (or left over from a different account/key) otherwise 400s *every*
+  billing call with "No such customer", permanently locking that account out of
+  upgrading with no self-service recovery. The check **fails open**: any other
+  Stripe error keeps the stored id, since dropping a valid one would orphan the
+  account from its live subscription and billing history.
 
 ### Social sign-in — Google (Phase 1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — upgrading from Free
+
+- **An account whose Stripe customer had been deleted could no longer upgrade
+  to any plan.** Checkout trusted the stored customer id, so Stripe rejected
+  every session with "No such customer" and the pricing page showed only
+  "There was an error choosing your plan. Please try again." — with no way for
+  the user to recover. The customer is now verified before use and recreated if
+  it is gone. A Stripe outage or network blip leaves the stored id untouched.
+
 ### Fixed — importing a `.obf` file
 - **Uploading a `.obf` file now imports.** `POST /api/boards/import_obf`
   only handled `.obz` uploads; a `.obf` fell through to

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -678,10 +678,41 @@ class User < ApplicationRecord
   # Lazily create the Stripe customer on first billing touch. Mobile signups
   # and legacy accounts have no customer until they hit checkout or the
   # billing portal.
+  #
+  # A stored id is verified, not trusted: if the customer was deleted in the
+  # Stripe dashboard (or the row predates an account/key change) every billing
+  # call 400s on "No such customer" with no way out — the user is permanently
+  # unable to upgrade. Re-create in that case so the path self-heals.
   def ensure_stripe_customer!
-    return stripe_customer_id if stripe_customer_id.present?
+    return stripe_customer_id if stripe_customer_id.present? && stripe_customer_live?
     update!(stripe_customer_id: User.create_stripe_customer(email))
     stripe_customer_id
+  end
+
+  # True when `stripe_customer_id` resolves to a real, non-deleted customer on
+  # the current Stripe key.
+  #
+  # Fails OPEN: only Stripe telling us the customer is gone (`resource_missing`
+  # / `deleted`) invalidates the id. A network blip, auth error, or outage
+  # returns true so we keep the stored id — dropping it would orphan the
+  # account from its subscription and billing history.
+  def stripe_customer_live?
+    customer = Stripe::Customer.retrieve(stripe_customer_id)
+    return true unless customer.respond_to?(:deleted) && customer.deleted
+
+    Rails.logger.warn "[Billing] stripe customer #{stripe_customer_id} is deleted for user=#{id}; recreating"
+    false
+  rescue Stripe::InvalidRequestError => e
+    if e.code.to_s == "resource_missing"
+      Rails.logger.warn "[Billing] stripe customer #{stripe_customer_id} missing for user=#{id}; recreating"
+      return false
+    end
+    raise
+  rescue Stripe::StripeError => e
+    # Transient/unrelated Stripe failure — keep the id and let the caller's own
+    # error handling deal with whatever happens next.
+    Rails.logger.error "[Billing] could not verify stripe customer for user=#{id}: #{e.class} - #{e.message}"
+    true
   end
 
   # Create a no-card Stripe trial subscription on the Partner Pro price so the

--- a/spec/models/user_stripe_customer_spec.rb
+++ b/spec/models/user_stripe_customer_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+# `User#ensure_stripe_customer!` is the single funnel every billing touch goes
+# through (checkout, top-ups, licenses, billing portal, plan changes). A stored
+# `stripe_customer_id` that no longer resolves on the current Stripe key used to
+# be handed straight to Stripe, which 400s with "No such customer" — permanently
+# locking that account out of upgrading, with no self-service way back.
+RSpec.describe User, "#ensure_stripe_customer!" do
+  let(:user) { FactoryBot.create(:user, stripe_customer_id: "cus_existing") }
+
+  def resource_missing_error
+    Stripe::InvalidRequestError.new(
+      "No such customer: 'cus_existing'",
+      "customer",
+      code: "resource_missing",
+    )
+  end
+
+  it "keeps a customer id that still resolves on Stripe" do
+    allow(Stripe::Customer).to receive(:retrieve)
+      .with("cus_existing")
+      .and_return(OpenStruct.new(id: "cus_existing"))
+    expect(Stripe::Customer).not_to receive(:create)
+
+    expect(user.ensure_stripe_customer!).to eq("cus_existing")
+    expect(user.reload.stripe_customer_id).to eq("cus_existing")
+  end
+
+  it "creates a customer when the user has none yet" do
+    user.update!(stripe_customer_id: nil)
+    expect(Stripe::Customer).not_to receive(:retrieve)
+    expect(Stripe::Customer).to receive(:create)
+      .with({ email: user.email })
+      .and_return(OpenStruct.new(id: "cus_brand_new"))
+
+    expect(user.ensure_stripe_customer!).to eq("cus_brand_new")
+    expect(user.reload.stripe_customer_id).to eq("cus_brand_new")
+  end
+
+  it "recreates the customer when Stripe reports it missing" do
+    allow(Stripe::Customer).to receive(:retrieve).and_raise(resource_missing_error)
+    expect(Stripe::Customer).to receive(:create)
+      .with({ email: user.email })
+      .and_return(OpenStruct.new(id: "cus_healed"))
+
+    expect(user.ensure_stripe_customer!).to eq("cus_healed")
+    expect(user.reload.stripe_customer_id).to eq("cus_healed")
+  end
+
+  it "recreates the customer when Stripe reports it deleted" do
+    allow(Stripe::Customer).to receive(:retrieve)
+      .and_return(OpenStruct.new(id: "cus_existing", deleted: true))
+    expect(Stripe::Customer).to receive(:create).and_return(OpenStruct.new(id: "cus_healed"))
+
+    expect(user.ensure_stripe_customer!).to eq("cus_healed")
+  end
+
+  # Fail open. Dropping a valid id on a Stripe blip would orphan the account
+  # from its live subscription and billing history — far worse than the 400 the
+  # caller is about to surface anyway.
+  it "keeps the stored id when Stripe cannot be reached" do
+    allow(Stripe::Customer).to receive(:retrieve)
+      .and_raise(Stripe::APIConnectionError.new("network down"))
+    expect(Stripe::Customer).not_to receive(:create)
+
+    expect(user.ensure_stripe_customer!).to eq("cus_existing")
+    expect(user.reload.stripe_customer_id).to eq("cus_existing")
+  end
+
+  it "keeps the stored id when Stripe rejects the request for an unrelated reason" do
+    allow(Stripe::Customer).to receive(:retrieve)
+      .and_raise(Stripe::AuthenticationError.new("bad key"))
+    expect(Stripe::Customer).not_to receive(:create)
+
+    expect(user.ensure_stripe_customer!).to eq("cus_existing")
+  end
+end

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -76,6 +76,37 @@ RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :reque
       expect(user.reload.stripe_customer_id).to eq("cus_new_123")
     end
 
+    # Production, 2026-08-03: a Free account could not upgrade to ANY plan.
+    # Its stored customer no longer existed on the live Stripe key, so every
+    # checkout 400'd on "No such customer" — with no way for the user to
+    # recover. Verify the stale id instead of trusting it.
+    it "recreates a stale Stripe customer instead of 400ing the checkout" do
+      user.update!(stripe_customer_id: "cus_deleted_in_dashboard")
+
+      allow(Stripe::Customer).to receive(:retrieve).and_raise(
+        Stripe::InvalidRequestError.new(
+          "No such customer: 'cus_deleted_in_dashboard'",
+          "customer",
+          code: "resource_missing",
+        ),
+      )
+      expect(Stripe::Customer).to receive(:create)
+        .with({ email: user.email })
+        .and_return(OpenStruct.new(id: "cus_healed_456"))
+
+      captured = nil
+      expect(Stripe::Checkout::Session).to receive(:create) do |params|
+        captured = params
+        OpenStruct.new(url: "https://checkout.stripe.com/c/pay/cs_test_healed")
+      end
+
+      do_post.call({ plan_key: "basic" })
+
+      expect(response).to have_http_status(:ok)
+      expect(captured[:customer]).to eq("cus_healed_456")
+      expect(user.reload.stripe_customer_id).to eq("cus_healed_456")
+    end
+
     it "records paid_plan_type on the user after creating the session" do
       user.update!(stripe_customer_id: "cus_existing")
       allow(Stripe::Checkout::Session).to receive(:create).and_return(OpenStruct.new(url: "https://stripe.test/x"))


### PR DESCRIPTION
## The bug

Production, 2026-08-03: a Free account could not upgrade to **any** plan. The pricing page showed only "There was an error choosing your plan. Please try again."

Prod web log:

```
ERROR -- : Error creating checkout session: Stripe::InvalidRequestError - No such customer: 'cus_RsSS...'
POST /api/stripe/checkout_sessions ... status=400
```

`User#ensure_stripe_customer!` checked only *presence*, never validity:

```ruby
return stripe_customer_id if stripe_customer_id.present?
```

So a customer that had been deleted from the Stripe dashboard (or created under a different account/key) went straight to `Stripe::Checkout::Session.create`, Stripe rejected it, and the controller's blanket `rescue StandardError` flattened it into a generic 400. **There was no recovery path** — that account could never check out again, on any plan, until the column was cleared by hand.

## Blast radius

Journald reaches back to 2026-05-17. Across that window:

| Failure | Count |
|---|---|
| `No such customer` | 3 — all today, one customer id |
| promo "minimum amount requirement" | 12 — already fixed by #548 |

One stale customer, not a Stripe-key-wide problem. But the bug class silently and permanently locks out any user whose Stripe customer is deleted.

## The fix

`ensure_stripe_customer!` now verifies the stored id and recreates the customer when Stripe answers `resource_missing` or `deleted`. One `Stripe::Customer.retrieve` per billing touch, covering all call sites (checkout, top-up, license, billing portal, plan changes) with no restructuring.

**It fails open by design.** Only Stripe explicitly saying the customer is gone invalidates the id — a network blip, outage, or auth error keeps it. Dropping a *valid* id would orphan the account from its live subscription and billing history, which is far worse than the error the caller was about to surface anyway.

## Test plan

New `spec/models/user_stripe_customer_spec.rb` (6 cases: valid id kept, blank id created, missing → recreated, deleted → recreated, connection error → kept, auth error → kept) plus a request spec reproducing the exact production symptom end-to-end.

Verified the tests are not vacuous — reverting `user.rb` to `HEAD` fails exactly the 3 healing tests:

```
41 examples, 3 failures   ← pre-fix
41 examples, 0 failures   ← with fix
```

Full billing surface (user models, checkout sessions, subscriptions, teams): **233 examples, 0 failures.**

## Notes for the reviewer

- **This does not unblock the affected account on its own** — the fix only takes effect on the *next* checkout attempt after deploy, which is exactly when it heals. No data migration needed.
- Still unconfirmed: whether that customer was deleted from the Stripe dashboard or prod's `STRIPE_SECRET_KEY` moved accounts. Three hits across three months of logs, all one id, points at "deleted." If the key did move, more accounts are silently stale and a sweep task would be worth adding.
- Deliberately **out of scope**: replacing the blanket `rescue StandardError` in `checkout_sessions#create` with typed rescues and a distinct error code. It is why this took a log dig rather than showing up in the API response — worth doing, but a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)