### PR TITLE
docs(boards): record the set-map invariants the frontend freeze exposed

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -776,6 +776,22 @@ collections of boards. CRUD is open to any signed-in user;
     then reads `group.boards` sees a stale, empty-looking cache —
     `BoardGroupCreator` reloads the group after populating/re-syncing so
     callers always see the current members.
+  - **On-demand groups are `builder: false` and must stay that way.** `builder`
+    means the group *owns* its member boards — `destroy_member_boards_if_builder`
+    deletes every one of them with the group — so a set assembled from someone's
+    pre-existing hand-linked boards can never carry the flag. The consequence is
+    that `builder` alone can't gate the set map: `Board#eligible_board_group` is
+    `builder || !predefined`, and the frontend's `eligibleSets`
+    (`ViewSetMapButton.tsx`) mirrors it. Keep the two in step — when they drifted
+    (the frontend read `builder ?? !predefined`, which nullish-coalesces to
+    `false` on exactly these groups) creating a set map never flipped the button
+    off "Create board group" and each click re-created the set.
+  - **The graph is not a tree.** `SetGraphBuilder` emits every folder→child edge,
+    and a real core set gives each category board a nav row back to home and
+    across to its siblings — board set 105 is 12 boards / 132 edges, a complete
+    digraph. Anything consuming the payload has to be shortest-path or otherwise
+    bounded; enumerating simple paths over one is factorial (~1.08e8 here) and
+    froze the map page.
 
 ## Responsive board layouts (sm/md derived from lg)
 


### PR DESCRIPTION
Docs only — no behavior change. The code fix is [itty-bitty-frontend#644](https://github.com/brittanyjohns/itty-bitty-frontend/pull/644).

Investigating the board-set map freezing on `/board-sets/105/map` turned up two backend contracts that nothing recorded, both of which the frontend then got wrong:

1. **On-demand groups are deliberately `builder: false`, and must stay that way.** `builder` means the group *owns* its member boards — `destroy_member_boards_if_builder` deletes every one of them along with the group — so a set assembled from a user's pre-existing hand-linked boards can never carry the flag. The consequence is that `builder` alone can't gate the set map. `Board#eligible_board_group` is `builder || !predefined` and the frontend's `eligibleSets` mirrors it; when they drifted (the frontend read `builder ?? !predefined`, which nullish-coalesces to `false` on exactly these groups) creating a set map never flipped the button off "Create board group" and each click re-created the set.

2. **The graph `SetGraphBuilder` emits is not a tree.** A real core set gives each category board a nav row back to home and across to its siblings — board set 105 is 12 boards / 132 edges, a complete digraph. Consumers have to be shortest-path or otherwise bounded; the frontend enumerated simple paths over it, which is factorial (~1.08e8 here) and froze the tab.

Both go in the existing on-demand-group-creation section of `.claude-notes/boards-and-teams.md`.

## Test plan

Documentation only — no code touched, so no tests to run or add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
