### PR TITLE
feat(internal-api): allow predictive_board_id on internal board_image create/bulk

### DIFF
--- a/.claude-notes/internal-api-board-linking.md
+++ b/.claude-notes/internal-api-board-linking.md
@@ -1,0 +1,62 @@
+# Internal API — linking boards (folder tiles)
+
+## The field
+
+`board_images.predictive_board_id` is the only thing that makes a tile open
+another board. `BoardImage#is_dynamic?` derives the frontend's "opens another
+board" badge from it, and every tree walk in the codebase —
+`Boards::PredictiveLinkSet`, `Boards::SetGraphBuilder`, the printables repo's
+`walkBoardTree` — follows this one column.
+
+## Where it can be set
+
+| Path | Auth |
+|---|---|
+| `POST /api/internal/boards/:id/board_images` and `.../bulk` | internal key |
+| `PATCH /api/board_images/:id` | user token |
+| `POST /api/images/:id/create_predictive_board` | user token |
+| `POST /api/board_screenshot_imports/:id/commit` | user token |
+| `POST /api/boards/import_obf` (.obz) | user token |
+| `POST /api/v1/board_builder` → `BuildBoardSetJob` | user token |
+
+The internal rows are new. Before them, an internal-key caller could create
+boards and tiles and set layout but never connect anything, so a multi-page set
+could not be assembled unattended.
+
+## Why the attribute needs no validation in the controller
+
+The model already guards both bad cases:
+
+- `check_predictive_board` (before_save) nulls an id that points at nothing
+  rather than raising, so a stale id degrades to a plain word tile instead of
+  500ing — which matters because `#bulk` is atomic and one bad cell would
+  otherwise roll back the whole board.
+- `is_dynamic?` requires `predictive_board_id != board_id`, so a self-link is
+  inert.
+
+Internal calls run as `User::DEFAULT_ADMIN_ID`, so the worst case is admin
+linking to an admin board.
+
+## Gotcha: linked children disappear from board search
+
+`Board#check_is_sub_board` (before_save) sets `sub_board = true` and adds the
+`"sub-board"` tag on any board something points at. `Boards::AdminSearch`
+filters `sub_board: [false, nil]`, so a newly-linked child drops out of
+`GET /api/internal/boards/search`. That's intended — it keeps fringe pages out
+of the catalog — but fetch children by id afterward, not by name.
+
+## Consumer
+
+The `speakanyway-board-build` skill (source in `marketing/skills/`) builds a
+root plus linked child pages in one pass. It creates children first so folder
+tiles can carry `predictive_board_id` in the same bulk call, and it verifies
+the link took by checking `dynamic` on the response — falling back to printing
+manual wiring instructions if this permit ever regresses.
+
+## Not done here
+
+`part_of_speech` is still absent from `apply_optional_attributes!`, so callers
+must send explicit `bg_color` hexes to get Fitzgerald colors. Adding it
+interacts with `BoardImage#set_colors` (`before_update if:
+:part_of_speech_changed?`), which would overwrite an explicit `bg_color` —
+needs its own decision about precedence.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@
   - `POSTHOG_CAPTURE_ENABLED` - Set to `true` to fire server-side PostHog events outside production (dev/staging opt-in). Production fires automatically; staging stays off unless this is set.
   - `RACK_ATTACK_*` - Optional rate-limit tuning (all have sensible defaults). Limits/windows for auth, password-reset, token-lookup, and AI-generation throttles — e.g. `RACK_ATTACK_LOGIN_LIMIT`, `RACK_ATTACK_LOGIN_EMAIL_LIMIT`, `RACK_ATTACK_AI_LIMIT`, `RACK_ATTACK_TOKEN_LIMIT`, `RACK_ATTACK_PASSWORD_RESET_LIMIT` (+ matching `_PERIOD`). `RACK_ATTACK_REDIS_URL` overrides the Redis used for counters (defaults to `REDIS_URL`). See the "Rate limiting" section in `CLAUDE.md`.
   - `CACHE_REDIS_URL` - Optional. Overrides the Redis instance/db used for the production `Rails.cache` store (defaults to `REDIS_URL`). Production caches through a namespaced (`ibb_cache`), fail-open Redis cache store.
