### PR TITLE
fix(mailer): stop staging from delivering mail to real recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Staging no longer sends email to real people.** Staging runs against live
+  SMTP credentials, so anything exercised there — signups, invitations, alerts
+  — used to deliver genuine mail to whatever address was on the record. Mail is
+  now dropped on staging by default. To test a template end to end, set
+  `STAGING_MAIL_ALLOWLIST` to a comma-separated list of exact addresses
+  (`brittany@speakanyway.com`) or domain suffixes (`@speakanyway.com`);
+  everything else is stripped from to/cc/bcc. Production and development are
+  unaffected.
+
 ### Fixed
 
 - **Boards built through the internal API land on real symbol art.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,14 @@ one-off handoff/scratch files stay untracked and local.
   `EMAIL_LOGO_URL`). Inline `cid` attachments are not an option: clients list
   every attachment part — inline ones included — so the logo showed up as a
   downloadable file. Transactional mail is therefore single-part `text/html`,
-  so specs must read bodies as `(mail.html_part || mail).body`.
+  so specs must read bodies as `(mail.html_part || mail).body`. **Staging
+  delivers no mail:** `StagingMailInterceptor` blocks every send when
+  `AppEnv.staging?`, so nothing exercised on staging reaches a real inbox. Set
+  `STAGING_MAIL_ALLOWLIST` (comma-separated exact addresses, or `@domain`
+  suffixes) to let specific recipients through when testing a template;
+  non-matching addresses are stripped from to/cc/bcc. `E2eMailInterceptor` is
+  separate and pattern-scoped — it drops `e2e+*@speakanyway.com` in every
+  environment.
 - **TTS/Audio:** AWS Polly
 - **AI:** OpenAI API (`ruby-openai`) — board generation, scenario builder,
   image generation. Every text-to-image prompt is composed by
@@ -214,7 +221,9 @@ an explicit decision, not a drive-by edit.
   `Suggestions::Registry` context allow-list (enforced by spec).
 - **Third-party sends are env-gated to production** (Mailchimp journeys,
   PostHog captures; staging excluded via `AppEnv.staging?`) so non-prod can't
-  email or track real users.
+  email or track real users. Transactional mail is covered by the same rule at
+  the delivery layer: `StagingMailInterceptor` drops every message on staging
+  unless the recipient is in `STAGING_MAIL_ALLOWLIST`.
 - **Email verification is keyed on `email_verified_at`, never `confirmed_at`.**
   `User#mark_email_verified!` is the only writer. Verified status may be
   conferred ONLY by a path where the user clicked a link delivered to their

--- a/config/initializers/staging_mail_interceptor.rb
+++ b/config/initializers/staging_mail_interceptor.rb
@@ -1,0 +1,59 @@
+# Stops staging from delivering mail to real people.
+#
+# Staging runs with RAILS_ENV=production against real SMTP credentials, so any
+# job or signup flow exercised there sends genuine email to whatever address
+# happens to be on the record. This interceptor blocks delivery outright when
+# AppEnv.staging?, which is the default: staging emails nobody.
+#
+# STAGING_MAIL_ALLOWLIST is the escape hatch for testing a template end to end.
+# It is a comma-separated list of exact addresses (brittany@speakanyway.com) or
+# domain suffixes (@speakanyway.com). Recipients that don't match are stripped
+# from to/cc/bcc; a message with no allowlisted recipient left is dropped.
+#
+# The interceptor is registered everywhere but no-ops unless AppEnv.staging? —
+# the staging check has to happen at delivery time, since autoloading AppEnv
+# while initializers run is not allowed. Production and development are
+# untouched. The separate E2eMailInterceptor stays pattern-scoped and applies
+# in every environment.
+class StagingMailInterceptor
+  RECIPIENT_FIELDS = %i[to cc bcc].freeze
+
+  def self.allowlist
+    ENV["STAGING_MAIL_ALLOWLIST"].to_s.split(",").filter_map do |entry|
+      entry.strip.downcase.presence
+    end
+  end
+
+  def self.allowed?(address)
+    normalized = address.to_s.strip.downcase
+    return false if normalized.blank?
+
+    allowlist.any? do |entry|
+      entry.start_with?("@") ? normalized.end_with?(entry) : normalized == entry
+    end
+  end
+
+  def self.delivering_email(message)
+    return unless AppEnv.staging?
+
+    original = RECIPIENT_FIELDS.flat_map { |field| Array(message.public_send(field)) }
+    kept = []
+
+    RECIPIENT_FIELDS.each do |field|
+      recipients = Array(message.public_send(field))
+      next if recipients.empty?
+
+      allowed = recipients.select { |address| allowed?(address) }
+      kept.concat(allowed)
+      # nil, not [], so the header is removed rather than left empty.
+      message.public_send(:"#{field}=", allowed.presence)
+    end
+
+    return if kept.any?
+
+    message.perform_deliveries = false
+    Rails.logger.info("[StagingMailInterceptor] dropped mail to #{original.join(", ")}")
+  end
+end
+
+ActionMailer::Base.register_interceptor(StagingMailInterceptor)

