### PR TITLE
chore(user): remove orphaned handle_myspeak_setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   everything else is stripped from to/cc/bcc. Production and development are
   unaffected.
 
+### Removed
+
+- Removed the orphaned `User#handle_myspeak_setup`. It built a `ChildAccount`
+  plus `Profile` for a MySpeak signup flow that no longer exists, and had zero
+  callers anywhere in the app.
+
 ### Added
 
 - **The internal API can now correct a tile, not just create one.**

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1817,33 +1817,6 @@ class User < ApplicationRecord
     !locked?
   end
 
-  def handle_myspeak_setup(myspeak_name: nil, myspeak_slug: nil)
-    myspeak_slug ||= settings["slug"] || email.split("@").first
-    myspeak_name ||= display_name
-    Rails.logger.info "Handling MySpeak setup for user #{email} with slug #{myspeak_slug} and name #{myspeak_name}"
-    @child_account = ChildAccount.new(username: myspeak_slug, name: myspeak_name, status: ChildAccount::SANDBOX)
-    if free?
-      @child_account.settings ||= {}
-      @child_account.settings["demo_board_limit"] = ChildAccount::FREE_DEMO_BOARD_LIMIT
-    end
-    @child_account.owner = self
-    @child_account.user = self if @child_account.respond_to?(:user=) # legacy (optional)
-
-    # Validate basic fields first
-    unless @child_account.valid?
-      Rails.logger.error "Child account validation failed: #{@child_account.errors.full_messages.join(", ")}"
-      return nil
-    end
-    if @child_account.save
-      Rails.logger.info "Child account created with ID #{@child_account.id} for MySpeak setup"
-      @child_account.create_profile!
-      Rails.logger.info "Profile created with slug #{myspeak_slug} for MySpeak setup"
-    else
-      Rails.logger.error "Failed to save child account for MySpeak setup: #{@child_account.errors.full_messages.join(", ")}"
-    end
-    @child_account
-  end
-
   # Single source of truth for "how many boards count against the limit."
   # Excludes predefined boards and every board that belongs to one of the user's
   # Board Builder groups — a builder wizard run persists a whole linked tree but


### PR DESCRIPTION
Supersedes #185 — same change, cut fresh from current `main` instead of rebasing a branch that was 306 commits behind.

## Summary

Deletes `User#handle_myspeak_setup` from `app/models/user.rb` (25 lines). It created a `ChildAccount` + `Profile` for an earlier MySpeak signup path that no longer exists.

It also assigned a `@child_account` instance variable on a model — a leftover from when the logic lived in a controller, and a smell in its own right.

## Verification

- `grep -rn "handle_myspeak_setup"` across the whole repo (all file types, not just `.rb`) → only the definition matched.
- Checked for dynamic dispatch (`send` / `public_send` reaching a myspeak/setup method) → none.
- `ruby -c app/models/user.rb` → Syntax OK.

## Test plan

- `bundle exec rspec spec/models/user_spec.rb` → **79 examples, 0 failures.**
- No new tests: this removes code with no callers and no behavior to assert.

## Note on #185

#185 can be closed. Its red CI was an unrelated pre-existing failure (`spec/models/board_spec.rb:397`, `display_image_url`) that also reddened #188 the same afternoon — not caused by the deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)