### PR TITLE
fix(export): bundle display-size tile images in the .obz package

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -343,7 +343,34 @@ Board Set) create a `BoardExport` and run `ExportBoardPackageJob` async;
   entirely on `ExportScope` to keep the package bounded.
   `Boards::ObzPackager::MAX_BYTES` (200MB) is a second, independent cap on
   total package size, since a small number of boards can still carry large
-  images.
+  images. It is a backstop, not the working constraint — display-size
+  bundling (below) is what keeps a realistic tree an order of magnitude under
+  it. Hitting it again means variant resolution stopped working; raising it
+  would trade an explicit, actionable failure for an OOM in Sidekiq.
+- **Both bundling modes ship display-size bytes, never originals.** `:inline`
+  and `:package` each resolve `Doc#tile_variant` (288px webp, q65 — see
+  `ApplicationRecord::TILE_VARIANT_TRANSFORMATIONS`) and fall back to the
+  original only when there is no usable variant (non-variable blobs like SVG,
+  or a processing failure). Originals routinely run 30-50x the variant, which
+  is enough on its own to blow both size caps: a single board's 23-board
+  predictive tree measured **665MB of originals against ~25MB of variants**.
+  Two rails hold this together:
+  - **The rendition, its path extension, and its `content_type` are decided
+    together**, in `ObfExporter#package_source_for`, and the chosen variant
+    rides along on `ObfExporter::Asset#variant`. `ObzPackager#read_asset_bytes`
+    downloads exactly that and must never re-decide — the board's `.obf` entry
+    has already declared the path as `.webp`, so a packager that
+    independently reads the original yields a manifest promising webp while
+    carrying PNG bytes.
+  - **The two modes make opposite calls on *unprocessed* variants, on
+    purpose.** `:inline` uses an already-processed variant only, because
+    `#processed` would transcode inside the Puma worker once per tile.
+    `:package` is only ever reached from `ExportBoardPackageJob`, so it calls
+    `#processed` and transcodes — there, it is ordinary background work. That
+    difference is load-bearing rather than cosmetic: unprocessed docs falling
+    back to originals dominated the total on a real board (86MB with
+    fallbacks vs ~25MB fully variant-backed), i.e. skipping them would leave
+    `MAX_BYTES` reachable.
 - **`asset_mode: :inline` (the synchronous `GET /download_obf` path) has its
   own, separate caps.** `ObfExporter::MAX_INLINE_TILES` (200) is checked
   against the board's tile count up front, before any work starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — exporting a large board as `.obz`
+
+- **Exporting a board with many linked boards no longer fails with "Package
+  exceeds the 200MB limit."** The `.obz` package bundled full-resolution
+  original images, so an ordinary board's predictive-link tree ran to
+  hundreds of megabytes and hit the size cap before finishing — one real
+  board's 23-board tree carried 665MB of originals. Packages now bundle the
+  same display-size tile images the app itself renders (288px webp), which
+  brings that board to roughly 25MB. Exported images are described as `webp`
+  in the package manifest and re-import cleanly.
+
 ### Fixed — importing a `.obf` file
 - **Uploading a `.obf` file now imports.** `POST /api/boards/import_obf`
   only handled `.obz` uploads; a `.obf` fell through to

--- a/app/services/boards/obf_exporter.rb
+++ b/app/services/boards/obf_exporter.rb
@@ -52,7 +52,13 @@ module Boards
       "image/webp" => "webp",
     }.freeze
 
-    Asset  = Struct.new(:kind, :id, :path, :doc)
+    # `variant` is the resolved display-size variant whose bytes back this
+    # asset, or nil to mean "download the original". It exists because the
+    # `path` extension and the OBF entry's `content_type` are decided HERE
+    # while the bytes are downloaded later, in ObzPackager#read_asset_bytes.
+    # Letting the packager re-decide independently is how a manifest ends up
+    # promising `images/12.webp` while carrying the original's PNG bytes.
+    Asset  = Struct.new(:kind, :id, :path, :doc, :variant)
     Result = Struct.new(:obf, :assets, :skipped_assets, :attribution)
 
     def initialize(board, exporting_user:, asset_mode: :url, board_paths: {})
@@ -148,8 +154,6 @@ module Boards
     def attach_asset(tile, doc)
       return tile.to_obf_image_format(exporting_user) unless doc.image.attached?
 
-      path = "images/#{doc.id}.#{asset_extension(doc)}"
-
       if asset_mode == :inline
         # Two tiles can point at the same doc (the same symbol used twice on a
         # board, or a shared Image resolving to one doc for both). :package
