### PR TITLE
fix(boards): import .obz files asynchronously instead of blocking the request

### DIFF
--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -707,25 +707,23 @@ class API::BoardsController < API::ApplicationController
 
       if file_extension == ".obz"
         begin
-          @board_group = BoardGroup.create!(name: group_name, user_id: current_user.id)
-          result = ObzImporter.new(
-            uploaded_file.read, current_user,
-            board_group: @board_group, import_all: true,
-            import_options: import_options,
-          ).import!
+          @board_group = BoardGroup.create!(name: group_name, user_id: current_user.id, status: "queued")
+          @board_group.import_source_file.attach(uploaded_file)
         rescue => e
           Rails.logger.error "OBZ import failed: #{e.message}"
           render json: { error: "OBZ import failed: #{e.message}" }, status: :unprocessable_content
           return
         end
 
+        ImportObzJob.perform_async(@board_group.id, current_user.id, import_options.stringify_keys)
+
         render json: {
           status: "ok",
-          message: "Imported OBZ file #{file_name}",
+          message: "Importing OBZ file #{file_name}",
           board_group_id: @board_group.id,
-          root_board_id: result[:root_board]&.id,
+          import_status: @board_group.status,
           include_images: import_options[:include_images],
-        }
+        }, status: :accepted
       elsif file_extension == ".obf"
         json_data = parse_obf_upload(uploaded_file)
         unless json_data

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2717,8 +2717,18 @@ class Board < ApplicationRecord
     reset_layouts_after_import = obj["reset_layouts_after_import"] || false
     apply_button_attributes = import_options[:apply_button_attributes] ? true : false
 
+    # Import files carry hundreds to thousands of buttons (a real OBZ core
+    # vocab set runs ~1400). Resolving each one's Image/BoardImage match with
+    # its own SELECT turned a single import into thousands of sequential
+    # queries. Preload every match this OBF's buttons could need ONCE, then
+    # have find_or_create_image_for_button / find_board_image_for_button read
+    # (and, for newly-created images, write back into) these in-memory caches
+    # instead of hitting the DB per button.
+    image_cache = preload_image_cache(current_user, buttons)
+    board_image_cache = preload_board_image_cache(board)
+
     buttons.each do |item|
-      image = find_or_create_image_for_button(item, current_user)
+      image = find_or_create_image_for_button(item, current_user, image_cache: image_cache)
       next unless image
 
       doc_data = images_by_obf_id[item["image_id"].to_s]
