### PR TITLE
fix(boards): freeze a published board's slug so printed QR codes keep working

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -715,6 +715,34 @@ Safe for non-admins because `update` is already gated to the owner:
 `User#can_edit?`. The only non-admin who can reach the assignment is the person
 who owns the board.
 
+### A published board's slug is frozen
+
+`Board#slug_locked?` (`published? && slug.present?`) makes the slug permanent
+once a board is published, enforced by the `freeze_published_slug` before_save.
+`/pb/<slug>` is what the QR codes on board printables encode
+(`Boards::Printables::CollectPages.qr_key_for`) and what users paste into IEPs
+and share links; there is no redirect and no slug history behind it, so a
+rename silently 404s laminated paper (#611).
+
+Two properties of the guard are load-bearing:
+
+- **It reverts, it does not raise.** The frontend re-derives the slug from the
+  name on every rename (`BoardForm`), so a slug param arrives on ordinary
+  updates. Rejecting the save would break renaming a published board entirely.
+  The rest of the update lands; only the slug snaps back, and the response
+  carries the real slug.
+- **It sits on the model, not the controller.** Four controller paths regenerate
+  slugs (`Api::BoardsController#update`, `Api::Internal::BoardsController` ×3)
+  plus jobs, services and rake tasks. A before_save covers all of them; a
+  controller guard would leak.
+
+Unpublished boards rename freely — nothing shareable exists yet — and a slug
+assigned in the same save that publishes is allowed (the guard reads
+`published_was`). Deliberate renames go through `Board#rename_slug!`, exposed as
+`force_slug: true` on the internal admin update and the
+`boards:rename_slug[id,new-slug]` rake task. Both break existing paper by
+design; the caller owns the reprint.
+
 ## Board Sets (BoardGroup) — user CRUD + limits
 
 Board Sets (`BoardGroup`, user-facing name "Board Sets") are user-owned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   runs on Sidekiq; a tree over the board cap is refused up front with a 422
   rather than half-built.
 
+### Fixed
+
+- **Renaming a published board no longer breaks its printed QR codes.** A
+  board's share link (`/pb/<slug>`) is derived from its name, and renaming the
+  board used to rebuild that link — silently 404ing every QR code already
+  printed onto a board printable, with no redirect. A published board's link is
+  now permanent: renaming still works and still updates the board's name
+  everywhere, it just leaves the shareable link alone. Unpublished boards are
+  unaffected, since nothing has been handed out yet.
+
 ### Removed
 
 - **The Events, Placeholders and Organizations screens are gone from the HTML

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,11 @@ an explicit decision, not a drive-by edit.
   Client-called endpoints may reflect plan state but never grant credits. All
   credit movement goes through `CreditService` and the immutable
   `credit_transactions` ledger; grants are idempotent on event id.
+- **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
+  and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
+  silently reverts a slug change on a published board (reverts, never raises —
+  the frontend re-derives the slug on every rename). Deliberate renames go
+  through `Board#rename_slug!`.
 - **Downgrades retain, never delete.** Over-limit boards become read-only;
   over-limit communicators enter fallback mode (public MySpeak page stays
   up). No plan change destroys user content.
@@ -244,7 +249,7 @@ an explicit decision, not a drive-by edit.
 | `.claude-notes/credits.md` | AI credit ledger: `CreditService`, feature costs, `check_credits!` / 402 contract, grant lifecycle + refresh/expiry cron jobs, menu image budget + refunds, free first-fill image generation, credits rake tasks, beta entitlement audit, email verification's welcome-token/credit grant |
 | `.claude-notes/marketing-integrations.md` | Mailchimp CRM sync + Customer Journeys (all journey keys + ENV wiring), dual-welcome design, plan-welcome idempotency, PostHog server-side events + `distinct_id` contract |
 | `.claude-notes/safety-profiles.md` | MySpeak safety pages: gated emergency-info reveal, view logging + parent alerts + throttling, coarse IP geolocation, random slugs + legacy-slug fallback |
-| `.claude-notes/boards-and-teams.md` | Team permissions / owner-pinning, SLP→family hand-off, board assignment deep clone (`AssignmentCloner`), non-destructive board removal, board deletion warn+confirm (409), Board Sets (BoardGroup) CRUD + limits, responsive layouts (sm/md derived from lg), OBF/OBZ import copyright policy, Make a Board From Screenshot |
+| `.claude-notes/boards-and-teams.md` | Team permissions / owner-pinning, SLP→family hand-off, board assignment deep clone (`AssignmentCloner`), non-destructive board removal, board deletion warn+confirm (409), frozen published slugs, Board Sets (BoardGroup) CRUD + limits, responsive layouts (sm/md derived from lg), OBF/OBZ import copyright policy, Make a Board From Screenshot |
 | `.claude-notes/board-builder.md` | Board Builder wizard end-to-end: starter templates, complexity levels + `StructurePlanner`, Core 60/84 robust vocab sets + seed self-healing, communicator AAC profile, gestalt (GLP) support, all builder rake tasks |
 | `.claude-notes/ops.md` | Monitoring/alerting details, AppSignal APM config, full Rack::Attack throttle rules + ENV vars |
 | `.claude-notes/marketing-assets.md` | AAC Classroom Kit hosting: `MarketingAsset`, internal endpoints, marketing print style, QR scannability rule (do not re-add long UTMs to tag QRs) |

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -493,6 +493,11 @@ class API::BoardsController < API::ApplicationController
         incoming_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
         @board.published = incoming_published unless incoming_published.nil?
       end
+      # Renaming a board re-derives this param from the name on the frontend,
+      # so it arrives on ordinary renames. On a PUBLISHED board the change is
+      # dropped by Board#freeze_published_slug — `/pb/<slug>` is printed into
+      # QR codes and paper can't be re-issued (#611). Deliberate renames go
+      # through the internal API's `force_slug` or `boards:rename_slug`.
       if board_params["slug"].present? && board_params["slug"] != @board.slug
         new_slug = @board.generate_unique_slug(board_params["slug"])
         @board.slug = new_slug

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -165,6 +165,8 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
 
   def update
     @board = Board.find(params[:id])
+    # Captured before assign_attributes, which may itself write `slug`.
+    persisted_slug = @board.slug
     @board.assign_attributes(board_params.except(:settings, :voice))
     @board.voice = VoiceService.normalize_voice(board_params[:voice]) if board_params[:voice].present?
 
@@ -176,7 +178,12 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     @board.parent_type = "User"
     @board.parent_id = @board.user_id || User::DEFAULT_ADMIN_ID
 
-    if board_params[:slug].present? && board_params[:slug] != @board.slug
+    # A published board's slug is frozen (printed QR codes encode `/pb/<slug>`
+    # — see Board#slug_locked?). This admin surface is the deliberate rename
+    # path: `force_slug: true` opts in, and the caller owns reprinting whatever
+    # is already in the wild. Without it the change is ignored, not rejected.
+    if board_params[:slug].present? && board_params[:slug] != persisted_slug
+      @board.allow_slug_change = force_slug?
       @board.slug = @board.generate_unique_slug(board_params[:slug])
     end
 
@@ -238,6 +245,10 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
     end
 
     board.save
+  end
+
+  def force_slug?
+    ActiveModel::Type::Boolean.new.cast(params[:force_slug])
   end
 
   def replace_existing_slug?

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -93,6 +93,11 @@ class Board < ApplicationRecord
 
   attr_accessor :skip_create_voice_audio
 
+  # Opt-in escape hatch for the one deliberate rename path (admin/internal API,
+  # `boards:rename_slug` rake task). Everything else is frozen — see
+  # `freeze_published_slug`.
+  attr_accessor :allow_slug_change
+
   validates :slug, uniqueness: true
 
   include UtilHelper
@@ -193,6 +198,7 @@ class Board < ApplicationRecord
 
   include ImageHelper
 
+  before_save :freeze_published_slug
   before_save :set_voice, if: :voice_changed?
   before_save :set_default_voice, unless: :voice?
   # before_save :update_display_image, unless: :display_image_url?
@@ -1396,6 +1402,43 @@ class Board < ApplicationRecord
     self.slug = slug
     slug
   end
+
+  # A published board's slug is permanent. It is the key in `/pb/<slug>`, which
+  # is what the QR codes on printed board printables encode — laminated paper
+  # can't be re-issued, so a rename would silently 404 every already-printed
+  # sheet with no redirect and no history (#611).
+  #
+  # Unpublished boards are unaffected: nothing shareable has been handed out.
+  def slug_locked?
+    published? && slug.present?
+  end
+
+  # The deliberate rename path. Used by the admin/internal API and the
+  # `boards:rename_slug` rake task — never by an ordinary board update.
+  # Callers are responsible for reprinting anything already in the wild.
+  def rename_slug!(requested_slug)
+    self.allow_slug_change = true
+    generate_unique_slug(requested_slug)
+    save
+  ensure
+    self.allow_slug_change = false
+  end
+
+  # Reverts a slug change on an already-published board rather than rejecting
+  # the save: the frontend re-derives the slug from the name on every rename
+  # (BoardForm), so raising here would break ordinary board renaming. The rest
+  # of the update goes through untouched, and the response carries the real
+  # (unchanged) slug.
+  def freeze_published_slug
+    return if new_record?
+    return if allow_slug_change
+    return unless slug_changed?
+    return unless published_was && slug_was.present?
+
+    Rails.logger.info "[board #{id}] ignoring slug change #{slug_was.inspect} -> #{slug.inspect}: published slugs are frozen"
+    self.slug = slug_was
+  end
+  private :freeze_published_slug
 
   def update_board_layout(screen_size)
     self.layout = {}

--- a/app/services/boards/printables/collect_pages.rb
+++ b/app/services/boards/printables/collect_pages.rb
@@ -16,10 +16,10 @@ module Boards
       # `find_by(id:)` then `find_by(slug:)` — and Board#public_url already
       # uses the slug, so the QR matches the link we hand out everywhere else.
       #
-      # Slugs are only mostly stable: #update regenerates one when a client
-      # sends a different `slug` param, and the column defaults to "". Hence
-      # `qr_key_for` falling back to the id, which never changes. A printed QR
-      # is permanent paper — an editable key is a real (accepted) trade.
+      # This is safe to print because a PUBLISHED board's slug is frozen
+      # (Board#slug_locked?, #611) — and only a published board is shareable
+      # in the first place. The column still defaults to "", hence `qr_key_for`
+      # falling back to the id, which never changes.
       QR_BASE_URL = "https://app.speakanyway.com/pb".freeze
 
       Page = Struct.new(:pdf_bytes, :board_id, :board_name, :variant, keyword_init: true)

--- a/lib/tasks/board_slugs.rake
+++ b/lib/tasks/board_slugs.rake
@@ -1,0 +1,35 @@
+namespace :boards do
+  # The deliberate rename path for a published board, whose slug is otherwise
+  # frozen (#611): `/pb/<slug>` is what the QR codes on printed board
+  # printables encode, and there is no redirect or slug history behind it.
+  #
+  # Renaming here breaks every sheet already printed with the old slug. Only
+  # do it for a board whose printables have not shipped, or reprint after.
+  #
+  #   bin/rails 'boards:rename_slug[123,new-slug]'
+  desc "Rename a board's slug, including a published board (breaks printed QR codes)"
+  task :rename_slug, [:board_id, :new_slug] => :environment do |_t, args|
+    board_id = args[:board_id].presence
+    new_slug = args[:new_slug].presence
+
+    abort "Usage: bin/rails 'boards:rename_slug[BOARD_ID,new-slug]'" if board_id.blank? || new_slug.blank?
+
+    board = Board.find_by(id: board_id)
+    abort "Board #{board_id} not found" if board.nil?
+
+    old_slug = board.slug
+    puts "Board #{board.id} (#{board.name.inspect}) published=#{board.published?}"
+    puts "  #{old_slug.inspect} -> requested #{new_slug.inspect}"
+
+    if board.published?
+      puts "  WARNING: this board is published. Any QR code already printed for"
+      puts "  /pb/#{old_slug} will 404 after this rename."
+    end
+
+    unless board.rename_slug!(new_slug)
+      abort "Failed to save: #{board.errors.full_messages.join(", ")}"
+    end
+
+    puts "  done: slug is now #{board.reload.slug.inspect} (#{board.public_url})"
+  end
+end

--- a/spec/models/board_slug_freeze_spec.rb
+++ b/spec/models/board_slug_freeze_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+# Model-level backstop for the frozen published slug (#611). The guard is a
+# before_save so it covers every caller — controllers, jobs, rake tasks — not
+# just the API update path.
+RSpec.describe Board, "published slug freeze", type: :model do
+  let(:user) { create(:user) }
+
+  # Slug first, publish second — the real order. A board gets its slug while
+  # it's still a draft, and publishing is what freezes it.
+  def board_with_slug(published:)
+    board = create(:board, user: user, name: "Snack Time", published: false)
+    board.generate_unique_slug
+    board.save!
+    board.update!(published: true) if published
+    board
+  end
+
+  describe "#slug_locked?" do
+    it "is true for a published board with a slug" do
+      expect(board_with_slug(published: true).slug_locked?).to be true
+    end
+
+    it "is false for an unpublished board" do
+      expect(board_with_slug(published: false).slug_locked?).to be false
+    end
+
+    it "is false for a published board that never got a slug" do
+      board = create(:board, user: user, published: true, slug: "")
+      # `slug` defaults to "" in the schema, so this is a real state.
+      expect(board.slug_locked?).to be false
+    end
+  end
+
+  describe "the before_save guard" do
+    it "reverts a slug change on a published board" do
+      board = board_with_slug(published: true)
+      original_slug = board.slug
+
+      board.slug = "something-else"
+      board.save!
+
+      expect(board.reload.slug).to eq(original_slug)
+    end
+
+    it "does not block the rest of the save" do
+      board = board_with_slug(published: true)
+
+      board.slug = "something-else"
+      board.name = "Lunch Time"
+      board.save!
+
+      expect(board.reload.name).to eq("Lunch Time")
+    end
+
+    it "allows the change on an unpublished board" do
+      board = board_with_slug(published: false)
+
+      board.slug = "something-else"
+      board.save!
+
+      expect(board.reload.slug).to eq("something-else")
+    end
+
+    it "allows a slug set in the same save that publishes the board" do
+      board = board_with_slug(published: false)
+
+      board.slug = "ready-to-print"
+      board.published = true
+      board.save!
+
+      expect(board.reload.slug).to eq("ready-to-print")
+    end
+
+    it "still fills in a blank slug on a published board" do
+      board = create(:board, user: user, name: "No Slug Yet", published: true, slug: "")
+
+      board.generate_unique_slug
+      board.save!
+
+      expect(board.reload.slug).to eq("no-slug-yet")
+    end
+
+    it "leaves new records alone" do
+      board = build(:board, user: user, name: "Fresh", published: true)
+      board.generate_unique_slug
+      board.save!
+
+      expect(board.reload.slug).to eq("fresh")
+    end
+  end
+
+  describe "#rename_slug!" do
+    it "is the deliberate escape hatch for a published board" do
+      board = board_with_slug(published: true)
+
+      expect(board.rename_slug!("deliberate-rename")).to be true
+      expect(board.reload.slug).to eq("deliberate-rename")
+    end
+
+    it "re-locks the slug afterward" do
+      board = board_with_slug(published: true)
+      board.rename_slug!("deliberate-rename")
+
+      board.slug = "sneaky-follow-up"
+      board.save!
+
+      expect(board.reload.slug).to eq("deliberate-rename")
+    end
+
+    it "still de-duplicates against an existing slug" do
+      create(:board, user: user, slug: "taken", published: false)
+      board = board_with_slug(published: true)
+
+      board.rename_slug!("taken")
+
+      expect(board.reload.slug).to start_with("taken-")
+    end
+  end
+end

--- a/spec/requests/api/boards_published_slug_freeze_spec.rb
+++ b/spec/requests/api/boards_published_slug_freeze_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+# A published board's slug is permanent: `/pb/<slug>` is what the QR codes on
+# printed board printables encode, and printed paper can't be re-issued (#611).
+# The change is IGNORED rather than rejected — the frontend re-derives the slug
+# from the name on every rename, so a 422 would break ordinary board renaming.
+RSpec.describe "API::Boards published slug freeze", type: :request do
+  let(:user) { create(:user) }
+
+  def update_board(board, params)
+    put "/api/boards/#{board.id}", params: params, headers: auth_headers(user)
+  end
+
+  context "when the board is published" do
+    let(:board) { create(:board, user: user, name: "Snack Time", published: false) }
+
+    # Slug first, publish second — the real order.
+    before do
+      board.generate_unique_slug
+      board.save!
+      board.update!(published: true)
+    end
+
+    it "keeps the old slug and still applies the rest of the update" do
+      original_slug = board.slug
+      expect(original_slug).to be_present
+
+      update_board(board, board: { name: "Lunch Time", slug: "lunch-time" })
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq(original_slug)
+      expect(board.name).to eq("Lunch Time")
+    end
+
+    it "leaves the already-printed /pb/<slug> URL resolving to the board" do
+      printed_slug = board.slug
+
+      update_board(board, board: { name: "Lunch Time", slug: "lunch-time" })
+
+      get "/api/boards/#{printed_slug}"
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["id"]).to eq(board.id)
+    end
+
+    it "keeps public_url stable across the rename" do
+      printed_url = board.public_url
+
+      update_board(board, board: { name: "Lunch Time", slug: "lunch-time" })
+
+      expect(board.reload.public_url).to eq(printed_url)
+    end
+  end
+
+  context "when the board is not published" do
+    let(:board) { create(:board, user: user, name: "Draft Board", published: false) }
+
+    before { board.generate_unique_slug && board.save! }
+
+    it "still renames the slug — nothing shareable has been handed out" do
+      update_board(board, board: { name: "Second Draft", slug: "second-draft" })
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("second-draft")
+    end
+  end
+end

