### PR TITLE
fix(internal-api): make label search agree with bulk, and make bulk retry-safe

### DIFF
--- a/.claude-notes/internal-api.md
+++ b/.claude-notes/internal-api.md
@@ -118,13 +118,82 @@ resolver *found*, not only ones it created. Two rails:
 Callers that would rather ship blanks than spend the call pass a request-level
 `generate_missing: false` (not per-cell).
 
+**Labels resolve in one batch per request.** `Boards::ImageResolver.resolve_all`
+does the art lookup in two queries however many labels are asked for, keyed by
+`ImageResolver.normalize(label)`, and picks exactly what a per-label `resolve`
+would. Per-cell resolution cost 2-3 queries per tile and was most of what pushed
+a 48-cell request past the proxy timeout. `resolve_all` may create a blank Image
+for a label with no match anywhere, so it belongs inside the caller's
+transaction and never on a read path.
+
+## Bulk is retry-safe only when the caller asks for it
+
+`bulk` used to return 500 *after* the cells committed, so the obvious client
+behaviour — retry on 5xx — doubled every tile on the board. Two rails now:
+
+- **`idempotency_key`** (request-level). The key and the ids it created are
+  recorded on `board.settings["internal_bulk_keys"]` (last
+  `IDEMPOTENCY_KEY_HISTORY` keys) **inside the transaction**, so a rolled-back
+  write leaves no key behind that a retry would replay against tiles that don't
+  exist. A repeat request with a known key creates nothing and replays the
+  original cells with `200` + an `Idempotent-Replay: true` header.
+- **`replace: true`** clears the board inside the same transaction, so a blind
+  retry converges instead of appending.
+
+Default behavior is unchanged (append, duplicates allowed) — the protection is
+opt-in so existing multi-batch callers keep working.
+
+**The multi-cell endpoints return a compact payload, not `api_view`.**
+`BoardImage#api_view` costs several queries per tile (docs + blobs, audio files,
+voice list, board lookups), all run after the transaction commits — hundreds of
+post-commit queries on a 48-cell build. `view=full` opts back in. The
+single-cell `create`/`update` still return `api_view`.
+
+## Correcting a tile (`update` / `bulk_update` / `destroy`)
+
+A symbol swap re-points `image_id` on the **same** `BoardImage`. The board's
+`layout` keys off `BoardImage` ids, so delete-and-recreate would orphan the
+layout entry and silently reflow the grid — never "fix" a tile that way. Tile
+text is left alone on a swap unless the caller passes `display_label`.
+
+Cells are always looked up through `@board.board_images`, so a cell id belonging
+to another board 404s rather than writing. `destroy` repacks displaced tiles and
+then rewrites the board-level `layout` (which would otherwise still name the
+removed id); surviving tiles keep their authored cells.
+
 ## Search endpoints
 
