### PR TITLE
feat(admin): add Board Printables UI to HTML admin dashboard (phase 7/8)

### DIFF
--- a/.claude-notes/board-printable-in-app-handoff.md
+++ b/.claude-notes/board-printable-in-app-handoff.md
@@ -295,8 +295,10 @@ opening the PR.
 - **One new gem** — get Brittany's explicit OK first.
 - **One migration**, `board_printables`. No backfill.
 - **No new ENV vars.**
-- Ships independently of the frontend; it's an admin-only API with no UI until
-  the counterpart PR lands.
+- Ships independently of the frontend. An HTML admin UI now exists at
+  `/admin/board_printables` (`Admin::BoardPrintablesController`) — board
+  search, generate form, and a status page that auto-refreshes while
+  pending/generating and shows download links once complete.
 
 ## Wrap-up
 

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -1,0 +1,51 @@
+module Admin
+  class BoardPrintablesController < Admin::ApplicationController
+    def index
+      @printables = BoardPrintable.includes(:board).recent.limit(50)
+      @board_search = params[:board_search]
+      @boards = if @board_search.present?
+        Board.where("name ILIKE ? OR CAST(id AS TEXT) = ?", "%#{@board_search}%", @board_search).limit(25)
+      else
+        []
+      end
+    end
+
+    def show
+      @printable = BoardPrintable.find(params[:id])
+    end
+
+    def create
+      board = Board.find_by(id: params[:board_id])
+      unless board
+        redirect_to admin_dashboard_board_printables_path, alert: "Board not found."
+        return
+      end
+
+      include_subboards = ActiveModel::Type::Boolean.new.cast(params[:include_subboards]) || false
+      max_boards = (params[:max_boards].presence&.to_i || BoardPrintable::DEFAULT_MAX_BOARDS)
+        .clamp(1, BoardPrintable::MAX_BOARDS_CEILING)
+
+      board_ids = Boards::Printables::CollectPages.walk_board_tree(
+        board: board,
+        include_subboards: include_subboards,
+        max_boards: max_boards,
+      ).map(&:id)
+
+      printable = BoardPrintable.create!(
+        board: board,
+        created_by: current_user,
+        status: "pending",
+        include_subboards: include_subboards,
+        max_boards: max_boards,
+        topic: params[:topic].presence,
+        board_ids: board_ids,
+      )
+
+      GenerateBoardPrintableJob.perform_async(printable.id)
+
+      redirect_to admin_dashboard_board_printable_path(printable), notice: "Generating printable for \"#{board.name}\"…"
+    rescue Boards::Printables::CollectPages::TreeTooLargeError => e
+      redirect_to admin_dashboard_board_printables_path, alert: e.message
+    end
+  end
+end

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -1,0 +1,13 @@
+module Admin
+  module BoardPrintablesHelper
+    def board_printable_status_badge(status)
+      case status
+      when "complete"   then "bg-green-900/60 text-green-300"
+      when "generating" then "bg-indigo-900/60 text-indigo-300"
+      when "pending"     then "bg-amber-900/60 text-amber-300"
+      when "failed"      then "bg-red-900/60 text-red-300"
+      else "admin-card-alt text-t2"
+      end
+    end
+  end
+end

