### PR TITLE
fix(tiles): make AAC tile colour corrections stick

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -726,3 +726,41 @@ tiles + Space/Delete.
   "sm"]` so an lg edit doesn't reflow away the QWERTY stagger or wide space bar.
 - Word-as-written playback needs no backend work: the frontend composes the
   string and uses the existing `POST /api/images/generate_audio`.
+
+
+## Tile colors (Modified Fitzgerald key)
+
+`part_of_speech` is the source of truth; `bg_color`/`text_color` are derived
+from it via `background_color_for` (`ImageHelper`) → `ColorHelper::PRESET_HEX`.
+Both `images` and `board_images` store their own snapshot of the pair, so
+nothing recolors retroactively — a category corrected later needs the row
+repainted.
+
+- **An explicitly assigned `part_of_speech` always wins.** `Image#ensure_defaults`
+  only calls `AacWordCategorizer` when the save isn't already changing
+  `part_of_speech`, so a plain `image.part_of_speech = "noun"; image.save!`
+  survives. The `update_column(s)` workarounds scattered around the codebase
+  (`reset_part_of_speech!`, `CategorizeImageJob`, `Board.apply_obf_part_of_speech`)
+  are now belt-and-braces, not load-bearing.
+- **Color follows category on save.** `Image`'s `after_save :update_background_color`
+  guards on `saved_change_to_part_of_speech?` — inside an `after_save` the
+  `*_changed?` predicates read *pending* changes and are always false. It skips
+  when `bg_color` moved in the same write (that color was authored) and writes
+  via `update_columns` so it can't re-enter `ensure_defaults`.
+- **`board_images.part_of_speech` is `null: false, default: "default"`**, so
+  `"default"` is a placeholder, not a category. Resolve it with
+  `BoardImage#effective_part_of_speech`, never a `part_of_speech ||
+  image.part_of_speech` chain — the `||` can never fall through.
+- **Authored colors are never recomputed.** OBF `background_color` is applied
+  after the main save via `update_columns` and stamped
+  `data["explicit_bg_color"] = true`.
+- **Repairing drifted rows:** `bin/rails tile_colors:repair` (dry run;
+  `WRITE=true` applies, `SCOPE=images|board_images`, `LIMIT=n`). It only ever
+  writes colors — a `board_image` category that differs from its `Image`'s is a
+  deliberate per-board override and is recolored from the tile's own category.
+  It skips any color that isn't one of the preset hexes, since only a preset
+  could have been derived. (`Image.update_all_background_colors` and
+  `BoardImage.fix_bg_hex` predate it and only touch grey/white/nil/non-hex rows.)
+- **Overrides are keyed on communicative function, not grammar** —
+  `AacWordCategorizer::OVERRIDES` codes "stop" as `important_function`
+  (protesting), while "help" stays a request verb.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Correcting a tile's word category now actually recolors the tile.** The
+  callback meant to repaint an image when its part of speech changed never
+  fired, and an ordinary save silently re-ran the auto-categorizer over a
+  hand-picked category — so corrections either didn't stick or left the tile
+  painted its old color (the live case: a "social" tile still showing
+  important-function red). Hand-set categories now survive a normal save, and
+  the color follows the category.
+- **Tiles that never had their own category now inherit the word's category.**
+  A tile carrying the stored `"default"` placeholder was painted grey instead
+  of taking the color of its underlying word.
+- **"stop" is now coded as an important function (red), not a verb (green).**
+  In the Modified Fitzgerald key tiles are colored by communicative function:
+  a child hitting "stop" is protesting, so it belongs beside no / don't /
+  can't and needs to stand out from the action words around it. ("stop!"
+  already worked; plain "stop" fell through.) "help" is unchanged — it reads
+  correctly as a request verb.
+- Added `bin/rails tile_colors:repair` (dry run by default, `WRITE=true` to
+  apply) to repaint existing tiles whose stored color drifted from their
+  category. Per-board category overrides and deliberately authored colors —
+  including explicit colors from OBF/OBZ imports — are left alone.
+
 - **Boards built through the internal API land on real symbol art.**
   `POST /api/internal/boards/:id/board_images` and `.../board_images/bulk`
   resolved a tile label with a naive `find_by(label:)`. Many labels have

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -3052,7 +3052,15 @@ class Board < ApplicationRecord
       updates[:text_color] = ColorHelper.text_hex_for(bg)
     end
     updates[:border_color] = item["border_color"] if item["border_color"].present?
