### PR TITLE
fix(boards): make "Regenerate from tiles" update the cover every time

### DIFF
--- a/.claude-notes/artifact-generation-services.md
+++ b/.claude-notes/artifact-generation-services.md
@@ -60,9 +60,13 @@ natural parent record (not a Board, not a Profile), so a small model owns it.
 
 - **`MarketingAsset`** (`app/models/marketing_asset.rb`): `has_one_attached :file`
   written at a **deterministic** S3 key (`marketing_assets/<slug>.pdf`) via
-  purge-then-reupload — same stable-key trick as `GeneratePreviewAssets#stable_preview_key`.
-  Prod S3 is `public: true`, so `#file_url` (CDN_HOST + key, `file.url` fallback)
-  is a permanent, unsigned CDN URL that never changes across regenerations.
+  purge-then-reupload. Prod S3 is `public: true`, so `#file_url` (CDN_HOST + key,
+  `file.url` fallback) is a permanent, unsigned CDN URL that never changes across
+  regenerations. **The stable key is a trade-off, not a pattern to copy:**
+  CloudFront omits the query string from its cache key, so re-uploading to a warm
+  key keeps serving the old file until the edge TTL expires — re-publishing needs
+  a CloudFront invalidation. Board previews hit this and moved to a
+  per-generation key (`GeneratePreviewAssets#versioned_preview_key`).
   `MarketingAsset.upsert_pdf!(slug:, bytes:, title:, kind:)` is idempotent.
 - **Endpoints** (behind `INTERNAL_API_KEY`): `POST /api/internal/marketing_assets`
   (multipart `file` + `slug`) → `{ slug, title, kind, url }`;

--- a/.claude-notes/marketing-assets.md
+++ b/.claude-notes/marketing-assets.md
@@ -15,11 +15,16 @@ which already depends on `pdf-lib`.
 
 - **`MarketingAsset` (`app/models/marketing_asset.rb`) hosts a PDF at a stable
   slug.** `has_one_attached :file` written at a **deterministic** S3 key
-  (`marketing_assets/<slug>.pdf`) via purge-then-reupload — the same
-  stable-key pattern as `Boards::GeneratePreviewAssets#stable_preview_key`.
+  (`marketing_assets/<slug>.pdf`) via purge-then-reupload.
   Production S3 is `public: true`, so `#file_url` (CDN_HOST + key, `file.url`
   fallback) is a permanent, unsigned CDN URL that **never changes across
-  regenerations**. `MarketingAsset.upsert_pdf!(slug:, bytes:, title:, kind:)` is
+  regenerations**. The stable key is required here (the /classroom page
+  hardcodes the URL) but carries a cost: CloudFront omits the query string from
+  its cache key, so a re-published kit keeps serving the old PDF until the edge
+  TTL expires — it needs a CloudFront invalidation. Do not copy the pattern for
+  mutable assets; board previews use a per-generation key instead
+  (`Boards::GeneratePreviewAssets#versioned_preview_key`).
+  `MarketingAsset.upsert_pdf!(slug:, bytes:, title:, kind:)` is
   idempotent — re-running the kit build overwrites in place, so the
   `KIT_DOWNLOAD_URL` is safe to hardcode on the frontend.
 - **Stable slugs for kit boards (`replace_existing_slug`).** The internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **"Regenerate from tiles" updates the board cover every time, not just the
+  first.** Regenerating produced a correct new snapshot on the server, but every
+  version was written to the same CDN path — and the CDN ignores the `?v=`
+  cache-buster the app appended, so once an edge had cached a board's cover it
+  kept serving that copy. The app reported "Cover updated from your board" while
+  the picture stayed put, and appeared to work intermittently because edge
+  servers cache independently. Each regeneration now publishes to its own path,
+  which the CDN has never seen, so the new cover is visible immediately. The
+  superseded image is deleted, so nothing accumulates.
 - **Tile text casing is consistent across a board.** A tile inherited whatever
   casing its creation path happened to use — paths handing over a Title Cased
   word list produced `Higher`, paths falling through to the image's lowercase

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -344,10 +344,12 @@ class Board < ApplicationRecord
     if ENV["ACTIVE_STORAGE_SERVICE"] == "amazon" || Rails.env.production?
       cdn_host = ENV["CDN_HOST"]
       if cdn_host
