### PR TITLE
fix(boards): reset published flag when cloning a board

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1158,6 +1158,7 @@ class Board < ApplicationRecord
     @cloned_board.user_id = cloned_user_id
     @cloned_board.name = new_name
     @cloned_board.predefined = false
+    @cloned_board.published = false
     @cloned_board.obf_id = nil
     @cloned_board.generated_token = nil
     @cloned_board.generated_token_expires_at = nil

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe Board, type: :model do
       expect(cloned.predefined).to be false
     end
 
+    it "does not mark the clone as published" do
+      board.update!(published: true)
+      cloned = board.clone_with_images(user.id)
+      expect(cloned.published).to be false
+    end
+
     it "copies board images to the new board" do
       cloned = board.clone_with_images(user.id)
       expect(cloned.board_images.count).to eq(board.board_images.count)


### PR DESCRIPTION
## Summary
- `Board#clone_with_images` already reset `predefined` to `false` on the cloned board but never reset `published`, so `dup` copied the source board's `published` state verbatim — cloning a published board produced an already-published clone.
- Now resets `@cloned_board.published = false` alongside the existing `predefined` reset, so every clone starts unpublished and not predefined.

## Test plan
- Added `does not mark the clone as published` spec to `spec/models/board_spec.rb`.
- Ran `bundle exec rspec spec/models/board_spec.rb -e "clone_with_images"` — 10 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)