### PR TITLE
fix(boards): keep folder pages added after a build inside the builder set

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -201,6 +201,17 @@ tree. "Set-ness" lives in the BoardGroup, not the fragile `builder_child`
 JSONB marker. The `builder_root` marker on the root board is still the detection
 key for re-runs and the backfill.
 
+**A set stays whole after the build, too (#586).** At build time the group
+membership and the reachable folder-tile graph are the same set, but they
+diverge the moment a user hand-extends the set. `Api::ImagesController
+#create_predictive_board` ("turn this tile into a folder") therefore adds the
+page it creates to the parent board's builder group via
+`Board#containing_builder_board_group` — which answers for any *member* of the
+set, not just the root, since folder tiles are usually added on a child page.
+`BuildBoardSetJob#set_board_ids` walks the link graph with no depth cap for the
+same reason (it's owner-scoped and cycle-safe, so it still terminates). Escaped
+pages don't publish, don't cascade-delete, and burn a board slot.
+
 **Backfill for pre-#407 sets (#409):** existing builder sets predate the
 BoardGroup, so `rake board_groups:backfill_builder_sets`
 (`lib/tasks/board_groups.rake`) wraps each `builder_root` tree lacking a builder

--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -673,6 +673,18 @@ contained while publishing was admin-only; now that owners can publish
 someone else's board. An admin editing another user's set is unaffected: the
 scope follows the root's owner, not the requester.
 
+**Group membership must therefore stay a superset of the set's reachable folder
+graph.** A page reachable from the published root by tapping a tile but missing
+from the group is invisible to publish, unpublish, delete, and the 0-slot board
+count — the visitor taps the tile and gets the 404 this feature exists to
+remove, and re-saving publish on the root doesn't help because
+`PublishCascade#needed?` only compares *members*. Two paths keep them in sync
+(issue #586): `Api::ImagesController#create_predictive_board` adds the page it
+creates to the parent board's builder group
+(`Board#containing_builder_board_group`, ownership-scoped on both ends), and
+`BuildBoardSetJob#set_board_ids` walks the link graph with **no depth cap**.
+Any new way to hang a page off a builder set needs the same join.
+
 **Image-removal bypass:** The guard is skipped entirely when the request carries
 `image_ids_to_remove` — that branch returns early (line 453 in the controller)
 without any board attribute assignment or save, so there is nothing to confirm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   visitors a 404. Board owners can now publish and unpublish their own boards.
   Curation is unchanged: marking a board as a starter board is still admin-only,
   and publishing your own board does not add it to the public board gallery.
+- New folder pages added to a Board Builder set after it was built now belong to
+  the set. Previously a page created by turning a tile into a folder escaped the
+  set entirely: publishing the set skipped it (so public visitors tapping that
+  folder still hit a dead end), deleting the set left it behind, and it counted
+  against the plan's board limit even though the rest of the set didn't. Pages
+  nested more than three levels deep are also covered now.
 - Publishing a Board Builder board set now publishes every page in the set, so
   public visitors no longer hit a dead end when tapping a folder button.
   Unpublishing removes the whole set from public view. Both ask for confirmation

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -427,6 +427,7 @@ class API::ImagesController < API::ApplicationController
     end
     @board_image.data["mute_name"] = true
     if @board_image.update(predictive_board_id: predictive_board.id)
+      attach_to_builder_set(@board, predictive_board)
       render json: { status: "ok", message: "Creating predictive board for image.", board: predictive_board }
     else
       render json: { status: "error", message: "Could not create predictive board." }
@@ -782,6 +783,30 @@ class API::ImagesController < API::ApplicationController
   end
 
   private
+
+  # A folder page created from a tile on a Board Builder set has to join that
+  # set's builder BoardGroup (issue #586). At build time the group membership
+  # and the reachable folder-tile graph are the same set, but they diverge the
+  # moment the set is hand-extended: the new page is reachable from the
+  # published root by tapping its tile, yet `Boards::PublishCascade` — like
+  # delete and the 0-slot board count — reads GROUP MEMBERSHIP, so a page that
+  # never joined is never published and a public visitor gets a 404.
+  #
+  # Ownership-scoped on both ends: only the current user's own groups are
+  # considered, so a folder tile added on a board shared from another account
+  # can't insert a board into that account's set. No-op for a board outside any
+  # builder set. `add_board` is idempotent, and a failure here must never fail
+  # the creation itself — the page exists and works either way.
+  def attach_to_builder_set(parent_board, new_board)
+    return unless parent_board && new_board
+
+    group = parent_board.containing_builder_board_group(current_user)
+    return unless group
+
+    group.add_board(new_board)
+  rescue => e
+    Rails.logger.error("[ImagesController] builder set attach failed board=#{new_board&.id}: #{e.class} - #{e.message}")
+  end
 
   # Issue #26 (IDOR): images are a shared library. A row is either PUBLIC
   # (is_private false/nil — e.g. the admin-owned symbol library, mirrors the

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -240,6 +240,21 @@ class Board < ApplicationRecord
       board_groups.where(builder: true).first
   end
 
+  # The builder BoardGroup this board is a MEMBER of — the root or any page of
+  # a built set. `builder_board_group` only answers for the root, but a folder
+  # tile is usually added on a `builder_child` page deeper in the set, and a
+  # page created from that tile has to join the same group or it escapes the
+  # set's publish cascade, delete, and 0-slot board count (issue #586).
+  #
+  # Scoped to `user`'s own groups for the same reason `eligible_board_group` is:
+  # `board_groups` carries no ownership filter, so without it a board could pull
+  # in another user's group.
+  def containing_builder_board_group(user)
+    return nil unless user
+
+    board_groups.where(user: user, builder: true).first
+  end
+
   # The BoardGroup a "view/create set map" action should use for this board,
   # mirroring the frontend's eligibleSets() rule in ViewSetMapButton.tsx: a
   # builder set takes priority (that's what the map is built for), otherwise

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -334,15 +334,22 @@ class BuildBoardSetJob
   end
 
   # Every board in the just-built set: BFS the predictive_board_id links from the
-  # root, bounded in depth and scoped to the owner's boards so a tile pointing at
-  # a shared/admin board can't pull it into the sweep.
-  def set_board_ids(root, max_depth = 3)
+  # root, scoped to the owner's boards so a tile pointing at a shared/admin board
+  # can't pull it into the sweep.
+  #
+  # Deliberately UNBOUNDED in depth (issue #586). A depth cap is an escape hatch:
+  # a page below the cap is reachable from the published root by tapping through,
+  # but never joins the builder BoardGroup — and publish/unpublish/delete/board
+  # count all read group membership, so it silently falls out of the set. Current
+  # templates don't nest past 3, but hand-extended sets do. The walk still
+  # terminates: `where.not(id: seen)` means each pass adds only boards it hasn't
+  # seen, so it's bounded by the owner's board count and cycle-safe.
+  def set_board_ids(root)
     owner_id = root.user_id
     seen = [root.id]
     frontier = [root.id]
-    depth = 0
 
-    while frontier.any? && depth < max_depth
+    while frontier.any?
       child_ids = BoardImage.where(board_id: frontier).where.not(predictive_board_id: nil)
         .pluck(:predictive_board_id).uniq
       children = Board.where(id: child_ids, user_id: owner_id).where.not(id: seen).pluck(:id)
@@ -350,7 +357,6 @@ class BuildBoardSetJob
 
       seen.concat(children)
       frontier = children
-      depth += 1
     end
 
     seen

--- a/spec/requests/api/images_create_predictive_board_spec.rb
+++ b/spec/requests/api/images_create_predictive_board_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+# POST /api/images/:id/create_predictive_board is the editor's "turn this tile
+# into a folder" action. When the tile lives on a Board Builder set, the page it
+# creates has to JOIN that set's builder BoardGroup (issue #586) — publish,
+# unpublish, delete, and the 0-slot board count all read group membership, so a
+# page that never joined is reachable by tapping its tile but invisible to every
+# one of those operations.
+RSpec.describe "API::Images create_predictive_board", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:image) { create(:image, label: "snacks", user: user) }
+
+  # A builder root + its BoardGroup, plus one builder_child page (the usual
+  # place a user adds a new folder tile — deeper than the root).
+  def build_builder_set(owner: user, published: false)
+    root = create(:board, user: owner, name: "Home", published: published,
+                          settings: { "builder_root" => true })
+    group = BoardGroup.create!(user: owner, name: "Milo's Set", builder: true,
+                               root_board_id: root.id)
+    group.board_group_boards.create!(board: root)
+    page = create(:board, user: owner, name: "Food", published: published,
+                          settings: { "builder_child" => true })
+    group.board_group_boards.create!(board: page)
+    [root, group, page]
+  end
+
+  def create_folder!(parent_board, as: user)
+    post "/api/images/#{image.id}/create_predictive_board",
+         params: { board_id: parent_board.id, word_list: %w[chips apple], name: "Snacks" },
+         headers: auth_headers(as)
+  end
+
+  it "adds the new page to the builder BoardGroup of the parent page" do
+    _root, group, page = build_builder_set
+
+    expect { create_folder!(page) }.to change { group.board_group_boards.count }.by(1)
+
+    expect(response).to have_http_status(:ok)
+    new_board = Board.find(JSON.parse(response.body)["board"]["id"])
+    expect(group.boards.reload).to include(new_board)
+    expect(page.board_images.find_by(image_id: image.id).predictive_board_id).to eq(new_board.id)
+  end
+
+  it "adds the new page when the tile is on the builder ROOT itself" do
+    root, group, _page = build_builder_set
+
+    create_folder!(root)
+
+    new_board = Board.find(JSON.parse(response.body)["board"]["id"])
+    expect(group.boards.reload).to include(new_board)
+  end
+
+  # countable_board_count memoizes, and `reload` does not clear the ivar — a
+  # fresh User instance is the only way to observe the change.
+  it "keeps the new page out of the plan's board count, like the rest of the set" do
+    _root, _group, page = build_builder_set
+
+    expect { create_folder!(page) }.not_to change { User.find(user.id).countable_board_count }
+  end
+
+  it "leaves the new page covered by the publish cascade" do
+    root, _group, page = build_builder_set(published: true)
+
+    create_folder!(page)
+    new_board = Board.find(JSON.parse(response.body)["board"]["id"])
+    expect(new_board.published).to be_falsey
+
+    cascade = Boards::PublishCascade.new(root.reload)
+    expect(cascade.needed?(published: true)).to be true
+    cascade.apply!(published: true)
+    expect(new_board.reload.published).to be true
+  end
+
+  it "is a no-op for a board that belongs to no builder set" do
+    plain = create(:board, user: user, name: "Loose board")
+
+    expect { create_folder!(plain) }.not_to change { BoardGroupBoard.count }
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "never inserts into another user's builder group" do
+    _root, other_group, other_page = build_builder_set(owner: other_user)
+    # A public image is loadable by anyone, and the parent board lookup is not
+    # ownership-scoped — the group insert must be.
+    image.update!(is_private: false)
+
+    expect { create_folder!(other_page, as: user) }
+      .not_to change { other_group.board_group_boards.count }
+  end
+end

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -619,6 +619,41 @@ RSpec.describe BuildBoardSetJob do
 
       expect(group.reload.boards.pluck(:id)).to match_array(user.boards.where(predefined: false).pluck(:id))
     end
+
+    # Issue #586: the membership walk used to stop at depth 3, so a page four
+    # hops from the root was reachable by tapping through but never a group
+    # member — and publish/unpublish/delete/board count all read membership.
+    it "attaches pages nested deeper than three hops from the root" do
+      root, group = precreate_root_and_group!(name: "Home")
+
+      # Hand-extend the set into a chain: root -> L1 -> L2 -> L3 -> L4.
+      pages = Array.new(4) { |i| create(:board, user: user, name: "L#{i + 1}") }
+      [root, *pages].each_cons(2) do |parent, child|
+        tile = create(:board_image, board: parent, label: child.name,
+                                    image: create(:image, label: child.name, user_id: user.id))
+        tile.update!(predictive_board_id: child.id)
+      end
+
+      # Root now has tiles, so this takes the already-built backfill path.
+      described_class.new.perform(root.id, communicator.id, "home", [], {}, { "board_group_id" => group.id })
+
+      expect(group.reload.boards.pluck(:id)).to match_array([root.id, *pages.map(&:id)])
+      expect(User.find(user.id).countable_board_count).to eq(0)
+    end
+
+    # A tile pointing at a board the owner doesn't own (a shared or admin seed
+    # board) still can't drag it into the set, cap or no cap.
+    it "does not sweep in boards the root's owner does not own" do
+      root, group = precreate_root_and_group!(name: "Home")
+      foreign = create(:board, user: create(:user), name: "Someone else's")
+      tile = create(:board_image, board: root, label: "Foreign",
+                                  image: create(:image, label: "Foreign", user_id: user.id))
+      tile.update!(predictive_board_id: foreign.id)
+
+      described_class.new.perform(root.id, communicator.id, "home", [], {}, { "board_group_id" => group.id })
+
+      expect(group.reload.boards.pluck(:id)).not_to include(foreign.id)
+    end
   end
 
   describe "missing root" do


### PR DESCRIPTION
## Summary

A page created by the editor's "turn this tile into a folder" action escaped its Board Builder set. `Api::ImagesController#create_predictive_board` wired the `predictive_board_id` link but never joined the builder `BoardGroup` — and publish, unpublish, delete, and the 0-slot board count all read group membership. The page was reachable from the published root by tapping its tile, but was never published, so a public visitor got the vague 404 the publish cascade exists to remove. Re-saving publish on the root didn't help: `Boards::PublishCascade#needed?` only compares *members*.

The fix joins the new page to the parent board's builder group. Adding `Board#containing_builder_board_group` was necessary because the existing `builder_board_group` only answers for a root, and folder tiles are usually added on a child page deeper in the set. Both ends are ownership-scoped, so a tile on a board shared from another account can't insert into that account's set.

Joining the group (rather than teaching `PublishCascade` to walk `predictive_board_id`) keeps one definition of "the set" — publish, delete, and the board count already agree on group membership, so the cascade itself needs no change.

Also drops the depth-3 cap on `BuildBoardSetJob#set_board_ids`, the same escape hatch one level down: a page four hops from the root was never attached either. The walk is owner-scoped and cycle-safe (`where.not(id: seen)`), so unbounded still terminates, bounded by the owner's board count.

Closes #586

## Test plan

New `spec/requests/api/images_create_predictive_board_spec.rb` (6 examples) — the new page joins the parent's builder group whether the tile is on the root or a child page; it stays out of `countable_board_count`; `PublishCascade` now reports and applies it; no-op for a board outside any builder set; never inserts into another user's group. Verified these fail on `main` (4 of 6 fail without the fix).

Two new `BuildBoardSetJob` examples — a chain 4 hops from the root attaches on re-run, and a tile pointing at a board the owner doesn't own still isn't swept in. The deep-nesting one fails without the cap change.

Ran and passing:

- `spec/requests/api/images_create_predictive_board_spec.rb`, `spec/sidekiq/build_board_set_job_spec.rb`, `spec/sidekiq/build_board_set_job_grid_spec.rb`, `spec/services/boards/publish_cascade_spec.rb`, `spec/requests/api/boards_publish_cascade_spec.rb`, `spec/requests/api/images_spec.rb` — 106 examples, 0 failures
- `spec/models/board_spec.rb`, `spec/requests/api/board_groups_spec.rb`, `spec/requests/api/boards_destroy_spec.rb`, `spec/requests/api/boards_create_board_group_spec.rb`, `spec/requests/api/board_membership_groups_spec.rb` — 139 examples, 0 failures

Full suite not run (targeted per PR conventions); CI covers it.

## Not included

Other `predictive_board_id` writers — `Api::BoardImagesController#update` (linking an *existing* board as a folder) and `board_screenshot_imports`. Those attach a board that already counts as its own board with its own publish state; folding it into a set would silently change its delete and count semantics. That's a separate product decision.

## Docs

`.claude-notes/board-builder.md` and the publish-cascade section of `.claude-notes/boards-and-teams.md` now state the invariant — group membership must stay a superset of the set's reachable folder graph, so any new way to hang a page off a builder set needs the same join. CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)