-        # Key is deterministic (board_previews/<id>/preview.png) so the URL is
-        # stable. Append `?v=<blob.created_at>` so clients and CloudFront pick
-        # up the new PNG on regeneration — the service purges + reuploads, so
-        # each regen mints a fresh blob row.
+        # Cache invalidation rides on the KEY, not on `?v=`: GeneratePreviewAssets
+        # writes every regeneration to its own path, because CloudFront omits the
+        # query string from its cache key (a `?v=` buster on a fixed key is a
+        # no-op — see Boards::GeneratePreviewAssets#versioned_preview_key). `?v=`
+        # is kept only as belt-and-braces for browser caches; it is not what makes
+        # a regenerated cover visible.
         "#{cdn_host}/#{preview_image.key}?v=#{preview_image.blob.created_at.to_i}"
       else
         preview_image.url # Fallback to the direct Active Storage URL

--- a/app/models/marketing_asset.rb
+++ b/app/models/marketing_asset.rb
@@ -4,12 +4,20 @@
 # the attachment.
 #
 # The file is attached at a DETERMINISTIC S3 key (`marketing_assets/<slug>.pdf`)
-# with purge-then-reupload on every regeneration, mirroring
-# Boards::GeneratePreviewAssets#stable_preview_key. Production S3 is
+# with purge-then-reupload on every regeneration. Production S3 is
 # `public: true`, so the resulting URL is a permanent, unsigned, CDN-stable
 # link that never changes across re-runs — exactly what the /classroom page's
-# KIT_DOWNLOAD_URL needs. Re-running the kit build is therefore idempotent:
-# same slug -> same URL, new bytes.
+# hardcoded KIT_DOWNLOAD_URL needs. Re-running the kit build is therefore
+# idempotent: same slug -> same URL, new bytes.
+#
+# CAVEAT: the stable key is a deliberate trade-off here, not a pattern to copy.
+# CloudFront omits the query string from its cache key, so new bytes at an
+# already-warm key keep serving the OLD file until the edge TTL expires — a
+# regenerated kit is not immediately visible to downloaders. Board previews hit
+# exactly this and moved to a per-generation key
+# (Boards::GeneratePreviewAssets#versioned_preview_key); this model cannot,
+# because the published URL must never change. Re-publishing the kit needs a
+# CloudFront invalidation.
 class MarketingAsset < ApplicationRecord
   has_one_attached :file
 

--- a/app/services/boards/generate_preview_assets.rb
+++ b/app/services/boards/generate_preview_assets.rb
@@ -64,26 +64,36 @@ module Boards
     def attach_png
       png_data = Grover.new(html, **grover_options).to_png
 
-      # Purge the existing attachment synchronously so the S3 object at the
-      # deterministic key is removed before we PUT the new one. Without this,
-      # `create_and_upload!` would hit the unique index on active_storage_blobs.key.
+      # Purge the superseded attachment (and its S3 object) before uploading the
+      # replacement, so old previews don't accumulate in the bucket.
       board.preview_image.purge if board.preview_image.attached?
 
       blob = ActiveStorage::Blob.create_and_upload!(
         io: StringIO.new(png_data),
         filename: "#{board.slug}-preview.png",
         content_type: "image/png",
-        key: stable_preview_key,
+        key: versioned_preview_key,
       )
       board.preview_image.attach(blob)
     end
 
