### PR TITLE
fix(internal-api): resolve tile labels through Boards::ImageResolver

### DIFF
--- a/.claude-notes/internal-api.md
+++ b/.claude-notes/internal-api.md
@@ -79,6 +79,45 @@ Only **35.9%** of the library can go in a product that's sold — roughly
 at 2,464 docs (ARASAAC, author "Sergio Palao"). Commercial-safe decomposes
 exactly as `OpenAI` 3,116 + `cc by` 400 + `public domain` 58 + `cc by 3.0` 52.
 
+## Label → Image resolution (`board_images` create + bulk)
+
+`Boards::ImageResolver` is the **only** sanctioned way to turn a tile label into
+an `Image` — for this namespace and everywhere else. Several `Image` rows
+routinely share a label (the OBF seed created art-less duplicates), so a naive
+`find_by(label:)` is `LIMIT 1` over arbitrary Postgres heap order and attaches
+a blank image roughly at random. That is exactly how a 60-tile internal build
+came out with 3 tiles on art while reporting `status: "complete"`. Never
+reintroduce a bare `find_by(label:)` here — match case-insensitively and order
+by `COUNT(docs) DESC, images.id ASC`.
+
+Note the first-branch trap: in this namespace `current_user` is *always* the
+default admin, so "prefer the current user's own images" and "prefer public
+admin images" select from overlapping sets. The art requirement, not the
+ownership scope, is what makes the choice correct.
+
+An explicit `image_id` bypasses resolution entirely and pins that exact record.
+That is the escape hatch for callers that resolved a label themselves via
+`POST /api/internal/images/search`.
+
+**Case pinning.** The resolver may return a differently-cased image (`"Run"` →
+`run`). The controller writes the caller's authored casing to the cell's
+`display_label` so tiles aren't silently renamed; an explicit `display_label`
+always wins.
+
+**AI art for misses is on by default.** A label that resolves to an art-less
+image gets `GenerateImagesJob` enqueued in batches of 3 — otherwise the tile is
+blank *forever*, since nothing else in this flow ever queues generation and
+`has_generating_images` would stay `false`. This covers art-less images the
+resolver *found*, not only ones it created. Two rails:
+
+- Enqueue happens **after** the bulk transaction commits. A rolled-back bulk
+  must never hand Sidekiq ids of Images that no longer exist.
+- The `image_id` path never generates. An explicit id is a deliberate pin, and
+  a paid OpenAI call is not a reasonable side effect of one.
+
+Callers that would rather ship blanks than spend the call pass a request-level
+`generate_missing: false` (not per-cell).
+
 ## Search endpoints
 
 - `GET|POST /api/internal/images/search` → `Images::LabelSearch`. Exact match

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable user-facing changes to this project will be documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Boards built through the internal API land on real symbol art.**
+  `POST /api/internal/boards/:id/board_images` and `.../board_images/bulk`
+  resolved a tile label with a naive `find_by(label:)`. Many labels have
+  several `Image` rows, so that returned one at random — routinely a blank,
+  art-less duplicate — and boards came out almost entirely empty while
+  reporting `status: "complete"`. One 60-tile build landed 3 tiles on art.
+  Both endpoints now resolve labels through `Boards::ImageResolver`: matching
+  is case-insensitive and prefers the image that actually has artwork. When
+  the resolved image is cased differently than the label sent, the cell keeps
+  the caller's casing so tiles aren't renamed.
+- **Tiles for words with no library art no longer stay blank forever.** A
+  label with no artwork anywhere now enqueues AI generation, so the tile fills
+  in shortly after the request instead of never. Pass `generate_missing: false`
+  to opt out. An explicit `image_id` still pins that exact record and never
+  triggers generation.
+
 ## [1.4.0] — 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ internal scripts can build a board cell-by-cell.
 **Body params**
 
 - `image_id` *(preferred)* — id of an existing `Image`. Used directly.
