### PR TITLE
feat(printables): generate cover-wrapped board printables in-app

### DIFF
--- a/.claude-notes/artifact-generation-services.md
+++ b/.claude-notes/artifact-generation-services.md
@@ -84,3 +84,64 @@ natural parent record (not a Board, not a Profile), so a small model owns it.
   tags render realistic sample data without a real child.
 
 See `.claude-notes/classroom-kit-hosting-handoff.md` for the end-to-end pipeline.
+
+## 7. Cover-wrapped board printables — the *sellable* PDF (SHIPPED)
+
+The in-app port of the `speakanyway-printables` Node pipeline's PDF-producing
+core (its steps 05, 08, 09). Engine #3 renders one board page; this wraps a
+board — or its whole subboard tree — in cover / how-to-use / license / credits
+and merges everything into a finished product PDF. Admin-only.
+
+- **Model:** `BoardPrintable` (`has_many_attached :files`, status
+  pending/generating/complete/failed, `board_ids` = the walked tree in BFS
+  order). Storage keys are scoped by record id
+  (`board_printables/<id>/<filename>`) so a re-run never collides on the unique
+  `active_storage_blobs.key` index. `#files_view` returns
+  `[{ variant, filename, url, byte_size }]` on the `CDN_HOST + key` convention.
+  Deliberately **not** `board.pdf_file` — that's engine #3's cached single-page
+  export and it rides in `Board#api_view`.
+- **Services** (`app/services/boards/printables/`): `CollectPages` (BFS walk +
+  two Grover renders per board), `RenderWrappers` (the four wrapper pages),
+  `MergePdf` (combine_pdf), `Generate` (orchestrates + attaches + stamps).
+  Job: `app/sidekiq/generate_board_printable_job.rb`.
+- **Endpoints:** `POST /api/admin/boards/:board_id/printables` (202),
+  `GET /api/admin/board_printables/:id`,
+  `GET /api/admin/board_printables/:id/download_url`.
+- **Output shape:** single board = **one** file (`<slug>.pdf`, variant `full`,
+  6 pages: cover, how-to-use, colour, low-ink, license, credits). Subboard tree
+  = **two** files (`<slug>.color.pdf` / `<slug>.low-ink.pdf`, variants `color`
+  and `low_ink`), each fully wrapped, `2N + 8` pages total. There is no combined
+  master; the cover is duplicated into both so either file stands alone.
+
+Things that will bite a future change:
+
+- **The tree size is checked in the controller, synchronously, before any record
+  exists.** An over-cap tree must answer **422**, and a job that raises cannot.
+  `CollectPages.walk_board_tree` is a class method for exactly this reason; the
+  job re-walks when it renders. Moving the check into the job would leave a
+  record stuck in `generating` with nothing attached.
+- **The walk raises rather than truncating.** Silently dropping boards ships an
+  incomplete product that looks complete. `max_boards` is clamped to
+  `MAX_BOARDS_CEILING` (100) — every board is two Chrome renders.
+- **Each board page's QR targets its own board**; only the cover's targets the
+  root. A buyer scanning page 5 of a 9-board bundle must land on that board.
+- **`hide_header: false` on every board page** — the QR lives inside the header
+  in `print.html.erb`, so hiding the header also kills the per-page QR. There is
+  no header-less-with-QR combination.
+- **Wrappers are a separate template/layout pair**
+  (`app/views/api/board_printables/*` + `layouts/pdf_printable.html.erb`), never
+  a branch inside `layouts/pdf.html.erb` — same rule as `pdf_marketing`.
+- **The layout deliberately does not `@import` Nunito** the way the pipeline's
+  `base.css` does. A network fetch inside PDF generation is a flaky failure
+  mode; it uses the system stack, matching `layouts/pdf.html.erb`. A spec
+  asserts the absence of `fonts.googleapis.com`.
+- **Merging, not one long HTML print**, is what preserves each page's own
+  orientation — portrait wrappers next to landscape board pages (any board with
+  ≥6 tiles goes landscape via `RenderAssetData#resolved_landscape`).
+
+**Licensing:** admin-only internal generation is fine, but *selling* the output
+is not automatically fine — `Images::CommercialLicense` is the gate, and per
+`.claude-notes/internal-api.md` only a minority of the image library is
+commercial-safe (ARASAAC, the largest source, is CC BY-NC-SA).
+
+Design + full context: `.claude-notes/board-printable-in-app-handoff.md`.

