### PR TITLE
feat(admin): sort the printables board picker and show created/updated dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   with each board page's QR pointing at that board rather than the root. Work
   runs on Sidekiq; a tree over the board cap is refused up front with a 422
   rather than half-built. The board picker collapses behind a toggle and
-  scrolls instead of running the length of the page, and each board shows how
-  many subboards it links to plus a link that opens its public page in a new
-  tab.
+  scrolls instead of running the length of the page. It is now a table with
+  sortable Board / Subboards / Created / Updated columns — sorting happens in
+  the database, so re-sorting changes which boards make the capped list rather
+  than just reshuffling the ones already on screen — and each row carries a
+  link that opens the board's public page in a new tab.
 
 ### Fixed
 

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -1,19 +1,35 @@
 module Admin
   class BoardPrintablesController < Admin::ApplicationController
     PUBLIC_BOARD_LIMIT = 100
+    SORTABLE_BOARD_COLUMNS = %w[name subboards created_at updated_at].freeze
+
+    # Directly linked subboards, as a scalar subquery, so "sort by subboards"
+    # happens in the database. Sorting the fetched page in Ruby would only
+    # order the first PUBLIC_BOARD_LIMIT rows the *name* sort happened to
+    # return, which is a different (and wrong) answer.
+    SUBBOARD_COUNT_SQL = <<~SQL.squish.freeze
+      (SELECT COUNT(DISTINCT bi.predictive_board_id)
+         FROM board_images bi
+        WHERE bi.board_id = boards.id
+          AND bi.predictive_board_id IS NOT NULL
+          AND bi.predictive_board_id <> bi.board_id)
+    SQL
 
     def index
       @printables = BoardPrintable.includes(:board).recent.limit(50)
+      @board_sort = params[:sort].presence_in(SORTABLE_BOARD_COLUMNS) || "name"
+      @board_dir = params[:dir].presence_in(%w[asc desc]) || "asc"
+
       @board_search = params[:board_search]
       @boards = if @board_search.present?
-        Board.where("name ILIKE ? OR CAST(id AS TEXT) = ?", "%#{@board_search}%", @board_search).limit(25)
+        sorted_boards(Board.where("name ILIKE ? OR CAST(id AS TEXT) = ?", "%#{@board_search}%", @board_search)).limit(25)
       else
         []
       end
 
       public_boards = Board.public_boards
       @public_boards_count = public_boards.count
-      @public_boards = public_boards.alphabetical.limit(PUBLIC_BOARD_LIMIT)
+      @public_boards = sorted_boards(public_boards).limit(PUBLIC_BOARD_LIMIT)
 
       @subboard_counts = direct_subboard_counts(@public_boards + @boards)
     end
@@ -57,6 +73,22 @@ module Admin
     end
 
     private
+
+    # @board_sort / @board_dir are whitelisted above, so they are safe to
+    # interpolate. Every sort falls back to name so the order is total —
+    # boards created in the same seed run otherwise shuffle between requests.
+    def sorted_boards(scope)
+      name_order = "LOWER(boards.name) ASC"
+
+      case @board_sort
+      when "name"
+        scope.reorder(Arel.sql("LOWER(boards.name) #{@board_dir.upcase}"))
+      when "subboards"
+        scope.reorder(Arel.sql("#{SUBBOARD_COUNT_SQL} #{@board_dir.upcase}, #{name_order}"))
+      else
+        scope.reorder(Arel.sql("boards.#{@board_sort} #{@board_dir.upcase}, #{name_order}"))
+      end
+    end
 
     # Directly linked subboards per board, in one grouped query — the full tree
     # would need a walk per row, and the list can be 100 boards long. Self-links

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -16,5 +16,16 @@ module Admin
       base_url = ENV["FRONT_END_URL"] || "http://localhost:8100"
       "#{base_url}/pb/#{Boards::Printables::CollectPages.qr_key_for(board)}"
     end
+
+    # The list is capped at PUBLIC_BOARD_LIMIT, so which boards you see depends
+    # on the sort — the summary line says which one picked them.
+    def board_sort_label(sort)
+      case sort
+      when "subboards"  then "subboard count"
+      when "created_at" then "created date"
+      when "updated_at" then "updated date"
+      else "name"
+      end
+    end
   end
 end

--- a/app/views/admin/board_printables/_board_option.html.erb
+++ b/app/views/admin/board_printables/_board_option.html.erb
@@ -1,34 +1,40 @@
 <% subboard_count = (defined?(subboard_counts) && subboard_counts ? subboard_counts[board.id] : nil).to_i %>
