### PR TITLE
feat(boards): create a Board Set map for any linked board on demand

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -636,6 +636,38 @@ collections of boards. CRUD is open to any signed-in user;
 - **`add_board` route.** `POST /api/board_groups/:id/add_board/:board_id`
   (`BoardGroup#add_board` does the join + layout init). Beyond the owner-or-admin
   set check, the *board* must belong to the caller or be predefined/public.
+- **On-demand group creation for any linked board.** `POST
+  /api/boards/:id/create_board_group` (`Api::BoardsController#create_board_group`,
+  owner-or-admin gated) lets the "set map" (`Boards::SetGraphBuilder`, `GET
+  /api/board_groups/:id/graph`) work for a board that was hand-linked via
+  folder buttons, not just Board Builder trees. `Boards::BoardGroupCreator`
+  does the work: `Boards::LinkedBoardsFinder` BFS-walks
+  `board_images.predictive_board_id` from the board and every reachable board
+  becomes a member. The group's owner is **always `board.user`** (the board's
+  real owner), never the acting user — an admin creating on behalf of someone
+  else must not end up owning the group, be limited by their own
+  `at_board_group_limit?`, or under/over-count the real owner's usage. When an
+  eligible group already exists, the service reuses it and **re-syncs**
+  membership (re-runs the BFS and adds any newly-reachable board that isn't
+  already a member — never removes existing members) so re-calling the
+  endpoint after adding a new folder link is both idempotent and additive
+  rather than freezing membership at first-creation time. `Board#eligible_board_group(user)`
+  takes the viewing user and filters `board_groups` to that user's own
+  groups — without it, the pre-existing `add_to_groups` ownership hole could
+  let this endpoint hand back another user's full group data. The
+  check-then-create/resync path runs inside `board.with_lock` to close a
+  concurrent-double-POST race.
+  - Two `BoardGroup` quirks are worked around from the outside rather than
+    fixed at the source (kept out of scope for this feature): the
+    `before_create :set_root_board` callback derives `root_board_id` from
+    `boards.first` when the group has no members yet, clobbering an
+    explicitly-passed `root_board_id` back to `nil` — `BoardGroupCreator`
+    re-asserts it with `update!` after populating. And `add_board`'s first
+    call memoizes the (at that point empty) `:boards` association via its own
+    `boards.include?(member)` guard, so a caller that adds several boards and
+    then reads `group.boards` sees a stale, empty-looking cache —
+    `BoardGroupCreator` reloads the group after populating/re-syncing so
+    callers always see the current members.
 
 ## Responsive board layouts (sm/md derived from lg)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Any board that links to other boards can now get a Board Set map created
+  for it on demand, not just Board Builder boards.** Previously the
+  bird's-eye "set map" only worked for boards the Board Builder wizard had
+  already grouped; a board you'd hand-linked together with folder buttons
+  had no way to get one. Creating a set now auto-discovers every linked
+  board and keeps picking up newly-added links on repeat use.
+
 ### Fixed — onboarding emails that were never being sent
 
 - **The "make your first board" nudge now actually reaches people.** The daily

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1170,6 +1170,30 @@ class API::BoardsController < API::ApplicationController
     render json: @new_board.api_view_with_images(current_user)
   end
 
+  def create_board_group
+    set_board
+    return if @board.nil? # set_board already rendered 404
+
+    unless @board.user_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    existing = @board.eligible_board_group
+    board_group = Boards::BoardGroupCreator.new(board: @board, user: current_user).call
+    status = existing ? :ok : :created
+    # api_view_with_boards omits root_board_id (unlike its sibling api_view) —
+    # merge it in so callers can identify the root board without a second call.
+    view = board_group.api_view_with_boards(current_user).merge(root_board_id: board_group.root_board_id)
+    render json: view, status: status
+  rescue Boards::BoardGroupCreator::LimitReached
+    render json: {
+      error: "You've reached your plan's board set limit. Upgrade to create more.",
+      limit: current_user.board_group_limit,
+      count: current_user.countable_board_group_count,
+    }, status: :unprocessable_content
+  end
+
   def create_from_template
     obf_data = params[:data]
     user_id = current_user.id

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1179,9 +1179,9 @@ class API::BoardsController < API::ApplicationController
       return
     end
 
-    existing = @board.eligible_board_group
-    board_group = Boards::BoardGroupCreator.new(board: @board, user: current_user).call
-    status = existing ? :ok : :created
+    creator = Boards::BoardGroupCreator.new(board: @board, user: current_user)
+    board_group = creator.call
+    status = creator.created? ? :created : :ok
     # api_view_with_boards omits root_board_id (unlike its sibling api_view) —
     # merge it in so callers can identify the root board without a second call.
     view = board_group.api_view_with_boards(current_user).merge(root_board_id: board_group.root_board_id)

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -244,9 +244,15 @@ class Board < ApplicationRecord
   # mirroring the frontend's eligibleSets() rule in ViewSetMapButton.tsx: a
   # builder set takes priority (that's what the map is built for), otherwise
   # any user-owned non-predefined set. nil when the board has neither.
-  def eligible_board_group
-    board_groups.where(builder: true).first ||
-      board_groups.where(predefined: [false, nil]).first
+  #
+  # Scoped to `user`'s own groups: `board_groups` has no ownership filter of
+  # its own, and (a pre-existing, separate hole) `add_to_groups` lets any
+  # board get added to any group id with no ownership check — so without this
+  # filter a board could surface another user's full group data here even
+  # though the viewer could never actually load that group's map.
+  def eligible_board_group(user)
+    board_groups.where(user: user, builder: true).first ||
+      board_groups.where(user: user, predefined: [false, nil]).first
   end
 
   def retranslate_on_language_change

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -240,6 +240,15 @@ class Board < ApplicationRecord
       board_groups.where(builder: true).first
   end
 
+  # The BoardGroup a "view/create set map" action should use for this board,
+  # mirroring the frontend's eligibleSets() rule in ViewSetMapButton.tsx: a
+  # builder set takes priority (that's what the map is built for), otherwise
+  # any user-owned non-predefined set. nil when the board has neither.
+  def eligible_board_group
+    board_groups.where(builder: true).first ||
+      board_groups.where(predefined: [false, nil]).first
+  end
+
   def retranslate_on_language_change
     return unless saved_change_to_language?
     schedule_translations_for(language)

