### PR TITLE
fix(board-images): normalize defaulted display_label casing at creation

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -165,6 +165,41 @@ Full permissions matrix and the rationale for the split lives in
 `../speakanyway/marketing/.claude-notes/handoff-workflow.md`.
 
 
+## Tile text casing (`display_label`)
+
+`label` is a **lowercase matching key** used for image lookup — never display
+text, never normalized. `display_label` is what renders on the tile.
+
+`Labels::CaseNormalizer` normalizes **defaulted** `display_label` casing at
+creation. Two `BoardImage` paths default it, and both route through
+`normalized_default_label`:
+
+- `set_defaults` (`before_create`) — the `image.display_label` fallback. It
+  runs **after** `part_of_speech` resolution so the phrase rule sees the real
+  value.
+- `set_labels` — the `|| label` fall-through only. A `display_label` stored in
+  `language_settings` is an authored translation and is used verbatim.
+
+Rules, in order: blank passes through; **any existing uppercase letter means
+the text was cased deliberately** (`iPad`, `TV`, `McDonald's`) and is returned
+untouched — that guard is what removes the need for an acronym exception list;
+non-English → sentence case (`todo listo` → `Todo listo`, since Title Case is
+an English convention); English `part_of_speech == "phrase"` → sentence case,
+because gestalt/GLP tiles are whole utterances; otherwise English Title Case
+(`all done` → `All Done`). A standalone `i` capitalizes anywhere in sentence
+case. The transform **only ever upcases a word's first letter** — it never
+downcases, so nothing that slips past the uppercase guard can be mangled.
+
+An explicitly supplied `display_label` never reaches the normalizer:
+`display_label.blank?` is false, so the caller's casing wins. That's what keeps
+the authored-casing pins (`pin_authored_label!`, `NavRowSync`,
+`ImageResolver#upgrade_board_tiles!`, `BoardFromScreenshot`, `SeededSetCloner`)
+and the bulk `label_case` endpoint working unchanged.
+
+Normalization is **forward-only** — no backfill. Rows created before this
+keep their casing; a backfill would have to distinguish deliberate casing from
+inherited casing on data where that signal is already lost.
+
 ## Make a Board From Screenshot
 
 Turns an uploaded screenshot of an existing AAC/communication board into a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Tile text casing is consistent across a board.** A tile inherited whatever
+  casing its creation path happened to use — paths handing over a Title Cased
+  word list produced `Higher`, paths falling through to the image's lowercase
+  matching label produced `swing` — so the same board rendered both. Cosmetic
+  on screen, a visible defect in print, where these boards become physical
+  signs. Tile text defaulted from the image is now normalized at creation:
+  Title Case for English words, sentence case for whole-utterance phrase tiles
+  and for non-English boards. A display label you type yourself is never
+  touched, and anything already carrying capitals (`iPad`, `TV`, `McDonald's`)
+  is left exactly as-is. Existing tiles keep their current casing.
+
 - **Boards built through the internal API land on real symbol art.**
   `POST /api/internal/boards/:id/board_images` and `.../board_images/bulk`
   resolved a tile label with a naive `find_by(label:)`. Many labels have

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -143,7 +143,26 @@ class BoardImage < ApplicationRecord
     image_language_settings = (image.language_settings || {})[lang] || {}
     self.language = lang
     self.label = image_language_settings["label"] || image.label
-    self.display_label = image_language_settings["display_label"] || label
+    # A stored translation is authored text — use it verbatim. Only the
+    # fall-through to `label` (a lowercase matching key) gets case-normalized.
+    translated = image_language_settings["display_label"]
+    self.display_label = translated.presence || normalized_default_label(label, lang)
+  end
+
+  # Tile text defaulted from the Image gets consistent casing so tiles created
+  # through different paths don't render "Higher" next to "swing" on the same
+  # board. `label` is never normalized — it's the lowercase matching key used
+  # for image lookup.
+  def normalized_default_label(text, lang = language)
+    Labels::CaseNormalizer.normalize(text, language: lang, part_of_speech: effective_part_of_speech)
+  end
+
+  # The part of speech this tile will actually carry: an explicitly set value
+  # wins, otherwise the shared Image's. Mirrors the resolution in set_defaults,
+  # which runs after set_labels on the add_image path.
+  def effective_part_of_speech
+    return part_of_speech if part_of_speech.present? && part_of_speech != "default"
+    image&.part_of_speech || "default"
   end
 
   # Delegates to the underlying Image's language_settings. Stored `label` /