--- a/.claude-notes/board-printable-in-app-handoff.md
+++ b/.claude-notes/board-printable-in-app-handoff.md
@@ -1,0 +1,306 @@
+# Handoff: cover-wrapped board printables in-app (backend)
+
+**Date:** 2026-08-06 · **Status:** not started
+**Full plan:** `../drafts/board-printable-in-app-plan.md` (this doc is self-contained; the plan adds context)
+**Counterpart:** `../itty-bitty-frontend/.claude-notes/board-printable-in-app-handoff.md`
+**Issue:** none filed
+
+## What we're building
+
+An admin-only endpoint that generates a **cover-wrapped, multi-page printable
+PDF** for a board (optionally the board plus its whole subboard tree) and
+persists it via ActiveStorage.
+
+This ports three steps out of the `speakanyway-printables` Node pipeline —
+its steps 05 (collect board pages), 08 (render wrapper pages), 09 (merge) —
+into Rails. Everything downstream in that pipeline (listing copy, marketing
+images, Drive upload, Etsy/Gumroad) stays where it is and is out of scope.
+
+**Target output, single board (6 pages):**
+
+```
+cover → how-to-use → board (color) → board (low-ink) → license → credits
+```
+
+**Target output, N-board subboard bundle (2N + 8 pages, split into two files):**
+
+```
+<slug>.color.pdf    = cover → how-to-use → N color pages   → license → credits
+<slug>.low-ink.pdf  = cover → how-to-use → N low-ink pages → license → credits
+```
+
+Board pages are ordered breadth-first from the root, root first. The color half
+comes before the low-ink half, matching the pipeline.
+
+## Decisions (already made — don't re-litigate)
+
+1. **Add a PDF-merge gem.** There is no Ruby merge library in app code today.
+   Per-page Grover renders, merged afterwards — this mirrors the pipeline's
+   `pdf-lib` usage exactly, and preserves each page's own orientation for free.
+   **Ask Brittany before adding it** (repo rule), and **verify the license is
+   compatible with a commercial closed-source product** — HexaPDF is AGPL-3.0
+   with a paid commercial option and is the wrong choice for that reason.
+   Prefer a permissive pure-Ruby option such as `combine_pdf`; read the gemspec
+   rather than trusting this note.
+2. **Both single-board and subboard-tree modes are in scope.**
+3. **New `BoardPrintable` model**, `has_many_attached :files`. Do **not** reuse
+   `board.pdf_file` — that's the existing single-page cached export and it's
+   exposed via `Board#api_view`.
+4. **`API::Admin::` namespace**, since the frontend admin UI is the caller.
+5. Frontend does not add a client-side admin guard; the backend 403 is the
+   real gate. Your authorization must therefore actually be correct.
+
+## Current state — what already exists
+
+### The board-page renderer (most of pipeline step 05 is already yours)
+
+`GET /api/internal/boards/:id/export.pdf`
+(`app/controllers/api/internal/boards_controller.rb:117-164`, routed at
+`config/routes.rb:438`) already renders exactly the board pages the printable
+needs. The printables pipeline is just an HTTP client for it — for a color page
+it sends:
+
+```
+GET /api/internal/boards/<id>/export.pdf
+    ?qr_code=true
+    &qr_target_url=https%3A%2F%2Fapp.speakanyway.com%2Fpb%2F<id>
+    &screen_size=lg&hide_colors=0&hide_header=0
+```
+
+and the low-ink page is identical with `hide_colors=1`.
+
+**Do not have Rails HTTP-call its own endpoint.** Go straight to the shared
+core, `Boards::RenderAssetData` (`app/services/boards/render_asset_data.rb:4`),
+which takes `board:`, `screen_size:`, `hide_colors:`, `hide_header:`,
+`include_qr:`, `qr_target_url:` and returns the assigns for
+`app/views/api/boards/print.html.erb` + `app/views/layouts/pdf.html.erb`.
+`api/internal/boards_controller.rb:117-164` is the reference for wiring assigns
+→ `render_to_string` → `Grover.new(html, **opts).to_pdf`.
+
+Two behaviours to know:
+
+- **Orientation is automatic.** `#resolved_landscape`
+  (`render_asset_data.rb:68-72`) makes any board with ≥6 tiles landscape. So a
+  finished printable legitimately mixes portrait wrappers with landscape board
+  pages. The merge gem preserves that; don't try to normalize it.
+- **`hide_header=1` also kills the QR**, because the QR lives inside the header
+  in `print.html.erb`. There is no header-less-with-QR combination. The
+  printable wants `hide_header=0` on every board page, so this doesn't bite —
+  just don't "clean up" the header later expecting the QR to survive.
+
+### Grover
+
+`Gemfile:148-149` (`grover`, `rqrcode`); global config at
+`config/initializers/grover.rb:3-15` — Letter, `wait_until: "networkidle0"`,
+`--no-sandbox`. The configured timeout is enormous, which is exactly why
+multi-page generation belongs on Sidekiq and never on a request thread.
+
+### ActiveStorage
+
+Services in `config/storage.yml`: `test` → Disk, `amazon` → S3 with
+`public: true`. Production uses `:amazon` (`config/environments/production.rb:54`).
+Because the bucket is public, **URLs are `CDN_HOST + key`, not presigned** —
+follow `Board#pdf_url` (`app/models/board.rb:351-363`) and
+`MarketingAsset#file_url` (`app/models/marketing_asset.rb:53-68`), both of which
+return nil rather than raising when nothing is attached.
+
+The canonical attach-a-generated-file pattern is
+`MarketingAsset#attach_pdf!` (`app/models/marketing_asset.rb:31-49`) —
+deterministic key, purge before re-attach so the unique index on `blobs.key`
+doesn't collide.
+
+### Admin auth
+
+`User#admin?` is a **role string**, not a boolean column
+(`app/models/user.rb:940-942` → `role == "admin"`).
+
+Copy `API::Admin::ApplicationController`
+(`app/controllers/api/admin/application_controller.rb:1-28`): it
+`prepend_before_action :authenticate_admin!` and looks the user up by
+`authentication_token` **scoped to `role: "admin"`**. Routes live under
+`namespace :api { namespace :admin { … } }` at `config/routes.rb:526-566`;
+`app/controllers/api/admin/boards_controller.rb:3` is a subclass example.
+
+### Sidekiq
+
+Jobs live in **`app/sidekiq/`** (not `app/jobs/`), plain classes with
+`include Sidekiq::Job`, invoked with `.perform_async`. Queues are defined in
+`config/sidekiq.yml`. The convention to copy is
+`app/sidekiq/generate_board_preview_job.rb`: thin job, delegates to a service
+under `app/services/`, service renders **and attaches atomically**, failures
+propagate so Sidekiq retries.
+
+### The subboard link
+
+`board_images.predictive_board_id` (`app/models/board_image.rb:23`), with
+`Board#predictive_board_images` (`app/models/board.rb:90`). **No Ruby tree walk
+exists yet** — the BFS lives only in the pipeline's TypeScript.
+
+## Work items
+
+### 1. `BoardPrintable` model + migration
+
+```ruby
+# db/migrate/..._create_board_printables.rb
+create_table :board_printables do |t|
+  t.references :board, null: false, foreign_key: true   # the ROOT board
+  t.references :created_by, foreign_key: { to_table: :users }
+  t.string  :status, null: false, default: "pending"    # pending/generating/complete/failed
+  t.boolean :include_subboards, null: false, default: false
+  t.integer :max_boards, null: false, default: 25
+  t.string  :topic
+  t.integer :page_count
+  t.jsonb   :board_ids, null: false, default: []        # every board in the bundle, BFS order
+  t.text    :error_message
+  t.timestamps
+end
+add_index :board_printables, [:board_id, :status]
+```
+
+`has_many_attached :files` — one attachment for single-board, two (color +
+low-ink) for a bundle. Storage keys scope by record id so re-runs never collide:
+`board_printables/#{id}/#{filename}`.
+
+Expose a `#files_view` returning `[{ variant:, filename:, url:, byte_size: }]`
+using the `CDN_HOST + key` convention above.
+
+### 2. `Boards::Printables::CollectPages` (pipeline step 05)
+
+Input: root board, `include_subboards`, `max_boards`.
+Output: ordered array of `{ pdf_bytes:, page_number:, board_id:, board_name:, variant: }`.
+
+- Resolve the root board.
+- If `include_subboards`, BFS from the root over each cell's
+  `predictive_board_id`. Dedupe by board id — seed the visited set with the root
+  so a child linking back to the root doesn't loop. Skip self-links. **Raise**
+  when the unique-board count would exceed `max_boards` (the pipeline throws
+  rather than truncating; match that — silently dropping boards would ship an
+  incomplete product).
+- Render each board twice through `Boards::RenderAssetData` + Grover:
+  `hide_colors: false` for the color half, `hide_colors: true` for low-ink.
+  Always `hide_header: false`, `screen_size: "lg"`, `include_qr: true`.
+- **Each page's QR targets its own board** — `https://app.speakanyway.com/pb/<that board's id>`.
+  This matters: a buyer scanning page 5 of a 9-board bundle should land on that
+  board, not the root. Only the cover QR points at the root.
+- Page order: all color pages (BFS order, root first), then all low-ink pages in
+  the same board order.
+
+### 3. `Boards::Printables::RenderWrappers` (pipeline step 08)
+
+Four pages, each its own Grover render, each Letter **portrait**:
+
+| Page | Content | Tokens |
+|---|---|---|
+| cover | board title, subtitle, logo, QR → **root** board | title, subtitle, logo, qr |
+| how-to-use | print/laminate guidance; wording branches on single vs "set of N" | board count |
+| license | personal-use terms | — |
+| credits | thanks + logo + QR | logo, qr |
+
+Follow the repo's existing rule that a distinct look is a **separate
+template/layout pair, never a conditional inside the shared one** — the comment
+at `app/controllers/api/internal/boards_controller.rb:136-139` states this for
+the marketing skin. So add `app/views/api/board_printables/_cover.html.erb`
+etc. plus a `layouts/pdf_printable.html.erb`; do not add branches to
+`layouts/pdf.html.erb`.
+
+QR generation uses `rqrcode`, already in the Gemfile;
+`app/services/boards/asset_rendering.rb` has the existing helpers. The pipeline
+renders its QR navy `#13496f` on cream `#FBF7F1` at 400px — match it so the
+in-app output looks like the pipeline's.
+
+**Fonts:** the pipeline's wrappers `@import` Nunito from Google Fonts at render
+time. Do not copy that — a network fetch inside PDF generation is a flaky
+failure mode. Match however `app/views/layouts/pdf.html.erb` already handles
+fonts.
+
+The how-to-use copy is worth lifting near-verbatim from the pipeline
+(`speakanyway-printables/src/plugins/aac/product-types/existing-board.ts`,
+`buildHowToUseHtml`) so in-app and pipeline products read identically.
+
+### 4. `Boards::Printables::MergePdf` (pipeline step 09)
+
+- **Single board (N=1):** one file — cover, how-to-use, page 1 (color),
+  page 2 (low-ink), license, credits.
+- **Bundle (N>1):** two files, no combined master. Each variant is fully
+  wrapped: cover → how-to-use → that variant's N pages → license → credits.
+  The cover and its root QR are duplicated into both, by design.
+
+Filenames key off the root board's slug (falling back to `board-<id>`):
+`<slug>.pdf`, or `<slug>.color.pdf` / `<slug>.low-ink.pdf`.
+
+### 5. `Boards::Printables::Generate` + `GenerateBoardPrintableJob`
+
+Orchestrator service calling 2 → 3 → 4, then attaching the results and setting
+`status`, `page_count`, `board_ids`. Job in `app/sidekiq/`, thin, delegating.
+Set `status: "failed"` with `error_message` on rescue, then re-raise so Sidekiq
+retries.
+
+### 6. `API::Admin::BoardPrintablesController`
+
+Subclass `API::Admin::ApplicationController`. Routes under the existing
+`namespace :api { namespace :admin { … } }`:
+
+| Verb | Path | Does |
+|---|---|---|
+| POST | `/api/admin/boards/:board_id/printables` | creates the record, enqueues the job, returns it (202) |
+| GET | `/api/admin/board_printables/:id` | status poll |
+| GET | `/api/admin/board_printables/:id/download_url` | `{ files: [{ variant, filename, url }] }` |
+
+Accepts `include_subboards`, `max_boards`, `topic`. Returns 422 with a clear
+message when the tree exceeds `max_boards`.
+
+## Testing
+
+Request specs go in `spec/requests/api/admin/`. Factories are all in
+`spec/factories.rb`: `:admin_user` (`:94`), `:user` (`:88`, role `"user"`),
+`:board` (`:113`), `:board_image` (`:136`), `:image` (`:126`).
+
+Copy the Chrome-avoiding stubs from
+`spec/requests/api/internal/board_pdf_export_spec.rb`:
+
+```ruby
+fake_grover = instance_double(Grover, to_pdf: "%PDF-fake")
+allow(Grover).to receive(:new).and_return(fake_grover)
+```
+
+Authorization matrix — prove every row:
+
+| Caller | Expect |
+|---|---|
+| no token | 401 |
+| valid token, `role: "user"` | 401 |
+| valid token, `role: "admin"` | 200/202 |
+| admin, board belonging to another user | 200 (admin is global — assert deliberately so the intent is recorded) |
+
+Behaviour to prove:
+
+- single board → one attachment, 6 pages, correct page order
+- `include_subboards` → BFS order with root first, root's own subboard link not
+  re-walked, duplicate board ids visited once
+- tree over `max_boards` → 422, nothing attached, no partial record left in
+  `generating`
+- bundle → exactly two attachments, color and low-ink, each fully wrapped
+- each board page's QR target is its own board; the cover's is the root
+- job failure → `status: "failed"` with `error_message` populated
+- re-running for the same board doesn't collide on `blobs.key`
+
+Also add a service spec for the BFS walk specifically — it's the piece most
+likely to regress and the cheapest to test in isolation.
+
+Run `bundle exec rspec spec/requests/api/admin spec/services/boards` before
+opening the PR.
+
+## Deploy notes
+
+- **One new gem** — get Brittany's explicit OK first.
+- **One migration**, `board_printables`. No backfill.
+- **No new ENV vars.**
+- Ships independently of the frontend; it's an admin-only API with no UI until
+  the counterpart PR lands.
+
+## Wrap-up
+
+Follow this repo's CLAUDE.md for git workflow and conventions. Open the PR and
+stop — never merge. Commit this doc in the PR so it survives the session.
+Update `.claude-notes/artifact-generation-services.md` — it catalogs the
+printable engines and this adds a fourth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Cover-wrapped board printables can be generated in the app.** A sellable,
+  print-ready PDF for a board previously required running the
+  `speakanyway-printables` GitHub Actions pipeline; its PDF-producing core now
+  lives in Rails behind admin-only endpoints. A single board produces one
+  6-page document (cover, how-to-use, colour board, low-ink board, license,
+  credits). Asking for subboards walks the board's linked-board tree and
+  returns two fully-wrapped files — a colour bundle and a low-ink bundle —
+  with each board page's QR pointing at that board rather than the root. Work
+  runs on Sidekiq; a tree over the board cap is refused up front with a 422
+  rather than half-built.
+
 ### Changed
 
 - **Staging no longer sends email to real people.** Staging runs against live