-- `label` *(fallback)* — used only if `image_id` is omitted. Looks up an admin/user-owned `Image` by label, then a public image, then creates a new admin-owned image with that label.
+- `label` *(fallback)* — used only if `image_id` is omitted. Resolved through `Boards::ImageResolver`: case-insensitive, and it picks the image that actually **has artwork** (most attached docs, lowest id to break ties) rather than an arbitrary same-label duplicate. Only if no image with that label has art does it reuse an existing blank one, or create a new admin-owned image.
 - `position` *(optional)* — integer used to set `BoardImage#position` after creation. If omitted, the cell is appended at `board_images_count` (its existing default).
 - `voice` *(optional)* — overrides the cell's voice. Normalized via `VoiceService`.
 - `language` *(optional)* — overrides the cell's language code.
@@ -653,8 +653,15 @@ internal scripts can build a board cell-by-cell.
 - `hidden`, `font_size`, `border_width`, `border_radius` *(optional)* — per-cell display overrides.
 - `bg_color`, `text_color`, `border_color` *(optional)* — run through `ColorHelper.to_hex`, so `"yellow"`, `"#FFEA75"`, and `"rgb(255,0,0)"` all work. Use these to apply Fitzgerald part-of-speech colors, since `part_of_speech` itself is not accepted here.
 - `hide_label` *(optional)* — merged into the cell's `data` jsonb without clobbering other keys.
+- `generate_missing` *(optional, default `true`)* — request-level, not per-cell. When a `label` resolves to an image with no artwork, `GenerateImagesJob` is enqueued (in batches of 3) so the tile fills in with AI art shortly after the request returns. Pass `false` to skip the OpenAI call and ship the tile blank. Never applies to the `image_id` path — an explicit id is treated as a deliberate pin.
 
 If neither `image_id` nor `label` is given, the request returns `422`.
+
+Because the resolver matches case-insensitively, `"Run"` may resolve to an
+image labeled `run`. The cell's `display_label` keeps the casing you sent, so
+the tile is not silently renamed — unless you pass an explicit `display_label`,
+which always wins.
+
 Duplicate cells (same image already on the board) are allowed — the model
 permits multiple `BoardImage` rows per `(board_id, image_id)` pair.
 

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -1,4 +1,9 @@
 class API::Internal::BoardImagesController < API::Internal::ApplicationController
+  # AI generation is queued in slices, mirroring
+  # `Board#find_or_create_images_from_word_list`, so one 60-tile build doesn't
+  # become one 60-image Sidekiq job.
+  GENERATE_BATCH_SIZE = 3
+
   def create
     @board = Board.find(params[:board_id])
 
@@ -9,6 +14,8 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
 
     if board_image&.persisted?
       apply_optional_attributes!(board_image, params)
+      pin_authored_label!(board_image, params, image)
+      queue_missing_art!(label_path?(params) ? [image.id] : [])
       render json: board_image.api_view(current_user), status: :created
     else
       errors = board_image&.errors&.full_messages&.join(", ") || "Unable to add image to board"
@@ -26,6 +33,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
 
     created = []
     errors = []
+    label_resolved_image_ids = []
 
     ActiveRecord::Base.transaction do
       raw_cells.each_with_index do |cell_params, index|
@@ -40,6 +48,7 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
           errors << { index: index, error: "image_id or label is required" }
           next
         end
+        label_resolved_image_ids << image.id if label_path?(cp)
 
         board_image = @board.add_image(image.id)
         unless board_image&.persisted?
@@ -53,6 +62,8 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
           next
         end
 
+        pin_authored_label!(board_image, cp, image)
+
         created << board_image
       end
 
@@ -62,21 +73,77 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     if errors.any?
       render json: { errors: errors }, status: :unprocessable_content
     else
+      # Only after the transaction has actually committed — a rolled-back bulk
+      # must not leave Sidekiq holding ids of Images that no longer exist.
+      queue_missing_art!(label_resolved_image_ids)
       render json: created.map { |bi| bi.api_view(current_user) }, status: :created
     end
   end
 
   private
 
