### PR TITLE
fix(boards): let board owners publish their own boards

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -663,12 +663,45 @@ The cascade set is the root's builder `BoardGroup` membership — the same set
 descendants (`board_images.predictive_board_id`) outside the builder set are
 deliberately **not** included: they aren't owned by the root.
 
-`published` is admin-only (`board_params` strips it for non-admins), so the
-cascade is unreachable for regular users.
+Members are additionally scoped to **the root board's owner**
+(`user_id: board.user_id`). `Board#builder_board_group` falls back to
+`board_groups.where(builder: true).first` with no ownership filter, and
+`add_to_groups` lets any board be added to any group id without an ownership
+check — so a group can contain a board its controller doesn't own. That was
+contained while publishing was admin-only; now that owners can publish
+(below), the scope is what stops the cascade becoming a route to flipping
+someone else's board. An admin editing another user's set is unaffected: the
+scope follows the root's owner, not the requester.
 
 **Image-removal bypass:** The guard is skipped entirely when the request carries
 `image_ids_to_remove` — that branch returns early (line 453 in the controller)
 without any board attribute assignment or save, so there is nothing to confirm.
+
+### `published` vs `predefined` — not the same permission
+
+These two are routinely conflated. They answer different questions, and only
+one is admin-only:
+
+- **`predefined`** — curation. Admin-only; `board_params` strips it for
+  non-admins (#27). It marks a board as a starter board, and it is one of the
+  three conditions for `Board.public_boards` (the curated gallery), which is
+  `user_id == DEFAULT_ADMIN_ID AND predefined AND published`. Stripping this is
+  what prevents a user self-promoting into the gallery. `User#can_edit?` also
+  returns false for any predefined board a non-admin touches.
+- **`published`** — share-link visibility, owned by **the board owner**. On a
+  user-owned board it only drives `Board#viewable_by?`: whether a logged-out
+  visitor can open that board's own `/pb/<slug>`. That link is how a user's
+  Public page (`PublicProfile`) and MySpeak tiles reach their boards, so an
+  owner who can't publish has a Public page whose every board 404s for
+  visitors. Permitted for non-admins as of #633 (filed on the frontend).
+
+Publishing your own board does **not** put it in the curated gallery — the
+gallery still requires admin ownership plus `predefined`.
+
+Safe for non-admins because `update` is already gated to the owner:
+`check_board_view_edit_permissions` (owner or admin) plus the inline
+`User#can_edit?`. The only non-admin who can reach the assignment is the person
+who owns the board.
 
 ## Board Sets (BoardGroup) — user CRUD + limits
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **The "Publish this board" toggle works for everyone, not just admins.** The
+  server was discarding `published` from anyone who wasn't an admin, so a
+  regular user could flip the toggle, get a "Board saved" confirmation, and
+  still have an unpublished board — with a public link and QR code that showed
+  visitors a 404. Board owners can now publish and unpublish their own boards.
+  Curation is unchanged: marking a board as a starter board is still admin-only,
+  and publishing your own board does not add it to the public board gallery.
 - Publishing a Board Builder board set now publishes every page in the set, so
   public visitors no longer hit a dead end when tapping a folder button.
   Unpublishing removes the whole set from public view. Both ask for confirmation

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -420,8 +420,9 @@ class API::BoardsController < API::ApplicationController
     # Warn+confirm before cascading publish across a Board Builder set, mirroring
     # the delete flow. This runs BEFORE any attribute is assigned, so a declined
     # cascade writes nothing at all — the client re-sends the identical payload
-    # with confirm=true. `published` is stripped from board_params for
-    # non-admins, so this is unreachable for them.
+    # with confirm=true. Reachable by any board owner since #633 let non-admins
+    # set `published`; PublishCascade scopes its members to the root's owner so
+    # a cascade can only ever flip boards the requester already owns.
     #
     # Skipped entirely when `image_ids_to_remove` is present: that branch
     # returns early below without ever assigning or saving `published`, so
@@ -1609,14 +1610,22 @@ class API::BoardsController < API::ApplicationController
                                   :query,
                                   :page,
                                   :display_image_url, :category, :image_ids_to_remove, :board_type, settings: {}, margin_settings: {}, tags: [])
