### PR TITLE
ci: disable the CI-failure triage workflow for now

### DIFF
--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -11,11 +11,29 @@ name: CI Failure Triage (Claude)
 #
 # NOTE: workflow_run workflows only run from the default branch (main), so
 # this does nothing until merged — including for its own PR.
+#
+# ---------------------------------------------------------------------------
+# DISABLED (2026-08-07). The automatic trigger is commented out below.
+#
+# Why: on its first real outing the `anthropics/claude-code-action` step
+# failed, and because it fires on every red CI/Security run it re-triggered
+# on each one while main was red — noise on top of the failure it was meant
+# to explain.
+#
+# To re-enable: delete the `workflow_dispatch:` line and uncomment the
+# `workflow_run:` block. Nothing else in this file needs to change.
+#
+# While disabled the workflow is inert: `workflow_dispatch` keeps the YAML
+# valid, and a manual run no-ops because the job's `if:` tests
+# `github.event.workflow_run.conclusion`, which is empty outside a
+# workflow_run event.
+# ---------------------------------------------------------------------------
 
 on:
-  workflow_run:
-    workflows: ["CI", "Security"]
-    types: [completed]
+  workflow_dispatch:
+  # workflow_run:
+  #   workflows: ["CI", "Security"]
+  #   types: [completed]
 
 permissions:
   contents: read # cannot push code — comment-only guardrail


### PR DESCRIPTION
Turns off the workflow added in #375, a few hours after merging it.

## Why

On its first real outing the `anthropics/claude-code-action` step failed ([run 31185191102](https://github.com/brittanyjohns/itty_bitty_boards/actions/runs/31185191102)). And because the workflow fires on *every* red **CI**/**Security** run, it re-triggered on each one while `main` was red — piling noise on top of the failure it was supposed to explain.

It did post successfully on two runs, so the idea works. It just needs a look at why the action step dies before it's worth having on automatically.

## What changed

The `workflow_run:` trigger is commented out; `workflow_dispatch:` takes its place to keep the YAML valid. No other change — the permissions model, prompt, and concurrency group are untouched.

While disabled the workflow is inert. A manual dispatch no-ops, because the job's `if:` tests `github.event.workflow_run.conclusion`, which is empty outside a `workflow_run` event.

## Re-enabling

Two lines, documented in the file header: delete `workflow_dispatch:`, uncomment the `workflow_run:` block.

I kept the file rather than deleting it so the wiring and the comment-only permission model (`contents: read`) survive for whenever you want to switch it back on.

## Test plan

- Parsed the workflow with Ruby's YAML loader → valid; triggers resolve to `{"workflow_dispatch" => nil}` only.
- Verified the job guard still reads `github.event.workflow_run.conclusion == 'failure'`, so a manual dispatch skips the job rather than erroring.
- No app code touched; no specs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)