### PR TITLE
feat(admin): add Events screen to HTML admin dashboard (phase 2/8)

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,0 +1,66 @@
+module Admin
+  class EventsController < Admin::ApplicationController
+    def index
+      @events = Event.order(created_at: :desc)
+    end
+
+    def show
+      @event = Event.includes(:contest_entries).find(params[:id])
+      @contest_entries = @event.contest_entries.order(name: :asc)
+      @qr_data_url = Boards::AssetRendering.qr_data_url_for(@event.public_url, size: 240)
+    end
+
+    def new
+      @event = Event.new
+    end
+
+    def create
+      @event = Event.new(event_params)
+      if @event.save
+        redirect_to admin_dashboard_event_path(@event), notice: "Event created."
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def edit
+      @event = Event.find(params[:id])
+    end
+
+    def update
+      @event = Event.find(params[:id])
+      if @event.update(event_params)
+        redirect_to admin_dashboard_event_path(@event), notice: "Event updated."
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def pick_winner
+      @event = Event.find(params[:id])
+      @event.contest_entries.update_all(winner: false)
+      winner = @event.contest_entries.sample
+
+      if winner
+        winner.update(winner: true)
+        redirect_to admin_dashboard_event_path(@event), notice: "Winner picked: #{winner.name} (#{winner.email})."
+      else
+        redirect_to admin_dashboard_event_path(@event), alert: "No entries to pick a winner from."
+      end
+    end
+
+    def download_entries
+      @event = Event.find(params[:id])
+      entries = @event.contest_entries.order(name: :asc)
+      send_data entries.to_csv,
+                filename: "#{@event.name.parameterize}-entries-#{Time.zone.now.strftime("%d%m%Y%H%M")}.csv",
+                type: "text/csv"
+    end
+
+    private
+
+    def event_params
+      params.require(:event).permit(:name, :slug, :date, :promo_code, :promo_code_details)
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,11 +17,13 @@ class Event < ApplicationRecord
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
 
-  before_create :set_slug
+  # before_validation (not before_create) so a blank slug is auto-derived from
+  # name in time for the presence/uniqueness validation above to see it.
+  before_validation :set_slug
 
   def set_slug
     if slug.blank?
-      self.slug = name.parameterize
+      self.slug = name.to_s.parameterize
     else
       self.slug = slug.parameterize
     end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_events_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Events</p>
