### PR TITLE
feat(boards): cascade publish/unpublish across a Board Builder set

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1014,3 +1014,6 @@ doesn't replace it; both can be set independently. Wiring:
   `image[part_of_speech]=phrase` and optional free-form `data[gestalt_source]` /
   `data[utterance_function]`, stored on `board_images.data`.
 
+- **Publishing:** a built set publishes and unpublishes as a unit, behind a 409
+  warn+confirm. See "Publish cascade (warn + confirm)" in
+  `.claude-notes/boards-and-teams.md`.

--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -642,6 +642,34 @@ delete in one step as before.
 - Frontend companion: handle the 409 with a confirm dialog and re-send with
   `confirm=true` (special copy for builder roots — it deletes the whole set).
 
+### Publish cascade (warn + confirm)
+
+A Board Builder set publishes and unpublishes as a **unit**. `Board#viewable_by?`
+gates each board on its own `published` flag, so publishing only the root leaves
+folder tiles 404ing for public visitors, and unpublishing only the root leaves
+every sub-page reachable by its own `/pb/<slug>`.
+
+`PUT /api/boards/:id` returns **409 `publish_cascade_confirmation_required`**
+when `published` would change on a builder root whose set members don't already
+match. The body carries `cascade: { action, board_group, affected: { count, names } }`.
+Re-send the identical payload with `confirm=true` to apply it; the root's save and
+`Boards::PublishCascade#apply!` run in one transaction.
+
+The guard runs **before any attribute is assigned**, so a declined cascade writes
+nothing — other fields in the same payload are neither applied nor lost.
+
+The cascade set is the root's builder `BoardGroup` membership — the same set
+`Boards::UsageCheck#builder_group` cascades on delete. Hand-linked folder-tile
+descendants (`board_images.predictive_board_id`) outside the builder set are
+deliberately **not** included: they aren't owned by the root.
+
+`published` is admin-only (`board_params` strips it for non-admins), so the
+cascade is unreachable for regular users.
+
+**Image-removal bypass:** The guard is skipped entirely when the request carries
+`image_ids_to_remove` — that branch returns early (line 453 in the controller)
+without any board attribute assignment or save, so there is nothing to confirm.
+
 ## Board Sets (BoardGroup) — user CRUD + limits
 
 Board Sets (`BoardGroup`, user-facing name "Board Sets") are user-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- Publishing a Board Builder board set now publishes every page in the set, so
+  public visitors no longer hit a dead end when tapping a folder button.
+  Unpublishing removes the whole set from public view. Both ask for confirmation
+  first.
+- Unpublishing a board works again — `published: false` was being silently
+  dropped by the update endpoint.
 - **Tile text casing is consistent across a board.** A tile inherited whatever
   casing its creation path happened to use — paths handing over a Title Cased
   word list produced `Higher`, paths falling through to the image's lowercase

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -448,7 +448,11 @@ class API::BoardsController < API::ApplicationController
       @board.tags = board_params["tags"] if board_params["tags"].present?
       @board.language = board_params["language"] if board_params["language"].present?
       @board.favorite = board_params["favorite"] if board_params["favorite"].present?
-      @board.published = board_params["published"] if board_params["published"].present?
+      # `.key?`, not `.present?` — `false.present?` is false, so a `.present?`
+      # guard silently drops `published: false` and makes unpublishing a no-op.
+      # Matches the `predefined` guard above: a missing key leaves the saved
+      # value untouched, an explicit false unpublishes.
+      @board.published = board_params["published"] if board_params.key?("published")
       if board_params["slug"].present? && board_params["slug"] != @board.slug
         new_slug = @board.generate_unique_slug(board_params["slug"])
         @board.slug = new_slug

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -422,9 +422,19 @@ class API::BoardsController < API::ApplicationController
     # cascade writes nothing at all — the client re-sends the identical payload
     # with confirm=true. `published` is stripped from board_params for
     # non-admins, so this is unreachable for them.
-    if board_params.key?("published")
+    #
+    # Skipped entirely when `image_ids_to_remove` is present: that branch
+    # returns early below without ever assigning or saving `published`, so
+    # there is nothing to confirm — and `board_params` (which calls
+    # `params.require(:board)`) must not be evaluated on a request that may
+    # carry no `board` key at all.
+    if params["image_ids_to_remove"].blank? && board_params.key?("published")
       target_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
