### PR TITLE
feat(admin): add Feedback inbox to HTML admin dashboard (phase 3/8)

### DIFF
--- a/app/controllers/admin/feedback_controller.rb
+++ b/app/controllers/admin/feedback_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  class FeedbackController < Admin::ApplicationController
+    def index
+      @type = params[:type].presence_in(FeedbackItem::FEEDBACK_TYPES) || "all"
+      @search = params[:search]
+
+      scope = FeedbackItem.includes(:user)
+      scope = scope.where(feedback_type: @type) unless @type == "all"
+      if @search.present?
+        term = "%#{@search}%"
+        scope = scope.left_joins(:user).where(
+          "feedback_items.subject ILIKE :t OR feedback_items.message ILIKE :t OR feedback_items.role ILIKE :t " \
+          "OR feedback_items.device ILIKE :t OR feedback_items.platform ILIKE :t " \
+          "OR users.email ILIKE :t OR users.name ILIKE :t",
+          t: term,
+        )
+      end
+
+      @feedback_items = scope.order(created_at: :desc).limit(200)
+      @counts = FeedbackItem.group(:feedback_type).count
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_feedback_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Feedback</p>
+      <p class="text-xs text-t2 mt-1">In-app feedback submissions — bugs, features, questions, praise</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/admin/feedback/index.html.erb
+++ b/app/views/admin/feedback/index.html.erb
@@ -1,0 +1,97 @@
+<% content_for :page_title, "Feedback" %>
+
+<%
+  type_label = ->(t) { { "bug" => "Bug", "feature" => "Feature", "question" => "Question", "praise" => "Praise" }[t] || t }
+  type_badge = ->(t) do
+    case t
+    when "bug"      then "bg-red-900/60 text-red-300"
+    when "feature"  then "bg-indigo-900/60 text-indigo-300"
+    when "question" then "bg-amber-900/60 text-amber-300"
+    when "praise"   then "bg-green-900/60 text-green-300"
+    else "admin-card-alt text-t2"
+    end
+  end
+%>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Feedback</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= @feedback_items.size %> shown (most recent 200)</p>
+  </div>
+</div>
+
+<div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+  <div class="flex flex-wrap items-center gap-2">
+    <%= link_to "All (#{@counts.values.sum})", admin_dashboard_feedback_path(search: @search),
+          class: "text-xs px-3 py-1.5 rounded border admin-input transition-colors #{@type == "all" ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"}" %>
+    <% FeedbackItem::FEEDBACK_TYPES.each do |t| %>
+      <%= link_to "#{type_label.call(t)} (#{@counts[t] || 0})", admin_dashboard_feedback_path(type: t, search: @search),
+            class: "text-xs px-3 py-1.5 rounded border admin-input transition-colors #{@type == t ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"}" %>
+    <% end %>
+  </div>
+
+  <%= form_tag admin_dashboard_feedback_path, method: :get, class: "flex items-center gap-2", data: { turbo: false } do %>
+    <%= hidden_field_tag :type, @type unless @type == "all" %>
+    <input type="text" name="search" value="<%= @search %>" placeholder="Search subject, message, email…"
+           class="admin-input border rounded px-3 py-1.5 text-xs w-64 focus:border-indigo-500 focus:outline-none">
+    <button type="submit" class="text-xs px-2 py-1.5 text-t2 hover:text-t1">Search</button>
+    <% if @search.present? %>
+      <%= link_to "Clear", admin_dashboard_feedback_path(type: @type == "all" ? nil : @type), class: "text-xs text-t3 hover:text-t1" %>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="flex flex-col gap-3">
+  <% @feedback_items.each do |item| %>
+    <details class="admin-card border rounded-xl">
+      <summary class="px-5 py-3 cursor-pointer flex items-center justify-between gap-3">
+        <div class="flex items-center gap-3 min-w-0">
+          <span class="<%= type_badge.call(item.feedback_type) %> inline-block text-xs rounded px-2 py-0.5 shrink-0"><%= type_label.call(item.feedback_type) %></span>
+          <span class="text-sm text-t1 truncate"><%= item.subject.presence || item.message.truncate(80) %></span>
+        </div>
+        <div class="flex items-center gap-3 shrink-0">
+          <span class="text-xs text-t2"><%= item.user&.email || "—" %></span>
+          <span class="text-xs text-t3 whitespace-nowrap"><%= item.created_at.strftime("%b %-d, %Y %H:%M") %></span>
+        </div>
+      </summary>
+      <div class="px-5 pb-4 pt-1 text-sm" style="border-top: 1px solid var(--border-light);">
+        <p class="text-t1 whitespace-pre-wrap mb-3 mt-3"><%= item.message %></p>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+          <div>
+            <div class="text-t2 mb-0.5">Role</div>
+            <div class="text-t1"><%= item.role.presence || "—" %></div>
+          </div>
+          <div>
+            <div class="text-t2 mb-0.5">Device</div>
+            <div class="text-t1"><%= item.device.presence || "—" %></div>
+          </div>
+          <div>
+            <div class="text-t2 mb-0.5">Platform</div>
+            <div class="text-t1"><%= item.platform.presence || "—" %></div>
+          </div>
+          <div>
+            <div class="text-t2 mb-0.5">App version</div>
+            <div class="text-t1"><%= item.app_version.presence || "—" %></div>
+          </div>
+          <div class="col-span-2 md:col-span-4">
+            <div class="text-t2 mb-0.5">Page URL</div>
+            <div class="text-t1 break-all"><%= item.page_url.presence || "—" %></div>
+          </div>
+          <div>
+            <div class="text-t2 mb-0.5">Allow contact</div>
+            <div class="text-t1"><%= item.allow_contact? ? "Yes" : "No" %></div>
+          </div>
+        </div>
+        <% if item.user %>
+          <%= link_to "View user →", admin_dashboard_user_path(item.user), class: "text-xs text-accent hover:underline mt-3 inline-block" %>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+
+  <% if @feedback_items.empty? %>
+    <div class="admin-card border rounded-xl px-5 py-10 text-center text-sm text-t3">
+      No feedback matches this filter.
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -112,6 +112,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Feedback", admin_dashboard_feedback_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/feedback") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    get "feedback", to: "feedback#index", as: :dashboard_feedback
   end
 
   get "main/index", as: :home

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,6 +21,14 @@ FactoryBot.define do
     data { "{}" }
   end
 