-    board_image.update_columns(updates) if updates.any?
+    return if updates.empty?
+
+    if updates.key?(:bg_color)
+      # Mark the color as authored, not derived, so the color-repair backfill
+      # (lib/tasks/tile_colors.rake) leaves it alone.
+      data = board_image.data || {}
+      updates[:data] = data.merge("explicit_bg_color" => true)
+    end
+    board_image.update_columns(updates)
   end
   private_class_method :apply_obf_explicit_colors
 

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -110,9 +110,18 @@ class BoardImage < ApplicationRecord
     self.text_color ||= ColorHelper.text_hex_for(bg_color)
   end
 
+  # `board_images.part_of_speech` is `null: false, default: "default"`, so a
+  # `part_of_speech || image.part_of_speech` chain can never fall through —
+  # "default" is a stored placeholder, not a category. Mirrors the
+  # `blank? || == "default"` test set_defaults uses on create so the two agree.
+  def effective_part_of_speech
+    own = part_of_speech.presence
+    return own if own && own != "default"
+    image&.part_of_speech.presence || "default"
+  end
+
   def set_background_color!
-    pos = part_of_speech || image.part_of_speech || "default"
-    img_color = background_color_for(pos)
+    img_color = background_color_for(effective_part_of_speech)
     set_background_color(img_color)
     self.save!
   end
@@ -132,8 +141,7 @@ class BoardImage < ApplicationRecord
   # NO save
   def set_colors
     set_text_color("black") unless text_color == "#000000"
-    pos = part_of_speech || image.part_of_speech || "default"
-    img_color = background_color_for(pos)
+    img_color = background_color_for(effective_part_of_speech)
     set_background_color(img_color)
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -96,7 +96,12 @@ class Image < ApplicationRecord
   after_save :update_board_images_audio, if: -> { need_to_update_board_images_audio? }
   after_save :update_board_images_display_image, if: -> { saved_change_to_src_url? }
   # after_save :update_board_images_next_words, if: -> { next_words_changed? }
-  after_save :update_background_color, if: -> { part_of_speech_changed? }
+  # saved_change_to_*, not *_changed?: inside an after_save the dirty-tracking
+  # predicates report *pending* changes, which are always empty by then — the
+  # `part_of_speech_changed?` form never fired at all.
+  # Skipped when bg_color moved in the same write — that color was authored (or
+  # already filled in by ensure_defaults), and the preset must not overwrite it.
+  after_save :update_background_color, if: -> { saved_change_to_part_of_speech? && !saved_change_to_bg_color? }
 
   before_save :update_src_url, if: -> { src_url.blank? && docs.any? }
 
@@ -257,10 +262,19 @@ class Image < ApplicationRecord
     end
   end
 
+  # Called from an after_save, so it must not re-enter save! — that would run
+  # ensure_defaults again and re-categorize over the value that just triggered
+  # this refresh. update_columns writes the derived colors and stops there.
   def update_background_color
-    self.bg_color = background_color_for(part_of_speech)
-    self.text_color = text_color_for(bg_color)
-    self.save!
+    bg = background_color_for(part_of_speech)
+    txt = text_color_for(bg)
+
+    if persisted?
+      update_columns(bg_color: bg, text_color: txt)
+    else
+      self.bg_color = bg
+      self.text_color = txt
+    end
   end
 
   def ensure_defaults
@@ -283,6 +297,15 @@ class Image < ApplicationRecord
       self.bg_color = background_color_for(part_of_speech) if bg_color.blank?
       self.text_color = text_color_for(bg_color) if text_color.blank?
       @defer_categorization = true if skip_categorize
