### PR TITLE
feat(admin): add Placeholders screen to HTML admin dashboard (phase 5/8)

### DIFF
--- a/app/controllers/admin/placeholders_controller.rb
+++ b/app/controllers/admin/placeholders_controller.rb
@@ -1,0 +1,42 @@
+module Admin
+  class PlaceholdersController < Admin::ApplicationController
+    def index
+      @profiles = Profile.where(placeholder: true).order(created_at: :desc)
+    end
+
+    def create
+      username = params[:username].presence || SecureRandom.hex(4)
+      user_email = params[:user_email]
+
+      if user_email.blank?
+        redirect_to admin_dashboard_placeholders_path, alert: "Email is required."
+        return
+      end
+
+      slug = username.parameterize
+      if Profile.find_by(username: username) || Profile.find_by(slug: slug)
+        redirect_to admin_dashboard_placeholders_path, alert: "This username has been taken. Please try again."
+        return
+      end
+
+      existing_user = User.find_by(email: user_email)
+      user = existing_user || User.create_from_email(user_email, nil, nil, slug)
+
+      unless user
+        redirect_to admin_dashboard_placeholders_path, alert: "Failed to invite user."
+        return
+      end
+
+      # Passing a user here has generate_with_username immediately create a
+      # communicator account and claim the profile to it (placeholder: false)
+      # — this is a "create a MySpeak page for this user now" utility, not an
+      # addition to the unclaimed placeholder list above.
+      profile = Profile.generate_with_username(username, user)
+      if profile
+        redirect_to admin_dashboard_placeholders_path, notice: "Created and claimed a MySpeak profile \"#{profile.username}\" for #{user.email}."
+      else
+        redirect_to admin_dashboard_placeholders_path, alert: "Failed to generate placeholder — username may already be taken."
+      end
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_placeholders_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Placeholders</p>
+      <p class="text-xs text-t2 mt-1">Pre-generated MySpeak profiles for print/QR handouts</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/admin/placeholders/index.html.erb
+++ b/app/views/admin/placeholders/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_title, "Placeholders" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Placeholder Profiles</h1>
+    <p class="text-sm text-t3 mt-0.5"><%= @profiles.size %> total &middot; pre-generated MySpeak profiles for print/QR handouts</p>
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-3">Generate a new placeholder</h2>
+  <%= form_tag admin_dashboard_placeholders_path, method: :post, class: "flex flex-wrap items-end gap-3" do %>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="placeholder_username">Username <span class="text-t3">(optional — random if blank)</span></label>
+      <input type="text" name="username" id="placeholder_username"
+             class="admin-input border rounded px-3 py-2 text-sm w-56 focus:border-indigo-500 focus:outline-none">
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-t2 mb-1" for="placeholder_user_email">Owner email</label>
+      <input type="email" name="user_email" id="placeholder_user_email" required
+             class="admin-input border rounded px-3 py-2 text-sm w-64 focus:border-indigo-500 focus:outline-none">
+    </div>
+    <button type="submit" class="text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">Generate</button>
+  <% end %>
+  <p class="text-[11px] text-t3 mt-2">Invites the email as a new user if one doesn't already exist, then immediately creates and claims a MySpeak profile for them (not added to the unclaimed list below).</p>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Username", "SKU", "Status", "Claim URL", "QR", "Created"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @profiles.each do |profile| %>
+        <tr class="admin-hover-row transition-colors align-top" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-medium whitespace-nowrap"><%= profile.username %></td>
+          <td class="px-5 py-3 text-xs text-t2 font-mono"><%= profile.sku.presence || "—" %></td>
+          <td class="px-5 py-3 text-xs">
+            <% if profile.claimed_at? %>
+              <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">Claimed</span>
+            <% else %>
+              <span class="admin-badge inline-block text-xs rounded px-2 py-0.5 text-t2">Unclaimed</span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs max-w-xs">
+            <%= link_to profile.claim_url, profile.claim_url, target: "_blank", rel: "noopener",
+                  class: "text-accent hover:underline break-all" %>
+          </td>
+          <td class="px-5 py-3">
+            <img src="<%= Boards::AssetRendering.qr_data_url_for(profile.claim_url, size: 80) %>" alt="QR code for <%= profile.username %>'s claim link" class="w-12 h-12">
+          </td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= profile.created_at.strftime("%b %-d, %Y") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @profiles.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No placeholder profiles yet.</div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -112,6 +112,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Placeholders", admin_dashboard_placeholders_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/placeholders") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    resources :placeholders, only: [:index, :create], as: :dashboard_placeholders
   end
 
   get "main/index", as: :home

