### PR TITLE
feat(admin): list public boards on Board Printables, open Sidekiq in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **Board Printables opens on the public board list instead of an empty search
+  box.** Every published public board is now listed up front with its own
+  Generate controls, so the common case — printing one of the curated public
+  boards — no longer starts by guessing a board name. The search box is still
+  there for any other board. The admin's Sidekiq links (nav and dashboard tile)
+  now open in a new tab so leaving for the job queue doesn't lose the admin
+  page.
+
 - **Staging no longer sends email to real people.** Staging runs against live
   SMTP credentials, so anything exercised there — signups, invitations, alerts
   — used to deliver genuine mail to whatever address was on the record. Mail is

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class BoardPrintablesController < Admin::ApplicationController
+    PUBLIC_BOARD_LIMIT = 100
+
     def index
       @printables = BoardPrintable.includes(:board).recent.limit(50)
       @board_search = params[:board_search]
@@ -8,6 +10,10 @@ module Admin
       else
         []
       end
+
+      public_boards = Board.public_boards
+      @public_boards_count = public_boards.count
+      @public_boards = public_boards.alphabetical.limit(PUBLIC_BOARD_LIMIT)
     end
 
     def show

--- a/app/views/admin/board_printables/_board_option.html.erb
+++ b/app/views/admin/board_printables/_board_option.html.erb
@@ -1,0 +1,23 @@
+<div class="admin-card-alt border-t rounded-lg p-3 flex flex-wrap items-end justify-between gap-3">
+  <div class="text-xs">
+    <span class="text-t1 font-medium"><%= board.name %></span>
+    <span class="text-t3">· ID <%= board.id %></span>
+    <% if board.category.present? %>
+      <span class="text-t3">· <%= board.category %></span>
+    <% end %>
+  </div>
+  <%= form_tag admin_dashboard_board_printables_path, method: :post, class: "flex flex-wrap items-end gap-2" do %>
+    <input type="hidden" name="board_id" value="<%= board.id %>">
+    <label class="flex items-center gap-1 text-[11px] text-t2">
+      <input type="checkbox" name="include_subboards" value="1">
+      Include subboards
+    </label>
+    <div>
+      <input type="number" name="max_boards" value="<%= BoardPrintable::DEFAULT_MAX_BOARDS %>" min="1" max="<%= BoardPrintable::MAX_BOARDS_CEILING %>"
+             class="admin-input border rounded px-2 py-1 text-xs w-20 focus:border-indigo-500 focus:outline-none" title="Max boards in tree">
+    </div>
+    <button type="submit" class="text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">
+      Generate
+    </button>
+  <% end %>
+</div>

--- a/app/views/admin/board_printables/index.html.erb
+++ b/app/views/admin/board_printables/index.html.erb
@@ -8,7 +8,24 @@
 </div>
 
 <div class="admin-card border rounded-xl p-5 mb-6">
-  <h2 class="text-sm font-medium text-t1 mb-3">Find a board</h2>
+  <div class="flex items-baseline justify-between gap-3 mb-3">
+    <h2 class="text-sm font-medium text-t1">Public boards</h2>
+    <span class="text-xs text-t3">
+      <%= pluralize(@public_boards_count, "published public board") %><%= " · showing first #{@public_boards.size}" if @public_boards_count > @public_boards.size %>
+    </span>
+  </div>
+
+  <% if @public_boards.any? %>
+    <div class="flex flex-col gap-3">
+      <%= render partial: "board_option", collection: @public_boards, as: :board %>
+    </div>
+  <% else %>
+    <p class="text-xs text-t3">No published public boards yet — use the search below to find any board.</p>
+  <% end %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-3">Find any board</h2>
   <%= form_tag admin_dashboard_board_printables_path, method: :get, class: "flex items-center gap-2 mb-4", data: { turbo: false } do %>
     <input type="text" name="board_search" value="<%= @board_search %>" placeholder="Search by board name or ID…"
            class="admin-input border rounded px-3 py-1.5 text-sm w-72 focus:border-indigo-500 focus:outline-none">
@@ -21,28 +38,7 @@
   <% if @board_search.present? %>
     <% if @boards.any? %>
       <div class="flex flex-col gap-3">
-        <% @boards.each do |board| %>
-          <div class="admin-card-alt border-t rounded-lg p-3 flex flex-wrap items-end justify-between gap-3">
-            <div class="text-xs">
-              <span class="text-t1 font-medium"><%= board.name %></span>
-              <span class="text-t3">· ID <%= board.id %></span>
-            </div>
-            <%= form_tag admin_dashboard_board_printables_path, method: :post, class: "flex flex-wrap items-end gap-2" do %>
-              <input type="hidden" name="board_id" value="<%= board.id %>">
-              <label class="flex items-center gap-1 text-[11px] text-t2">
-                <input type="checkbox" name="include_subboards" value="1">
-                Include subboards
-              </label>
-              <div>
-                <input type="number" name="max_boards" value="<%= BoardPrintable::DEFAULT_MAX_BOARDS %>" min="1" max="<%= BoardPrintable::MAX_BOARDS_CEILING %>"
-                       class="admin-input border rounded px-2 py-1 text-xs w-20 focus:border-indigo-500 focus:outline-none" title="Max boards in tree">
-              </div>
-              <button type="submit" class="text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">
-                Generate
-              </button>
-            <% end %>
-          </div>
-        <% end %>
+        <%= render partial: "board_option", collection: @boards, as: :board %>
       </div>
     <% else %>
       <p class="text-xs text-t3">No boards match "<%= @board_search %>".</p>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -67,7 +67,7 @@
       <p class="text-xs text-t2 mt-1">Generate cover-wrapped, print-ready PDFs from a board or subboard tree</p>
     <% end %>
 