-      if target_published != @board.published
+      # `.cast` maps nil/"" to nil, not false. `published` is a nullable
+      # column, so a malformed value must not be treated as "unpublish" —
+      # skip the cascade guard rather than let a nil target match (and
+      # NULL out) every non-NULL member.
+      if [true, false].include?(target_published) && target_published != @board.published
         cascade = Boards::PublishCascade.new(@board)
         if cascade.needed?(published: target_published) && params[:confirm].to_s != "true"
           render json: {
@@ -531,6 +541,16 @@ class API::BoardsController < API::ApplicationController
 
       # The root's save and the set cascade share one transaction: a failed
       # cascade must not leave the root published with its members behind.
+      #
+      # `raise ActiveRecord::Rollback unless saved` is not what protects that
+      # invariant — when `@board.save` returns false nothing was written, so
+      # there is nothing to roll back. The real protection is `apply!`
+      # raising and propagating out of this block, which aborts the
+      # transaction and leaves the root's save uncommitted too. Also note:
+      # under transactional fixtures this block has no savepoint of its own,
+      # so a spec asserting "a cascade failure rolls back the root" would
+      # pass vacuously here — such a spec needs `requires_new: true` to
+      # actually exercise a rollback.
       saved = false
       ActiveRecord::Base.transaction do
         saved = @board.save

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -416,6 +416,30 @@ class API::BoardsController < API::ApplicationController
       render json: { error: "Unauthorized" }, status: :unauthorized
       return
     end
+
+    # Warn+confirm before cascading publish across a Board Builder set, mirroring
+    # the delete flow. This runs BEFORE any attribute is assigned, so a declined
+    # cascade writes nothing at all — the client re-sends the identical payload
+    # with confirm=true. `published` is stripped from board_params for
+    # non-admins, so this is unreachable for them.
+    if board_params.key?("published")
+      target_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
+      if target_published != @board.published
+        cascade = Boards::PublishCascade.new(@board)
+        if cascade.needed?(published: target_published) && params[:confirm].to_s != "true"
+          render json: {
+                   error: "publish_cascade_confirmation_required",
+                   message: "\"#{@board.name}\" is the home of a board set — this change applies to every page in the set.",
+                   board: { id: @board.id, name: @board.name },
+                   cascade: cascade.summary(published: target_published),
+                 }, status: :conflict
+          return
+        end
+        @publish_cascade = cascade
+        @publish_cascade_target = target_published
+      end
+    end
+
     if params["image_ids_to_remove"].present?
       image_ids_to_remove = params["image_ids_to_remove"]
       image_ids_to_remove.each do |image_id|
@@ -505,8 +529,17 @@ class API::BoardsController < API::ApplicationController
         @board.margin_settings = margins
       end
 
+      # The root's save and the set cascade share one transaction: a failed
+      # cascade must not leave the root published with its members behind.
+      saved = false
+      ActiveRecord::Base.transaction do
+        saved = @board.save
+        raise ActiveRecord::Rollback unless saved
+        @publish_cascade&.apply!(published: @publish_cascade_target)
+      end
+
       respond_to do |format|
-        if @board.save
+        if saved
           if params[:layout].present?
             # only save if changes are present
             layout_param = params[:layout]

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -485,8 +485,13 @@ class API::BoardsController < API::ApplicationController
       # `.key?`, not `.present?` — `false.present?` is false, so a `.present?`
       # guard silently drops `published: false` and makes unpublishing a no-op.
       # Matches the `predefined` guard above: a missing key leaves the saved
-      # value untouched, an explicit false unpublishes.
-      @board.published = board_params["published"] if board_params.key?("published")
+      # value untouched, an explicit false unpublishes. Cast and require a
+      # real boolean so a malformed value (nil/"") can't NULL the column —
+      # mirrors the cascade guard's own `[true, false]` check on the members.
+      if board_params.key?("published")
+        incoming_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
+        @board.published = incoming_published unless incoming_published.nil?
+      end
       if board_params["slug"].present? && board_params["slug"] != @board.slug
         new_slug = @board.generate_unique_slug(board_params["slug"])
         @board.slug = new_slug

--- a/app/services/boards/publish_cascade.rb
+++ b/app/services/boards/publish_cascade.rb
@@ -1,0 +1,74 @@
+module Boards
+  # Publishing a Board Builder root without its set leaves a broken public
+  # page: Board#viewable_by? gates each board on its own `published` flag, so
+  # a visitor tapping a folder tile on a published root hits the sub-page's
+  # 404. Unpublishing only the root leaks the reverse — every sub-page stays
+  # reachable by its own /pb/<slug>.
+  #
+  # This cascades `published` across the boards owned by the root's builder
+  # BoardGroup — the SAME set Boards::UsageCheck#builder_group cascades on
+  # delete, so a built set publishes, unpublishes, and deletes as one unit.
+  # Deliberately NOT PredictiveLinkSet: hand-linked folder tiles outside the
+  # builder set are not owned by the root and are not ours to flip.
+  class PublishCascade
+    # Counts in the summary are exact; name lists are sampled so a large set
+    # can't blow up the 409 payload. Mirrors UsageCheck::NAME_SAMPLE_LIMIT.
+    NAME_SAMPLE_LIMIT = 10
+
+    def initialize(board)
+      @board = board
+    end
+
+    # Only boards that would actually change count, so re-saving an
+    # already-synced set never prompts the user.
+    def needed?(published:)
+      member_boards_to_change(published).exists?
+    end
+
+    def summary(published:)
+      group = builder_group
+      scope = member_boards_to_change(published)
+
+      {
+        action: published ? "publish" : "unpublish",
+        board_group: group ? { id: group.id, name: group.name } : nil,
+        affected: {
+          count: scope.count,
+          names: scope.limit(NAME_SAMPLE_LIMIT).pluck(:name),
+        },
+      }
+    end
+
+    # Flips the members only — the root is saved by the caller through the
+    # normal update path. update_all skips callbacks on purpose: a built set
+    # can be dozens of boards and only one boolean column changes. It also
+    # skips timestamps, so updated_at is set explicitly.
+    def apply!(published:)
+      ids = member_boards_to_change(published).pluck(:id)
+      return 0 if ids.empty?
+
+      Board.where(id: ids).update_all(published: published, updated_at: Time.current)
+      ids.size
+    end
+
+    # The builder BoardGroup owning this root's built tree, or nil when this
+    # board isn't a Board Builder root.
+    def builder_group
+      return @builder_group if defined?(@builder_group)
+      @builder_group = board.builder_board_group
+    end
+
+    private
+
+    attr_reader :board
+
+    # Member boards whose published flag differs from the target. Excludes the
+    # root itself — it's a member of its own group, but the caller saves it.
+    def member_boards_to_change(published)
+      group = builder_group
+      return Board.none unless group
+
+      group.boards.where.not(id: board.id).where.not(published: published)
+    end
+  end
+end

--- a/app/services/boards/publish_cascade.rb
+++ b/app/services/boards/publish_cascade.rb
@@ -68,7 +68,12 @@ module Boards
       group = builder_group
       return Board.none unless group
 
-      group.boards.where.not(id: board.id).where.not(published: published)
+      # `where.not(published: published)` is SQL `NOT (published = X)`, which
+      # evaluates to NULL (excluded) for a NULL row — a legacy member with
+      # published IS NULL would silently never be counted or flipped, leaving
+      # it out of sync after a confirmed cascade. IS DISTINCT FROM treats NULL
+      # as a real, comparable value so those members are included too.
+      group.boards.where.not(id: board.id).where("published IS DISTINCT FROM ?", published)
     end
   end
 end

--- a/app/services/boards/publish_cascade.rb
+++ b/app/services/boards/publish_cascade.rb
@@ -73,7 +73,7 @@ module Boards
       # published IS NULL would silently never be counted or flipped, leaving
       # it out of sync after a confirmed cascade. IS DISTINCT FROM treats NULL
       # as a real, comparable value so those members are included too.
-      group.boards.where.not(id: board.id).where("published IS DISTINCT FROM ?", published)
+      group.boards.distinct.where.not(id: board.id).where("published IS DISTINCT FROM ?", published)
     end
   end
 end

--- a/docs/superpowers/plans/2026-08-05-publish-cascade-builder-set.md
+++ b/docs/superpowers/plans/2026-08-05-publish-cascade-builder-set.md
@@ -1,0 +1,1351 @@
+# Publish Cascade for Board Builder Sets — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publishing or unpublishing a Board Builder root board cascades to every board in its builder set, behind a confirmation prompt, so a published set's folder tiles don't 404 for public visitors.
+
+**Architecture:** A new read-plus-apply service `Boards::PublishCascade` mirrors the existing `Boards::UsageCheck`. `Api::BoardsController#update` gains a guard that returns 409 `publish_cascade_confirmation_required` before writing anything, unless `confirm=true` — the exact warn-then-confirm protocol the board-delete flow already uses. The frontend catches that 409 in `updateBoard`, shows the existing `ConfirmAlert`, and resends with `confirm: true`.
+
+**Tech Stack:** Rails 8 + RSpec + FactoryBot (backend); React + Ionic + Vitest (frontend).
+
+## Global Constraints
+
+- **Brand name is `SpeakAnyWay`** — one word, S/A/W capitalized. Never "SAW" or "Speak Anyway".
+- **UI copy says "communicator"**, backend says `child_account`. Say *nonspeaking*, never *nonverbal*.
+- **HTTP error semantics:** 409 = conflict requiring confirmation. Never leak internals in API errors.
+- **Never commit to `main`.** All work happens on branch `feat/publish-cascade-builder-set` in the worktrees listed below.
+- **Backend worktree:** `/Users/brittanyjohns/Projects/speakanyway/itty_bitty_boards/.claude/worktrees/publish-cascade`
+- **Frontend worktree:** `/Users/brittanyjohns/Projects/speakanyway/itty-bitty-frontend/.claude/worktrees/publish-cascade`
+- **Do not install new gems or npm packages.**
+- Run backend tests with `bundle exec rspec <path>` from the backend worktree root.
+- Run frontend tests with `npx vitest run <path>` from the frontend worktree root.
+
+## File Structure
+
+**Backend** (`itty_bitty_boards`)
+
+| File | Responsibility |
+|---|---|
+| `app/services/boards/publish_cascade.rb` | **Create.** Decides whether a cascade is needed, summarizes what it will affect, applies it. |
+| `app/controllers/api/boards_controller.rb` | **Modify.** Fix the `published` assignment bug (line ~451); add the 409 guard and the confirmed cascade to `#update`. |
+| `spec/services/boards/publish_cascade_spec.rb` | **Create.** Unit spec for the service. |
+| `spec/requests/api/boards_publish_cascade_spec.rb` | **Create.** Request spec for the 409 → confirm → cascade flow. |
+| `.claude-notes/boards-and-teams.md` | **Modify.** Document the publish-cascade invariant. |
+| `.claude-notes/board-builder.md` | **Modify.** Pointer to the above. |
+| `CHANGELOG.md` | **Modify.** User-facing entry. |
+
+**Frontend** (`itty-bitty-frontend`)
+
+| File | Responsibility |
+|---|---|
+| `src/data/boards.ts` | **Modify.** Add `PublishCascadeError` + `PublishCascadeSummary`; make `updateBoard` detect the 409 and accept a `confirm` option. |
+| `src/components/utils/publishCascade.ts` | **Create.** Turns the 409 payload into dialog copy. |
+| `src/components/utils/publishCascade.test.ts` | **Create.** Unit test for the copy helper. |
+| `src/data/boards.publishCascade.test.ts` | **Create.** Unit test that `updateBoard` throws on the 409 and passes `confirm`. |
+| `src/components/boards/BoardForm.tsx` | **Modify.** Catch the error, open `ConfirmAlert`, resend with confirm. |
+| `CHANGELOG.md` | **Modify.** User-facing entry. |
+
+**Note on frontend test scope:** there is no component-test harness for `BoardForm` (it depends on Ionic + several contexts, and no existing `*.test.tsx` covers a form of this size). Frontend automated tests therefore cover the two pure units — the copy helper and the `updateBoard` 409 contract. Task 8 includes a manual verification script for the wiring itself.
+
+---
+
+## Task 1: Make `published: false` actually persist
+
+`Api::BoardsController#update` currently assigns with
+`@board.published = board_params["published"] if board_params["published"].present?`.
+In Ruby `false.present?` is `false`, so **unpublishing is silently dropped today** — the
+request 200s and the board stays published. The unpublish half of this feature cannot
+work until this is fixed. The `predefined` line directly above already uses the correct
+`.key?` guard; this makes `published` match it.
+
+**Files:**
+- Modify: `app/controllers/api/boards_controller.rb:451`
+- Test: `spec/requests/api/boards_publish_cascade_spec.rb` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PUT /api/boards/:id` with `board: { published: false }` now persists `false`. Tasks 2–3 depend on this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/requests/api/boards_publish_cascade_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+# Publish cascade: publishing or unpublishing a Board Builder root cascades to
+# every member board of its builder BoardGroup, behind a 409 warn+confirm.
+RSpec.describe "API::Boards publish cascade", type: :request do
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  def update_board(target, as:, params:)
+    put "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
+  end
+
+  describe "unpublishing a plain board" do
+    let(:board) { create(:board, user: admin, published: true) }
+
+    it "persists published=false" do
+      update_board(board, as: admin, params: { board: { published: false } })
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.published).to be false
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/requests/api/boards_publish_cascade_spec.rb -e "persists published=false"
+```
+
+Expected: FAIL — `expected false, got true`. The `.present?` guard dropped the assignment.
+
+- [ ] **Step 3: Fix the guard**
+
+In `app/controllers/api/boards_controller.rb`, replace this line:
+
+```ruby
+      @board.published = board_params["published"] if board_params["published"].present?
+```
+
+with:
+
+```ruby
+      # `.key?`, not `.present?` — `false.present?` is false, so a `.present?`
+      # guard silently drops `published: false` and makes unpublishing a no-op.
+      # Matches the `predefined` guard above: a missing key leaves the saved
+      # value untouched, an explicit false unpublishes.
+      @board.published = board_params["published"] if board_params.key?("published")
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/requests/api/boards_publish_cascade_spec.rb
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Check for regressions in the existing board specs**
+
+```bash
+bundle exec rspec spec/requests/api/boards_spec.rb spec/requests/api/board_read_only_spec.rb
+```
+
+Expected: all PASS. If a spec now fails because it relied on `published: false` being ignored, that spec was encoding the bug — fix the spec, and note it in the commit body.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/controllers/api/boards_controller.rb spec/requests/api/boards_publish_cascade_spec.rb
+git commit -m "fix(boards): let published=false actually unpublish a board
+
+board_params[\"published\"].present? is false for false, so unpublishing was
+silently dropped. Use .key?, matching the predefined guard above it."
+```
+
+---
+
+## Task 2: `Boards::PublishCascade` service
+
+**Files:**
+- Create: `app/services/boards/publish_cascade.rb`
+- Test: `spec/services/boards/publish_cascade_spec.rb`
+
+**Interfaces:**
+- Consumes: `Board#builder_root?` (`app/models/board.rb:230`), `Board#builder_board_group` (`app/models/board.rb:237`), which returns a `BoardGroup` with `builder: true, root_board_id: <board>.id` whose members come from `board_group_boards`.
+- Produces, used by Task 3:
+  - `Boards::PublishCascade.new(board)`
+  - `#needed?(published:) -> Boolean`
+  - `#summary(published:) -> Hash` with keys `:action`, `:board_group`, `:affected`
+  - `#apply!(published:) -> Integer` (count of member boards written)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/services/boards/publish_cascade_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+# Boards::PublishCascade decides whether publishing/unpublishing a Board
+# Builder root needs to cascade to its set, and applies it. Members that
+# already match the target don't count — re-saving a synced set never prompts.
+RSpec.describe Boards::PublishCascade do
+  let(:user) { create(:user) }
+
+  # A builder root plus a builder BoardGroup owning `member_count` sub-boards.
+  def build_builder_set(published: false, member_count: 2, members_published: false)
+    root = create(:board, user: user, name: "Home", published: published,
+                          settings: { "builder_root" => true })
+    group = BoardGroup.create!(user: user, name: "Milo's Set", builder: true,
+                               root_board_id: root.id)
+    group.board_group_boards.create!(board: root)
+    members = Array.new(member_count) do |i|
+      m = create(:board, user: user, name: "Page #{i + 1}", published: members_published,
+                         settings: { "builder_child" => true })
+      group.board_group_boards.create!(board: m)
+      m
+    end
+    [root, group, members]
+  end
+
+  describe "#needed?" do
+    it "is true when publishing a root whose members are unpublished" do
+      root, _group, _members = build_builder_set
+      expect(described_class.new(root).needed?(published: true)).to be true
+    end
+
+    it "is false when every member already matches the target" do
+      root, _group, _members = build_builder_set(members_published: true)
+      expect(described_class.new(root).needed?(published: true)).to be false
+    end
+
+    it "is false for a board that is not a builder root" do
+      plain = create(:board, user: user)
+      expect(described_class.new(plain).needed?(published: true)).to be false
+    end
+
+    it "is false for a builder root with no member boards besides itself" do
+      root = create(:board, user: user, settings: { "builder_root" => true })
+      group = BoardGroup.create!(user: user, name: "Empty", builder: true, root_board_id: root.id)
+      group.board_group_boards.create!(board: root)
+      expect(described_class.new(root).needed?(published: true)).to be false
+    end
+
+    it "is true when unpublishing a root whose members are published" do
+      root, _group, _members = build_builder_set(published: true, members_published: true)
+      expect(described_class.new(root).needed?(published: false)).to be true
+    end
+  end
+
+  describe "#summary" do
+    it "reports the action, group, and exact affected count" do
+      root, group, _members = build_builder_set(member_count: 3)
+      summary = described_class.new(root).summary(published: true)
+
+      expect(summary[:action]).to eq("publish")
+      expect(summary[:board_group]).to eq({ id: group.id, name: "Milo's Set" })
+      expect(summary[:affected][:count]).to eq(3)
+      expect(summary[:affected][:names]).to contain_exactly("Page 1", "Page 2", "Page 3")
+    end
+
+    it "says unpublish when the target is false" do
+      root, _group, _members = build_builder_set(published: true, members_published: true)
+      expect(described_class.new(root).summary(published: false)[:action]).to eq("unpublish")
+    end
+
+    it "caps the name list but keeps the count exact" do
+      root, _group, _members = build_builder_set(member_count: 14)
+      summary = described_class.new(root).summary(published: true)
+
+      expect(summary[:affected][:count]).to eq(14)
+      expect(summary[:affected][:names].size).to eq(described_class::NAME_SAMPLE_LIMIT)
+    end
+  end
+
+  describe "#apply!" do
+    it "publishes every member and returns the count written" do
+      root, _group, members = build_builder_set(member_count: 3)
+      count = described_class.new(root).apply!(published: true)
+
+      expect(count).to eq(3)
+      expect(members.map { |m| m.reload.published }).to all(be true)
+    end
+
+    it "does not write the root board itself" do
+      root, _group, _members = build_builder_set
+      described_class.new(root).apply!(published: true)
+      expect(root.reload.published).to be false
+    end
+
+    it "unpublishes every member" do
+      root, _group, members = build_builder_set(published: true, members_published: true)
+      described_class.new(root).apply!(published: false)
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "touches updated_at on the members it writes" do
+      root, _group, members = build_builder_set
+      before = members.first.updated_at
+      travel_to(1.hour.from_now) { described_class.new(root).apply!(published: true) }
+      expect(members.first.reload.updated_at).to be > before
+    end
+
+    it "is a no-op returning 0 for a non-builder board" do
+      plain = create(:board, user: user)
+      expect(described_class.new(plain).apply!(published: true)).to eq(0)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/services/boards/publish_cascade_spec.rb
+```
+
+Expected: FAIL with `uninitialized constant Boards::PublishCascade`.
+
+- [ ] **Step 3: Write the service**
+
+Create `app/services/boards/publish_cascade.rb`:
+
+```ruby
+module Boards
+  # Publishing a Board Builder root without its set leaves a broken public
+  # page: Board#viewable_by? gates each board on its own `published` flag, so
+  # a visitor tapping a folder tile on a published root hits the sub-page's
+  # 404. Unpublishing only the root leaks the reverse — every sub-page stays
+  # reachable by its own /pb/<slug>.
+  #
+  # This cascades `published` across the boards owned by the root's builder
+  # BoardGroup — the SAME set Boards::UsageCheck#builder_group cascades on
+  # delete, so a built set publishes, unpublishes, and deletes as one unit.
+  # Deliberately NOT PredictiveLinkSet: hand-linked folder tiles outside the
+  # builder set are not owned by the root and are not ours to flip.
+  class PublishCascade
+    # Counts in the summary are exact; name lists are sampled so a large set
+    # can't blow up the 409 payload. Mirrors UsageCheck::NAME_SAMPLE_LIMIT.
+    NAME_SAMPLE_LIMIT = 10
+
+    def initialize(board)
+      @board = board
+    end
+
+    # Only boards that would actually change count, so re-saving an
+    # already-synced set never prompts the user.
+    def needed?(published:)
+      member_boards_to_change(published).exists?
+    end
+
+    def summary(published:)
+      group = builder_group
+      scope = member_boards_to_change(published)
+
+      {
+        action: published ? "publish" : "unpublish",
+        board_group: group ? { id: group.id, name: group.name } : nil,
+        affected: {
+          count: scope.count,
+          names: scope.limit(NAME_SAMPLE_LIMIT).pluck(:name),
+        },
+      }
+    end
+
+    # Flips the members only — the root is saved by the caller through the
+    # normal update path. update_all skips callbacks on purpose: a built set
+    # can be dozens of boards and only one boolean column changes. It also
+    # skips timestamps, so updated_at is set explicitly.
+    def apply!(published:)
+      ids = member_boards_to_change(published).pluck(:id)
+      return 0 if ids.empty?
+
+      Board.where(id: ids).update_all(published: published, updated_at: Time.current)
+      ids.size
+    end
+
+    # The builder BoardGroup owning this root's built tree, or nil when this
+    # board isn't a Board Builder root.
+    def builder_group
+      return @builder_group if defined?(@builder_group)
+      @builder_group = board.builder_board_group
+    end
+
+    private
+
+    attr_reader :board
+
+    # Member boards whose published flag differs from the target. Excludes the
+    # root itself — it's a member of its own group, but the caller saves it.
+    def member_boards_to_change(published)
+      group = builder_group
+      return Board.none unless group
+
+      group.boards.where.not(id: board.id).where.not(published: published)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/services/boards/publish_cascade_spec.rb
+```
+
+Expected: all PASS. If the `updated_at` example fails because `travel_to` isn't available, confirm `config.include ActiveSupport::Testing::TimeHelpers` is in `spec/rails_helper.rb`; if it isn't, add it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/boards/publish_cascade.rb spec/services/boards/publish_cascade_spec.rb
+git commit -m "feat(boards): add Boards::PublishCascade service
+
+Decides whether publishing/unpublishing a Board Builder root needs to
+cascade to its set, summarizes what it affects, and applies it. Cascades
+over builder BoardGroup membership - the same set UsageCheck cascades on
+delete - so a built set publishes and deletes as one unit."
+```
+
+---
+
+## Task 3: Controller 409 guard and confirmed cascade
+
+**Files:**
+- Modify: `app/controllers/api/boards_controller.rb` — `#update`, starting at line 412
+- Test: `spec/requests/api/boards_publish_cascade_spec.rb` (extend the file from Task 1)
+
+**Interfaces:**
+- Consumes: `Boards::PublishCascade#needed?`, `#summary`, `#apply!` from Task 2; the fixed `published` assignment from Task 1.
+- Produces: `PUT /api/boards/:id` returns 409 `publish_cascade_confirmation_required` with a `cascade` key; `?confirm=true` performs the cascade.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the whole body of `spec/requests/api/boards_publish_cascade_spec.rb` with this (it keeps the Task 1 example and adds the cascade cases):
+
+```ruby
+require "rails_helper"
+
+# Publish cascade: publishing or unpublishing a Board Builder root cascades to
+# every member board of its builder BoardGroup, behind a 409 warn+confirm that
+# mirrors the board-delete flow. `published` is admin-only server-side, so the
+# cascade is only ever reachable by admins.
+RSpec.describe "API::Boards publish cascade", type: :request do
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let(:member_user) { create(:user) }
+
+  def update_board(target, as:, params:)
+    put "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
+  end
+
+  # A builder root plus a builder BoardGroup owning two sub-boards.
+  def build_builder_set(owner:, published: false, members_published: false)
+    root = create(:board, user: owner, name: "Home", published: published,
+                          settings: { "builder_root" => true })
+    group = BoardGroup.create!(user: owner, name: "Milo's Set", builder: true,
+                               root_board_id: root.id)
+    group.board_group_boards.create!(board: root)
+    members = ["Food", "Feelings"].map do |name|
+      m = create(:board, user: owner, name: name, published: members_published,
+                         settings: { "builder_child" => true })
+      group.board_group_boards.create!(board: m)
+      m
+    end
+    [root, members]
+  end
+
+  describe "unpublishing a plain board" do
+    let(:board) { create(:board, user: admin, published: true) }
+
+    it "persists published=false" do
+      update_board(board, as: admin, params: { board: { published: false } })
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.published).to be false
+    end
+  end
+
+  describe "publishing a builder root with unpublished members" do
+    it "returns 409 with the affected set and writes nothing" do
+      root, members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:conflict)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("publish_cascade_confirmation_required")
+      expect(body["cascade"]["action"]).to eq("publish")
+      expect(body["cascade"]["board_group"]["name"]).to eq("Milo's Set")
+      expect(body["cascade"]["affected"]["count"]).to eq(2)
+      expect(body["cascade"]["affected"]["names"]).to contain_exactly("Food", "Feelings")
+
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "leaves other attributes in the same payload unwritten" do
+      root, _members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true, name: "Renamed" } })
+
+      expect(response).to have_http_status(:conflict)
+      expect(root.reload.name).to eq("Home")
+    end
+
+    it "publishes the root and every member with confirm=true" do
+      root, members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+      expect(members.map { |m| m.reload.published }).to all(be true)
+    end
+  end
+
+  describe "unpublishing a published builder root" do
+    it "returns 409 with the unpublish action" do
+      root, _members = build_builder_set(owner: admin, published: true, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: false } })
+
+      expect(response).to have_http_status(:conflict)
+      expect(JSON.parse(response.body)["cascade"]["action"]).to eq("unpublish")
+    end
+
+    it "unpublishes the root and every member with confirm=true" do
+      root, members = build_builder_set(owner: admin, published: true, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: false }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+  end
+
+  describe "when no cascade is needed" do
+    it "does not prompt when members already match the target" do
+      root, _members = build_builder_set(owner: admin, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+    end
+
+    it "does not prompt for a board that is not a builder root" do
+      plain = create(:board, user: admin, name: "Plain")
+      other = create(:board, user: admin, published: false)
+
+      update_board(plain, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(plain.reload.published).to be true
+      expect(other.reload.published).to be false
+    end
+
+    it "does not prompt when published is absent from the payload" do
+      root, _members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { name: "Renamed" } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.name).to eq("Renamed")
+    end
+  end
+
+  describe "non-admin" do
+    it "cannot trigger the cascade because published is stripped" do
+      root, members = build_builder_set(owner: member_user)
+
+      update_board(root, as: member_user, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+bundle exec rspec spec/requests/api/boards_publish_cascade_spec.rb
+```
+
+Expected: the "unpublishing a plain board" example PASSES (Task 1). Every cascade example FAILS — 409 examples get 200 because no guard exists yet.
+
+- [ ] **Step 3: Add the guard to `#update`**
+
+In `app/controllers/api/boards_controller.rb`, inside `def update`, insert the guard immediately after the authorization check and **before** the `if params["image_ids_to_remove"].present?` branch — i.e. between these two existing lines:
+
+```ruby
+    unless current_user.can_edit?(@board)
+      render json: { error: "Unauthorized" }, status: :unauthorized
+      return
+    end
+```
+
+and
+
+```ruby
+    if params["image_ids_to_remove"].present?
+```
+
+Insert:
+
+```ruby
+    # Warn+confirm before cascading publish across a Board Builder set, mirroring
+    # the delete flow. This runs BEFORE any attribute is assigned, so a declined
+    # cascade writes nothing at all — the client re-sends the identical payload
+    # with confirm=true. `published` is stripped from board_params for
+    # non-admins, so this is unreachable for them.
+    if board_params.key?("published")
+      target_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
+      if target_published != @board.published
+        cascade = Boards::PublishCascade.new(@board)
+        if cascade.needed?(published: target_published) && params[:confirm].to_s != "true"
+          render json: {
+                   error: "publish_cascade_confirmation_required",
+                   message: "\"#{@board.name}\" is the home of a board set — this change applies to every page in the set.",
+                   board: { id: @board.id, name: @board.name },
+                   cascade: cascade.summary(published: target_published),
+                 }, status: :conflict
+          return
+        end
+        @publish_cascade = cascade
+        @publish_cascade_target = target_published
+      end
+    end
+```
+
+- [ ] **Step 4: Apply the cascade in the same transaction as the root save**
+
+Still in `#update`, the success path is a `respond_to` block whose condition is the
+save itself (`app/controllers/api/boards_controller.rb:503-504`):
+
+```ruby
+      respond_to do |format|
+        if @board.save
+          if params[:layout].present?
+```
+
+The save has to move out of the condition so it can share a transaction with the
+cascade — otherwise the root commits before the members flip, and a cascade failure
+leaves the set half-published. Replace those three lines with:
+
+```ruby
+      # The root's save and the set cascade share one transaction: a failed
+      # cascade must not leave the root published with its members behind.
+      saved = false
+      ActiveRecord::Base.transaction do
+        saved = @board.save
+        raise ActiveRecord::Rollback unless saved
+        @publish_cascade&.apply!(published: @publish_cascade_target)
+      end
+
+      respond_to do |format|
+        if saved
+          if params[:layout].present?
+```
+
+Everything inside the block — the layout handling, `broadcast_board_update!`, both
+`format.json` branches, and the closing `end`s — is unchanged.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+bundle exec rspec spec/requests/api/boards_publish_cascade_spec.rb
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Check for regressions across the board request specs**
+
+```bash
+bundle exec rspec spec/requests/api/boards_spec.rb spec/requests/api/boards_destroy_spec.rb spec/requests/api/board_read_only_spec.rb spec/requests/api/board_groups_spec.rb spec/services/boards/
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/controllers/api/boards_controller.rb spec/requests/api/boards_publish_cascade_spec.rb
+git commit -m "feat(boards): cascade publish/unpublish across a Board Builder set
+
+PUT /boards/:id now returns 409 publish_cascade_confirmation_required when
+toggling published on a builder root would leave its set out of sync. The
+guard runs before any attribute is assigned, so a declined cascade writes
+nothing; re-sending with confirm=true publishes the root and every member
+in one transaction."
+```
+
+---
+
+## Task 4: Backend documentation
+
+**Files:**
+- Modify: `.claude-notes/boards-and-teams.md`
+- Modify: `.claude-notes/board-builder.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the behavior built in Tasks 1–3.
+- Produces: nothing code-facing.
+
+- [ ] **Step 1: Document the invariant in `boards-and-teams.md`**
+
+Find the existing "Board deletion safety (warn + confirm)" section and add this immediately after it:
+
+```markdown
+### Publish cascade (warn + confirm)
+
+A Board Builder set publishes and unpublishes as a **unit**. `Board#viewable_by?`
+gates each board on its own `published` flag, so publishing only the root leaves
+folder tiles 404ing for public visitors, and unpublishing only the root leaves
+every sub-page reachable by its own `/pb/<slug>`.
+
+`PUT /api/boards/:id` returns **409 `publish_cascade_confirmation_required`**
+when `published` would change on a builder root whose set members don't already
+match. The body carries `cascade: { action, board_group, affected: { count, names } }`.
+Re-send the identical payload with `confirm=true` to apply it; the root's save and
+`Boards::PublishCascade#apply!` run in one transaction.
+
+The guard runs **before any attribute is assigned**, so a declined cascade writes
+nothing — other fields in the same payload are neither applied nor lost.
+
+The cascade set is the root's builder `BoardGroup` membership — the same set
+`Boards::UsageCheck#builder_group` cascades on delete. Hand-linked folder-tile
+descendants (`board_images.predictive_board_id`) outside the builder set are
+deliberately **not** included: they aren't owned by the root.
+
+`published` is admin-only (`board_params` strips it for non-admins), so the
+cascade is unreachable for regular users.
+```
+
+- [ ] **Step 2: Add the pointer in `board-builder.md`**
+
+Add this line to the end of the document:
+
+```markdown
+- **Publishing:** a built set publishes and unpublishes as a unit, behind a 409
+  warn+confirm. See "Publish cascade (warn + confirm)" in
+  `.claude-notes/boards-and-teams.md`.
+```
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+Add under the topmost unreleased heading in `CHANGELOG.md` (create an `## Unreleased` heading at the top if none exists):
+
+```markdown
+### Fixed
+- Publishing a Board Builder board set now publishes every page in the set, so
+  public visitors no longer hit a dead end when tapping a folder button.
+  Unpublishing removes the whole set from public view. Both ask for confirmation
+  first.
+- Unpublishing a board works again — `published: false` was being silently
+  dropped by the update endpoint.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -f .claude-notes/boards-and-teams.md .claude-notes/board-builder.md
+git add CHANGELOG.md
+git commit -m "docs(boards): document the publish cascade invariant"
+```
+
+Note the `-f` — `.claude-notes/` is gitignored and durable subsystem docs are force-added.
+
+---
+
+## Task 5: Frontend — typed 409 error and `confirm` option
+
+Work from the **frontend worktree** for Tasks 5–8.
+
+**Files:**
+- Modify: `src/data/boards.ts` — `updateBoard` (line ~518) and the error classes near line ~630
+- Test: `src/data/boards.publishCascade.test.ts` (create)
+
+**Interfaces:**
+- Consumes: the 409 body shape from Task 3 — `{ error: "publish_cascade_confirmation_required", message, board: { id, name }, cascade: { action, board_group: { id, name }, affected: { count, names } } }`.
+- Produces, used by Tasks 6–7:
+  - `export interface PublishCascadeSummary { action: "publish" | "unpublish"; board_group: { id: number; name: string } | null; affected: { count: number; names: string[] } }`
+  - `export class PublishCascadeError extends Error { cascade: PublishCascadeSummary | null; boardName: string }`
+  - `updateBoard(board, updatedLayout?, screenSize?, xMargin?, yMargin?, duplicateWords?, opts?: { confirm?: boolean })`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/data/boards.publishCascade.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { updateBoard, PublishCascadeError } from "./boards";
+
+const CASCADE_BODY = {
+  error: "publish_cascade_confirmation_required",
+  message: "\"Home\" is the home of a board set.",
+  board: { id: 1, name: "Home" },
+  cascade: {
+    action: "publish",
+    board_group: { id: 9, name: "Milo's Set" },
+    affected: { count: 12, names: ["Food", "Feelings"] },
+  },
+};
+
+const board: any = { id: 1, name: "Home", published: true, settings: {} };
+
+describe("updateBoard publish cascade", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("throws PublishCascadeError with the cascade payload on a 409", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 409,
+        ok: false,
+        json: async () => CASCADE_BODY,
+      }),
+    );
+
+    await expect(updateBoard(board)).rejects.toBeInstanceOf(PublishCascadeError);
+
+    try {
+      await updateBoard(board);
+    } catch (e) {
+      const err = e as PublishCascadeError;
+      expect(err.cascade?.action).toBe("publish");
+      expect(err.cascade?.affected.count).toBe(12);
+      expect(err.boardName).toBe("Home");
+    }
+  });
+
+  it("sends confirm=true in the body when the option is set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ id: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await updateBoard(board, undefined, undefined, undefined, undefined, false, {
+      confirm: true,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.confirm).toBe(true);
+  });
+
+  it("does not send confirm when the option is absent", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ id: 1 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await updateBoard(board);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.confirm).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/data/boards.publishCascade.test.ts
+```
+
+Expected: FAIL — `PublishCascadeError` is not exported.
+
+- [ ] **Step 3: Add the types and the error class**
+
+In `src/data/boards.ts`, add immediately after the existing `BoardInUseError` class:
+
+```ts
+// The 409 publish_cascade_confirmation_required payload: publishing or
+// unpublishing a Board Builder root applies to every page in its set.
+export interface PublishCascadeSummary {
+  action: "publish" | "unpublish";
+  board_group: { id: number; name: string } | null;
+  affected: { count: number; names: string[] };
+}
+
+// Thrown when PUT /boards/:id returns 409 publish_cascade_confirmation_required.
+// Nothing was written. Retry the identical payload with { confirm: true }.
+export class PublishCascadeError extends Error {
+  cascade: PublishCascadeSummary | null;
+  boardName: string;
+  constructor(body: any) {
+    super(body?.message || "publish_cascade_confirmation_required");
+    this.name = "PublishCascadeError";
+    this.cascade = body?.cascade ?? null;
+    this.boardName = body?.board?.name ?? "";
+  }
+}
+```
+
+- [ ] **Step 4: Make `updateBoard` async, detect the 409, and accept `confirm`**
+
+Replace the `updateBoard` signature line:
+
+```ts
+  duplicateWords?: boolean,
+) => {
+```
+
+with:
+
+```ts
+  duplicateWords?: boolean,
+  // Re-send after the user confirms a publish cascade (409
+  // publish_cascade_confirmation_required). Only ever set by that retry.
+  opts?: { confirm?: boolean },
+) => {
+```
+
+Then replace the whole `const updatedBoard = fetch(...)` block through `return updatedBoard;` with:
+
+```ts
+  const response = await fetch(`${BASE_URL}boards/${board.id}`, {
+    method: "PUT",
+    headers: signedInHeaders(),
+    body: JSON.stringify({
+      board: payload,
+      word_list: board.word_list,
+      duplicate_words: duplicateWords,
+      layout: updatedLayout,
+      screen_size: screenSize,
+      image_ids_to_remove: board.image_ids_to_remove,
+      xMargin: xMargin,
+      yMargin: yMargin,
+      ...(opts?.confirm ? { confirm: true } : {}),
+    }),
+  });
+
+  if (response.status === 409) {
+    let body: any = null;
+    try {
+      body = await response.json();
+    } catch {
+      /* no body */
+    }
+    if (body?.error === "publish_cascade_confirmation_required") {
+      throw new PublishCascadeError(body);
+    }
+    return body;
+  }
+
+  return await response.json();
+```
+
+Change the arrow function to `async`: the declaration becomes
+
+```ts
+export const updateBoard = async (
+```
+
+Note: this drops the old `.catch((error) => console.error(...))`, which swallowed every network failure and returned `undefined`. Callers now see rejections. Task 7 handles that in `BoardForm`; other callers pass layout-only saves that never set `published`, so they cannot hit the 409.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+npx vitest run src/data/boards.publishCascade.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Typecheck and check for callers broken by the async change**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors. If a caller assigned `updateBoard(...)` without `await` and used the result synchronously, add the `await`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/data/boards.ts src/data/boards.publishCascade.test.ts
+git commit -m "feat(boards): surface the publish-cascade 409 from updateBoard
+
+Adds PublishCascadeError + PublishCascadeSummary and a confirm option so
+the caller can re-send after the user approves the cascade. updateBoard is
+now async and no longer swallows failures into console.error."
+```
+
+---
+
+## Task 6: Frontend — confirmation copy helper
+
+**Files:**
+- Create: `src/components/utils/publishCascade.ts`
+- Test: `src/components/utils/publishCascade.test.ts`
+
+**Interfaces:**
+- Consumes: `PublishCascadeError` and `PublishCascadeSummary` from Task 5.
+- Produces, used by Task 7: `publishCascadeCopy(err: PublishCascadeError) -> { header: string; body: string; confirmLabel: string }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/utils/publishCascade.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { publishCascadeCopy } from "./publishCascade";
+import { PublishCascadeError } from "../../data/boards";
+
+const err = (action: "publish" | "unpublish", count: number) =>
+  new PublishCascadeError({
+    message: "cascade",
+    board: { id: 1, name: "Home" },
+    cascade: {
+      action,
+      board_group: { id: 9, name: "Milo's Set" },
+      affected: { count, names: ["Food", "Feelings"] },
+    },
+  });
+
+describe("publishCascadeCopy", () => {
+  it("frames publishing as making the whole set visible", () => {
+    const copy = publishCascadeCopy(err("publish", 12));
+    expect(copy.header).toBe("Publish the whole set?");
+    expect(copy.body).toContain("12 pages");
+    expect(copy.body).toContain("publicly visible");
+    expect(copy.confirmLabel).toBe("Publish set");
+  });
+
+  it("frames unpublishing as removing the whole set", () => {
+    const copy = publishCascadeCopy(err("unpublish", 12));
+    expect(copy.header).toBe("Unpublish the whole set?");
+    expect(copy.body).toContain("12 pages");
+    expect(copy.body).toContain("remove");
+    expect(copy.confirmLabel).toBe("Unpublish set");
+  });
+
+  it("uses singular wording for one page", () => {
+    const copy = publishCascadeCopy(err("publish", 1));
+    expect(copy.body).toContain("1 page ");
+    expect(copy.body).not.toContain("pages");
+  });
+
+  it("falls back to the raw message when the payload is missing", () => {
+    const bare = new PublishCascadeError({ message: "Something changed." });
+    expect(publishCascadeCopy(bare).body).toBe("Something changed.");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run src/components/utils/publishCascade.test.ts
+```
+
+Expected: FAIL — cannot resolve `./publishCascade`.
+
+- [ ] **Step 3: Write the helper**
+
+Create `src/components/utils/publishCascade.ts`:
+
+```ts
+import { PublishCascadeError } from "../../data/boards";
+
+// Turn the backend's publish_cascade_confirmation_required payload into copy
+// for the confirm dialog. Publishing is framed as what makes the public page
+// work (unpublished pages 404 when a visitor taps a folder button);
+// unpublishing is framed as closing the direct-link leak.
+export const publishCascadeCopy = (
+  err: PublishCascadeError,
+): { header: string; body: string; confirmLabel: string } => {
+  const cascade = err.cascade;
+
+  if (!cascade) {
+    return { header: "Apply to the whole set?", body: err.message, confirmLabel: "Continue" };
+  }
+
+  const { count } = cascade.affected;
+  const pages = count === 1 ? "1 page " : `${count} pages `;
+
+  if (cascade.action === "unpublish") {
+    return {
+      header: "Unpublish the whole set?",
+      body: `This board set has ${pages}beyond this one. Unpublishing will also remove ${count === 1 ? "it" : "them"} from public view.`,
+      confirmLabel: "Unpublish set",
+    };
+  }
+
+  return {
+    header: "Publish the whole set?",
+    body: `This board set has ${pages}beyond this one. Publishing will also make ${count === 1 ? "it" : "them"} publicly visible, so folder buttons work for everyone.`,
+    confirmLabel: "Publish set",
+  };
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run src/components/utils/publishCascade.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/utils/publishCascade.ts src/components/utils/publishCascade.test.ts
+git commit -m "feat(boards): add publish-cascade confirm dialog copy helper"
+```
+
+---
+
+## Task 7: Frontend — wire the confirm dialog into `BoardForm`
+
+**Files:**
+- Modify: `src/components/boards/BoardForm.tsx` — `handleSubmit` (line ~428) and the JSX render tail
+
+**Interfaces:**
+- Consumes: `updateBoard(..., opts)` and `PublishCascadeError` (Task 5), `publishCascadeCopy` (Task 6), the existing `ConfirmAlert` at `src/components/utils/ConfirmAlert.tsx`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the imports**
+
+At the top of `src/components/boards/BoardForm.tsx`, add to the existing `src/data/boards` import the two new names, and add the two new imports:
+
+```tsx
+import { PublishCascadeError } from "../../data/boards";
+import { publishCascadeCopy } from "../utils/publishCascade";
+import ConfirmAlert from "../utils/ConfirmAlert";
+```
+
+If `ConfirmAlert` is already imported in this file, don't duplicate it.
+
+- [ ] **Step 2: Add the pending-cascade state**
+
+Next to the other `useState` declarations near the top of the component, add:
+
+```tsx
+  // Set when a save was rejected with 409 publish_cascade_confirmation_required.
+  // Holds the error so the dialog can render its copy and the retry can re-send.
+  const [pendingCascade, setPendingCascade] = useState<PublishCascadeError | null>(null);
+```
+
+- [ ] **Step 3: Extract the save so it can be retried with confirm**
+
+In `handleSubmit`, replace this block:
+
+```tsx
+    const savedBoard = await updateBoard(
+      toSave,
+      updatedLayout,
+      currentScreenSize,
+      xMargin,
+      yMargin,
+    );
+    pushBoardUp(savedBoard);
+
+    setShowLoading(false);
+    setToastMessage("Board saved successfully");
+    setIsToastOpen(true);
+  };
+```
+
+with:
+
+```tsx
+    await saveBoard(toSave, { confirm: false });
+  };
+
+  // The single save path. A publish cascade comes back as a 409 with nothing
+  // written; we stash it, show the confirm dialog, and re-send the identical
+  // payload with confirm: true when the user approves.
+  const saveBoard = async (
+    toSave: any,
+    { confirm }: { confirm: boolean },
+  ) => {
+    try {
+      const savedBoard = await updateBoard(
+        toSave,
+        updatedLayout,
+        currentScreenSize,
+        xMargin,
+        yMargin,
+        false,
+        confirm ? { confirm: true } : undefined,
+      );
+      pushBoardUp(savedBoard);
+      setPendingCascade(null);
+      setShowLoading(false);
+      setToastMessage("Board saved successfully");
+      setIsToastOpen(true);
+    } catch (e) {
+      setShowLoading(false);
+      if (e instanceof PublishCascadeError) {
+        // Nothing was saved — hold the payload so the retry re-sends it intact.
+        setPendingCascade(e);
+        setPendingCascadePayload(toSave);
+        return;
+      }
+      setToastMessage("Could not save board. Please try again.");
+      setIsToastOpen(true);
+    }
+  };
+```
+
+- [ ] **Step 4: Add the held payload state**
+
+Alongside `pendingCascade` from Step 2, add:
+
+```tsx
+  // The exact payload the 409 rejected, so the confirmed retry re-sends it
+  // unchanged rather than rebuilding it from possibly-restaled state.
+  const [pendingCascadePayload, setPendingCascadePayload] = useState<any>(null);
+```
+
+- [ ] **Step 5: Render the dialog**
+
+In the component's returned JSX, add this next to the other overlays (near the existing loading/toast elements at the end of the render):
+
+```tsx
+      {pendingCascade && (
+        <ConfirmAlert
+          openAlert={Boolean(pendingCascade)}
+          message={publishCascadeCopy(pendingCascade).header}
+          subMessage={publishCascadeCopy(pendingCascade).body}
+          confirmLabel={publishCascadeCopy(pendingCascade).confirmLabel}
+          onConfirm={() => {
+            const payload = pendingCascadePayload;
+            setPendingCascade(null);
+            setShowLoading(true);
+            saveBoard(payload, { confirm: true });
+          }}
+          onCanceled={() => {
+            setPendingCascade(null);
+            setPendingCascadePayload(null);
+          }}
+          onDidDismiss={() => setPendingCascade(null)}
+        />
+      )}
+```
+
+- [ ] **Step 6: Typecheck and build**
+
+```bash
+npx tsc --noEmit && npm run build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 7: Run the full frontend test suite for regressions**
+
+```bash
+npx vitest run
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Manual verification**
+
+There is no component-test harness for `BoardForm`, so verify the wiring by hand against a local backend (`bin/dev` in the backend worktree, `npm run dev` in the frontend worktree), signed in as an admin:
+
+1. Open a Board Builder set's root board in the board editor, go to "Sharing & Publishing".
+2. Toggle **Publish** on and save → the dialog reads "Publish the whole set?" with the correct page count.
+3. Cancel → nothing saves; the board stays unpublished.
+4. Save again and confirm → the root and every sub-page show `published: true`.
+5. Open the public `/pb/<slug>` in a signed-out window and tap a folder button → the sub-page loads instead of 404ing.
+6. Toggle **Publish** off and save → the dialog reads "Unpublish the whole set?"; confirming unpublishes all of them.
+7. Save the root again with no publish change → no dialog appears.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/boards/BoardForm.tsx
+git commit -m "feat(boards): confirm before cascading publish across a board set
+
+Catches the 409 from updateBoard, shows the existing ConfirmAlert with
+set-aware copy, and re-sends the untouched payload with confirm: true when
+the user approves."
+```
+
+---
+
+## Task 8: Frontend CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the behavior built in Tasks 5–7.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the entry**
+
+Add under the topmost unreleased heading in `CHANGELOG.md` (create an `## Unreleased` heading at the top if none exists):
+
+```markdown
+### Fixed
+- Publishing a board set now asks whether to publish every page in it, so the
+  public page's folder buttons work instead of hitting a dead end. Unpublishing
+  asks the same and removes the whole set from public view.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for the publish cascade confirm flow"
+```
+
+---
+
+## Task 9: File the follow-up issue
+
+The spec explicitly puts this out of scope, but it must not be lost: `BoardForm.tsx`
+shows the publish toggle, public URL, and QR code to every signed-in user, while
+`board_params` deletes `:published` for non-admins. A non-admin toggling Publish
+gets a success toast and no publish.
+
+**Files:** none.
+
+- [ ] **Step 1: Open the issue**
+
+```bash
+gh issue create --repo brittanyjohns/itty-bitty-frontend \
+  --title "Publish toggle is shown to non-admins but the backend discards it" \
+  --body "BoardForm.tsx renders the \"Publish this board\" toggle, the public URL, and the QR code for every signed-in user. The backend strips \`:published\` from \`board_params\` for non-admins (\`app/controllers/api/boards_controller.rb\`, the admin guard in \`board_params\`), so a non-admin toggling Publish gets a success toast and no publish.
+
+Either admin-gate the toggle in the UI, or allow board owners to publish their own boards. This is a permissions decision, not a bug fix.
+
+Found while building the publish cascade for Board Builder sets, which is admin-only for exactly this reason."
+```
+
+---
+
+## Verification Before Completion
+
+Before claiming done, run and confirm zero failures:
+
+**Backend** (from the backend worktree):
+
+```bash
+bundle exec rspec spec/services/boards/publish_cascade_spec.rb spec/requests/api/boards_publish_cascade_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/boards_destroy_spec.rb spec/requests/api/board_read_only_spec.rb spec/requests/api/board_groups_spec.rb
+```
+
+**Frontend** (from the frontend worktree):
+
+```bash
+npx vitest run && npx tsc --noEmit && npm run build
+```
+
+Then complete the Task 7 Step 8 manual checklist. Report the actual command output — do not claim passing tests without it.
+
+## PR
+
+Two PRs, backend first (the frontend 409 handling is inert until the backend
+ships it). Both from branch `feat/publish-cascade-builder-set`.
+
+- `brittanyjohns/itty_bitty_boards` — the cascade service, controller guard, the
+  `published: false` fix, specs, and `.claude-notes` docs.
+- `brittanyjohns/itty-bitty-frontend` — the typed 409, copy helper, and dialog wiring.
+
+Cross-link them in both descriptions, and note in the frontend PR that it depends
+on the backend one.

--- a/docs/superpowers/specs/2026-08-05-publish-cascade-builder-set-design.md
+++ b/docs/superpowers/specs/2026-08-05-publish-cascade-builder-set-design.md
@@ -53,6 +53,19 @@ introduced. `Boards::PredictiveLinkSet` is deliberately not used.
 
 ## Backend design
 
+### Prerequisite: `published: false` is silently dropped today
+
+`Api::BoardsController#update` assigns with
+`@board.published = board_params["published"] if board_params["published"].present?`.
+`false.present?` is `false`, so an explicit `published: false` never reaches the
+model — the request 200s and the board stays published. **Unpublishing is
+currently a no-op through this endpoint.**
+
+The unpublish half of this feature cannot work until the guard becomes
+`board_params.key?("published")`, matching the `predefined` line directly above
+it. This is a genuine bug independent of the cascade, and is fixed first so the
+cascade has working behavior to build on.
+
 ### `Boards::PublishCascade`
 
 New read-plus-apply service in `app/services/boards/`, a sibling to

--- a/docs/superpowers/specs/2026-08-05-publish-cascade-builder-set-design.md
+++ b/docs/superpowers/specs/2026-08-05-publish-cascade-builder-set-design.md
@@ -1,0 +1,187 @@
+# Publish cascade for Board Builder sets
+
+**Date:** 2026-08-05
+**Repos:** `itty_bitty_boards` (backend), `itty-bitty-frontend` (frontend)
+**Status:** Approved design
+
+## Problem
+
+`Board#viewable_by?` gates every board independently — it returns true for a
+published board and otherwise falls through to owner/admin/team checks. Publishing
+a board sets exactly one `boards.published` flag; nothing propagates that flag to
+any other board.
+
+For a Board Builder set this produces a broken public page. An admin publishes the
+root board, a member of the public opens `/pb/<slug>`, taps a folder tile pointing
+at a sub-page, and `Api::BoardsController#show` runs `viewable_by?` against the
+*sub-board* — which is still unpublished — and returns the deliberately vague 404.
+The set looks published but only its first page works.
+
+The inverse leaks the other way: unpublishing the root leaves every sub-page
+publicly reachable by its own `/pb/<slug>` URL.
+
+## Scope
+
+Publishing and unpublishing a Board Builder root cascades to that set's member
+boards, behind a confirmation prompt.
+
+**In scope**
+- Cascade over Board Builder `BoardGroup` membership, both directions.
+- Warn-then-confirm before any write.
+- Admin-only, matching the current server-side permission on `published`.
+
+**Out of scope**
+- Folder-tile (`board_images.predictive_board_id`) descendants that are not
+  Board Builder set members.
+- The `BoardForm` publish toggle being shown to non-admins while
+  `board_params` discards `:published` for them. Filed separately.
+- `ChildBoard#published`, which is a distinct communicator-dashboard flag.
+
+## What defines the set
+
+A board is a cascade root when both hold:
+
+- `Board#builder_root?` (`app/models/board.rb:230`) — checks
+  `settings["builder_root"]`.
+- `Board#builder_board_group` (`app/models/board.rb:237`) resolves a
+  `BoardGroup` with `builder: true, root_board_id: <board>.id`.
+
+Members are that group's `board_group_boards` boards. This is the same group
+`Boards::UsageCheck#builder_group` already uses to cascade deletion, so the
+cascade set is identical in both directions and no new graph traversal is
+introduced. `Boards::PredictiveLinkSet` is deliberately not used.
+
+## Backend design
+
+### `Boards::PublishCascade`
+
+New read-plus-apply service in `app/services/boards/`, a sibling to
+`Boards::UsageCheck` and following its shape (constructor takes the board,
+memoizes the builder group, caps name lists).
+
+```ruby
+Boards::PublishCascade.new(board)
+  #needed?(published:)  # -> Boolean
+  #summary(published:)  # -> Hash for the 409 body
+  #apply!(published:)   # -> Integer count of member boards changed
+```
+
+`#needed?` is true when the board is a builder root with a group **and** at
+least one member board other than the root has `published != published`.
+Members that already match the target do not count, so re-saving an
+already-cascaded set never prompts.
+
+`#summary` returns:
+
+```ruby
+{
+  action: "publish",              # or "unpublish"
+  board_group: { id:, name: },
+  affected: { count: 12, names: ["Food", "Feelings", ...] }  # names capped at 10
+}
+```
+
+The name cap reuses `UsageCheck::NAME_SAMPLE_LIMIT`'s rationale: counts are
+exact, name lists are sampled so a large set cannot blow up the payload.
+
+`#apply!` writes members with
+`Board.where(id: member_ids).update_all(published:, updated_at: Time.current)`.
+Callbacks are skipped intentionally — a built tree can be dozens of boards and
+only one boolean column is changing. `updated_at` is set explicitly because
+`update_all` does not touch it. The root board is **not** written by this
+method; the controller saves it through the normal update path.
+
+### Controller guard
+
+Publishing has no dedicated endpoint. It rides `PATCH/PUT /boards/:id` →
+`Api::BoardsController#update` (`app/controllers/api/boards_controller.rb:451`),
+which assigns `@board.published` from `board_params`.
+
+The guard runs at the **top of `#update`, before any attribute is assigned**, and
+fires only when all of the following hold:
+
+1. `:published` survived `board_params` (i.e. `current_user` is an admin — the
+   non-admin strip at lines 1462–1468 is unchanged).
+2. The requested value differs from `@board.published`.
+3. `Boards::PublishCascade#needed?` is true for that target value.
+4. `params[:confirm]` is not truthy.
+
+When it fires, the controller returns **409** with:
+
+```json
+{
+  "error": "publish_cascade_confirmation_required",
+  "cascade": { "action": "publish", "board_group": {...}, "affected": {...} }
+}
+```
+
+Failing before assignment means a rejected save writes nothing at all — the
+user's unrelated edits in the same payload are neither applied nor lost, because
+the client resends the identical payload with `confirm=true`. This is the exact
+protocol the delete flow already uses (`#destroy` → `Boards::UsageCheck` → 409
+`board_in_use` → resend with `confirm=true`), which is why no new route is added.
+
+With `confirm=true`, the root board's update and `PublishCascade#apply!` run
+inside a single `ActiveRecord::Base.transaction`, so a failed root save cannot
+leave members flipped.
+
+## Frontend design
+
+`BoardForm.tsx` already seeds `publishBoard` from `board.published` and sends
+`published: publishBoard` in the save payload. The change is the two-step
+warn-then-confirm that `BoardEditorHeader.tsx` uses for delete:
+
+1. Save throws on the 409. Catch it, read the `cascade` payload.
+2. Build the message with a new `publishCascadeDescription()` helper placed
+   alongside `src/components/utils/boardUsage.ts`, which turns the payload into
+   a sentence.
+3. Open the existing `ConfirmAlert` (`src/components/utils/ConfirmAlert.tsx` —
+   generic despite its `ConfirmDeleteAlert` default-export name).
+4. On confirm, resend the same payload with `confirm: true`.
+
+Copy, keyed on `cascade.action`:
+
+- **publish** — "This board set has 12 pages. Publishing will also make all 12
+  publicly visible."
+- **unpublish** — "This will also remove 12 pages from public view."
+
+The publish wording frames the cascade as what makes the public page work; the
+unpublish wording frames it as closing the direct-link leak. Neither dialog is
+reachable by non-admins, since the 409 can only fire when `:published` survived
+`board_params`.
+
+## Testing
+
+**Backend** (request specs on `PATCH /boards/:id`, plus a unit spec for the
+service):
+
+- Builder root with unpublished members → 409, and no board's `published`
+  changed.
+- Same request with `confirm=true` → root and all members published.
+- Published builder root → unpublish with `confirm=true` → root and all members
+  unpublished.
+- Builder root whose members already match the target → no 409, normal update.
+- Non-builder-root board → no 409, normal update, no other board touched.
+- Non-admin sending `published` → still stripped, no cascade, no 409.
+- A 409'd request carrying other changed attributes (e.g. `name`) leaves those
+  unwritten.
+
+**Frontend** (`BoardForm`): 409 opens the confirm dialog with the affected count;
+confirming resends with `confirm: true`; cancelling sends nothing further and
+leaves the toggle reflecting the unsaved intent.
+
+## Documentation
+
+- `.claude-notes/boards-and-teams.md` — a "Publish cascade (warn + confirm)"
+  section next to the existing board-deletion warn+confirm section, documenting
+  the invariant: a Board Builder set publishes and unpublishes as a unit.
+- `.claude-notes/board-builder.md` — pointer to the above.
+- `CHANGELOG.md` in both repos.
+
+## Follow-up filed separately
+
+`BoardForm.tsx` presents the publish toggle, public URL, and QR code to every
+signed-in user, but `board_params` deletes `:published` for non-admins. Either
+the toggle should be admin-gated or board owners should be allowed to publish
+their own boards. Resolving that is a permissions decision independent of this
+cascade work.

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe "API::Boards publish cascade", type: :request do
       expect(root.reload.name).to eq("Home")
     end
 
+    it "creates no images from a word_list on a declined cascade" do
+      # Placement matters here in a way "nothing persisted" doesn't prove: the
+      # assignment block runs find_or_create_images_from_word_list, which
+      # creates Image/BoardImage rows regardless of whether @board.save ever
+      # runs. A guard placed anywhere before the save (but after assignment)
+      # would still leave these rows behind.
+      root, _members = build_builder_set(owner: admin)
+
+      expect {
+        update_board(root, as: admin, params: { board: { published: true }, word_list: ["apple"] })
+      }.not_to change { BoardImage.where(board: root).count }
+
+      expect(response).to have_http_status(:conflict)
+    end
+
     it "publishes the root and every member with confirm=true" do
       root, members = build_builder_set(owner: admin)
 
@@ -125,6 +140,37 @@ RSpec.describe "API::Boards publish cascade", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(root.reload.name).to eq("Renamed")
+    end
+  end
+
+  describe "image_ids_to_remove in the same request as a publish toggle" do
+    it "removes the image without applying an unconfirmed cascade, instead of an unbreakable confirm loop" do
+      # The image_ids_to_remove branch returns early and never assigns or
+      # saves `published`, so a confirm=true here must not be read as "the
+      # cascade applied" — the guard is skipped entirely for this request
+      # shape, matching the plain image-removal behavior it always had.
+      root, members = build_builder_set(owner: admin)
+      image = create(:image)
+      board_image = create(:board_image, board: root, image: image)
+
+      update_board(root, as: admin,
+                    params: { board: { published: true }, confirm: "true",
+                              image_ids_to_remove: [image.id] })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.board_images.exists?(id: board_image.id)).to be false
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "does not raise when image_ids_to_remove is present without a board key" do
+      root, _members = build_builder_set(owner: admin)
+      image = create(:image)
+      create(:board_image, board: root, image: image)
+
+      update_board(root, as: admin, params: { image_ids_to_remove: [image.id] })
+
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -1,12 +1,31 @@
 require "rails_helper"
 
 # Publish cascade: publishing or unpublishing a Board Builder root cascades to
-# every member board of its builder BoardGroup, behind a 409 warn+confirm.
+# every member board of its builder BoardGroup, behind a 409 warn+confirm that
+# mirrors the board-delete flow. `published` is admin-only server-side, so the
+# cascade is only ever reachable by admins.
 RSpec.describe "API::Boards publish cascade", type: :request do
   let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let(:member_user) { create(:user) }
 
   def update_board(target, as:, params:)
     put "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
+  end
+
+  # A builder root plus a builder BoardGroup owning two sub-boards.
+  def build_builder_set(owner:, published: false, members_published: false)
+    root = create(:board, user: owner, name: "Home", published: published,
+                          settings: { "builder_root" => true })
+    group = BoardGroup.create!(user: owner, name: "Milo's Set", builder: true,
+                               root_board_id: root.id)
+    group.board_group_boards.create!(board: root)
+    members = ["Food", "Feelings"].map do |name|
+      m = create(:board, user: owner, name: name, published: members_published,
+                         settings: { "builder_child" => true })
+      group.board_group_boards.create!(board: m)
+      m
+    end
+    [root, members]
   end
 
   describe "unpublishing a plain board" do
@@ -16,6 +35,108 @@ RSpec.describe "API::Boards publish cascade", type: :request do
       update_board(board, as: admin, params: { board: { published: false } })
       expect(response).to have_http_status(:ok)
       expect(board.reload.published).to be false
+    end
+  end
+
+  describe "publishing a builder root with unpublished members" do
+    it "returns 409 with the affected set and writes nothing" do
+      root, members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:conflict)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("publish_cascade_confirmation_required")
+      expect(body["cascade"]["action"]).to eq("publish")
+      expect(body["cascade"]["board_group"]["name"]).to eq("Milo's Set")
+      expect(body["cascade"]["affected"]["count"]).to eq(2)
+      expect(body["cascade"]["affected"]["names"]).to contain_exactly("Food", "Feelings")
+
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "leaves other attributes in the same payload unwritten" do
+      root, _members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true, name: "Renamed" } })
+
+      expect(response).to have_http_status(:conflict)
+      expect(root.reload.name).to eq("Home")
+    end
+
+    it "publishes the root and every member with confirm=true" do
+      root, members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: true }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+      expect(members.map { |m| m.reload.published }).to all(be true)
+    end
+  end
+
+  describe "unpublishing a published builder root" do
+    it "returns 409 with the unpublish action" do
+      root, _members = build_builder_set(owner: admin, published: true, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: false } })
+
+      expect(response).to have_http_status(:conflict)
+      expect(JSON.parse(response.body)["cascade"]["action"]).to eq("unpublish")
+    end
+
+    it "unpublishes the root and every member with confirm=true" do
+      root, members = build_builder_set(owner: admin, published: true, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: false }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+  end
+
+  describe "when no cascade is needed" do
+    it "does not prompt when members already match the target" do
+      root, _members = build_builder_set(owner: admin, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+    end
+
+    it "does not prompt for a board that is not a builder root" do
+      plain = create(:board, user: admin, name: "Plain")
+      other = create(:board, user: admin, published: false)
+
+      update_board(plain, as: admin, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(plain.reload.published).to be true
+      expect(other.reload.published).to be false
+    end
+
+    it "does not prompt when published is absent from the payload" do
+      root, _members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { name: "Renamed" } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.name).to eq("Renamed")
+    end
+  end
+
+  describe "non-admin" do
+    it "cannot trigger the cascade because published is stripped" do
+      root, members = build_builder_set(owner: member_user)
+
+      update_board(root, as: member_user, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
     end
   end
 end

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe "API::Boards publish cascade", type: :request do
       expect(response).to have_http_status(:ok)
       expect(root.reload.name).to eq("Renamed")
     end
+
+    it "does not cascade a malformed published value" do
+      # `.cast` maps nil to nil, not false or true, so the guard's
+      # `[true, false].include?(target_published)` check skips the cascade
+      # entirely rather than matching a nil target against every member. The
+      # root itself still goes through the normal (non-cascade) assignment
+      # path below, which is why its own column ends up nil rather than
+      # strictly unchanged — the guard's job is only to keep that malformed
+      # value from also NULLing out every member.
+      root, members = build_builder_set(owner: admin)
+
+      update_board(root, as: admin, params: { board: { published: nil } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be_falsy
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
   end
 
   describe "image_ids_to_remove in the same request as a publish toggle" do

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+# Publish cascade: publishing or unpublishing a Board Builder root cascades to
+# every member board of its builder BoardGroup, behind a 409 warn+confirm.
+RSpec.describe "API::Boards publish cascade", type: :request do
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  def update_board(target, as:, params:)
+    put "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
+  end
+
+  describe "unpublishing a plain board" do
+    let(:board) { create(:board, user: admin, published: true) }
+
+    it "persists published=false" do
+      update_board(board, as: admin, params: { board: { published: false } })
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.published).to be false
+    end
+  end
+end

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -146,17 +146,25 @@ RSpec.describe "API::Boards publish cascade", type: :request do
       # `.cast` maps nil to nil, not false or true, so the guard's
       # `[true, false].include?(target_published)` check skips the cascade
       # entirely rather than matching a nil target against every member. The
-      # root itself still goes through the normal (non-cascade) assignment
-      # path below, which is why its own column ends up nil rather than
-      # strictly unchanged — the guard's job is only to keep that malformed
-      # value from also NULLing out every member.
+      # root's own assignment is guarded the same way, so a malformed value
+      # leaves its stored `published` exactly as it was — not NULLed.
       root, members = build_builder_set(owner: admin)
 
       update_board(root, as: admin, params: { board: { published: nil } })
 
       expect(response).to have_http_status(:ok)
-      expect(root.reload.published).to be_falsy
+      expect(root.reload.published).to eq(false)
       expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "leaves an already-published root's published value untouched by a malformed value" do
+      root, members = build_builder_set(owner: admin, published: true, members_published: true)
+
+      update_board(root, as: admin, params: { board: { published: nil } })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to eq(true)
+      expect(members.map { |m| m.reload.published }).to all(be true)
     end
   end
 

--- a/spec/services/boards/publish_cascade_spec.rb
+++ b/spec/services/boards/publish_cascade_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+# Boards::PublishCascade decides whether publishing/unpublishing a Board
+# Builder root needs to cascade to its set, and applies it. Members that
+# already match the target don't count — re-saving a synced set never prompts.
+RSpec.describe Boards::PublishCascade do
+  let(:user) { create(:user) }
+
+  # A builder root plus a builder BoardGroup owning `member_count` sub-boards.
+  def build_builder_set(published: false, member_count: 2, members_published: false)
+    root = create(:board, user: user, name: "Home", published: published,
+                          settings: { "builder_root" => true })
+    group = BoardGroup.create!(user: user, name: "Milo's Set", builder: true,
+                               root_board_id: root.id)
+    group.board_group_boards.create!(board: root)
+    members = Array.new(member_count) do |i|
+      m = create(:board, user: user, name: "Page #{i + 1}", published: members_published,
+                         settings: { "builder_child" => true })
+      group.board_group_boards.create!(board: m)
+      m
+    end
+    [root, group, members]
+  end
+
+  describe "#needed?" do
+    it "is true when publishing a root whose members are unpublished" do
+      root, _group, _members = build_builder_set
+      expect(described_class.new(root).needed?(published: true)).to be true
+    end
+
+    it "is false when every member already matches the target" do
+      root, _group, _members = build_builder_set(members_published: true)
+      expect(described_class.new(root).needed?(published: true)).to be false
+    end
+
+    it "is false for a board that is not a builder root" do
+      plain = create(:board, user: user)
+      expect(described_class.new(plain).needed?(published: true)).to be false
+    end
+
+    it "is false for a builder root with no member boards besides itself" do
+      root = create(:board, user: user, settings: { "builder_root" => true })
+      group = BoardGroup.create!(user: user, name: "Empty", builder: true, root_board_id: root.id)
+      group.board_group_boards.create!(board: root)
+      expect(described_class.new(root).needed?(published: true)).to be false
+    end
+
+    it "is true when unpublishing a root whose members are published" do
+      root, _group, _members = build_builder_set(published: true, members_published: true)
+      expect(described_class.new(root).needed?(published: false)).to be true
+    end
+  end
+
+  describe "#summary" do
+    it "reports the action, group, and exact affected count" do
+      root, group, _members = build_builder_set(member_count: 3)
+      summary = described_class.new(root).summary(published: true)
+
+      expect(summary[:action]).to eq("publish")
+      expect(summary[:board_group]).to eq({ id: group.id, name: "Milo's Set" })
+      expect(summary[:affected][:count]).to eq(3)
+      expect(summary[:affected][:names]).to contain_exactly("Page 1", "Page 2", "Page 3")
+    end
+
+    it "says unpublish when the target is false" do
+      root, _group, _members = build_builder_set(published: true, members_published: true)
+      expect(described_class.new(root).summary(published: false)[:action]).to eq("unpublish")
+    end
+
+    it "caps the name list but keeps the count exact" do
+      root, _group, _members = build_builder_set(member_count: 14)
+      summary = described_class.new(root).summary(published: true)
+
+      expect(summary[:affected][:count]).to eq(14)
+      expect(summary[:affected][:names].size).to eq(described_class::NAME_SAMPLE_LIMIT)
+    end
+  end
+
+  describe "#apply!" do
+    it "publishes every member and returns the count written" do
+      root, _group, members = build_builder_set(member_count: 3)
+      count = described_class.new(root).apply!(published: true)
+
+      expect(count).to eq(3)
+      expect(members.map { |m| m.reload.published }).to all(be true)
+    end
+
+    it "does not write the root board itself" do
+      root, _group, _members = build_builder_set
+      described_class.new(root).apply!(published: true)
+      expect(root.reload.published).to be false
+    end
+
+    it "unpublishes every member" do
+      root, _group, members = build_builder_set(published: true, members_published: true)
+      described_class.new(root).apply!(published: false)
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "touches updated_at on the members it writes" do
+      root, _group, members = build_builder_set
+      before = members.first.updated_at
+      travel_to(1.hour.from_now) { described_class.new(root).apply!(published: true) }
+      expect(members.first.reload.updated_at).to be > before
+    end
+
+    it "is a no-op returning 0 for a non-builder board" do
+      plain = create(:board, user: user)
+      expect(described_class.new(plain).apply!(published: true)).to eq(0)
+    end
+  end
+end

--- a/spec/services/boards/publish_cascade_spec.rb
+++ b/spec/services/boards/publish_cascade_spec.rb
@@ -109,4 +109,49 @@ RSpec.describe Boards::PublishCascade do
       expect(described_class.new(plain).apply!(published: true)).to eq(0)
     end
   end
+
+  describe "a member with published: nil" do
+    # SQL `NOT (published = X)` evaluates to NULL (excluded) for a NULL row.
+    # A legacy member whose `published` column is NULL must still be treated
+    # as "not yet matching" any boolean target — otherwise it's silently
+    # skipped by #needed?/#summary and never flipped by #apply!, in either
+    # publish or unpublish direction.
+    def build_set_with_null_member
+      root = create(:board, user: user, name: "Home", published: false,
+                            settings: { "builder_root" => true })
+      group = BoardGroup.create!(user: user, name: "Milo's Set", builder: true,
+                                 root_board_id: root.id)
+      group.board_group_boards.create!(board: root)
+      null_member = create(:board, user: user, name: "Null Page",
+                                   settings: { "builder_child" => true })
+      null_member.update_column(:published, nil)
+      group.board_group_boards.create!(board: null_member)
+      [root, null_member]
+    end
+
+    it "is included by #needed? and #summary when publishing" do
+      root, null_member = build_set_with_null_member
+      cascade = described_class.new(root)
+
+      expect(cascade.needed?(published: true)).to be true
+      summary = cascade.summary(published: true)
+      expect(summary[:affected][:count]).to eq(1)
+      expect(summary[:affected][:names]).to contain_exactly(null_member.name)
+    end
+
+    it "is flipped to true by #apply!(published: true)" do
+      root, null_member = build_set_with_null_member
+      described_class.new(root).apply!(published: true)
+      expect(null_member.reload.published).to be true
+    end
+
+    it "is included by #needed? and flipped to false by #apply!(published: false)" do
+      root, null_member = build_set_with_null_member
+      cascade = described_class.new(root)
+
+      expect(cascade.needed?(published: false)).to be true
+      cascade.apply!(published: false)
+      expect(null_member.reload.published).to be false
+    end
+  end
 end


### PR DESCRIPTION
Publishing a Board Builder root board now publishes every page in its set, behind a confirmation prompt. Unpublishing does the same in reverse.

## Why

`Board#viewable_by?` gates each board on its own `published` flag. Publishing only the root left public visitors hitting the deliberately-vague 404 the moment they tapped a folder tile into an unpublished sub-page — the set looked published but only its first page worked. Unpublishing only the root left every sub-page reachable by its own `/pb/<slug>`.

## What changed

**A prerequisite bug fix.** `#update` guarded the `published` assignment with `board_params["published"].present?`. `false.present?` is `false`, so **unpublishing was a silent no-op** — the request 200'd and the board stayed published. Now guarded on `.key?`, matching the `predefined` line above it.

**`Boards::PublishCascade`** — a sibling to `Boards::UsageCheck`. Decides whether a cascade is needed, summarizes what it affects, and applies it. Cascades over builder `BoardGroup` membership — the same set `UsageCheck#builder_group` cascades on delete, so a built set publishes, unpublishes, and deletes as one unit. Deliberately not `predictive_board_id` descendants: hand-linked tiles outside the set aren't owned by the root. Members are matched with `published IS DISTINCT FROM ?` so a legacy NULL row is still swept.

**A 409 warn-then-confirm guard on `PUT /boards/:id`**, mirroring the delete flow's protocol so no new route was needed. Returns `publish_cascade_confirmation_required` with `cascade: { action, board_group, affected: { count, names } }`. The guard runs **before any attribute is assigned**, so a declined cascade writes nothing — including the independent side effects of `find_or_create_images_from_word_list`, which there's a spec for. Re-sending with `confirm=true` saves the root and applies the cascade in one transaction.

`published` is admin-only (`board_params` strips it for non-admins), so the cascade is unreachable for regular users.

## Review-caught bugs worth naming

- **`confirm=true` + `image_ids_to_remove` was an unbreakable confirmation loop.** The guard ran before that early-return branch, so confirming returned 200 with nothing published and the user could retry forever. The guard is now skipped entirely when that branch will handle the request.
- **`published: nil` could NULL out any board's column.** The `.present?` → `.key?` fix incidentally removed the block on `nil` (`nil.present?` was also false). The assignment now casts and requires a real boolean, matching the cascade guard.

## Test plan

`bundle exec rspec spec/services/boards/publish_cascade_spec.rb spec/requests/api/boards_publish_cascade_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/boards_destroy_spec.rb spec/requests/api/board_read_only_spec.rb spec/requests/api/board_groups_spec.rb`

**146 examples, 0 failures.**

Covers: 409 fires and writes nothing; `confirm=true` cascades both directions; already-synced sets don't prompt; non-builder-root boards never prompt; non-admins can't reach it; `published: nil` leaves the column untouched; NULL members are swept.

Not exercised against a running app — the manual click-through (publish → confirm → tap a folder tile on `/pb/<slug>` signed-out) hasn't been done.

## Docs

`.claude-notes/boards-and-teams.md` gains a "Publish cascade (warn + confirm)" section next to the delete one; pointer in `.claude-notes/board-builder.md`; CHANGELOG entry.

## Follow-ups filed

- brittanyjohns/itty_bitty_boards#586 — folder pages created *after* a build never join the builder `BoardGroup`, so the cascade misses them on hand-extended sets.
- brittanyjohns/itty-bitty-frontend#633 — the publish toggle is shown to non-admins while the backend discards it.

Frontend counterpart: brittanyjohns/itty-bitty-frontend — **merge this first**, the frontend's 409 handling is inert without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)