+  # An explicit `image_id` pins that exact record; a bare `label` goes through
+  # label resolution (and is the only path that may create an Image or spend an
+  # OpenAI call).
+  def label_path?(p)
+    p[:image_id].blank? && p[:label].present?
+  end
+
+  # `Boards::ImageResolver` — not a naive `find_by(label:)` — is the single
+  # source of truth for label -> Image. A label can match several Image rows,
+  # and only the resolver prefers the art-bearing one (most docs, lowest id to
+  # break ties) and matches case-insensitively. `find_by` returns arbitrary
+  # Postgres heap order, which is how this endpoint used to attach blank,
+  # art-less duplicates to almost every tile.
   def resolve_image_from(p)
     if p[:image_id].present?
       Image.find_by(id: p[:image_id])
     elsif p[:label].present?
-      label = p[:label].to_s.strip
-      Image.find_by(label: label, user_id: current_user.id) ||
-        Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil]) ||
-        Image.create(label: label, user_id: current_user.id)
+      Boards::ImageResolver.resolve(p[:label].to_s.strip, owner: current_user)
     end
+  end
+
+  # The resolver matches case-insensitively, so "Run" can legitimately resolve
+  # to an Image labeled "run". Keep the caller's authored casing on the cell
+  # rather than silently renaming the tile — same rule as
+  # `ImageResolver.upgrade_board_tiles!`.
+  def pin_authored_label!(board_image, p, image)
+    return unless label_path?(p)
+    return if p[:display_label].present?
+
+    authored = p[:label].to_s.strip
+    return if authored.blank? || authored == image.label
+
+    board_image.update(display_label: authored)
+  end
+
+  # Queue AI art for any label that resolved to an Image with no artwork.
+  # Without this a tile for an unmatched label stays permanently blank: nothing
+  # else in this flow ever enqueues generation.
+  #
+  # Covers art-less images the resolver *found*, not just ones it created — an
+  # existing blank duplicate is every bit as blank as a fresh one.
+  def queue_missing_art!(image_ids)
+    return if image_ids.empty?
+    return unless generate_missing?
+
+    ids = Image.where(id: image_ids.uniq)
+               .where.missing(:docs)
+               .pluck(:id)
+    return if ids.empty?
+
+    ids.each_slice(GENERATE_BATCH_SIZE) do |batch|
+      GenerateImagesJob.perform_async(batch, @board.id)
+    end
+  end
+
+  # Generation is on by default (callers building a board expect filled tiles).
+  # `generate_missing: false` opts out when the caller would rather ship blanks
+  # than spend the OpenAI call.
+  def generate_missing?
+    return true if params[:generate_missing].nil?
+
+    ActiveModel::Type::Boolean.new.cast(params[:generate_missing]) != false
   end
 
   def apply_optional_attributes!(board_image, p)

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
   before do
     allow(ENV).to receive(:[]).and_call_original
     allow(ENV).to receive(:[]).with("INTERNAL_API_KEY").and_return(internal_key)
+    allow(GenerateImagesJob).to receive(:perform_async)
+  end
+
+  def with_art(image, count: 1)
+    count.times { create(:doc, documentable: image, user: admin_user) }
+    image
   end
 
   describe "POST /api/internal/boards/:board_id/board_images" do
@@ -244,6 +250,155 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(errors).to be_an(Array)
       expect(errors.first["index"]).to eq(1)
       expect(errors.first["error"]).to match(/image_id or label is required/)