--- a/Gemfile
+++ b/Gemfile
@@ -147,8 +147,9 @@ gem "browser", "~> 5.3"
 gem "geocoder", "~> 1.8" # Coarse IP→location lookup for safety-profile view alerts
 gem "annotaterb", "~> 4.13" # Rails 8-compatible successor to the annotate gem
 
-gem "grover"     # HTML → PDF via headless Chrome
-gem "rqrcode"    # Generate QR code PNGs
+gem "grover"      # HTML → PDF via headless Chrome
+gem "rqrcode"     # Generate QR code PNGs
+gem "combine_pdf" # Merge per-page Grover renders into one PDF (MIT, pure Ruby)
 
 gem "devise_invitable", "~> 2.0.10"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chunky_png (1.4.0)
+    combine_pdf (1.0.31)
+      matrix
+      ruby-rc4 (>= 0.1.5)
     concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     crack (1.0.1)
@@ -527,6 +530,7 @@ GEM
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
+    ruby-rc4 (0.1.5)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
       logger
@@ -626,6 +630,7 @@ DEPENDENCIES
   browser (~> 5.3)
   bundler-audit
   capybara
+  combine_pdf
   cssbundling-rails
   debug
   devise

--- a/app/controllers/api/admin/board_printables_controller.rb
+++ b/app/controllers/api/admin/board_printables_controller.rb
@@ -1,0 +1,76 @@
+class API::Admin::BoardPrintablesController < API::Admin::ApplicationController
+  before_action :set_printable, only: [:show, :download_url]
+
+  # POST /api/admin/boards/:board_id/printables
+  def create
+    board = Board.find_by(id: params[:board_id])
+    return render json: { error: "Board not found" }, status: :not_found unless board
+
+    # The tree is walked here, synchronously, BEFORE anything is created —
+    # an over-cap tree has to answer 422, and a job that raises can't. It's a
+    # cheap id-only walk; the job re-walks when it renders.
+    board_ids = Boards::Printables::CollectPages.walk_board_tree(
+      board: board,
+      include_subboards: include_subboards?,
+      max_boards: max_boards,
+    ).map(&:id)
+
+    printable = BoardPrintable.create!(
+      board: board,
+      created_by: current_admin,
+      status: "pending",
+      include_subboards: include_subboards?,
+      max_boards: max_boards,
+      topic: params[:topic].presence,
+      board_ids: board_ids,
+    )
+
+    GenerateBoardPrintableJob.perform_async(printable.id)
+
+    render json: printable.api_view, status: :accepted
+  rescue Boards::Printables::CollectPages::TreeTooLargeError => e
+    render json: { error: e.message }, status: :unprocessable_content
+  end
+
+  # GET /api/admin/board_printables/:id
+  def show
+    render json: @printable.api_view
+  end
+
+  # GET /api/admin/board_printables/:id/download_url
+  #
+  # Hands back the storage URLs as JSON so the browser can *navigate* to each
+  # file rather than fetch() it — an authenticated fetch is a preflighted CORS
+  # request, and the storage origin has no CORS rule for our origins.
+  def download_url
+    unless @printable.complete? && @printable.files.attached?
+      return render json: { error: "Printable not ready" }, status: :not_found
+    end
+
+    render json: { files: @printable.files_view }
+  end
+
+  private
+
+  def set_printable
+    @printable = BoardPrintable.find_by(id: params[:id])
+    return if @printable
+
+    render json: { error: "Printable not found" }, status: :not_found
+  end
+
+  def include_subboards?
+    return @include_subboards if defined?(@include_subboards)
+
+    @include_subboards = ActiveModel::Type::Boolean.new.cast(params[:include_subboards]) || false
+  end
+
+  # Clamped rather than trusted: every board in the tree is two Chrome
+  # renders, so an unbounded value is a way to hang a worker by typo.
+  def max_boards
+    @max_boards ||= begin
+      requested = params[:max_boards].presence&.to_i || BoardPrintable::DEFAULT_MAX_BOARDS
+      requested.clamp(1, BoardPrintable::MAX_BOARDS_CEILING)
+    end
+  end
+end

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -1,0 +1,103 @@
+# A cover-wrapped, print-ready PDF generated from a board (optionally the
+# board plus its whole subboard tree). Admin-only; this is the in-app port of
+# the speakanyway-printables pipeline's PDF-producing core.
+#
+# One attachment for a single board (the 6-page document), two for a subboard
+# bundle (a colour variant and a low-ink variant, each fully wrapped).
+#
+# Deliberately NOT `board.pdf_file` — that's the existing single-page cached
+# board export and it's exposed through Board#api_view.
+class BoardPrintable < ApplicationRecord
+  STATUSES = %w[pending generating complete failed].freeze
+
+  DEFAULT_MAX_BOARDS = 25
+  # A hard ceiling on what an admin may ask for. Every board in the tree is
+  # two Grover renders, so an unbounded max_boards is a way to hang a Sidekiq
+  # worker for hours by typo.
+  MAX_BOARDS_CEILING = 100
+
+  # The single-board document carries both the colour and the low-ink page,
+  # so it is neither variant — it's the whole printable.
+  VARIANT_FULL = "full".freeze
+  VARIANT_COLOR = "color".freeze
+  VARIANT_LOW_INK = "low_ink".freeze
+
+  belongs_to :board
+  belongs_to :created_by, class_name: "User", optional: true
+
+  has_many_attached :files
+
+  validates :status, inclusion: { in: STATUSES }
+
+  scope :recent, -> { order(created_at: :desc) }
+
+  def complete? = status == "complete"
+
+  def mark_generating! = update!(status: "generating")
+
+  def mark_failed!(message)
+    update!(status: "failed", error_message: message.to_s.truncate(1000))
+  end
+
+  # Scoped by record id so re-running for the same board never collides on the
+  # unique index over active_storage_blobs.key.
+  def storage_key_for(filename) = "board_printables/#{id}/#{filename}"
+
+  def attach_pdf!(filename:, bytes:, variant:)
+    key = storage_key_for(filename)
+    # Purge anything already at the deterministic key first, same reason as
+    # MarketingAsset#attach_pdf! — create_and_upload! would otherwise collide.
+    files.find { |f| f.key == key }&.purge
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(bytes),
+      filename: filename,
+      content_type: "application/pdf",
+      key: key,
+      metadata: { "variant" => variant },
+    )
+    files.attach(blob)
+    blob
+  end
+
+  def files_view
+    return [] unless files.attached?
+
+    files.map do |file|
+      {
+        variant: file.metadata["variant"].presence || VARIANT_FULL,
+        filename: file.filename.to_s,
+        url: url_for_file(file),
+        byte_size: file.byte_size,
+      }
+    end
+  end
+
+  def api_view
+    {
+      id: id,
+      status: status,
+      board_id: board_id,
+      include_subboards: include_subboards,
+      page_count: page_count,
+      error_message: error_message,
+      files: files_view,
+    }
+  end
+
+  private
+
+  # Production S3 is `public: true`, so the URL is CDN_HOST + key rather than
+  # a presigned one — same convention as Board#pdf_url and
+  # MarketingAsset#file_url. Never raises: a download URL must not break the
+  # status response.
+  def url_for_file(file)
+    cdn_host = ENV["CDN_HOST"]
+    return "#{cdn_host}/#{file.key}" if cdn_host.present?
+
+    file.url
+  rescue => e
+    Rails.logger.warn("BoardPrintable#url_for_file failed for #{id}: #{e.class}: #{e.message}")
+    nil
+  end
+end

