### PR TITLE
fix(mailer): drop outbound mail to e2e test accounts

### DIFF
--- a/config/initializers/e2e_mail_interceptor.rb
+++ b/config/initializers/e2e_mail_interceptor.rb
@@ -1,0 +1,27 @@
+# Drops outbound mail addressed to e2e test accounts.
+#
+# The frontend's Playwright suite (itty-bitty-frontend #620) creates throwaway
+# accounts as e2e+<run-id>-<n>@speakanyway.com on STAGING. The speakanyway.com
+# domain forwards unknown addresses to a real inbox, so every test run was
+# flooding it with confirmation emails. Nobody legitimately uses this address
+# pattern, so the interceptor is registered in every environment — pattern-
+# scoped, not env-scoped — which also covers the (guarded-against) case of a
+# suite pointed at the wrong host.
+#
+# Mail with a mix of recipients keeps its real ones and just sheds the e2e
+# addresses; mail addressed only to e2e accounts is discarded outright.
+class E2eMailInterceptor
+  E2E_RECIPIENT = /\Ae2e\+[^@\s]*@speakanyway\.com\z/i
+
+  def self.delivering_email(message)
+    real = Array(message.to).reject { |addr| addr.match?(E2E_RECIPIENT) }
+    if real.empty?
+      message.perform_deliveries = false
+      Rails.logger.info("[E2eMailInterceptor] dropped mail to #{Array(message.to).join(", ")}")
+    elsif real.length != Array(message.to).length
+      message.to = real
+    end
+  end
+end
+
+ActionMailer::Base.register_interceptor(E2eMailInterceptor)

--- a/spec/initializers/e2e_mail_interceptor_spec.rb
+++ b/spec/initializers/e2e_mail_interceptor_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe E2eMailInterceptor do
+  def message_to(*recipients)
+    Mail::Message.new.tap { |m| m.to = recipients }
+  end
+
+  it "blocks delivery when every recipient is an e2e address" do
+    message = message_to("e2e+local123-1@speakanyway.com")
+    described_class.delivering_email(message)
+    expect(message.perform_deliveries).to be false
+  end
+
+  it "is case-insensitive and handles multiple e2e recipients" do
+    message = message_to("E2E+Run-9@SpeakAnyWay.com", "e2e+x@speakanyway.com")
+    described_class.delivering_email(message)
+    expect(message.perform_deliveries).to be false
+  end
+
+  it "strips e2e addresses but still delivers to real recipients" do
+    message = message_to("parent@example.com", "e2e+run-1@speakanyway.com")
+    described_class.delivering_email(message)
+    expect(message.perform_deliveries).to be true
+    expect(message.to).to eq(["parent@example.com"])
+  end
+
+  it "leaves ordinary mail untouched" do
+    message = message_to("parent@example.com")
+    described_class.delivering_email(message)
+    expect(message.perform_deliveries).to be true
+    expect(message.to).to eq(["parent@example.com"])
+  end
+
+  it "does not match lookalike domains or missing plus tags" do
+    %w[e2e@speakanyway.com e2e+x@speakanyway.com.evil.com someone+e2e@speakanyway.com].each do |addr|
+      message = message_to(addr)
+      described_class.delivering_email(message)
+      expect(message.perform_deliveries).to be(true), "expected #{addr} to deliver"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The frontend's new Playwright e2e suite ([itty-bitty-frontend #620](https://github.com/brittanyjohns/itty-bitty-frontend/issues/620)) creates throwaway `e2e+<run-id>@speakanyway.com` accounts on staging. The speakanyway.com domain forwards unknown addresses to a real inbox, so every run flooded it with Devise confirmation emails.

Adds a mail interceptor that blocks delivery when every recipient matches `e2e+*@speakanyway.com` (case-insensitive, anchored — lookalike domains and non-plus addresses are untouched) and strips e2e addresses from mixed recipient lists. Registered in all environments deliberately: the pattern is exclusively test accounts, and this also covers the guarded-against case of a suite aimed at the wrong host.

## Test plan

- `bundle exec rspec spec/initializers/e2e_mail_interceptor_spec.rb` — 5 examples, 0 failures: drops all-e2e mail, case-insensitive, strips e2e from mixed lists, leaves ordinary mail and lookalike domains untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)