--- a/app/views/admin/board_printables/index.html.erb
+++ b/app/views/admin/board_printables/index.html.erb
@@ -1,0 +1,86 @@
+<% content_for :page_title, "Board Printables" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Board Printables</h1>
+    <p class="text-sm text-t3 mt-0.5">Generate a cover-wrapped, print-ready PDF for a board (optionally its whole subboard tree)</p>
+  </div>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-3">Find a board</h2>
+  <%= form_tag admin_dashboard_board_printables_path, method: :get, class: "flex items-center gap-2 mb-4", data: { turbo: false } do %>
+    <input type="text" name="board_search" value="<%= @board_search %>" placeholder="Search by board name or ID…"
+           class="admin-input border rounded px-3 py-1.5 text-sm w-72 focus:border-indigo-500 focus:outline-none">
+    <button type="submit" class="text-xs px-3 py-1.5 rounded border admin-input text-t1">Search</button>
+    <% if @board_search.present? %>
+      <%= link_to "Clear", admin_dashboard_board_printables_path, class: "text-xs text-t3 hover:text-t1" %>
+    <% end %>
+  <% end %>
+
+  <% if @board_search.present? %>
+    <% if @boards.any? %>
+      <div class="flex flex-col gap-3">
+        <% @boards.each do |board| %>
+          <div class="admin-card-alt border-t rounded-lg p-3 flex flex-wrap items-end justify-between gap-3">
+            <div class="text-xs">
+              <span class="text-t1 font-medium"><%= board.name %></span>
+              <span class="text-t3">· ID <%= board.id %></span>
+            </div>
+            <%= form_tag admin_dashboard_board_printables_path, method: :post, class: "flex flex-wrap items-end gap-2" do %>
+              <input type="hidden" name="board_id" value="<%= board.id %>">
+              <label class="flex items-center gap-1 text-[11px] text-t2">
+                <input type="checkbox" name="include_subboards" value="1">
+                Include subboards
+              </label>
+              <div>
+                <input type="number" name="max_boards" value="<%= BoardPrintable::DEFAULT_MAX_BOARDS %>" min="1" max="<%= BoardPrintable::MAX_BOARDS_CEILING %>"
+                       class="admin-input border rounded px-2 py-1 text-xs w-20 focus:border-indigo-500 focus:outline-none" title="Max boards in tree">
+              </div>
+              <button type="submit" class="text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">
+                Generate
+              </button>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-xs text-t3">No boards match "<%= @board_search %>".</p>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <div class="px-5 py-3" style="border-bottom: 1px solid var(--border);">
+    <h2 class="text-sm font-medium text-t1">Recent printables</h2>
+  </div>
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Board", "Status", "Pages", "Subboards", "Requested", "Created"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @printables.each do |printable| %>
+        <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3 text-xs text-t1 font-medium">
+            <%= link_to printable.board&.name || "Board ##{printable.board_id}", admin_dashboard_board_printable_path(printable), class: "hover:text-accent transition-colors" %>
+          </td>
+          <td class="px-5 py-3">
+            <span class="<%= board_printable_status_badge(printable.status) %> inline-block text-xs rounded px-2 py-0.5"><%= printable.status %></span>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2"><%= printable.page_count || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= printable.include_subboards? ? "Yes (#{printable.board_ids.size})" : "No" %></td>
+          <td class="px-5 py-3 text-xs text-t2"><%= printable.created_by&.email || "—" %></td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= printable.created_at.strftime("%b %-d, %Y %H:%M") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @printables.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">No printables generated yet.</div>
+  <% end %>
+</div>

--- a/app/views/admin/board_printables/show.html.erb
+++ b/app/views/admin/board_printables/show.html.erb
@@ -1,0 +1,54 @@
+<% content_for :page_title, "Printable ##{@printable.id}" %>
+<% if %w[pending generating].include?(@printable.status) %>
+  <% content_for :head_extra, tag.meta("http-equiv": "refresh", content: "5") %>
+<% end %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @printable.board&.name || "Board ##{@printable.board_id}" %></h1>
+    <p class="text-sm text-t3 mt-0.5">Printable #<%= @printable.id %></p>
+  </div>
+  <%= link_to "← All printables", admin_dashboard_board_printables_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <div class="flex items-center gap-3 mb-4">
+    <span class="<%= board_printable_status_badge(@printable.status) %> inline-block text-xs rounded px-2.5 py-1"><%= @printable.status %></span>
+    <% if %w[pending generating].include?(@printable.status) %>
+      <span class="text-xs text-t3">This page refreshes automatically every 5 seconds.</span>
+    <% end %>
+  </div>
+
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs mb-4">
+    <div>
+      <div class="text-t2 mb-0.5">Subboards</div>
+      <div class="text-t1"><%= @printable.include_subboards? ? "Yes (#{@printable.board_ids.size} boards)" : "No" %></div>
+    </div>
+    <div>
+      <div class="text-t2 mb-0.5">Max boards</div>
+      <div class="text-t1"><%= @printable.max_boards %></div>
+    </div>
+    <div>
+      <div class="text-t2 mb-0.5">Pages</div>
+      <div class="text-t1"><%= @printable.page_count || "—" %></div>
+    </div>
+    <div>
+      <div class="text-t2 mb-0.5">Requested by</div>
+      <div class="text-t1"><%= @printable.created_by&.email || "—" %></div>
+    </div>
+  </div>
+
+  <% if @printable.status == "failed" %>
+    <div class="admin-flash-err border rounded-lg px-4 py-3 text-sm">
+      <%= @printable.error_message.presence || "Generation failed." %>
+    </div>
+  <% elsif @printable.complete? %>
+    <div class="flex flex-wrap gap-3">
+      <% @printable.files_view.each do |file| %>
+        <%= link_to "Download #{file[:variant].humanize} (#{number_to_human_size(file[:byte_size])})", file[:url],
+              target: "_blank", rel: "noopener",
+              class: "text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_board_printables_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Board Printables</p>
+      <p class="text-xs text-t2 mt-1">Generate cover-wrapped, print-ready PDFs from a board or subboard tree</p>
+    <% end %>
+
     <%= link_to "/sidekiq",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -84,6 +84,7 @@
       if (t === 'dark') document.documentElement.classList.add('dark');
     })();
   </script>