--- a/app/services/boards/board_group_creator.rb
+++ b/app/services/boards/board_group_creator.rb
@@ -1,0 +1,46 @@
+module Boards
+  # Creates (or reuses) a BoardGroup for a board so its "set map" becomes
+  # available, even when the board was never built via the Board Builder
+  # wizard and so never got a builder: true group automatically.
+  class BoardGroupCreator
+    class LimitReached < StandardError; end
+
+    def initialize(board:, user:)
+      @board = board
+      @user = user
+    end
+
+    def call
+      existing = board.eligible_board_group
+      return existing if existing
+
+      raise LimitReached if user.at_board_group_limit?
+
+      create_group!
+    end
+
+    private
+
+    attr_reader :board, :user
+
+    def create_group!
+      members = Boards::LinkedBoardsFinder.new(board).call
+      group = nil
+      ActiveRecord::Base.transaction do
+        group = BoardGroup.create!(user: user, name: board.name, builder: false, root_board_id: board.id)
+        members.each { |member| group.add_board(member) }
+        # BoardGroup#set_root_board (a before_create callback) derives
+        # root_board_id from boards.first at creation time, when the group
+        # has no members yet — it always clobbers the value above back to
+        # nil. Re-assert it now that the group is populated; update! (not
+        # update_column) so out-of-band validations still run.
+        group.update!(root_board_id: board.id) unless group.root_board_id == board.id
+      end
+      # #add_board's own `boards.include?(member)` guard memoizes the
+      # (initially empty) :boards association before any members are
+      # attached; reload so the caller sees every board just added rather
+      # than that stale, empty cache.
+      group.reload
+    end
+  end
+end

--- a/app/services/boards/board_group_creator.rb
+++ b/app/services/boards/board_group_creator.rb
@@ -4,31 +4,64 @@ module Boards
   # wizard and so never got a builder: true group automatically.
   class BoardGroupCreator
     class LimitReached < StandardError; end
+    # BoardGroup#add_board rescues RecordInvalid/StandardError internally and
+    # returns nil rather than raising, so the ActiveRecord::Base.transaction
+    # below can't roll back on a failed member add on its own — we have to
+    # notice the nil and raise ourselves, or a real failure would silently
+    # ship a partially-populated group instead of surfacing.
+    class MembershipAddFailed < StandardError; end
 
     def initialize(board:, user:)
       @board = board
       @user = user
+      @created = false
     end
 
+    # The group's owner is always the board's real owner (see #owner), never
+    # the acting `user` — `user` only matters for authorization, handled by
+    # the controller before this is ever called.
     def call
-      existing = board.eligible_board_group
-      return existing if existing
+      board.with_lock do
+        existing = board.eligible_board_group(owner)
+        if existing
+          resync_membership!(existing)
+          @group = existing
+        else
+          raise LimitReached if owner.at_board_group_limit?
+          @group = create_group!
+          @created = true
+        end
+      end
+      @group
+    end
 
-      raise LimitReached if user.at_board_group_limit?
-
-      create_group!
+    # Whether the most recent #call created a brand new group (true) or
+    # reused (and possibly re-synced) an existing eligible group (false).
+    # Lets callers distinguish 201 vs 200 without a second, redundant
+    # eligible_board_group query.
+    def created?
+      @created
     end
 
     private
 
     attr_reader :board, :user
 
+    # The board's actual owner. An admin acting on someone else's board must
+    # never have the resulting group land in the admin's own account, be
+    # checked against the admin's own plan limit, or inflate the real owner's
+    # count incorrectly — the group always belongs to, and is limited by,
+    # whoever actually owns the board.
+    def owner
+      board.user
+    end
+
     def create_group!
       members = Boards::LinkedBoardsFinder.new(board).call
       group = nil
       ActiveRecord::Base.transaction do
-        group = BoardGroup.create!(user: user, name: board.name, builder: false, root_board_id: board.id)
-        members.each { |member| group.add_board(member) }
+        group = BoardGroup.create!(user: owner, name: board.name, builder: false, root_board_id: board.id)
+        members.each { |member| add_board!(group, member) }
         # BoardGroup#set_root_board (a before_create callback) derives
         # root_board_id from boards.first at creation time, when the group
         # has no members yet — it always clobbers the value above back to
@@ -41,6 +74,29 @@ module Boards
       # attached; reload so the caller sees every board just added rather
       # than that stale, empty cache.
       group.reload
+    end
+
+    # The map's membership must not silently freeze the moment a group is
+    # created: re-run the same BFS and add any newly-reachable board that
+    # isn't already a member. Never removes members — a board someone
+    # deliberately kept in the set via the manual add/remove UI (even if no
+    # longer folder-linked) must not be dropped as a side effect of this
+    # endpoint. Makes re-calling create_board_group both idempotent and
+    # additive: new folder links show up on the map on the next call.
+    def resync_membership!(group)
+      discovered = Boards::LinkedBoardsFinder.new(board).call
+      current_ids = group.board_group_boards.pluck(:board_id)
+      newly_reachable = discovered.reject { |member| current_ids.include?(member.id) }
+      return if newly_reachable.empty?
+
+      newly_reachable.each { |member| add_board!(group, member) }
+      group.reload
+    end
+
+    def add_board!(group, member)
+      result = group.add_board(member)
+      raise MembershipAddFailed, "failed to add board #{member.id} to group #{group.id}" if result.nil?
+      result
     end
   end
 end

--- a/app/services/boards/linked_boards_finder.rb
+++ b/app/services/boards/linked_boards_finder.rb
@@ -1,0 +1,39 @@
+module Boards
+  # BFS over folder→child links (board_images.predictive_board_id) starting
+  # at a given board. Used by Boards::SetGraphBuilder (root-BFS fallback for
+  # sets that predate #407's board_group membership backfill) and by
+  # Boards::BoardGroupCreator (auto-populating a brand new group).
+  class LinkedBoardsFinder
+    # Defensive hard cap so a cyclic/garbage tree can't spin forever.
+    MAX_BOARDS = 500
+
+    def initialize(root_board)
+      @root_board = root_board
+    end
+
+    def call
+      return [] if root_board.blank?
+
+      visited = {}
+      queue = [root_board.id]
+      until queue.empty? || visited.size >= MAX_BOARDS
+        board_id = queue.shift
+        next if visited.key?(board_id)
+
+        board = Board.includes(board_images: :image).find_by(id: board_id)
+        next unless board
+
+        visited[board_id] = board
+        board.board_images.each do |bi|
+          target = bi.predictive_board_id
+          queue << target if target.present? && target != bi.board_id && !visited.key?(target)
+        end
+      end
+      visited.values
+    end
+
+    private
+
+    attr_reader :root_board
+  end
+end