+    elsif will_save_change_to_part_of_speech? && part_of_speech.present?
+      # An explicitly assigned part_of_speech wins over the categorizer — an
+      # ordinary `image.part_of_speech = "noun"; image.save!` must survive.
+      # Without this, the else-branch below silently re-categorized every save,
+      # which is why several callers had to reach for update_column(s).
+      # Only fill blanks here so a new record never lands with no color; an
+      # existing record's repaint is the after_save's job.
+      self.bg_color = background_color_for(part_of_speech) if bg_color.blank?
+      self.text_color = text_color_for(bg_color) if text_color.blank?
     else
       pos = AacWordCategorizer.categorize(label)
       self.part_of_speech = pos

--- a/app/services/aac_word_categorizer.rb
+++ b/app/services/aac_word_categorizer.rb
@@ -45,6 +45,11 @@ class AacWordCategorizer
     "won't" => "important_function",
     "wont" => "important_function",
     "help!" => "important_function",
+    # Coded by communicative function, not grammar: a child hitting "stop" is
+    # protesting or asking for something to end, so it belongs with no / don't /
+    # can't — findable fast and visually distinct from the action words beside
+    # it. ("help" stays a request verb and reads correctly green.)
+    "stop" => "important_function",
     "stop!" => "important_function",
 
     # Determiners / articles / deixis

--- a/lib/tasks/tile_colors.rake
+++ b/lib/tasks/tile_colors.rake
@@ -1,0 +1,96 @@
+# Repairs AAC tile colors that drifted from their part_of_speech.
+#
+# `images.bg_color` / `board_images.bg_color` are snapshots taken when the row
+# was written, so a part_of_speech corrected later leaves the stored color
+# behind (a "social" tile still painted red, etc). This finds those rows and
+# repaints them from the category.
+#
+# It NEVER touches part_of_speech. A board_image whose category differs from its
+# Image's is a deliberate per-board override (see Board.apply_obf_part_of_speech)
+# — it gets recolored from its own category, not reset to the Image's.
+#
+#   bin/rails tile_colors:repair                 # dry run, reports only
+#   bin/rails tile_colors:repair WRITE=true      # actually writes
+#   bin/rails tile_colors:repair SCOPE=board_images LIMIT=500
+module TileColorRepair
+  # Only colors the preset table itself could have produced count as derived.
+  # Anything else is an authored color — an OBF button's explicit
+  # background_color, or a hand-picked one — and must not be "repaired".
+  DERIVED_HEXES = ColorHelper::PRESET_HEX.values.map(&:upcase).to_set.freeze
+
+  BATCH_SIZE = 500
+  SAMPLE_SIZE = 10
+
+  module_function
+
+  def authored?(record)
+    return true if record.is_a?(BoardImage) && record.data.is_a?(Hash) && record.data["explicit_bg_color"]
+    return false if record.bg_color.blank?
+
+    !DERIVED_HEXES.include?(ColorHelper.to_hex(record.bg_color, default: "").upcase)
+  end
+
+  # nil when the row is already correct or must be left alone.
+  def repair_for(record)
+    return nil if authored?(record)
+
+    pos = record.is_a?(BoardImage) ? record.effective_part_of_speech : record.part_of_speech
+    expected = record.background_color_for(pos)
+    return nil if expected.blank?
+
+    current = record.bg_color.presence && ColorHelper.to_hex(record.bg_color, default: "").upcase
+    return nil if current == expected.upcase
+
+    { bg_color: expected, text_color: ColorHelper.text_hex_for(expected), pos: pos, was: record.bg_color }
+  end
+
+  def sweep(relation, label:, write:, limit: nil, out: $stdout)
+    scanned = 0
+    repaired = 0
+    samples = []
+
+    relation.find_each(batch_size: BATCH_SIZE) do |record|
+      break if limit && repaired >= limit
+      scanned += 1
+
+      repair = repair_for(record)
+      next unless repair
+
+      repaired += 1
+      if samples.size < SAMPLE_SIZE
+        samples << "  ##{record.id} #{record.label.inspect} #{repair[:pos]}: #{repair[:was].inspect} -> #{repair[:bg_color]}"
+      end
+
+      # update_columns: a plain save would re-run Image#ensure_defaults /
+      # BoardImage#set_colors and could fight the stored category.
+      record.update_columns(bg_color: repair[:bg_color], text_color: repair[:text_color]) if write
+    end
+
+    out.puts "#{label}: scanned #{scanned}, #{write ? "repaired" : "would repair"} #{repaired}"
+    out.puts samples.join("\n") unless samples.empty?
+    repaired
+  end
+end
+
+namespace :tile_colors do
+  desc "Repaint images/board_images whose bg_color disagrees with their part_of_speech (dry run unless WRITE=true)"
+  task repair: :environment do
+    write = %w[true 1 yes].include?(ENV["WRITE"].to_s.downcase)
+    limit = ENV["LIMIT"].presence&.to_i
+    scope = ENV["SCOPE"].presence || "all"
+
+    puts write ? "*** WRITING changes ***" : "*** DRY RUN — pass WRITE=true to apply ***"
+
+    total = 0
+    if %w[all images].include?(scope)
+      total += TileColorRepair.sweep(Image.where.not(part_of_speech: nil),
+                                     label: "images", write: write, limit: limit)
+    end
+    if %w[all board_images].include?(scope)
+      total += TileColorRepair.sweep(BoardImage.includes(:image),
+                                     label: "board_images", write: write, limit: limit)
+    end
+
+    puts "Total: #{total}"
+  end
+end

