### PR TITLE
fix(auth): stop login 500ing on teams with a soft-deleted member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Sign-in no longer fails for accounts on a team with a deleted member.**
+  Deleted user accounts are kept as soft-deleted records, but the team
+  membership rows pointing at them stayed behind. Building the login payload
+  tried to read a name and email off those missing users and returned a server
+  error, locking every member of the affected team out of the app. Deleted
+  members are now simply left out of the team and communicator lists.
+
 - **Image search no longer reports art as missing when it exists.** Searching a
   label like `want` or `where` returned only phrase matches (`i want pasta`,
   `where are the lions?`) and could omit the image labelled exactly `want` —

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -943,14 +943,22 @@ class ChildAccount < ApplicationRecord
   # for backward-compat with the `supporters` field in `api_view`; new
   # canonical role set is just `member`. Issue #216.
   def supporters
-    team_users.includes(:user).where(role: "member").distinct.map(&:user)
+    team_members_with_roles("member")
   end
 
   # Curators across all of this account's teams. `admin` is the
   # account owner, `supervisor` is the SLP / power collaborator.
   # Surfaced in `api_view` under the `supervisors` key. Issue #216.
   def supervisors
-    team_users.includes(:user).where(role: %w[admin supervisor]).distinct.map(&:user)
+    team_members_with_roles(%w[admin supervisor])
+  end
+
+  # `team_users` can outlive the user it points at (rows removed outside the
+  # `dependent: :destroy` path), and every caller reads `s.id` / `s.name` off
+  # the result. INNER JOIN so orphaned rows drop out at the DB level instead
+  # of surfacing as a nil in the payload.
+  def team_members_with_roles(roles)
+    team_users.joins(:user).includes(:user).where(role: roles).distinct.map(&:user).compact
   end
 
   def startup_url

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -97,6 +97,17 @@ class Team < ApplicationRecord
     team_users.detect { |tu| tu.user_id == user.id }&.role
   end
 