-- `GET|POST /api/internal/images/search` → `Images::LabelSearch`. Exact match
-  first, prefix fallback. Scoped to `Image.default_public.searchable.with_artifacts`
-  — user and private images are never reachable, and this is not overridable.
-  Images with no attached doc are excluded (a printable can't use them, so a
-  null-URL result would be noise).
+- `GET|POST /api/internal/images/search` → `Images::LabelSearch`. Scoped to
+  `Image.default_public.searchable.with_artifacts` — user and private images are
+  never reachable, and this is not overridable. Images with no attached doc are
+  excluded (a printable can't use them, so a null-URL result would be noise).
+
+  **Ranked in tiers, and the first tier is literal equality.**
+  `search_by_exact_label` is NOT an equality match — it is a pg_search tsearch
+  scope (`prefix: false`), so it matches the *word* "want" anywhere in a label
+  ("i want pasta", "want slide") and orders by `ts_rank` with no tiebreak. The
+  genuinely exact row was routinely outranked and truncated at `limit`, which is
+  how a pre-flight check reported core vocabulary as art-less while `bulk` was
+  attaching exact-label art for the same word. The literal tier
+  (`LOWER(label) = LOWER(?)`, ordered `COUNT(docs) DESC, id ASC`) runs first and
+  orders exactly the way `Boards::ImageResolver` does, so the two endpoints agree
+  on which Image wins a label. Do not collapse the tiers back into one query.
+
+  **`resolve=true`** prepends what `board_images/bulk` would actually attach
+  (`match: "resolve"`), reached through `ImageResolver` — which reads the default
+  admin's own images, private ones included, before the public scope. That is the
+  only way a caller can see a pick search's own scope excludes. A resolve row is
+  never dropped by `commercial_safe` filtering (hiding it would report "no art"
+  for a label that will get art); its flags carry the verdict. No resolve row
+  means no art exists and `bulk` would attach a blank + queue generation — search
+  itself must never create an Image.
+
+- `GET /api/internal/images/:id` serializes licensing (`has_art`, `source_type`,
+  `original_url`, `license`, `commercial_safe`, `attribution_required`,
+  `share_alike`) for the same Doc a search result would describe, via
+  `Images::LabelSearch.library_doc`. Without it there was no way to license-check
+  art after `bulk` attached it — every image read back as "unsafe, no license"
+  whether or not that was true.
 - `GET /api/internal/boards/search` → `Boards::AdminSearch`. Scoped to admin
   boards, excluding menus, sub-boards and Board Builder children. Returns
   **unpublished boards by default**; callers building shippable products must

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,41 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   everything else is stripped from to/cc/bcc. Production and development are
   unaffected.
 
+### Added
+
+- **The internal API can now correct a tile, not just create one.**
+  `PATCH /api/internal/boards/:id/board_images/:cell_id` (and an atomic
+  `bulk_update`) swap a tile's symbol, colours or label in place, and `DELETE`
+  removes one and resyncs the board's layout. A symbol swap keeps the same
+  `BoardImage`, so the grid doesn't move — previously a wrong image or colour
+  on an API-built board could only be fixed by hand in the editor, which
+  doesn't scale to a set of boards headed for print.
+
 ### Fixed
 
+- **Image search no longer reports art as missing when it exists.** Searching a
+  label like `want` or `where` returned only phrase matches (`i want pasta`,
+  `where are the lions?`) and could omit the image labelled exactly `want` —
+  the very one a board build attaches. Pre-flight "will this board have art?"
+  checks were therefore reporting core vocabulary as uncovered, nearly
+  triggering unnecessary AI generation and rewordings. Exact labels now rank
+  first, ordered the same way board building picks them, and `resolve=true`
+  reports exactly what a build would attach for a label.
+- **`GET /api/internal/images/:id` reports licensing.** It previously carried no
+  licence data at all, so every image read back as "not commercial safe, no
+  licence" whether or not that was true — meaning art attached to boards headed
+  for Etsy/print could not be licence-checked after the fact. It now returns
+  `has_art`, `source_type`, `original_url`, `license`, `commercial_safe`,
+  `attribution_required` and `share_alike`.
+- **Bulk tile creation no longer duplicates a board when a request is retried.**
+  Large bulk writes could return `500` *after* the tiles had been written; the
+  natural client response — retry — produced a board holding every tile twice.
+  Label resolution is now batched (two queries for a whole request instead of
+  two or three per tile) and the response payload is compact by default, which
+  removes most of the work that ran after the write committed. Callers can pass
+  an `idempotency_key` to make a retry replay the original tiles instead of
+  creating new ones, or `replace: true` so a retry converges on the intended
+  board. Pass `view=full` for the previous, heavier response shape.
 - **Tile text casing is consistent across a board.** A tile inherited whatever
   casing its creation path happened to use — paths handing over a Title Cased
   word list produced `Higher`, paths falling through to the image's lowercase

--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ For Hatchbox, set `INTERNAL_API_KEY` in the app's environment variables panel.
 | `GET` | `/api/internal/boards/:id/export.pdf` | Render a board as a PDF |
 | `POST` | `/api/internal/boards/:id/board_images` | Add a tile to a board |
 | `POST` | `/api/internal/boards/:id/board_images/bulk` | Add multiple tiles to a board |
+| `PATCH` | `/api/internal/boards/:id/board_images/:cell_id` | Correct one tile (swap image, colors, label) |
+| `PATCH` | `/api/internal/boards/:id/board_images/bulk_update` | Correct many tiles atomically |
+| `DELETE` | `/api/internal/boards/:id/board_images/:cell_id` | Remove a tile and resync the layout |
 | `POST` | `/api/internal/generated_boards` | Create a generated board |
 | `GET` | `/api/internal/images/search` | Find images by label (single) |
 | `POST` | `/api/internal/images/search` | Find images by label (bulk, ≤100) |
@@ -688,11 +691,19 @@ back, so a board never ends up half-built. The response array is in **input
 order**, which is what lets you map the returned `BoardImage` ids straight onto a
 layout you then `PATCH`.
 
+**Request-level params** (alongside `cells`):
+
+- `idempotency_key` *(optional, strongly recommended)* — makes a retry safe. The board remembers the key and the cells it created (its last 20 keys); a repeat request with the same key creates nothing and replays the original cells with `200 OK` and an `Idempotent-Replay: true` header instead of `201`. A request that rolled back records no key, so retrying it builds the board for real. The key is not checked against the body — reuse one only for a retry of the *same* request, and pick a new key per batch (e.g. `"<board-slug>-<batch-index>"`).
+- `replace` *(optional, default `false`)* — clears the board's existing tiles inside the same transaction before writing the new ones, then resyncs the board layout. Use it when a retry should converge on the intended board rather than append to a partial one.
+- `view` *(optional)* — `"full"` returns each cell's full `api_view`. The default is a compact payload (see below).
+- `generate_missing` *(optional, default `true`)* — as on the single-cell endpoint.
+
 ```sh
 curl -X POST https://<host>/api/internal/boards/123/board_images/bulk \
   -H "Authorization: Bearer $INTERNAL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
+    "idempotency_key": "playground-root-2026-08-06",
     "cells": [
       { "label": "I",        "position": 0, "bg_color": "#FFEA75" },
       { "label": "want",     "position": 1, "bg_color": "#A1F571" },
@@ -701,9 +712,49 @@ curl -X POST https://<host>/api/internal/boards/123/board_images/bulk \
   }'
 ```
 
-Response: `201 Created` with an array of `api_view`s, or `422` with
-`{ "errors": [ { "index": 1, "error": "..." } ] }` identifying which entries
-failed.
+Response: `201 Created` with an array of compact cell payloads — `id`,
+`board_id`, `image_id`, `label`, `display_label`, `position`, `layout`,
+`hidden`, `voice`, `language`, the colors, `font_size`, `part_of_speech`,
+`data`, `predictive_board_id`, `dynamic`, `src`, `display_image_url`, `status`
+— or `422` with `{ "errors": [ { "index": 1, "error": "..." } ] }` identifying
+which entries failed.
+
+The compact payload is the default because `BoardImage#api_view` costs several
+queries **per tile** (docs and their blobs, audio files, voice list, board
+lookups), all of them run after the transaction commits. On a 48-cell request
+that was hundreds of post-commit queries — enough to time out a request whose
+write had already landed. Pass `view=full` if you need the heavier shape.
+
+**Do not blind-retry a 5xx from this endpoint without an `idempotency_key`.**
+Without one, a retry appends a second copy of every cell.
+
+#### `PATCH` / `DELETE` `/api/internal/boards/:id/board_images/:cell_id`
+
+Corrects or removes a tile that already exists. `PATCH` takes the same
+attributes as the create endpoints, plus `image_id` to **swap the symbol in
+place**.
+
+A swap re-points `image_id` on the same `BoardImage` rather than
+delete-and-recreate: the board's `layout` keys off `BoardImage` ids, so
+recreating would orphan the layout entry and silently reflow the grid. The
+tile's text is left alone unless you pass `display_label`.
+
+```sh
+# Swap a tile onto a commercial-safe symbol without touching the grid.
+curl -X PATCH https://<host>/api/internal/boards/5679/board_images/146356 \
+  -H "Authorization: Bearer $INTERNAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "image_id": 14305 }'
+```
+
+- A cell id that isn't on the given board returns `404` and writes nothing.
+- An `image_id` that doesn't exist returns `422`.
+- `PATCH .../board_images/bulk_update` takes `{ "cells": [{ "id": 146356, ... }] }`
+  and is atomic the same way `bulk` is — one bad entry rolls back every cell and
+  returns `422` with the offending `index`.
+- `DELETE` removes the cell, repacks displaced tiles and rewrites the board's
+  denormalized `layout` so it no longer references the removed id. Surviving
+  tiles keep their authored cells — the freed slot is not closed up under them.
 
 #### Folder tiles — linking one board to another
 
@@ -771,8 +822,9 @@ board via the existing board endpoints to see when generation finishes.
 
 #### `GET /api/internal/images/search`
 
-Find images in the public library by label. Exact match first, falling back to
-prefix matching when there is no exact hit.
+Find images in the public library by label. Results are ranked in tiers:
+literal label equality first (ordered the way `Boards::ImageResolver` orders —
+most artwork, then lowest id), then word matches, then prefix matches.
 
 ```sh
 curl -G https://<host>/api/internal/images/search \
@@ -783,7 +835,19 @@ curl -G https://<host>/api/internal/images/search \
 
 Params: `q` *(required)*, `match` (`exact` default, or `prefix`), `limit`
 (default 10, max 50), `commercial_safe` (default false),
-`include_share_alike` (default false).
+`include_share_alike` (default false), `resolve` (default false).
+
+**Use `resolve=true` for a pre-flight check.** Ordinary search reads
+`Image.default_public`, while `board_images/bulk` resolves through
+`Boards::ImageResolver`, which looks at the default admin's own images
+(private ones included) first. A label can therefore resolve to art that plain
+search can never return. `resolve=true` prepends the image `bulk` would
+actually attach, tagged `"match": "resolve"`, so "will this board have art?"
+tooling reads the same slice of the library the write does. A resolve row is
+never dropped by `commercial_safe=true` — hiding it would report "no art" for a
+label that will in fact get art; read its `commercial_safe` flag instead. No
+resolve row means no art exists for the label and `bulk` would attach a blank
+tile and queue AI generation (search itself never creates an image).
 
 Response `200`:
 
@@ -846,7 +910,9 @@ curl -X POST https://<host>/api/internal/images/search \
 
 Params: `labels` *(required, array, max 100)*, `limit_per_label` (default 3,
 max 25), `match` (`exact` default, or `prefix`), `commercial_safe` (default
-false), `include_share_alike` (default false).
+false), `include_share_alike` (default false), `resolve` (default false — same
+meaning as on the `GET` endpoint, and the right flag for a pre-flight art
+check).
 
 Response `200` — **every requested label gets a key**, misses included, so you
 can spot gaps without diffing against your request:
@@ -915,11 +981,26 @@ Response shape:
   "status": "complete",
   "image_prompt": "a red apple",
   "src": "https://.../apple.png",
-  "error": null
+  "error": null,
+  "has_art": true,
+  "source_type": "OpenAI",
+  "original_url": "https://cdn.../abc123",
+  "license": null,
+  "commercial_safe": true,
+  "attribution_required": false,
+  "share_alike": false
 }
 ```
 
 `status` will be `generating`, `complete`, or `failed`.
+
+The licensing fields describe the same Doc a search result would describe, so
+art attached by `board_images/bulk` can be license-checked **after the fact** —
+which matters when these boards feed the printables pipeline. `has_art: false`
+means no artwork at all, which is a different situation from artwork under an
+unusable license; both used to read identically. Pass
+`include_share_alike=true` to have share-alike licenses count as
+commercial-safe.
 
 ### Polling for generation status
 

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -4,6 +4,10 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
   # become one 60-image Sidekiq job.
   GENERATE_BATCH_SIZE = 3
 
+  # How many idempotency keys a board remembers. Bounded because they live in
+  # the board's `settings` jsonb, which is loaded on every board read.
+  IDEMPOTENCY_KEY_HISTORY = 20
+
   def create
     @board = Board.find(params[:board_id])
 
@@ -31,19 +35,34 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
       return render json: { error: "cells must be a non-empty array" }, status: :unprocessable_content
     end
 
+    # A retry of a request that already committed replays the original cells
+    # instead of creating a second copy of every tile. Without this the
+    # documented-atomic endpoint punishes the obvious client behaviour —
+    # retry on 5xx — with a silently duplicated board (#574).
+    if idempotency_key && (replayed = replayed_cells(idempotency_key))
+      response.headers["Idempotent-Replay"] = "true"
+      return render json: replayed.map { |bi| cell_view(bi) }, status: :ok
+    end
+
+    cells = raw_cells.map { |cell| normalize_cell(cell) }
+
     created = []
     errors = []
     label_resolved_image_ids = []
 
     ActiveRecord::Base.transaction do
-      raw_cells.each_with_index do |cell_params, index|
-        # ActionController::Parameters in nested arrays come through as
-        # ActionController::Parameters instances; coerce to a hash with
-        # indifferent access so resolve_image_from / apply_optional_attributes!
-        # work the same way as in #create.
-        cp = cell_params.respond_to?(:permit!) ? cell_params.permit!.to_h.with_indifferent_access : cell_params.to_h.with_indifferent_access
+      @board.board_images.destroy_all if replace?
 
-        image = resolve_image_from(cp)
+      # One resolution pass for every distinct label in the request. Resolving
+      # per cell cost 2-3 queries per tile, which is most of what pushed a
+      # 48-cell request toward the proxy timeout that produced #574.
+      resolved = Boards::ImageResolver.resolve_all(
+        cells.filter_map { |cp| cp[:label].to_s.strip if label_path?(cp) },
+        owner: current_user,
+      )
+
+      cells.each_with_index do |cp, index|
+        image = resolve_image_from(cp, resolved: resolved)
         if image.nil?
           errors << { index: index, error: "image_id or label is required" }
           next
@@ -67,20 +86,108 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
         created << board_image
       end
 
+      remember_idempotency_key!(idempotency_key, created) if errors.empty? && idempotency_key
+
       raise ActiveRecord::Rollback if errors.any?
     end
 
     if errors.any?
       render json: { errors: errors }, status: :unprocessable_content
     else
+      resync_layout! if replace?
       # Only after the transaction has actually committed — a rolled-back bulk
       # must not leave Sidekiq holding ids of Images that no longer exist.
       queue_missing_art!(label_resolved_image_ids)
-      render json: created.map { |bi| bi.api_view(current_user) }, status: :created
+      render json: created.map { |bi| cell_view(bi) }, status: :created
     end
   end
 
+  # PATCH /api/internal/boards/:board_id/board_images/:id
+  #
+  # The internal API could create a tile but never correct one (#584), so a
+  # wrong symbol, colour or label was permanent from the API's point of view
+  # and the only repair path was a human in the editor UI.
+  def update
+    @board = Board.find(params[:board_id])
+    board_image = find_cell(params[:id])
+    return render json: { error: "board_image not found" }, status: :not_found if board_image.nil?
+
+    result = apply_cell_update!(board_image, params)
+    return render json: { error: result }, status: :unprocessable_content if result.is_a?(String)
+
+    render json: board_image.reload.api_view(current_user)
+  end
+
+  # PATCH /api/internal/boards/:board_id/board_images/bulk_update
+  #
+  # Atomic multi-cell edit — the repair counterpart to `bulk`, so a whole
+  # board's colours or voice can be corrected in one call.
+  def bulk_update
+    @board = Board.find(params[:board_id])
+
+    raw_cells = params[:cells]
+    unless raw_cells.is_a?(Array) && raw_cells.any?
+      return render json: { error: "cells must be a non-empty array" }, status: :unprocessable_content
+    end
+
+    updated = []
+    errors = []
+
+    ActiveRecord::Base.transaction do
+      raw_cells.map { |cell| normalize_cell(cell) }.each_with_index do |cp, index|
+        board_image = cp[:id].present? ? find_cell(cp[:id]) : nil
+        if board_image.nil?
+          errors << { index: index, error: "board_image not found on this board" }
+          next
+        end
+
+        result = apply_cell_update!(board_image, cp)
+        if result.is_a?(String)
+          errors << { index: index, error: result }
+          next
+        end
+
+        updated << board_image
+      end
+
+      raise ActiveRecord::Rollback if errors.any?
+    end
+
+    if errors.any?
+      render json: { errors: errors }, status: :unprocessable_content
+    else
+      render json: updated.map { |bi| cell_view(bi.reload) }
+    end
+  end
+
+  # DELETE /api/internal/boards/:board_id/board_images/:id
+  def destroy
+    @board = Board.find(params[:board_id])
+    board_image = find_cell(params[:id])
+    return render json: { error: "board_image not found" }, status: :not_found if board_image.nil?
+
+    board_image.destroy
+    resync_layout!
+
+    render json: { id: board_image.id, deleted: true, board_images_count: @board.reload.board_images.count }
+  end
+
   private
+
+  # ActionController::Parameters in nested arrays come through as
+  # ActionController::Parameters instances; coerce to a hash with indifferent
+  # access so the shared attribute helpers work the same way as in #create.
+  def normalize_cell(cell)
+    if cell.respond_to?(:permit!)
+      cell.permit!.to_h.with_indifferent_access
+    else
+      cell.to_h.with_indifferent_access
+    end
+  end
+
+  def find_cell(id)
+    @board.board_images.find_by(id: id)
+  end
 
   # An explicit `image_id` pins that exact record; a bare `label` goes through
   # label resolution (and is the only path that may create an Image or spend an
@@ -95,11 +202,16 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
   # break ties) and matches case-insensitively. `find_by` returns arbitrary
   # Postgres heap order, which is how this endpoint used to attach blank,
   # art-less duplicates to almost every tile.
-  def resolve_image_from(p)
+  #
+  # `resolved` is the batch pass's label -> Image map; a miss there falls back
+  # to a single resolve so the two paths can never disagree.
+  def resolve_image_from(p, resolved: nil)
     if p[:image_id].present?
       Image.find_by(id: p[:image_id])
     elsif p[:label].present?
-      Boards::ImageResolver.resolve(p[:label].to_s.strip, owner: current_user)
+      label = p[:label].to_s.strip
+      resolved&.[](Boards::ImageResolver.normalize(label)) ||
+        Boards::ImageResolver.resolve(label, owner: current_user)
     end
   end
 
@@ -146,6 +258,70 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
     ActiveModel::Type::Boolean.new.cast(params[:generate_missing]) != false
   end
 
+  # `replace: true` clears the board first, so even a blind retry converges on
+  # the intended board instead of doubling it.
+  def replace?
+    ActiveModel::Type::Boolean.new.cast(params[:replace]) == true
+  end
+
+  def idempotency_key
+    @idempotency_key ||= params[:idempotency_key].to_s.strip.presence
+  end
+
+  # Returns the cells a previous request with this key created, or nil if the
+  # key is new. An empty result (every remembered cell has since been deleted)
+  # counts as new — replaying nothing would be indistinguishable from a
+  # no-op success.
+  def replayed_cells(key)
+    ids = Array(@board.settings.is_a?(Hash) ? @board.settings.dig("internal_bulk_keys", key) : nil)
+    return nil if ids.empty?
+
+    cells = @board.board_images.where(id: ids).index_by(&:id)
+    ordered = ids.filter_map { |id| cells[id.to_i] }
+    ordered.presence
+  end
+
+  # Recorded INSIDE the bulk transaction: a rolled-back write must not leave a
+  # key behind that would make the caller's retry replay tiles that do not
+  # exist.
+  def remember_idempotency_key!(key, board_images)
+    settings = (@board.settings.is_a?(Hash) ? @board.settings : {}).deep_dup
+    keys = settings["internal_bulk_keys"].is_a?(Hash) ? settings["internal_bulk_keys"] : {}
+    keys = keys.except(key).merge(key => board_images.map(&:id)).to_a.last(IDEMPOTENCY_KEY_HISTORY).to_h
+    settings["internal_bulk_keys"] = keys
+    @board.update_column(:settings, settings)
+  end
+
+  # The board's denormalized `layout` keys off BoardImage ids, so it goes stale
+  # the moment a cell is removed. Repack first (a delete can free a cell a
+  # displaced tile belongs in), then rewrite the board-level copy.
+  def resync_layout!
+    Boards::LayoutRepacker.repack!(@board)
+    Boards::LayoutRepacker.resync_board_layout!(@board)
+  end
+
+  # Applies an update to one existing cell. Returns true, or an error string.
+  #
+  # A symbol swap re-points `image_id` on the SAME BoardImage rather than
+  # delete-and-recreate: `layout` keys off BoardImage ids, so recreating would
+  # orphan the layout entry and silently reflow the grid.
+  def apply_cell_update!(board_image, p)
+    if p[:image_id].present?
+      image = Image.find_by(id: p[:image_id])
+      return "image not found" if image.nil?
+
+      if image.id != board_image.image_id
+        board_image.image_id = image.id
+        board_image.display_image_url = image.display_image_url(current_user).presence || image.src_url
+        return board_image.errors.full_messages.join(", ") unless board_image.save
+      end
+    end
+
+    return true if apply_optional_attributes!(board_image, p)
+
+    board_image.errors.full_messages.join(", ")
+  end
+
   def apply_optional_attributes!(board_image, p)
     updates = {}
     updates[:position]      = p[:position].to_i if p[:position].present?
@@ -180,5 +356,48 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
 
     return true if updates.empty?
     board_image.update(updates)
+  end
+
+  # Compact per-cell payload for the multi-cell endpoints.
+  #
+  # `BoardImage#api_view` costs several queries PER TILE (docs + their
+  # ActiveStorage blobs, audio files, voice list, board lookups). For a 48-cell
+  # bulk that is a few hundred queries run AFTER the transaction commits — the
+  # exact shape of #574, where the write landed and the response still 500'd,
+  # and the caller's retry then duplicated every tile. Everything here is
+  # already loaded on the record. `view=full` opts back into `api_view` for
+  # callers that need the heavier payload.
+  def cell_view(board_image)
+    return board_image.api_view(current_user) if full_view?
+
+    {
+      id: board_image.id,
+      board_id: board_image.board_id,
+      image_id: board_image.image_id,
+      label: board_image.label,
+      display_label: board_image.display_label,
+      position: board_image.position,
+      layout: board_image.layout,
+      hidden: board_image.hidden,
+      voice: board_image.voice,
+      language: board_image.language,
+      bg_color: board_image.bg_color,
+      text_color: board_image.text_color,
+      border_color: board_image.border_color,
+      border_width: board_image.border_width,
+      border_radius: board_image.border_radius,
+      font_size: board_image.font_size,
+      part_of_speech: board_image.part_of_speech,
+      data: board_image.data,
+      predictive_board_id: board_image.predictive_board_id,
+      dynamic: board_image.is_dynamic?,
+      src: board_image.display_image_url,
+      display_image_url: board_image.display_image_url,
+      status: board_image.status,
+    }
+  end
+
+  def full_view?
+    params[:view].to_s == "full"
   end
 end

--- a/app/controllers/api/internal/images_controller.rb
+++ b/app/controllers/api/internal/images_controller.rb
@@ -121,6 +121,35 @@ class API::Internal::ImagesController < API::Internal::ApplicationController
       image_prompt: image.image_prompt,
       src: image.display_image_url(current_user),
       error: image.error,
+    }.merge(license_payload(image))
+  end
+
+  # Licensing for the Doc a search result would describe. Without this there is
+  # no way to check what `bulk` actually attached — every image read back as
+  # "no license recorded" whether or not it had one (#575), which matters
+  # because these boards feed the printables pipeline.
+  #
+  # `has_art` is deliberately separate from the flags: no doc at all is a very
+  # different situation from a doc under an unusable license, and both used to
+  # come back looking identical.
+  def license_payload(image)
+    doc = Images::LabelSearch.library_doc(image)
+    return { has_art: false, source_type: nil, original_url: nil, license: nil,
+             commercial_safe: false, attribution_required: false, share_alike: false } if doc.nil?
+
+    license = Images::CommercialLicense.for(
+      doc,
+      include_share_alike: truthy_param?(params[:include_share_alike]),
+    )
+
+    {
+      has_art: doc.image.attached?,
+      source_type: doc.source_type,
+      original_url: doc.display_url,
+      license: license.license,
+      commercial_safe: license.commercial_safe?,
+      attribution_required: license.attribution_required?,
+      share_alike: license.share_alike?,
     }
   end
 