+      <p class="text-xs text-t2 mt-1">Giveaway/contest events, entries, and QR codes</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,0 +1,38 @@
+<% if event.errors.any? %>
+  <div class="admin-flash-err border rounded-lg px-4 py-3 mb-6 text-sm">
+    <%= event.errors.full_messages.to_sentence %>
+  </div>
+<% end %>
+
+<%= form_with model: event, url: url, local: true do |f| %>
+  <div class="admin-card border rounded-xl p-5 mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="event_name">Name</label>
+      <%= f.text_field :name, id: "event_name", required: true,
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="event_slug">Slug <span class="text-t3">(auto from name if left blank)</span></label>
+      <%= f.text_field :slug, id: "event_slug",
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="event_date">Date</label>
+      <%= f.text_field :date, id: "event_date",
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="event_promo_code">Promo code</label>
+      <%= f.text_field :promo_code, id: "event_promo_code",
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+    <div class="md:col-span-2">
+      <label class="block text-xs font-medium text-t2 mb-1" for="event_promo_code_details">Promo code details</label>
+      <%= f.text_area :promo_code_details, id: "event_promo_code_details", rows: 2,
+            class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+    </div>
+  </div>
+
+  <%= f.submit event.persisted? ? "Save changes" : "Create event",
+        class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>
+<% end %>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "Edit #{@event.name}" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-semibold text-t1 tracking-tight">Edit Event</h1>
+  <%= link_to "← Back", admin_dashboard_event_path(@event), class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", event: @event, url: admin_dashboard_event_path(@event) %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title, "Events" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Events</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= @events.size %> total</p>
+  </div>
+  <%= link_to "New event", new_admin_dashboard_event_path,
+        class: "text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Name", "Slug", "Date", "Entries", "Winner", "Created"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @events.each do |event| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-medium">
+            <%= link_to event.name, admin_dashboard_event_path(event), class: "hover:text-accent transition-colors" %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2 font-mono"><%= event.slug %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= event.date.presence || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= event.contest_entries.size %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= event.winner&.name || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= event.created_at.strftime("%b %-d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @events.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No events yet.</div>
+  <% end %>
+</div>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "New Event" %>
+
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-semibold text-t1 tracking-tight">New Event</h1>
+  <%= link_to "← All events", admin_dashboard_events_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", event: @event, url: admin_dashboard_events_path %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,0 +1,87 @@
+<% content_for :page_title, @event.name %>
+
+<% winner = @event.winner %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @event.name %></h1>
+    <p class="text-sm text-t3 mt-0.5 font-mono"><%= @event.slug %></p>
+  </div>
+  <div class="flex items-center gap-3">
+    <%= link_to "Edit", edit_admin_dashboard_event_path(@event),
+          class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+    <%= link_to "← All events", admin_dashboard_events_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+  <div class="admin-card border rounded-xl p-5 md:col-span-2">
+    <div class="grid grid-cols-2 gap-4 text-sm mb-4">
+      <div>
+        <div class="text-xs text-t2 mb-1">Date</div>
+        <div class="text-t1"><%= @event.date.presence || "—" %></div>
+      </div>
+      <div>
+        <div class="text-xs text-t2 mb-1">Promo code</div>
+        <div class="text-t1"><%= @event.promo_code.presence || "—" %></div>
+      </div>
+      <div class="col-span-2">
+        <div class="text-xs text-t2 mb-1">Public entry URL</div>
+        <%= link_to @event.public_url, @event.public_url, target: "_blank", rel: "noopener",
+              class: "text-accent hover:underline text-xs break-all" %>
+      </div>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-3 pt-4" style="border-top: 1px solid var(--border-light);">
+      <%= button_to "Pick a winner", pick_winner_admin_dashboard_event_path(@event), method: :post,
+            class: "text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer",
+            form: { data: { turbo_confirm: "Pick a random winner from #{@contest_entries.size} entries? This clears any previous winner." } } %>
+      <%= link_to "Download entries (CSV)", download_entries_admin_dashboard_event_path(@event),
+            class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+    </div>
+
+    <% if winner %>
+      <div class="mt-4 admin-card-alt border rounded-lg p-3 text-sm">
+        <span class="text-t2">Winner:</span> <span class="text-t1 font-medium"><%= winner.name %></span> — <span class="text-t2"><%= winner.email %></span>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="admin-card border rounded-xl p-5 flex flex-col items-center justify-center">
+    <p class="text-xs text-t2 mb-3">Entry QR code</p>
+    <img src="<%= @qr_data_url %>" alt="QR code for <%= @event.public_url %>" class="w-40 h-40">
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <div class="px-5 py-3" style="border-bottom: 1px solid var(--border);">
+    <h2 class="text-sm font-medium text-t1">Entries (<%= @contest_entries.size %>)</h2>
+  </div>
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Name", "Email", "Submitted", "Winner"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @contest_entries.each do |entry| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1"><%= entry.name %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= entry.email %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= entry.created_at.strftime("%b %-d, %Y %H:%M") %></td>
+          <td class="px-5 py-3 text-xs">
+            <% if entry.winner? %>
+              <span class="admin-badge inline-block text-xs rounded px-2 py-0.5 text-t1">🏆 Winner</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @contest_entries.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No entries yet.</div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -112,6 +112,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Events", admin_dashboard_events_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/events") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,12 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    resources :events, only: [:index, :show, :new, :create, :edit, :update], as: :dashboard_events do
+      member do
+        post :pick_winner
+        get :download_entries
+      end
+    end
   end
 
   get "main/index", as: :home

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,5 +14,26 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#set_slug" do
+    it "auto-derives the slug from name when slug is left blank" do
+      event = Event.new(name: "Spring Giveaway 2026!")
+
+      expect(event.save).to be true
+      expect(event.slug).to eq("spring-giveaway-2026")
+    end
+
+    it "parameterizes an explicitly-provided slug" do
+      event = Event.new(name: "Spring Giveaway", slug: "Custom Slug")
+
+      expect(event.save).to be true
+      expect(event.slug).to eq("custom-slug")
+    end
+
+    it "is invalid without a name to derive a slug from" do
+      event = Event.new(name: "")
+
+      expect(event.save).to be false
+      expect(event.errors[:slug]).to be_present
+    end
+  end
 end

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Events (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin away from every action" do
+      sign_in create(:user)
+      event = create(:event)
+
+      get admin_dashboard_events_path
+      expect(response).to redirect_to(root_path)
+
+      get admin_dashboard_event_path(event)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_events_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/events" do
+    it "lists events" do
+      sign_in admin
+      create(:event, name: "Spring Giveaway")
+
+      get admin_dashboard_events_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Spring Giveaway")
+    end
+  end
+
+  describe "GET /admin/events/:id" do
+    it "shows event detail, entries, and a QR code for the public entry URL" do
+      sign_in admin
+      event = create(:event, name: "Spring Giveaway")
+      create(:contest_entry, event: event, name: "Alice", email: "alice@example.com")
+
+      get admin_dashboard_event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Spring Giveaway")
+      expect(response.body).to include("Alice")
+      expect(response.body).to include("data:image/png;base64,")
+    end
+  end
+
+  describe "POST /admin/events" do
+    it "creates an event" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_events_path, params: { event: { name: "New Event" } }
+      }.to change(Event, :count).by(1)
+
+      expect(response).to redirect_to(admin_dashboard_event_path(Event.last))
+    end
+
+    it "re-renders the form on validation failure" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_events_path, params: { event: { name: "" } }
+      }.not_to change(Event, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe "PUT /admin/events/:id" do
+    it "updates an event" do
+      sign_in admin
+      event = create(:event, name: "Old Name")
+
+      put admin_dashboard_event_path(event), params: { event: { name: "New Name" } }
+
+      expect(response).to redirect_to(admin_dashboard_event_path(event))
+      expect(event.reload.name).to eq("New Name")
+    end
+  end
+
+  describe "POST /admin/events/:id/pick_winner" do
+    it "picks a winner from the entries and clears any previous winner" do
+      sign_in admin
+      event = create(:event)
+      old_winner = create(:contest_entry, event: event, winner: true)
+      create(:contest_entry, event: event)
+
+      post pick_winner_admin_dashboard_event_path(event)
+
+      expect(response).to redirect_to(admin_dashboard_event_path(event))
+      expect(event.contest_entries.where(winner: true).count).to eq(1)
+      expect(event.winner).to be_present
+    end
+
+    it "alerts instead of erroring when there are no entries" do
+      sign_in admin
+      event = create(:event)
+
+      post pick_winner_admin_dashboard_event_path(event)
+
+      expect(response).to redirect_to(admin_dashboard_event_path(event))
+      follow_redirect!
+      expect(response.body).to include("No entries")
+    end
+  end
+
+  describe "GET /admin/events/:id/download_entries" do
+    it "streams a CSV of entries" do
+      sign_in admin
+      event = create(:event)
+      create(:contest_entry, event: event, name: "Alice", email: "alice@example.com")
+
+      get download_entries_admin_dashboard_event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("alice@example.com")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Second phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard. See [PR #594](https://github.com/brittanyjohns/itty_bitty_boards/pull/594) for phase 1 and the overall plan.

Adds the **Events** screen (giveaway/contest events), which previously only existed as `API::Admin::EventsController` (JSON, consumed by the React admin at `/admin/events`) with no HTML equivalent.

- `Admin::EventsController` — index, show, new/create, edit/update, `pick_winner`, `download_entries`
- QR code for the public entry URL, rendered server-side via the existing `Boards::AssetRendering.qr_data_url_for` helper (already used for board printables) — no new gem needed, `rqrcode` was already in the Gemfile
- **Bug fix along the way:** `Event#set_slug` ran on `before_create`, which is *after* the slug presence validation, so creating an event with a blank slug (the documented "auto-derive from name" behavior) always failed validation first. Same bug exists on the JSON API side. Fixed by moving it to `before_validation`; added model spec coverage.
- Nav link + dashboard card added
- Not ported: `delete_event`/`delete_entry` API endpoints — dead code in the current frontend (no delete button wired up anywhere), so no HTML equivalent needed for parity.

## Test plan
- [x] `bundle exec rspec spec/requests/admin/events_spec.rb spec/models/event_spec.rb` — 13 examples, 0 failures
- [x] `bundle exec rspec spec/requests/admin/ spec/sidekiq/mailchimp_event_job_spec.rb` — 123 examples, 0 failures (no regressions from the Event model change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)