--- a/app/services/boards/printables/collect_pages.rb
+++ b/app/services/boards/printables/collect_pages.rb
@@ -1,0 +1,144 @@
+# Port of the printables pipeline's step 05 (build-content). Walks the board
+# tree, then renders every board twice — once in colour, once low-ink.
+#
+# The renderer itself already exists: this goes straight to
+# Boards::RenderAssetData rather than HTTP-calling our own
+# /api/internal/boards/:id/export.pdf endpoint the way the Node pipeline does.
+module Boards
+  module Printables
+    class CollectPages
+      # Raised when the walked tree would exceed max_boards. The pipeline
+      # throws rather than truncating, and so do we — silently dropping boards
+      # would ship an incomplete product that looks complete.
+      class TreeTooLargeError < StandardError; end
+
+      # The numeric /pb/ route is the canonical deep link. Slugs are for
+      # humans on the cover; IDs stay in the QR for routing.
+      QR_BASE_URL = "https://app.speakanyway.com/pb".freeze
+
+      Page = Struct.new(:pdf_bytes, :board_id, :board_name, :variant, keyword_init: true)
+
+      # Breadth-first from the root, root first, deduped by board id.
+      #
+      # Exposed as a class method because the controller needs the tree size
+      # *synchronously*, before it creates a record or enqueues anything — a
+      # job that raises can't produce a 422.
+      def self.walk_board_tree(board:, include_subboards: false, max_boards: BoardPrintable::DEFAULT_MAX_BOARDS)
+        return [board] unless include_subboards
+
+        # Seeding visited with the root is what stops a child that links back
+        # to the root from looping forever.
+        visited = Set.new([board.id])
+        ordered = [board]
+        queue = [board]
+
+        until queue.empty?
+          current = queue.shift
+
+          child_ids = BoardImage
+            .where(board_id: current.id)
+            .where.not(predictive_board_id: nil)
+            .order(:position, :id)
+            .pluck(:predictive_board_id)
+
+          child_ids.each do |child_id|
+            next if child_id == current.id || visited.include?(child_id)
+
+            child = Board.find_by(id: child_id)
+            next unless child
+
+            visited << child_id
+            if visited.size > max_boards
+              raise TreeTooLargeError,
+                "This board links to more than #{max_boards} boards. " \
+                "Raise the board limit or turn off subboards."
+            end
+
+            ordered << child
+            queue << child
+          end
+        end
+
+        ordered
+      end
+
+      def initialize(board:, include_subboards: false, max_boards: BoardPrintable::DEFAULT_MAX_BOARDS)
+        @board = board
+        @include_subboards = include_subboards
+        @max_boards = max_boards
+      end
+
+      # => { boards: [Board], pages: [Page] }
+      #
+      # Page order matches the pipeline: every colour page in BFS order, then
+      # every low-ink page in the same board order.
+      def call
+        boards = self.class.walk_board_tree(
+          board: board,
+          include_subboards: include_subboards,
+          max_boards: max_boards,
+        )
+
+        color_pages = boards.map { |b| render_page(b, variant: BoardPrintable::VARIANT_COLOR) }
+        low_ink_pages = boards.map { |b| render_page(b, variant: BoardPrintable::VARIANT_LOW_INK) }
+
+        { boards: boards, pages: color_pages + low_ink_pages }
+      end
+
+      private
+
+      attr_reader :board, :include_subboards, :max_boards
+
+      def render_page(target, variant:)
+        hide_colors = variant == BoardPrintable::VARIANT_LOW_INK
+
+        # hide_header stays false on every board page: the QR lives inside the
+        # header in print.html.erb, so hiding the header would also kill the
+        # per-page QR. There is no header-less-with-QR combination.
+        render_data = Boards::RenderAssetData.new(
+          board: target,
+          screen_size: "lg",
+          hide_colors: hide_colors,
+          hide_header: false,
+          routes: Rails.application.routes.url_helpers,
+          include_qr: true,
+          qr_target_url: qr_target_url_for(target),
+        ).call
+
+        html = ApplicationController.render(
+          template: "api/boards/print",
+          layout: "pdf",
+          assigns: render_data,
+          formats: [:html],
+        )
+
+        Page.new(
+          pdf_bytes: Grover.new(html, **grover_options(render_data[:landscape])).to_pdf,
+          board_id: target.id,
+          board_name: target.name,
+          variant: variant,
+        )
+      end
+
+      # Every board page's QR targets ITS OWN board, so a buyer scanning page 5
+      # of a 9-board bundle lands on that board rather than the root. Only the
+      # cover's QR points at the root (see RenderWrappers).
+      def qr_target_url_for(target) = "#{QR_BASE_URL}/#{target.id}"
+
+      # Board pages keep the automatic orientation from
+      # RenderAssetData#resolved_landscape (anything with ≥6 tiles goes
+      # landscape). The merge preserves each page's own size, so a finished
+      # printable legitimately mixes portrait wrappers with landscape boards.
+      def grover_options(landscape)
+        {
+          format: "Letter",
+          landscape: landscape,
+          viewport: { width: landscape ? 792 : 612, height: landscape ? 612 : 792 },
+          full_page: false,
+          prefer_css_page_size: true,
+          print_background: true,
+        }
+      end
+    end
+  end
+end

--- a/app/services/boards/printables/generate.rb
+++ b/app/services/boards/printables/generate.rb
@@ -1,0 +1,61 @@
+# Orchestrates the three printable stages — collect board pages, render the
+# wrapper pages, merge — then attaches the results and stamps the record.
+#
+# Everything here is Grover work, so it only ever runs on Sidekiq, never on a
+# request thread: the configured Grover timeout is enormous and a 25-board
+# bundle is 50 Chrome renders.
+module Boards
+  module Printables
+    class Generate
+      def initialize(printable:)
+        @printable = printable
+      end
+
+      def call
+        printable.mark_generating!
+
+        collected = CollectPages.new(
+          board: printable.board,
+          include_subboards: printable.include_subboards,
+          max_boards: printable.max_boards,
+        ).call
+
+        wrappers = RenderWrappers.new(
+          board: printable.board,
+          board_count: collected[:boards].length,
+          topic: printable.topic,
+        ).call
+
+        files = MergePdf.new(
+          wrappers: wrappers,
+          pages: collected[:pages],
+          boards: collected[:boards],
+          slug: printable.board.slug.presence || "board-#{printable.board.id}",
+        ).call
+
+        files.each do |file|
+          printable.attach_pdf!(filename: file.filename, bytes: file.bytes, variant: file.variant)
+        end
+
+        printable.update!(
+          status: "complete",
+          page_count: files.sum(&:page_count),
+          board_ids: collected[:boards].map(&:id),
+          error_message: nil,
+        )
+
+        printable
+      rescue => e
+        # Record the failure for the admin UI, then re-raise so Sidekiq's
+        # retry still applies — a transient Chrome/S3 blip should get another
+        # attempt, not be swallowed into a permanent "failed".
+        printable.mark_failed!(e.message)
+        raise
+      end
+
+      private
+
+      attr_reader :printable
+    end
+  end
+end

--- a/app/services/boards/printables/merge_pdf.rb
+++ b/app/services/boards/printables/merge_pdf.rb
@@ -1,0 +1,71 @@
+# Port of the printables pipeline's step 09 (merge-final-pdf), using
+# combine_pdf where the pipeline uses pdf-lib.
+#
+# Merging per-page renders rather than printing one long HTML document is what
+# lets portrait wrappers sit next to landscape board pages: a merge preserves
+# each page's own size, while a single Chrome print would have to force one
+# @page orientation on everything.
+module Boards
+  module Printables
+    class MergePdf
+      MergedFile = Struct.new(:variant, :filename, :bytes, :page_count, keyword_init: true)
+
+      def initialize(wrappers:, pages:, boards:, slug:)
+        @wrappers = wrappers
+        @pages = pages
+        @boards = boards
+        @slug = slug.presence || "board"
+      end
+
+      # Single board  => one file:  cover, how-to-use, colour, low-ink, license, credits
+      # Subboard tree => two files: each is cover, how-to-use, that variant's N
+      #                  board pages, license, credits. No combined master —
+      #                  the cover and its root QR are duplicated into both, by
+      #                  design, so either file stands alone.
+      def call
+        return [single_file] if boards.length <= 1
+
+        [
+          bundle_file(BoardPrintable::VARIANT_COLOR, "#{slug}.color.pdf"),
+          bundle_file(BoardPrintable::VARIANT_LOW_INK, "#{slug}.low-ink.pdf"),
+        ]
+      end
+
+      private
+
+      attr_reader :wrappers, :pages, :boards, :slug
+
+      def single_file
+        build(
+          variant: BoardPrintable::VARIANT_FULL,
+          filename: "#{slug}.pdf",
+          board_pages: pages,
+        )
+      end
+
+      def bundle_file(variant, filename)
+        build(
+          variant: variant,
+          filename: filename,
+          board_pages: pages.select { |page| page.variant == variant },
+        )
+      end
+
+      def build(variant:, filename:, board_pages:)
+        pdf = CombinePDF.new
+        pdf << CombinePDF.parse(wrappers[:cover])
+        pdf << CombinePDF.parse(wrappers[:how_to_use])
+        board_pages.each { |page| pdf << CombinePDF.parse(page.pdf_bytes) }
+        pdf << CombinePDF.parse(wrappers[:license])
+        pdf << CombinePDF.parse(wrappers[:credits])
+
+        MergedFile.new(
+          variant: variant,
+          filename: filename,
+          bytes: pdf.to_pdf,
+          page_count: pdf.pages.length,
+        )
+      end
+    end
+  end
+end

--- a/app/services/boards/printables/render_wrappers.rb
+++ b/app/services/boards/printables/render_wrappers.rb
@@ -1,0 +1,104 @@
+# Port of the printables pipeline's step 08 (render-wrappers). Four Letter
+# portrait pages that bookend the board pages: cover, how-to-use, license,
+# credits.
+#
+# Each is its own Grover render so the merge can order them freely and so a
+# wrapper's portrait orientation survives next to landscape board pages.
+module Boards
+  module Printables
+    class RenderWrappers
+      # Matches the pipeline's cover/credits QR exactly: navy on cream at
+      # 400px, so an in-app printable and a pipeline printable are
+      # indistinguishable.
+      QR_DARK = "#13496f".freeze
+      QR_LIGHT = "#FBF7F1".freeze
+      QR_SIZE = 400
+
+      def initialize(board:, board_count:, topic: nil)
+        @board = board
+        @board_count = board_count
+        @topic = topic.presence
+      end
+
+      # => { cover: bytes, how_to_use: bytes, license: bytes, credits: bytes }
+      def call
+        {
+          cover: render("cover", assigns: cover_assigns),
+          how_to_use: render("how_to_use", assigns: how_to_use_assigns),
+          license: render("license", assigns: {}),
+          credits: render("credits", assigns: credits_assigns),
+        }
+      end
+
+      private
+
+      attr_reader :board, :board_count, :topic
+
+      def set? = board_count > 1
+
+      def cover_assigns
+        {
+          title: Boards::AssetRendering.board_title_for(board),
+          subtitle: subtitle,
+          logo: Boards::AssetRendering.logo_base64,
+          qr_data_url: qr_data_url,
+        }
+      end
+
+      def how_to_use_assigns
+        {
+          is_set: set?,
+          topic: topic,
+          noun: set? ? "set of #{board_count} communication boards" : "communication board",
+        }
+      end
+
+      def credits_assigns
+        { logo: Boards::AssetRendering.logo_base64, qr_data_url: qr_data_url }
+      end
+
+      def subtitle
+        return "Words for #{topic}" if topic
+        return "A set of #{board_count} communication boards" if set?
+
+        "A printable communication board"
+      end
+
+      # The cover's QR is the one page whose QR targets the ROOT board — it
+      # represents the whole bundle. Every interior board page targets its own
+      # board (see CollectPages).
+      def qr_data_url
+        @qr_data_url ||= begin
+          png = RQRCode::QRCode.new("#{CollectPages::QR_BASE_URL}/#{board.id}").as_png(
+            bit_depth: 8,
+            border_modules: 0,
+            color_mode: ChunkyPNG::COLOR_TRUECOLOR,
+            color: QR_DARK,
+            fill: QR_LIGHT,
+            size: QR_SIZE,
+          )
+          "data:image/png;base64,#{Base64.strict_encode64(png.to_s)}"
+        end
+      end
+
+      def render(template, assigns:)
+        html = ApplicationController.render(
+          template: "api/board_printables/#{template}",
+          layout: "pdf_printable",
+          assigns: assigns,
+          formats: [:html],
+        )
+
+        Grover.new(
+          html,
+          format: "Letter",
+          landscape: false,
+          viewport: { width: 612, height: 792 },
+          full_page: false,
+          prefer_css_page_size: true,
+          print_background: true,
+        ).to_pdf
+      end
+    end
+  end
+end