@@ -2728,7 +2738,8 @@ class Board < ApplicationRecord
       reset_layouts_after_import ||= coords.nil?
 
       board_image = upsert_board_image(board, image, item, coords, temp_display_image,
-                                       apply_button_attributes: apply_button_attributes)
+                                       apply_button_attributes: apply_button_attributes,
+                                       board_image_cache: board_image_cache)
       dynamic_data[image.id] = {
         "board_id" => board.id,
         "board" => board,
@@ -2802,18 +2813,58 @@ class Board < ApplicationRecord
   # An admin can flip the flag later via the admin UI. Existing matches are
   # returned as-is — we don't downgrade visibility on something the user
   # already owns.
-  def self.find_or_create_image_for_button(item, user)
+  #
+  # `image_cache` (from preload_image_cache) skips the 2-3 per-button SELECTs
+  # this used to run — pass nil to fall back to the original per-call
+  # queries (kept for callers outside the from_obf hot loop).
+  def self.find_or_create_image_for_button(item, user, image_cache: nil)
     label = item["label"]
+    obf_id = item["image_id"]
     image = nil
     if item["ext_saw_image_id"]
-      image = Image.find_by(id: item["ext_saw_image_id"].to_i, user_id: user.id)
+      ext_id = item["ext_saw_image_id"].to_i
+      image = image_cache ? image_cache[:by_ext_id][ext_id] : Image.find_by(id: ext_id, user_id: user.id)
     end
-    image ||= Image.where(user_id: user.id, label: label, obf_id: item["image_id"]).order(:id).first
-    image ||= Image.where(user_id: user.id, label: label).order(:id).first
-    image ||= Image.create!(label: label, user_id: user.id, obf_id: item["image_id"], is_private: true)
+    if image_cache
+      image ||= image_cache[:by_label_and_obf_id][[label, obf_id]]
+      image ||= image_cache[:by_label][label]
+    else
+      image ||= Image.where(user_id: user.id, label: label, obf_id: obf_id).order(:id).first
+      image ||= Image.where(user_id: user.id, label: label).order(:id).first
+    end
+    unless image
+      image = Image.create!(label: label, user_id: user.id, obf_id: obf_id, is_private: true)
+      if image_cache
+        image_cache[:by_label_and_obf_id][[label, obf_id]] ||= image
+        image_cache[:by_label][label] ||= image
+      end
+    end
     image
   end
   private_class_method :find_or_create_image_for_button
+
+  # One-shot preload for find_or_create_image_for_button: every Image match
+  # this OBF's buttons could resolve to, keyed the same way the per-button
+  # lookups were. `.order(:id)` + `||=` while building each hash preserves
+  # the original `.order(:id).first` tie-break (lowest id wins).
+  def self.preload_image_cache(user, buttons)
+    ext_ids = buttons.filter_map { |b| b["ext_saw_image_id"]&.to_i }.uniq
+    labels = buttons.filter_map { |b| b["label"] }.uniq
+
+    by_ext_id = ext_ids.any? ? Image.where(id: ext_ids, user_id: user.id).index_by(&:id) : {}
+
+    by_label_and_obf_id = {}
+    by_label = {}
+    if labels.any?
+      Image.where(user_id: user.id, label: labels).order(:id).each do |img|
+        by_label_and_obf_id[[img.label, img.obf_id]] ||= img
+        by_label[img.label] ||= img
+      end
+    end
+
+    { by_ext_id: by_ext_id, by_label_and_obf_id: by_label_and_obf_id, by_label: by_label }
+  end
+  private_class_method :preload_image_cache
 
   # Downloads / attaches an image binary from an OBF image entry to a Doc on
   # the SpeakAnyWay Image. Copyright-sensitive: gated behind
@@ -2856,7 +2907,7 @@ class Board < ApplicationRecord
   end
   private_class_method :attach_image_doc
 
-  def self.upsert_board_image(board, image, item, coords, display_url, apply_button_attributes: false)
+  def self.upsert_board_image(board, image, item, coords, display_url, apply_button_attributes: false, board_image_cache: nil)
     obf_button_id = item["id"].presence&.to_s
 
     # Idempotency key is the AUTHORED OBF button id, NOT the resolved image_id.
@@ -2866,7 +2917,7 @@ class Board < ApplicationRecord
     # how a re-seed grew a second "all done" tile on the Core 60 builder source.
     # Match the button first so a re-import updates the same tile; fall back to
     # image_id for tiles seeded before button ids were stamped.
-    board_image = find_board_image_for_button(board, image, obf_button_id)
+    board_image = find_board_image_for_button(board, image, obf_button_id, board_image_cache: board_image_cache)
     unless board_image
       board_image = board.board_images.new(image_id: image.id, voice: board.voice,
                                            position: board.board_images_count,
@@ -2879,6 +2930,10 @@ class Board < ApplicationRecord
       # Previously skipped here; result was imported tiles had no audio
       # at all because nothing else compensated.
       board_image.save!
+      if board_image_cache
+        board_image_cache[:by_button_id][obf_button_id] = board_image if obf_button_id.present?
+        board_image_cache[:by_image_id][image.id] ||= board_image
+      end
     end
 
     # Heal resolution drift on an existing tile: re-point it at the freshly
@@ -2915,7 +2970,17 @@ class Board < ApplicationRecord
   # Resolve the existing tile for an authored OBF button. Prefer the stable
   # button id (stamped on board_image.data); fall back to image_id for tiles
   # seeded before stamping existed. nil → caller creates a fresh tile.
-  def self.find_board_image_for_button(board, image, obf_button_id)
+  #
+  # `board_image_cache` (from preload_board_image_cache) skips the 1-2
+  # per-button SELECTs this used to run — pass nil to fall back to the
+  # original per-call queries (kept for callers outside the from_obf hot loop).
+  def self.find_board_image_for_button(board, image, obf_button_id, board_image_cache: nil)
+    if board_image_cache
+      existing = obf_button_id.present? ? board_image_cache[:by_button_id][obf_button_id] : nil
+      return existing if existing
+      return board_image_cache[:by_image_id][image.id]
+    end
+
     if obf_button_id.present?
       existing = board.board_images.where("data ->> 'obf_button_id' = ?", obf_button_id).first
       return existing if existing
@@ -2923,6 +2988,28 @@ class Board < ApplicationRecord
     board.board_images.find_by(image_id: image.id)
   end
   private_class_method :find_board_image_for_button
+
+  # One-shot preload for find_board_image_for_button: every board_image the
+  # board already has, keyed the same way the per-button lookups were. Loaded
+  # once per from_obf call, so a from_obf call against an EXISTING board (a
+  # re-import/re-seed) still sees its current tiles — this only removes the
+  # per-button re-query, not cross-call staleness.
+  #
+  # Queries BoardImage directly rather than `board.board_images` — the
+  # association may already be loaded (and stale) on a `board` object the
+  # caller is holding onto across multiple writes, and the original per-button
+  # code always issued a fresh query, never reading a cached association.
+  def self.preload_board_image_cache(board)
+    by_button_id = {}
+    by_image_id = {}
+    BoardImage.where(board_id: board.id).each do |bi|
+      button_id = bi.data.is_a?(Hash) ? bi.data["obf_button_id"] : nil
+      by_button_id[button_id] = bi if button_id.present?
+      by_image_id[bi.image_id] ||= bi
+    end
+    { by_button_id: by_button_id, by_image_id: by_image_id }
+  end
+  private_class_method :preload_board_image_cache
 
   # Persist the authored OBF button id on the tile so a later re-import matches
   # this same tile even if button→image resolution drifts. Only writes when the

--- a/app/models/board_group.rb
+++ b/app/models/board_group.rb
@@ -24,6 +24,7 @@
 #  settings              :jsonb            not null
 #  description           :text
 #  builder               :boolean          default(FALSE), not null
+#  status                :string
 #
 class BoardGroup < ApplicationRecord
   # has_many :board_group_boards, dependent: :destroy
@@ -33,6 +34,11 @@ class BoardGroup < ApplicationRecord
   has_many :images, through: :board_images
   belongs_to :user
   belongs_to :root_board, class_name: "Board", optional: true
+
+  # Holds the raw uploaded .obz while ImportObzJob processes it in the
+  # background — the file must be durable Sidekiq args, since 20+MB of zip
+  # bytes don't belong in a Redis-backed job payload.
+  has_one_attached :import_source_file
 
   scope :predefined, -> { where(predefined: true) }
   scope :builder, -> { where(builder: true) }
@@ -127,6 +133,14 @@ class BoardGroup < ApplicationRecord
       return cover.display_image_url if cover
     end
     read_attribute(:display_image_url)
+  end
+
+  # Delegates to the root board's rendered preview once import/build has
+  # produced one. Used by the frontend's generic generation-status poller
+  # (BoardGenerationStatusPage) while status is still "queued"/"processing" —
+  # nil is a normal, expected value there, not an error.
+  def preview_image_url
+    root_board&.preview_image_url
   end
 
   def etsy_link
@@ -273,11 +287,14 @@ class BoardGroup < ApplicationRecord
       small_screen_columns: small_screen_columns,
       medium_screen_columns: medium_screen_columns,
       large_screen_columns: large_screen_columns,
+      root_board_id: root_board_id,
       settings: settings,
       margin_settings: margin_settings,
       slug: slug,
       public_url: public_url,
       featured: featured,
+      status: status,
+      preview_image_url: preview_image_url,
       created_at: created_at.strftime("%Y-%m-%d %H:%M:%S"),
       boards: cached_board_group_boards.map do |board_group_board|
         board = board_group_board.board

--- a/app/sidekiq/import_obz_job.rb
+++ b/app/sidekiq/import_obz_job.rb
@@ -1,0 +1,58 @@
+# app/sidekiq/import_obz_job.rb
+#
+# Async half of the .obz import (POST /api/boards/import_obf). The controller
+# does the synchronous pre-work — creates the BoardGroup with
+# status: "queued", attaches the uploaded .obz to it via ActiveStorage (raw
+# zip bytes don't belong in a Sidekiq/Redis job payload) — and enqueues this
+# job. Everything ObzImporter does (unzipping, creating each board, matching/
+# attaching images) runs here instead of blocking the request.
+#
+# Status lifecycle mirrors BuildBoardSetJob/GenerateBoardJob so the frontend's
+# existing BoardGenerationStatusPage polling works unmodified: "queued" ->
+# "processing" -> "complete"/"failed" (re-raised after marking failed so
+# Sidekiq's single configured retry gets a chance).
+class ImportObzJob
+  include Sidekiq::Job
+  sidekiq_options retry: 1, queue: :default
+
+  def perform(board_group_id, user_id, import_options = {})
+    board_group = BoardGroup.find_by(id: board_group_id)
+    unless board_group
+      Rails.logger.error "ImportObzJob: BoardGroup with ID #{board_group_id} not found."
+      return
+    end
+
+    current_user = User.find_by(id: user_id)
+    unless current_user
+      Rails.logger.error "ImportObzJob: User with ID #{user_id} not found for BoardGroup #{board_group_id}."
+      board_group.update_column(:status, "failed")
+      return
+    end
+
+    unless board_group.import_source_file.attached?
+      Rails.logger.error "ImportObzJob: no import_source_file attached to BoardGroup #{board_group_id}."
+      board_group.update_column(:status, "failed")
+      return
+    end
+
+    board_group.update_column(:status, "processing")
+
+    bytes = board_group.import_source_file.download
+    result = ObzImporter.new(
+      bytes, current_user,
+      board_group: board_group, import_all: true,
+      import_options: (import_options || {}).symbolize_keys,
+    ).import!
+
+    if result[:root_board]
+      board_group.update_column(:status, "complete")
+      board_group.import_source_file.purge
+    else
+      board_group.update_column(:status, "failed")
+    end
+  rescue => e
+    Rails.logger.error "\n**** SIDEKIQ - ImportObzJob #{board_group_id} \n\nERROR **** \n#{e.message}\n#{e.backtrace&.join("\n")}\n"
+    board_group&.update_column(:status, "failed")
+    raise
+  end
+end

--- a/db/migrate/20260804191025_add_status_to_board_groups.rb
+++ b/db/migrate/20260804191025_add_status_to_board_groups.rb
@@ -1,0 +1,5 @@
+class AddStatusToBoardGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_column :board_groups, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_30_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_04_191025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -158,6 +158,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_30_120000) do
     t.jsonb "settings", default: {}, null: false
     t.text "description"
     t.boolean "builder", default: false, null: false
+    t.string "status"
     t.index ["builder"], name: "index_board_groups_on_builder"
     t.index ["description"], name: "index_board_groups_on_description"
     t.index ["featured"], name: "index_board_groups_on_featured"

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -12,16 +12,37 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it "imports a .obz file and creates a board for the user" do
+    # Sidekiq::Testing.fake! queues are process-global and nothing in the
+    # suite clears them between examples, so a job enqueued by a previous
+    # example would otherwise drain into this one's assertions.
+    before { ImportObzJob.jobs.clear }
+
+    it "accepts the .obz upload and queues the import instead of blocking" do
       expect {
         post "/api/boards/import_obf",
              params: { file: obz_upload },
              headers: auth_headers(user)
-      }.to change { user.boards.count }.by(1)
-      expect(response).to have_http_status(:ok)
+      }.to change { ImportObzJob.jobs.size }.by(1)
+
+      expect(user.boards.count).to eq(0)
+      expect(response).to have_http_status(:accepted)
       body = JSON.parse(response.body)
       expect(body["status"]).to eq("ok")