--- a/lib/tasks/tile_colors.rake
+++ b/lib/tasks/tile_colors.rake
@@ -13,21 +13,26 @@
 #   bin/rails tile_colors:repair WRITE=true      # actually writes
 #   bin/rails tile_colors:repair SCOPE=board_images LIMIT=500
 module TileColorRepair
-  # Only colors the preset table itself could have produced count as derived.
-  # Anything else is an authored color — an OBF button's explicit
-  # background_color, or a hand-picked one — and must not be "repaired".
-  DERIVED_HEXES = ColorHelper::PRESET_HEX.values.map(&:upcase).to_set.freeze
-
   BATCH_SIZE = 500
   SAMPLE_SIZE = 10
 
   module_function
 
+  # Only colors the preset table itself could have produced count as derived.
+  # Anything else is an authored color — an OBF button's explicit
+  # background_color, or a hand-picked one — and must not be "repaired".
+  #
+  # Resolved lazily: rake loads every .rake file before the :environment task
+  # runs, so app constants aren't autoloadable at file-load time.
+  def derived_hexes
+    @derived_hexes ||= ::ColorHelper::PRESET_HEX.values.map { |hex| hex.upcase }.to_set.freeze
+  end
+
   def authored?(record)
     return true if record.is_a?(BoardImage) && record.data.is_a?(Hash) && record.data["explicit_bg_color"]
     return false if record.bg_color.blank?
 
-    !DERIVED_HEXES.include?(ColorHelper.to_hex(record.bg_color, default: "").upcase)
+    !derived_hexes.include?(::ColorHelper.to_hex(record.bg_color, default: "").upcase)
   end
 
   # nil when the row is already correct or must be left alone.
@@ -38,10 +43,10 @@ module TileColorRepair
     expected = record.background_color_for(pos)
     return nil if expected.blank?
 
-    current = record.bg_color.presence && ColorHelper.to_hex(record.bg_color, default: "").upcase
+    current = record.bg_color.presence && ::ColorHelper.to_hex(record.bg_color, default: "").upcase
     return nil if current == expected.upcase
 
-    { bg_color: expected, text_color: ColorHelper.text_hex_for(expected), pos: pos, was: record.bg_color }
+    { bg_color: expected, text_color: ::ColorHelper.text_hex_for(expected), pos: pos, was: record.bg_color }
   end
 
   def sweep(relation, label:, write:, limit: nil, out: $stdout)