--- a/app/sidekiq/generate_board_printable_job.rb
+++ b/app/sidekiq/generate_board_printable_job.rb
@@ -1,0 +1,11 @@
+class GenerateBoardPrintableJob
+  include Sidekiq::Job
+  sidekiq_options retry: 3, queue: :default
+
+  def perform(board_printable_id)
+    printable = BoardPrintable.find_by(id: board_printable_id)
+    return unless printable
+
+    Boards::Printables::Generate.new(printable: printable).call
+  end
+end

--- a/app/views/api/board_printables/cover.html.erb
+++ b/app/views/api/board_printables/cover.html.erb
@@ -1,0 +1,15 @@
+<div class="cover">
+  <% if @qr_data_url.present? %>
+    <img class="qr" src="<%= @qr_data_url %>" alt="QR code" />
+    <p class="qr-caption">Scan for free voice output</p>
+  <% end %>
+  <% if @logo.present? %>
+    <img class="logo" src="data:image/png;base64,<%= @logo %>" alt="SpeakAnyWay" />
+  <% end %>
+  <h1 class="title"><%= @title %></h1>
+  <p class="subtitle"><%= @subtitle %></p>
+  <div class="footer">
+    <p class="brand">A SpeakAnyWay printable</p>
+    <p class="url">speakanyway.com</p>
+  </div>
+</div>

--- a/app/views/api/board_printables/credits.html.erb
+++ b/app/views/api/board_printables/credits.html.erb
@@ -1,0 +1,19 @@
+<div class="wrapper-page">
+  <% if @logo.present? %>
+    <img class="logo-small" src="data:image/png;base64,<%= @logo %>" alt="SpeakAnyWay" />
+  <% end %>
+  <h2>About SpeakAnyWay</h2>
+  <p>
+    SpeakAnyWay is a free AAC app built by a mom of two communicators. Scan any
+    QR code in this file and the board opens online, where every word speaks out
+    loud when you tap it — free, no sign-in, no subscription. We make tools that
+    help families connect — without the price tag of traditional AAC.
+  </p>
+  <p class="cta">
+    Find more printables and the free app at <strong>speakanyway.com</strong>
+  </p>
+  <% if @qr_data_url.present? %>
+    <img class="qr-large" src="<%= @qr_data_url %>" alt="QR code to the board" />
+  <% end %>
+  <p class="thanks">Thank you for supporting SpeakAnyWay. 💙</p>
+</div>

--- a/app/views/api/board_printables/how_to_use.html.erb
+++ b/app/views/api/board_printables/how_to_use.html.erb
@@ -1,0 +1,44 @@
+<%# Copy lifted near-verbatim from the printables pipeline's buildHowToUseHtml
+    (speakanyway-printables/src/plugins/aac/product-types/existing-board.ts) so
+    an in-app printable and a pipeline printable read identically. %>
+<div class="wrapper-page">
+  <h2>How to use this</h2>
+
+  <p class="intro">
+    <% if @topic.present? %>
+      This <%= @noun %> helps everyone participate in <strong><%= @topic %></strong>.
+      Print it, hang it, or laminate it for everyday use.
+    <% else %>
+      This <%= @noun %> gives your communicator words at their fingertips.
+      Print it, hang it, or laminate it for everyday use.
+    <% end %>
+  </p>
+
+  <ul class="tips">
+    <li>
+      <% if @is_set %>
+        This PDF prints every board twice: the first half in full color, the
+        second half with white tile backgrounds for a cleaner, lower-ink print.
+        Use whichever fits your printer.
+      <% else %>
+        This PDF has two prints of the same board: page 1 in full color, page 2
+        with white tile backgrounds for a cleaner, lower-ink print. Use
+        whichever fits your printer.
+      <% end %>
+    </li>
+    <li>Print at home or at a print shop, Letter size.</li>
+    <li>
+      Scan the QR code on the cover<%= " or any page" if @is_set %> to open the
+      board<%= "s" if @is_set %> in the free SpeakAnyWay app — every word speaks
+      out loud when tapped.
+    </li>
+    <li>Practice with your communicator before you need it. Familiarity helps.</li>
+    <li>Add or swap words as your communicator's vocabulary grows.</li>
+  </ul>
+
+  <p class="note">
+    <%= @is_set ? "Every board" : "The same board" %> is free in the SpeakAnyWay
+    app — scan the QR code on the cover and tap any word to hear it spoken out
+    loud. No sign-in, no subscription.
+  </p>
+</div>

--- a/app/views/api/board_printables/license.html.erb
+++ b/app/views/api/board_printables/license.html.erb
@@ -1,0 +1,19 @@
+<div class="wrapper-page">
+  <h2>License</h2>
+  <p>
+    This printable is licensed for personal and classroom use by the original
+    purchaser.
+  </p>
+  <p>You may:</p>
+  <ul class="tips">
+    <li>Print as many copies as you need for your family or classroom.</li>
+    <li>Share with your communicator's full team — therapists, teachers, caregivers.</li>
+  </ul>
+  <p>Please don't:</p>
+  <ul class="tips">
+    <li>Resell or redistribute this file.</li>
+    <li>Share the digital file outside your immediate team.</li>
+    <li>Modify and republish as your own work.</li>
+  </ul>
+  <p class="note">© SpeakAnyWay. All rights reserved.</p>
+</div>

--- a/app/views/layouts/pdf_printable.html.erb
+++ b/app/views/layouts/pdf_printable.html.erb
@@ -1,0 +1,229 @@
+<%# Layout for the cover / how-to-use / license / credits wrapper pages of a
+    board printable. A separate layout+template pair rather than a branch
+    inside layouts/pdf.html.erb, which backs real users' board exports and
+    must stay byte-identical — same rule as pdf_marketing.html.erb.
+
+    Palette and page metrics are ported from the speakanyway-printables
+    pipeline (src/templates/shared/base.css, wrappers/cover.css,
+    wrappers/wrapper-page.css) so in-app output and pipeline output look
+    identical. The one deliberate difference: the pipeline @imports Nunito
+    from Google Fonts at render time. A network fetch inside PDF generation is
+    a flaky failure mode, so this matches layouts/pdf.html.erb and uses the
+    system stack instead. %>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Board printable</title>
+
+    <style>
+      :root {
+        --navy: #13496f;
+        --blue-mid: #0163aa;
+        --cyan: #4ECDE6;
+        --magenta: #C857E8;
+        --cream: #FBF7F1;
+        --ink: #1A1A1A;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html, body {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
+
+      body {
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+        color: var(--ink);
+        background: var(--cream);
+      }
+
+      /* Wrappers are always Letter portrait; the board pages they wrap bring
+         their own orientation and the merge preserves it. */
+      @page {
+        margin: 0;
+        size: letter;
+      }
+
+      /* ── Cover ───────────────────────────────────────────────────────── */
+      .cover {
+        width: 8.5in;
+        height: 11in;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background: var(--cream);
+        padding: 1in 1in 0.75in;
+        position: relative;
+        text-align: center;
+      }
+
+      .cover .qr {
+        position: absolute;
+        top: 0.5in;
+        right: 0.5in;
+        width: 1in;
+        height: 1in;
+      }
+
+      .cover .qr-caption {
+        position: absolute;
+        top: 1.58in;
+        right: 0.5in;
+        width: 1.15in;
+        margin: 0;
+        font-size: 8pt;
+        font-weight: 600;
+        line-height: 1.25;
+        text-align: center;
+        color: var(--blue-mid);
+      }
+
+      .cover .logo {
+        width: 1.75in;
+        height: 1.75in;
+        margin-bottom: 0.5in;
+      }
+
+      .cover .title {
+        font-size: 48pt;
+        font-weight: 800;
+        color: var(--navy);
+        line-height: 1.1;
+        max-width: 6.5in;
+        margin-bottom: 0.25in;
+      }
+
+      .cover .subtitle {
+        font-size: 20pt;
+        font-weight: 400;
+        color: var(--blue-mid);
+        max-width: 6in;
+        line-height: 1.3;
+      }
+
+      .cover .footer {
+        position: absolute;
+        bottom: 0.6in;
+        left: 0;
+        right: 0;
+      }
+
+      .cover .footer .brand {
+        font-size: 12pt;
+        color: var(--navy);
+        font-weight: 600;
+        margin-bottom: 4pt;
+      }
+
+      .cover .footer .url {
+        font-size: 10pt;
+        color: var(--blue-mid);
+      }
+
+      /* ── How-to-use / license / credits ──────────────────────────────── */
+      .wrapper-page {
+        width: 8.5in;
+        height: 11in;
+        background: var(--cream);
+        padding: 1.25in 1in 1in;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+      }
+
+      .wrapper-page h2 {
+        font-size: 36pt;
+        font-weight: 800;
+        color: var(--navy);
+        margin-bottom: 0.4in;
+      }
+
+      .wrapper-page p {
+        font-size: 14pt;
+        font-weight: 400;
+        color: var(--ink);
+        line-height: 1.5;
+        max-width: 5.5in;
+        margin-bottom: 0.25in;
+      }
+
+      .wrapper-page .intro {
+        font-size: 16pt;
+        color: var(--blue-mid);
+        max-width: 6in;
+        margin-bottom: 0.5in;
+      }
+
+      .wrapper-page .tips {
+        list-style: none;
+        padding: 0;
+        margin-bottom: 0.4in;
+        max-width: 5in;
+      }
+
+      .wrapper-page .tips li {
+        font-size: 13pt;
+        color: var(--ink);
+        line-height: 1.5;
+        padding-left: 1.5em;
+        text-indent: -1.5em;
+        margin-bottom: 0.15in;
+        text-align: left;
+      }
+
+      .wrapper-page .tips li::before {
+        content: "•";
+        color: var(--cyan);
+        font-weight: 800;
+        display: inline-block;
+        width: 1em;
+        margin-left: 0;
+        font-size: 18pt;
+      }
+
+      .wrapper-page .note {
+        font-size: 13pt;
+        color: var(--blue-mid);
+        font-style: italic;
+        margin-top: 0.4in;
+      }
+
+      .wrapper-page .logo-small {
+        width: 1in;
+        height: 1in;
+        margin-bottom: 0.4in;
+      }
+
+      .wrapper-page .qr-large {
+        width: 1.5in;
+        height: 1.5in;
+        margin: 0.4in 0;
+      }
+
+      .wrapper-page .cta {
+        font-size: 14pt;
+        color: var(--navy);
+        font-weight: 600;
+      }
+
+      .wrapper-page .thanks {
+        font-size: 13pt;
+        color: var(--magenta);
+        font-weight: 600;
+        margin-top: auto;
+      }
+    </style>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -566,6 +566,12 @@ Rails.application.routes.draw do
         collection do
           get "generated_boards"
         end
+        resources :printables, only: [:create], controller: "board_printables"
+      end
+      resources :board_printables, only: [:show] do
+        member do
+          get "download_url"
+        end
       end
       resources :clinician_applications, only: [:index] do
         member do

--- a/db/migrate/20260806140000_create_board_printables.rb
+++ b/db/migrate/20260806140000_create_board_printables.rb
@@ -1,0 +1,21 @@
+class CreateBoardPrintables < ActiveRecord::Migration[8.0]
+  def change
+    create_table :board_printables do |t|
+      # The ROOT board. When include_subboards is set, board_ids holds the
+      # whole walked tree in BFS order; this column is always its first entry.
+      t.references :board, null: false, foreign_key: true
+      t.references :created_by, foreign_key: { to_table: :users }
+      t.string :status, null: false, default: "pending"
+      t.boolean :include_subboards, null: false, default: false
+      t.integer :max_boards, null: false, default: 25
+      t.string :topic
+      t.integer :page_count
+      t.jsonb :board_ids, null: false, default: []
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :board_printables, [:board_id, :status]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_04_191025) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_06_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -199,6 +199,23 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_04_191025) do
     t.index ["image_id"], name: "index_board_images_on_image_id"
     t.index ["label"], name: "index_board_images_on_label"
     t.index ["predictive_board_id"], name: "index_board_images_on_predictive_board_id"
