### PR TITLE
feat(users): mark internal/test accounts explicitly, not just by email pattern

### DIFF
--- a/.claude-notes/marketing-integrations.md
+++ b/.claude-notes/marketing-integrations.md
@@ -160,9 +160,25 @@ GitHub build). Two distinct uses:
     only when `MAILCHIMP_JOURNEYS_ENABLED=true`. CRM sync is **not** gated.
   - **Demo/internal accounts get no journey email.** `MailchimpEventJob`'s
     `"journey"` branch — the single choke point every journey trigger passes
-    through — returns early for `user.demo_user?` (`bhannajohns+*` /
-    `@speakanyway.com`), so demo traffic can't pull real campaign sends or skew
-    a journey's open/click stats. The #297 guards were reverted on 2026-06-10
+    through — returns early for `user.demo_user?`, so demo traffic can't pull
+    real campaign sends or skew a journey's open/click stats.
+    **`demo_user?` is not email patterns alone.** Patterns
+    (`User::DEMO_EMAIL_PATTERNS`, extensible without a deploy via the
+    `DEMO_EMAIL_PATTERNS` ENV) miss most real test accounts — a July 2026
+    testing session produced `speakanyway@gmail.com`, `testaria@gmail.com`,
+    `speak@test.com` and a dozen more, none matching `@speakanyway.com`, and
+    they were about to consume journey sends and hard-bounce. So there is also
+    an explicit `settings["internal_account"]` marker, set with
+    `users:internal:mark[<ids-or-emails>]` (`:unmark` reverses, `:list` shows
+    everything currently treated as internal). **Prefer marking to widening the
+    patterns** — a pattern broad enough to catch `arias@gmail.com` will
+    eventually catch a paying customer.
+    `User.demo_accounts` (the SQL scope behind admin/Mission Control metrics)
+    and `demo_user?` (the send gate) derive from the same patterns + flag and
+    **must stay in agreement**, or the dashboards and the emails disagree about
+    who is real. The scope's columns are table-qualified because Mission
+    Control joins `boards`, which has its own `settings` column.
+    The #297 guards were reverted on 2026-06-10
     to allow end-to-end testing and reinstated at this single seam instead;
     **set `MAILCHIMP_JOURNEYS_ALLOW_DEMO=true` to test with a demo account
     rather than removing the guard again.** CRM sync is deliberately NOT gated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — test accounts counted as real users
+
+- **Internal test accounts can now be marked as such explicitly.** Demo
+  accounts were recognised only by email pattern (`bhannajohns+…`,
+  `@speakanyway.com`), so test accounts created under ordinary-looking
+  addresses were treated as real customers — consuming marketing emails,
+  bouncing when the address wasn't deliverable, and inflating growth metrics.
+  Accounts can now be flagged directly, and the flag is respected everywhere
+  demo accounts are already excluded.
+
 ### Fixed — onboarding emails that were never being sent
 
 - **The "make your first board" nudge now actually reaches people.** The daily

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,7 +148,47 @@ class User < ApplicationRecord
   scope :partner, -> { where(role: "partner") }
 
   scope :non_admin, -> { where("role IS NULL OR role != ?", "admin") }
