### PR TITLE
feat(admin): add Organizations screen to HTML admin dashboard (phase 1/8)

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,0 +1,70 @@
+module Admin
+  class OrganizationsController < Admin::ApplicationController
+    def index
+      @organizations = Organization.order(created_at: :desc)
+    end
+
+    def show
+      @organization = Organization.find(params[:id])
+      @member_search = params[:member_search]
+      @members = @organization.users.order(:email)
+      @members = @members.where("email ILIKE ? OR name ILIKE ?", "%#{@member_search}%", "%#{@member_search}%") if @member_search.present?
+    end
+
+    def new
+      @organization = Organization.new
+    end
+
+    def create
+      @organization = Organization.new(organization_params)
+      if @organization.save
+        redirect_to admin_dashboard_organization_path(@organization), notice: "Organization created."
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def edit
+      @organization = Organization.find(params[:id])
+    end
+
+    def update
+      @organization = Organization.find(params[:id])
+      if @organization.update(organization_params)
+        redirect_to admin_dashboard_organization_path(@organization), notice: "Organization updated."
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def assign_user
+      @organization = Organization.find(params[:id])
+      user_email = params[:user_email]
+
+      user = User.invite!(email: user_email, skip_invitation: true)
+      # invite! always returns a User instance — for an already-registered
+      # email it resolves to that existing (persisted) record with a stale
+      # "already taken" error attached, which we intentionally ignore here.
+      if user.persisted?
+        inviting_user_id = @organization.admin_user_id
+        if inviting_user_id
+          user.invited_by_id = inviting_user_id
+          user.invited_by_type = "User"
+          user.send_welcome_to_organization_email(@organization)
+        end
+        user.stripe_customer_id = User.create_stripe_customer(user_email)
+        user.organization_id = @organization.id
+        user.save
+        redirect_to admin_dashboard_organization_path(@organization), notice: "#{user_email} added to #{@organization.name}."
+      else
+        redirect_to admin_dashboard_organization_path(@organization), alert: user.errors.full_messages.to_sentence
+      end
+    end
+
+    private
+
+    def organization_params
+      params.require(:organization).permit(:name, :slug, :admin_user_id)
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_organizations_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Organizations</p>
+      <p class="text-xs text-t2 mt-1">Manage organizations, admins, and members</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/admin/organizations/_form.html.erb
+++ b/app/views/admin/organizations/_form.html.erb
@@ -1,0 +1,30 @@
+<% if organization.errors.any? %>
+  <div class="admin-flash-err border rounded-lg px-4 py-3 mb-6 text-sm">
+    <%= organization.errors.full_messages.to_sentence %>
+  </div>
+<% end %>
+
+<%= form_with model: organization, url: url, local: true do |f| %>
+  <div class="admin-card border rounded-xl p-5 mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="organization_name">Name</label>
+      <%= f.text_field :name, id: "organization_name", required: true,
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="organization_slug">Slug</label>
+      <%= f.text_field :slug, id: "organization_slug",
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div class="md:col-span-2">
+      <label class="block text-xs font-medium text-t2 mb-1" for="organization_admin_user_id">Admin user</label>
+      <%= f.select :admin_user_id,
+            options_from_collection_for_select(User.order(:email), :id, :email, organization.admin_user_id),
+            { include_blank: "Select admin user" },
+            { id: "organization_admin_user_id", class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" } %>
+    </div>
+  </div>
+
+  <%= f.submit organization.persisted? ? "Save changes" : "Create organization",
+        class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>
+<% end %>

--- a/app/views/admin/organizations/edit.html.erb
+++ b/app/views/admin/organizations/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "Edit #{@organization.name}" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-semibold text-t1 tracking-tight">Edit Organization</h1>
+  <%= link_to "← Back", admin_dashboard_organization_path(@organization), class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", organization: @organization, url: admin_dashboard_organization_path(@organization) %>

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, "Organizations" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Organizations</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= @organizations.size %> total</p>
+  </div>
+  <%= link_to "New organization", new_admin_dashboard_organization_path,
+        class: "text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Name", "Slug", "Admin user", "Members", "Created"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @organizations.each do |organization| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-medium">
+            <%= link_to organization.name.presence || "(unnamed)", admin_dashboard_organization_path(organization), class: "hover:text-accent transition-colors" %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2 font-mono"><%= organization.slug.presence || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= organization.admin_user&.email || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= organization.users.size %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= organization.created_at.strftime("%b %-d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @organizations.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No organizations yet.</div>
+  <% end %>
+</div>

--- a/app/views/admin/organizations/new.html.erb
+++ b/app/views/admin/organizations/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "New Organization" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-semibold text-t1 tracking-tight">New Organization</h1>
+  <%= link_to "← All organizations", admin_dashboard_organizations_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", organization: @organization, url: admin_dashboard_organizations_path %>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -1,0 +1,79 @@
+<% content_for :page_title, @organization.name %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @organization.name %></h1>
+    <p class="text-sm text-t3 mt-0.5 font-mono"><%= @organization.slug.presence || "no slug" %></p>
+  </div>
+  <div class="flex items-center gap-3">
+    <%= link_to "Edit", edit_admin_dashboard_organization_path(@organization),
+          class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+    <%= link_to "← All organizations", admin_dashboard_organizations_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+  <div>
+    <div class="text-xs text-t2 mb-1">Admin user</div>
+    <div class="text-t1"><%= @organization.admin_user&.email || "—" %></div>
+  </div>
+  <div>
+    <div class="text-xs text-t2 mb-1">Plan type</div>
+    <div class="text-t1"><%= @organization.plan_type.presence || "—" %></div>
+  </div>
+  <div>
+    <div class="text-xs text-t2 mb-1">Created</div>
+    <div class="text-t1"><%= @organization.created_at.strftime("%b %-d, %Y") %></div>
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-3">Add member</h2>
+  <%= form_tag assign_user_admin_dashboard_organization_path(@organization), method: :post, class: "flex items-center gap-2" do %>
+    <input type="email" name="user_email" placeholder="user@example.com" required
+           class="admin-input border rounded px-3 py-2 text-sm w-64 focus:border-indigo-500 focus:outline-none">
+    <button type="submit" class="text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">Invite &amp; add</button>
+  <% end %>
+  <p class="text-[11px] text-t3 mt-2">Invites the email as a new user if one doesn't already exist, then adds them to this organization.</p>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <div class="flex items-center justify-between px-5 py-3" style="border-bottom: 1px solid var(--border);">
+    <h2 class="text-sm font-medium text-t1">Members (<%= @organization.users.size %>)</h2>
+    <%= form_tag admin_dashboard_organization_path(@organization), method: :get, class: "flex items-center gap-2", data: { turbo: false } do %>
+      <input type="text" name="member_search" value="<%= @member_search %>" placeholder="Search members…"
+             class="admin-input border rounded px-3 py-1.5 text-xs w-48 focus:border-indigo-500 focus:outline-none">
+      <button type="submit" class="text-xs px-2 py-1.5 text-t2 hover:text-t1">Search</button>
+      <% if @member_search.present? %>
+        <%= link_to "Clear", admin_dashboard_organization_path(@organization), class: "text-xs text-t3 hover:text-t1" %>
+      <% end %>
+    <% end %>
+  </div>
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Email", "Name", "Role", "Joined"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @members.each do |member| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1">
+            <%= link_to member.email, admin_dashboard_user_path(member), class: "hover:text-accent transition-colors" %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2"><%= member.name.presence || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= member.role %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= member.created_at.strftime("%b %-d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @members.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">
+      <%= @member_search.present? ? "No members match “#{@member_search}”." : "No members yet." %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -112,6 +112,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Organizations", admin_dashboard_organizations_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/organizations") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,11 @@ Rails.application.routes.draw do
         post :deny
       end
     end