+  end
+
+  create_table "board_printables", force: :cascade do |t|
+    t.bigint "board_id", null: false
+    t.bigint "created_by_id"
+    t.string "status", default: "pending", null: false
+    t.boolean "include_subboards", default: false, null: false
+    t.integer "max_boards", default: 25, null: false
+    t.string "topic"
+    t.integer "page_count"
+    t.jsonb "board_ids", default: [], null: false
+    t.text "error_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_id", "status"], name: "index_board_printables_on_board_id_and_status"
+    t.index ["board_id"], name: "index_board_printables_on_board_id"
+    t.index ["created_by_id"], name: "index_board_printables_on_created_by_id"
   end
 
   create_table "board_screenshot_cells", force: :cascade do |t|
@@ -1099,6 +1116,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_04_191025) do
   add_foreign_key "board_groups", "boards", column: "root_board_id"
   add_foreign_key "board_images", "boards"
   add_foreign_key "board_images", "images"
+  add_foreign_key "board_printables", "boards"
+  add_foreign_key "board_printables", "users", column: "created_by_id"
   add_foreign_key "board_screenshot_cells", "board_screenshot_imports"
   add_foreign_key "board_screenshot_imports", "users"
   add_foreign_key "boards", "users"

--- a/spec/requests/api/admin/board_printables_spec.rb
+++ b/spec/requests/api/admin/board_printables_spec.rb
@@ -1,0 +1,206 @@
+require "rails_helper"
+
+RSpec.describe "API::Admin::BoardPrintables", type: :request do
+  let(:admin) { create(:admin_user) }
+  let(:owner) { create(:user) }
+  let!(:board) { create(:board, user: owner, name: "Core Words", slug: "core-words") }
+
+  def link(from, to, position: 0)
+    create(:board_image, board: from, predictive_board_id: to.id, position: position)
+  end
+
+  def json = JSON.parse(response.body)
+
+  describe "POST /api/admin/boards/:board_id/printables" do
+    it "creates a pending record and enqueues the job" do
+      expect {
+        post "/api/admin/boards/#{board.id}/printables",
+          params: { include_subboards: true, max_boards: 10, topic: "mealtime" },
+          headers: auth_headers(admin)
+      }.to change(GenerateBoardPrintableJob.jobs, :size).by(1)
+
+      expect(response).to have_http_status(:accepted)
+      expect(json["status"]).to eq("pending")
+      expect(json["board_id"]).to eq(board.id)
+      expect(json["include_subboards"]).to be(true)
+      expect(json["files"]).to eq([])
+
+      printable = BoardPrintable.find(json["id"])
+      expect(printable.created_by).to eq(admin)
+      expect(printable.max_boards).to eq(10)
+      expect(printable.topic).to eq("mealtime")
+      expect(printable.board_ids).to eq([board.id])
+    end
+
+    it "defaults to a single board with the standard cap" do
+      post "/api/admin/boards/#{board.id}/printables", headers: auth_headers(admin)
+
+      printable = BoardPrintable.find(json["id"])
+      expect(printable.include_subboards).to be(false)
+      expect(printable.max_boards).to eq(BoardPrintable::DEFAULT_MAX_BOARDS)
+      expect(printable.topic).to be_nil
+    end
+
+    it "records the walked tree in BFS order when subboards are included" do
+      child = create(:board, user: owner)
+      link(board, child)
+
+      post "/api/admin/boards/#{board.id}/printables",
+        params: { include_subboards: true }, headers: auth_headers(admin)
+
+      expect(BoardPrintable.find(json["id"]).board_ids).to eq([board.id, child.id])
+    end
+
+    it "clamps an absurd max_boards to the ceiling rather than trusting it" do
+      post "/api/admin/boards/#{board.id}/printables",
+        params: { include_subboards: true, max_boards: 100_000 }, headers: auth_headers(admin)
+
+      expect(BoardPrintable.find(json["id"]).max_boards)
+        .to eq(BoardPrintable::MAX_BOARDS_CEILING)
+    end
+
+    it "404s for a board that doesn't exist" do
+      post "/api/admin/boards/0/printables", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:not_found)
+      expect(BoardPrintable.count).to eq(0)
+    end
+
+    # Admin is global by design: a printable can be generated from any board,
+    # not just the admin's own. Asserted deliberately so the intent is recorded.
+    it "allows an admin to generate from a board owned by someone else" do
+      expect(board.user).not_to eq(admin)
+
+      post "/api/admin/boards/#{board.id}/printables", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    describe "when the subboard tree is over the cap" do
+      before { 3.times { |i| link(board, create(:board, user: owner), position: i) } }
+
+      it "422s, creates nothing, and enqueues nothing" do
+        expect {
+          post "/api/admin/boards/#{board.id}/printables",
+            params: { include_subboards: true, max_boards: 2 }, headers: auth_headers(admin)
+        }.not_to change(GenerateBoardPrintableJob.jobs, :size)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json["error"]).to match(/more than 2 boards/)
+        # Nothing left half-created in "generating" for a poller to sit on.
+        expect(BoardPrintable.count).to eq(0)
+      end
+
+      it "still succeeds with subboards off, since the cap only bounds the walk" do
+        post "/api/admin/boards/#{board.id}/printables",
+          params: { include_subboards: false, max_boards: 2 }, headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:accepted)
+      end
+    end
+  end
+
+  describe "GET /api/admin/board_printables/:id" do
+    let(:printable) { BoardPrintable.create!(board: board, created_by: admin, status: "generating") }
+
+    it "returns the current status for polling" do
+      get "/api/admin/board_printables/#{printable.id}", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(json["status"]).to eq("generating")
+      expect(json["files"]).to eq([])
+    end
+
+    it "surfaces the failure message once the job has failed" do
+      printable.mark_failed!("Chrome crashed")
+
+      get "/api/admin/board_printables/#{printable.id}", headers: auth_headers(admin)
+
+      expect(json["status"]).to eq("failed")
+      expect(json["error_message"]).to eq("Chrome crashed")
+    end
+
+    it "404s for an id that doesn't exist" do
+      get "/api/admin/board_printables/0", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /api/admin/board_printables/:id/download_url" do
+    let(:printable) { BoardPrintable.create!(board: board, created_by: admin, status: "pending") }
+
+    def attach_both_variants
+      printable.attach_pdf!(
+        filename: "core-words.color.pdf", bytes: "%PDF-1.5 colour",
+        variant: BoardPrintable::VARIANT_COLOR,
+      )
+      printable.attach_pdf!(
+        filename: "core-words.low-ink.pdf", bytes: "%PDF-1.5 low ink",
+        variant: BoardPrintable::VARIANT_LOW_INK,
+      )
+      printable.update!(status: "complete")
+    end
+
+    it "returns one entry per file, labelled by variant" do
+      attach_both_variants
+
+      get "/api/admin/board_printables/#{printable.id}/download_url", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      files = json["files"].sort_by { |f| f["variant"] }
+      expect(files.map { |f| f["variant"] }).to eq(["color", "low_ink"])
+      expect(files.map { |f| f["filename"] })
+        .to eq(["core-words.color.pdf", "core-words.low-ink.pdf"])
+      expect(files.map { |f| f["url"] }).to all(be_present)
+    end
+
+    it "404s while the job is still running" do
+      get "/api/admin/board_printables/#{printable.id}/download_url", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "404s when the record says complete but nothing is attached" do
+      printable.update!(status: "complete")
+
+      get "/api/admin/board_printables/#{printable.id}/download_url", headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # The frontend deliberately ships no client-side admin guard, so this 401 is
+  # the only real gate on the feature.
+  describe "authorization" do
+    let(:printable) { BoardPrintable.create!(board: board, created_by: admin, status: "pending") }
+
+    it "401s a create with no token" do
+      expect {
+        post "/api/admin/boards/#{board.id}/printables"
+      }.not_to change(BoardPrintable, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "401s a create from a signed-in non-admin" do
+      expect {
+        post "/api/admin/boards/#{board.id}/printables", headers: auth_headers(owner)
+      }.not_to change(BoardPrintable, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "401s a status poll from a signed-in non-admin" do
+      get "/api/admin/board_printables/#{printable.id}", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "401s a download_url from a signed-in non-admin" do
+      get "/api/admin/board_printables/#{printable.id}/download_url", headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/services/boards/printables/collect_pages_spec.rb
+++ b/spec/services/boards/printables/collect_pages_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+# The BFS walk is the piece most likely to regress and the cheapest to test in
+# isolation — no rendering, no Chrome, just ids.
+RSpec.describe Boards::Printables::CollectPages, ".walk_board_tree" do
+  let(:user) { create(:user) }
+  let(:root) { create(:board, user: user, name: "Root") }
+
+  def link(from, to, position: 0)
+    create(:board_image, board: from, predictive_board_id: to.id, position: position)
+  end
+
+  def walk(board: root, include_subboards: true, max_boards: 25)
+    described_class.walk_board_tree(
+      board: board,
+      include_subboards: include_subboards,
+      max_boards: max_boards,
+    ).map(&:id)
+  end
+
+  it "returns only the root when subboards are off, however many are linked" do
+    link(root, create(:board, user: user))
+
+    expect(walk(include_subboards: false)).to eq([root.id])
+  end
+
+  it "walks breadth-first with the root first" do
+    a = create(:board, user: user, name: "A")
+    b = create(:board, user: user, name: "B")
+    c = create(:board, user: user, name: "C")
+    link(root, a, position: 0)
+    link(root, b, position: 1)
+    link(a, c)
+
+    # Breadth-first: both of the root's children come before A's child.
+    expect(walk).to eq([root.id, a.id, b.id, c.id])
+  end
+
+  it "visits a board linked from two places only once" do
+    a = create(:board, user: user)
+    b = create(:board, user: user)
+    shared = create(:board, user: user)
+    link(root, a, position: 0)
+    link(root, b, position: 1)
+    link(a, shared)
+    link(b, shared)
+
+    expect(walk).to eq([root.id, a.id, b.id, shared.id])
+  end
+
+  it "terminates when a child links back to the root" do
+    a = create(:board, user: user)
+    link(root, a)
+    link(a, root)
+
+    expect(walk).to eq([root.id, a.id])
+  end
+
+  it "ignores a tile that links a board to itself" do
+    link(root, root)
+
+    expect(walk).to eq([root.id])
+  end
+
+  it "skips a link whose target board no longer exists" do
+    a = create(:board, user: user)
+    link(root, a, position: 0)
+    create(:board_image, board: root, predictive_board_id: 999_999_999, position: 1)
+
+    expect(walk).to eq([root.id, a.id])
+  end
+
+  it "ignores tiles with no predictive link" do
+    create(:board_image, board: root)
+
+    expect(walk).to eq([root.id])
+  end
+
+  # The pipeline throws rather than truncating; silently dropping boards would
+  # ship an incomplete product that looks complete.
+  it "raises rather than truncating when the tree exceeds max_boards" do
+    3.times { |i| link(root, create(:board, user: user), position: i) }
+
+    expect { walk(max_boards: 3) }.to raise_error(
+      described_class::TreeTooLargeError, /more than 3 boards/
+    )
+  end
+
+  it "counts the root toward max_boards" do
+    2.times { |i| link(root, create(:board, user: user), position: i) }
+
+    expect { walk(max_boards: 3) }.not_to raise_error
+    expect { walk(max_boards: 2) }.to raise_error(described_class::TreeTooLargeError)
+  end
+end

--- a/spec/services/boards/printables/generate_spec.rb
+++ b/spec/services/boards/printables/generate_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe Boards::Printables::Generate do
+  let(:user) { create(:user) }
+  let(:root) { create(:board, user: user, name: "Core Words", slug: "core-words") }
+
+  # A real one-page PDF, so the merge runs for real and page counts mean
+  # something. Grover's "%PDF-fake" stub can't be parsed by combine_pdf.
+  let(:one_page_pdf) do
+    pdf = CombinePDF.new
+    pdf << CombinePDF.create_page
+    pdf.to_pdf
+  end
+
+  let(:qr_targets) { [] }
+
+  before do
+    # Bypass Chromium entirely; every render returns the same blank page.
+    allow(Grover).to receive(:new).and_return(instance_double(Grover, to_pdf: one_page_pdf))
+    # Bypass the heavy ERB renders — this service's template responsibility is
+    # just feeding assigns in, which the view specs would cover separately.
+    allow(ApplicationController).to receive(:render).and_return("<html></html>")
+
+    # RenderAssetData still runs for real, so the QR targeting is genuinely
+    # exercised rather than asserted against a stub.
+    allow(Boards::RenderAssetData).to receive(:new).and_wrap_original do |original, **kwargs|
+      qr_targets << kwargs[:qr_target_url]
+      original.call(**kwargs)
+    end
+  end
+
+  def link(from, to, position: 0)
+    create(:board_image, board: from, predictive_board_id: to.id, position: position)
+  end
+
+  def printable_for(**attrs)
+    BoardPrintable.create!(board: root, created_by: user, **attrs)
+  end
+
+  describe "a single board" do
+    it "attaches one fully-wrapped 6-page file" do
+      printable = printable_for
+
+      described_class.new(printable: printable).call
+      printable.reload
+
+      expect(printable.status).to eq("complete")
+      expect(printable.files.count).to eq(1)
+      # cover, how-to-use, colour, low-ink, license, credits
+      expect(printable.page_count).to eq(6)
+      expect(printable.board_ids).to eq([root.id])
+      expect(printable.error_message).to be_nil
+    end
+
+    it "names the file from the board slug and marks it as the whole printable" do
+      printable = printable_for
+
+      described_class.new(printable: printable).call
+
+      file = printable.reload.files_view.first
+      expect(file[:filename]).to eq("core-words.pdf")
+      expect(file[:variant]).to eq(BoardPrintable::VARIANT_FULL)
+    end
+
+    it "falls back to the board id when the board has no slug" do
+      root.update_column(:slug, nil)
+      printable = printable_for
+
+      described_class.new(printable: printable).call
+
+      expect(printable.reload.files_view.first[:filename]).to eq("board-#{root.id}.pdf")
+    end
+  end
+
+  describe "a subboard bundle" do
+    let!(:child_a) { create(:board, user: user, name: "Food") }
+    let!(:child_b) { create(:board, user: user, name: "Play") }
+
+    before do
+      link(root, child_a, position: 0)
+      link(root, child_b, position: 1)
+    end
+
+    it "attaches exactly two files, colour and low-ink, each fully wrapped" do
+      printable = printable_for(include_subboards: true)
+
+      described_class.new(printable: printable).call
+      printable.reload
+
+      expect(printable.status).to eq("complete")
+      files = printable.files_view.sort_by { |f| f[:variant] }
+      expect(files.map { |f| f[:variant] })
+        .to eq([BoardPrintable::VARIANT_COLOR, BoardPrintable::VARIANT_LOW_INK])
+      expect(files.map { |f| f[:filename] })
+        .to eq(["core-words.color.pdf", "core-words.low-ink.pdf"])
+
+      # 2N + 8: each file is cover + how-to-use + 3 board pages + license + credits.
+      expect(printable.page_count).to eq(14)
+      expect(printable.board_ids).to eq([root.id, child_a.id, child_b.id])
+    end
+
+    it "points every board page's QR at its own board, and the cover's at the root" do
+      printable = printable_for(include_subboards: true)
+
+      described_class.new(printable: printable).call
+
+      # Two renders per board (colour + low-ink), each targeting that board.
+      [root, child_a, child_b].each do |board|
+        expect(qr_targets.count("https://app.speakanyway.com/pb/#{board.id}")).to eq(2)
+      end
+      expect(qr_targets.length).to eq(6)
+    end
+  end
+
+  describe "when generation fails" do
+    it "records the failure and re-raises so Sidekiq retries" do
+      allow(Grover).to receive(:new).and_raise(StandardError, "Chrome crashed")
+      printable = printable_for
+
+      expect { described_class.new(printable: printable).call }
+        .to raise_error(StandardError, "Chrome crashed")
+
+      printable.reload
+      expect(printable.status).to eq("failed")
+      expect(printable.error_message).to eq("Chrome crashed")
+      expect(printable.files).not_to be_attached
+    end
+  end
+
+  # The deterministic storage key is scoped by record id, so this only has to
+  # survive a re-run of the SAME record — which is what a Sidekiq retry does.
+  it "can regenerate the same record without colliding on the blob key" do
+    printable = printable_for
+
+    described_class.new(printable: printable).call
+    expect { described_class.new(printable: printable).call }.not_to raise_error
+
+    expect(printable.reload.files.count).to eq(1)
+  end
+end

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+# Grover is stubbed but ApplicationController.render is NOT — the point of this
+# spec is that the four wrapper templates and the pdf_printable layout actually
+# compile and say the right things. Stubbing the render out (as the Generate
+# spec does) would let an ERB typo through every other test.
+RSpec.describe Boards::Printables::RenderWrappers do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user, name: "Core Words") }
+
+  let(:rendered) { {} }
+
+  before do
+    order = %i[cover how_to_use license credits]
+    index = 0
+    allow(Grover).to receive(:new) do |html, **_opts|
+      rendered[order[index]] = html
+      index += 1
+      instance_double(Grover, to_pdf: "%PDF-#{index}")
+    end
+  end
+
+  def render(board_count: 1, topic: nil)
+    described_class.new(board: board, board_count: board_count, topic: topic).call
+  end
+
+  it "returns bytes for all four wrapper pages" do
+    result = render
+
+    expect(result.keys).to contain_exactly(:cover, :how_to_use, :license, :credits)
+    expect(result.values).to all(start_with("%PDF"))
+  end
+
+  describe "the cover" do
+    it "shows the board name and the SpeakAnyWay footer" do
+      render
+
+      expect(rendered[:cover]).to include("Core Words")
+      expect(rendered[:cover]).to include("A SpeakAnyWay printable")
+      expect(rendered[:cover]).to include("speakanyway.com")
+    end
+
+    # The cover represents the whole bundle, so its QR is the one that points
+    # at the root board; interior pages point at their own (see CollectPages).
+    it "embeds a QR image" do
+      render
+
+      expect(rendered[:cover]).to include('class="qr"')
+      expect(rendered[:cover]).to include("data:image/png;base64,")
+    end
+
+    it "describes a single board" do
+      render
+
+      expect(rendered[:cover]).to include("A printable communication board")
+    end
+
+    it "describes a set by its board count" do
+      render(board_count: 4)
+
+      expect(rendered[:cover]).to include("A set of 4 communication boards")
+    end
+
+    it "leads with the topic when one was given" do
+      render(board_count: 4, topic: "mealtime")
+
+      expect(rendered[:cover]).to include("Words for mealtime")
+    end
+  end
+
+  describe "the how-to-use page" do
+    it "explains the two prints of one board for a single board" do
+      render
+
+      expect(rendered[:how_to_use]).to include("This communication board")
+      expect(rendered[:how_to_use]).to include("page 1 in full color")
+      expect(rendered[:how_to_use]).to include("The same board")
+    end
+
+    it "explains the colour/low-ink halves for a set" do
+      render(board_count: 4)
+
+      expect(rendered[:how_to_use]).to include("set of 4 communication boards")
+      expect(rendered[:how_to_use]).to include("prints every board twice")
+      expect(rendered[:how_to_use]).to include("Every board")
+    end
+
+    it "names the topic when one was given" do
+      render(topic: "mealtime")
+
+      expect(rendered[:how_to_use]).to include("mealtime")
+    end
+  end
+
+  it "renders the personal-use license terms" do
+    render
+
+    expect(rendered[:license]).to include("License")
+    expect(rendered[:license]).to include("personal and classroom use")
+    expect(rendered[:license]).to include("Resell or redistribute")
+  end
+
+  it "renders the credits page with a QR back to the board" do
+    render
+
+    expect(rendered[:credits]).to include("About SpeakAnyWay")
+    expect(rendered[:credits]).to include("data:image/png;base64,")
+  end
+
+  # The pipeline's base.css @imports Nunito from Google Fonts. A network fetch
+  # inside PDF generation is a flaky failure mode, so the layout must not.
+  it "never reaches out to the network for fonts" do
+    render
+
+    expect(rendered[:cover]).not_to include("fonts.googleapis.com")
+    expect(rendered[:cover]).to include("system-ui")
+  end
+end


