### PR TITLE
feat(admin): add Word Events log to HTML admin dashboard (phase 4/8)

### DIFF
--- a/app/controllers/admin/word_events_controller.rb
+++ b/app/controllers/admin/word_events_controller.rb
@@ -1,0 +1,13 @@
+module Admin
+  class WordEventsController < Admin::ApplicationController
+    SORTABLE = %w[created_at word user_id].freeze
+
+    def index
+      @sort = params[:sort].presence_in(SORTABLE) || "created_at"
+      @dir = params[:dir].presence_in(%w[asc desc]) || "desc"
+
+      scope = WordEvent.includes(:user, :child_account, :board, :image).where.not(user_id: current_user.id)
+      @word_events = scope.order(@sort => @dir.to_sym).limit(100)
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_word_events_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Word Events</p>
+      <p class="text-xs text-t2 mt-1">Recent word-tap activity across all users</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/admin/word_events/index.html.erb
+++ b/app/views/admin/word_events/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title, "Word Events" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Word Events</h1>
+    <p class="text-sm text-t3 mt-0.5">Most recent 100, excluding your own activity</p>
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% [
+          ["Word",    "word"],
+          ["User",    "user_id"],
+          [nil,       nil],
+          [nil,       nil],
+          ["When",    "created_at"],
+        ].each do |label, col| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3">
+            <% if col %>
+              <% next_dir = (@sort == col && @dir == "asc") ? "desc" : "asc" %>
+              <%= link_to admin_dashboard_word_events_path(sort: col, dir: next_dir),
+                    class: "hover:text-t1 transition-colors inline-flex items-center gap-1" do %>
+                <%= label %>
+                <% if @sort == col %>
+                  <span class="text-accent"><%= @dir == "asc" ? "↑" : "↓" %></span>
+                <% end %>
+              <% end %>
+            <% end %>
+          </th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @word_events.each do |event| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-medium">
+            <%= event.word.presence || "—" %>
+            <% if event.previous_word.present? %>
+              <span class="text-t3">← <%= event.previous_word %></span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2">
+            <%= link_to event.user.email, admin_dashboard_user_path(event.user), class: "hover:text-accent transition-colors" %>
+            <% if event.child_account %>
+              <div class="text-[10px] text-t3">via <%= event.child_account.username %></div>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2"><%= event.board&.name || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= event.part_of_speech.presence || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap">
+            <%= event.timestamp&.strftime("%b %-d, %Y %H:%M") || event.created_at.strftime("%b %-d, %Y %H:%M") %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @word_events.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No word events yet.</div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -112,6 +112,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Word Events", admin_dashboard_word_events_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/word_events") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    get "word_events", to: "word_events#index", as: :dashboard_word_events
   end
 
   get "main/index", as: :home

--- a/spec/requests/admin/word_events_spec.rb
+++ b/spec/requests/admin/word_events_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Admin::WordEvents (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin" do
+      sign_in create(:user)
+
+      get admin_dashboard_word_events_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_word_events_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/word_events" do
+    it "lists word events for other users" do
+      sign_in admin
+      user = create(:user, email: "speaker@example.com")
+      create(:word_event, user: user, word: "hello")
+
+      get admin_dashboard_word_events_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("hello")
+      expect(response.body).to include("speaker@example.com")
+    end
+
+    it "excludes the current admin's own word events" do
+      sign_in admin
+      create(:word_event, user: admin, word: "adminword")
+      other = create(:user)
+      create(:word_event, user: other, word: "otherword")
+
+      get admin_dashboard_word_events_path
+
+      expect(response.body).not_to include("adminword")
+      expect(response.body).to include("otherword")
+    end
+
+    it "sorts by the requested column and direction" do
+      sign_in admin
+      user = create(:user)
+      create(:word_event, user: user, word: "aaa", created_at: 2.days.ago)
+      create(:word_event, user: user, word: "zzz", created_at: 1.hour.ago)
+
+      get admin_dashboard_word_events_path(sort: "word", dir: "asc")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index("aaa")).to be < response.body.index("zzz")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fourth phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard. See [PR #594](https://github.com/brittanyjohns/itty_bitty_boards/pull/594) (phase 1), [PR #595](https://github.com/brittanyjohns/itty_bitty_boards/pull/595) (phase 2), and [PR #596](https://github.com/brittanyjohns/itty_bitty_boards/pull/596) (phase 3) for prior phases and the overall plan.

Adds the **Word Events** log, which previously only existed as `API::Admin::WordEventsController` (JSON, one of the two datasets on the React admin's Dashboard page) with no HTML equivalent.

- `Admin::WordEventsController#index` — most recent 100 events, sortable by word/user/created_at, excludes the current admin's own activity (same scoping as the JSON version)
- Shows word (+ previous word), reporting user (linked to their admin page), child account if applicable, board, part of speech, and timestamp
- Nav link + dashboard card added

## Test plan
- [x] `bundle exec rspec spec/requests/admin/word_events_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec rspec spec/requests/admin/` — 97 examples, 0 failures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)