+    resources :organizations, only: [:index, :show, :new, :create, :edit, :update], as: :dashboard_organizations do
+      member do
+        post :assign_user
+      end
+    end
     resources :video_boards, only: [:index, :new, :create, :show, :destroy], as: :dashboard_video_boards do
       member do
         post :publish

--- a/spec/requests/admin/organizations_spec.rb
+++ b/spec/requests/admin/organizations_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Organizations (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin away from every action" do
+      sign_in create(:user)
+      organization = create(:organization)
+
+      get admin_dashboard_organizations_path
+      expect(response).to redirect_to(root_path)
+
+      get admin_dashboard_organization_path(organization)
+      expect(response).to redirect_to(root_path)
+
+      get new_admin_dashboard_organization_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_organizations_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/organizations" do
+    it "lists organizations" do
+      sign_in admin
+      organization = create(:organization, name: "Sunny Elementary")
+
+      get admin_dashboard_organizations_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sunny Elementary")
+    end
+  end
+
+  describe "GET /admin/organizations/:id" do
+    it "shows organization detail and members" do
+      sign_in admin
+      organization = create(:organization, name: "Sunny Elementary")
+      member = create(:user, organization: organization, email: "member@example.com")
+
+      get admin_dashboard_organization_path(organization)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sunny Elementary")
+      expect(response.body).to include(member.email)
+    end
+
+    it "filters members by member_search" do
+      sign_in admin
+      organization = create(:organization)
+      create(:user, organization: organization, email: "alice@example.com")
+      bob = create(:user, organization: organization, email: "bob@example.com")
+
+      get admin_dashboard_organization_path(organization, member_search: "bob")
+
+      expect(response.body).to include(bob.email)
+      expect(response.body).not_to include("alice@example.com")
+    end
+  end
+
+  describe "POST /admin/organizations" do
+    it "creates an organization" do
+      sign_in admin
+      org_admin = create(:user)
+
+      expect {
+        post admin_dashboard_organizations_path, params: { organization: { name: "New Org", slug: "new-org", admin_user_id: org_admin.id } }
+      }.to change(Organization, :count).by(1)
+
+      expect(response).to redirect_to(admin_dashboard_organization_path(Organization.last))
+    end
+
+    it "re-renders the form on validation failure" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_organizations_path, params: { organization: { name: "" } }
+      }.not_to change(Organization, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PUT /admin/organizations/:id" do
+    it "updates an organization" do
+      sign_in admin
+      organization = create(:organization, name: "Old Name")
+
+      put admin_dashboard_organization_path(organization), params: { organization: { name: "New Name" } }
+
+      expect(response).to redirect_to(admin_dashboard_organization_path(organization))
+      expect(organization.reload.name).to eq("New Name")
+    end
+  end
+
+  describe "POST /admin/organizations/:id/assign_user" do
+    it "adds an existing user to the organization" do
+      sign_in admin
+      organization = create(:organization)
+      user = create(:user, email: "existing@example.com")
+
+      post assign_user_admin_dashboard_organization_path(organization), params: { user_email: user.email }
+
+      expect(response).to redirect_to(admin_dashboard_organization_path(organization))
+      expect(user.reload.organization_id).to eq(organization.id)
+    end
+
+    it "invites a brand-new email and adds them to the organization" do
+      sign_in admin
+      organization = create(:organization)
+
+      expect {
+        post assign_user_admin_dashboard_organization_path(organization), params: { user_email: "brandnew@example.com" }
+      }.to change(User, :count).by(1)
+
+      new_user = User.find_by(email: "brandnew@example.com")
+      expect(new_user.organization_id).to eq(organization.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
First phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard, so the frontend admin dashboard can eventually be retired without losing functionality.

This phase adds the **Organizations** screen, which previously only existed as `API::Admin::OrganizationsController` (JSON, consumed by the React admin at `/admin/organizations`) with no HTML equivalent.

- `Admin::OrganizationsController` — index, show, new/create, edit/update, `assign_user`
- Views under `app/views/admin/organizations/` matching the existing admin layout/Tailwind conventions
- Add-member flow mirrors `API::Admin::OrganizationsController#assign_user`: invites a brand-new email as a user, or adds an existing user, to the organization
- Server-side member search (replaces the client-side `SearchBar` filter used in the React admin) instead of porting live in-browser filtering
- Nav link + dashboard card added

Full inventory of frontend-vs-backend admin gaps and the remaining 7-phase plan (Events, Feedback, Word Events, Placeholders, Users parity, Board Printables UI, then frontend retirement) was scoped with Brittany before starting; this PR is phase 1 only.

## Test plan
- [x] `bundle exec rspec spec/requests/admin/organizations_spec.rb` — 10 examples, 0 failures (authorization, CRUD, member search, assign_user for both new and existing emails)
- [x] `bundle exec rspec spec/requests/admin/` — full admin suite, 102 examples, 0 failures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)