--- a/spec/lib/tasks/tile_colors_rake_spec.rb
+++ b/spec/lib/tasks/tile_colors_rake_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "tile_colors rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["tile_colors:repair"] }
+
+  def run(env = {})
+    env.each { |k, v| ENV[k] = v }
+    task.reenable
+    silence_stream { task.invoke }
+  ensure
+    env.each_key { |k| ENV.delete(k) }
+  end
+
+  def silence_stream
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  let(:board) { FactoryBot.create(:board) }
+  let(:image) { FactoryBot.create(:image, label: "my turn") }
+  let!(:board_image) { FactoryBot.create(:board_image, board: board, image: image) }
+
+  # The live "my turn" shape: classified social (pink), still painted red.
+  def make_mismatched!
+    image.update_columns(part_of_speech: "social", bg_color: "#FF7070")
+    board_image.update_columns(part_of_speech: "social", bg_color: "#FF7070")
+  end
+
+  it "is a dry run by default" do
+    make_mismatched!
+
+    run
+
+    expect(image.reload.bg_color).to eq("#FF7070")
+    expect(board_image.reload.bg_color).to eq("#FF7070")
+  end
+
+  it "repaints mismatched rows with WRITE=true" do
+    make_mismatched!
+
+    run("WRITE" => "true")
+
+    expect(image.reload.bg_color).to eq("#FF99B8")
+    expect(image.part_of_speech).to eq("social")
+    expect(board_image.reload.bg_color).to eq("#FF99B8")
+    expect(board_image.text_color).to eq("#000000")
+  end
+
+  it "is a no-op on a second run" do
+    make_mismatched!
+    run("WRITE" => "true")
+    updated_at = board_image.reload.updated_at
+
+    run("WRITE" => "true")
+
+    expect(board_image.reload.bg_color).to eq("#FF99B8")
+    expect(board_image.updated_at).to eq(updated_at)
+  end
+
+  it "recolors a per-board override from the tile's own category, never resetting it" do
+    image.update_columns(part_of_speech: "verb", bg_color: "#A1F571")
+    board_image.update_columns(part_of_speech: "noun", bg_color: "#A1F571")
+
+    run("WRITE" => "true")
+
+    expect(board_image.reload.part_of_speech).to eq("noun")
+    expect(board_image.bg_color).to eq("#FFC457")
+    expect(image.reload.part_of_speech).to eq("verb")
+    expect(image.bg_color).to eq("#A1F571")
+  end
+
+  it "leaves an OBF-authored explicit color alone" do
+    image.update_columns(part_of_speech: "social", bg_color: "#FF99B8")
+    board_image.update_columns(part_of_speech: "social",
+                               bg_color: "#123456",
+                               data: { "explicit_bg_color" => true })
+
+    run("WRITE" => "true")
+
+    expect(board_image.reload.bg_color).to eq("#123456")
+  end
+
+  it "leaves any non-preset color alone even without the flag" do
+    board_image.update_columns(part_of_speech: "social", bg_color: "#ABCDEF")
+
+    run("WRITE" => "true")
+
+    expect(board_image.reload.bg_color).to eq("#ABCDEF")
+  end
+
+  it "honors SCOPE" do
+    make_mismatched!
+
+    run("WRITE" => "true", "SCOPE" => "images")
+
+    expect(image.reload.bg_color).to eq("#FF99B8")
+    expect(board_image.reload.bg_color).to eq("#FF7070")
+  end
+end

--- a/spec/models/board_image_tile_colors_spec.rb
+++ b/spec/models/board_image_tile_colors_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe BoardImage, "tile colors" do
+  let(:board) { FactoryBot.create(:board) }
+  let(:image) { FactoryBot.create(:image, label: "my turn") }
+  let(:board_image) { FactoryBot.create(:board_image, board: board, image: image) }
+
+  before { image.update!(part_of_speech: "social") }
+
+  describe "#effective_part_of_speech" do
+    it "treats the stored 'default' placeholder as unset and inherits the Image's category" do
+      board_image.update_columns(part_of_speech: "default")
+
+      expect(board_image.reload.effective_part_of_speech).to eq("social")
+    end
+
+    it "keeps a per-board override" do
+      board_image.update_columns(part_of_speech: "noun")
+
+      expect(board_image.reload.effective_part_of_speech).to eq("noun")
+    end
+
+    it "falls back to 'default' when neither carries a category" do
+      image.update_columns(part_of_speech: nil)
+      board_image.update_columns(part_of_speech: "default")
+
+      expect(board_image.reload.effective_part_of_speech).to eq("default")
+    end
+  end
+
+  describe "#set_colors" do
+    it "colors a 'default' tile from its Image's category instead of grey" do
+      board_image.update_columns(part_of_speech: "default", bg_color: "#D1D1D1")
+
+      board_image.reload.set_colors!
+
+      expect(board_image.reload.bg_color).to eq("#FF99B8")
+    end
+
+    it "colors from the tile's own category when it overrides the Image's" do
+      board_image.update_columns(part_of_speech: "noun", bg_color: "#D1D1D1")
+
+      board_image.reload.set_colors!
+
+      expect(board_image.reload.bg_color).to eq("#FFC457")
+    end
+  end
+end