@@ -144,6 +173,10 @@ class API::Internal::ImagesController < API::Internal::ApplicationController
       limit: limit || params[:limit].presence || default_limit || Images::LabelSearch::DEFAULT_LIMIT,
       commercial_safe: truthy_param?(params[:commercial_safe]),
       include_share_alike: truthy_param?(params[:include_share_alike]),
+      # `resolve=true` prepends the image `board_images/bulk` would actually
+      # attach for the label, so a pre-flight check reads the same slice of the
+      # library the write does.
+      resolve: truthy_param?(params[:resolve]),
     )
   end
 

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -39,6 +39,62 @@ module Boards
         Image.create!(label: word, user_id: owner.id)
     end
 
+    # Batch form of `resolve` for a whole request's worth of labels. Returns a
+    # hash keyed by `normalize(label)`, so callers look a label up with the same
+    # key regardless of the casing they authored.
+    #
+    # Resolving per tile costs 2-3 queries each; a 48-tile board build was
+    # spending most of its wall clock here and landing near the proxy timeout
+    # that made the endpoint return 500 *after* committing (#574). This does the
+    # art lookup in two queries total, however many labels are asked for.
+    #
+    # Same rules as `resolve`, including creating a blank Image for a label with
+    # no match anywhere — so call it inside the caller's transaction, and never
+    # from a read-only path.
+    def resolve_all(labels, owner:)
+      # key (downcased) => the authored casing, so a label with no match
+      # anywhere creates an Image the same way a single `resolve` would rather
+      # than a silently downcased one.
+      authored = {}
+      Array(labels).each do |label|
+        word = Boards::InterestWords.normalize_word(label).to_s
+        next if word.blank?
+
+        authored[word.downcase] ||= word
+      end
+      return {} if authored.empty?
+
+      words = authored.keys
+      arted = best_arted_all(owner.images, words)
+      arted = best_arted_all(default_public_scope, words - arted.keys).merge(arted)
+
+      words.index_with do |word|
+        arted[word] || resolve(authored[word], owner: owner)
+      end
+    end
+
+    # The art-bearing image for each of `words`, keyed by normalized label.
+    # Ordering matches `best_arted` (most docs, then lowest id), and the first
+    # row seen per label wins — so a batch resolve picks exactly the Image a
+    # per-label resolve would.
+    def best_arted_all(relation, words)
+      return {} if words.empty?
+
+      relation
+        .where("LOWER(images.label) IN (?)", words)
+        .left_joins(:docs)
+        .group("images.id")
+        .having("COUNT(docs.id) > 0")
+        .order(Arel.sql("COUNT(docs.id) DESC, images.id ASC"))
+        .each_with_object({}) { |image, map| map[normalize(image.label)] ||= image }
+    end
+
+    # The lookup key for a label: normalized the way `resolve` normalizes, then
+    # downcased, since matching is case-insensitive.
+    def normalize(label)
+      Boards::InterestWords.normalize_word(label).to_s.downcase
+    end
+
     # Re-points every blank (art-less) tile on `board` to the curated art-bearing
     # image for the same label, leaving tiles that already have art untouched.
     # This is the same blank->art upgrade `SeededSetCloner#copy_tiles!` does for