@@ -175,8 +179,11 @@ module Boards
                                                         data: cached[:data], content_type: cached[:content_type])
       end
 
-      assets << Asset.new(:image, doc.id.to_s, path, doc)
-      tile.to_obf_image_format(exporting_user, mode: :package, path: path, content_type: doc.image.content_type)
+      variant, content_type, extension = package_source_for(doc)
+      path = "images/#{doc.id}.#{extension}"
+
+      assets << Asset.new(:image, doc.id.to_s, path, doc, variant)
+      tile.to_obf_image_format(exporting_user, mode: :package, path: path, content_type: content_type)
     rescue TooLarge
       raise
     rescue StandardError => e
@@ -195,14 +202,16 @@ module Boards
     # displays — over the full-resolution original. An original is routinely
     # 30-50x the variant's size, so bundling originals meant an ordinary board
     # blew MAX_INLINE_BYTES and had no working sync export at all. A single
-    # .obf is a display-fidelity artifact; the async .obz path (asset_mode:
-    # :package) is the one that still carries originals.
+    # .obf is a display-fidelity artifact. So is the async .obz — both bundle
+    # display-size bytes; see #package_source_for.
     #
     # Only an ALREADY-PROCESSED variant is used. Calling #processed on an
     # unprocessed variant would transcode it right here inside the Puma
     # worker, once per tile — exactly the kind of in-request work the caps
     # exist to prevent. Unprocessed (and non-variable blobs, e.g. SVG) fall
-    # back to the original, which is correct if larger.
+    # back to the original, which is correct if larger. #package_source_for
+    # makes the opposite call for the same reason inverted: it runs in
+    # Sidekiq, where transcoding is just background work.
     def inline_bytes_for(doc)
       variant = doc.tile_variant if doc.tile_variant_processed?
       if variant
@@ -217,6 +226,33 @@ module Boards
       # degrades the tile to a url reference.
       Rails.logger.warn "[ObfExporter] tile variant unreadable for doc #{doc.id}: #{e.class}: #{e.message}"
       [doc.image.download, doc.image.content_type]
+    end
+
+    # The display-size source :package bundles: the resolved variant (or nil
+    # for "use the original"), plus the content_type and path extension that
+    # describe THOSE bytes. Returned together precisely so the three can never
+    # disagree.
+    #
+    # Unlike #inline_bytes_for, this calls #processed on an UNPROCESSED
+    # variant, transcoding it here. That inversion is deliberate and safe:
+    # :package is only ever reached from ExportBoardPackageJob, a Sidekiq
+    # worker, where the in-request work that MAX_INLINE_* exists to keep out
+    # of a Puma worker is simply background work. Skipping unprocessed
+    # variants instead would leave the originals in the package, and on a real
+    # board those fallbacks dominate the total (665MB of originals vs 86MB
+    # with fallbacks vs ~25MB fully variant-backed) — i.e. it would leave the
+    # size cap reachable, which is the bug this path is fixing.
+    #
+    # Non-variable blobs (SVG) and any processing failure fall back to the
+    # original, which stays correct — just larger.
+    def package_source_for(doc)
+      variant = doc.tile_variant
+      return [nil, doc.image.content_type, asset_extension(doc)] unless variant
+
+      [variant.processed, variant_content_type, Doc::TILE_VARIANT_TRANSFORMATIONS.fetch(:format).to_s]
+    rescue StandardError => e
+      Rails.logger.warn "[ObfExporter] tile variant unusable for doc #{doc.id}: #{e.class}: #{e.message}"
+      [nil, doc.image.content_type, asset_extension(doc)]
     end
 
     # Derived from the transformation Doc#tile_variant actually applies rather

--- a/app/services/boards/obz_packager.rb
+++ b/app/services/boards/obz_packager.rb
@@ -15,6 +15,13 @@ module Boards
     # Belt to ExportScope::MAX_BOARDS' braces: a small number of boards can
     # still carry very large images. Fails with an explicit error rather than
     # letting the job die on memory or the upload time out.
+    #
+    # This is a backstop, not the working constraint. Packages bundle
+    # display-size tile variants (ObfExporter#package_source_for), which is
+    # what keeps a realistic tree well under it — a 23-board export measured
+    # 665MB of originals against ~25MB of variants. Reaching this cap again
+    # means variant resolution stopped working, not that the cap is too low;
+    # raising it would trade an explicit failure for an OOM in Sidekiq.
     MAX_BYTES = 200 * 1024 * 1024
 
     Result = Struct.new(:bytes, :summary)