-<div class="admin-card-alt border-t rounded-lg p-3 flex flex-wrap items-end justify-between gap-3">
-  <div class="text-xs">
-    <span class="text-t1 font-medium"><%= board.name %></span>
-    <span class="text-t3">· ID <%= board.id %></span>
-    <% if board.category.present? %>
-      <span class="text-t3">· <%= board.category %></span>
-    <% end %>
+<tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
+  <td class="px-3 py-2">
+    <div class="text-t1 font-medium"><%= board.name %></div>
+    <div class="text-[11px] text-t3 flex flex-wrap items-center gap-1">
+      <span>ID <%= board.id %></span>
+      <% if board.category.present? %>
+        <span>· <%= board.category %></span>
+      <% end %>
+      <%= link_to "Open ↗", board_public_page_url(board), target: "_blank", rel: "noopener",
+                  class: "text-t2 hover:text-accent underline transition-colors",
+                  title: "Open this board in a new tab" %>
+    </div>
+  </td>
+  <td class="px-3 py-2 whitespace-nowrap">
     <% if subboard_count.positive? %>
-      <span class="ml-1 inline-block text-[11px] rounded px-1.5 py-0.5 bg-indigo-900/60 text-indigo-300" title="Directly linked subboards">
+      <span class="inline-block text-[11px] rounded px-1.5 py-0.5 bg-indigo-900/60 text-indigo-300" title="Directly linked subboards">
         <%= pluralize(subboard_count, "subboard") %>
       </span>
     <% else %>
-      <span class="ml-1 text-[11px] text-t3">No subboards</span>
+      <span class="text-[11px] text-t3">None</span>
     <% end %>
-    <%= link_to "Open ↗", board_public_page_url(board), target: "_blank", rel: "noopener",
-                class: "ml-1 text-[11px] text-t2 hover:text-accent underline transition-colors",
-                title: "Open this board in a new tab" %>
-  </div>
-  <%= form_tag admin_dashboard_board_printables_path, method: :post, class: "flex flex-wrap items-end gap-2" do %>
-    <input type="hidden" name="board_id" value="<%= board.id %>">
-    <label class="flex items-center gap-1 text-[11px] text-t2">
-      <input type="checkbox" name="include_subboards" value="1">
-      Include subboards
-    </label>
-    <div>
+  </td>
+  <td class="px-3 py-2 text-t2 whitespace-nowrap"><%= board.created_at.strftime("%b %-d, %Y") %></td>
+  <td class="px-3 py-2 text-t2 whitespace-nowrap"><%= board.updated_at.strftime("%b %-d, %Y") %></td>
+  <td class="px-3 py-2">
+    <%= form_tag admin_dashboard_board_printables_path, method: :post, class: "flex flex-wrap items-center justify-end gap-2" do %>
+      <input type="hidden" name="board_id" value="<%= board.id %>">
+      <label class="flex items-center gap-1 text-[11px] text-t2 whitespace-nowrap">
+        <input type="checkbox" name="include_subboards" value="1">
+        Include subboards
+      </label>
       <input type="number" name="max_boards" value="<%= BoardPrintable::DEFAULT_MAX_BOARDS %>" min="1" max="<%= BoardPrintable::MAX_BOARDS_CEILING %>"
-             class="admin-input border rounded px-2 py-1 text-xs w-20 focus:border-indigo-500 focus:outline-none" title="Max boards in tree">
-    </div>
-    <button type="submit" class="text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0">
-      Generate
-    </button>
-  <% end %>
-</div>
+             class="admin-input border rounded px-2 py-1 text-xs w-16 focus:border-indigo-500 focus:outline-none" title="Max boards in tree">
+      <button type="submit" class="text-xs font-medium px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0 whitespace-nowrap">
+        Generate
+      </button>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/admin/board_printables/_board_table.html.erb
+++ b/app/views/admin/board_printables/_board_table.html.erb
@@ -1,0 +1,34 @@
+<%# Shared picker table — the public-board list and the search results are the
+    same thing with a different scope, so they share one set of columns and one
+    sort. Header links carry board_search along so sorting never drops the
+    search you are looking at. %>
+<div class="max-h-96 overflow-y-auto rounded-lg" style="border: 1px solid var(--border);">
+  <table class="w-full text-xs">
+    <thead>
+      <tr>
+        <% [
+          ["Board",     "name"],
+          ["Subboards", "subboards"],
+          ["Created",   "created_at"],
+          ["Updated",   "updated_at"],
+        ].each do |label, col| %>
+          <th class="admin-card sticky top-0 z-10 text-left text-xs font-medium text-t2 px-3 py-2 whitespace-nowrap"
+              style="border-bottom: 1px solid var(--border);">
+            <% next_dir = (@board_sort == col && @board_dir == "asc") ? "desc" : "asc" %>
+            <%= link_to admin_dashboard_board_printables_path(sort: col, dir: next_dir, board_search: @board_search.presence),
+                  class: "hover:text-t1 transition-colors inline-flex items-center gap-1" do %>
+              <%= label %>
+              <% if @board_sort == col %>
+                <span class="text-accent"><%= @board_dir == "asc" ? "↑" : "↓" %></span>
+              <% end %>
+            <% end %>
+          </th>
+        <% end %>
+        <th class="admin-card sticky top-0 z-10 px-3 py-2" style="border-bottom: 1px solid var(--border);"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: "board_option", collection: boards, as: :board, locals: { subboard_counts: subboard_counts } %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/board_printables/index.html.erb
+++ b/app/views/admin/board_printables/index.html.erb
@@ -8,17 +8,18 @@
 </div>
 
 <div class="admin-card border rounded-xl p-5 mb-6">