-  - `GOOGLE_OAUTH_CLIENT_ID` - Google OAuth client ID. Also the expected `aud` on ID tokens verified by `POST /api/v1/auths/google` (Google sign-in, Phase 1). When blank, that endpoint rejects every request with 401.
-  - `GOOGLE_OAUTH_CLIENT_SECRET` - Google OAuth client secret (not yet exercised server-side — the current flow verifies a frontend-obtained ID token, no server-side token exchange).
 
 - Database creation:
 
@@ -650,6 +648,11 @@ internal scripts can build a board cell-by-cell.
 - `position` *(optional)* — integer used to set `BoardImage#position` after creation. If omitted, the cell is appended at `board_images_count` (its existing default).
 - `voice` *(optional)* — overrides the cell's voice. Normalized via `VoiceService`.
 - `language` *(optional)* — overrides the cell's language code.
+- `predictive_board_id` *(optional)* — makes this a **folder tile** that opens another board when tapped. See "Folder tiles" below.
+- `display_label` *(optional)* — the text shown on the cell, when it should differ from the image's label.
+- `hidden`, `font_size`, `border_width`, `border_radius` *(optional)* — per-cell display overrides.
+- `bg_color`, `text_color`, `border_color` *(optional)* — run through `ColorHelper.to_hex`, so `"yellow"`, `"#FFEA75"`, and `"rgb(255,0,0)"` all work. Use these to apply Fitzgerald part-of-speech colors, since `part_of_speech` itself is not accepted here.
+- `hide_label` *(optional)* — merged into the cell's `data` jsonb without clobbering other keys.
 
 If neither `image_id` nor `label` is given, the request returns `422`.
 Duplicate cells (same image already on the board) are allowed — the model
@@ -667,6 +670,73 @@ curl -X POST https://<host>/api/internal/boards/123/board_images \
 ```
 
 Response: `201 Created` with the new `BoardImage`'s `api_view`.
+
+#### `POST /api/internal/boards/:id/board_images/bulk`
+
+Adds many cells in **one atomic request**. Takes the same per-cell params as the
+single-cell endpoint above, wrapped in a `cells` array.
+
+Atomic means all cells commit or none do — one bad entry rolls the whole request
+back, so a board never ends up half-built. The response array is in **input
+order**, which is what lets you map the returned `BoardImage` ids straight onto a
+layout you then `PATCH`.
+
+```sh
+curl -X POST https://<host>/api/internal/boards/123/board_images/bulk \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "cells": [
+      { "label": "I",        "position": 0, "bg_color": "#FFEA75" },
+      { "label": "want",     "position": 1, "bg_color": "#A1F571" },
+      { "label": "Feelings", "position": 2, "bg_color": "#5ECFFF", "predictive_board_id": 456 }
+    ]
+  }'
+```
+
+Response: `201 Created` with an array of `api_view`s, or `422` with
+`{ "errors": [ { "index": 1, "error": "..." } ] }` identifying which entries
+failed.
+
+#### Folder tiles — linking one board to another
+
+`predictive_board_id` on a cell is the **only** thing that makes tapping a tile
+open a different board. It's what turns a flat grid into a navigable set: a root
+board with "Food", "Feelings" and "Play" tiles that each open their own page.
+
+Set it on either `board_images` or `board_images/bulk`. The cell's `api_view`
+comes back with `dynamic: true` when the link took, which is the reliable way to
+confirm it — the frontend derives its "opens another board" badge from that same
+flag.
+
+```sh
+# Create the child page first, then link a tile on the root to it.
+curl -X POST https://<host>/api/internal/boards/123/board_images \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "label": "Feelings", "position": 12, "predictive_board_id": 456 }'
+```
+
+Three behaviors worth knowing before you script this:
+
+1. **A bad target id degrades, it doesn't error.** `BoardImage`'s
+   `check_predictive_board` callback nulls a `predictive_board_id` that points at
+   nothing rather than raising. The cell is still created — as an ordinary word
+   tile. This is deliberate: because `bulk` is atomic, a raise would roll back an
+   entire board over one stale id. Check `dynamic` on the response rather than
+   assuming a `201` means the link stuck.
+2. **Self-links are inert.** A cell whose `predictive_board_id` equals its own
+   `board_id` is never reported as `dynamic`.
+3. **Linked children drop out of board search.** `Board#check_is_sub_board`
+   flags any board something points at as a sub-board, and
+   `GET /api/internal/boards/search` filters sub-boards out. That's intended — it
+   keeps fringe pages out of the catalog — but it means you should fetch child
+   boards by id afterward, not by searching for their name.
+
+Build order follows from #1: **create child boards first**, then create the root
+with its folder tiles carrying `predictive_board_id` in the same `bulk` call. A
+child page's "back to home" tile is the one link that can't be made that way; the
+app renders a native back arrow for it, so it usually isn't needed.
 
 #### `POST /api/internal/generated_boards`
 

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -86,6 +86,16 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     updates[:language]      = p[:language] if p[:language].present?
     updates[:display_label] = p[:display_label].to_s.strip if p[:display_label].present?
 