--- a/app/services/images/label_search.rb
+++ b/app/services/images/label_search.rb
@@ -23,21 +23,37 @@ module Images
     COMMERCIAL_SAFE_OVERFETCH_MULTIPLIER = 4
     COMMERCIAL_SAFE_FETCH_CEILING = 200
 
-    attr_reader :match, :limit, :commercial_safe, :include_share_alike
+    attr_reader :match, :limit, :commercial_safe, :include_share_alike, :resolve
 
-    def initialize(match: "exact", limit: DEFAULT_LIMIT, commercial_safe: false, include_share_alike: false)
+    def initialize(match: "exact", limit: DEFAULT_LIMIT, commercial_safe: false, include_share_alike: false, resolve: false)
       @match = match.to_s == "prefix" ? "prefix" : "exact"
       @limit = clamp(limit)
       @commercial_safe = commercial_safe
       @include_share_alike = include_share_alike
+      @resolve = resolve
     end
 
     def call(label)
       label = label.to_s.strip
       return [] if label.blank?
 
-      matched, kind = fetch(label)
-      matched.filter_map { |image| serialize(image, kind) }.first(limit)
+      results = []
+      seen = Set.new
+
+      # Tiers are lazy: a tier is only queried when the one above it failed to
+      # fill `limit`, so an exact hit costs one lookup, not four.
+      tiers(label).each do |candidates, kind|
+        candidates.call.each do |image|
+          next unless seen.add?(image.id)
+
+          row = serialize(image, kind)
+          results << row if row
+          break if results.size >= limit
+        end
+        break if results.size >= limit
+      end
+
+      results
     end
 
     private
@@ -46,17 +62,64 @@ module Images
       Image.default_public.searchable.with_artifacts
     end
 