@@ -686,7 +705,6 @@ class BoardImage < ApplicationRecord
     audio_file = nil
     self.voice = board.voice
     self.language = board.language
-    self.display_label = image.display_label if display_label.blank?
     self.language_settings = image.language_settings
 
     # audio_file = image.find_audio_for_voice(voice, language)
@@ -705,6 +723,10 @@ class BoardImage < ApplicationRecord
     if part_of_speech.blank? || part_of_speech == "default"
       self.part_of_speech = image.part_of_speech || "default"
     end
+
+    # Last, so the casing rule sees the resolved part_of_speech. A caller that
+    # supplied its own display_label keeps it exactly as given.
+    self.display_label = normalized_default_label(image.display_label) if display_label.blank?
   end
 
   def create_voice_audio_after_create

--- a/app/services/labels/case_normalizer.rb
+++ b/app/services/labels/case_normalizer.rb
@@ -1,0 +1,87 @@
+module Labels
+  # Casing rules for tile text (`display_label`).
+  #
+  # `Image#label` is a lowercase matching key, not display text. Creation paths
+  # that hand us a Title Cased word list produce Title Cased tiles; paths that
+  # fall through to the raw `label` produce lowercase ones — so one board ends
+  # up rendering "Higher" next to "swing". That reads as a defect in print,
+  # where these boards become physical signs.
+  #
+  # This normalizes the **defaulted** case only. Callers that explicitly supply
+  # a `display_label` never route through here — their casing wins.
+  #
+  # The transform only ever upcases the first letter of a word. It never
+  # downcases, so nothing that slips past `deliberate_casing?` can be mangled.
+  module CaseNormalizer
+    # Whole-utterance tiles (gestalt / GLP) read as sentences, not headlines.
+    PHRASE_PART_OF_SPEECH = "phrase".freeze
+
+    # A word whose leading alphabetic run is exactly "i" — matches "i", "i'll",
+    # "i," but not "in" or "is".
+    STANDALONE_I = /\A\P{Alpha}*i(?!\p{Alpha})/i
+
+    module_function
+
+    # @param text [String, nil] the defaulted label
+    # @param language [String, nil] the tile's authored language
+    # @param part_of_speech [String, nil] the tile's resolved part of speech
+    def normalize(text, language: nil, part_of_speech: nil)
+      text = text.to_s
+      return text if text.strip.empty?
+      return text if deliberate_casing?(text)
+
+      english = english?(language)
+      if english && part_of_speech.to_s != PHRASE_PART_OF_SPEECH
+        title_case(text)
+      else
+        sentence_case(text, english: english)
+      end
+    end
+
+    # Any existing uppercase letter means the text was cased on purpose —
+    # "iPad", "TV", "McDonald's". A naive titleize would wreck all three, and an
+    # exception list would have to be maintained forever. Leave it alone.
+    def deliberate_casing?(text)
+      text.to_s.match?(/\p{Upper}/)
+    end
+
+    # Title Case is an English convention; Spanish wants "Todo listo", not
+    # "Todo Listo".
+    def english?(language)
+      lang = language.to_s.strip.downcase
+      lang.empty? || lang == "en" || lang.start_with?("en-", "en_")
+    end
+
+    def title_case(text)
+      transform_words(text) { |word| upcase_first(word) }
+    end
+
+    # First word capitalized, the rest left as authored — except a standalone
+    # "i", which stays capitalized wherever it lands.
+    def sentence_case(text, english: true)
+      first = true
+      transform_words(text) do |word|
+        if first
+          first = false
+          upcase_first(word)
+        elsif english && word.match?(STANDALONE_I)
+          upcase_first(word)
+        else
+          word
+        end
+      end
+    end
+
+    # Upcase the first alphabetic character, leaving leading punctuation and
+    # every interior character untouched.
+    def upcase_first(word)
+      word.sub(/\p{Alpha}/) { |char| char.upcase }
+    end
+
+    # Split on whitespace, keeping the separators so the original spacing
+    # survives the round trip.
+    def transform_words(text)
+      text.split(/(\s+)/).map { |chunk| chunk.match?(/\S/) ? yield(chunk) : chunk }.join
+    end
+  end
+end

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -67,7 +67,85 @@ RSpec.describe BoardImage, type: :model do
       board_image = FactoryBot.create(:board_image, board: board, image: image, language: "es")
       board_image.set_labels
       expect(board_image.label).to eq("hello")