+    # Folder tiles. predictive_board_id is the only thing that makes a tile open
+    # another board, so without it an internal-key caller can build every board
+    # in a set but never connect them.
+    #
+    # No extra validation is needed here on purpose: BoardImage's before_save
+    # check_predictive_board nulls an id that points at nothing rather than
+    # raising, and is_dynamic? ignores self-links. A bad value therefore
+    # degrades to an ordinary word tile instead of 500ing a bulk request.
+    updates[:predictive_board_id] = p[:predictive_board_id].to_i if p[:predictive_board_id].present?
+
     updates[:hidden]        = ActiveModel::Type::Boolean.new.cast(p[:hidden]) unless p[:hidden].nil?
     updates[:font_size]     = p[:font_size].to_i if p[:font_size].present?
     updates[:border_width]  = p[:border_width].to_i unless p[:border_width].nil?

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -112,6 +112,50 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       bi = board.board_images.last
       expect(bi.data).to include("hide_label" => true)
     end
+
+    context "folder tiles (predictive_board_id)" do
+      let!(:target_board) { create(:board, user: admin_user, name: "Feelings") }
+
+      it "links a tile to another board and reports it as dynamic" do
+        image = create(:image, label: "feelings-folder", user_id: admin_user.id)
+
+        post "/api/internal/boards/#{board.id}/board_images",
+             params: { image_id: image.id, predictive_board_id: target_board.id }.to_json,
+             headers: auth_headers
+
+        expect(response).to have_http_status(:created)
+        bi = board.board_images.last
+        expect(bi.predictive_board_id).to eq(target_board.id)
+        expect(bi.is_dynamic?).to eq(true)
+        expect(JSON.parse(response.body)["dynamic"]).to eq(true)
+      end
+
+      it "degrades to a plain word tile when the target board does not exist" do
+        image = create(:image, label: "dangling-folder", user_id: admin_user.id)
+
+        post "/api/internal/boards/#{board.id}/board_images",
+             params: { image_id: image.id, predictive_board_id: 0 }.to_json,
+             headers: auth_headers
+
+        # check_predictive_board nulls the id rather than raising, which is what
+        # lets this attribute be permitted without extra validation.
+        expect(response).to have_http_status(:created)
+        bi = board.board_images.last
+        expect(bi.predictive_board_id).to be_nil
+        expect(bi.is_dynamic?).to eq(false)
+      end
+
+      it "does not treat a self-link as dynamic" do
+        image = create(:image, label: "self-folder", user_id: admin_user.id)
+
+        post "/api/internal/boards/#{board.id}/board_images",
+             params: { image_id: image.id, predictive_board_id: board.id }.to_json,
+             headers: auth_headers
+
+        expect(response).to have_http_status(:created)
+        expect(board.board_images.last.is_dynamic?).to eq(false)
+      end
+    end
   end
 
   describe "POST /api/internal/boards/:board_id/board_images/bulk" do