-  <details>
+  <%# Sorting reloads the page, so a sort click has to leave the picker open. %>
+  <details <%= "open" if params[:sort].present? %>>
     <summary class="flex items-baseline justify-between gap-3 cursor-pointer list-none">
       <h2 class="text-sm font-medium text-t1">Public boards <span class="text-t3 font-normal">(click to expand)</span></h2>
       <span class="text-xs text-t3">
-        <%= pluralize(@public_boards_count, "published public board") %><%= " · showing first #{@public_boards.size}" if @public_boards_count > @public_boards.size %>
+        <%= pluralize(@public_boards_count, "published public board") %><%= " · showing first #{@public_boards.size} by #{board_sort_label(@board_sort)}" if @public_boards_count > @public_boards.size %>
       </span>
     </summary>
 
     <% if @public_boards.any? %>
-      <div class="flex flex-col gap-3 mt-3 max-h-96 overflow-y-auto pr-1">
-        <%= render partial: "board_option", collection: @public_boards, as: :board, locals: { subboard_counts: @subboard_counts } %>
+      <div class="mt-3">
+        <%= render "board_table", boards: @public_boards, subboard_counts: @subboard_counts %>
       </div>
     <% else %>
       <p class="text-xs text-t3 mt-3">No published public boards yet — use the search below to find any board.</p>
@@ -31,6 +32,8 @@
   <%= form_tag admin_dashboard_board_printables_path, method: :get, class: "flex items-center gap-2 mb-4", data: { turbo: false } do %>
     <input type="text" name="board_search" value="<%= @board_search %>" placeholder="Search by board name or ID…"
            class="admin-input border rounded px-3 py-1.5 text-sm w-72 focus:border-indigo-500 focus:outline-none">
+    <input type="hidden" name="sort" value="<%= @board_sort %>">
+    <input type="hidden" name="dir" value="<%= @board_dir %>">
     <button type="submit" class="text-xs px-3 py-1.5 rounded border admin-input text-t1">Search</button>
     <% if @board_search.present? %>
       <%= link_to "Clear", admin_dashboard_board_printables_path, class: "text-xs text-t3 hover:text-t1" %>
@@ -39,9 +42,7 @@
 
   <% if @board_search.present? %>
     <% if @boards.any? %>
-      <div class="flex flex-col gap-3 max-h-96 overflow-y-auto pr-1">
-        <%= render partial: "board_option", collection: @boards, as: :board, locals: { subboard_counts: @subboard_counts } %>
-      </div>
+      <%= render "board_table", boards: @boards, subboard_counts: @subboard_counts %>
     <% else %>
       <p class="text-xs text-t3">No boards match "<%= @board_search %>".</p>
     <% end %>

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -92,7 +92,20 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
 
       get admin_dashboard_board_printables_path
 
-      expect(response.body).to include("No subboards")
+      expect(response.body).to include("None")
+    end
+
+    it "shows a created and updated date for each public board" do
+      sign_in admin
+      created = Time.zone.local(2026, 3, 4, 12, 0)
+      updated = Time.zone.local(2026, 5, 6, 12, 0)
+      create(:board, user: default_admin, predefined: true, published: true, name: "Public Dated",
+             created_at: created, updated_at: updated)
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).to include("Mar 4, 2026")
+      expect(response.body).to include("May 6, 2026")
     end
 
     it "links each public board to its public page in a new tab" do
@@ -104,6 +117,81 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
 
       expect(response.body).to include("/pb/#{key}")
       expect(response.body).to include('target="_blank"')