-      expect(board_image.display_label).to eq("hello")
+      # Non-English boards get sentence case, not English Title Case.
+      expect(board_image.display_label).to eq("Hello")
+    end
+  end
+
+  describe "display_label casing on create" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user, language: "en") }
+
+    def tile_for(image, **attrs)
+      FactoryBot.create(:board_image, board: board, image: image, **attrs)
+    end
+
+    it "title cases a label defaulted from the image" do
+      image = FactoryBot.create(:image, label: "swing")
+      tile = tile_for(image)
+
+      expect(tile.display_label).to eq("Swing")
+      expect(tile.label).to eq("swing")
+    end
+
+    it "title cases every word of a multi-word label" do
+      image = FactoryBot.create(:image, label: "all done")
+      tile = tile_for(image)
+
+      expect(tile.display_label).to eq("All Done")
+      expect(tile.label).to eq("all done")
+    end
+
+    it "gives tiles created through different paths the same casing" do
+      lowercase_source = FactoryBot.create(:image, label: "faster")
+      titled_source = FactoryBot.create(:image, label: "higher")
+
+      defaulted = tile_for(lowercase_source)
+      authored = tile_for(titled_source, display_label: "Higher")
+
+      expect([defaulted.display_label, authored.display_label]).to eq(%w[Faster Higher])
+    end
+
+    it "keeps an explicitly supplied display_label exactly as given" do
+      image = FactoryBot.create(:image, label: "ipad")
+      tile = tile_for(image, display_label: "iPad")
+
+      expect(tile.display_label).to eq("iPad")
+      expect(tile.label).to eq("ipad")
+    end
+
+    it "leaves brand and acronym casing on the image label alone" do
+      image = FactoryBot.create(:image, label: "TV")
+      tile = tile_for(image)
+
+      expect(tile.display_label).to eq("TV")
+      expect(tile.label).to eq("TV")
+    end
+
+    it "sentence cases whole-utterance phrase tiles" do
+      image = FactoryBot.create(:image, label: "i want more", part_of_speech: "phrase")
+      tile = tile_for(image)
+
+      expect(tile.display_label).to eq("I want more")
+      expect(tile.label).to eq("i want more")
+    end
+
+    it "does not apply English Title Case to a non-English board" do
+      spanish_board = FactoryBot.create(:board, user: user, language: "es")
+      image = FactoryBot.create(:image, label: "todo listo")
+      tile = FactoryBot.create(:board_image, board: spanish_board, image: image, language: "es")
+
+      expect(tile.display_label).to eq("Todo listo")
+      expect(tile.label).to eq("todo listo")
+    end
+
+    it "normalizes the label defaulted through Board#add_image" do
+      image = FactoryBot.create(:image, label: "faster")
+      board.add_image(image.id)
+
+      tile = board.board_images.reload.find_by(image_id: image.id)
+      expect(tile.display_label).to eq("Faster")
+      expect(tile.label).to eq("faster")
     end
   end
 