+  <%= yield(:head_extra) if content_for?(:head_extra) %>
 </head>
 <body class="h-full admin-body font-sans antialiased">
 
@@ -112,6 +113,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Board Printables", admin_dashboard_board_printables_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_printables") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    resources :board_printables, only: [:index, :show, :create], as: :dashboard_board_printables
   end
 
   get "main/index", as: :home

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -1,0 +1,184 @@
+require "rails_helper"
+
+RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+  let(:owner) { create(:user) }
+  let!(:board) { create(:board, user: owner, name: "Core Words") }
+
+  def link(from, to, position: 0)
+    create(:board_image, board: from, predictive_board_id: to.id, position: position)
+  end
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  describe "authorization" do
+    it "redirects a non-admin away from every action" do
+      sign_in create(:user)
+      printable = BoardPrintable.create!(board: board, status: "pending", board_ids: [board.id])
+
+      get admin_dashboard_board_printables_path
+      expect(response).to redirect_to(root_path)
+
+      get admin_dashboard_board_printable_path(printable)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects a signed-out visitor" do
+      get admin_dashboard_board_printables_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /admin/board_printables" do
+    it "lists recent printables" do
+      sign_in admin
+      BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], created_by: admin)
+
+      get admin_dashboard_board_printables_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Core Words")
+      expect(response.body).to include("complete")
+    end
+
+    it "searches boards by name" do
+      sign_in admin
+
+      get admin_dashboard_board_printables_path(board_search: "Core")
+
+      expect(response.body).to include("Core Words")
+    end
+
+    it "searches boards by id" do
+      sign_in admin
+
+      get admin_dashboard_board_printables_path(board_search: board.id.to_s)
+
+      expect(response.body).to include("Core Words")
+    end
+  end
+
+  describe "GET /admin/board_printables/:id" do
+    it "shows a pending printable with an auto-refresh meta tag" do
+      sign_in admin
+      printable = BoardPrintable.create!(board: board, status: "pending", board_ids: [board.id])
+
+      get admin_dashboard_board_printable_path(printable)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('http-equiv="refresh"')
+    end
+
+    it "shows download links for a complete printable" do
+      sign_in admin
+      printable = BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id])
+      allow(printable).to receive(:files_view).and_return([
+        { variant: "full", filename: "core-words.pdf", url: "https://cdn.example.com/core-words.pdf", byte_size: 12_345 },
+      ])
+      allow(BoardPrintable).to receive(:find).and_return(printable)
+
+      get admin_dashboard_board_printable_path(printable)
+
+      expect(response.body).to include("https://cdn.example.com/core-words.pdf")
+      expect(response.body).not_to include('http-equiv="refresh"')
+    end
+
+    it "shows the error message for a failed printable" do
+      sign_in admin
+      printable = BoardPrintable.create!(board: board, status: "failed", board_ids: [board.id], error_message: "Grover timed out")
+
+      get admin_dashboard_board_printable_path(printable)
+
+      expect(response.body).to include("Grover timed out")
+    end
+  end
+
+  describe "POST /admin/board_printables" do
+    it "creates a pending record and enqueues the job" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_board_printables_path,
+          params: { board_id: board.id, include_subboards: "1", max_boards: "10", topic: "mealtime" }
+      }.to change(GenerateBoardPrintableJob.jobs, :size).by(1)
+
+      printable = BoardPrintable.last
+      expect(printable.board).to eq(board)
+      expect(printable.created_by).to eq(admin)
+      expect(printable.include_subboards).to be(true)
+      expect(printable.max_boards).to eq(10)
+      expect(printable.topic).to eq("mealtime")
+      expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+    end
+
+    it "defaults to a single board with the standard cap when no options are given" do
+      sign_in admin
+
+      post admin_dashboard_board_printables_path, params: { board_id: board.id }
+
+      printable = BoardPrintable.last
+      expect(printable.include_subboards).to be(false)
+      expect(printable.max_boards).to eq(BoardPrintable::DEFAULT_MAX_BOARDS)
+      expect(printable.board_ids).to eq([board.id])
+    end
+
+    it "records the walked tree in BFS order when subboards are included" do
+      sign_in admin
+      child = create(:board, user: owner)
+      link(board, child)
+
+      post admin_dashboard_board_printables_path, params: { board_id: board.id, include_subboards: "1" }
+
+      expect(BoardPrintable.last.board_ids).to eq([board.id, child.id])
+    end
+
+    it "clamps an absurd max_boards to the ceiling rather than trusting it" do
+      sign_in admin
+
+      post admin_dashboard_board_printables_path, params: { board_id: board.id, max_boards: "100000" }
+
+      expect(BoardPrintable.last.max_boards).to eq(BoardPrintable::MAX_BOARDS_CEILING)
+    end
+
+    it "alerts without creating a record when the board doesn't exist" do
+      sign_in admin
+
+      expect {
+        post admin_dashboard_board_printables_path, params: { board_id: -1 }
+      }.not_to change(BoardPrintable, :count)
+
+      expect(response).to redirect_to(admin_dashboard_board_printables_path)
+    end
+
+    it "alerts when the tree exceeds max_boards rather than creating a partial record" do
+      sign_in admin
+      child = create(:board, user: owner)
+      link(board, child)
+
+      expect {
+        post admin_dashboard_board_printables_path, params: { board_id: board.id, include_subboards: "1", max_boards: "1" }
+      }.not_to change(BoardPrintable, :count)
+
+      expect(response).to redirect_to(admin_dashboard_board_printables_path)
+      # Exact wording belongs to Boards::Printables::CollectPages, not this controller.
+      expect(flash[:alert]).to be_present
+    end
+
+    context "when signed in as non-admin" do
+      it "redirects to root and does not create a printable" do
+        sign_in create(:user)
+
+        expect {
+          post admin_dashboard_board_printables_path, params: { board_id: board.id }
+        }.not_to change(BoardPrintable, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Seventh phase of moving admin functionality from the frontend React admin dashboard (`itty-bitty-frontend`) to the Rails HTML admin dashboard. See [PR #594](https://github.com/brittanyjohns/itty_bitty_boards/pull/594)–[#600](https://github.com/brittanyjohns/itty_bitty_boards/pull/600) for prior phases and the overall plan.

Unlike phases 1-6, this one is **net-new** rather than a migration. `API::Admin::BoardPrintablesController` shipped in #589 with no UI anywhere — frontend or backend — per its own handoff doc (`.claude-notes/board-printable-in-app-handoff.md`): "ships independently of the frontend; it's an admin-only API with no UI until the counterpart PR lands." This is that counterpart, built directly against the Rails admin instead.

- `Admin::BoardPrintablesController` — board search by name/id, a generate form (`include_subboards`, `max_boards`, `topic`), and a status page
- Status page auto-refreshes every 5s while `pending`/`generating` (plain `<meta http-equiv="refresh">`, no JS polling) and shows per-variant download links once `complete`, or the error message if `failed`
- Reuses the exact same `Boards::Printables::CollectPages` + `BoardPrintable` + `GenerateBoardPrintableJob` pipeline the JSON API drives — same BFS tree walk, same `max_boards` clamp/reject behavior, same attachments
- Small layout addition: `content_for(:head_extra)` yield point in `layouts/admin.html.erb` — the first admin page needing something in `<head>` beyond the shared stylesheet/script tags
- Updated the handoff doc's "no UI" note now that one exists

## Test plan
- [x] `bundle exec rspec spec/requests/admin/board_printables_spec.rb` — 15 examples, 0 failures (authorization, search, create incl. BFS order/max_boards clamp/tree-too-large, status page states)
- [x] `bundle exec rspec spec/requests/admin/` — 107 examples, 0 failures (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)