+    end
+
+    describe "sorting the public board list" do
+      def public_board_order(body)
+        %w[Apple Mango Zebra].sort_by { |name| body.index(">#{name}<") || Float::INFINITY }
+      end
+
+      let!(:zebra) do
+        create(:board, user: default_admin, predefined: true, published: true, name: "Zebra",
+               created_at: 3.days.ago, updated_at: 1.hour.ago)
+      end
+      let!(:apple) do
+        create(:board, user: default_admin, predefined: true, published: true, name: "Apple",
+               created_at: 1.day.ago, updated_at: 3.hours.ago)
+      end
+      let!(:mango) do
+        create(:board, user: default_admin, predefined: true, published: true, name: "Mango",
+               created_at: 2.days.ago, updated_at: 2.hours.ago)
+      end
+
+      before { sign_in admin }
+
+      it "sorts by name ascending by default" do
+        get admin_dashboard_board_printables_path
+
+        expect(public_board_order(response.body)).to eq(%w[Apple Mango Zebra])
+      end
+
+      it "reverses on dir=desc" do
+        get admin_dashboard_board_printables_path(sort: "name", dir: "desc")
+
+        expect(public_board_order(response.body)).to eq(%w[Zebra Mango Apple])
+      end
+
+      it "sorts by created date" do
+        get admin_dashboard_board_printables_path(sort: "created_at", dir: "asc")
+
+        expect(public_board_order(response.body)).to eq(%w[Zebra Mango Apple])
+      end
+
+      it "sorts by updated date" do
+        get admin_dashboard_board_printables_path(sort: "updated_at", dir: "asc")
+
+        expect(public_board_order(response.body)).to eq(%w[Apple Mango Zebra])
+      end
+
+      it "sorts by subboard count in the database, not just the fetched page" do
+        link(mango, create(:board, user: owner, name: "Mango Child"))
+        link(zebra, create(:board, user: owner, name: "Zebra Child A"), position: 0)
+        link(zebra, create(:board, user: owner, name: "Zebra Child B"), position: 1)
+
+        get admin_dashboard_board_printables_path(sort: "subboards", dir: "desc")
+
+        expect(public_board_order(response.body)).to eq(%w[Zebra Mango Apple])
+      end
+
+      it "ignores an unknown sort column rather than interpolating it" do
+        get admin_dashboard_board_printables_path(sort: "id; DROP TABLE boards", dir: "asc")
+
+        expect(response).to have_http_status(:ok)
+        expect(public_board_order(response.body)).to eq(%w[Apple Mango Zebra])
+      end
+
+      it "keeps the picker expanded when a sort is applied" do
+        get admin_dashboard_board_printables_path(sort: "created_at")
+
+        expect(response.body).to include("<details open>")
+      end
+
+      it "carries the search term through the sort header links" do
+        get admin_dashboard_board_printables_path(board_search: "Core", sort: "created_at", dir: "desc")
+
+        expect(response.body).to include("board_search=Core")
+        expect(response.body).to include("Core Words")
+      end
     end
 
     it "searches boards by name" do


### PR DESCRIPTION
## Summary

The **Public boards** picker on Board Printables was an unordered card list
with no dates on it, so there was no way to find the board you last touched or
the one with the biggest subboard tree. It's now a table with sortable columns:

| Board | Subboards | Created | Updated | |
|---|---|---|---|---|
| name, ID · category, Open ↗ | badge or "None" | `Aug 7, 2026` | `Aug 7, 2026` | generate form |

Header links follow the `@sort` / `@dir` + ↑/↓ pattern the Users and Word
Events admin screens already use, so this behaves the way the rest of the
dashboard does.

## Notes for the reviewer

- **Sorting runs in the database, subboard count included** — via a scalar
  subquery, not a Ruby sort. This is the load-bearing bit: the list is capped
  at `PUBLIC_BOARD_LIMIT` (100), so sorting after the fetch would only reorder
  whichever 100 boards the *name* sort happened to return. "Boards with the
  most subboards" would then give a confidently wrong answer. Every sort falls
  back to name so the order is total and doesn't shuffle between requests for
  boards created in the same seed run.
- **`sort` / `dir` are whitelisted with `presence_in`** before being
  interpolated into `Arel.sql`, same guard as `Admin::UsersController`. There's
  a test that a junk `sort` param falls back to name rather than reaching the
  query.
- **The picker and the search results share one table partial and one sort.**
  Header links carry `board_search` through; the search form carries `sort` /
  `dir` back as hidden fields.
- **`<details>` opens when a sort param is present.** Sorting is a page reload,
  so without this every header click would collapse the list you just sorted.

## Test plan

`bundle exec rspec spec/requests/admin/board_printables_spec.rb` — **29 examples, 0 failures.**

Nine new examples cover each sort column, the direction toggle, the DB-level
subboard sort, the junk-param fallback, the stays-expanded behavior, search-term
passthrough, and the two new date columns. I also dumped the rendered HTML and
checked the table structure, sticky header, and per-row form by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
