### PR TITLE
fix(users): account deletion crashed in production on a column that isn't there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed — deleting an account
+
+- **Deleting an account failed outright in production.** Every deletion path —
+  the in-app "delete my account" endpoint, admin deletion, and demo cleanup —
+  raised partway through and left the account untouched. The anonymization step
+  cleared a database column that exists in the schema definition but had never
+  actually been added to the production database, so the code worked in every
+  environment except the live one. The column is now cleared only where it
+  exists.
+
 ### Fixed — test accounts counted as real users
 
 - **Internal test accounts can now be marked as such explicitly.** Demo

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -35,8 +35,21 @@ module UsersHelper
     self.organization_id = nil
     self.vendor_id = nil
 
-    # Optional: remove potentially identifying keys
-    self.child_lookup_key = nil
+    # Optional: remove potentially identifying keys.
+    #
+    # Guarded on the column actually existing. `users.child_lookup_key` is
+    # declared in schema.rb but is ABSENT in production: the migration that
+    # adds it (20240715200059_devise_create_child_accounts) gained those lines
+    # after it had already run there, and Rails tracks migrations by version,
+    # so prod never executed them. Dev/CI build from schema.rb and do have the
+    # column — which is why an unguarded assignment passed every test and
+    # raised NoMethodError on the only environment that matters, breaking
+    # EVERY account deletion (including the user-facing "delete my account"
+    # endpoint and admin cleanup).
+    #
+    # Guarding rather than deleting the line: where the column exists it may
+    # hold an identifying key, and anonymization should still clear it.
+    self.child_lookup_key = nil if has_attribute?(:child_lookup_key)
 
     # Keep Stripe IDs for recordkeeping unless you have a separate tombstone table.
     # self.stripe_customer_id = nil

--- a/spec/models/user_soft_delete_spec.rb
+++ b/spec/models/user_soft_delete_spec.rb
@@ -36,6 +36,54 @@ RSpec.describe "User soft-delete cleanup integration", type: :model do
     end
   end
 
+  # Regression guard for a production-only break: anonymization assigned
+  # users.child_lookup_key unconditionally. That column is declared in
+  # schema.rb (so dev/CI, which build from schema.rb, have it and every test
+  # passed) but is ABSENT in production, because the migration that adds it
+  # gained those lines after it had already run there. Result: NoMethodError
+  # on every account deletion in prod — including the user-facing endpoint —
+  # while the suite stayed green. Simulating the column's absence is the only
+  # way a test can see this.
+  describe "when users.child_lookup_key does not exist (production's shape)" do
+    # BOTH stubs are required. Faking has_attribute? alone proves nothing:
+    # the unguarded assignment would still call a setter that really exists in
+    # the test schema and pass. The setter has to be absent too, exactly as it
+    # is in production.
+    before do
+      allow(AccountDeletionCleanupJob).to receive(:perform_async)
+      allow(user).to receive(:has_attribute?).and_call_original
+      allow(user).to receive(:has_attribute?).with(:child_lookup_key).and_return(false)
+      allow(user).to receive(:child_lookup_key=)
+        .and_raise(NoMethodError.new("undefined method `child_lookup_key=' for an instance of User"))
+    end
+
+    it "soft-deletes without raising" do
+      expect { user.soft_delete_account!(reason: "user_requested", actor_id: user.id) }
+        .not_to raise_error
+    end
+
+    it "still anonymizes and marks the account deleted" do
+      user.soft_delete_account!(reason: "user_requested", actor_id: user.id)
+      user.reload
+
+      expect(user.deleted_at).to be_present
+      expect(user.email).not_to eq("test@example.com")
+      expect(user.name).to eq("Deleted User")
+    end
+  end
+
+  describe "when the column does exist" do
+    it "still clears it, so an identifying key isn't left behind" do
+      allow(AccountDeletionCleanupJob).to receive(:perform_async)
+      skip "column absent in this environment too" unless User.column_names.include?("child_lookup_key")
+      user.update_column(:child_lookup_key, "lookup-abc")
+
+      user.soft_delete_account!(reason: "user_requested", actor_id: user.id)
+
+      expect(user.reload.child_lookup_key).to be_nil
+    end
+  end
+
   describe "#soft_delete_account! (non-Stripe path)" do
     it "enqueues AccountDeletionCleanupJob for users without a Stripe customer" do
       expect(AccountDeletionCleanupJob).to receive(:perform_async).with(


### PR DESCRIPTION
Found while cleaning up test accounts — the deletion raised `undefined method 'child_lookup_key=' for an instance of User`.

## Impact

**Every account deletion has been failing in production.** `soft_delete_account!` raises partway through, in both its Stripe and non-Stripe branches, so it affects:

- `API::UsersController#destroy` — the in-app **"delete my account"** button (`reason: "user_requested"`)
- `API::Admin::UsersController` — admin deletion, single and bulk
- `Admin::MissionControlController` / `Admin::UsersController` — demo cleanup

Worth flagging that the first one is a compliance path: user deletion requests are not completing.

Nothing was left half-deleted — it raises before any state change. I verified the 13 accounts I'd tried to delete are all still active with `deleted_at: nil`.

## Root cause: schema drift, hidden by the test environment

`users.child_lookup_key` is declared in `schema.rb` but **does not exist in the production database**. Confirmed on prod:

```
has child_lookup_key column: false
```

The migration that adds it, `20240715200059_devise_create_child_accounts`, contains:

```ruby
add_column :users, :child_lookup_key, :string unless column_exists?(:users, :child_lookup_key)
```

Those lines were added to the migration *after* it had already run on production. Rails records migrations by version, so prod never re-ran it and never got the column. Dev and CI build from `schema.rb`, which does declare it — so **every environment except production has the column, and the entire suite passed while the live site was broken**.

`anonymize_personal_data_and_delete_all_data!` then assigns it unconditionally.

## The fix

The column is assigned in exactly one place and read nowhere — it's vestigial. Rather than add a migration for a dead field, the assignment is guarded on the column existing. Guarded rather than deleted because where the column *does* exist it may hold an identifying key, and anonymization should still clear it.

## Test plan

The interesting part is that a naive regression test **does not catch this**. Stubbing `has_attribute?` alone passes with or without the fix, because the unguarded assignment still calls a setter that genuinely exists in the test schema. Reproducing production takes both an absent attribute *and* an absent setter.

Verified by reverting the fix:

```
### WITHOUT the fix ###   7 examples, 2 failures
   NoMethodError: undefined method `child_lookup_key=' for an instance of User
### WITH the fix ###      7 examples, 0 failures
```

`spec/models/user_soft_delete_spec.rb` + `spec/models/user_lifecycle_spec.rb` + `spec/helpers`: 48 examples, 0 failures.

## Follow-up worth considering separately

This class of drift — an edited migration that already ran on prod — can hide anywhere. A `schema.rb`-vs-production-columns diff in CI or a deploy check would catch the rest; I haven't looked for other instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)