--- a/spec/requests/api/internal/boards_spec.rb
+++ b/spec/requests/api/internal/boards_spec.rb
@@ -278,6 +278,41 @@ RSpec.describe "API::Internal::Boards", type: :request do
         expect(response).to have_http_status(:ok)
         expect(board.reload.name).to eq("New Name")
       end
+
+      # A published board's slug is frozen because printed QR codes encode
+      # `/pb/<slug>` (#611). This admin surface is the one deliberate rename
+      # path, opted into with `force_slug`.
+      context "renaming a published board's slug" do
+        let!(:published_board) do
+          b = create(:board, name: "Snack Time", user: admin_user, published: false)
+          b.generate_unique_slug
+          b.save!
+          b.update!(published: true)
+          b
+        end
+
+        def patch_slug(params)
+          patch "/api/internal/boards/#{published_board.id}",
+                params: params.to_json,
+                headers: auth_headers.merge("Content-Type" => "application/json")
+        end
+
+        it "ignores the new slug without force_slug" do
+          original_slug = published_board.slug
+
+          patch_slug(board: { slug: "lunch-time" })
+
+          expect(response).to have_http_status(:ok)
+          expect(published_board.reload.slug).to eq(original_slug)
+        end
+
+        it "applies the new slug with force_slug" do
+          patch_slug(board: { slug: "lunch-time" }, force_slug: true)
+
+          expect(response).to have_http_status(:ok)
+          expect(published_board.reload.slug).to eq("lunch-time")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Board printables encode `https://app.speakanyway.com/pb/<slug>` into the QR on the cover and on every board page — but the slug was mutable. `BoardForm` on the frontend re-derives the slug from the board name on **every** name edit and sends it on update, so renaming a published board silently rebuilt its share link and 404'd every sheet already printed. No redirect, no history, no signal.