-    # Exact first, prefix as a fallback — labels are stored inconsistently
-    # enough that exact-only would produce spurious empty results.
-    def fetch(label)
-      if match == "prefix"
-        [base_scope.search_by_label(label).limit(fetch_limit), "prefix"]
-      else
-        exact = base_scope.search_by_exact_label(label).limit(fetch_limit).to_a
-        return [exact, "exact"] if exact.any?
+    # Ranked tiers, best first. Everything below the first tier existed before;
+    # the two additions are the `resolve` tier and the literal-equality tier.
+    #
+    # `search_by_exact_label` is NOT an equality match — it is a pg_search
+    # tsearch scope with `prefix: false`, so it matches the *word* "want"
+    # anywhere in a label ("i want pasta", "want slide") and orders by ts_rank
+    # with no tiebreak. The genuinely exact row could therefore be outranked by
+    # phrase matches and truncated away at `limit`, which is how a pre-flight
+    # check reported core vocabulary as having no art while `bulk` was happily
+    # attaching an exact-label image for the same word (#575). The literal tier
+    # runs first and orders exactly the way Boards::ImageResolver does, so the
+    # two endpoints agree on which Image wins a label.
+    def tiers(label)
+      list = []
+      list << [-> { resolved_candidates(label) }, "resolve"] if resolve
+      list << [-> { literal_matches(label) }, "exact"]
+      list << [-> { base_scope.search_by_exact_label(label).limit(fetch_limit) }, "exact"] if match != "prefix"
+      list << [-> { base_scope.search_by_label(label).limit(fetch_limit) }, "prefix"]
+      list
+    end
 
-        [base_scope.search_by_label(label).limit(fetch_limit), "prefix"]
-      end
+    # Exactly what `POST /api/internal/boards/:id/board_images/bulk` would
+    # attach for this label. The resolver reads a DIFFERENT slice of the library
+    # than search does — `owner.images` (the default admin's, private ones
+    # included) before the public scope — so a label can resolve to an image
+    # ordinary search can never return. This tier is the caller's only way to
+    # see that ahead of the write.
+    #
+    # Returns nothing when no art exists for the label: the resolver would then
+    # attach a blank image and queue AI generation, and search must not
+    # pre-create that Image as a side effect of a read.
+    def resolved_candidates(label)
+      owner = User.find_by(id: User::DEFAULT_ADMIN_ID)
+      return [] if owner.nil?
+
+      Array(Boards::ImageResolver.best_arted_for(label, owner))
+    end
+
+    # Literal, case-insensitive label equality, ordered the way
+    # Boards::ImageResolver orders: most artwork first, lowest id to break ties.
+    #
+    # Two queries on purpose. `with_artifacts` is an `includes`, and mixing it
+    # with the `left_joins(:docs) + GROUP BY` needed for the doc-count ordering
+    # makes Rails eager_load into the grouped query. Rank ids first, then load
+    # the page with its preloads intact.
+    def literal_matches(label)
+      ids = Image.default_public.searchable
+                 .where("LOWER(images.label) = LOWER(?)", label)
+                 .left_joins(:docs)
+                 .group("images.id")
+                 .having("COUNT(docs.id) > 0")
+                 .order(Arel.sql("COUNT(docs.id) DESC, images.id ASC"))
+                 .limit(fetch_limit)
+                 .pluck(:id)
+      return [] if ids.empty?
+
+      by_id = Image.where(id: ids).with_artifacts.index_by(&:id)
+      ids.filter_map { |id| by_id[id] }
     end
 
     # Behaviour is unchanged when commercial_safe filtering is off.
@@ -71,7 +134,11 @@ module Images
       return nil unless doc&.image&.attached?
 
       license = Images::CommercialLicense.for(doc, include_share_alike: include_share_alike)
-      return nil if commercial_safe && !license.commercial_safe?
+      # A resolve row is never filtered out: the point of the tier is "here is
+      # what bulk will attach", and hiding an unsafe pick behind the
+      # commercial_safe filter reports "no art" for a label that will in fact
+      # get art. The flags below let the caller judge it.
+      return nil if commercial_safe && kind != "resolve" && !license.commercial_safe?
 
       blob = doc.image.blob
 
@@ -100,6 +167,10 @@ module Images
       }
     end
 
+    def library_doc(image)
+      self.class.library_doc(image)
+    end
+
     # image.display_doc(nil) is NOT safe here: for an admin-owned image it
     # resolves to `docs.last` with no filter on doc.user_id at all. Non-admin
     # users can attach their own Docs to shared public admin-owned Images
@@ -119,7 +190,10 @@ module Images
     # `docs` carries no default ordering scope, so `max_by(&:id)` is
     # equivalent to the previous `.order(:id).last` ("most recent" wins).
     # Do not "optimize" this back into a `.where`.
-    def library_doc(image)
+    #
+    # Exposed as a class method as well so the internal images#show endpoint
+    # reports licensing for the same Doc a search result would describe.
+    def self.library_doc(image)
       image.docs.select { |doc| [nil, User::DEFAULT_ADMIN_ID].include?(doc.user_id) }.max_by(&:id)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,9 +446,10 @@ Rails.application.routes.draw do
         member do
           get :export, action: :export_pdf, defaults: { format: :pdf }
         end
-        resources :board_images, only: [:create] do
+        resources :board_images, only: [:create, :update, :destroy] do
           collection do
             post :bulk
+            patch :bulk_update
           end
         end
       end

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -401,4 +401,279 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(GenerateImagesJob).to have_received(:perform_async).with([image.id], board.id)
     end
   end