### PR DESCRIPTION
Implements `.claude-notes/board-printable-in-app-handoff.md` (committed here so it survives the session). Counterpart frontend PR: brittanyjohns/itty-bitty-frontend#635.

## What this adds

Admin-only endpoints that generate a **cover-wrapped, print-ready PDF** for a board and persist it via Active Storage. This is the in-app port of the `speakanyway-printables` Node pipeline's PDF-producing core (its steps 05, 08, 09); everything downstream in that pipeline — listing copy, marketing images, Drive, Etsy/Gumroad — stays where it is.

| Verb | Path | Does |
|---|---|---|
| POST | `/api/admin/boards/:board_id/printables` | creates the record, enqueues the job, returns it (202) |
| GET | `/api/admin/board_printables/:id` | status poll |
| GET | `/api/admin/board_printables/:id/download_url` | `{ files: [{ variant, filename, url, byte_size }] }` |

**Output shape.** Single board → **one** file, `<slug>.pdf`, variant `full`, 6 pages: cover → how-to-use → colour board → low-ink board → license → credits. Subboard tree → **two** files, `<slug>.color.pdf` and `<slug>.low-ink.pdf`, each fully wrapped, `2N + 8` pages total. No combined master — the cover is duplicated into both so either file stands alone.

- `BoardPrintable` + migration — `has_many_attached :files`, storage keys scoped by record id so a Sidekiq retry never collides on the unique `active_storage_blobs.key` index. Deliberately not `board.pdf_file`, which is the existing single-page cached export exposed via `Board#api_view`.
- `Boards::Printables::{CollectPages,RenderWrappers,MergePdf,Generate}` + `GenerateBoardPrintableJob`.
- Wrapper views under `app/views/api/board_printables/` with `layouts/pdf_printable.html.erb`.