-    # Only admins may curate `predefined`/`published` boards — those flags decide
-    # whether a board enters the public/curated gallery. Strip them for everyone
-    # else so a regular user can't self-promote their own board (#27, mirrors the
-    # board_groups_controller pattern).
-    unless current_user&.admin?
-      permitted.delete(:predefined)
-      permitted.delete(:published)
-    end
+    # `predefined` is curation and stays admin-only: it decides whether a board
+    # is offered as a starter board, and `Board.public_boards` (the curated
+    # gallery) is `admin-owned AND predefined AND published`. Stripping
+    # `predefined` is what stops a regular user self-promoting into that
+    # gallery (#27, mirrors the board_groups_controller pattern).
+    #
+    # `published` is NOT curation — on a user-owned board it only decides
+    # whether `Board#viewable_by?` lets a logged-out visitor open the board's
+    # own /pb/<slug> link, which is how a user's Public page and MySpeak tiles
+    # reach their boards. Owners need it, and stripping it here made the UI's
+    # Publish toggle a silent no-op (#633, frontend). It is safe to permit for
+    # non-admins because `update` is already gated to the owner
+    # (check_board_view_edit_permissions + User#can_edit?, which also refuses
+    # any predefined board), so the only non-admin who can set it is the person
+    # who owns the board.
+    permitted.delete(:predefined) unless current_user&.admin?
     permitted
   end
 

--- a/app/services/boards/publish_cascade.rb
+++ b/app/services/boards/publish_cascade.rb
@@ -64,6 +64,16 @@ module Boards
 
     # Member boards whose published flag differs from the target. Excludes the
     # root itself — it's a member of its own group, but the caller saves it.
+    #
+    # Scoped to the root's owner. `Board#builder_board_group` falls back to
+    # `board_groups.where(builder: true).first` with no ownership filter, and
+    # `add_to_groups` lets any board be added to any group id without an
+    # ownership check (a known pre-existing hole, documented on
+    # Board#eligible_board_group). That was contained while `published` was
+    # admin-only, but #633 opened publishing to owners — without this filter a
+    # user could flip `published` on someone else's board just by getting it
+    # into a group they control. An admin editing another user's set is
+    # unaffected: the scope follows the root board's owner, not the requester.
     def member_boards_to_change(published)
       group = builder_group
       return Board.none unless group
@@ -73,7 +83,10 @@ module Boards
       # published IS NULL would silently never be counted or flipped, leaving
       # it out of sync after a confirmed cascade. IS DISTINCT FROM treats NULL
       # as a real, comparable value so those members are included too.
-      group.boards.distinct.where.not(id: board.id).where("published IS DISTINCT FROM ?", published)
+      group.boards.distinct
+           .where(user_id: board.user_id)
+           .where.not(id: board.id)
+           .where("published IS DISTINCT FROM ?", published)
     end
   end
 end

--- a/spec/requests/api/boards_publish_cascade_spec.rb
+++ b/spec/requests/api/boards_publish_cascade_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 # Publish cascade: publishing or unpublishing a Board Builder root cascades to
 # every member board of its builder BoardGroup, behind a 409 warn+confirm that
-# mirrors the board-delete flow. `published` is admin-only server-side, so the
-# cascade is only ever reachable by admins.
+# mirrors the board-delete flow. Since #633 any board owner can set `published`,
+# so the cascade is reachable by non-admins too — its members are scoped to the
+# root board's owner so it can only ever flip boards the requester owns.
 RSpec.describe "API::Boards publish cascade", type: :request do
   let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
   let(:member_user) { create(:user) }
@@ -168,6 +169,61 @@ RSpec.describe "API::Boards publish cascade", type: :request do
     end
   end
 