@@ -114,9 +121,16 @@ module Boards
     # writing any board .obf entry — a bigger restructure than this rare
     # failure mode warrants; the dangling reference is surfaced instead, via
     # packaging_failures / README.txt, so it's visible rather than silent.
+    # Downloads exactly the bytes ObfExporter's Asset promised — the resolved
+    # display-size variant when there is one, the original otherwise. This
+    # must never re-decide which rendition to read: the board's .obf entry has
+    # already declared this asset's path extension and content_type from the
+    # exporter's choice.
     def read_asset_bytes(asset)
       if asset.kind == :sound
         asset.doc.download
+      elsif asset.variant
+        asset.variant.download
       else
         asset.doc.image.download
       end

--- a/spec/services/boards/obf_exporter_spec.rb
+++ b/spec/services/boards/obf_exporter_spec.rb
@@ -53,12 +53,18 @@ RSpec.describe Boards::ObfExporter do
     end
 
     # Doc#extension reads original_image_url, which is nil for user uploads.
-    # The zip path must come from the blob or it ends in a bare dot.
-    it "derives the asset extension from the attached blob" do
+    # The zip path must come from the blob or it ends in a bare dot. Only
+    # reachable now when there's no usable variant, since a variant-backed
+    # asset takes its extension from the variant format instead.
+    it "derives the asset extension from the attached blob when there is no usable variant" do
       add_tile("grandma")
+      allow_any_instance_of(Doc).to receive(:tile_variant).and_return(nil)
+
       result = described_class.new(board.reload, exporting_user: user, asset_mode: :package).call
 
       expect(result.assets.first.path).to match(%r{\Aimages/\d+\.png\z})
+      expect(result.assets.first.variant).to be_nil
+      expect(result.obf["images"].first[:content_type]).to eq("image/png")
     end
 
     it "records an attribution entry for a bundled CC BY asset" do
@@ -266,6 +272,64 @@ RSpec.describe Boards::ObfExporter do
     # fallback also fell back to a per-tile query, so the bound would have
     # scaled to roughly 2 * tile_count instead of tile_count + 2.
     expect(audio_query_count).to be <= tile_count + 2
+  end
+
+  # Board 5776's export failed at ObzPackager's 200MB cap: the package path
+  # bundled full-resolution originals (665MB across its 23-board tree, vs
+  # ~25MB of display-size variants). :package now resolves the same
+  # display-size rendition :inline does.
+  describe "display-size bundling (asset_mode: :package)" do
+    it "bundles the webp tile variant, and describes it as webp everywhere" do
+      add_tile("grandma")
+
+      result = described_class.new(board.reload, exporting_user: user, asset_mode: :package).call
+      asset = result.assets.first
+
+      expect(asset.path).to match(%r{\Aimages/\d+\.webp\z})
+      expect(asset.variant).to be_present
+      expect(result.obf["images"].first[:content_type]).to eq("image/webp")
+      expect(result.obf["images"].first[:path]).to eq(asset.path)
+    end
+
+    # The variant bytes are what actually shrink the package. Asserting the
+    # asset carries a variant is not enough — a variant that resolves to the
+    # original's bytes would pass that and still blow the cap.
+    it "carries bytes materially smaller than the original" do
+      add_tile("grandma")
+
+      result = described_class.new(board.reload, exporting_user: user, asset_mode: :package).call
+      asset = result.assets.first
+
+      expect(asset.variant.download.bytesize).to be < asset.doc.image.download.bytesize
+    end
+
+    # The inverse of #inline_bytes_for's rule. :package runs in Sidekiq, so
+    # transcoding an unprocessed variant here is background work — and it is
+    # what keeps unprocessed docs from silently reintroducing originals.
+    it "processes an unprocessed variant rather than falling back to the original" do
+      add_tile("grandma")
+      doc = board.reload.board_images.first.export_doc(user)
+      expect(doc.tile_variant_processed?).to be(false)
+
+      result = described_class.new(board.reload, exporting_user: user, asset_mode: :package).call
+
+      expect(result.assets.first.path).to end_with(".webp")
+      expect(doc.reload.tile_variant_processed?).to be(true)
+    end
+
+    it "falls back to the original when variant processing fails" do
+      add_tile("grandma")
+      allow_any_instance_of(ActiveStorage::Variant).to receive(:processed).and_raise(StandardError, "vips exploded")
+      allow_any_instance_of(ActiveStorage::VariantWithRecord).to receive(:processed)
+        .and_raise(StandardError, "vips exploded")
+
+      result = described_class.new(board.reload, exporting_user: user, asset_mode: :package).call
+      asset = result.assets.first
+
+      expect(asset.variant).to be_nil
+      expect(asset.path).to end_with(".png")
+      expect(result.obf["images"].first[:content_type]).to eq("image/png")
+    end
   end
 
   describe "sound bundling (asset_mode: :package)" do