-      expect(body["root_board_id"]).to be_present
+      expect(body["board_group_id"]).to be_present
+      expect(body["import_status"]).to eq("queued")
+    end
+
+    it "creates the board(s) once the queued job runs" do
+      post "/api/boards/import_obf",
+           params: { file: obz_upload },
+           headers: auth_headers(user)
+      board_group_id = JSON.parse(response.body)["board_group_id"]
+
+      expect { ImportObzJob.drain }.to change { user.boards.count }.by(1)
+
+      board_group = BoardGroup.find(board_group_id)
+      expect(board_group.status).to eq("complete")
+      expect(board_group.root_board_id).to be_present
     end
 
     # A bare .obf is a single JSON board document. It used to fall through to
@@ -144,18 +165,19 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
         Rack::Test::UploadedFile.new(obz_path, "application/zip")
       end
 
-      it "succeeds without opt-in and reports include_images=false" do
+      it "queues without opt-in and reports include_images=false" do
         post "/api/boards/import_obf",
              params: { file: fresh_upload },
              headers: auth_headers(user)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:accepted)
         expect(JSON.parse(response.body)["include_images"]).to eq(false)
       end
 
-      it "marks all newly-created Images as is_private" do
+      it "marks all newly-created Images as is_private once the job runs" do
         post "/api/boards/import_obf",
              params: { file: fresh_upload },
              headers: auth_headers(user)