## New gem

`combine_pdf` 1.0.31 — **MIT**, pure Ruby, no native extensions. License verified on RubyGems before adding, per the handoff's warning that HexaPDF is AGPL-3.0 + paid-commercial and a poor fit here. Approved in chat before I wrote the merge service.

Merging per-page renders (rather than printing one long HTML document) is what preserves each page's own orientation for free: wrappers are Letter portrait, board pages go landscape whenever a board has ≥6 tiles via `RenderAssetData#resolved_landscape`.

## Decisions worth flagging in review

- **The tree size is checked in the controller, synchronously, before any record exists.** An over-cap tree has to answer 422, and a job that raises cannot — checking inside the job would strand a record in `generating` with nothing attached, which is exactly what a polling frontend would sit on forever. `CollectPages.walk_board_tree` is a class method for this reason; the job re-walks when it renders.
- **The walk raises rather than truncating**, matching the pipeline. Silently dropping boards ships an incomplete product that looks complete. `max_boards` is clamped to a ceiling of 100 — every board in the tree is two Chrome renders, so an unbounded value is a way to hang a worker by typo.
- **Each board page's QR targets its own board**, not the root, so a buyer scanning page 5 of a 9-board bundle lands on that board. Only the cover's QR points at the root.
- **`hide_header: false` on every board page** — the QR lives inside the header in `print.html.erb`, so hiding the header would also kill the per-page QR.
- **No HTTP call to our own internal endpoint.** The services go straight to `Boards::RenderAssetData`, the shared core behind `/api/internal/boards/:id/export.pdf`.
- **The layout does not `@import` Nunito** the way the pipeline's `base.css` does — a network fetch inside PDF generation is a flaky failure mode. It uses the system stack, matching `layouts/pdf.html.erb`; a spec asserts `fonts.googleapis.com` never appears.
- **Auth is the only gate.** The frontend deliberately ships no client-side admin guard (existing convention), so `API::Admin::ApplicationController`'s 401 is the real one — the authorization matrix is asserted explicitly, including the deliberate "an admin may generate from someone else's board."

## Test plan

**46 new examples, all passing.**

- `spec/services/boards/printables/collect_pages_spec.rb` (9) — BFS order with root first, dedupe across two parents, terminates on a child linking back to the root, ignores self-links and dangling ids, raises rather than truncating, root counts toward the cap.
- `spec/services/boards/printables/generate_spec.rb` (7) — single board → one 6-page file named from the slug (falls back to `board-<id>`); bundle → exactly two files, colour + low-ink, `2N + 8` pages, `board_ids` in BFS order; each board's QR targeted twice at its own board; failure marks `failed` with `error_message` and re-raises so Sidekiq retries; a re-run of the same record doesn't collide on the blob key.
- `spec/services/boards/printables/render_wrappers_spec.rb` (12) — Grover stubbed but `ApplicationController.render` **not**, so the four templates and the layout actually compile. Covers cover/set/topic subtitles, single-vs-set how-to-use wording, license terms, credits, and the no-remote-fonts rule.
- `spec/requests/api/admin/board_printables_spec.rb` (18) — create/poll/download_url, the 422 path (creates nothing, enqueues nothing), `max_boards` clamping, and the full authorization matrix.

`bundle exec rspec spec/requests/api/admin spec/services/boards` → **400 examples, 0 failures.**

Also smoke-tested the wrappers through **real headless Chrome** (the specs stub Grover) and rendered the merged output to images: all four pages render correctly and match the pipeline's design.

## Deploy notes

- One new gem (`combine_pdf`), one migration (`board_printables`), no backfill.
- **No new ENV vars.** Storage rides the existing `:amazon` service (`public: true`), so URLs are `CDN_HOST + key` — no presigning.
- Ships independently; it's an admin-only API and the frontend PR is what makes it reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)