--- a/spec/services/boards/obz_packager_spec.rb
+++ b/spec/services/boards/obz_packager_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Boards::ObzPackager do
     board.reload
   end
 
+  # Every blob whose bytes could back this doc's zip entry: the original AND
+  # the display-size variant the packager actually downloads
+  # (ObfExporter#package_source_for). A test simulating an unreadable asset
+  # must break the rendition that is really read, or it silently stops
+  # simulating anything — which is exactly what happened when :package moved
+  # off originals.
+  def asset_blob_ids(doc)
+    ids = [doc.image.blob.id]
+    variant = doc.tile_variant
+    processed = variant&.processed
+    ids << processed.image.blob.id if processed.respond_to?(:image)
+    ids
+  end
+
   before do
     allow_any_instance_of(BoardImage).to receive(:tile_image_url).and_return("https://example.test/i.png")
     allow_any_instance_of(BoardImage).to receive(:audio_url).and_return(nil)
@@ -52,6 +66,33 @@ RSpec.describe Boards::ObzPackager do
     files = entries_in(described_class.new(scope, exporting_user: user).call.bytes)
 
     expect(files.keys).to include("boards/#{a.id}.obf", "boards/#{b.id}.obf")
+  end
+
+  # The packager downloads bytes for an asset whose path/content_type were
+  # decided upstream in ObfExporter. If it re-decides which rendition to read,
+  # the zip ends up promising webp and carrying PNG — so assert the entry the
+  # manifest names actually holds the smaller variant bytes.
+  it "writes the display-size variant bytes under the path the manifest names" do
+    board = board_with_tile("Root")
+    doc = board.board_images.first.export_doc(user)
+    original_size = doc.image.download.bytesize
+    scope = Boards::ExportScope::Result.new([board], board, [])
+
+    result = described_class.new(scope, exporting_user: user).call
+    files = entries_in(result.bytes)
+
+    manifest = JSON.parse(files["manifest.json"])
+    path = manifest["paths"]["images"][doc.id.to_s]
+
+    expect(path).to end_with(".webp")
+    expect(files).to have_key(path)
+    expect(files[path].bytesize).to be < original_size
+    # RIFF....WEBP — the bytes are genuinely webp, not the original renamed.
+    expect(files[path][0, 4]).to eq("RIFF")
+
+    obf = JSON.parse(files["boards/#{board.id}.obf"])
+    expect(obf["images"].first["path"]).to eq(path)
+    expect(obf["images"].first["content_type"]).to eq("image/webp")
   end
 
   it "refuses to build a package over the size cap" do
@@ -100,10 +141,10 @@ RSpec.describe Boards::ObzPackager do
     # reference the identical asset path.
     board_b.board_images.first.update!(image_id: board_a.board_images.first.image_id)
 
-    broken_blob_id = shared_doc.image.blob.id
+    broken_blob_ids = asset_blob_ids(shared_doc)
     read_attempts = 0
     allow_any_instance_of(ActiveStorage::Blob).to receive(:download).and_wrap_original do |original, *args, &block|
-      if original.receiver.id == broken_blob_id
+      if broken_blob_ids.include?(original.receiver.id)
         read_attempts += 1
         raise StandardError, "S3 unavailable"
       end
@@ -162,10 +203,10 @@ RSpec.describe Boards::ObzPackager do
     healthy_board = board_with_tile("Healthy")
     broken_doc = broken_board.board_images.first.export_doc(user)
     broken_doc_id = broken_doc.id
-    broken_blob_id = broken_doc.image.blob.id
+    broken_blob_ids = asset_blob_ids(broken_doc)
 
     allow_any_instance_of(ActiveStorage::Blob).to receive(:download).and_wrap_original do |original, *args, &block|
-      raise StandardError, "S3 unavailable" if original.receiver.id == broken_blob_id
+      raise StandardError, "S3 unavailable" if broken_blob_ids.include?(original.receiver.id)
 
       original.call(*args, &block)
     end
@@ -210,7 +251,7 @@ RSpec.describe Boards::ObzPackager do
     files = entries_in(described_class.new(scope, exporting_user: user).call.bytes)
 
     image_entries = files.keys.select { |k| k.start_with?("images/") }
-    expect(image_entries).to eq(["images/#{doc.id}.png"])
+    expect(image_entries).to eq(["images/#{doc.id}.webp"])
   end
 
   # Attaches audio_files (has_many_attached, on Image) BEFORE doc.image