+
+  # #574: bulk intermittently 500'd AFTER the cells had been written, so the
+  # obvious client behaviour — retry on 5xx — silently duplicated every tile.
+  describe "retry safety" do
+    def bulk_post(cells, extra = {})
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: cells }.merge(extra).to_json,
+           headers: auth_headers
+    end
+
+    let!(:img_a) { create(:image, label: "retry-a", user_id: admin_user.id) }
+    let!(:img_b) { create(:image, label: "retry-b", user_id: admin_user.id) }
+
+    it "replays the original cells instead of duplicating them when the key repeats" do
+      cells = [{ image_id: img_a.id, position: 0 }, { image_id: img_b.id, position: 1 }]
+
+      bulk_post(cells, idempotency_key: "build-42")
+      expect(response).to have_http_status(:created)
+      first_ids = JSON.parse(response.body).map { |c| c["id"] }
+
+      expect { bulk_post(cells, idempotency_key: "build-42") }
+        .not_to change { board.reload.board_images.count }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Idempotent-Replay"]).to eq("true")
+      expect(JSON.parse(response.body).map { |c| c["id"] }).to eq(first_ids)
+    end
+
+    it "still creates cells for a different key on the same board" do
+      bulk_post([{ image_id: img_a.id }], idempotency_key: "build-1")
+
+      expect { bulk_post([{ image_id: img_b.id }], idempotency_key: "build-2") }
+        .to change { board.reload.board_images.count }.by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it "duplicates as before when no key is supplied (behaviour is opt-in)" do
+      bulk_post([{ image_id: img_a.id }])
+
+      expect { bulk_post([{ image_id: img_a.id }]) }
+        .to change { board.reload.board_images.count }.by(1)
+    end
+
+    it "does not remember a key for a request that rolled back" do
+      bulk_post([{ image_id: img_a.id }, { position: 1 }], idempotency_key: "rolled-back")
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(board.reload.settings.dig("internal_bulk_keys", "rolled-back")).to be_nil
+
+      expect { bulk_post([{ image_id: img_a.id }], idempotency_key: "rolled-back") }
+        .to change { board.reload.board_images.count }.by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "replaces existing tiles when replace is true" do
+      bulk_post([{ image_id: img_a.id }, { image_id: img_b.id }])
+      expect(board.reload.board_images.count).to eq(2)
+
+      bulk_post([{ image_id: img_a.id }], replace: true)
+
+      expect(response).to have_http_status(:created)
+      expect(board.reload.board_images.count).to eq(1)
+      expect(board.board_images.first.image_id).to eq(img_a.id)
+      # The board-level layout no longer references the replaced tiles.
+      expect(board.reload.layout.values.flat_map(&:keys).uniq).to eq([board.board_images.first.id.to_s])
+    end
+
+    it "keeps other settings keys intact when remembering a key" do
+      board.update!(settings: { "video_seeder" => true })
+
+      bulk_post([{ image_id: img_a.id }], idempotency_key: "keep-settings")
+
+      expect(board.reload.settings["video_seeder"]).to eq(true)
+      expect(board.settings["internal_bulk_keys"]).to have_key("keep-settings")
+    end
+  end
+
+  # #574, the other half: `api_view` costs several queries PER TILE, all run
+  # after the transaction commits.
+  describe "bulk response payload" do
+    def bulk_post(cells, extra = {})
+      post "/api/internal/boards/#{board.id}/board_images/bulk",
+           params: { cells: cells }.merge(extra).to_json,
+           headers: auth_headers
+    end
+
+    it "returns a compact cell payload by default" do
+      image = create(:image, label: "compact", user_id: admin_user.id)
+
+      bulk_post([{ image_id: image.id, bg_color: "yellow" }])
+
+      cell = JSON.parse(response.body).first
+      expect(cell).to include("id", "board_id", "image_id", "label", "display_label",
+                              "position", "layout", "bg_color", "src", "dynamic", "data")
+      expect(cell).not_to have_key("docs")
+      expect(cell).not_to have_key("audio_files")
+      expect(cell).not_to have_key("voice_list")
+      expect(cell["bg_color"]).to eq("#FFEA75")
+    end
+
+    it "returns the full api_view when view=full is requested" do
+      image = create(:image, label: "full-view", user_id: admin_user.id)
+
+      bulk_post([{ image_id: image.id }], view: "full")
+
+      cell = JSON.parse(response.body).first
+      expect(cell).to include("docs", "audio_files", "voice_list", "board_name")
+    end
+
+    it "issues fewer queries than the full api_view for the same cells" do
+      images = 6.times.map { |i| create(:image, label: "flat-#{i}", user_id: admin_user.id) }
+
+      count_queries = lambda do |cells, extra|
+        queries = 0
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          next if payload[:sql].to_s.match?(/\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i)
+
+          queries += 1
+        end
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          post "/api/internal/boards/#{board.id}/board_images/bulk",
+               params: { cells: cells }.merge(extra).to_json, headers: auth_headers
+        end
+        queries
+      end
+
+      lean = count_queries.call(images.first(3).map { |i| { image_id: i.id } }, {})
+      full = count_queries.call(images.last(3).map { |i| { image_id: i.id } }, { view: "full" })
+
+      # The per-tile docs / audio / voice-list lookups in api_view are what a
+      # 48-cell request was paying for AFTER the transaction committed.
+      expect(lean).to be < full
+    end
+  end
+
+  # #584: the internal API could create a tile but never correct one.
+  describe "PATCH /api/internal/boards/:board_id/board_images/:id" do
+    let!(:original) { with_art(create(:image, label: "more-unsafe", user_id: admin_user.id)) }
+    let!(:replacement) { with_art(create(:image, label: "more", user_id: admin_user.id)) }
+    let!(:cell) { board.add_image(original.id) }
+
+    it "returns 401 without a valid bearer token" do
+      patch "/api/internal/boards/#{board.id}/board_images/#{cell.id}", params: { bg_color: "red" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "swaps the image while preserving the BoardImage id and layout" do
+      layout_before = cell.reload.layout
+      board_layout_before = board.reload.layout
+
+      patch "/api/internal/boards/#{board.id}/board_images/#{cell.id}",
+            params: { image_id: replacement.id }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["id"]).to eq(cell.id)
+      expect(cell.reload.image_id).to eq(replacement.id)
+      expect(cell.layout).to eq(layout_before)
+      expect(board.reload.layout).to eq(board_layout_before)
+    end
+
+    it "updates style attributes the same way bulk does at create time" do
+      patch "/api/internal/boards/#{board.id}/board_images/#{cell.id}",
+            params: { bg_color: "yellow", display_label: "MORE", hidden: true, hide_label: true }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      cell.reload
+      expect(cell.bg_color).to eq("#FFEA75")
+      expect(cell.display_label).to eq("MORE")
+      expect(cell.hidden).to eq(true)
+      expect(cell.data).to include("hide_label" => true)
+    end
+
+    it "does not rename the tile when only the image is swapped" do
+      cell.update!(display_label: "more")
+
+      patch "/api/internal/boards/#{board.id}/board_images/#{cell.id}",
+            params: { image_id: replacement.id }.to_json,
+            headers: auth_headers
+
+      expect(cell.reload.display_label).to eq("more")
+    end
+
+    it "404s for a board_image belonging to another board, without writing" do
+      other_board = create(:board, user: admin_user)
+      other_cell = other_board.add_image(original.id)
+
+      patch "/api/internal/boards/#{board.id}/board_images/#{other_cell.id}",
+            params: { image_id: replacement.id }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(other_cell.reload.image_id).to eq(original.id)
+    end
+
+    it "422s for an image_id that does not exist" do
+      patch "/api/internal/boards/#{board.id}/board_images/#{cell.id}",
+            params: { image_id: 0 }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(cell.reload.image_id).to eq(original.id)
+    end
+  end
+
+  describe "PATCH /api/internal/boards/:board_id/board_images/bulk_update" do
+    let!(:image) { create(:image, label: "bulk-edit", user_id: admin_user.id) }
+    let!(:cell_a) { board.add_image(image.id) }
+    let!(:cell_b) { board.add_image(image.id) }
+
+    it "updates several cells atomically" do
+      patch "/api/internal/boards/#{board.id}/board_images/bulk_update",
+            params: { cells: [{ id: cell_a.id, bg_color: "yellow" }, { id: cell_b.id, voice: "alloy" }] }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(cell_a.reload.bg_color).to eq("#FFEA75")
+      expect(cell_b.reload.voice).to be_present
+    end
+
+    it "rolls back every cell when one is not on this board" do
+      other_board = create(:board, user: admin_user)
+      foreign = other_board.add_image(image.id)
+
+      patch "/api/internal/boards/#{board.id}/board_images/bulk_update",
+            params: { cells: [{ id: cell_a.id, bg_color: "yellow" }, { id: foreign.id, bg_color: "red" }] }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["errors"].first["index"]).to eq(1)
+      expect(cell_a.reload.bg_color).not_to eq("#FFEA75")
+    end
+
+    it "422s when cells is empty" do
+      patch "/api/internal/boards/#{board.id}/board_images/bulk_update",
+            params: { cells: [] }.to_json,
+            headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "DELETE /api/internal/boards/:board_id/board_images/:id" do
+    let!(:image) { create(:image, label: "deletable", user_id: admin_user.id) }
+    let!(:cell_a) { board.add_image(image.id) }
+    let!(:cell_b) { board.add_image(image.id) }
+
+    it "removes the cell and drops it from the board's layout" do
+      expect {
+        delete "/api/internal/boards/#{board.id}/board_images/#{cell_a.id}", headers: auth_headers
+      }.to change { board.reload.board_images.count }.by(-1)
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("deleted" => true, "id" => cell_a.id)
+      expect(board.reload.layout.values.flat_map(&:keys)).not_to include(cell_a.id.to_s)
+      expect(BoardImage.find_by(id: cell_a.id)).to be_nil
+    end
+
+    it "keeps the surviving cells" do
+      delete "/api/internal/boards/#{board.id}/board_images/#{cell_a.id}", headers: auth_headers
+
+      expect(board.reload.board_images.pluck(:id)).to eq([cell_b.id])
+    end
+
+    it "404s for a board_image belonging to another board" do
+      other_board = create(:board, user: admin_user)
+      foreign = other_board.add_image(image.id)
+
+      delete "/api/internal/boards/#{board.id}/board_images/#{foreign.id}", headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(BoardImage.find_by(id: foreign.id)).to be_present
+    end
+  end
 end

--- a/spec/requests/api/internal/images_search_spec.rb
+++ b/spec/requests/api/internal/images_search_spec.rb
@@ -129,4 +129,58 @@ RSpec.describe "API::Internal::Images search", type: :request do
       expect(body["results"]["widget"].size).to eq(25)
     end
   end
+
+  # #575: search and board_images/bulk disagreed about which Image a label
+  # resolves to, so a pre-flight art check reported core vocabulary as missing
+  # while bulk was attaching exact-label art for the same word.
+  describe "agreement with board_images/bulk" do
+    it "ranks the exact-label image first instead of phrase matches" do
+      ["i want to buy this", "want slide", "i want pasta", "dont want"].each do |phrase|
+        image_with_doc(label: phrase)
+      end
+      exact = image_with_doc(label: "want")
+
+      get "/api/internal/images/search", params: { q: "want", limit: 5 }, headers: auth_headers
+
+      expect(body["results"].first["id"]).to eq(exact.id)
+      expect(body["results"].first["label"]).to eq("want")
+    end
+
+    it "reports the exact-label image in a bulk search too" do
+      image_with_doc(label: "where are the lions?")
+      exact = image_with_doc(label: "where")
+
+      post "/api/internal/images/search",
+           params: { labels: ["where"], limit_per_label: 1 }.to_json, headers: json_headers
+
+      expect(body["results"]["where"].map { |r| r["id"] }).to eq([exact.id])
+    end
+
+    it "surfaces what bulk would attach when resolve=true" do
+      # Private admin-owned art: outside search's scope, inside the resolver's.
+      hidden = Image.create!(label: "resolve-only", user_id: admin.id, is_private: true)
+      doc = hidden.docs.create!(user_id: admin.id, source_type: "OpenAI", raw: "resolve-only")
+      doc.image.attach(io: StringIO.new(file_fixture("sample.png").read),
+                       filename: "r.png", content_type: "image/png")
+
+      get "/api/internal/images/search", params: { q: "resolve-only" }, headers: auth_headers
+      expect(body["results"]).to eq([])
+
+      get "/api/internal/images/search",
+          params: { q: "resolve-only", resolve: "true" }, headers: auth_headers
+
+      expect(body["results"].first["id"]).to eq(hidden.id)
+      expect(body["results"].first["match"]).to eq("resolve")
+    end
+
+    it "supports resolve in the bulk search" do
+      exact = image_with_doc(label: "up")
+
+      post "/api/internal/images/search",
+           params: { labels: ["up"], resolve: true, limit_per_label: 1 }.to_json, headers: json_headers
+
+      expect(body["results"]["up"].first["id"]).to eq(exact.id)
+      expect(body["results"]["up"].first["match"]).to eq("resolve")
+    end
+  end
 end