--- a/spec/requests/admin/placeholders_spec.rb
+++ b/spec/requests/admin/placeholders_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe "Admin::Placeholders (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin" do
+      sign_in create(:user)
+
+      get admin_dashboard_placeholders_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_placeholders_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/placeholders" do
+    it "lists placeholder profiles with claim URL and QR code" do
+      sign_in admin
+      profile = Profile.generate_with_username("printcard1")
+
+      get admin_dashboard_placeholders_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("printcard1")
+      expect(response.body).to include(profile.claim_url)
+      expect(response.body).to include("data:image/png;base64,")
+    end
+
+    it "does not list non-placeholder profiles" do
+      sign_in admin
+      create(:profile, username: "regular_profile", placeholder: false)
+
+      get admin_dashboard_placeholders_path
+
+      expect(response.body).not_to include("regular_profile")
+    end
+  end
+
+  describe "POST /admin/placeholders" do
+    it "creates and claims a profile for an existing user (generate_with_username's actual behavior)" do
+      sign_in admin
+      owner = create(:user, email: "owner@example.com")
+
+      expect {
+        post admin_dashboard_placeholders_path, params: { username: "handout1", user_email: owner.email }
+      }.to change(Profile, :count).by(1)
+
+      profile = Profile.find_by(username: "handout1")
+      expect(profile).not_to be_placeholder
+      expect(profile.claimed_at).to be_present
+      expect(profile.profileable).to be_a(ChildAccount)
+      expect(profile.profileable.owner_id).to eq(owner.id)
+      expect(response).to redirect_to(admin_dashboard_placeholders_path)
+    end
+
+    it "invites a brand-new email as a user before creating the placeholder" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_placeholders_path, params: { username: "handout2", user_email: "brandnew@example.com" }
+      }.to change(User, :count).by(1).and change(Profile, :count).by(1)
+    end
+
+    it "rejects a username that's already taken" do
+      sign_in admin
+      owner = create(:user)
+      Profile.generate_with_username("taken", owner)
+
+      expect {
+        post admin_dashboard_placeholders_path, params: { username: "taken", user_email: "someoneelse@example.com" }
+      }.not_to change(Profile, :count)
+
+      expect(response).to redirect_to(admin_dashboard_placeholders_path)
+      follow_redirect!
+      expect(response.body).to include("has been taken")
+    end
+
+    it "requires an email" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_placeholders_path, params: { username: "handout3" }
+      }.not_to change(Profile, :count)
+
+      expect(response).to redirect_to(admin_dashboard_placeholders_path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fifth phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard. See [PR #594](https://github.com/brittanyjohns/itty_bitty_boards/pull/594)–[#597](https://github.com/brittanyjohns/itty_bitty_boards/pull/597) for prior phases and the overall plan.

Adds the **Placeholders** screen (pre-generated MySpeak profiles for print/QR handouts), which previously only existed as `profiles/placeholders` + `profiles/generate` (JSON, consumed by the React admin at `/admin/placeholders`) with no HTML equivalent — and wasn't admin-gated on the backend at all until now.

- `Admin::PlaceholdersController#index` — lists unclaimed placeholder profiles with claim URL and a QR code (reuses `Boards::AssetRendering.qr_data_url_for`, same helper as the Events QR code from phase 2 — no new gem)
- `#create` mirrors `API::ProfilesController#generate`'s exact logic (invite-by-email, username collision check, `Profile.generate_with_username`)
- **Behavior note surfaced along the way:** `Profile.generate_with_username(username, user)` — when a user is passed — immediately creates a communicator account and claims the profile to it (`placeholder: false`). It does *not* add an unclaimed row to the list above, despite what the original frontend copy implied. That's existing model behavior on the JSON side too; I wrote the admin copy to describe what actually happens rather than repeat the original screen's inaccurate framing.
- Nav link + dashboard card added

## Test plan
- [x] `bundle exec rspec spec/requests/admin/placeholders_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rspec spec/requests/admin/` — 100 examples, 0 failures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)