--- a/spec/initializers/staging_mail_interceptor_spec.rb
+++ b/spec/initializers/staging_mail_interceptor_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe StagingMailInterceptor do
+  def message_to(*recipients, cc: nil, bcc: nil)
+    Mail::Message.new.tap do |m|
+      m.to = recipients
+      m.cc = cc if cc
+      m.bcc = bcc if bcc
+    end
+  end
+
+  def staging!(allowlist: nil)
+    allow(AppEnv).to receive(:staging?).and_return(true)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("STAGING_MAIL_ALLOWLIST").and_return(allowlist)
+  end
+
+  context "outside staging" do
+    it "leaves mail alone" do
+      allow(AppEnv).to receive(:staging?).and_return(false)
+      message = message_to("parent@example.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+      expect(message.to).to eq(["parent@example.com"])
+    end
+  end
+
+  context "on staging with no allowlist" do
+    before { staging! }
+
+    it "blocks delivery" do
+      message = message_to("parent@example.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be false
+    end
+
+    it "blocks delivery to cc and bcc recipients too" do
+      message = message_to("parent@example.com", cc: "slp@example.com", bcc: "admin@example.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be false
+    end
+  end
+
+  context "on staging with an allowlist" do
+    it "delivers to an exactly allowlisted address" do
+      staging!(allowlist: "brittany@speakanyway.com")
+      message = message_to("brittany@speakanyway.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+      expect(message.to).to eq(["brittany@speakanyway.com"])
+    end
+
+    it "matches case-insensitively and ignores surrounding whitespace" do
+      staging!(allowlist: " Brittany@SpeakAnyWay.com , other@example.com ")
+      message = message_to("brittany@speakanyway.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+    end
+
+    it "allows a whole domain with an @-prefixed entry" do
+      staging!(allowlist: "@speakanyway.com")
+      message = message_to("anyone@speakanyway.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+    end
+
+    it "strips non-allowlisted recipients but still delivers to allowlisted ones" do
+      staging!(allowlist: "@speakanyway.com")
+      message = message_to("parent@example.com", "brittany@speakanyway.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+      expect(message.to).to eq(["brittany@speakanyway.com"])
+    end
+
+    it "strips non-allowlisted cc and bcc recipients" do
+      staging!(allowlist: "brittany@speakanyway.com")
+      message = message_to("brittany@speakanyway.com", cc: "slp@example.com", bcc: "admin@example.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+      expect(message.to).to eq(["brittany@speakanyway.com"])
+      expect(message.cc).to be_nil
+      expect(message.bcc).to be_nil
+    end
+
+    it "drops mail when no recipient is allowlisted" do
+      staging!(allowlist: "brittany@speakanyway.com")
+      message = message_to("parent@example.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be false
+    end
+
+    it "does not treat a domain entry as a substring match on other domains" do
+      staging!(allowlist: "@speakanyway.com")
+      message = message_to("parent@speakanyway.com.evil.com")
+
+      described_class.delivering_email(message)
+
+      expect(message.perform_deliveries).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Staging runs with `RAILS_ENV=production` against live SMTP credentials, so anything exercised there — signups, team invitations, safety alerts — delivered genuine email to whatever address was on the record.

`StagingMailInterceptor` now blocks delivery whenever `AppEnv.staging?`. Default behavior: **staging emails nobody**, no ENV change needed.

`STAGING_MAIL_ALLOWLIST` is the escape hatch for testing a template end to end — a comma-separated list of exact addresses (`brittany@speakanyway.com`) or domain suffixes (`@speakanyway.com`). Non-matching recipients are stripped from `to`/`cc`/`bcc`; a message with no allowlisted recipient left is dropped and logged.

Notes:
- Registered in every environment but no-ops outside staging — the env check happens at delivery time because autoloading `AppEnv` while initializers run isn't allowed.
- Production and development are untouched.
- The existing `E2eMailInterceptor` is unchanged and stays pattern-scoped (`e2e+*@speakanyway.com`, every env).
- CHANGELOG.md also restores a stray `## [Unreleased]` heading that had been renamed to a duplicate `## [1.3.0]` in the working tree.

## Test plan

- `bundle exec rspec spec/initializers/` — **15 examples, 0 failures** (10 new, covering: no-op outside staging, drop-all with no allowlist, cc/bcc coverage, exact-address and `@domain` allowlist matches, case/whitespace normalization, partial stripping, and that `@speakanyway.com` doesn't match `parent@speakanyway.com.evil.com`).
- `bin/rails runner` boots clean; interceptor list reads `["E2eMailInterceptor", "StagingMailInterceptor"]`.
- Pre-existing, unrelated: two examples in `spec/mailers/{base,user}_mailer_spec.rb` fail locally with `PG::UniqueViolation: users_pkey` (stale PK sequence in the local test DB). Verified they fail identically with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)