+    end
+  end
+
+  # Regression coverage for #572: label resolution used a naive `find_by`, which
+  # returns arbitrary Postgres heap order and routinely attached a blank,
+  # art-less duplicate instead of the illustrated library image.
+  describe "label resolution" do
+    def bulk_post(cells, extra = {})
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: cells }.merge(extra).to_json,
+           headers: auth_headers
+    end
+
+    it "attaches the art-bearing image, not a lower-id blank duplicate" do
+      blank = create(:image, label: "run", user_id: admin_user.id)
+      arted = with_art(create(:image, label: "run", user_id: admin_user.id))
+
+      bulk_post([{ label: "run", position: 0 }])
+
+      expect(response).to have_http_status(:created)
+      expect(board.reload.board_images.last.image_id).to eq(arted.id)
+      expect(board.board_images.last.image_id).not_to eq(blank.id)
+    end
+
+    it "prefers the image with the most artwork when several have art" do
+      few  = with_art(create(:image, label: "ball", user_id: admin_user.id), count: 1)
+      many = with_art(create(:image, label: "ball", user_id: admin_user.id), count: 3)
+
+      bulk_post([{ label: "ball" }])
+
+      expect(board.reload.board_images.last.image_id).to eq(many.id)
+      expect(board.board_images.last.image_id).not_to eq(few.id)
+    end
+
+    it "matches the label case-insensitively instead of creating a duplicate" do
+      arted = with_art(create(:image, label: "stop", user_id: admin_user.id))
+
+      expect {
+        bulk_post([{ label: "Stop" }])
+      }.not_to change(Image, :count)
+
+      expect(board.reload.board_images.last.image_id).to eq(arted.id)
+    end
+
+    it "keeps the caller's authored casing as the cell's display_label" do
+      with_art(create(:image, label: "stop", user_id: admin_user.id))
+
+      bulk_post([{ label: "Stop" }])
+
+      expect(board.reload.board_images.last.display_label).to eq("Stop")
+    end
+
+    it "does not override an explicit display_label with the authored casing" do
+      with_art(create(:image, label: "stop", user_id: admin_user.id))
+
+      bulk_post([{ label: "Stop", display_label: "🛑" }])
+
+      expect(board.reload.board_images.last.display_label).to eq("🛑")
+    end
+
+    it "still pins the exact record when image_id is given" do
+      blank = create(:image, label: "run", user_id: admin_user.id)
+      with_art(create(:image, label: "run", user_id: admin_user.id))
+
+      bulk_post([{ image_id: blank.id }])
+
+      expect(board.reload.board_images.last.image_id).to eq(blank.id)
+    end
+
+    it "creates the image with create! so validation failures surface" do
+      expect {
+        bulk_post([{ label: "zzz-brand-new-word" }])
+      }.to change(Image, :count).by(1)
+
+      expect(Image.last.label).to eq("zzz-brand-new-word")
+    end
+  end
+
+  # #572, second bug: a tile created for a label with no library art used to
+  # stay permanently blank — nothing in this flow enqueued generation.
+  describe "AI art for labels with no library art" do
+    def bulk_post(cells, extra = {})
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: cells }.merge(extra).to_json,
+           headers: auth_headers
+    end
+
+    it "enqueues generation for a label that resolved to an art-less image" do
+      bulk_post([{ label: "zzz-no-art-anywhere" }])
+
+      expect(response).to have_http_status(:created)
+      image = Image.find_by(label: "zzz-no-art-anywhere")
+      expect(GenerateImagesJob).to have_received(:perform_async).with([image.id], board.id)
+    end
+
+    it "enqueues for an existing blank image, not just a newly created one" do
+      blank = create(:image, label: "zzz-existing-blank", user_id: admin_user.id)
+
+      bulk_post([{ label: "zzz-existing-blank" }])
+
+      expect(GenerateImagesJob).to have_received(:perform_async).with([blank.id], board.id)
+    end
+
+    it "does not enqueue when the label already has art" do
+      with_art(create(:image, label: "apple-arted", user_id: admin_user.id))
+
+      bulk_post([{ label: "apple-arted" }])
+
+      expect(GenerateImagesJob).not_to have_received(:perform_async)
+    end
+
+    it "does not enqueue for the explicit image_id path" do
+      blank = create(:image, label: "pinned-blank", user_id: admin_user.id)
+
+      bulk_post([{ image_id: blank.id }])
+
+      expect(GenerateImagesJob).not_to have_received(:perform_async)
+    end
+
+    it "does not enqueue when generate_missing is false" do
+      bulk_post([{ label: "zzz-opted-out" }], generate_missing: false)
+
+      expect(response).to have_http_status(:created)
+      expect(GenerateImagesJob).not_to have_received(:perform_async)
+    end
+
+    it "batches in slices of three" do
+      labels = (1..4).map { |i| { label: "zzz-batch-#{i}" } }
+
+      bulk_post(labels)
+
+      expect(GenerateImagesJob).to have_received(:perform_async).twice
+    end
+
+    it "enqueues nothing when the bulk request rolls back" do
+      bulk_post([{ label: "zzz-rolled-back" }, { position: 1 }])
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(GenerateImagesJob).not_to have_received(:perform_async)
+    end
+
+    it "enqueues for the single-cell endpoint too" do
+      post "/api/internal/boards/#{board.id}/board_images",
+           params: { label: "zzz-single-no-art" }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      image = Image.find_by(label: "zzz-single-no-art")
+      expect(GenerateImagesJob).to have_received(:perform_async).with([image.id], board.id)
     end
   end
 end