+        ImportObzJob.drain
         expect(user.images.where(label: ["happy", "sad"]).pluck(:is_private)).to all(eq(true))
       end
 
@@ -167,7 +189,7 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
         expect(JSON.parse(response.body)["error"]).to eq("image_license_required")
       end
 
-      it "succeeds and persists the audit when include_images=true with ack" do
+      it "queues with the ack and persists the audit once the job runs" do
         post "/api/boards/import_obf",
              params: {
                file: fresh_upload,
@@ -175,9 +197,11 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
                image_license_acknowledged: "true",
              },
              headers: auth_headers(user)
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:accepted)
         body = JSON.parse(response.body)
         expect(body["include_images"]).to eq(true)
+
+        ImportObzJob.drain
 
         bg = BoardGroup.find(body["board_group_id"])
         expect(bg.settings["imported_from_obf"]).to include(

--- a/spec/sidekiq/import_obz_job_spec.rb
+++ b/spec/sidekiq/import_obz_job_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe ImportObzJob do
+  let(:user) { create(:user) }
+  let(:obz_path) { Rails.root.join("spec/data/simple.obz") }
+
+  # Mirrors what Api::BoardsController#import_obf persists in-request before
+  # enqueueing this job: a BoardGroup in "queued" with the raw .obz attached.
+  def precreate_board_group!(owner: user)
+    board_group = BoardGroup.create!(name: "Imported simple.obz", user_id: owner.id, status: "queued")
+    board_group.import_source_file.attach(
+      io: File.open(obz_path), filename: "simple.obz", content_type: "application/zip",
+    )
+    board_group
+  end
+
+  it "imports the boards and marks the group complete" do
+    board_group = precreate_board_group!
+
+    expect {
+      described_class.new.perform(board_group.id, user.id, {})
+    }.to change { user.boards.count }.by(1)
+
+    board_group.reload
+    expect(board_group.status).to eq("complete")
+    expect(board_group.root_board_id).to be_present
+  end
+
+  it "purges the uploaded .obz once the import succeeds" do
+    board_group = precreate_board_group!
+
+    described_class.new.perform(board_group.id, user.id, {})
+
+    expect(board_group.reload.import_source_file.attached?).to be false
+  end
+
+  it "passes import_options through to the importer (image opt-in audit)" do
+    board_group = precreate_board_group!
+
+    described_class.new.perform(
+      board_group.id, user.id,
+      "include_images" => true, "license_acknowledged" => true, "acknowledged_by_user_id" => user.id,
+    )
+
+    board_group.reload
+    expect(board_group.settings["imported_from_obf"]).to include(
+      "include_images" => true, "license_acknowledged" => true,
+    )
+  end
+
+  it "marks the group failed and re-raises when the importer errors" do
+    board_group = precreate_board_group!
+    allow(ObzImporter).to receive(:new).and_raise(StandardError, "boom")
+
+    expect {
+      described_class.new.perform(board_group.id, user.id, {})
+    }.to raise_error(StandardError, "boom")
+
+    expect(board_group.reload.status).to eq("failed")
+  end
+
+  it "no-ops when the BoardGroup no longer exists" do
+    expect { described_class.new.perform(0, user.id, {}) }.not_to raise_error
+  end
+
+  it "marks failed when the user no longer exists" do
+    board_group = precreate_board_group!
+
+    described_class.new.perform(board_group.id, 0, {})
+
+    expect(board_group.reload.status).to eq("failed")
+  end
+
+  it "marks failed when no .obz was attached" do
+    board_group = BoardGroup.create!(name: "No file", user_id: user.id, status: "queued")
+
+    described_class.new.perform(board_group.id, user.id, {})
+
+    expect(board_group.reload.status).to eq("failed")
+  end
+end


### PR DESCRIPTION
## Summary
- OBZ import (`POST /api/boards/import_obf`, `.obz` branch) ran the entire `ObzImporter` synchronously inside the HTTP request — for a real 23-board/1398-button core vocab set, that's ~1400 sequential per-button DB round trips with zero progress feedback, plus a frontend toast that claimed "check back later" after the work had already finished.
- New `ImportObzJob` (mirrors the existing `BuildBoardSetJob` async pattern) does the actual import in the background. The controller now creates the `BoardGroup` with `status: "queued"`, attaches the uploaded `.obz` via ActiveStorage (Sidekiq args can't carry ~20MB of zip bytes), enqueues the job, and returns `202` immediately with the group id to poll.
- `BoardGroup#status`/`#preview_image_url`/`#root_board_id` are now exposed on `api_view_with_boards` so the frontend's existing generic generation-status poller works unmodified against a `BoardGroup`.
- Fixed the underlying N+1 in `Board.from_obf` (shared with the `.obf`/JSON import path and admin vocab-set seeding): preloads Image and BoardImage matches once per import instead of issuing 2-4 SELECTs per button. Measured ~35% fewer total queries on a 50-button sample (570 → 372); the win scales with button count.
- Along the way, found and fixed a real staleness bug: the board-image preload originally read via the `board.board_images` association, which can be a stale cached collection if the caller already loaded it earlier (caught by a flaky-looking `VocabSets` spec failure that only reproduced when run alongside other spec files — root-caused to the association cache, not the DB).

## Test plan
- `bundle exec rspec spec/requests/api/boards/import_export_spec.rb spec/sidekiq/import_obz_job_spec.rb spec/models/board_from_obf_idempotency_spec.rb spec/models/obz_importer_spec.rb` — all passing
- `bundle exec rspec spec/services/boards/fringe_templates_spec.rb spec/services/vocab_sets_spec.rb spec/requests/api/boards/create_from_template_limit_spec.rb spec/services/images/redistribution_license_spec.rb spec/models/board_spec.rb` (every other `Board.from_obf` caller) — all passing across multiple random seeds
- `bundle exec rspec spec/models/board_group_spec.rb spec/requests/api/board_groups_spec.rb spec/services/boards/obz_round_trip_spec.rb` — all passing
- Ad hoc query-count benchmark confirming the N+1 reduction (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)