-    # Deterministic per-board key so the public CDN URL never changes across
-    # regenerations. Stale-URL chasing in callers becomes unnecessary; clients
-    # cache-bust on the `?v=<updated_at>` query string emitted by
-    # Board#preview_image_url.
-    def stable_preview_key
-      "board_previews/#{board.id}/preview.png"
+    # A NEW key — and therefore a new CDN path — for every regeneration.
+    #
+    # This deliberately is NOT one stable key per board. The CloudFront
+    # distribution in front of the bucket does not include the query string in
+    # its cache key, so the `?v=<blob.created_at>` buster on
+    # Board#preview_image_url invalidates nothing: after the first generation
+    # warmed the edge, every later regeneration wrote fresh bytes to a key whose
+    # cached copy kept being served. Covers appeared to update ("Cover updated
+    # from your board") while the picture never changed, intermittently, because
+    # edge servers cache independently.
+    #
+    # Callers can safely depend on a changing path: display_image_url /
+    # preview_image_url resolve live from the attachment, and the denormalized
+    # settings["preset_display_image_url"] is refreshed in #call, in the same
+    # operation that produced the PNG.
+    def versioned_preview_key
+      "board_previews/#{board.id}/#{Time.current.to_i}-#{SecureRandom.hex(4)}/preview.png"
     end
 
     def attach_pdf

--- a/spec/services/boards/generate_preview_assets_spec.rb
+++ b/spec/services/boards/generate_preview_assets_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Boards::GeneratePreviewAssets, type: :service do
   end
 
   describe "#call(generate_png: true)" do