--- a/spec/models/image_tile_colors_spec.rb
+++ b/spec/models/image_tile_colors_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe Image, "tile colors" do
+  # The global AacWordCategorizer stub (spec/support/stub_aac_categorizer.rb)
+  # returns "noun" for every label, so a freshly created image is orange.
+  let(:image) { FactoryBot.create(:image, label: "my turn") }
+
+  describe "refreshing bg_color when part_of_speech changes" do
+    it "repaints the image when the category is corrected" do
+      expect(image.reload.part_of_speech).to eq("noun")
+      expect(image.bg_color).to eq("#FFC457")
+
+      image.update!(part_of_speech: "social")
+
+      expect(image.reload.part_of_speech).to eq("social")
+      expect(image.bg_color).to eq("#FF99B8")
+      expect(image.text_color).to eq("#000000")
+    end
+
+    it "repaints important_function red" do
+      image.update!(part_of_speech: "important_function")
+
+      expect(image.reload.bg_color).to eq("#FF7070")
+    end
+
+    it "does not repaint when part_of_speech is unchanged" do
+      image.update_columns(bg_color: "#123456")
+      image.skip_categorize = true
+      image.update!(label: "my turn now")
+
+      expect(image.reload.bg_color).to eq("#123456")
+    end
+  end
+
+  describe "ensure_defaults" do
+    it "preserves an explicitly assigned part_of_speech through an ordinary save" do
+      image.part_of_speech = "pronoun"
+      image.save!
+
+      expect(image.reload.part_of_speech).to eq("pronoun")
+      expect(image.bg_color).to eq("#FFEA75")
+    end
+
+    it "does not call the categorizer when the category was assigned by hand" do
+      image # create first, so the create-path categorization is already done
+      expect(AacWordCategorizer).not_to receive(:categorize)
+
+      image.update!(part_of_speech: "adverb")
+    end
+
+    it "still categorizes a save that does not touch part_of_speech" do
+      image
+      expect(AacWordCategorizer).to receive(:categorize).with("my turn").and_return("verb")
+
+      image.update!(label: "my turn")
+
+      expect(image.reload.part_of_speech).to eq("verb")
+      expect(image.bg_color).to eq("#A1F571")
+    end
+
+    it "respects a bg_color assigned in the same save as the category" do
+      image.assign_attributes(part_of_speech: "pronoun", bg_color: "#123456")
+      image.save!
+
+      expect(image.reload.bg_color).to eq("#123456")
+    end
+  end
+end

--- a/spec/services/aac_word_categorizer_spec.rb
+++ b/spec/services/aac_word_categorizer_spec.rb
@@ -117,6 +117,16 @@ RSpec.describe AacWordCategorizer, type: :service do
         expect(described_class.categorize("what")).to eq("question")
       end
 
+      it "returns 'important_function' for plain 'stop' without calling the LLM" do
+        expect(described_class).not_to receive(:call_llm)
+        expect(described_class.categorize("stop")).to eq("important_function")
+        expect(described_class.categorize("Stop ")).to eq("important_function")
+      end
+
+      it "leaves plain 'help' to the categorizer — it reads as a request verb" do
+        expect(described_class::OVERRIDES).not_to have_key("help")
+      end
+
       it "returns 'determiner' for 'the'" do
         expect(described_class.categorize("the")).to eq("determiner")
       end


### PR DESCRIPTION
## Summary