-  scope :demo_accounts, -> { non_admin.where("email LIKE ? OR email LIKE ?", "%bhannajohns+%", "%@speakanyway.com") }
+  # Demo/internal accounts, recognised two ways:
+  #   1. an email matching a known pattern (below, extensible via ENV), or
+  #   2. an explicit settings["internal_account"] = true marker.
+  #
+  # (2) exists because pattern-matching alone kept missing real test accounts:
+  # a testing session created speakanyway@gmail.com, testaria@gmail.com,
+  # speak@test.com and friends, none of which match "@speakanyway.com", and
+  # they went on to consume journey sends, bounce, and pollute growth metrics.
+  # Mark those by hand with `users:internal:mark` rather than inventing ever
+  # broader patterns that risk catching a real customer.
+  #
+  # This scope and #demo_user? MUST stay in agreement — the scope drives
+  # admin/Mission Control metrics while the predicate gates Mailchimp journey
+  # sends, so a divergence means the dashboards and the emails disagree about
+  # who is real. Both derive from .demo_email_patterns + the same flag.
+  DEMO_EMAIL_PATTERNS = ["bhannajohns+", "@speakanyway.com"].freeze
+  INTERNAL_ACCOUNT_FLAG = "internal_account".freeze
+
+  # Additional substrings via DEMO_EMAIL_PATTERNS (comma-separated), so a new
+  # test-account convention doesn't need a deploy.
+  def self.demo_email_patterns
+    extra = ENV["DEMO_EMAIL_PATTERNS"].to_s.split(",").map(&:strip).reject(&:blank?)
+    DEMO_EMAIL_PATTERNS + extra
+  end
+
+  def self.internal_account_condition
+    { INTERNAL_ACCOUNT_FLAG => true }.to_json
+  end
+
+  # Columns are table-qualified: this scope gets joined (Mission Control joins
+  # boards for a per-user board count) and `boards` has a `settings` column
+  # too, so a bare reference is ambiguous and the query errors.
+  scope :demo_accounts, -> {
+    patterns = demo_email_patterns
+    email_sql = Array.new(patterns.size, "users.email ILIKE ?").join(" OR ")
+    non_admin.where(
+      "(#{email_sql}) OR users.settings @> ?",
+      *patterns.map { |p| "%#{p}%" },
+      internal_account_condition
+    )
+  }
   # Exact complement of demo_accounts (admins are never demo). Growth/usage
   # metrics use this so internal/test activity doesn't inflate the numbers.
   scope :non_demo, -> { where.not(id: demo_accounts.select(:id)) }
@@ -1354,8 +1394,22 @@ class User < ApplicationRecord
     Rails.logger.error "Mailchimp tag update failed: #{e.message}"
   end
 
+  # Ruby counterpart of the demo_accounts scope — keep the two in agreement
+  # (see the scope's note). Gates Mailchimp journey sends and the DEMO_USER
+  # merge field.
   def demo_user?
-    email.include?("bhannajohns+") || email.include?("@speakanyway.com")
+    return true if settings.is_a?(Hash) && settings[INTERNAL_ACCOUNT_FLAG] == true
+
+    address = email.to_s.downcase
+    self.class.demo_email_patterns.any? { |pattern| address.include?(pattern.downcase) }
+  end
+
+  def mark_internal!
+    update!(settings: (settings || {}).merge(INTERNAL_ACCOUNT_FLAG => true))
+  end
+
+  def unmark_internal!
+    update!(settings: (settings || {}).except(INTERNAL_ACCOUNT_FLAG))
   end
 
   def partner_pro?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -177,17 +177,24 @@ class User < ApplicationRecord
     { INTERNAL_ACCOUNT_FLAG => true }.to_json
   end
 