-    it "attaches the preview image at a deterministic key" do
+    it "attaches the preview image under the board's preview namespace" do
       described_class.new(
         board: board,
         routes: Rails.application.routes.url_helpers,
@@ -23,25 +23,43 @@ RSpec.describe Boards::GeneratePreviewAssets, type: :service do
 
       board.reload
       expect(board.preview_image).to be_attached
-      expect(board.preview_image.key).to eq("board_previews/#{board.id}/preview.png")
+      expect(board.preview_image.key).to match(%r{\Aboard_previews/#{board.id}/[^/]+/preview\.png\z})
     end
 
-    it "keeps the same blob key across regenerations" do
+    # The CDN in front of the bucket does not include the query string in its
+    # cache key, so a `?v=` buster on a fixed key never invalidates anything —
+    # covers silently stopped updating after the first regeneration. A distinct
+    # PATH per generation is the only reliable invalidation. Do not "simplify"
+    # this back to one stable key.
+    it "gives every regeneration its own key so the CDN can't serve a stale PNG" do
       service = described_class.new(
         board: board,
         routes: Rails.application.routes.url_helpers,
       )
 
       service.call(generate_png: true)
-      board.reload
-      first_key = board.preview_image.key
+      first_key = board.reload.preview_image.key
 
       service.call(generate_png: true)
-      board.reload
-      second_key = board.preview_image.key
+      second_key = board.reload.preview_image.key
 
-      expect(second_key).to eq(first_key)
-      expect(second_key).to eq("board_previews/#{board.id}/preview.png")
+      expect(second_key).not_to eq(first_key)
+      expect(second_key).to start_with("board_previews/#{board.id}/")
+    end
+
+    it "purges the superseded object so old previews don't accumulate" do
+      service = described_class.new(
+        board: board,
+        routes: Rails.application.routes.url_helpers,
+      )
+
+      service.call(generate_png: true)
+      first_blob = board.reload.preview_image.blob
+
+      service.call(generate_png: true)
+
+      expect(ActiveStorage::Blob.where(id: first_blob.id)).to be_empty
+      expect(board.preview_image.service.exist?(first_blob.key)).to be(false)
     end
 
     it "refreshes the preset display image URL to the freshly generated preview" do

--- a/spec/sidekiq/generate_board_preview_job_spec.rb
+++ b/spec/sidekiq/generate_board_preview_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
 
     board.reload
     expect(board.preview_image).to be_attached
-    expect(board.preview_image.key).to eq("board_previews/#{board.id}/preview.png")
+    expect(board.preview_image.key).to match(%r{\Aboard_previews/#{board.id}/[^/]+/preview\.png\z})
     # The preset must point at the generated preview blob, but the exact URL
     # form depends on the configured storage backend: the Disk service yields a
     # signed /rails/active_storage/ route (CI default), while an S3/CDN-backed
@@ -28,7 +28,7 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
     # so the test isn't coupled to a developer's local storage config.
     expect(board.settings["preset_display_image_url"]).to be_present
     expect(board.settings["preset_display_image_url"]).to match(
-      %r{/rails/active_storage/|board_previews/#{board.id}/preview\.png},
+      %r{/rails/active_storage/|board_previews/#{board.id}/[^/]+/preview\.png},
     )
   end
 


### PR DESCRIPTION
## Summary

"Regenerate from tiles" appeared to work only once per board: the app reported **"Cover updated from your board"** while the picture stayed put.

The backend was never at fault. Every regeneration rendered and uploaded a correct new PNG. The problem was that all of them went to **one fixed key** (`board_previews/<id>/preview.png`), with a `?v=<blob.created_at>` query string as the cache-buster — and **CloudFront omits the query string from its cache key** on this distribution, so that buster invalidated nothing. Once an edge had cached a board's cover (the objects carry no `Cache-Control`, so the long default TTL applies), every later regeneration wrote fresh bytes nobody could see.

That also explains why it looked intermittent: edge servers cache independently, so it worked whenever a request happened to land on a cold one.

## Evidence

Probing the production distribution with `v=` values that had **never been requested**:

```
x-cache: Hit from cloudfront   age: 1139   last-modified: 15:46:19
x-cache: Hit from cloudfront   age: 1139   last-modified: 15:46:19
x-cache: Miss from cloudfront              last-modified: 16:28:47   <- cold edge, real origin fetch
x-cache: Hit from cloudfront   age: 1      last-modified: 16:28:47
```

A cache entry 19 minutes *older than the URL itself* — conclusive that `?v=` is not part of the cache key. The `Miss` line confirms S3 held the fresh object all along.

Ruled out along the way, each with a check rather than a guess: the Sidekiq job (ran and minted new blobs both times in prod logs), the API payload (returns a fresh URL), the rendered PNG (downloaded it — matches all 48 current tiles), the service worker (no `cdn-images` cache exists, and its route regex is `$`-anchored so `?v=` URLs never match it), `ion-img` src handling, and the `BoardForm` poll loop.

## Change

`Boards::GeneratePreviewAssets` now writes each regeneration to its own path — `board_previews/<id>/<ts>-<rand>/preview.png` — which the CDN has never seen, so it is a guaranteed miss. The superseded object is still purged, so nothing accumulates.

The fixed key came from #138, which adopted it to stop stale-URL chasing across denormalized copies. **That motivation is gone:** #408 made `display_image_url` / `preview_image_url` resolve live from the attachment, and `settings["preset_display_image_url"]` is refreshed in the same operation that produces the PNG. `?v=` is kept only as belt-and-braces for browser caches; there's a comment at the key so it doesn't get "simplified" back.

## Reviewer notes

- **`MarketingAsset` has the same latent staleness** but is deliberately left alone: the /classroom page hardcodes its URL, so the key must stay stable. Documented instead — re-publishing the kit needs a CloudFront invalidation.
- **Separate defect, not fixed here** (different repo): `generatePreviewImage` in `itty-bitty-frontend/src/data/boards.ts` never checks `response.ok`, so a 403/429/500 is swallowed as success and the UI shows a false "Generating cover…". Since that endpoint is gated by `check_board_editable!`, on a free plan every non-editable board fails silently. Tracked separately.
- An optional follow-up: now that each path is immutable, setting a long `Cache-Control` on these uploads would be strictly better for CDN performance. Skipped here to keep the change minimal and avoid touching storage config.

## Test plan

- Rewrote the spec that asserted `keeps the same blob key across regenerations` — it encoded the bug — into one asserting each regeneration gets its own key.
- Added a spec that the superseded object is actually deleted from the service (this failed before the change: purge-then-reupload at the same key meant the object was immediately recreated).
- Updated the two key assertions in `spec/sidekiq/generate_board_preview_job_spec.rb`.

```
bundle exec rspec spec/services/boards spec/sidekiq spec/models/marketing_asset_spec.rb
=> 628 examples, 0 failures, 1 pending
```

Full verification of the CDN behaviour itself requires a deploy — the caching behaviour is proven above and the fix follows directly, but the new path can't be observed being served until it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)