### PR TITLE
fix(labels): default tile casing to lowercase instead of Title Case

### DIFF
--- a/app/services/labels/case_normalizer.rb
+++ b/app/services/labels/case_normalizer.rb
@@ -7,11 +7,16 @@ module Labels
   # up rendering "Higher" next to "swing". That reads as a defect in print,
   # where these boards become physical signs.
   #
+  # The default is lowercase (the AAC core-vocabulary convention), not Title
+  # Case — so the fix for the inconsistency above is "Higher" settling down to
+  # "higher", not "swing" climbing up to "Swing".
+  #
   # This normalizes the **defaulted** case only. Callers that explicitly supply
   # a `display_label` never route through here — their casing wins.
   #
-  # The transform only ever upcases the first letter of a word. It never
-  # downcases, so nothing that slips past `deliberate_casing?` can be mangled.
+  # The transform only ever upcases the first letter of a word (and only for
+  # the standalone pronoun "I"). It never downcases, so nothing that slips past
+  # `deliberate_casing?` can be mangled.
   module CaseNormalizer
     # Whole-utterance tiles (gestalt / GLP) read as sentences, not headlines.
     PHRASE_PART_OF_SPEECH = "phrase".freeze
@@ -32,7 +37,7 @@ module Labels
 
       english = english?(language)
       if english && part_of_speech.to_s != PHRASE_PART_OF_SPEECH
-        title_case(text)
+        lowercase_case(text)
       else
         sentence_case(text, english: english)
       end
@@ -52,8 +57,13 @@ module Labels
       lang.empty? || lang == "en" || lang.start_with?("en-", "en_")
     end
 
-    def title_case(text)
-      transform_words(text) { |word| upcase_first(word) }
+    # AAC core-vocabulary convention: tiles stay lowercase, not Title Case or
+    # sentence-initial capitals — most single/multi-word boards (LAMP, Unity,
+    # Word Power, PrAACtical AAC) present core words lowercase throughout. The
+    # pronoun "I" is the one grammar rule that survives regardless of style or
+    # position in the tile text.
+    def lowercase_case(text)
+      transform_words(text) { |word| word.match?(STANDALONE_I) ? upcase_first(word) : word }
     end
 
     # First word capitalized, the rest left as authored — except a standalone

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -80,30 +80,31 @@ RSpec.describe BoardImage, type: :model do
       FactoryBot.create(:board_image, board: board, image: image, **attrs)
     end
 
-    it "title cases a label defaulted from the image" do
+    it "leaves a label defaulted from the image lowercase" do
       image = FactoryBot.create(:image, label: "swing")
       tile = tile_for(image)
 
-      expect(tile.display_label).to eq("Swing")
+      expect(tile.display_label).to eq("swing")
       expect(tile.label).to eq("swing")
     end
 
-    it "title cases every word of a multi-word label" do
+    it "leaves every word of a multi-word label lowercase" do
       image = FactoryBot.create(:image, label: "all done")
       tile = tile_for(image)
 
-      expect(tile.display_label).to eq("All Done")
+      expect(tile.display_label).to eq("all done")
       expect(tile.label).to eq("all done")
     end
 
     it "gives tiles created through different paths the same casing" do
-      lowercase_source = FactoryBot.create(:image, label: "faster")
-      titled_source = FactoryBot.create(:image, label: "higher")
+      via_direct_create = FactoryBot.create(:image, label: "faster")
+      via_add_image = FactoryBot.create(:image, label: "higher")
 
-      defaulted = tile_for(lowercase_source)
-      authored = tile_for(titled_source, display_label: "Higher")
+      direct_tile = tile_for(via_direct_create)
+      board.add_image(via_add_image.id)
+      added_tile = board.board_images.reload.find_by(image_id: via_add_image.id)
 
-      expect([defaulted.display_label, authored.display_label]).to eq(%w[Faster Higher])
+      expect([direct_tile.display_label, added_tile.display_label]).to eq(%w[faster higher])
     end
 
     it "keeps an explicitly supplied display_label exactly as given" do
@@ -144,7 +145,7 @@ RSpec.describe BoardImage, type: :model do
       board.add_image(image.id)
 
       tile = board.board_images.reload.find_by(image_id: image.id)
-      expect(tile.display_label).to eq("Faster")
+      expect(tile.display_label).to eq("faster")
       expect(tile.label).to eq("faster")
     end
   end