+  # `User` is soft-deleted (`default_scope { where(deleted_at: nil) }`), so a
+  # team_users row can outlive the user it points at and preload `user` as nil.
+  # INNER JOIN so those rows drop out rather than blowing up on `tu.user.name`.
+  def member_views(owner_ids)
+    team_users.joins(:user).includes(:user).map { |tu|
+      { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
+        role: tu.role, plan_type: tu.user.plan_type,
+        is_account_owner: owner_ids.include?(tu.user_id) }
+    }
+  end
+
   def index_api_view(viewing_user = nil)
     owner_ids = account_owner_ids
     {
@@ -107,11 +118,7 @@ class Team < ApplicationRecord
       created_by_email: created_by&.email,
       current_user_role: role_for(viewing_user),
       account_owner_ids: owner_ids,
-      members: team_users.includes(:user).map { |tu|
-        { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
-          role: tu.role, plan_type: tu.user.plan_type,
-          is_account_owner: owner_ids.include?(tu.user_id) }
-      },
+      members: member_views(owner_ids),
       accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, owner_id: a.owner_id, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
 
       created_at: created_at.strftime("%Y-%m-%d %H:%M:%S"),
@@ -133,11 +140,7 @@ class Team < ApplicationRecord
       created_by_email: created_by&.email,
       account_owner_ids: owner_ids,
       accounts: accounts.includes(:user).map { |a| { id: a.id, name: a.name, owner_id: a.owner_id, created_by_id: a.user_id, created_by_name: a.user&.name, created_by_email: a.user&.email, avatar_url: a.avatar_url } },
-      members: team_users.includes(:user).map { |tu|
-        { id: tu.id, user_id: tu.user_id, name: tu.user.name, email: tu.user.email,
-          role: tu.role, plan_type: tu.user.plan_type,
-          is_account_owner: owner_ids.include?(tu.user_id) }
-      },
+      members: member_views(owner_ids),
       boards: team_boards.includes(board: :user).map { |tb| { id: tb.board_id, name: tb.board.name, board_type: tb.board.board_type, display_image_url: tb.board.display_image_url, added_by_id: tb.created_by_id, board_owner_name: tb.board.user&.display_name, board_owner_id: tb.board.user_id } },
       created_at: created_at.strftime("%Y-%m-%d %H:%M:%S"),
       updated_at: updated_at.strftime("%Y-%m-%d %H:%M:%S"),

--- a/spec/models/child_account_spec.rb
+++ b/spec/models/child_account_spec.rb
@@ -124,6 +124,40 @@ RSpec.describe ChildAccount, type: :model do
     end
   end
 
+  # User carries `default_scope { where(deleted_at: nil) }`, so a team_users row
+  # pointing at a soft-deleted user preloads its `user` as nil. Every payload
+  # reads `s.id` off these, so a nil there 500s login.
+  describe "team member lists with a soft-deleted user" do
+    let(:account) { FactoryBot.create(:child_account, user: user) }
+    let(:team) { FactoryBot.create(:team, created_by: user) }
+    let(:live_supervisor) { FactoryBot.create(:user) }
+    let(:deleted_supervisor) { FactoryBot.create(:user) }
+    let(:deleted_supporter) { FactoryBot.create(:user) }
+
+    before do
+      TeamAccount.create!(team: team, account: account)
+      TeamUser.create!(team: team, user: live_supervisor, role: "supervisor")
+      TeamUser.create!(team: team, user: deleted_supervisor, role: "supervisor")
+      TeamUser.create!(team: team, user: deleted_supporter, role: "member")
+      deleted_supervisor.update_columns(deleted_at: Time.current)
+      deleted_supporter.update_columns(deleted_at: Time.current)
+    end
+
+    it "omits the soft-deleted users instead of returning nils" do
+      expect(account.supervisors).to all(be_present)
+      expect(account.supervisors.map(&:id)).to include(live_supervisor.id)
+      expect(account.supervisors.map(&:id)).not_to include(deleted_supervisor.id)
+      expect(account.supporters).to all(be_present)
+      expect(account.supporters.map(&:id)).not_to include(deleted_supporter.id)
+    end
+
+    it "renders index_api_view and api_view without raising" do
+      expect { account.index_api_view }.not_to raise_error
+      expect { account.api_view }.not_to raise_error
+      expect(account.index_api_view[:supervisors].map { |s| s[:id] }).not_to include(deleted_supervisor.id)
+    end
+  end
+
   # public_api_view backs unauthenticated public profile pages. Unlike the full
   # api_view, it must never leak parent email, passcode, claim tokens, or other
   # internal fields — only safe display data.


### PR DESCRIPTION
## Problem

Production `POST /api/v1/login` was throwing `NoMethodError: undefined method 'id' for nil` at `child_account.rb:1255` (`index_api_view` → `supervisors.map`).

`User` has `default_scope { where(deleted_at: nil) }` — deleted accounts are soft-deleted. The `team_users` row pointing at such a user survives (the FK is intact, the row just references a hidden record), so `team_users.includes(:user).map(&:user)` yields **nil** for that member. Every consumer then reads `s.id` / `s.name` off it and 500s — locking out every member of the affected team.

Same latent bug in `Team#index_api_view` / `#show_api_view`, which do `tu.user.name` (confirmed by the new spec before the second fix).

## Fix

- `ChildAccount#supporters` / `#supervisors` route through a shared `team_members_with_roles`, which `joins(:user)` (INNER JOIN honours the default scope) and `.compact`s.
- `Team`'s two duplicate `members:` blocks collapse into `member_views(owner_ids)`, also `joins(:user)`.

Soft-deleted members drop out of the payload at the DB level instead of surfacing as nils. No data migration needed — the rows are harmless once they're filtered.

## Test plan

New specs in `spec/models/child_account_spec.rb` create a team with a soft-deleted supervisor and supporter, then assert the lists contain no nils and that `index_api_view` / `api_view` render. Verified the first spec revision failed on `team.rb:111` before that file was fixed.

```
bundle exec rspec spec/models/child_account_spec.rb spec/models/team_upsert_member_spec.rb spec/models/team_user_spec.rb spec/models/team_account_spec.rb spec/requests/api/auth_spec.rb spec/requests/api/v1/auths_posthog_spec.rb
→ 60 examples, 0 failures, 1 pending

bundle exec rspec spec/requests/api/team_permissions_spec.rb spec/requests/api/teams_controller_spec.rb spec/requests/api/teams_create_board_spec.rb
→ 50 examples, 0 failures
```

CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)