### PR DESCRIPTION
## Summary

Board 5776's export failed in production. Root cause: the `.obz` package bundled full-resolution originals, and the board legitimately exceeds the 200MB cap.

From prod Sidekiq (`itty-bitty-boards-sidekiq.service`, 2026-08-03 15:05:51 UTC, `BoardExport` id 2):

```
[ExportBoardPackageJob] Package exceeds the 200MB limit
```

Not transient, and not a corrupt asset. Measured on production (read-only):

| | |
|---|---|
| Boards in scope (root + predictive tree, depth ≤6) | 23 |
| Unique image docs | 1,064 |
| **Originals** | **665.2 MB** (avg 640 KB; largest 3.77 MB) — 3.3× the cap |
| Same set as 288px webp tile variants | 85.9 MB |
| Fully variant-backed (missing variants processed) | ~25 MB |

It aborts about a third of the way through `write_assets`.

This is the same arithmetic #558 fixed for the synchronous `.obf` path — originals run 30–50× the variant, so ordinary boards blow the cap. That fix was deliberately scoped to `asset_mode: :inline`, and `obf_exporter.rb` stated "the async .obz path is the one that still carries originals." Board 5776 is the case showing that split doesn't hold: the async path has the same problem with a larger constant.

## What changed

- **`ObfExporter#package_source_for`** resolves the display-size rendition for `:package`, returning the variant, its `content_type`, and its path extension **together** so the three can't disagree. The chosen variant rides on `Asset#variant`.
- **`ObzPackager#read_asset_bytes`** downloads exactly that, and no longer independently picks a rendition. This coupling is the point: the path extension and `content_type` are decided in the exporter while the bytes are downloaded in the packager, so a packager that re-decides yields a manifest promising `images/12.webp` while carrying the original's PNG bytes.
- **`MAX_BYTES` stays at 200MB**, redocumented as a backstop rather than the working constraint. Raising it would trade an explicit, actionable failure for an OOM in Sidekiq on the shared box.

### One deliberate asymmetry

`:package` calls `#processed` on an *unprocessed* variant; `:inline` never does. That inversion is intentional and documented at both sites: `:package` is only ever reached from `ExportBoardPackageJob`, so transcoding there is ordinary background work, not the in-request work `MAX_INLINE_*` exists to keep out of a Puma worker.

It's also load-bearing. 104 of the 1,064 docs had no processed variant, and those fallbacks to originals were the *majority* of the remaining 86MB — skipping them would leave the cap reachable.

Non-variable blobs (SVG) and any processing failure still fall back to the original, which stays correct, just larger.

## Reviewer notes

- **`ObzImporter` already infers `image/webp`** from a `.webp` path, so `obz_round_trip_spec.rb` — the contract between packager and importer — holds unchanged.
- **Three existing packager specs were silently testing nothing.** They simulated an unreadable asset by stubbing `ActiveStorage::Blob#download` for the *original* blob's id. Since the packager now reads the variant's blob, those stubs stopped simulating anything and passed vacuously. They're repointed at the rendition actually read via a new `asset_blob_ids` helper. The resilience behavior itself is unchanged — the rescue in `read_asset_bytes` covers both sources.
- **This is a format change to `.obz`**, treated as the bug fix rather than flagged as a product decision: 288px webp is right for OBF/OBZ interchange (other AAC apps render tiles small) and matches what the sync `.obf` path already exports. The stale "obz carries originals" comments are retired explicitly rather than left to drift.

## Test plan

`bundle exec rspec` over the export/import surface — **115 examples, 0 failures**:

`obf_exporter` · `obz_packager` · `obz_round_trip` · `export_scope` · `asset_rendering` · `board_exports` (request) · `boards/import_export` (request) · `obz_importer`

New coverage:

- package mode bundles the webp variant and describes it as webp in the path, the OBF entry's `content_type`, and the manifest
- the bundled bytes are materially smaller than the original — a variant resolving back to the original's bytes would pass a "has a variant" assertion and still blow the cap
- an unprocessed variant is processed rather than falling back to the original
- variant processing failure falls back to the original, with `.png` / `image/png` described consistently
- no-usable-variant falls back to the blob extension (the pre-existing case, now only reachable via that path)
- packager-side: the entry the manifest names holds the variant bytes, asserting the `RIFF` magic so a renamed original can't pass

Docs: `.claude-notes/boards-and-teams.md` gains the display-size invariant and the two rails that keep it correct; `CHANGELOG.md` gets a user-facing entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)