### PR DESCRIPTION
## Summary

The internal `board_images` create + bulk endpoints resolved a tile `label` with a naive `find_by(label:)`. Many labels have several `Image` rows, so that's `LIMIT 1` over arbitrary Postgres heap order — routinely a blank, art-less duplicate. That's why a 60-tile build on staging landed **3 tiles on art** while reporting `status: "complete"`.

Both endpoints now delegate the label path to `Boards::ImageResolver` (the resolver the repo already had for exactly this failure): case-insensitive match, ordered by `COUNT(docs) DESC, images.id ASC`, so the illustrated library image wins. It also creates with `create!` rather than `create`, closing the "Minor" note in the issue — a non-persisted Image can no longer reach `Board#add_image`. An explicit `image_id` still pins that exact record and skips resolution.

Because the resolver may return a differently-cased image (`"Run"` → `run`), the caller's authored casing is written to the cell's `display_label` so tiles aren't silently renamed. An explicit `display_label` still wins.

**Second bug — blank tiles never got AI art.** A label that resolves to an art-less image now enqueues `GenerateImagesJob` in batches of 3, matching `Board#find_or_create_images_from_word_list`. Nothing in this flow queued generation before, so such a tile stayed blank *permanently* and `has_generating_images` stayed `false`. Three rails:

- Covers art-less images the resolver **found**, not only ones it created — an existing blank duplicate is just as permanently blank.
- Enqueue happens **after** the bulk transaction commits, so a rolled-back request can't hand Sidekiq ids of Images that no longer exist.
- The `image_id` path never generates. An explicit id is a deliberate pin, not a reason to spend an OpenAI call.

Request-level `generate_missing: false` opts out (chosen over opt-in so existing callers stop producing blank boards without needing changes).

The bulk response stays a bare array — the printables client (`speakanyway.ts`, `build-boards.ts`) reads `created.length` / `.map`, so wrapping it in an object would break that repo.

Closes #572

## Test plan

`bundle exec rspec spec/requests/api/internal/ spec/services/boards/image_resolver_spec.rb` → **135 examples, 0 failures**.

15 new examples in `spec/requests/api/internal/board_images_spec.rb`:

- art-bearing image wins over a lower-id blank duplicate (the exact repro from the issue)
- image with the most docs wins when several have art
- case-insensitive match doesn't create a duplicate
- authored casing lands on `display_label`; an explicit `display_label` still wins
- explicit `image_id` still pins, including to a blank image
- generation enqueued for a newly created blank, and for an existing blank
- not enqueued when the label already has art
- not enqueued on the `image_id` path
- not enqueued when `generate_missing: false`
- batched in slices of three
- nothing enqueued when the bulk request rolls back
- single-cell endpoint enqueues too

## Docs

- `.claude-notes/internal-api.md` — new "Label → Image resolution" section: the never-reintroduce-`find_by(label:)` rule, the `current_user`-is-always-admin trap that made the old first branch useless, case pinning, and the two enqueue rails.
- `README.md` — updated the `label` param description and documented `generate_missing`.
- `CHANGELOG.md` — new `[Unreleased] / Fixed` section.

## Follow-up (not in this PR)

Staging board **276** (`At the Playground`) was kept as evidence and is safe to delete once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)