--- a/spec/services/boards/board_pdf_layout_normalizer_spec.rb
+++ b/spec/services/boards/board_pdf_layout_normalizer_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Boards::BoardPdfLayoutNormalizer, type: :service do
       image = create(:image, label: "dog", src_url: "https://cdn.example/dog.png")
       add_tile(image)
 
-      expect(tile_for("dog")["image_url"]).to eq("https://cdn.example/dog.png")
+      # The normalizer keys its output on display_label, which is Title Cased
+      # when defaulted from the image's lowercase matching label.
+      expect(tile_for("Dog")["image_url"]).to eq("https://cdn.example/dog.png")
     end
 
     it "leaves a label-only tile blank instead of borrowing a same-label library image" do

--- a/spec/services/labels/case_normalizer_spec.rb
+++ b/spec/services/labels/case_normalizer_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Labels::CaseNormalizer do
+  describe ".normalize" do
+    it "title cases a single lowercase word" do
+      expect(described_class.normalize("swing")).to eq("Swing")
+    end
+
+    it "title cases every word of a multi-word label" do
+      expect(described_class.normalize("all done")).to eq("All Done")
+    end
+
+    it "capitalizes a standalone i" do
+      expect(described_class.normalize("i")).to eq("I")
+    end
+
+    context "when the text already carries deliberate casing" do
+      it "leaves brand casing alone" do
+        expect(described_class.normalize("iPad")).to eq("iPad")
+      end
+
+      it "leaves acronyms alone" do
+        expect(described_class.normalize("TV")).to eq("TV")
+      end
+
+      it "leaves interior capitals alone" do
+        expect(described_class.normalize("McDonald's")).to eq("McDonald's")
+      end
+
+      it "leaves an already Title Cased phrase alone" do
+        expect(described_class.normalize("All Done")).to eq("All Done")
+      end
+    end
+
+    context "with a phrase part of speech" do
+      it "sentence cases instead of title casing" do
+        expect(described_class.normalize("i want more please", part_of_speech: "phrase"))
+          .to eq("I want more please")
+      end
+
+      it "capitalizes a standalone i anywhere in the phrase" do
+        expect(described_class.normalize("can i go now", part_of_speech: "phrase"))
+          .to eq("Can I go now")
+      end
+
+      it "capitalizes a contracted i" do
+        expect(described_class.normalize("now i'm done", part_of_speech: "phrase"))
+          .to eq("Now I'm done")
+      end
+
+      it "does not capitalize words that merely start with i" do
+        expect(described_class.normalize("put it in there", part_of_speech: "phrase"))
+          .to eq("Put it in there")
+      end
+    end
+
+    context "with a non-English language" do
+      it "sentence cases rather than applying English Title Case" do
+        expect(described_class.normalize("todo listo", language: "es")).to eq("Todo listo")
+      end
+
+      it "does not apply the English standalone-i rule" do
+        expect(described_class.normalize("si i no", language: "es")).to eq("Si i no")
+      end
+
+      it "still title cases regional English" do
+        expect(described_class.normalize("all done", language: "en-US")).to eq("All Done")
+      end
+    end
+
+    it "returns blank input unchanged" do
+      expect(described_class.normalize(nil)).to eq("")
+      expect(described_class.normalize("   ")).to eq("   ")
+    end
+
+    it "preserves the original spacing" do
+      expect(described_class.normalize("all  done")).to eq("All  Done")
+    end
+
+    it "never downcases" do
+      expect(described_class.normalize("HELP", part_of_speech: "phrase")).to eq("HELP")
+    end
+  end
+end


### PR DESCRIPTION
Tile `display_label` inherited whatever casing its creation path happened to use, so the same board rendered `Higher` next to `swing` (live example: `at-the-swing` 5680, 18 of 20 tiles Title Case). Cosmetic on screen, a real defect in print, where these boards become physical signs.

Closes #577

## What changed

**`Labels::CaseNormalizer`** (new) normalizes **defaulted** tile text only. Rules, in order:

1. Blank → unchanged.
2. **Any existing uppercase letter → unchanged.** This is the acronym/brand guard: `iPad`, `TV`, `McDonald's` pass through untouched, with no exception list to maintain.
3. Non-English → sentence case (`todo listo` → `Todo listo`). Title Case is an English convention.
4. English + `part_of_speech == "phrase"` → sentence case; gestalt/GLP tiles are whole utterances. Standalone `i` capitalizes anywhere.
5. English otherwise → Title Case (`all done` → `All Done`, matching the existing tiles on 5680).

The transform only ever upcases a word's first letter — it never downcases, so nothing that slips past rule 2 can be mangled.

**`BoardImage`** — two paths default `display_label`, and the issue only names one:

- `set_defaults` (`before_create`), moved below the `part_of_speech` resolution so the phrase rule sees the resolved value.
- `set_labels`, on the `|| label` fall-through only. This one matters: `Board#add_image` — the main "add a tile" route — calls `set_labels` first, which leaves `display_label` present, so `set_defaults` bails. Normalizing only `set_defaults` would have missed the biggest producer of lowercase tiles.

A stored `language_settings["display_label"]` is an authored translation and is used verbatim.

**Not touched.** `label` is never normalized — it's the lowercase matching key for image lookup, and changing it would break exact-label matching in `GenerateBoardJob` and the bulk image search. Explicit callers never reach the normalizer (`display_label.blank?` is false), so `pin_authored_label!`, `NavRowSync`, `ImageResolver#upgrade_board_tiles!`, `BoardFromScreenshot`, `SeededSetCloner`, and the bulk `label_case` endpoint are unchanged.

**Forward-only — no backfill**, as the issue suggests. Board 5680's existing tiles keep their casing. A backfill would have to tell deliberate casing from inherited casing on data where that signal is already lost; worth its own task once the rule has settled.

## Acceptance

| Issue criterion | Covered by |
|---|---|
| Two tiles from different paths render the same casing | `board_image_spec` "gives tiles created through different paths the same casing" + the `Board#add_image` case |
| Explicit `display_label` survives unchanged | "keeps an explicitly supplied display_label exactly as given" |
| `label` unchanged in all cases | asserted in every creation example |
| Non-English not Title Cased with English rules | "does not apply English Title Case to a non-English board" |

## Test plan

- `spec/services/labels/case_normalizer_spec.rb` (new, 17 examples) — title case, multi-word, `iPad`/`TV`/`McDonald's`, standalone and contracted `i`, phrase sentence case, non-English, `en-US`, blank, spacing, never-downcases.
- `spec/models/board_image_spec.rb` — 8 new creation-time examples.
- Two existing specs updated for the intended behavior change, both asserting things other than casing: `set_labels` "falls back to the English image label" (`hello` → `Hello` on an `es` board), and the PDF layout normalizer's tile lookup key (it keys on `display_label`, now `Dog`).

Ran:

- `spec/services/labels`, `spec/models/board_image_spec.rb`, `spec/requests/api/board_images_label_case_spec.rb`, `spec/requests/api/internal/board_images_spec.rb`, `spec/services/boards/board_pdf_layout_normalizer_spec.rb`, `spec/models/image_spec.rb`, `spec/services/boards/image_resolver_spec.rb` — **all pass**.
- Full `spec/services spec/models` — **1642 examples, 0 failures, 7 pending**, on two seeds.

One note on that sweep: an intermediate run surfaced 21 failures in `mission_control`, `team_user`, and `credit_service` — none label-related. Re-running the identical command and seed gave 0 failures, and `main` shows a failure in the same `mission_control` family, so that's pre-existing order-sensitivity in those count-based specs, not this change.

## Docs

- `CHANGELOG.md` — Unreleased/Fixed entry.
- `.claude-notes/boards-and-teams.md` — new "Tile text casing" section: the `label` vs `display_label` split, both defaulting paths, the rule order, and the forward-only decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)