--- a/app/services/boards/set_graph_builder.rb
+++ b/app/services/boards/set_graph_builder.rb
@@ -9,10 +9,6 @@ module Boards
   # v1 targets builder sets (the `predictive_board_id` tree keyed on a
   # BoardGroup), but the shape generalizes to any BoardGroup.
   class SetGraphBuilder
-    # Defensive hard cap on the root-BFS fallback so a cyclic/garbage set can't
-    # spin forever. Builder sets are tiny (root + ~a dozen pages).
-    MAX_BOARDS = 500
-
     def initialize(board_group, viewing_user: nil)
       @board_group = board_group
       @viewing_user = viewing_user
@@ -68,22 +64,8 @@ module Boards
     def bfs_boards_from_root
       return [] if root_board_id.blank?
 
-      visited = {}
-      queue = [root_board_id]
-      until queue.empty? || visited.size >= MAX_BOARDS
-        board_id = queue.shift
-        next if visited.key?(board_id)
-
-        board = Board.includes(board_images: :image).find_by(id: board_id)
-        next unless board
-
-        visited[board_id] = board
-        board.board_images.each do |bi|
-          target = bi.predictive_board_id
-          queue << target if target.present? && target != bi.board_id && !visited.key?(target)
-        end
-      end
-      visited.values
+      root_board = Board.find_by(id: root_board_id)
+      Boards::LinkedBoardsFinder.new(root_board).call
     end
 
     # Every tile with a non-null predictive_board_id whose target board is in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,6 +293,7 @@ Rails.application.routes.draw do
         put "associate_image"
         put "associate_images"
         post "clone"
+        post "create_board_group"
         put "add_to_team"
         put "add_to_groups"
         post "assign_accounts"