--- a/spec/services/boards/board_pdf_layout_normalizer_spec.rb
+++ b/spec/services/boards/board_pdf_layout_normalizer_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Boards::BoardPdfLayoutNormalizer, type: :service do
       image = create(:image, label: "dog", src_url: "https://cdn.example/dog.png")
       add_tile(image)
 
-      # The normalizer keys its output on display_label, which is Title Cased
+      # The normalizer keys its output on display_label, which stays lowercase
       # when defaulted from the image's lowercase matching label.
-      expect(tile_for("Dog")["image_url"]).to eq("https://cdn.example/dog.png")
+      expect(tile_for("dog")["image_url"]).to eq("https://cdn.example/dog.png")
     end
 
     it "leaves a label-only tile blank instead of borrowing a same-label library image" do

--- a/spec/services/labels/case_normalizer_spec.rb
+++ b/spec/services/labels/case_normalizer_spec.rb
@@ -2,16 +2,20 @@ require "rails_helper"
 
 RSpec.describe Labels::CaseNormalizer do
   describe ".normalize" do
-    it "title cases a single lowercase word" do
-      expect(described_class.normalize("swing")).to eq("Swing")
+    it "leaves a single lowercase word lowercase" do
+      expect(described_class.normalize("swing")).to eq("swing")
     end
 
-    it "title cases every word of a multi-word label" do
-      expect(described_class.normalize("all done")).to eq("All Done")
+    it "leaves every word of a multi-word label lowercase" do
+      expect(described_class.normalize("all done")).to eq("all done")
     end
 
     it "capitalizes a standalone i" do
       expect(described_class.normalize("i")).to eq("I")
+    end
+
+    it "capitalizes a standalone i anywhere in a multi-word label" do
+      expect(described_class.normalize("was it i")).to eq("was it I")
     end
 
     context "when the text already carries deliberate casing" do
@@ -63,8 +67,8 @@ RSpec.describe Labels::CaseNormalizer do
         expect(described_class.normalize("si i no", language: "es")).to eq("Si i no")
       end
 
-      it "still title cases regional English" do
-        expect(described_class.normalize("all done", language: "en-US")).to eq("All Done")
+      it "still applies the lowercase default for regional English" do
+        expect(described_class.normalize("all done", language: "en-US")).to eq("all done")
       end
     end
 
@@ -74,7 +78,11 @@ RSpec.describe Labels::CaseNormalizer do
     end
 
     it "preserves the original spacing" do
-      expect(described_class.normalize("all  done")).to eq("All  Done")
+      expect(described_class.normalize("all  done")).to eq("all  done")
+    end
+
+    it "preserves spacing around a capitalized standalone i" do
+      expect(described_class.normalize("was  it  i")).to eq("was  it  I")
     end
 
     it "never downcases" do


### PR DESCRIPTION
## Summary
- `Labels::CaseNormalizer` now defaults defaulted English, non-phrase tile text to lowercase instead of Title Case (`"all done"` stays `"all done"` instead of becoming `"All Done"`), matching the common AAC core-vocabulary convention (LAMP, Unity, Word Power, PrAACtical AAC boards present core words lowercase).
- The standalone pronoun "I" still capitalizes wherever it appears — that's a grammar rule, not a casing style, so it's unaffected by this change.
- Phrase tiles, non-English tiles, and deliberately-cased text (brand names, acronyms, explicit overrides) are untouched — those code paths already bypassed or used sentence case, not Title Case.
- Investigated whether curated folder/header tiles (Board Builder folders, nav tiles, "My Favorites") needed similar treatment — those pin explicit Title Case text on a separate, intentional code path (documented in their own comments) and are left as-is per discussion.

## Why
Title Case was the wrong default for single/multi-word vocabulary tiles — this flips the default set in #582 to match AAC convention while keeping every other casing rule (deliberate-casing bypass, standalone "I", phrase/non-English sentence case) intact.

## Test plan
- Updated `spec/services/labels/case_normalizer_spec.rb`, `spec/models/board_image_spec.rb`, and `spec/services/boards/board_pdf_layout_normalizer_spec.rb` to reflect the new lowercase default.
- Ran the directly relevant specs: `case_normalizer_spec`, `board_image_spec`, `board_pdf_layout_normalizer_spec`, `image_resolver_spec`, `board_images_spec` (internal + label_case), `image_spec` — **123 examples, 0 failures**.
- `ruby -c` syntax check on all changed files.