Four defects meant a corrected `part_of_speech` never reached the stored tile colour. Live evidence: board `at-the-slide` (5679), tile `my turn` — `part_of_speech: "social"` (pink `#FF99B8`) but `bg_color: "#FF7070"` (red).

**1. The Image colour-refresh callback was dead code.** `after_save :update_background_color, if: -> { part_of_speech_changed? }` — inside an `after_save`, `*_changed?` reports *pending* changes, which are always empty by then, so it never fired. Now guards on `saved_change_to_part_of_speech?`, skips when `bg_color` moved in the same write (that colour was authored), and writes via `update_columns` so it can't re-enter `ensure_defaults`.

**2. `ensure_defaults` clobbered hand-corrections.** Its else-branch re-ran `AacWordCategorizer` on every save, so `image.part_of_speech = "noun"; image.save!` was silently re-categorised. It now skips the categorizer when the save is already changing `part_of_speech`. The existing `update_column(s)` workarounds (`reset_part_of_speech!`, `CategorizeImageJob`, `Board.apply_obf_part_of_speech`) are left in place but are no longer load-bearing.

**3. `set_colors`' fallback never fired.** `part_of_speech || image.part_of_speech || "default"` can't fall through — the column is `null: false, default: "default"`. Extracted `BoardImage#effective_part_of_speech`, mirroring the `blank? || == "default"` test `set_defaults` already uses on create, so a placeholder tile inherits its Image's category instead of going grey.

**4. Plain "stop" wasn't in the override table**, so it fell through to the LLM and came back `verb` → green. Added `"stop" => "important_function"`, matching the existing `"stop!"`. Modified Fitzgerald codes by communicative function: a child hitting "stop" is protesting, and it needs to be visually distinct from the action words beside it. `"help"` deliberately left alone — it reads correctly as a request verb.

## Backfill

`bin/rails tile_colors:repair` — dry run by default, `WRITE=true` to apply, `SCOPE=images|board_images`, `LIMIT=n`. Batched, idempotent, reports counts + a sample.

It **only ever writes colours**, never `part_of_speech`. A `board_image` whose category differs from its Image's is a deliberate per-board override, so it's recoloured from the tile's own category. Authored colours are skipped two ways: any `bg_color` that isn't one of the preset hexes (only a preset could have been *derived*), plus a new `data["explicit_bg_color"]` stamp that `Board.apply_obf_explicit_colors` now writes alongside the colour, so OBF-authored colours are unambiguously excluded going forward.

## Test plan

New specs:
- `spec/models/image_tile_colors_spec.rb` — the `after_save` fires on a real category change and repaints to the exact hex (regression test for `my turn`); an explicitly assigned category survives `save!`; the categorizer is not called on that save but still is on one that doesn't touch the category; a `bg_color` set in the same write is respected.
- `spec/models/board_image_tile_colors_spec.rb` — a `"default"` tile inherits its Image's category and colour; a per-board override keeps its own.
- `spec/services/aac_word_categorizer_spec.rb` — `categorize("stop")` returns `important_function` with `call_llm` asserted not to be reached; `"help"` asserted absent from `OVERRIDES`.
- `spec/lib/tasks/tile_colors_rake_spec.rb` — dry run by default; fixes a mismatched row; leaves a per-board override's category alone while recolouring it; leaves an OBF explicit colour and any non-preset colour alone; no-op on a second run; honours `SCOPE`.

Ran `bundle exec rspec spec/models spec/services spec/lib spec/sidekiq spec/tasks` — **2088 examples, 0 failures, 8 pending**. Request specs are running; will note here if anything turns up.

## Docs

`CHANGELOG.md` entry, plus a new "Tile colors (Modified Fitzgerald key)" section in `.claude-notes/boards-and-teams.md` recording the invariants (explicit category wins; colour derives from category; `"default"` is a placeholder; authored colours are never recomputed; how to run the repair task).

## Follow-up, not in scope

`AacWordCategorizer` and `OpenAiClient#categorize_word` are duplicate categorizers with overlapping override tables — consolidating them is worth its own issue but widens this PR too far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)