### PR TITLE
docs(changelog): stamp v1.4.0 and insert the missed v1.3.0 boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable user-facing changes to this project will be documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.4.0] — 2026-08-05
 
 ### Added
 
@@ -463,6 +463,8 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   filter admin boards by tag, name or description, published or not.
 - `rake images:license_audit` — read-only report of the image library's
   license breakdown.
+
+## [1.3.0] — 2026-07-21
 
 ### Added — Video tiles accept iPhone recordings, and the 30s limit is now enforced
 - Tile video uploads now accept **.mov / HEVC** files, so a clip recorded on an


### PR DESCRIPTION
## Summary
- Rename `## [Unreleased]` to `## [1.4.0] — 2026-08-05`, aligned with the frontend's v1.4.0 App Store release
- Insert a `## [1.3.0] — 2026-07-21` header at the release boundary: the `[Unreleased]` section had never been stamped since 1.2.1 and still contained everything that shipped with frontend v1.3.0 (video tiles, 5-Year licenses/Clinician plan, Rails 8, rate limiting, Board Builder work, …)

Boundary: everything from "Video tiles accept iPhone recordings" (#523, merged 2026-07-20) down is now under 1.3.0; everything above (merged 2026-07-22 onward) is under 1.4.0. Judgment call at the seam: "Internal API image and board search" (#530) merged 2026-07-22 — one day after the cut — so it landed in 1.4.0; it's internal-only either way. No entry text was rewritten.

## Test plan
Changelog-only change — no code touched, so no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)