--- a/docs/superpowers/plans/2026-08-04-create-board-group-for-board.md
+++ b/docs/superpowers/plans/2026-08-04-create-board-group-for-board.md
@@ -1,0 +1,511 @@
+# Create a Board Group (map) for any linked board — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a board's owner (or admin) create a `BoardGroup` for it on demand — auto-populated with every board reachable via folder links — so the "set map" becomes available even for boards never built via the Board Builder wizard.
+
+**Architecture:** Extract the existing BFS traversal in `Boards::SetGraphBuilder` into a shared `Boards::LinkedBoardsFinder` service. Add a `Boards::BoardGroupCreator` service that reuses it to build (or find-and-reuse) a `BoardGroup` for a board. Expose it via a new `POST /api/boards/:id/create_board_group` member route.
+
+**Tech Stack:** Ruby on Rails 8, RSpec, FactoryBot.
+
+## Global Constraints
+
+- Standard Ruby style, fat models/thin controllers, snake_case (repo `CLAUDE.md`).
+- Never expose internal errors in API responses — generic messages only.
+- New features get tests; don't backfill tests for unrelated existing code.
+- Reuse the existing 422 board-set-limit contract: `{ error, limit, count }` (see `Api::BoardGroupsController#create` and `Api::V1::BoardBuilderController#create`).
+- Reuse the existing eligible-group rule the frontend already applies (`builder: true` OR non-predefined owned group) so the new endpoint never creates a duplicate group for a board that already has a working map.
+
+---
+
+### Task 1: Extract `Boards::LinkedBoardsFinder` from `SetGraphBuilder`
+
+**Files:**
+- Create: `app/services/boards/linked_boards_finder.rb`
+- Modify: `app/services/boards/set_graph_builder.rb:68-87` (replace `bfs_boards_from_root` body with a delegation)
+- Test: `spec/services/boards/linked_boards_finder_spec.rb`
+
+**Interfaces:**
+- Produces: `Boards::LinkedBoardsFinder.new(root_board).call` → `Array<Board>`, BFS over `board_images.predictive_board_id` starting at `root_board`, root included, capped at `Boards::LinkedBoardsFinder::MAX_BOARDS` (500, same cap `SetGraphBuilder` used), each board `includes(board_images: :image)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+require "rails_helper"
+
+RSpec.describe Boards::LinkedBoardsFinder do
+  let(:user) { FactoryBot.create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  it "returns the root plus every board reachable via folder links" do
+    home  = FactoryBot.create(:board, user: user, name: "Home")
+    food  = FactoryBot.create(:board, user: user, name: "Food")
+    fruit = FactoryBot.create(:board, user: user, name: "Fruit")
+    orphan = FactoryBot.create(:board, user: user, name: "Orphan")
+
+    add_tile(home, label: "Food", links_to: food)
+    add_tile(food, label: "Fruit", links_to: fruit)
+    add_tile(orphan, label: "lonely")
+
+    result = described_class.new(home).call
+    expect(result.map(&:id)).to contain_exactly(home.id, food.id, fruit.id)
+  end
+
+  it "does not loop forever on a cycle" do
+    a = FactoryBot.create(:board, user: user, name: "A")
+    b = FactoryBot.create(:board, user: user, name: "B")
+    add_tile(a, label: "to b", links_to: b)
+    add_tile(b, label: "to a", links_to: a)
+
+    result = described_class.new(a).call
+    expect(result.map(&:id)).to contain_exactly(a.id, b.id)
+  end
+
+  it "returns just the root when it links to nothing" do
+    solo = FactoryBot.create(:board, user: user, name: "Solo")
+    add_tile(solo, label: "word")
+
+    result = described_class.new(solo).call
+    expect(result.map(&:id)).to contain_exactly(solo.id)
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/services/boards/linked_boards_finder_spec.rb`
+Expected: FAIL — `uninitialized constant Boards::LinkedBoardsFinder`
+
+- [ ] **Step 3: Write the implementation**
+
+```ruby
+module Boards
+  # BFS over folder→child links (board_images.predictive_board_id) starting
+  # at a given board. Used by Boards::SetGraphBuilder (root-BFS fallback for
+  # sets that predate #407's board_group membership backfill) and by
+  # Boards::BoardGroupCreator (auto-populating a brand new group).
+  class LinkedBoardsFinder
+    # Defensive hard cap so a cyclic/garbage tree can't spin forever.
+    MAX_BOARDS = 500
+
+    def initialize(root_board)
+      @root_board = root_board
+    end
+
+    def call
+      return [] if root_board.blank?
+
+      visited = {}
+      queue = [root_board.id]
+      until queue.empty? || visited.size >= MAX_BOARDS
+        board_id = queue.shift
+        next if visited.key?(board_id)
+
+        board = Board.includes(board_images: :image).find_by(id: board_id)
+        next unless board
+
+        visited[board_id] = board
+        board.board_images.each do |bi|
+          target = bi.predictive_board_id
+          queue << target if target.present? && target != bi.board_id && !visited.key?(target)
+        end
+      end
+      visited.values
+    end
+
+    private
+
+    attr_reader :root_board
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/services/boards/linked_boards_finder_spec.rb`
+Expected: PASS (3 examples)
+
+- [ ] **Step 5: Point `SetGraphBuilder` at the new service and re-run its existing spec**
+
+Replace `app/services/boards/set_graph_builder.rb:68-87`:
+
+```ruby
+    def bfs_boards_from_root
+      return [] if root_board_id.blank?
+
+      root_board = Board.find_by(id: root_board_id)
+      Boards::LinkedBoardsFinder.new(root_board).call
+    end
+```
+
+(Delete the old BFS body — `MAX_BOARDS` constant on `SetGraphBuilder` can stay or go; if kept elsewhere unused, remove it since `LinkedBoardsFinder::MAX_BOARDS` now owns the cap.)
+
+Run: `bundle exec rspec spec/services/boards/set_graph_builder_spec.rb`
+Expected: PASS (no behavior change — same test suite as before, all green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/boards/linked_boards_finder.rb app/services/boards/set_graph_builder.rb spec/services/boards/linked_boards_finder_spec.rb
+git commit -m "refactor(boards): extract folder-link BFS into Boards::LinkedBoardsFinder"
+```
+
+---
+
+### Task 2: `Board#eligible_board_group` helper
+
+**Files:**
+- Modify: `app/models/board.rb` (add near `builder_board_group`, `app/models/board.rb:237-241`)
+- Test: `spec/models/board_eligible_board_group_spec.rb`
+
+**Interfaces:**
+- Consumes: `board_groups` association (`app/models/board.rb:67`), `BoardGroup.builder` scope (`app/models/board_group.rb:38`).
+- Produces: `board.eligible_board_group` → `BoardGroup | nil`. Mirrors the frontend's `eligibleSets()` rule (`src/components/boards/ViewSetMapButton.tsx`): a `builder: true` group, or any non-predefined group, in that preference order.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+require "rails_helper"
+
+RSpec.describe Board, "#eligible_board_group" do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  it "returns nil when the board belongs to no group" do
+    expect(board.eligible_board_group).to be_nil
+  end
+
+  it "returns a builder group over a non-predefined group when both exist" do
+    plain_group = create(:board_group, user: user, builder: false, predefined: false)
+    plain_group.add_board(board)
+    builder_group = create(:board_group, user: user, builder: true)
+    builder_group.add_board(board)
+
+    expect(board.eligible_board_group).to eq(builder_group)
+  end
+
+  it "returns a non-predefined, non-builder group" do
+    group = create(:board_group, user: user, builder: false, predefined: false)
+    group.add_board(board)
+
+    expect(board.eligible_board_group).to eq(group)
+  end
+
+  it "ignores a predefined, non-builder group" do
+    group = create(:board_group, user: user, builder: false, predefined: true)
+    group.add_board(board)
+
+    expect(board.eligible_board_group).to be_nil
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/models/board_eligible_board_group_spec.rb`
+Expected: FAIL — `undefined method 'eligible_board_group'`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `app/models/board.rb`, right after `builder_board_group` (`app/models/board.rb:241`):
+
+```ruby
+  # The BoardGroup a "view/create set map" action should use for this board,
+  # mirroring the frontend's eligibleSets() rule in ViewSetMapButton.tsx: a
+  # builder set takes priority (that's what the map is built for), otherwise
+  # any user-owned non-predefined set. nil when the board has neither.
+  def eligible_board_group
+    board_groups.where(builder: true).first ||
+      board_groups.where(predefined: [false, nil]).first
+  end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/models/board_eligible_board_group_spec.rb`
+Expected: PASS (4 examples)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/board.rb spec/models/board_eligible_board_group_spec.rb
+git commit -m "feat(boards): add Board#eligible_board_group helper"
+```
+
+---
+
+### Task 3: `Boards::BoardGroupCreator` service
+
+**Files:**
+- Create: `app/services/boards/board_group_creator.rb`
+- Test: `spec/services/boards/board_group_creator_spec.rb`
+
+**Interfaces:**
+- Consumes: `Boards::LinkedBoardsFinder.new(board).call` (Task 1), `Board#eligible_board_group` (Task 2), `BoardGroup#add_board` (`app/models/board_group.rb:156`), `User#at_board_group_limit?` (`app/models/user.rb:1830`).
+- Produces: `Boards::BoardGroupCreator.new(board: board, user: user).call` → `BoardGroup`. Raises `Boards::BoardGroupCreator::LimitReached` (a plain `StandardError` subclass) when `user.at_board_group_limit?` and no eligible group already exists.
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+require "rails_helper"
+
+RSpec.describe Boards::BoardGroupCreator do
+  let(:user) { create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  describe "when the board has no eligible group yet" do
+    it "creates a new group rooted at the board with every reachable board as a member" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "Food", links_to: food)
+      add_tile(food, label: "apple")
+
+      group = described_class.new(board: home, user: user).call
+
+      expect(group).to be_persisted
+      expect(group.root_board_id).to eq(home.id)
+      expect(group.name).to eq("Home")
+      expect(group.builder).to be(false)
+      expect(group.boards.map(&:id)).to contain_exactly(home.id, food.id)
+    end
+  end
+
+  describe "when the board already has an eligible group" do
+    it "returns the existing group instead of creating a duplicate" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      expect {
+        result = described_class.new(board: home, user: user).call
+        expect(result).to eq(existing)
+      }.not_to change(BoardGroup, :count)
+    end
+  end
+
+  describe "when the user is at their board-group limit" do
+    before { user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0)) }
+
+    it "raises LimitReached and creates nothing" do
+      home = create(:board, user: user, name: "Home")
+
+      expect {
+        described_class.new(board: home, user: user).call
+      }.to raise_error(Boards::BoardGroupCreator::LimitReached)
+      expect(BoardGroup.count).to eq(0)
+    end
+
+    it "still returns the existing group without raising, even at the limit" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      expect { described_class.new(board: home, user: user).call }.not_to raise_error
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/services/boards/board_group_creator_spec.rb`
+Expected: FAIL — `uninitialized constant Boards::BoardGroupCreator`
+
+- [ ] **Step 3: Write the implementation**
+
+```ruby
+module Boards
+  # Creates (or reuses) a BoardGroup for a board so its "set map" becomes
+  # available, even when the board was never built via the Board Builder
+  # wizard and so never got a builder: true group automatically.
+  class BoardGroupCreator
+    class LimitReached < StandardError; end
+
+    def initialize(board:, user:)
+      @board = board
+      @user = user
+    end
+
+    def call
+      existing = board.eligible_board_group
+      return existing if existing
+
+      raise LimitReached if user.at_board_group_limit?
+
+      create_group!
+    end
+
+    private
+
+    attr_reader :board, :user
+
+    def create_group!
+      members = Boards::LinkedBoardsFinder.new(board).call
+      group = nil
+      ActiveRecord::Base.transaction do
+        group = BoardGroup.create!(user: user, name: board.name, builder: false, root_board_id: board.id)
+        members.each { |member| group.add_board(member) }
+      end
+      group
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/services/boards/board_group_creator_spec.rb`
+Expected: PASS (4 examples)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/boards/board_group_creator.rb spec/services/boards/board_group_creator_spec.rb
+git commit -m "feat(boards): add Boards::BoardGroupCreator service"
+```
+
+---
+
+### Task 4: `POST /api/boards/:id/create_board_group` endpoint
+
+**Files:**
+- Modify: `config/routes.rb:284-312` (add member route)
+- Modify: `app/controllers/api/boards_controller.rb` (add `create_board_group` action, near `clone` at `app/controllers/api/boards_controller.rb:1163-1171`)
+- Test: `spec/requests/api/boards_create_board_group_spec.rb`
+
+**Interfaces:**
+- Consumes: `Boards::BoardGroupCreator.new(board:, user:).call` (Task 3), `BoardGroup#api_view_with_boards(viewing_user)` (`app/models/board_group.rb:260`), `set_board` (`app/controllers/api/boards_controller.rb:1422-1433`).
+- Produces: route `create_board_group_api_board_path(id)` → `POST /api/boards/:id/create_board_group`.
+
+- [ ] **Step 1: Add the route**
+
+In `config/routes.rb`, inside the `resources :boards do ... member do ... end end` block (`config/routes.rb:284-312`), add alongside `post "clone"`:
+
+```ruby
+        post "create_board_group"
+```
+
+- [ ] **Step 2: Write the failing request spec**
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "API::Boards#create_board_group", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  let!(:home) { create(:board, user: user, name: "Home") }
+  let!(:food) { create(:board, user: user, name: "Food") }
+
+  before { add_tile(home, label: "Food", links_to: food) }
+
+  it "creates a group for the board and returns it" do
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    expect(body["root_board_id"]).to eq(home.id)
+    board_ids = body["boards"].map { |b| b["id"] }
+    expect(board_ids).to contain_exactly(home.id, food.id)
+  end
+
+  it "returns the existing group (200) instead of duplicating it" do
+    existing = home.board_groups.create!(user: user, name: "Existing", builder: true)
+    existing.add_board(home)
+
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["id"]).to eq(existing.id)
+  end
+
+  it "returns 401 for a non-owner, non-admin user" do
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(other_user)
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(BoardGroup.where(root_board_id: home.id)).to be_empty
+  end
+
+  it "returns the standard board-set-limit 422 shape when the user is at their limit" do
+    user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0))
+
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    body = JSON.parse(response.body)
+    expect(body["error"]).to be_present
+    expect(body).to have_key("limit")
+    expect(body).to have_key("count")
+  end
+end
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/requests/api/boards_create_board_group_spec.rb`
+Expected: FAIL — routing error (`No route matches [POST] "/api/boards/.../create_board_group"`)
+
+- [ ] **Step 4: Write the controller action**
+
+Add to `app/controllers/api/boards_controller.rb`, right after `clone` (`app/controllers/api/boards_controller.rb:1171`):
+
+```ruby
+  def create_board_group
+    set_board
+    return if @board.nil? # set_board already rendered 404
+
+    unless @board.user_id == current_user.id || current_user.admin?
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+
+    existing = @board.eligible_board_group
+    board_group = Boards::BoardGroupCreator.new(board: @board, user: current_user).call
+    status = existing ? :ok : :created
+    render json: board_group.api_view_with_boards(current_user), status: status
+  rescue Boards::BoardGroupCreator::LimitReached
+    render json: {
+      error: "You've reached your plan's board set limit. Upgrade to create more.",
+      limit: current_user.board_group_limit,
+      count: current_user.countable_board_group_count,
+    }, status: :unprocessable_content
+  end
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/requests/api/boards_create_board_group_spec.rb`
+Expected: PASS (4 examples)
+
+- [ ] **Step 6: Run the full boards + board_groups request/service suites to check for regressions**
+
+Run: `bundle exec rspec spec/requests/api/boards_spec.rb spec/requests/api/board_groups_spec.rb spec/services/boards/ spec/models/board_eligible_board_group_spec.rb spec/requests/api/boards_create_board_group_spec.rb spec/requests/api/boards_destroy_spec.rb`
+Expected: all PASS, zero failures
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config/routes.rb app/controllers/api/boards_controller.rb spec/requests/api/boards_create_board_group_spec.rb
+git commit -m "feat(boards): add POST /api/boards/:id/create_board_group endpoint"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** `Boards::LinkedBoardsFinder` (Task 1) ↔ spec's BFS extraction; `Board#eligible_board_group` (Task 2) ↔ spec's "reuse existing eligible group" rule; `Boards::BoardGroupCreator` (Task 3) ↔ spec's creation/limit/reuse behavior; endpoint (Task 4) ↔ spec's auth/limit/response-shape requirements. Frontend handoff is explicitly out of scope for this plan (delivered separately).
+- **Type consistency:** `Boards::LinkedBoardsFinder.new(root_board).call` used identically in Task 1's `SetGraphBuilder` delegation and Task 3's creator. `Board#eligible_board_group` used identically in Task 2's own spec, Task 3's service, and Task 4's controller (to decide 200 vs 201). `Boards::BoardGroupCreator::LimitReached` raised in Task 3, rescued in Task 4 — names match.
+- **No placeholders:** every step has runnable code and an exact command to verify it.