--- a/spec/requests/api/internal/images_spec.rb
+++ b/spec/requests/api/internal/images_spec.rb
@@ -64,5 +64,60 @@ RSpec.describe "API::Internal::Images", type: :request do
       expect(body["label"]).to eq("carrot")
       expect(body).to have_key("status")
     end
+
+    # #575, point 2: the payload carried no licensing at all, so art attached
+    # by `bulk` read as "not commercial safe, no license record" whether or not
+    # that was true — and these boards feed the printables pipeline.
+    describe "licensing" do
+      def image_with_doc(label:, source_type: "OpenAI", license: nil, user: admin_user)
+        img = Image.create!(label: label, user_id: user.id)
+        doc = img.docs.create!(user_id: user.id, source_type: source_type, license: license, raw: label)
+        doc.image.attach(io: StringIO.new(file_fixture("sample.png").read),
+                         filename: "#{label}.png", content_type: "image/png")
+        img
+      end
+
+      it "reports a commercial-safe image as safe, with its source and original URL" do
+        safe = image_with_doc(label: "safe-carrot", source_type: "OpenAI")
+
+        get "/api/internal/images/#{safe.id}", headers: auth_headers
+
+        body = JSON.parse(response.body)
+        expect(body["has_art"]).to be true
+        expect(body["commercial_safe"]).to be true
+        expect(body["source_type"]).to eq("OpenAI")
+        expect(body["original_url"]).to be_present
+      end
+
+      it "reports an ARASAAC-style image as unsafe and attribution-required" do
+        unsafe = image_with_doc(label: "arasaac-carrot", source_type: "ObfImport",
+                                license: { "type" => "CC BY-NC-SA", "author_name" => "Sergio Palao" })
+
+        get "/api/internal/images/#{unsafe.id}", headers: auth_headers
+
+        body = JSON.parse(response.body)
+        expect(body["commercial_safe"]).to be false
+        expect(body["attribution_required"]).to be true
+        expect(body["share_alike"]).to be true
+        expect(body["license"]["author_name"]).to eq("Sergio Palao")
+      end
+
+      it "distinguishes no artwork from unusable artwork" do
+        get "/api/internal/images/#{image.id}", headers: auth_headers
+
+        body = JSON.parse(response.body)
+        expect(body["has_art"]).to be false
+        expect(body["license"]).to be_nil
+        expect(body["commercial_safe"]).to be false
+      end
+
+      it "admits share-alike with include_share_alike" do
+        sa = image_with_doc(label: "sa-carrot", source_type: "ObfImport", license: { "type" => "CC BY-SA" })
+
+        get "/api/internal/images/#{sa.id}", params: { include_share_alike: "true" }, headers: auth_headers
+
+        expect(JSON.parse(response.body)["commercial_safe"]).to be true
+      end
+    end
   end
 end

--- a/spec/services/boards/image_resolver_spec.rb
+++ b/spec/services/boards/image_resolver_spec.rb
@@ -9,6 +9,84 @@ RSpec.describe Boards::ImageResolver do
     image
   end
 
+  # #574: resolving a label at a time cost 2-3 queries per tile, which is most
+  # of what pushed a 48-cell bulk request toward the timeout that made the
+  # endpoint 500 after committing.
+  describe ".resolve_all" do
+    it "picks the same image per label as .resolve does" do
+      create(:image, label: "animals", user_id: admin.id)
+      animals = with_art(create(:image, label: "animals", user_id: admin.id))
+      few = with_art(create(:image, label: "ball", user_id: admin.id), count: 1)
+      many = with_art(create(:image, label: "ball", user_id: admin.id), count: 3)
+      owner_art = with_art(create(:image, label: "dog", user_id: owner.id))
+
+      resolved = described_class.resolve_all(["Animals", "ball", "dog"], owner: owner)
+
+      expect(resolved["animals"]).to eq(animals)
+      expect(resolved["ball"]).to eq(many)
+      expect(resolved["ball"]).not_to eq(few)
+      expect(resolved["dog"]).to eq(owner_art)
+      %w[Animals ball dog].each do |label|
+        expect(resolved[described_class.normalize(label)]).to eq(described_class.resolve(label, owner: owner))
+      end
+    end
+
+    it "keys on the normalized label so any casing looks the same up" do
+      arted = with_art(create(:image, label: "stop", user_id: admin.id))
+
+      resolved = described_class.resolve_all(["Stop", "STOP", "stop"], owner: owner)
+
+      expect(resolved.keys).to eq(["stop"])
+      expect(resolved["stop"]).to eq(arted)
+    end
+
+    it "falls back to an existing blank image, and creates one only when nothing matches" do
+      blank = create(:image, label: "zzz_niche", user_id: admin.id)
+
+      resolved = nil
+      expect {
+        resolved = described_class.resolve_all(["zzz_niche", "brand_new_batch_word"], owner: owner)
+      }.to change(Image, :count).by(1)
+
+      expect(resolved["zzz_niche"]).to eq(blank)
+      expect(resolved["brand_new_batch_word"].label).to eq("brand_new_batch_word")
+    end
+
+    it "keeps the authored casing on an image it has to create" do
+      resolved = described_class.resolve_all(["BrandNewCased"], owner: owner)
+
+      expect(resolved["brandnewcased"].label).to eq("BrandNewCased")
+    end
+
+    it "does not scale its query count with the number of labels" do
+      def query_count_for(n, owner, admin)
+        labels = n.times.map { |i| "batchword#{n}x#{i}" }
+        labels.each { |label| create(:doc, documentable: create(:image, label: label, user_id: admin.id), user: admin) }
+
+        queries = 0
+        callback = lambda do |_name, _start, _finish, _id, payload|
+          next if payload[:sql].to_s.match?(/\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i)
+
+          queries += 1
+        end
+
+        ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+          expect(described_class.resolve_all(labels, owner: owner).size).to eq(n)
+        end
+        queries
+      end
+
+      # Flat: the art lookup is two queries (owner scope, then public scope)
+      # however many labels are asked for — not 2-3 per label as `resolve` is.
+      expect(query_count_for(12, owner, admin)).to eq(query_count_for(3, owner, admin))
+    end
+
+    it "returns an empty hash for no labels" do
+      expect(described_class.resolve_all([], owner: owner)).to eq({})
+      expect(described_class.resolve_all([" ", nil], owner: owner)).to eq({})
+    end
+  end
+
   describe ".resolve" do
     it "prefers a public/admin image that has art over a blank same-label image" do
       blank = create(:image, label: "animals", user_id: admin.id)         # lower id, no art

--- a/spec/services/images/label_search_spec.rb
+++ b/spec/services/images/label_search_spec.rb
@@ -99,6 +99,120 @@ RSpec.describe Images::LabelSearch do
     end
   end
 