@@ -156,6 +200,29 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(created[0].bg_color).to eq("#FFEA75")
       expect(created[0].data).to include("hide_label" => true)
       expect(created[1].border_width).to eq(6)
+    end
+
+    it "mixes linked folder tiles and plain word tiles in one request" do
+      food = create(:board, user: admin_user, name: "Food")
+      play = create(:board, user: admin_user, name: "Play")
+      word = create(:image, label: "want-bulk", user_id: admin_user.id)
+      food_tile = create(:image, label: "food-folder-bulk", user_id: admin_user.id)
+      play_tile = create(:image, label: "play-folder-bulk", user_id: admin_user.id)
+
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: {
+             cells: [
+               { image_id: word.id, position: 0 },
+               { image_id: food_tile.id, position: 1, predictive_board_id: food.id },
+               { image_id: play_tile.id, position: 2, predictive_board_id: play.id },
+             ],
+           }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      created = board.reload.board_images.order(:position).to_a
+      expect(created.map(&:predictive_board_id)).to eq([nil, food.id, play.id])
+      expect(JSON.parse(response.body).map { |c| c["dynamic"] }).to eq([false, true, true])
     end
 
     it "rolls back atomically when any entry is invalid" do


### PR DESCRIPTION
## Summary

Lets the internal API wire folder tiles, so a multi-page AAC set can be built unattended.

`board_images.predictive_board_id` is the only field that makes a tile open another board. Every path that could set it — `PATCH /api/board_images/:id`, `create_predictive_board`, screenshot import, `.obz` import, `POST /api/v1/board_builder` — requires a **user** auth token. The internal namespace could create boards, add tiles, and set layout, but never connect them. So scripting a root-plus-fringe set through the internal key silently produced N disconnected boards.

The fix is one attribute added to `apply_optional_attributes!`. Both `#create` and `#bulk` route through that method, so both gain linking from the single addition. No new endpoint, no route change, no schema change.

## Why no extra validation

The model already guards both failure modes, and leaning on that is deliberate:

- `BoardImage#check_predictive_board` (before_save) nulls an id that points at nothing rather than raising. That matters because `#bulk` is atomic — a stale id would otherwise roll back an entire board instead of degrading one tile to a plain word.
- `is_dynamic?` requires `predictive_board_id != board_id`, so a self-link is inert.

Internal calls run as `User::DEFAULT_ADMIN_ID`, so the worst case is admin linking to an admin board — no cross-tenant exposure.

## Known side effect (expected, documented)

`Board#check_is_sub_board` flags any board that something now points at as `sub_board`, and `Boards::AdminSearch` filters those out. A newly-linked child therefore drops out of `GET /api/internal/boards/search`. That's the correct behavior — it keeps fringe pages out of the catalog — but it surprises you if you go looking for a child by name afterward. Noted in `.claude-notes/internal-api-board-linking.md`.

## Test plan

Extended `spec/requests/api/internal/board_images_spec.rb` with five cases:

- links a tile to another board; `predictive_board_id` persists and `api_view` reports `dynamic: true`
- a nonexistent target id creates the tile with the link nulled rather than 500ing (proves the `check_predictive_board` guard)
- a self-link is not reported as dynamic
- `#bulk` with mixed linked and plain cells persists all three, order preserved, `dynamic` correct per cell
- existing coverage unchanged

```
bundle exec rspec spec/requests/api/internal/board_images_spec.rb
```

Manual smoke worth doing after merge: create two boards via the internal API, link a tile on the first to the second, and confirm the tile shows the "opens another board" badge in the app.

## Out of scope

`part_of_speech` is still not permitted, so callers send explicit `bg_color` hexes for Fitzgerald colors. Adding it collides with `BoardImage#set_colors` (`before_update if: :part_of_speech_changed?`), which would overwrite an explicit `bg_color` — that needs its own decision about precedence, so it's a separate PR.

## Consumer

The `speakanyway-board-build` skill. It creates child pages before the root so folder tiles can carry `predictive_board_id` in the same bulk call, and it verifies the link took by reading `dynamic` off the response — falling back to printing manual wiring instructions if this ever regresses.