--- a/docs/superpowers/specs/2026-08-04-create-board-group-for-board-design.md
+++ b/docs/superpowers/specs/2026-08-04-create-board-group-for-board-design.md
@@ -49,9 +49,11 @@ Behavior:
    and `BoardBuilderController#create`).
 3. BFS-discover boards via `Boards::LinkedBoardsFinder.new(board).call`.
 4. In a transaction: create `BoardGroup.new(user: user, name: board.name,
-   builder: false, root_board_id: board.id)`, then
-   `board_group_boards.create!` for each discovered board in BFS order
-   (`position: index`).
+   builder: false, root_board_id: board.id)`, then call `add_board` for each
+   discovered board in BFS order. Membership order follows `add_board`'s own
+   default behavior (it doesn't set an explicit `position`) — this is
+   cosmetic and doesn't affect the graph endpoint, which builds its own
+   edges rather than relying on `position`.
 5. Return the group.
 
 ### Endpoint
@@ -83,7 +85,7 @@ Behavior:
 - `spec/services/boards/linked_boards_finder_spec.rb` — BFS traversal,
   cycles, cap.
 - `spec/services/boards/board_group_creator_spec.rb` — creates a new group
-  with correct members/positions; returns existing eligible group instead of
+  with correct members; returns existing eligible group instead of
   duplicating; raises `LimitReached` at the plan limit.
 - `spec/requests/api/boards_create_board_group_spec.rb` (or added to the
   existing boards request spec) — 401 for non-owner, 422 at limit, 200/201

--- a/docs/superpowers/specs/2026-08-04-create-board-group-for-board-design.md
+++ b/docs/superpowers/specs/2026-08-04-create-board-group-for-board-design.md
@@ -1,0 +1,90 @@
+# Create a Board Group (map) for any linked board
+
+## Problem
+
+The Board Set "bird's-eye map" (`Boards::SetGraphBuilder`, `GET /api/board_groups/:id/graph`)
+only works for boards already in an eligible `BoardGroup`. Board Builder boards
+get one automatically (`builder: true`, created in
+`Api::V1::BoardBuilderController#create`). Boards a user links together by
+hand (folder buttons pointing at other boards, no wizard involved) never get a
+`BoardGroup` at all, so they can never get a map.
+
+## Goal
+
+Given any board, let the owner (or admin) create a `BoardGroup` for it on
+demand, auto-populated with every board reachable via folder links, so the
+map becomes available immediately.
+
+## Design
+
+### `Boards::LinkedBoardsFinder`
+
+Extract the existing BFS traversal out of
+`Boards::SetGraphBuilder#bfs_boards_from_root` into a small shared service:
+
+```ruby
+Boards::LinkedBoardsFinder.new(root_board).call # => [Board, ...] reachable via
+                                                 # board_images.predictive_board_id,
+                                                 # root included, same MAX_BOARDS cap
+```
+
+`SetGraphBuilder#bfs_boards_from_root` becomes a thin call into this service
+(no behavior change for the graph endpoint — same cap, same traversal).
+
+### `Boards::BoardGroupCreator`
+
+```ruby
+Boards::BoardGroupCreator.new(board: board, user: user).call
+# => BoardGroup (existing or newly created)
+# raises Boards::BoardGroupCreator::LimitReached if user.at_board_group_limit?
+```
+
+Behavior:
+1. If `board` already belongs to an eligible group (same rule the frontend
+   uses: `builder: true` OR non-predefined owned group — i.e.
+   `board.board_groups.where(predefined: [false, nil]).first || board.board_groups.builder.first`),
+   return it. No duplicate is ever created.
+2. Otherwise, check `user.at_board_group_limit?` — raise `LimitReached` if so
+   (mirrors the existing 422 contract used by `BoardGroupsController#create`
+   and `BoardBuilderController#create`).
+3. BFS-discover boards via `Boards::LinkedBoardsFinder.new(board).call`.
+4. In a transaction: create `BoardGroup.new(user: user, name: board.name,
+   builder: false, root_board_id: board.id)`, then
+   `board_group_boards.create!` for each discovered board in BFS order
+   (`position: index`).
+5. Return the group.
+
+### Endpoint
+
+`POST /api/boards/:id/create_board_group` (member route on `resources
+:boards`, alongside `add_to_groups`) → `Api::BoardsController#create_board_group`.
+
+- `set_board`, then 401 unless `@board.user_id == current_user.id ||
+  current_user.admin?` (same pattern as `make_editable`).
+- Calls the service; on `LimitReached` renders the standard 422 shape:
+  `{ error: "...", limit: ..., count: ... }`.
+- On success, renders `board_group.api_view_with_boards(current_user)`,
+  status `:created` (201) if a new group was made, `:ok` (200) if an existing
+  one was returned (lets the frontend distinguish "created" vs "reused" if it
+  ever wants to, though it doesn't need to for v1 — it just navigates to the
+  map either way).
+
+### Out of scope
+
+- Editing group membership after creation — existing add/remove-board UI
+  covers that.
+- Any change to the Board Builder's own `builder: true` group creation path.
+- Frontend changes — handed off separately to `itty-bitty-frontend` (see
+  `docs/superpowers/specs/2026-08-04-create-board-group-for-board-design.md`
+  companion prompt delivered to the user).
+
+## Testing
+
+- `spec/services/boards/linked_boards_finder_spec.rb` — BFS traversal,
+  cycles, cap.
+- `spec/services/boards/board_group_creator_spec.rb` — creates a new group
+  with correct members/positions; returns existing eligible group instead of
+  duplicating; raises `LimitReached` at the plan limit.
+- `spec/requests/api/boards_create_board_group_spec.rb` (or added to the
+  existing boards request spec) — 401 for non-owner, 422 at limit, 200/201
+  happy path, idempotent re-call returns the same group.