+  # #633 — the same cascade, driven by a plain owner rather than an admin.
+  describe "a non-admin owner cascading their own set" do
+    let(:owner) { create(:user) }
+
+    it "prompts with 409 and writes nothing until confirmed" do
+      root, members = build_builder_set(owner: owner)
+
+      update_board(root, as: owner, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:conflict)
+      expect(JSON.parse(response.body)["error"]).to eq("publish_cascade_confirmation_required")
+      expect(root.reload.published).to be false
+      expect(members.map { |m| m.reload.published }).to all(be false)
+    end
+
+    it "cascades the whole set on confirm" do
+      root, members = build_builder_set(owner: owner)
+
+      update_board(root, as: owner, params: { board: { published: true }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+      expect(members.map { |m| m.reload.published }).to all(be true)
+    end
+
+    # `add_to_groups` lets any board be added to any group with no ownership
+    # check, so a group the owner controls can contain a board they don't own.
+    # The cascade must never flip that board.
+    it "never touches a group member owned by someone else" do
+      root, members = build_builder_set(owner: owner)
+      intruder = create(:board, user: member_user, name: "Not Yours", published: false)
+      root.builder_board_group.board_group_boards.create!(board: intruder)
+
+      update_board(root, as: owner, params: { board: { published: true }, confirm: "true" })
+
+      expect(response).to have_http_status(:ok)
+      expect(root.reload.published).to be true
+      expect(members.map { |m| m.reload.published }).to all(be true)
+      expect(intruder.reload.published).to be_falsey
+    end
+
+    it "excludes a foreign board from the confirmation summary" do
+      root, _members = build_builder_set(owner: owner)
+      intruder = create(:board, user: member_user, name: "Not Yours", published: false)
+      root.builder_board_group.board_group_boards.create!(board: intruder)
+
+      update_board(root, as: owner, params: { board: { published: true } })
+
+      expect(response).to have_http_status(:conflict)
+      affected = JSON.parse(response.body).dig("cascade", "affected")
+      expect(affected["count"]).to eq(2)
+      expect(affected["names"]).not_to include("Not Yours")
+    end
+  end
+
   describe "image_ids_to_remove in the same request as a publish toggle" do
     it "removes the image without applying an unconfirmed cascade, instead of an unbreakable confirm loop" do
       # The image_ids_to_remove branch returns early and never assigns or
@@ -196,18 +252,6 @@ RSpec.describe "API::Boards publish cascade", type: :request do
       update_board(root, as: admin, params: { image_ids_to_remove: [image.id] })
 
       expect(response).to have_http_status(:ok)
-    end
-  end
-
-  describe "non-admin" do
-    it "cannot trigger the cascade because published is stripped" do
-      root, members = build_builder_set(owner: member_user)
-
-      update_board(root, as: member_user, params: { board: { published: true } })
-
-      expect(response).to have_http_status(:ok)
-      expect(root.reload.published).to be false
-      expect(members.map { |m| m.reload.published }).to all(be false)
     end
   end
 end

--- a/spec/requests/api/mass_assignment_spec.rb
+++ b/spec/requests/api/mass_assignment_spec.rb
@@ -21,19 +21,52 @@ RSpec.describe "Mass-assignment of ownership fields", type: :request do
     end
   end
 
-  # #27 — `predefined`/`published` decide whether a board enters the public
-  # curated gallery; a non-admin must not be able to self-promote via update.
-  describe "PATCH /api/boards/:id (predefined/published self-promotion)" do
+  # #27 — `predefined` decides whether a board is offered as a starter board and
+  # is one of the three conditions for `Board.public_boards` (the curated
+  # gallery), so a non-admin must not be able to self-promote via update.
+  #
+  # #633 — `published` is deliberately NOT in that category. On a user-owned
+  # board it only controls `Board#viewable_by?`, i.e. whether the owner's own
+  # /pb/<slug> share link opens for a visitor. Owners set it themselves.
+  describe "PATCH /api/boards/:id (predefined/published)" do
     let(:board) { create(:board, user: owner, predefined: false, published: false) }
 
-    it "ignores predefined/published from a non-admin owner" do
+    it "ignores predefined from a non-admin owner but honours published" do
       patch "/api/boards/#{board.id}",
             params: { board: { predefined: true, published: true } },
             headers: auth_headers(owner)
 
       board.reload
       expect(board.predefined).to be_falsey
-      expect(board.published).to be_falsey
+      expect(board.published).to be true
+    end
+
+    it "lets a non-admin owner unpublish their own board again" do
+      board.update!(published: true)
+
+      patch "/api/boards/#{board.id}",
+            params: { board: { published: false } },
+            headers: auth_headers(owner)
+
+      expect(board.reload.published).to be false
+    end
+
+    it "does not put a self-published user board into the curated gallery" do
+      patch "/api/boards/#{board.id}",
+            params: { board: { published: true } },
+            headers: auth_headers(owner)
+
+      expect(board.reload.published).to be true
+      expect(Board.public_boards).not_to include(board)
+    end
+
+    it "does not let a non-owner publish someone else's board" do
+      patch "/api/boards/#{board.id}",
+            params: { board: { published: true } },
+            headers: auth_headers(attacker)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(board.reload.published).to be_falsey
     end
 
     it "still lets an admin curate predefined/published" do

--- a/spec/services/boards/publish_cascade_spec.rb
+++ b/spec/services/boards/publish_cascade_spec.rb
@@ -154,4 +154,46 @@ RSpec.describe Boards::PublishCascade do
       expect(null_member.reload.published).to be false
     end
   end
+
+  # #633 — publishing is no longer admin-only, so the cascade must not be a
+  # route to flipping a board you don't own. `add_to_groups` has no ownership
+  # check, so a group can legitimately contain a foreign board.
+  describe "a group member owned by another user" do
+    let(:other_user) { create(:user) }
+
+    def build_set_with_foreign_member
+      root, group, members = build_builder_set
+      foreign = create(:board, user: other_user, name: "Someone Else's", published: false)
+      group.board_group_boards.create!(board: foreign)
+      [root, members, foreign]
+    end
+
+    it "is excluded from #summary's affected count and names" do
+      root, _members, _foreign = build_set_with_foreign_member
+
+      summary = described_class.new(root).summary(published: true)
+
+      expect(summary[:affected][:count]).to eq(2)
+      expect(summary[:affected][:names]).not_to include("Someone Else's")
+    end
+
+    it "is not flipped by #apply!" do
+      root, members, foreign = build_set_with_foreign_member
+
+      expect(described_class.new(root).apply!(published: true)).to eq(2)
+      expect(members.map { |m| m.reload.published }).to all(be true)
+      expect(foreign.reload.published).to be false
+    end
+
+    it "alone does not make a cascade needed" do
+      root = create(:board, user: user, settings: { "builder_root" => true })
+      group = BoardGroup.create!(user: user, name: "Set", builder: true, root_board_id: root.id)
+      group.board_group_boards.create!(board: root)
+      group.board_group_boards.create!(
+        board: create(:board, user: other_user, published: false),
+      )
+
+      expect(described_class.new(root).needed?(published: true)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Fixes brittanyjohns/itty-bitty-frontend#633 — the frontend's "Publish this board" toggle was a silent no-op for every non-admin. `board_params` stripped `published` alongside `predefined`, so a regular user could flip it, get a "Board saved successfully" toast, and still have an unpublished board sitting behind a public URL and QR code that 404'd for visitors.

## The permissions call

The issue framed this as "admin-gate the toggle, or let owners publish." Going with **owners publish**, because the two flags aren't the same permission:

| | what it gates | who |
|---|---|---|
| `predefined` | starter-board curation; one of the three conditions for `Board.public_boards` (`admin-owned AND predefined AND published`) | **admin only** — unchanged |
| `published` | `Board#viewable_by?`, i.e. whether a logged-out visitor can open that board's own `/pb/<slug>` | **the board's owner** |

Stripping `predefined` is what stops self-promotion into the curated gallery. `published` never did that job — publishing your own board still doesn't enter the gallery, because the gallery also requires admin ownership.

Meanwhile the share link *is* how a user's Public page reaches their boards: `PublicProfile.tsx:180` sends visitors to `/pb/<slug>`. So the old rule left every non-admin with a Public page listing boards that 404 for anyone who taps them, and no way to fix it.

Safe for non-admins because `update` is already gated to the owner — `check_board_view_edit_permissions` (owner or admin) plus the inline `User#can_edit?`, which additionally refuses any `predefined` board.

## Cascade ownership scope (folded in, not scope creep)

Opening publishing to owners makes `Boards::PublishCascade` reachable by non-admins for the first time. `Board#builder_board_group` falls back to `board_groups.where(builder: true).first` with **no ownership filter**, and `add_to_groups` lets any board be added to any group id with no ownership check — a pre-existing hole already documented on `Board#eligible_board_group`. Contained while publishing was admin-only; without a fix it would have become a route to flipping `published` on a board you don't own.

`member_boards_to_change` is now scoped to `user_id: board.user_id`. Admins editing another user's set are unaffected — the scope follows the root board's owner, not the requester.

## Not in this PR

- `@board.favorite = board_params["favorite"] if board_params["favorite"].present?` has the identical `false.present?` bug that #587 fixed for `published` — unfavoriting via this path is a no-op. Separate concern, filed separately.
- No plan/tier gating on who may publish.
- No frontend change needed: `updateBoard` already sends `published` on every save (`src/data/boards.ts:550`).

## Test plan

`bundle exec rspec spec/requests/api spec/services/boards spec/models/board_spec.rb` — **1666 examples, 0 failures.**

New coverage:
- `mass_assignment_spec` — owner publishes; owner unpublishes; a self-published user board is **not** in `Board.public_boards`; a non-owner still gets 401; `predefined` still ignored for non-admins; admin can still set both.
- `boards_publish_cascade_spec` — non-admin owner gets the 409 prompt and writes nothing, then cascades their whole set on confirm; a foreign board in their group is never flipped and never appears in the confirmation summary.
- `publish_cascade_spec` — foreign member excluded from `#summary` counts/names and from `#apply!`; a foreign member alone doesn't make a cascade "needed".

Two existing specs asserted the old behavior and were updated: the `mass_assignment_spec` self-promotion case (now: `predefined` ignored, `published` honoured), and a `boards_publish_cascade_spec` "non-admin cannot trigger the cascade" case, removed as duplicate of the new owner-cascade block.

Docs: `.claude-notes/boards-and-teams.md` gains a `published` vs `predefined` section and the cascade ownership-scope rationale; `CHANGELOG.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)