+  factory :feedback_item do
+    association :user
+    feedback_type { "bug" }
+    role { "parent" }
+    subject { FFaker::Lorem.sentence(3) }
+    message { FFaker::Lorem.paragraph }
+  end
+
   factory :download_lead do
     sequence(:email) { |n| "lead#{n}@example.com" }
     name { FFaker::Name.name }

--- a/spec/requests/admin/feedback_spec.rb
+++ b/spec/requests/admin/feedback_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Feedback (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin" do
+      sign_in create(:user)
+
+      get admin_dashboard_feedback_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_feedback_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/feedback" do
+    it "lists all feedback by default, newest first" do
+      sign_in admin
+      user = create(:user, email: "reporter@example.com")
+      older = create(:feedback_item, user: user, feedback_type: "bug", subject: "Old bug", created_at: 2.days.ago)
+      newer = create(:feedback_item, user: user, feedback_type: "feature", subject: "New idea", created_at: 1.hour.ago)
+
+      get admin_dashboard_feedback_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index("New idea")).to be < response.body.index("Old bug")
+    end
+
+    it "filters by feedback type" do
+      sign_in admin
+      user = create(:user)
+      create(:feedback_item, user: user, feedback_type: "bug", subject: "A bug report")
+      create(:feedback_item, user: user, feedback_type: "praise", subject: "Great app")
+
+      get admin_dashboard_feedback_path(type: "bug")
+
+      expect(response.body).to include("A bug report")
+      expect(response.body).not_to include("Great app")
+    end
+
+    it "searches across subject, message, and reporter email" do
+      sign_in admin
+      user = create(:user, email: "findme@example.com")
+      create(:feedback_item, user: user, subject: "Unrelated subject", message: "unrelated message")
+      matching = create(:feedback_item, user: user, subject: "Matches nothing", message: "nothing matches")
+
+      get admin_dashboard_feedback_path(search: "findme")
+
+      expect(response.body).to include(matching.subject)
+    end
+
+    it "shows the reporting user's email and a link to their admin page" do
+      sign_in admin
+      user = create(:user, email: "reporter@example.com")
+      create(:feedback_item, user: user)
+
+      get admin_dashboard_feedback_path
+
+      expect(response.body).to include("reporter@example.com")
+      expect(response.body).to include(admin_dashboard_user_path(user))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Third phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard. See [PR #594](https://github.com/brittanyjohns/itty_bitty_boards/pull/594) (phase 1) and [PR #595](https://github.com/brittanyjohns/itty_bitty_boards/pull/595) (phase 2) for prior phases and the overall plan.

Adds the **Feedback inbox** screen, which previously only existed as `API::Admin::FeedbackController` (JSON, consumed by the React admin at `/admin/feedback`) with no HTML equivalent.

- `Admin::FeedbackController#index` — type filter chips with live counts, server-side search across subject/message/role/device/platform/reporter email+name
- Expand/collapse per-item detail via `<details>`/`<summary>` — no JS needed, unlike the React admin's fully in-memory filter/search/expand
- Link from each item to the reporting user's admin page
- Nav link + dashboard card added
- Not ported: `DELETE /admin/feedback/:id` — dead code in the current frontend (no delete button wired up anywhere), so no HTML equivalent needed for parity

## Test plan
- [x] `bundle exec rspec spec/requests/admin/feedback_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rspec spec/requests/admin/` — 98 examples, 0 failures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)