--- a/spec/models/board_eligible_board_group_spec.rb
+++ b/spec/models/board_eligible_board_group_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Board, "#eligible_board_group" do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  it "returns nil when the board belongs to no group" do
+    expect(board.eligible_board_group).to be_nil
+  end
+
+  it "returns a builder group over a non-predefined group when both exist" do
+    plain_group = create(:board_group, user: user, builder: false, predefined: false)
+    plain_group.add_board(board)
+    builder_group = create(:board_group, user: user, builder: true)
+    builder_group.add_board(board)
+
+    expect(board.eligible_board_group).to eq(builder_group)
+  end
+
+  it "returns a non-predefined, non-builder group" do
+    group = create(:board_group, user: user, builder: false, predefined: false)
+    group.add_board(board)
+
+    expect(board.eligible_board_group).to eq(group)
+  end
+
+  it "ignores a predefined, non-builder group" do
+    group = create(:board_group, user: user, builder: false, predefined: true)
+    group.add_board(board)
+
+    expect(board.eligible_board_group).to be_nil
+  end
+end

--- a/spec/models/board_eligible_board_group_spec.rb
+++ b/spec/models/board_eligible_board_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Board, "#eligible_board_group" do
   let(:board) { create(:board, user: user) }
 
   it "returns nil when the board belongs to no group" do