This is option 1 from #611: freeze the slug once the board is published.

`Board#freeze_published_slug` (a `before_save`) reverts a slug change on a board that was already published with a slug. Two deliberate choices:

- **It reverts, it doesn't raise.** Since a slug param rides along on ordinary renames, a 422 would break renaming published boards entirely. The name change and the rest of the update land normally; only the slug snaps back, and the response carries the real slug.
- **It lives on the model, not the controllers.** Four controller paths regenerate slugs (`Api::BoardsController#update`, `Api::Internal::BoardsController` ×3) plus jobs, services and rake tasks — a before_save covers all of them.

Unpublished boards rename freely, and a slug set in the same save that publishes the board is allowed (the guard reads `published_was`).

Deliberate renames go through `Board#rename_slug!`, exposed two ways: `force_slug: true` on the internal admin update, and `bin/rails 'boards:rename_slug[ID,new-slug]'` (which warns when the board is published). Both break existing paper by design.

**Not included:** nothing recovers slugs that already changed before this ships — there's no record of past renames. A typo in a published board's slug is now permanent without the admin path, which is the accepted downside of option 1 over the slug-history table.

Closes #611

## Test plan

New coverage:
- `spec/models/board_slug_freeze_spec.rb` — `slug_locked?`, the guard (reverts on published, doesn't block the rest of the save, allows unpublished, allows publish-and-slug in one save, still fills a blank slug, ignores new records), and `rename_slug!` (works, re-locks after, still de-dupes).
- `spec/requests/api/boards_published_slug_freeze_spec.rb` — renaming a published board keeps the slug, still applies the name, leaves `/pb/<old-slug>` resolving, and keeps `public_url` stable; unpublished boards still rename.
- `spec/requests/api/internal/boards_spec.rb` — internal update ignores the slug without `force_slug`, applies it with.

Ran locally, all passing:
- new specs + `spec/requests/api/internal/boards_spec.rb` — 37 examples, 0 failures
- `spec/models/board_spec.rb`, `spec/requests/api/boards_spec.rb`, `boards_publish_cascade_spec.rb`, `board_read_only_spec.rb`, `public_boards_myspeak_spec.rb` — 186 examples, 0 failures
- `spec/requests/api/internal`, `spec/services/boards`, `board_pdf_spec.rb`, `board_exports_spec.rb`, `build_board_set_job_spec.rb` — 620 examples, 0 failures
- `bin/rails -T boards:rename_slug` loads and lists

Docs: CHANGELOG entry, a new section in `.claude-notes/boards-and-teams.md`, an invariant bullet in `CLAUDE.md`, and the now-stale "an editable key is an accepted trade" comment in `collect_pages.rb` corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)