-  # Columns are table-qualified: this scope gets joined (Mission Control joins
-  # boards for a per-user board count) and `boards` has a `settings` column
-  # too, so a bare reference is ambiguous and the query errors.
+  # Built in Arel rather than a SQL string. The pattern list is variable-length,
+  # so a string fragment would have to interpolate the `?` placeholders — safe
+  # in fact, but indistinguishable from injection to Brakeman, and this reads
+  # better anyway. `matches` compiles to ILIKE on Postgres.
+  #
+  # Columns come out table-qualified, which matters: this scope gets joined
+  # (Mission Control joins boards for a per-user board count) and `boards` has
+  # a `settings` column too, so an unqualified reference is ambiguous.
   scope :demo_accounts, -> {
-    patterns = demo_email_patterns
-    email_sql = Array.new(patterns.size, "users.email ILIKE ?").join(" OR ")
-    non_admin.where(
-      "(#{email_sql}) OR users.settings @> ?",
-      *patterns.map { |p| "%#{p}%" },
-      internal_account_condition
+    table = arel_table
+    email_match = demo_email_patterns
+      .map { |pattern| table[:email].matches("%#{pattern}%") }
+      .reduce(:or)
+    internal_flag = Arel::Nodes::InfixOperation.new(
+      "@>", table[:settings], Arel::Nodes.build_quoted(internal_account_condition)
     )
+
+    non_admin.where(email_match.or(internal_flag))
   }
   # Exact complement of demo_accounts (admins are never demo). Growth/usage
   # metrics use this so internal/test activity doesn't inflate the numbers.

--- a/lib/tasks/internal_accounts.rake
+++ b/lib/tasks/internal_accounts.rake
@@ -1,0 +1,70 @@
+# Mark accounts as internal/test so they stop consuming Mailchimp journey
+# sends and stop inflating growth metrics.
+#
+# The email-pattern rules (User::DEMO_EMAIL_PATTERNS) only catch accounts that
+# follow a naming convention. Real test accounts routinely don't —
+# speakanyway@gmail.com, testaria@gmail.com, speak@test.com — and broadening
+# the patterns enough to catch them risks catching a paying customer. So these
+# get marked explicitly instead.
+#
+# Marking is reversible (`unmark`) and only ever writes the
+# settings["internal_account"] key.
+namespace :users do
+  namespace :internal do
+    def resolve_users(list)
+      ids, emails = list.to_s.split(",").map(&:strip).reject(&:blank?).partition { |t| t.match?(/\A\d+\z/) }
+      User.where(id: ids).or(User.where(email: emails))
+    end
+
+    desc "List every account currently treated as internal/demo"
+    task :list => :environment do
+      scope = User.demo_accounts.order(:id)
+      puts "#{scope.count} internal/demo account(s):"
+      scope.each do |user|
+        via = user.settings.is_a?(Hash) && user.settings[User::INTERNAL_ACCOUNT_FLAG] ? "flag" : "email pattern"
+        puts format("  %-6s %-42s (%s)", user.id, user.email, via)
+      end
+      puts "\nPatterns in effect: #{User.demo_email_patterns.join(", ")}"
+    end
+
+    desc "Mark accounts internal by id and/or email (DRY_RUN=false to apply)"
+    task :mark, [:list] => :environment do |_t, args|
+      abort "Pass ids and/or emails: rake 'users:internal:mark[803,804,speak@test.com]'" if args[:list].blank?
+
+      dry_run = ENV["DRY_RUN"] != "false"
+      scope = resolve_users(args[:list])
+      puts "Matched #{scope.count} account(s)."
+
+      scope.find_each do |user|
+        if dry_run
+          puts "[dry-run] would mark #{user.id} (#{user.email}) internal"
+        else
+          user.mark_internal!
+          puts "Marked #{user.id} (#{user.email}) internal"
+        end
+      end
+
+      puts(dry_run ? "Dry run — nothing changed. Re-run with DRY_RUN=false to apply." : "Done.")
+    end
+
+    desc "Undo :mark for accounts by id and/or email (DRY_RUN=false to apply)"
+    task :unmark, [:list] => :environment do |_t, args|
+      abort "Pass ids and/or emails: rake 'users:internal:unmark[803]'" if args[:list].blank?
+
+      dry_run = ENV["DRY_RUN"] != "false"
+      scope = resolve_users(args[:list])
+      puts "Matched #{scope.count} account(s)."
+
+      scope.find_each do |user|
+        if dry_run
+          puts "[dry-run] would unmark #{user.id} (#{user.email})"
+        else
+          user.unmark_internal!
+          puts "Unmarked #{user.id} (#{user.email})"
+        end
+      end
+
+      puts(dry_run ? "Dry run — nothing changed. Re-run with DRY_RUN=false to apply." : "Done.")
+    end
+  end
+end

--- a/spec/models/user_internal_account_spec.rb
+++ b/spec/models/user_internal_account_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+# demo_user? (gates Mailchimp journey sends) and the demo_accounts scope
+# (drives admin/Mission Control metrics) are two expressions of one concept.
+# If they disagree, the dashboards and the emails disagree about who is real —
+# so every case here is asserted against BOTH.
+RSpec.describe "internal/demo account identification" do
+  def expect_treated_as_internal(user, internal:)
+    expect(user.demo_user?).to eq(internal)
+    expect(User.demo_accounts.exists?(user.id)).to eq(internal)
+    expect(User.non_demo.exists?(user.id)).to eq(!internal)
+  end
+
+  describe "email patterns" do
+    it "treats a bhannajohns+ alias as internal" do
+      expect_treated_as_internal(create(:user, email: "bhannajohns+demo@gmail.com"), internal: true)
+    end
+
+    it "treats an @speakanyway.com address as internal" do
+      expect_treated_as_internal(create(:user, email: "someone@speakanyway.com"), internal: true)
+    end
+
+    it "treats an ordinary customer as real" do
+      expect_treated_as_internal(create(:user, email: "parent@example.com"), internal: false)
+    end
+
+    it "matches case-insensitively" do
+      expect_treated_as_internal(create(:user, email: "Someone@SpeakAnyWay.com"), internal: true)
+    end
+
+    it "picks up extra patterns from DEMO_EMAIL_PATTERNS" do
+      user = create(:user, email: "qa-bot@example.org")
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("DEMO_EMAIL_PATTERNS").and_return("qa-bot@,loadtest+")
+
+      expect_treated_as_internal(user, internal: true)
+    end
+  end
+
+  # The gap that motivated the flag: a real testing session produced
+  # speakanyway@gmail.com / testaria@gmail.com / speak@test.com, none of which
+  # match a pattern, and they consumed journey sends and bounced.
+  describe "the explicit internal_account flag" do
+    it "treats a flagged account as internal even with an ordinary-looking email" do
+      user = create(:user, email: "speakanyway@gmail.com")
+      expect(user.demo_user?).to be false
+
+      user.mark_internal!
+      expect_treated_as_internal(user.reload, internal: true)
+    end
+
+    it "is reversible" do
+      user = create(:user, email: "testaria@gmail.com")
+      user.mark_internal!
+      user.unmark_internal!
+
+      expect_treated_as_internal(user.reload, internal: false)
+      expect(user.settings).not_to have_key("internal_account")
+    end
+
+    it "preserves other settings keys when marking" do
+      user = create(:user)
+      user.update!(settings: (user.settings || {}).merge("first_board_nudge_sent" => true))
+
+      user.mark_internal!
+
+      expect(user.reload.settings["first_board_nudge_sent"]).to eq(true)
+      expect(user.settings["internal_account"]).to eq(true)
+    end
+
+    # Mission Control joins boards onto this scope, and boards has its own
+    # `settings` column — an unqualified reference makes the query ambiguous.
+    it "survives being joined to a table that also has a settings column" do
+      user = create(:user, email: "speakanyway@gmail.com")
+      user.mark_internal!
+      create(:board, user: user)
+
+      expect {
+        User.demo_accounts.left_joins(:boards)
+          .select("users.id, COUNT(boards.id) AS boards_count")
+          .group("users.id").to_a
+      }.not_to raise_error
+    end
+
+    it "keeps admins out of demo_accounts, matching the previous scope" do
+      admin = create(:admin_user, email: "boss@speakanyway.com")
+
+      expect(User.demo_accounts.exists?(admin.id)).to be false
+    end
+  end
+
+  describe "Mailchimp journey gating" do
+    it "stops a flagged account from receiving a journey trigger" do
+      user = create(:user, email: "speak@test.com")
+      user.mark_internal!
+      mailchimp = instance_double(MailchimpService)
+      allow(MailchimpService).to receive(:new).and_return(mailchimp)
+      allow(MailchimpClient).to receive(:journeys_enabled?).and_return(true)
+      allow(MailchimpClient).to receive(:journey).and_return(journey_id: 10, step_id: 20)
+
+      expect(mailchimp).not_to receive(:trigger_journey)
+
+      MailchimpEventJob.new.perform(user.id, "journey", { "journey_key" => "first_board_nudge" })
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #563. Found while reviewing who the first-board nudge was about to email.

## The problem

Demo accounts were identified purely by email pattern — `bhannajohns+…` or `@speakanyway.com`. Real test accounts routinely don't follow that convention.

Of the 26 accounts eligible for the first real first-board nudge send, **13 were internal test accounts** that no pattern caught:

```
803  speakanyway@gmail.com        809  ariamarie@gmail.com     823  ispeakanyway@gmail.com
804  speakanywaytest@gmail.com    810  artiamaria@gmail.com    824  ispeakaria@gmail.com
805  testemail@gmail.com          811  arias@gmail.com         825  letmespeakanyway@gmail.com
814  speak@test.com               812  testspeak@gmail.com
817  mccollume63@gmail            813  testaria@gmail.com
```

They cluster in two testing sessions (803–814 within an hour on Jul 26; 823–825 within five minutes on Jul 31).

Two of those addresses are undeliverable — `speak@test.com` and `mccollume63@gmail` (no TLD). Sending to that batch would have carried an ~8% hard-bounce rate, which is the fastest way to damage the sending domain's reputation and, with it, the transactional mail the app depends on. The rest quietly inflate growth metrics and make every journey's open/click rate half noise.

## Approach

Widening the patterns enough to catch `arias@gmail.com` or `speak@test.com` would eventually catch a paying customer, so this doesn't try. Instead:

- **Explicit marker** — `settings["internal_account"] = true`, managed by `users:internal:mark[<ids-or-emails>]`, with `:unmark` to reverse and `:list` to show everything currently treated as internal. Dry-run by default, matching the repo's other maintenance tasks.
- **Patterns stay**, and are now extensible without a deploy via the `DEMO_EMAIL_PATTERNS` ENV (comma-separated substrings), and match case-insensitively.

## The part worth reviewing

`demo_user?` (the Mailchimp journey send gate) and `User.demo_accounts` (the SQL scope behind the admin dashboard, Mission Control, and `non_demo` growth metrics) were two independent definitions of one concept. They now derive from the same patterns + flag — otherwise the dashboards and the emails disagree about who is real, which is how this class of bug survives.

The scope's columns are table-qualified. Mission Control joins `boards` onto it for a per-user board count, and `boards` has its own `settings` column, so a bare reference made the query ambiguous — caught by the admin request specs, and there's now a regression test that joins the scope directly.

## Test plan

- New `spec/models/user_internal_account_spec.rb` (11 examples) asserts every case against **both** `demo_user?` and the scope, since keeping them in agreement is the point.
- Covers: both built-in patterns, case-insensitivity, `DEMO_EMAIL_PATTERNS` extension, the flag on an ordinary-looking address, reversibility, other `settings` keys preserved, admins still excluded, the join-ambiguity regression, and that a flagged account gets no journey trigger.
- `spec/models` + `spec/sidekiq` + `spec/requests/admin` + `spec/services/mission_control` green locally.

A broad local run reported 7 failures out of 3336 that I have not yet attributed — the targeted specs pass and the same combinations pass on re-run (they look order-dependent), but CI's verdict here is the one that counts. I'll confirm before this is merged.

## Operational note

The marker is new code, so it can't be applied to prod until this deploys. The immediate mitigation for today's send is to flag those 13 accounts as already-nudged using the existing `first_board_nudge_sent` field, which needs no new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)