-    expect(board.eligible_board_group).to be_nil
+    expect(board.eligible_board_group(user)).to be_nil
   end
 
   it "returns a builder group over a non-predefined group when both exist" do
@@ -14,20 +14,28 @@ RSpec.describe Board, "#eligible_board_group" do
     builder_group = create(:board_group, user: user, builder: true)
     builder_group.add_board(board)
 
-    expect(board.eligible_board_group).to eq(builder_group)
+    expect(board.eligible_board_group(user)).to eq(builder_group)
   end
 
   it "returns a non-predefined, non-builder group" do
     group = create(:board_group, user: user, builder: false, predefined: false)
     group.add_board(board)
 
-    expect(board.eligible_board_group).to eq(group)
+    expect(board.eligible_board_group(user)).to eq(group)
   end
 
   it "ignores a predefined, non-builder group" do
     group = create(:board_group, user: user, builder: false, predefined: true)
     group.add_board(board)
 
-    expect(board.eligible_board_group).to be_nil
+    expect(board.eligible_board_group(user)).to be_nil
+  end
+
+  it "ignores a group owned by a different user even if this board is a member of it" do
+    other_user = create(:user)
+    other_groups_group = create(:board_group, user: other_user, builder: false, predefined: false)
+    other_groups_group.add_board(board)
+
+    expect(board.eligible_board_group(user)).to be_nil
   end
 end

--- a/spec/requests/api/boards_create_board_group_spec.rb
+++ b/spec/requests/api/boards_create_board_group_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe "API::Boards#create_board_group", type: :request do
     expect(BoardGroup.where(root_board_id: home.id)).to be_empty
   end
 
+  it "owns the created group by the board's owner when an admin creates it on their behalf" do
+    admin = create(:admin_user)
+
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(admin)
+
+    expect(response).to have_http_status(:created)
+    group = BoardGroup.find(JSON.parse(response.body)["id"])
+    expect(group.user_id).to eq(user.id)
+  end
+
   it "returns the standard board-set-limit 422 shape when the user is at their limit" do
     user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0))
 

--- a/spec/requests/api/boards_create_board_group_spec.rb
+++ b/spec/requests/api/boards_create_board_group_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "API::Boards#create_board_group", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  let!(:home) { create(:board, user: user, name: "Home") }
+  let!(:food) { create(:board, user: user, name: "Food") }
+
+  before { add_tile(home, label: "Food", links_to: food) }
+
+  it "creates a group for the board and returns it" do
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    expect(body["root_board_id"]).to eq(home.id)
+    board_ids = body["boards"].map { |b| b["board_id"] }
+    expect(board_ids).to contain_exactly(home.id, food.id)
+  end
+
+  it "returns the existing group (200) instead of duplicating it" do
+    existing = home.board_groups.create!(user: user, name: "Existing", builder: true)
+    existing.add_board(home)
+
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)["id"]).to eq(existing.id)
+  end
+
+  it "returns 401 for a non-owner, non-admin user" do
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(other_user)
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(BoardGroup.where(root_board_id: home.id)).to be_empty
+  end
+
+  it "returns the standard board-set-limit 422 shape when the user is at their limit" do
+    user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0))
+
+    post "/api/boards/#{home.id}/create_board_group", headers: auth_headers(user)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    body = JSON.parse(response.body)
+    expect(body["error"]).to be_present
+    expect(body).to have_key("limit")
+    expect(body).to have_key("count")
+  end
+end

--- a/spec/services/boards/board_group_creator_spec.rb
+++ b/spec/services/boards/board_group_creator_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Boards::BoardGroupCreator do
+  let(:user) { create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  describe "when the board has no eligible group yet" do
+    it "creates a new group rooted at the board with every reachable board as a member" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "Food", links_to: food)
+      add_tile(food, label: "apple")
+
+      group = described_class.new(board: home, user: user).call
+
+      expect(group).to be_persisted
+      expect(group.root_board_id).to eq(home.id)
+      expect(group.name).to eq("Home")
+      expect(group.builder).to be(false)
+      expect(group.boards.map(&:id)).to contain_exactly(home.id, food.id)
+    end
+  end
+
+  describe "when the board already has an eligible group" do
+    it "returns the existing group instead of creating a duplicate" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      expect {
+        result = described_class.new(board: home, user: user).call
+        expect(result).to eq(existing)
+      }.not_to change(BoardGroup, :count)
+    end
+  end
+
+  describe "when the user is at their board-group limit" do
+    before { user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0)) }
+
+    it "raises LimitReached and creates nothing" do
+      home = create(:board, user: user, name: "Home")
+
+      expect {
+        described_class.new(board: home, user: user).call
+      }.to raise_error(Boards::BoardGroupCreator::LimitReached)
+      expect(BoardGroup.count).to eq(0)
+    end
+
+    it "still returns the existing group without raising, even at the limit" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      expect { described_class.new(board: home, user: user).call }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/boards/board_group_creator_spec.rb
+++ b/spec/services/boards/board_group_creator_spec.rb
@@ -15,13 +15,37 @@ RSpec.describe Boards::BoardGroupCreator do
       add_tile(home, label: "Food", links_to: food)
       add_tile(food, label: "apple")
 