-    <%= link_to "/sidekiq",
+    <%= link_to "/sidekiq", target: "_blank", rel: "noopener",
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Sidekiq</p>
       <p class="text-xs text-t2 mt-1">Background job queues, retries, and dead jobs</p>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -121,7 +121,7 @@
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_printables") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
-          <%= link_to "Sidekiq", "/sidekiq",
+          <%= link_to "Sidekiq", "/sidekiq", target: "_blank", rel: "noopener",
                 class: "text-xs px-3 py-1.5 rounded text-t2 hover:text-t1 transition-colors" %>
         </nav>
       </div>

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
 
   let(:admin) { create(:admin_user) }
   let(:owner) { create(:user) }
+  let(:default_admin) do
+    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+  end
   let!(:board) { create(:board, user: owner, name: "Core Words") }
 
   def link(from, to, position: 0)
@@ -44,6 +47,29 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Core Words")
       expect(response.body).to include("complete")
+    end
+
+    it "lists published public boards without needing a search" do
+      sign_in admin
+      public_board = create(:board, user: default_admin, predefined: true, published: true, name: "Public Mealtime")
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).to include("Public Mealtime")
+      expect(response.body).to include("value=\"#{public_board.id}\"")
+      # A private board isn't offered up front — it stays behind the search.
+      expect(response.body).not_to include("Core Words")
+    end
+
+    it "leaves unpublished and menu boards out of the public list" do
+      sign_in admin
+      create(:board, user: default_admin, predefined: true, published: false, name: "Draft Public Board")
+      create(:board, user: default_admin, predefined: true, published: true, parent_type: "Menu", name: "Menu Public Board")
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).not_to include("Draft Public Board")
+      expect(response.body).not_to include("Menu Public Board")
     end
 
     it "searches boards by name" do

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe "Admin::Dashboard", type: :request do
       end
     end
 
+    it "opens the Sidekiq links in a new tab so the dashboard stays put" do
+      get admin_root_path
+
+      # Both the nav link and the tile card point at the mounted Sidekiq web UI.
+      sidekiq_links = response.body.scan(/<a[^>]*href="\/sidekiq"[^>]*>/)
+      expect(sidekiq_links.size).to eq(2)
+      expect(sidekiq_links).to all(include('target="_blank"'))
+      expect(sidekiq_links).to all(include('rel="noopener"'))
+    end
+
     context "when signed in as non-admin" do
       before do
         sign_out admin


### PR DESCRIPTION
## What changed

**Board Printables opens on the public board list.** Generating a printable
previously started from an empty search box, so the common case — printing one
of the curated public boards — began by guessing a board name. The screen now
lists every published public board up front, each row carrying its own
include-subboards / max-boards / Generate controls.

- `Admin::BoardPrintablesController#index` loads `Board.public_boards.alphabetical`,
  capped at 100 (`PUBLIC_BOARD_LIMIT`) with a count header that says so when the
  list is truncated. `public_boards` is the existing model scope — admin-owned,
  `predefined`, `published`, non-menu, non-OBF — so drafts and menu boards stay out.
- The search box is still there below it, relabelled "Find any board", for
  anything outside that set.
- The per-board Generate row moved into a shared `_board_option` partial used by
  both the public list and the search results, so the two paths can't drift.

**Sidekiq links open in a new tab.** Both the top-nav link in the admin layout
and the dashboard tile got `target="_blank" rel="noopener"`, so stepping out to
the job queue no longer loses the admin page.

## Why

Both are papercuts on the admin flow added in #601 — the printables screen was
unusable without already knowing a board name, and the Sidekiq detour was a
one-way trip.

## Test plan

`bundle exec rspec spec/requests/admin/board_printables_spec.rb spec/requests/admin/dashboard_spec.rb`
→ **22 examples, 0 failures** (run after rebasing onto `origin/main`).

New specs:
- public boards are listed without a search, and a private board is *not*
- unpublished and menu boards are excluded from the public list
- both `/sidekiq` anchors on the dashboard carry `target="_blank"` and `rel="noopener"`

## Notes for review

- The 100-board cap is a rendering guard, not a filter — the header reports the
  true count when it kicks in. If the public set ever outgrows that, this wants
  real pagination rather than a bigger number.
- CHANGELOG entry added under Unreleased → Changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)