+  # #575: `search_by_exact_label` is a pg_search tsearch scope, not an equality
+  # match — it matches the word "want" anywhere in a label and orders by
+  # ts_rank. Exact-label images were being outranked by phrase matches and cut
+  # off at `limit`, so a pre-flight check reported core vocabulary as having no
+  # art while `bulk` was attaching an exact-label image for the same word.
+  describe "exact label ranking" do
+    it "ranks the literal label above phrase matches containing the word" do
+      %w[i\ want\ pasta want\ slide dont\ want i\ want\ to\ buy\ this].each do |phrase|
+        image_with_doc(label: phrase)
+      end
+      exact = image_with_doc(label: "want")
+
+      results = described_class.new(limit: 5).call("want")
+
+      expect(results.first[:id]).to eq(exact.id)
+      expect(results.first[:label]).to eq("want")
+      expect(results.first[:match]).to eq("exact")
+    end
+
+    it "returns the literal label even when the limit is smaller than the phrase-match count" do
+      3.times { |i| image_with_doc(label: "where are the lions #{i}") }
+      exact = image_with_doc(label: "where")
+
+      results = described_class.new(limit: 1).call("where")
+
+      expect(results.map { |r| r[:id] }).to eq([exact.id])
+    end
+
+    it "orders several exact-label images by artwork count, matching Boards::ImageResolver" do
+      few = image_with_doc(label: "up")
+      many = image_with_doc(label: "up")
+      2.times do
+        doc = many.docs.create!(user_id: admin.id, source_type: "OpenAI", raw: "up")
+        doc.image.attach(io: StringIO.new(file_fixture("sample.png").read),
+                         filename: "up.png", content_type: "image/png")
+      end
+
+      results = described_class.new.call("up")
+
+      expect(results.map { |r| r[:id] }.first(2)).to eq([many.id, few.id])
+      expect(Boards::ImageResolver.best_arted_for("up", admin).id).to eq(results.first[:id])
+    end
+
+    it "hoists the literal label above prefix matches in prefix mode too" do
+      image_with_doc(label: "apple sauce")
+      exact = image_with_doc(label: "apple")
+
+      results = described_class.new(match: "prefix", limit: 5).call("apple")
+
+      expect(results.first[:id]).to eq(exact.id)
+    end
+
+    it "does not match a different label case-sensitively" do
+      exact = image_with_doc(label: "Stop")
+      expect(described_class.new.call("stop").first[:id]).to eq(exact.id)
+    end
+  end
+
+  describe "resolve mode" do
+    it "surfaces the image bulk would attach even when search's scope excludes it" do
+      # An admin-owned PRIVATE image is outside Image.default_public (so search
+      # can never return it) but inside Boards::ImageResolver's first branch
+      # (owner.images), so `bulk` attaches it. That divergence is #575.
+      hidden = image_with_doc(label: "want-private", private_flag: true)
+
+      expect(described_class.new.call("want-private")).to eq([])
+
+      results = described_class.new(resolve: true).call("want-private")
+      expect(results.first[:id]).to eq(hidden.id)
+      expect(results.first[:match]).to eq("resolve")
+    end
+
+    it "agrees with Boards::ImageResolver on which image wins a label" do
+      image_with_doc(label: "go")
+      winner = image_with_doc(label: "go")
+      doc = winner.docs.create!(user_id: admin.id, source_type: "OpenAI", raw: "go")
+      doc.image.attach(io: StringIO.new(file_fixture("sample.png").read),
+                       filename: "go.png", content_type: "image/png")
+
+      results = described_class.new(resolve: true).call("go")
+
+      expect(results.first[:match]).to eq("resolve")
+      expect(results.first[:id]).to eq(Boards::ImageResolver.best_arted_for("go", admin).id)
+    end
+
+    it "returns no resolve row when no art exists, and creates nothing" do
+      Image.create!(label: "artless", user_id: admin.id)
+
+      expect {
+        expect(described_class.new(resolve: true).call("artless")).to eq([])
+      }.not_to change(Image, :count)
+    end
+
+    it "reports the resolved image even when it fails the commercial_safe filter" do
+      # Hiding it would report "no art" for a label that will in fact get art.
+      image_with_doc(label: "nc-resolve", source_type: "ObfImport",
+                     license: { "type" => "CC BY-NC" })
+
+      results = described_class.new(resolve: true, commercial_safe: true).call("nc-resolve")
+
+      expect(results.size).to eq(1)
+      expect(results.first[:match]).to eq("resolve")
+      expect(results.first[:commercial_safe]).to be false
+    end
+
+    it "does not duplicate the resolved image in the exact tier" do
+      image_with_doc(label: "dedupe")
+
+      results = described_class.new(resolve: true).call("dedupe")
+
+      expect(results.size).to eq(1)
+    end
+  end
+
   describe "limit" do
     it "clamps the limit to MAX_LIMIT" do
       expect(described_class.new(limit: 9_999).limit).to eq(described_class::MAX_LIMIT)


### PR DESCRIPTION
Fixes three related defects on the internal API surface the printables board-build pipeline drives. Closes #575, #574, #584.

## #575 — search omitted art that `bulk` attaches

Two independent causes, both real:

1. **`search_by_exact_label` is not an equality match.** It is a pg_search `tsearch` scope (`prefix: false`), so it matches the *word* `want` anywhere in a label (`i want pasta`, `want slide`) and orders by `ts_rank` with no tiebreak — the genuinely exact row was outranked and truncated at `limit`. This alone reproduces every row in the issue's table.
2. **Scope divergence.** Search reads `Image.default_public`; `Boards::ImageResolver` reads `owner.images` (the default admin's, private ones included) *first*. A label can resolve to an image search can never return.

Fixes:

- `Images::LabelSearch` now ranks in lazy tiers, literal `LOWER(label) = LOWER(?)` first, ordered `COUNT(docs) DESC, id ASC` — the same ordering the resolver uses. The pg_search word/prefix tiers follow, deduped by id.
- `resolve=true` on both search endpoints prepends exactly what `bulk` would attach (`match: "resolve"`). Never dropped by `commercial_safe=true` — hiding it would report "no art" for a label that will get art; the flags carry the verdict. No resolve row means no art exists (search never creates an Image).
- `GET /api/internal/images/:id` serializes `has_art`, `source_type`, `original_url`, `license`, `commercial_safe`, `attribution_required`, `share_alike`.

## #574 — 500 after the write committed, retries duplicated tiles

The bigger suspect was *after* the transaction: `created.map { |bi| bi.api_view(current_user) }`. `api_view` does per-tile `image.docs.for_user(...)`, ActiveStorage audio, `voice_list`, `board.name` — hundreds of post-commit queries for 48 cells, which is exactly the "write landed, response 500'd" signature.

- Label resolution batched via `Boards::ImageResolver.resolve_all` — two queries per request instead of 2-3 per tile.
- Multi-cell endpoints return a **compact payload**; `view=full` opts back into `api_view`. (Response-shape change, escape hatch provided — the single-cell `create`/`update` still return `api_view`.)
- **`idempotency_key`** (opt-in): key → created ids recorded on `board.settings` *inside* the transaction, so a rolled-back write leaves no key. A repeat returns `200` + `Idempotent-Replay: true` and creates nothing.
- **`replace: true`**: clears the board in the same transaction so a blind retry converges.

Default behaviour is unchanged (append, duplicates allowed), so existing multi-batch callers keep working.

**Not in scope:** the nginx/Hatchbox `proxy_read_timeout` stopgap — deployment config, per repo conventions. Worth raising it for this route independently if you want belt and braces.

## #584 — no way to correct a tile

- `PATCH .../board_images/:id` — reuses `apply_optional_attributes!`, adds `image_id` swap that re-points the **same** `BoardImage` so `layout` is untouched (delete-and-recreate would orphan the layout entry and reflow the grid). Tile text is left alone unless `display_label` is passed.
- `PATCH .../board_images/bulk_update` — atomic multi-cell edit.
- `DELETE .../board_images/:id` — repacks displaced tiles, then rewrites the board-level `layout` so it no longer names the removed id.
- Cells are scoped through `@board.board_images`, so a foreign cell id 404s rather than writing.

## Test plan

`bundle exec rspec spec/requests/api/internal spec/services/images spec/services/boards spec/sidekiq/build_board_set_job_grid_spec.rb spec/models/board_image_spec.rb` — **628 examples, 0 failures.**

New coverage: exact-label ranking (4 of the 5 new ranking examples fail without the fix — verified by stashing the change), resolve mode incl. the private-image divergence, `images/:id` licensing, batched resolution + its flat query count, idempotent replay / rollback-leaves-no-key / `replace`, compact vs `view=full` payload, PATCH image swap preserving id + layout, cross-board 404, `bulk_update` atomicity, DELETE layout resync.

Docs: `README.md` internal API section (endpoint table, bulk params, PATCH/DELETE, search `resolve`, `images/:id` shape), `.claude-notes/internal-api.md`, `CHANGELOG.md`.

## Follow-up (separate repo)

`marketing/skills/speakanyway-board-build/scripts/build_board.py` still blind-retries a 5xx. It should send an `idempotency_key` per batch and `GET` the board before retrying. Happy to do that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)