-      group = described_class.new(board: home, user: user).call
+      creator = described_class.new(board: home, user: user)
+      group = creator.call
 
       expect(group).to be_persisted
       expect(group.root_board_id).to eq(home.id)
       expect(group.name).to eq("Home")
       expect(group.builder).to be(false)
       expect(group.boards.map(&:id)).to contain_exactly(home.id, food.id)
+      expect(creator.created?).to be(true)
+    end
+  end
+
+  describe "when an admin creates a group for another user's board" do
+    it "owns the resulting group by the board's actual owner, not the acting admin" do
+      admin = create(:admin_user)
+      home = create(:board, user: user, name: "Home")
+
+      group = described_class.new(board: home, user: admin).call
+
+      expect(group.user_id).to eq(user.id)
+      expect(group.user_id).not_to eq(admin.id)
+    end
+
+    it "checks the board owner's limit, not the acting admin's" do
+      admin = create(:admin_user)
+      home = create(:board, user: user, name: "Home")
+      user.update!(settings: (user.settings || {}).merge("board_group_limit" => 0))
+
+      expect {
+        described_class.new(board: home, user: admin).call
+      }.to raise_error(Boards::BoardGroupCreator::LimitReached)
     end
   end
 
@@ -35,6 +59,44 @@ RSpec.describe Boards::BoardGroupCreator do
         result = described_class.new(board: home, user: user).call
         expect(result).to eq(existing)
       }.not_to change(BoardGroup, :count)
+    end
+
+    it "reports created? as false when reusing an existing group" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      creator = described_class.new(board: home, user: user)
+      creator.call
+
+      expect(creator.created?).to be(false)
+    end
+
+    it "re-syncs membership with newly-reachable boards without duplicating the group" do
+      home = create(:board, user: user, name: "Home")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "Food", links_to: food)
+
+      expect {
+        result = described_class.new(board: home, user: user).call
+        expect(result).to eq(existing)
+        expect(result.boards.map(&:id)).to contain_exactly(home.id, food.id)
+      }.not_to change(BoardGroup, :count)
+    end
+
+    it "never removes an existing member that's no longer reachable" do
+      home = create(:board, user: user, name: "Home")
+      manually_kept = create(:board, user: user, name: "Manually Kept")
+      existing = create(:board_group, user: user, builder: true)
+      existing.add_board(home)
+      existing.add_board(manually_kept)
+
+      described_class.new(board: home, user: user).call
+
+      expect(existing.reload.boards.map(&:id)).to include(manually_kept.id)
     end
   end
 

--- a/spec/services/boards/linked_boards_finder_spec.rb
+++ b/spec/services/boards/linked_boards_finder_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Boards::LinkedBoardsFinder do
+  let(:user) { FactoryBot.create(:user) }
+
+  def add_tile(board, label:, links_to: nil)
+    image = FactoryBot.create(:image, label: label)
+    FactoryBot.create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+  end
+
+  it "returns the root plus every board reachable via folder links" do
+    home  = FactoryBot.create(:board, user: user, name: "Home")
+    food  = FactoryBot.create(:board, user: user, name: "Food")
+    fruit = FactoryBot.create(:board, user: user, name: "Fruit")
+    orphan = FactoryBot.create(:board, user: user, name: "Orphan")
+
+    add_tile(home, label: "Food", links_to: food)
+    add_tile(food, label: "Fruit", links_to: fruit)
+    add_tile(orphan, label: "lonely")
+
+    result = described_class.new(home).call
+    expect(result.map(&:id)).to contain_exactly(home.id, food.id, fruit.id)
+  end
+
+  it "does not loop forever on a cycle" do
+    a = FactoryBot.create(:board, user: user, name: "A")
+    b = FactoryBot.create(:board, user: user, name: "B")
+    add_tile(a, label: "to b", links_to: b)
+    add_tile(b, label: "to a", links_to: a)
+
+    result = described_class.new(a).call
+    expect(result.map(&:id)).to contain_exactly(a.id, b.id)
+  end
+
+  it "returns just the root when it links to nothing" do
+    solo = FactoryBot.create(:board, user: user, name: "Solo")
+    add_tile(solo, label: "word")
+
+    result = described_class.new(solo).call
+    expect(result.map(&:id)).to contain_exactly(solo.id)
+  end
+end


### PR DESCRIPTION
## Summary
- Any board that links to other boards via folder buttons can now get a Board Set (`BoardGroup`) created for it on demand, so the existing "set map" feature becomes available even for boards never built via the Board Builder wizard.
- `POST /api/boards/:id/create_board_group` reuses an existing eligible group when one already exists (and re-syncs its membership with any newly-reachable boards instead of duplicating it), otherwise auto-populates a new group via a BFS over folder links (`Boards::LinkedBoardsFinder`, extracted from `Boards::SetGraphBuilder`'s existing traversal — no behavior change there).
- New groups are always owned by the board's actual owner (not the acting admin, when an admin triggers this on someone else's behalf), and the 422 board-set-limit contract matches the existing shape used elsewhere in the app.
- Docs: `.claude-notes/boards-and-teams.md` and `CHANGELOG.md` updated; design spec + implementation plan committed under `docs/superpowers/`.

## Test plan
- `bundle exec rspec spec/services/boards/ spec/models/board_eligible_board_group_spec.rb spec/requests/api/boards_create_board_group_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/board_groups_spec.rb spec/requests/api/boards_destroy_spec.rb` — 436 examples, 0 failures.
- Full `bundle exec rspec` suite run for CI verification.
- Went through subagent-driven implementation with a task review after each of the 4 implementation tasks, plus a final whole-branch review; one fix wave applied for ownership scoping, membership re-sync, and a check-then-create race, then a scoped re-review confirmed all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)