### PR TITLE
fix(images): make label a lowercase matching key, and render tile text from display_label

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -165,10 +165,31 @@ Full permissions matrix and the rationale for the split lives in
 `../speakanyway/marketing/.claude-notes/handoff-workflow.md`.
 
 
-## Tile text casing (`display_label`)
+## `Image#label` vs `Image#display_label`
 
-`label` is a **lowercase matching key** used for image lookup — never display
-text, never normalized. `display_label` is what renders on the tile.
+**`label` is a lowercase, stripped matching key. `display_label` is the text.**
+The columns exist on both `images` and `board_images` and mean the same thing
+on each.
+
+`Image#set_label` enforces it on every write: `label` is downcased and
+stripped, and the authored casing is captured into `display_label` (on create,
+and re-derived on a rename unless the caller set `display_label` in the same
+write). Punctuation is deliberately **not** stripped — `McDonald's` must not
+collapse into `mcdonalds` and split from its own artwork.
+
+**Never look an image up with `find_by(label:)`.** Use the `Image.by_label`
+scope, which normalizes the caller's input and matches on `LOWER(label)`
+(backed by `index_images_on_lower_label`). The bare form is what let the
+library fill with blank twins: a user typing "Swing" missed the curated
+`swing` image, and the calling site's very next line created a new, art-less
+`Image`. `Boards::ImageResolver` layers art-preference on top of the same
+case-insensitive match and is the right entry point for **tile** resolution
+specifically.
+
+`board_images.label` inherits the image's key, so it is lowercase too. Tests
+and code that want the tile's *text* must read `display_label`.
+
+### Casing of a defaulted `display_label`
 
 `Labels::CaseNormalizer` normalizes **defaulted** `display_label` casing at
 creation. Two `BoardImage` paths default it, and both route through
@@ -177,18 +198,22 @@ creation. Two `BoardImage` paths default it, and both route through
 - `set_defaults` (`before_create`) — the `image.display_label` fallback. It
   runs **after** `part_of_speech` resolution so the phrase rule sees the real
   value.
-- `set_labels` — the `|| label` fall-through only. A `display_label` stored in
-  `language_settings` is an authored translation and is used verbatim.
+- `set_labels` — the fall-through when `language_settings` holds no authored
+  translation for the tile's language. It defaults from the translated label
+  if one exists, else from **`image.display_label`** — never from `self.label`,
+  which is the lowercase key and would flatten `Food` to `food`.
 
 Rules, in order: blank passes through; **any existing uppercase letter means
 the text was cased deliberately** (`iPad`, `TV`, `McDonald's`) and is returned
 untouched — that guard is what removes the need for an acronym exception list;
 non-English → sentence case (`todo listo` → `Todo listo`, since Title Case is
 an English convention); English `part_of_speech == "phrase"` → sentence case,
-because gestalt/GLP tiles are whole utterances; otherwise English Title Case
-(`all done` → `All Done`). A standalone `i` capitalizes anywhere in sentence
-case. The transform **only ever upcases a word's first letter** — it never
-downcases, so nothing that slips past the uppercase guard can be mangled.
+because gestalt/GLP tiles are whole utterances; otherwise **lowercase**, the
+AAC core-vocabulary convention (LAMP, Unity, Word Power) — `all done` stays
+`all done`. A standalone `i` capitalizes anywhere, since that is grammar rather
+than casing style. The transform **only ever upcases a word's first letter** —
+it never downcases, so nothing that slips past the uppercase guard can be
+mangled.
 
 An explicitly supplied `display_label` never reaches the normalizer:
 `display_label.blank?` is false, so the caller's casing wins. That's what keeps
@@ -196,9 +221,19 @@ the authored-casing pins (`pin_authored_label!`, `NavRowSync`,
 `ImageResolver#upgrade_board_tiles!`, `BoardFromScreenshot`, `SeededSetCloner`)
 and the bulk `label_case` endpoint working unchanged.
 
-Normalization is **forward-only** — no backfill. Rows created before this
+`Board#add_image` must **not** prime `image.language_settings` with the image's
+own label before calling `set_labels`. That in-memory write was read back as an
+authored translation, which both skipped the normalizer and — on a non-English
+board — overwrote that language's real translation with the English text.
+
+Existing `board_images` rows are **not** backfilled. Tiles created before this
 keep their casing; a backfill would have to distinguish deliberate casing from
-inherited casing on data where that signal is already lost.
+inherited casing on data where that signal is already lost. The `images`
+backfill is a different case and did run: `display_label` took each row's
+authored casing verbatim, and only single plain Title-Cased `category` folder
+tiles with an existing lowercase twin (`Animals`, `Play`, `Time`) were
+lowercased. The twin test is what protects the imported source-collection names
+(`CommuniKate weather`, `Core 24 - Small Words`).
 
 ## Make a Board From Screenshot
 

--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -186,8 +186,12 @@ library fill with blank twins: a user typing "Swing" missed the curated
 case-insensitive match and is the right entry point for **tile** resolution
 specifically.
 
-`board_images.label` inherits the image's key, so it is lowercase too. Tests
-and code that want the tile's *text* must read `display_label`.
+`board_images.label` is **not** normalized by a callback. It is lowercase when
+`set_labels` derives it from the image, but builders that assign it directly
+(`NavRowSync`, `PhrasesPageBuilder`, `SeededSetCloner`'s favorites tile) keep
+whatever casing they wrote. So tile `label` casing is *mixed* by design, and
+tests or code that want the tile's **text** must read `display_label` —
+matching a tile by `label` against a capitalized literal is unreliable.
 
 ### Casing of a defaulted `display_label`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,23 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Adding a word to a board finds the picture that already exists for it.**
+  Image lookup was case-sensitive, so typing "Swing" (or pasting a Title Cased
+  word list) sailed past the curated `swing` symbol and silently created a
+  brand-new, art-less image beside it — a blank tile on the board and a
+  duplicate in the library, over and over. Every lookup now matches
+  case-insensitively and ignores stray whitespace, so the existing artwork gets
+  reused. The internal API already worked this way; the rest of the app now
+  matches it.
+
+- **Tile text no longer inherits whatever casing the creation path used.** An
+  image now stores the word twice: a plain lowercase key it is looked up by,
+  and the text as it was actually written. Tiles render from the second, so
+  "iPad", "TV" and "McDonald's" keep their capitals while ordinary words settle
+  to lowercase — and a folder tile still reads "Food", not "food". Existing
+  tiles keep their current text; nothing on a board you already built is
+  rewritten.
+
 - **Renaming a published board no longer breaks its printed QR codes.** A
   board's share link (`/pb/<slug>`) is derived from its name, and renaming the
   board used to rebuild that link — silently 404ing every QR code already

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,13 +209,16 @@ an explicit decision, not a drive-by edit.
   Client-called endpoints may reflect plan state but never grant credits. All
   credit movement goes through `CreditService` and the immutable
   `credit_transactions` ledger; grants are idempotent on event id.
-- **`label` is a lowercase matching key; `display_label` is the text.** True on
-  both `images` and `board_images`. `Image#set_label` downcases and strips
-  `label` on every write and captures the authored casing into `display_label`.
-  Never look an image up with `find_by(label:)` — use the `Image.by_label`
-  scope (or `Boards::ImageResolver` when resolving a *tile*, which adds
-  art-preference). A case-sensitive lookup misses the curated symbol and the
-  calling site then creates a blank duplicate.
+- **`images.label` is a lowercase matching key; `display_label` is the text.**
+  `Image#set_label` downcases and strips `label` on every write and captures
+  the authored casing into `display_label`. Never look an image up with
+  `find_by(label:)` — use the `Image.by_label` scope (or
+  `Boards::ImageResolver` when resolving a *tile*, which adds art-preference).
+  A case-sensitive lookup misses the curated symbol and the calling site then
+  creates a blank duplicate. `board_images.label` is **not** normalized by any
+  callback: it is lowercase when `set_labels` derives it from the image, but
+  builders that write it directly (`NavRowSync`, `PhrasesPageBuilder`) keep
+  their own casing — read `display_label` for tile text either way.
 - **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
   and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
   silently reverts a slug change on a published board (reverts, never raises —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,13 @@ an explicit decision, not a drive-by edit.
   Client-called endpoints may reflect plan state but never grant credits. All
   credit movement goes through `CreditService` and the immutable
   `credit_transactions` ledger; grants are idempotent on event id.
+- **`label` is a lowercase matching key; `display_label` is the text.** True on
+  both `images` and `board_images`. `Image#set_label` downcases and strips
+  `label` on every write and captures the authored casing into `display_label`.
+  Never look an image up with `find_by(label:)` — use the `Image.by_label`
+  scope (or `Boards::ImageResolver` when resolving a *tile*, which adds
+  art-preference). A case-sensitive lookup misses the curated symbol and the
+  calling site then creates a blank duplicate.
 - **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
   and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
   silently reverts a slug change on a published board (reverts, never raises —

--- a/app/controllers/api/account/boards_controller.rb
+++ b/app/controllers/api/account/boards_controller.rb
@@ -83,7 +83,7 @@ class API::Account::BoardsController < API::Account::ApplicationController
         images: board.board_images.map do |board_image|
           {
             id: board_image.image.id,
-            label: board_image.image.label,
+            label: board_image.image.display_label,
             image_prompt: board_image.image.image_prompt,
             bg_color: board_image.image.bg_class,
             text_color: board_image.image.text_color,

--- a/app/controllers/api/account/images_controller.rb
+++ b/app/controllers/api/account/images_controller.rb
@@ -14,8 +14,8 @@ class API::Account::ImagesController < API::Account::ApplicationController
     label = image_params["label"]
 
     is_private = image_params["private"] || false
-    @image = Image.find_by(label: label, user_id: @user.id)
-    @image = Image.public_img.find_by(label: label) unless @image
+    @image = Image.by_label(label).find_by(user_id: @user.id)
+    @image = Image.public_img.by_label(label).first unless @image
     @found_image = @image
     @image = Image.create(label: label, private: is_private, user_id: @user.id, image_prompt: image_params[:image_prompt], image_type: "User") unless @image || (@found_image && duplicate_image)
 

--- a/app/controllers/api/audits_controller.rb
+++ b/app/controllers/api/audits_controller.rb
@@ -15,8 +15,8 @@ class API::AuditsController < API::ApplicationController
     image = Image.find(params[:imageId]) if params[:imageId]
     board = Board.includes(:user).find(params[:boardId]) if params[:boardId]
     unless image
-      image = current_account.images.find_by(label: params[:word]) if current_account
-      image = current_user.images.find_by(label: params[:word]) if current_user
+      image = current_account.images.by_label(params[:word]).first if current_account
+      image = current_user.images.by_label(params[:word]).first if current_user
     end
 
     board_image_id = params[:boardImageId]

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -967,8 +967,8 @@ class API::BoardsController < API::ApplicationController
   def add_image
     set_board
     # @board = Board.with_artifacts.find(params[:id])
-    @found_image = Image.find_by(label: image_params[:label], user_id: current_user.id, private: true)
-    @found_image ||= Image.find_by(label: image_params[:label])
+    @found_image = Image.by_label(image_params[:label]).find_by(user_id: current_user.id, private: true)
+    @found_image ||= Image.by_label(image_params[:label]).first
     if @found_image
       @image = @found_image
       img_saved = true

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -15,7 +15,7 @@ class API::ImagesController < API::ApplicationController
     end
 
     if params[:query].present?
-      @images = @images.where(label: params[:query]).order(Arel.sql("#{sort_field} #{sort_order}")).page params[:page]
+      @images = @images.by_label(params[:query]).order(Arel.sql("#{sort_field} #{sort_order}")).page params[:page]
     else
       @images = @images.order(Arel.sql("#{sort_field} #{sort_order}")).page params[:page]
     end
@@ -56,7 +56,7 @@ class API::ImagesController < API::ApplicationController
   def user_docs
     @current_user = current_user
     label = params[:label]
-    @images = Image.with_artifacts.where(label: label, user_id: @current_user.id)
+    @images = Image.with_artifacts.by_label(label).where(user_id: @current_user.id)
     if @current_user.admin?
       @docs = UserDoc.where(image_id: @images.pluck(:id)).includes(:doc, :image).order(created_at: :desc).page params[:page]
     else
@@ -74,7 +74,7 @@ class API::ImagesController < API::ApplicationController
     label = image_params[:label]
     image_id = params["image"]["id"]
     @image = accessible_image(image_id) if image_id.present?
-    @image = Image.find_by(label: label, user_id: @current_user.id) unless @image
+    @image = Image.by_label(label).find_by(user_id: @current_user.id) unless @image
     @image = Image.create(label: label, user_id: @current_user.id) unless @image
     @doc = attach_doc_to_image(@image, @current_user, params[:cropped_image], params[:file_extension])
 
@@ -99,7 +99,7 @@ class API::ImagesController < API::ApplicationController
     end
 
     label = params[:query]
-    @existing_image = Image.find_by(label: label, user_id: @current_user.id) unless @existing_image
+    @existing_image = Image.by_label(label).find_by(user_id: @current_user.id) unless @existing_image
     @image = nil
     if @existing_image
       @image = @existing_image
@@ -326,7 +326,7 @@ class API::ImagesController < API::ApplicationController
     duplicate_image = image_params[:duplicate] == "1"
 
     label = image_params[:label]
-    @existing_image = Image.find_by(label: label, user_id: @current_user.id)
+    @existing_image = Image.by_label(label).find_by(user_id: @current_user.id)
     @image = nil
     if @existing_image && find_first && !duplicate_image
       @image = @existing_image
@@ -535,7 +535,7 @@ class API::ImagesController < API::ApplicationController
       status: "generating",
       display_doc: {
         id: @current_doc&.id,
-        label: @image&.label,
+        label: @image&.display_label,
         user_id: @current_doc&.user_id,
         src: @current_doc&.image&.url,
         is_current: true,
@@ -546,7 +546,7 @@ class API::ImagesController < API::ApplicationController
       docs: @image_docs.map do |doc|
         {
           id: doc.id,
-          label: @image.label,
+          label: @image.display_label,
           user_id: doc.user_id,
           src: doc.image.url,
           is_current: doc.id == @current_doc_id,
@@ -573,8 +573,8 @@ class API::ImagesController < API::ApplicationController
     label = image_params["label"]
 
     is_private = image_params["private"] || false
-    @image = Image.find_by(label: label, user_id: @current_user.id)
-    @image = Image.public_img.find_by(label: label) unless @image
+    @image = Image.by_label(label).find_by(user_id: @current_user.id)
+    @image = Image.public_img.by_label(label).first unless @image
     @found_image = @image
     @image = Image.create(label: label, private: is_private, user_id: @current_user.id, image_prompt: image_params[:image_prompt], image_type: "User") unless @image || (@found_image && duplicate_image)
 
@@ -613,8 +613,8 @@ class API::ImagesController < API::ApplicationController
   def find_by_label
     @current_user = current_user
     label = params[:label]
-    @image = Image.find_by(label: label, user_id: @current_user.id)
-    @image = Image.public_img.find_by(label: label) unless @image
+    @image = Image.by_label(label).find_by(user_id: @current_user.id)
+    @image = Image.public_img.by_label(label).first unless @image
     if @image
       @image_with_display_doc = @image.with_display_doc(@current_user)
       render json: @image_with_display_doc
@@ -676,7 +676,7 @@ class API::ImagesController < API::ApplicationController
     @images_with_display_doc = @images.map do |image|
       {
         id: image.id,
-        label: image.label,
+        label: image.display_label,
         image_prompt: image.image_prompt,
         src: image.display_image_url(@current_user),
         audio: image.default_audio_url,
@@ -692,7 +692,7 @@ class API::ImagesController < API::ApplicationController
     @images_with_display_doc = @images.map do |image|
       {
         id: image.id,
-        label: image.label,
+        label: image.display_label,
         image_prompt: image.image_prompt,
         src: image.display_image_url(current_user),
         audio: image.default_audio_url,

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1058,9 +1058,9 @@ class Board < ApplicationRecord
         image_ids_to_generate << image.id
         queued_count += 1
       else
-        image = user.images.find_by(label: word) if user_id
+        image = user.images.by_label(word).first if user_id
 
-        image = Image.public_img.find_by(label: word, user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
+        image = Image.public_img.by_label(word).find_by(user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
         new_image = Image.create(label: word) unless image
         image ||= new_image
         display_doc = image.display_tile_url(user)
@@ -1118,8 +1118,15 @@ class Board < ApplicationRecord
     return if image_id.blank?
     @image = Image.with_artifacts.find_by(id: image_id)
 
-    language_settings = @image.language_settings || {}
-    language_settings[self.language] = { "display_label" => @image.label, "label" => @image.label }
+    # No language_settings priming here. This used to write
+    # `{ "display_label" => @image.label }` into the image's in-memory
+    # language_settings purely as a side channel into set_labels — which reads
+    # that key as an *authored translation* and uses it verbatim. Two things
+    # broke as a result: the tile skipped Labels::CaseNormalizer entirely (it
+    # got the raw lowercase matching key instead of the image's display text),
+    # and on a non-English board it overwrote that language's real translation
+    # with the English label. set_labels already falls back to the image's own
+    # label/display_label when no translation exists, so this was never needed.
     self.voice = VoiceService.normalize_voice(self.voice)
     new_board_image = board_images.new(image_id: image_id.to_i, voice: self.voice, position: board_images_count, language: self.language)
     new_board_image.set_labels
@@ -1223,9 +1230,9 @@ class Board < ApplicationRecord
       # end
 
       if image.user_id
-        image = Image.find_by(label: image.label, user_id: @cloned_board.user_id) if image.user_id == @cloned_board.user_id
+        image = Image.by_label(image.label).find_by(user_id: @cloned_board.user_id) if image.user_id == @cloned_board.user_id
       else
-        image = Image.find_by(label: image.label, user_id: [nil, @cloned_board.user_id, User::DEFAULT_ADMIN_ID])
+        image = Image.by_label(image.label).find_by(user_id: [nil, @cloned_board.user_id, User::DEFAULT_ADMIN_ID])
       end
       image = Image.create(label: original_image.label, user_id: @cloned_board.user_id) unless image
       layout = @layouts.find { |l| l[0] == original_image.id }&.second
@@ -2249,7 +2256,7 @@ class Board < ApplicationRecord
         @predictive_images = @predictive_board&.board_images&.order(:position) || []
       end
       button = {
-        label: bi.label,
+        label: bi.display_label.presence || bi.label,
       # image_id: bi.id,
       # predictive_images: @predictive_images.map { |pi| { label: pi.label, image_id: pi.id } },
       # predictive_board_id: @predictive_board_id,
@@ -2275,13 +2282,15 @@ class Board < ApplicationRecord
     @board = Board.create!(name: obf_data["name"], board_type: "dynamic", user_id: user_id, parent_type: "User", parent_id: user_id)
     obf_data["images"].each do |image_data|
       image_data = image_data.with_indifferent_access
-      @image = Image.searchable.where(user_id: @board.user_id).find_by(label: image_data["label"])
+      @image = Image.searchable.where(user_id: @board.user_id).by_label(image_data["label"]).first
       @image = Image.create(label: image_data["label"]) unless @image
       new_board_image = @board.add_image(@image.id)
       if image_data["predictive_images"]&.any?
-        @predictive_board = Board.create!(name: @image.label, board_type: "predictive", user_id: user_id, parent_type: "Image", parent_id: @image.id)
+        # display_label, not label: a board name is text a human reads, and
+        # label is the lowercase matching key.
+        @predictive_board = Board.create!(name: @image.display_label, board_type: "predictive", user_id: user_id, parent_type: "Image", parent_id: @image.id)
         image_data["predictive_images"].each do |predictive_image_label|
-          @predictive_image = Image.searchable.where(user_id: @board.user_id).find_by(label: predictive_image_label)
+          @predictive_image = Image.searchable.where(user_id: @board.user_id).by_label(predictive_image_label).first
           @predictive_image = Image.create(label: predictive_image_label) unless @predictive_image
           @predictive_board.add_image(@predictive_image.id) if @predictive_image
         end
@@ -2484,8 +2493,8 @@ class Board < ApplicationRecord
 
   def matching_image
     normalized_name = name.downcase.strip
-    image = Image.find_by(label: normalized_name, user_id: user_id)
-    image = Image.find_by(label: normalized_name, user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
+    image = Image.by_label(normalized_name).find_by(user_id: user_id)
+    image = Image.by_label(normalized_name).find_by(user_id: [User::DEFAULT_ADMIN_ID, nil]) unless image
     image
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1327,7 +1327,11 @@ class Board < ApplicationRecord
   def set_current_word_list
     data = self.data || {}
 
-    words = board_images.order(:position).pluck(:label)
+    # display_label, not label: this list is surfaced as `word_list` in the
+    # board payload, and before `label` became a pure matching key it carried
+    # the tile's text. Both sides of the clone-dedup comparison in
+    # CloneBoardJob read this same field, so matching is unaffected.
+    words = board_images.order(:position).pluck(:display_label)
     return [] if words.blank?
 
     data["current_word_list"] = words
@@ -1933,7 +1937,7 @@ class Board < ApplicationRecord
         {
           id: @board_image.id,
           image_id: @image.id,
-          label: @board_image.localized_label(viewer_lang),
+          label: @board_image.localized_display_label(viewer_lang),
           display_label: @board_image.localized_display_label(viewer_lang),
           hidden: @board_image.hidden,
           root_board_id: @root_board&.id,
@@ -2142,7 +2146,7 @@ class Board < ApplicationRecord
         {
           id: @board_image.id,
           image_id: @image.id,
-          label: @board_image.localized_label(viewer_lang),
+          label: @board_image.localized_display_label(viewer_lang),
           display_label: @board_image.localized_display_label(viewer_lang),
           hidden: @board_image.hidden,
           root_board_id: @root_board&.id,

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2894,12 +2894,18 @@ class Board < ApplicationRecord
       ext_id = item["ext_saw_image_id"].to_i
       image = image_cache ? image_cache[:by_ext_id][ext_id] : Image.find_by(id: ext_id, user_id: user.id)
     end
+    # Key on the normalized label, not the raw OBF one. Buttons are authored
+    # with display casing ("I", "Food") while images store the lowercase
+    # matching key, so a raw-label lookup misses every capitalized button and
+    # falls through to create! — minting a fresh duplicate Image on every
+    # import and re-seed.
+    key = Image.normalize_label(label)
     if image_cache
-      image ||= image_cache[:by_label_and_obf_id][[label, obf_id]]
-      image ||= image_cache[:by_label][label]
+      image ||= image_cache[:by_label_and_obf_id][[key, obf_id]]
+      image ||= image_cache[:by_label][key]
     else
-      image ||= Image.where(user_id: user.id, label: label, obf_id: obf_id).order(:id).first
-      image ||= Image.where(user_id: user.id, label: label).order(:id).first
+      image ||= Image.by_label(label).where(user_id: user.id, obf_id: obf_id).order(:id).first
+      image ||= Image.by_label(label).where(user_id: user.id).order(:id).first
     end
     unless image
       image = Image.create!(label: label, user_id: user.id, obf_id: obf_id, is_private: true)
@@ -2925,9 +2931,17 @@ class Board < ApplicationRecord
     by_label_and_obf_id = {}
     by_label = {}
     if labels.any?
-      Image.where(user_id: user.id, label: labels).order(:id).each do |img|
-        by_label_and_obf_id[[img.label, img.obf_id]] ||= img
-        by_label[img.label] ||= img
+      # Match and key on the normalized label so a button authored as "Food"
+      # resolves to the stored `food` image instead of creating a twin. Both
+      # hashes are keyed the same way find_or_create_image_for_button looks
+      # them up.
+      keys = labels.map { |l| Image.normalize_label(l) }.uniq
+      Image.where(user_id: user.id)
+           .where("LOWER(images.label) IN (?)", keys)
+           .order(:id).each do |img|
+        key = Image.normalize_label(img.label)
+        by_label_and_obf_id[[key, img.obf_id]] ||= img
+        by_label[key] ||= img
       end
     end
 
@@ -3001,7 +3015,14 @@ class Board < ApplicationRecord
       board_image.save!
       if board_image_cache
         board_image_cache[:by_button_id][obf_button_id] = board_image if obf_button_id.present?
-        board_image_cache[:by_image_id][image.id] ||= board_image
+        # Deliberately NOT indexed by image_id. by_image_id is the legacy
+        # adoption path for tiles that predate button-id stamping, and it must
+        # only ever offer tiles that existed BEFORE this pass. Registering a
+        # tile we just created lets a later button sharing the same Image adopt
+        # it instead of creating its own — which is exactly what dropped the
+        # "play" and "more" word tiles once case-insensitive lookup made them
+        # share an Image with the "Play" and "More" folders.
+        board_image_cache[:by_image_id][image.id] ||= board_image if obf_button_id.blank?
       end
     end
 
@@ -3010,6 +3031,16 @@ class Board < ApplicationRecord
     # onto this same tile instead of forking a duplicate.
     board_image.image_id = image.id if board_image.image_id != image.id
     stamp_obf_button_id(board_image, obf_button_id)
+
+    # The button's label is AUTHORED tile text — pin it rather than letting the
+    # tile default its display_label from the shared Image. Core 84 authors both
+    # a "more" word button and a "More" folder button; they resolve to one Image
+    # (lookup is case-insensitive by design), so whichever was imported first
+    # decided that Image's display casing and the folder rendered as "more".
+    # Labels::CaseNormalizer is deliberately bypassed here for the same reason it
+    # is for every other authored label: the author already chose the casing.
+    authored_label = item["label"].presence
+    board_image.display_label = authored_label if authored_label
 
     apply_obf_part_of_speech(board_image, image, item) if apply_button_attributes
 
@@ -3043,16 +3074,31 @@ class Board < ApplicationRecord
   # `board_image_cache` (from preload_board_image_cache) skips the 1-2
   # per-button SELECTs this used to run — pass nil to fall back to the
   # original per-call queries (kept for callers outside the from_obf hot loop).
+  # The image_id fallback is CLAIM-ONCE. Two authored buttons can legitimately
+  # resolve to the same Image — Core 60/84 author both a "more" word tile and a
+  # "More" category folder, and image lookup is case-insensitive, so they share
+  # one Image record. Handing the same pre-existing tile to both buttons made
+  # the second button reuse the first's tile instead of creating its own, and
+  # the seeded home boards came out 58/82 tiles instead of 60/84 — the "play"
+  # and "more" word tiles silently vanished.
+  #
+  # Deleting the entry as it is consumed keeps the legacy upgrade path working
+  # (a tile seeded before button-id stamping is still adopted, exactly once)
+  # while stopping a second button from collapsing onto it.
   def self.find_board_image_for_button(board, image, obf_button_id, board_image_cache: nil)
     if board_image_cache
       existing = obf_button_id.present? ? board_image_cache[:by_button_id][obf_button_id] : nil
       return existing if existing
-      return board_image_cache[:by_image_id][image.id]
+      return board_image_cache[:by_image_id].delete(image.id)
     end
 
     if obf_button_id.present?
       existing = board.board_images.where("data ->> 'obf_button_id' = ?", obf_button_id).first
       return existing if existing
+      # Only adopt an unstamped tile: a stamped one belongs to a different
+      # button that happens to share this Image.
+      return board.board_images.where(image_id: image.id)
+                  .where("data IS NULL OR data ->> 'obf_button_id' IS NULL").first
     end
     board.board_images.find_by(image_id: image.id)
   end

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -155,10 +155,16 @@ class BoardImage < ApplicationRecord
     image_language_settings = (image.language_settings || {})[lang] || {}
     self.language = lang
     self.label = image_language_settings["label"] || image.label
-    # A stored translation is authored text — use it verbatim. Only the
-    # fall-through to `label` (a lowercase matching key) gets case-normalized.
+    # A stored translation is authored text — use it verbatim. Everything else
+    # is *defaulted* and gets case-normalized.
+    #
+    # The default source is deliberately NOT `self.label`: that is the lowercase
+    # matching key, so defaulting from it would flatten the image's authored
+    # display text ("Food" -> "food", "iPad" -> "ipad"). Use the translated
+    # label when this tile has one, otherwise the image's own display text.
     translated = image_language_settings["display_label"]
-    self.display_label = translated.presence || normalized_default_label(label, lang)
+    default_source = image_language_settings["label"].presence || image.display_label
+    self.display_label = translated.presence || normalized_default_label(default_source, lang)
   end
 
   # Tile text defaulted from the Image gets consistent casing so tiles created
@@ -282,7 +288,7 @@ class BoardImage < ApplicationRecord
       image.display_tile_url(viewing_user) ||
       image.display_image_url(viewing_user) ||
       image.src_url.presence ||
-      Image.find_by(label: image.label, user_id: [nil, User::DEFAULT_ADMIN_ID])&.src_url
+      Image.by_label(image.label).find_by(user_id: [nil, User::DEFAULT_ADMIN_ID])&.src_url
   end
 
   def get_predictive_image_for(viewing_user)
@@ -435,7 +441,7 @@ class BoardImage < ApplicationRecord
   def to_obf_button_format(load_board_path: nil, boards_by_id: nil)
     btn = {
       id: id.to_s,
-      label: label,
+      label: display_label.presence || label,
       image_id: id.to_s,
       background_color: get_background_color_css,
       border_color: border_color || "rgb(68, 68, 68)",
@@ -590,7 +596,7 @@ class BoardImage < ApplicationRecord
     {
       id: id,
       image_id: image_id,
-      label: localized_label(viewer_lang),
+      label: localized_display_label(viewer_lang),
       board_id: board_id,
       board_name: board.name,
       board_type: board.board_type,

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -34,6 +34,7 @@
 #  obf_id              :string
 #  language_settings   :jsonb
 #  language            :string           default("en")
+#  display_label       :string
 #
 
 require "open-uri"
@@ -89,6 +90,22 @@ class Image < ApplicationRecord
   scope :created_before, ->(date) { where("created_at < ?", date) }
 
   scope :with_less_than_3_docs, -> { joins(:docs).group("images.id").having("count(docs.id) < 3") }
+
+  # The only correct way to look an image up by its label.
+  #
+  # `label` is normalized to lowercase on write, but callers hand us whatever
+  # the user typed ("Swing", " swing "). A bare `find_by(label:)` misses on
+  # casing and the calling site's very next line creates a duplicate — that is
+  # how the library filled up with blank, art-less twins of curated images.
+  # Backed by index_images_on_lower_label.
+  scope :by_label, ->(label) { where("LOWER(images.label) = ?", normalize_label(label)) }
+
+  # The matching key for an arbitrary label string. Lowercase + stripped only;
+  # punctuation is preserved so "McDonald's" stays distinct from "mcdonalds".
+  def self.normalize_label(text)
+    text.to_s.strip.downcase
+  end
+
   before_save :set_label
   before_save :ensure_defaults
 
@@ -517,7 +534,7 @@ class Image < ApplicationRecord
   def create_words_from_next_words
     return unless next_words
     next_words.each do |word|
-      existing_word = Image.public_img.find_by(label: word)
+      existing_word = Image.public_img.by_label(word).first
       if existing_word
         Rails.logger.debug "Word already exists: #{existing_word.label}"
         if existing_word.next_words.blank?
@@ -706,7 +723,7 @@ class Image < ApplicationRecord
     audio_files = []
     voices = VoiceService.get_voice_options
     voices.each do |voice|
-      audio_image = Image.find_by(label: "This is the voice #{voice[:label]}", private: true, image_type: "SampleVoice", language: language)
+      audio_image = Image.by_label("This is the voice #{voice[:label]}").find_by(private: true, image_type: "SampleVoice", language: language)
       if audio_image
         Rails.logger.debug "Sample voice already exists: #{audio_image.id}"
         audio_files << audio_image.audio_files
@@ -733,7 +750,7 @@ class Image < ApplicationRecord
   end
 
   def self.find_sample_audio_for_voice(voice)
-    Image.find_by(label: "This is the voice #{voice}").audio_files&.last
+    Image.by_label("This is the voice #{voice}").first&.audio_files&.last
   end
 
   def sanitize_url(url)
@@ -1113,15 +1130,30 @@ class Image < ApplicationRecord
     label&.gsub(" ", "+")
   end
 
+  # Splits the two jobs `label` used to do at once.
+  #
+  # `label` is the lowercase matching key — the column every `find_by(label:)`
+  # in the app keys on. Storing the caller's casing there meant a user typing
+  # "Swing" missed the curated `swing` image (art and all) and minted a blank
+  # duplicate instead.
+  #
+  # `display_label` keeps the authored casing so normalizing the key costs us
+  # nothing renderable: "iPad", "McDonald's" and "PE" survive intact.
+  #
+  # Punctuation is deliberately NOT stripped here. The original commented-out
+  # form ran `gsub(/[^0-9a-zA-Z!? ]/, "")`, which would have turned
+  # "McDonald's" into "McDonalds" and split it from its own art.
   def set_label
-    item_name = label
-    # item_name.downcase!
-    # item_name.strip!
-    # item_name.gsub!(/[^0-9a-zA-Z!? ]/, "")
-    if item_name.blank?
-      item_name = "image #{id || "new"}"
+    item_name = label.to_s.strip
+    item_name = "image #{id || "new"}" if item_name.blank?
+
+    # Track the authored casing on create, and re-derive it on a rename — but
+    # never clobber a display_label the caller set explicitly in the same write.
+    if self[:display_label].blank? || (will_save_change_to_label? && !will_save_change_to_display_label?)
+      self.display_label = item_name
     end
-    self.label = item_name
+
+    self.label = Image.normalize_label(item_name)
   end
 
   def display_tile_url(viewing_user = nil)
@@ -1205,8 +1237,11 @@ class Image < ApplicationRecord
     base_doc
   end
 
+  # The authored casing, falling back to the matching key. The fallback covers
+  # rows written before the column existed and any path that builds an Image in
+  # memory without saving it.
   def display_label
-    label
+    self[:display_label].presence || label
   end
 
   # Looks up a translated label from language_settings; enqueues a background
@@ -1318,7 +1353,7 @@ class Image < ApplicationRecord
     {
       id: id,
       image_type: image_type,
-      label: localized_label(viewer_lang),
+      label: localized_display_label(viewer_lang),
       user_id: user_id,
       obf_id: obf_id,
       docs: docs.map(&:api_view),
@@ -1348,7 +1383,7 @@ class Image < ApplicationRecord
   def admin_view
     {
       id: id,
-      label: label,
+      label: display_label,
       image_type: image_type,
       src: display_tile_url(viewing_user) || display_image_url(viewing_user) || src_url,
       full_src: display_image_url(viewing_user) || src_url,
@@ -1378,7 +1413,7 @@ class Image < ApplicationRecord
   end
 
   def matching_viewer_images(viewing_user = nil)
-    imgs = Image.where(label: label, user_id: [nil, viewing_user&.id]).where.not(id: id)
+    imgs = Image.by_label(label).where(user_id: [nil, viewing_user&.id]).where.not(id: id)
     imgs = imgs.where.not(status: "marked_for_deletion")
     imgs.order(created_at: :desc)
   end
@@ -1441,7 +1476,7 @@ class Image < ApplicationRecord
     {
       id: id,
       image_type: image_type,
-      label: label,
+      label: display_label,
       image_prompt: image_prompt,
       display_doc: doc_img_url,
       data: data,
@@ -1489,7 +1524,7 @@ class Image < ApplicationRecord
       docs: image_docs.map do |doc|
         {
           id: doc.id,
-          label: label,
+          label: display_label,
           user_id: doc.user_id,
           src: doc.tile_url,
           display_url: doc.tile_url,
@@ -1614,7 +1649,7 @@ class Image < ApplicationRecord
 
   def self.create_image_from_google_search(img_url, label, title, snippet, file_format, user_id = User::DEFAULT_ADMIN_ID)
     return if Rails.env.test?
-    existing_image = Image.public_img.find_by(label: label)
+    existing_image = Image.public_img.by_label(label).first
     image = nil
     if existing_image
       image = existing_image

--- a/app/models/open_symbol.rb
+++ b/app/models/open_symbol.rb
@@ -54,13 +54,13 @@ class OpenSymbol < ApplicationRecord
   end
 
   def matching_image
-    matching_image = Image.find_by(label: self.label, private: [false, nil])
+    matching_image = Image.by_label(self.label).find_by(private: [false, nil])
     return unless matching_image && matching_image.docs.where(processed: self.name.parameterize, raw: self.search_string).any?
     matching_image
   end
 
   def has_matching_image?
-    matching_image = Image.find_by(label: self.label, private: [false, nil])
+    matching_image = Image.by_label(self.label).find_by(private: [false, nil])
     return unless matching_image
     matching_image.docs.where(processed: self.name.parameterize, raw: self.search_string).any?
   end
@@ -110,7 +110,7 @@ class OpenSymbol < ApplicationRecord
 
   def add_to_matching_image
     return if has_matching_image?
-    matching_image = Image.find_by(label: self.label, private: [false, nil])
+    matching_image = Image.by_label(self.label).find_by(private: [false, nil])
     downloaded_image = get_downloaded_image
     puts "Downloaded Image: #{downloaded_image.inspect}"
     if matching_image

--- a/app/models/openai_prompt.rb
+++ b/app/models/openai_prompt.rb
@@ -181,9 +181,9 @@ class OpenaiPrompt < ApplicationRecord
     begin
       json_word_list["words_phrases"].each do |word|
         item_name = prompt_image_name(word)
-        image = Image.find_by(label: item_name, user_id: self.user_id)
-        image = Image.find_by(label: item_name, private: false) unless image
-        image = Image.find_by(label: item_name, private: nil) unless image
+        image = Image.by_label(item_name).find_by(user_id: self.user_id)
+        image = Image.by_label(item_name).find_by(private: false) unless image
+        image = Image.by_label(item_name).find_by(private: nil) unless image
         new_image = Image.create(label: item_name, image_type: self.class.name) unless image
         image = new_image if new_image
         # A subject description only — Images::PromptBuilder supplies the style

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -95,9 +95,9 @@ class Scenario < ApplicationRecord
     begin
       word_list.each do |word|
         item_name = prompt_image_name(word)
-        image = Image.find_by(label: item_name, user_id: self.user_id)
-        image = Image.find_by(label: item_name, private: false) unless image
-        image = Image.find_by(label: item_name, private: nil) unless image
+        image = Image.by_label(item_name).find_by(user_id: self.user_id)
+        image = Image.by_label(item_name).find_by(private: false) unless image
+        image = Image.by_label(item_name).find_by(private: nil) unless image
         new_image = Image.create(label: item_name, image_type: self.class.name) unless image
         image = new_image if new_image
         # A subject description only — Images::PromptBuilder supplies the style

--- a/app/models/word_event.rb
+++ b/app/models/word_event.rb
@@ -93,7 +93,7 @@ class WordEvent < ApplicationRecord
     without_image = WordEvent.where(image_id: nil)
     without_image.each do |event|
       user = event.user || event.child_account&.user
-      image = Image.find_by(label: event.word, user_id: [user.id, nil])
+      image = Image.by_label(event.word).find_by(user_id: [user.id, nil])
       event.update(image_id: image&.id)
     end
   end

--- a/app/services/boards/glp_templates.rb
+++ b/app/services/boards/glp_templates.rb
@@ -182,7 +182,7 @@ module Boards
     # A whole-phrase Image tagged part_of_speech: "phrase" so the tile renders
     # (and downstream gating reads) as a gestalt script, not a single word.
     def find_or_create_phrase_image(phrase, admin)
-      image = Image.find_by(label: phrase, user_id: admin.id) || Image.new(label: phrase, user_id: admin.id)
+      image = Image.by_label(phrase).find_by(user_id: admin.id) || Image.new(label: phrase, user_id: admin.id)
       image.part_of_speech = TILE_PART_OF_SPEECH
       image.save!
       image

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -24,7 +24,8 @@ module Boards
     # Matching is case-INSENSITIVE: folder labels are capitalized ("Animals",
     # "People") while curated library art is often stored lowercase, and a
     # case-sensitive `find_by(label:)` would miss it and fall through to a blank.
-    # A newly-created image keeps the normalized label's original casing.
+    # A newly-created image keeps the authored casing on `display_label`;
+    # `Image#set_label` normalizes `label` itself to the lowercase matching key.
     def resolve(label, owner:)
       word = Boards::InterestWords.normalize_word(label)
 

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -165,9 +165,9 @@ module Boards
         original_image = board_image.image
         image = original_image
         if image.user_id
-          image = Image.find_by(label: image.label, user_id: target.user_id) if image.user_id == target.user_id
+          image = Image.by_label(image.label).find_by(user_id: target.user_id) if image.user_id == target.user_id
         else
-          image = Image.find_by(label: image.label, user_id: [nil, target.user_id, User::DEFAULT_ADMIN_ID])
+          image = Image.by_label(image.label).find_by(user_id: [nil, target.user_id, User::DEFAULT_ADMIN_ID])
         end
         image ||= Image.create(label: original_image.label, user_id: target.user_id)
 

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -97,7 +97,9 @@ module Boards
           key: Boards::RobustSets.slug_for(root),
           name: root.name,
           kind: "robust",
-          tiles: root.board_images.order(:position).map(&:label),
+          # display_label: this preview list is shown to the user picking a
+          # template, so it needs the tile's text, not the matching key.
+          tiles: root.board_images.order(:position).map(&:display_label),
         }
       end
     end

--- a/app/services/boards/starter_blueprints.rb
+++ b/app/services/boards/starter_blueprints.rb
@@ -124,8 +124,8 @@ module Boards
     # can be added later. Resolution order: the user's own image, then a
     # public/admin image, else create.
     def resolve_or_create_image(label, user)
-      image = user.images.find_by(label: label)
-      image ||= Image.public_img.find_by(label: label, user_id: [User::DEFAULT_ADMIN_ID, nil])
+      image = user.images.by_label(label).first
+      image ||= Image.public_img.by_label(label).find_by(user_id: [User::DEFAULT_ADMIN_ID, nil])
       image ||= Image.create!(label: label, user_id: user.id)
       image
     end

--- a/app/services/video_boards/board_seeder.rb
+++ b/app/services/video_boards/board_seeder.rb
@@ -24,7 +24,7 @@ module VideoBoards
     # Same reuse-don't-generate policy as core_boards: prefer an existing public
     # image with artwork, else create one without queuing generation.
     def find_or_build_image(label)
-      matches = Image.default_public.where(label: label).order(:created_at)
+      matches = Image.default_public.by_label(label).order(:created_at)
       matches.find { |img| img.docs.any? } || matches.last ||
         Image.default_public.new(label: label) do |img|
           img.image_prompt = label

--- a/db/migrate/20260807120000_add_display_label_to_images.rb
+++ b/db/migrate/20260807120000_add_display_label_to_images.rb
@@ -1,0 +1,21 @@
+# `images.label` is documented everywhere as the *lowercase matching key* — it
+# is what every `find_by(label:)` in the app keys on — but nothing ever enforced
+# that, so it doubled as display text and drifted into whatever casing the
+# creating path happened to use.
+#
+# Splitting the two roles is what lets `label` be normalized without losing
+# deliberately-cased text ("iPad", "McDonald's", "Wendy's", "PE"): the authored
+# casing moves to `display_label`, and `label` becomes a pure key.
+#
+# The indexes are overdue independently — `label` is the hottest lookup column
+# in the app and had no index at all. The functional one backs the
+# case-insensitive `LOWER(label) = ?` form that `Boards::ImageResolver` and the
+# new `Image.by_label` scope use.
+class AddDisplayLabelToImages < ActiveRecord::Migration[8.0]
+  def change
+    add_column :images, :display_label, :string
+
+    add_index :images, :label
+    add_index :images, "LOWER(label)", name: "index_images_on_lower_label"
+  end
+end

--- a/db/migrate/20260807120100_backfill_image_display_labels.rb
+++ b/db/migrate/20260807120100_backfill_image_display_labels.rb
@@ -1,0 +1,70 @@
+# Backfill for the label/display_label split.
+#
+# Three passes, and the order between them is load-bearing:
+#
+# 1. Every row's authored casing moves verbatim into `display_label`. Nothing
+#    renders differently after this pass — it only stops the information from
+#    being destroyed by pass 3.
+#
+# 2. Folder tiles that picked up accidental Title Case from the seed path
+#    ("Animals", "Play", "Time") get lowercased. The signal for "accidental" is
+#    that the *same word already exists lowercase* elsewhere in the library —
+#    which is exactly the collision that made one board render "Higher" next to
+#    "swing". This must run before pass 3, because after pass 3 every row has a
+#    lowercase twin and the test stops meaning anything.
+#
+#    Deliberately narrow: `image_type = 'category'` and a single plain
+#    Title-Cased word. That covers the ~21 real folder tiles and cannot touch
+#    the imported source-collection names ("CommuniKate weather",
+#    "Core 24 - Small Words", "Home - Sequoia 15 - Calloway") or any acronym or
+#    brand ("PE", "iPad", "McDonald's"), none of which are single plain words.
+#
+# 3. `label` becomes the lowercase, stripped matching key the whole app already
+#    assumed it was.
+#
+# Raw SQL rather than find_each: this touches every image row, and Image's
+# before_save chain (categorization, color defaults, board-image fan-out) has no
+# business firing for a casing correction.
+class BackfillImageDisplayLabels < ActiveRecord::Migration[8.0]
+  def up
+    say_with_time "Copying authored casing into images.display_label" do
+      execute(<<~SQL)
+        UPDATE images
+           SET display_label = label
+         WHERE display_label IS NULL
+      SQL
+    end
+
+    say_with_time "Lowercasing accidentally Title-Cased folder tiles" do
+      execute(<<~SQL)
+        UPDATE images
+           SET display_label = LOWER(display_label)
+         WHERE image_type = 'category'
+           AND display_label ~ '^[A-Z][a-z]+$'
+           AND EXISTS (
+                 SELECT 1
+                   FROM images AS twin
+                  WHERE twin.label = LOWER(images.display_label)
+                    AND twin.id <> images.id
+               )
+      SQL
+    end
+
+    say_with_time "Normalizing images.label to the lowercase matching key" do
+      execute(<<~SQL)
+        UPDATE images
+           SET label = LOWER(BTRIM(label))
+         WHERE label IS DISTINCT FROM LOWER(BTRIM(label))
+      SQL
+    end
+  end
+
+  # Irreversible on purpose. `label`'s pre-migration casing is recoverable from
+  # `display_label` for most rows, but not for the folder tiles pass 2 cleaned —
+  # and restoring the rest would re-break every case-sensitive lookup this
+  # migration exists to fix. Rolling back means dropping the column (the
+  # preceding migration), not resurrecting the old casing.
+  def down
+    say "No-op: label normalization is not reversible."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_06_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_07_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -547,7 +547,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_06_140000) do
     t.string "obf_id"
     t.jsonb "language_settings", default: {}
     t.string "language", default: "en"
+    t.string "display_label"
+    t.index "lower((label)::text)", name: "index_images_on_lower_label"
     t.index ["category"], name: "index_images_on_category"
+    t.index ["label"], name: "index_images_on_label"
     t.index ["language_settings"], name: "index_images_on_language_settings_gin", using: :gin
     t.index ["obf_id"], name: "index_images_on_obf_id"
     t.index ["use_custom_audio"], name: "index_images_on_use_custom_audio"

--- a/db/seeds/keyboard_boards.rb
+++ b/db/seeds/keyboard_boards.rb
@@ -67,11 +67,19 @@ keyboards = [
   },
 ]
 
+# Letter images are scoped by image_type, NOT by label alone. `Image#label` is
+# a lowercase matching key, so the "A" and "I" keys would otherwise match the
+# article "a" and the pronoun "I" — both of which are real vocabulary images
+# carrying symbol artwork. A keyboard key must render its letter, never a word's
+# symbol, so letters get their own image namespace.
+LETTER_IMAGE_TYPE = "letter".freeze
+
 find_or_create_image = lambda do |label|
-  image = Image.find_by(label: label, user_id: admin.id)
+  image = Image.by_label(label).find_by(user_id: admin.id, image_type: LETTER_IMAGE_TYPE)
   return image if image
 
-  image = Image.new(label: label, user_id: admin.id, part_of_speech: "default")
+  image = Image.new(label: label, user_id: admin.id, part_of_speech: "default",
+                    image_type: LETTER_IMAGE_TYPE)
   # Single letters aren't dictionary words — without this flag ensure_defaults
   # would make a synchronous OpenAI categorization call per tile at seed time.
   image.skip_categorize = true
@@ -118,12 +126,16 @@ keyboards.each do |attrs|
       end
 
     image = find_or_create_image.call(tile[:label])
-    board_image = board.board_images.find_by(label: tile[:label])
+    # Keyed on display_label — the authored key text ("A", "Space"). `label` is
+    # the lowercase matching key, so keying on it here would miss on every
+    # re-seed and append a duplicate tile.
+    board_image = board.board_images.find_by(display_label: tile[:label])
     unless board_image
       board_image = board.board_images.new(
         image_id: image.id,
         voice: board.voice,
         language: board.language,
+        display_label: tile[:label],
         bg_color: color,
         text_color: text_color,
         position: position,

--- a/spec/db/seeds/keyboard_boards_seed_spec.rb
+++ b/spec/db/seeds/keyboard_boards_seed_spec.rb
@@ -36,24 +36,24 @@ RSpec.describe "db/seeds/keyboard_boards.rb", type: :model do
     run_seed
     board = Board.find_by!(slug: "keyboard-abc")
 
-    letter = board.board_images.find_by!(label: "A")
+    letter = board.board_images.find_by!(display_label: "A")
     expect(letter.data).to include("tile_type" => "letter")
 
-    space = board.board_images.find_by!(label: "Space")
+    space = board.board_images.find_by!(display_label: "Space")
     expect(space.data).to include("tile_type" => "action", "tile_action" => "space")
 
-    delete = board.board_images.find_by!(label: "Delete")
+    delete = board.board_images.find_by!(display_label: "Delete")
     expect(delete.data).to include("tile_type" => "action", "tile_action" => "backspace")
   end
 
   it "authors keyboard-shaped layouts for every screen size" do
     run_seed
 
-    abc_space = Board.find_by!(slug: "keyboard-abc").board_images.find_by!(label: "Space")
+    abc_space = Board.find_by!(slug: "keyboard-abc").board_images.find_by!(display_label: "Space")
     qwerty = Board.find_by!(slug: "keyboard-qwerty")
-    qwerty_space = qwerty.board_images.find_by!(label: "Space")
-    qwerty_delete = qwerty.board_images.find_by!(label: "Delete")
-    qwerty_a = qwerty.board_images.find_by!(label: "A")
+    qwerty_space = qwerty.board_images.find_by!(display_label: "Space")
+    qwerty_delete = qwerty.board_images.find_by!(display_label: "Delete")
+    qwerty_a = qwerty.board_images.find_by!(display_label: "A")
 
     %w[lg md sm xs xxs].each do |screen|
       expect(abc_space.layout[screen]).to include("w" => 2, "y" => 4)
@@ -71,9 +71,9 @@ RSpec.describe "db/seeds/keyboard_boards.rb", type: :model do
     run_seed
     board = Board.find_by!(slug: "keyboard-abc")
 
-    expect(board.board_images.find_by!(label: "A").bg_color).to eq("#FDE68A")
-    expect(board.board_images.find_by!(label: "B").bg_color).to eq("#DBEAFE")
-    expect(board.board_images.find_by!(label: "Space").bg_color).to eq("#E5E7EB")
+    expect(board.board_images.find_by!(display_label: "A").bg_color).to eq("#FDE68A")
+    expect(board.board_images.find_by!(display_label: "B").bg_color).to eq("#DBEAFE")
+    expect(board.board_images.find_by!(display_label: "Space").bg_color).to eq("#E5E7EB")
   end
 
   it "is idempotent — re-running does not duplicate boards or tiles" do
@@ -129,8 +129,8 @@ RSpec.describe "db/seeds/keyboard_boards.rb", type: :model do
     expect(clone.predefined).to be(false)
     expect(clone.board_images.count).to eq(28)
 
-    cloned_space = clone.board_images.find_by!(label: "Space")
+    cloned_space = clone.board_images.find_by!(display_label: "Space")
     expect(cloned_space.data).to include("tile_type" => "action", "tile_action" => "space")
-    expect(clone.board_images.find_by!(label: "A").data).to include("tile_type" => "letter")
+    expect(clone.board_images.find_by!(display_label: "A").data).to include("tile_type" => "letter")
   end
 end

--- a/spec/lib/tasks/core_boards_rake_spec.rb
+++ b/spec/lib/tasks/core_boards_rake_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "core_boards rake task", type: :task do
       expect(board).to be_present
       expect(board.board_images.count).to eq(40)
       expect(board.tags).to include("bedtime")
-      expect(board.board_images.order(:position).pluck(:label)[4]).to eq("bed")
+      expect(board.board_images.order(:position).pluck(:display_label)[4]).to eq("bed")
     end
   end
 

--- a/spec/lib/tasks/core_boards_rake_spec.rb
+++ b/spec/lib/tasks/core_boards_rake_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "core_boards rake task", type: :task do
     end
 
     it "places core words on the left half and topic words on the right half" do
-      labels = board.board_images.order(:position).pluck(:label)
+      labels = board.board_images.order(:position).pluck(:display_label)
       expect(labels[0, 4]).to eq(%w[I want help yes])
       expect(labels[4, 4]).to eq(%w[lunch eat hot cold])
       expect(labels[8]).to eq("you")

--- a/spec/models/board_format_with_ai_spec.rb
+++ b/spec/models/board_format_with_ai_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Board, "#format_board_with_ai", type: :model do
     board.format_board_with_ai
     board.reload
 
-    expect(board.board_images.order(:position).pluck(:label)).to eq(words)
+    expect(board.board_images.order(:position).pluck(:display_label)).to eq(words)
   end
 
   it "does not place a w=2 tile so it overlaps the previous tile (regression)" do

--- a/spec/models/board_from_obf_idempotency_spec.rb
+++ b/spec/models/board_from_obf_idempotency_spec.rb
@@ -50,4 +50,89 @@ RSpec.describe "Board.from_obf re-import idempotency", type: :model do
     expect(tile.image_id).to eq(old_image.id)
     expect(tile.data["obf_button_id"]).to eq("b1")
   end
+
+  # OBF buttons are authored with display casing ("Food"), while images store
+  # the lowercase matching key. The import's own image cache queried and keyed
+  # on the RAW button label, so every capitalised button missed and fell through
+  # to Image.create! — minting a fresh duplicate on each import.
+  describe "capitalised button labels" do
+    def capitalised_obf
+      {
+        "id" => "core", "name" => "Core",
+        "buttons" => [{ "id" => "b1", "label" => "Food", "image_id" => nil }],
+        "grid" => { "rows" => 1, "columns" => 1, "order" => [["b1"]] },
+        "images" => [],
+      }
+    end
+
+    # Counts images for the BUTTON's label specifically — from_obf also creates
+    # an image for the board's own name, which is not what these guard.
+    it "resolves a capitalised button to the existing lowercase image" do
+      existing = create(:image, label: "Food", user_id: user.id)
+      expect(existing.label).to eq("food")
+
+      expect { Board.from_obf(capitalised_obf, user) }
+        .not_to change { Image.by_label("Food").count }
+
+      board = user.boards.find_by(obf_id: "core")
+      expect(board.board_images.first.image_id).to eq(existing.id)
+    end
+
+    it "does not mint a new image for the button on every re-import" do
+      Board.from_obf(capitalised_obf, user)
+      expect(Image.by_label("Food").count).to eq(1)
+
+      Board.from_obf(capitalised_obf, user)
+      expect(Image.by_label("Food").count).to eq(1)
+    end
+  end
+
+  # Core 60/84 author both a "more" word tile and a "More" category folder.
+  # Case-insensitive image lookup makes them share ONE Image, and the legacy
+  # by_image_id adoption path then handed the folder's tile to the word button —
+  # the seeded home boards came out 58/82 tiles instead of 60/84.
+  it "gives two authored buttons their own tiles even when they share an Image" do
+    shared = create(:image, label: "more", user_id: user.id)
+
+    data = {
+      "id" => "core", "name" => "Core",
+      "buttons" => [
+        { "id" => "word",   "label" => "more" },
+        { "id" => "folder", "label" => "More" },
+      ],
+      "grid" => { "rows" => 1, "columns" => 2, "order" => [%w[word folder]] },
+      "images" => [],
+    }
+
+    board, = Board.from_obf(data, user)
+
+    expect(board.board_images.count).to eq(2), "the word tile and the folder tile must both survive"
+    expect(board.board_images.map { |bi| bi.data["obf_button_id"] }).to contain_exactly("word", "folder")
+    expect(board.board_images.map(&:image_id).uniq).to eq([shared.id])
+  end
+
+  # Both buttons share one Image, so whichever was imported first would
+  # otherwise decide that Image's display casing for both tiles — which is how
+  # the Core 84 "More" and "Play" folders came out rendering as "more"/"play".
+  it "keeps each button's authored casing even when both share an Image" do
+    create(:image, label: "more", user_id: user.id)
+
+    data = {
+      "id" => "core", "name" => "Core",
+      "buttons" => [
+        { "id" => "word",   "label" => "more" },
+        { "id" => "folder", "label" => "More" },
+      ],
+      "grid" => { "rows" => 1, "columns" => 2, "order" => [%w[word folder]] },
+      "images" => [],
+    }
+
+    board, = Board.from_obf(data, user)
+    by_button = board.board_images.index_by { |bi| bi.data["obf_button_id"] }
+
+    expect(by_button["word"].display_label).to eq("more")
+    expect(by_button["folder"].display_label).to eq("More")
+    # ...while the matching key stays lowercase on both.
+    expect(by_button.values.map(&:label).uniq).to eq(["more"])
+  end
 end

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -127,12 +127,18 @@ RSpec.describe BoardImage, type: :model do
       expect(tile.label).to eq("ipad")
     end
 
-    it "leaves brand and acronym casing on the image label alone" do
+    it "carries brand and acronym casing through from the image's display_label" do
       image = FactoryBot.create(:image, label: "TV")
       tile = tile_for(image)
 
+      # The Image split the two roles at write time: "tv" is the matching key,
+      # "TV" is the display text. The tile inherits each into its counterpart,
+      # and CaseNormalizer leaves the deliberate casing alone.
+      expect(image.label).to eq("tv")
+      expect(image.display_label).to eq("TV")
+
       expect(tile.display_label).to eq("TV")
-      expect(tile.label).to eq("TV")
+      expect(tile.label).to eq("tv")
     end
 
     it "sentence cases whole-utterance phrase tiles" do

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -440,7 +440,7 @@ RSpec.describe Board, type: :model do
         queued = board.find_or_create_images_from_word_list(["Single"], menu_prompts: prompts)
 
         expect(queued).to eq(1)
-        expect(board.images.find_by(label: "Single").image_type).to eq("menu")
+        expect(board.images.by_label("Single").first.image_type).to eq("menu")
       end
 
       it "falls back to library reuse for menu items over the budget" do
@@ -527,24 +527,34 @@ RSpec.describe Board, type: :model do
         FactoryBot.create(:image, label: "Apple")
       end
 
-      # The lookup is case-sensitive — "Apple" and "apple" are treated as different images.
-      it "creates a new image for the differently-cased word" do
+      # `label` is a lowercase matching key, so "Apple" and "apple" are the same
+      # image. Reusing it is the whole point: a case-sensitive lookup used to
+      # miss the curated row and mint a blank, art-less twin beside it.
+      it "reuses the existing image instead of creating a differently-cased twin" do
         words = ["apple", "banana", "cherry"]
         expect {
           board.find_or_create_images_from_word_list(words)
-        }.to change(Image, :count).by(3)
+        }.to change(Image, :count).by(2)
+      end
+
+      it "keeps the authored casing available as display text" do
+        board.find_or_create_images_from_word_list(["apple"])
+
+        apple = Image.by_label("apple").first
+        expect(apple.label).to eq("apple")
+        expect(apple.display_label).to eq("Apple")
       end
     end
 
     context "when words contain leading/trailing whitespace" do
-      # The method does NOT currently strip whitespace — labels are stored as-is.
-      # This documents actual behavior; stripping would be a future improvement.
-      it "stores the labels with whitespace intact" do
+      # Whitespace is stripped as part of building the matching key, so
+      # "  apple  " and "apple" no longer land on two separate images.
+      it "strips the labels down to the matching key" do
         words = ["  apple  ", "banana", "  cherry"]
         expect {
           board.find_or_create_images_from_word_list(words)
         }.to change(Image, :count).by(3)
-        expect(board.images.pluck(:label)).to include("  apple  ", "  cherry", "banana")
+        expect(board.images.pluck(:label)).to include("apple", "cherry", "banana")
       end
     end
   end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -34,6 +34,7 @@
 #  obf_id              :string
 #  language_settings   :jsonb
 #  language            :string           default("en")
+#  display_label       :string
 #
 require "rails_helper"
 
@@ -129,6 +130,90 @@ RSpec.describe Image, type: :model do
     let(:doc) { FactoryBot.create(:doc, documentable: image) }
 
     context ""
+  end
+
+  describe "label / display_label split" do
+    it "stores label as a lowercase, stripped matching key" do
+      image = FactoryBot.create(:image, label: "  Swing  ")
+
+      expect(image.label).to eq("swing")
+    end
+
+    it "keeps the authored casing in display_label" do
+      image = FactoryBot.create(:image, label: "iPad")
+
+      expect(image.label).to eq("ipad")
+      expect(image.display_label).to eq("iPad")
+    end
+
+    it "preserves punctuation in the matching key" do
+      image = FactoryBot.create(:image, label: "McDonald's")
+
+      expect(image.label).to eq("mcdonald's")
+      expect(image.display_label).to eq("McDonald's")
+    end
+
+    it "does not overwrite a display_label the caller supplied explicitly" do
+      image = FactoryBot.create(:image, label: "tv", display_label: "TV")
+
+      expect(image.label).to eq("tv")
+      expect(image.display_label).to eq("TV")
+    end
+
+    it "re-derives display_label when the label is renamed" do
+      image = FactoryBot.create(:image, label: "Swing")
+      image.update!(label: "Slide")
+
+      expect(image.label).to eq("slide")
+      expect(image.display_label).to eq("Slide")
+    end
+
+    it "keeps an explicit display_label set in the same write as a rename" do
+      image = FactoryBot.create(:image, label: "swing")
+      image.update!(label: "ipad", display_label: "iPad")
+
+      expect(image.label).to eq("ipad")
+      expect(image.display_label).to eq("iPad")
+    end
+
+    it "falls back to label when display_label was never stored" do
+      image = FactoryBot.create(:image, label: "swing")
+      image.update_column(:display_label, nil)
+
+      expect(image.reload.display_label).to eq("swing")
+    end
+  end
+
+  describe ".by_label" do
+    it "matches regardless of the casing the caller typed" do
+      image = FactoryBot.create(:image, label: "swing")
+
+      expect(Image.by_label("Swing")).to include(image)
+      expect(Image.by_label("SWING")).to include(image)
+      expect(Image.by_label("  swing ")).to include(image)
+    end
+
+    # The bug this whole change exists to kill: a case-sensitive lookup missed
+    # the curated image and the calling site's next line minted a blank twin.
+    it "finds the curated image a case-sensitive find_by would have missed" do
+      curated = FactoryBot.create(:image, label: "swing")
+
+      expect(Image.find_by(label: "Swing")).to be_nil
+      expect(Image.by_label("Swing").first).to eq(curated)
+    end
+
+    it "does not match a different label" do
+      FactoryBot.create(:image, label: "swing")
+
+      expect(Image.by_label("slide")).to be_empty
+    end
+
+    it "is chainable with other scopes" do
+      mine = FactoryBot.create(:image, label: "swing", user_id: 42)
+      FactoryBot.create(:image, label: "swing", user_id: 99)
+
+      expect(Image.by_label("Swing").find_by(user_id: 42)).to eq(mine)
+    end
   end
 
   describe "#localized_label" do

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -731,7 +731,7 @@ RSpec.describe "API::Boards", type: :request do
 
       expect(response).to have_http_status(:ok)
 
-      new_image = Image.find_by(label: "I want more")
+      new_image = Image.by_label("I want more").first
       expect(new_image.part_of_speech).to eq("phrase")
 
       board_image = board.reload.board_images.find_by(image_id: new_image.id)

--- a/spec/requests/api/images_label_casing_spec.rb
+++ b/spec/requests/api/images_label_casing_spec.rb
@@ -1,0 +1,104 @@
+# spec/requests/api/images_label_casing_spec.rb
+#
+# The normal (non-internal) API paths for adding an image / building a board
+# used to look images up with a case-sensitive `find_by(label:)`. A user typing
+# "Swing" sailed past the curated `swing` symbol, and the calling site's very
+# next line created a blank, art-less Image beside it — a duplicate in the
+# library and an empty tile on the board.
+#
+# The internal API was fixed for this in #573 via Boards::ImageResolver; these
+# cover the same guarantee on the paths the app itself uses.
+
+require "rails_helper"
+
+RSpec.describe "Images label casing", type: :request do
+  def j
+    JSON.parse(response.body)
+  rescue
+    {}
+  end
+
+  before do
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:authenticate_token!).and_return(true)
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:current_user).and_return(user)
+  end
+
+  let!(:user) { create(:user) }
+
+  # The curated library symbol: lowercase matching key, artwork attached.
+  let!(:curated) do
+    create(:image, label: "swing", user_id: nil, private: false).tap do |img|
+      create(:doc, documentable: img, processed: "img")
+    end
+  end
+
+  describe "POST /api/images/find_or_create" do
+    it "reuses the curated image when the caller types a different casing" do
+      expect {
+        post "/api/images/find_or_create", params: { image: { label: "Swing" } }
+      }.not_to change(Image, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(j["id"]).to eq(curated.id)
+    end
+
+    it "reuses the curated image when the caller sends stray whitespace" do
+      expect {
+        post "/api/images/find_or_create", params: { image: { label: "  swing  " } }
+      }.not_to change(Image, :count)
+
+      expect(j["id"]).to eq(curated.id)
+    end
+
+    it "still creates an image for a genuinely new word" do
+      expect {
+        post "/api/images/find_or_create", params: { image: { label: "Trampoline" } }
+      }.to change(Image, :count).by(1)
+
+      created = Image.by_label("trampoline").first
+      expect(created.label).to eq("trampoline")
+      expect(created.display_label).to eq("Trampoline")
+    end
+  end
+
+  describe "POST /api/boards/:id/add_image" do
+    let!(:board) { create(:board, user: user, language: "en") }
+
+    it "attaches the curated image rather than minting a cased duplicate" do
+      expect {
+        post "/api/boards/#{board.id}/add_image", params: { image: { label: "Swing" } }
+      }.not_to change(Image, :count)
+
+      tile = board.board_images.reload.last
+      expect(tile.image_id).to eq(curated.id)
+    end
+
+    it "gives the tile the lowercase matching key and normalized display text" do
+      post "/api/boards/#{board.id}/add_image", params: { image: { label: "Swing" } }
+
+      tile = board.board_images.reload.last
+      expect(tile.label).to eq("swing")
+      expect(tile.display_label).to eq("swing")
+    end
+
+    it "carries deliberate casing from the image onto the tile" do
+      create(:image, label: "iPad", user_id: nil, private: false)
+
+      post "/api/boards/#{board.id}/add_image", params: { image: { label: "ipad" } }
+
+      tile = board.board_images.reload.last
+      expect(tile.label).to eq("ipad")
+      expect(tile.display_label).to eq("iPad")
+    end
+  end
+
+  describe "GET /api/images/find_by_label" do
+    it "finds the image regardless of the casing asked for" do
+      get "/api/images/find_by_label", params: { label: "SWING" }
+
+      expect(j["id"]).to eq(curated.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -329,13 +329,13 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(root.status).to eq("complete")
 
         # "dinosaurs" was routed into the existing Play folder (alongside seeds).
-        play_tile = root.board_images.find { |bi| bi.label == "Play" }
+        play_tile = root.board_images.find { |bi| bi.display_label == "Play" }
         expect(play_tile.predictive_board_id).to be_present
         play_board = Board.find(play_tile.predictive_board_id)
         expect(play_board.board_images.map(&:label)).to include("dinosaurs", "ball")
 
         # "grandma" had no category folder, so it landed in "My Favorites".
-        favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+        favorites_tile = root.board_images.find { |bi| bi.display_label == "My Favorites" }
         expect(favorites_tile.predictive_board_id).to be_present
         favorites_board = Board.find(favorites_tile.predictive_board_id)
         expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
@@ -364,7 +364,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         root = Board.find(body["id"])
         # "grandma" has no dictionary category but was explicitly routed to Play
-        play_tile = root.board_images.find { |bi| bi.label == "Play" }
+        play_tile = root.board_images.find { |bi| bi.display_label == "Play" }
         play_board = Board.find(play_tile.predictive_board_id)
         expect(play_board.board_images.map(&:label)).to include("grandma")
 
@@ -439,11 +439,11 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(ChildBoard.count).to eq(0)
 
         # Interests route exactly as they do for an attached build.
-        play_tile = root.board_images.find { |bi| bi.label == "Play" }
+        play_tile = root.board_images.find { |bi| bi.display_label == "Play" }
         play_board = Board.find(play_tile.predictive_board_id)
         expect(play_board.board_images.map(&:label)).to include("dinosaurs")
 
-        favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+        favorites_tile = root.board_images.find { |bi| bi.display_label == "My Favorites" }
         favorites_board = Board.find(favorites_tile.predictive_board_id)
         expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
       end
@@ -834,12 +834,12 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
         expect(User.find(user.id).countable_board_group_count).to eq(1)
 
         # Cloned core tiles landed on the SAME root the 201 returned.
-        expect(root.board_images.map(&:label)).to include("I", "Food")
+        expect(root.board_images.map(&:display_label)).to include("I", "Food")
 
         # "pizza" routed into the cloned Food fringe page, linked from the root.
         cloned_food = user.boards.find_by(name: "Food")
         expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
-        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
         expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
         # The cloned fringe page is also a group member (not just the root), so

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -554,7 +554,7 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
 
         expect(response).to have_http_status(:created)
         BuildBoardSetJob.drain
-        expect(Image.find_by(label: "Food", user_id: no_seed_user.id)).to be_present
+        expect(Image.by_label("Food").find_by(user_id: no_seed_user.id)).to be_present
         expect(Board.find(JSON.parse(response.body)["id"]).status).to eq("complete")
       end
     end

--- a/spec/services/boards/board_tree_builder_spec.rb
+++ b/spec/services/boards/board_tree_builder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect(root.name).to eq("Home")
 
       # Root's folder tile links to the Food board.
-      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
       expect(food_tile.predictive_board_id).to be_present
       expect(food_tile.is_dynamic?).to be(true)
 
@@ -46,7 +46,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect(food_board.name).to eq("Food")
 
       # Food board's folder tile links to the Drinks board (level 3).
-      drinks_tile = food_board.board_images.find { |bi| bi.label == "Drinks" }
+      drinks_tile = food_board.board_images.find { |bi| bi.display_label == "Drinks" }
       expect(drinks_tile.predictive_board_id).to be_present
       expect(drinks_tile.is_dynamic?).to be(true)
 
@@ -55,7 +55,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect(drinks_board.board_images.map(&:label)).to contain_exactly("water", "juice")
 
       # Leaf tiles never get a predictive board.
-      i_tile = root.board_images.find { |bi| bi.label == "I" }
+      i_tile = root.board_images.find { |bi| bi.display_label == "I" }
       expect(i_tile.predictive_board_id).to be_nil
     end
 
@@ -113,7 +113,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect(built.pluck(:name)).to contain_exactly("Level0", "Level1", "Level2")
 
       level2 = built.find_by(name: "Level2")
-      c_tile = level2.board_images.find { |bi| bi.label == "C" }
+      c_tile = level2.board_images.find { |bi| bi.display_label == "C" }
       expect(c_tile.predictive_board_id).to be_nil
     end
 
@@ -182,7 +182,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
       expect(root.settings["builder_root"]).to be(true)
       expect(root.settings["builder_child"]).to be_falsey
 
-      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
       sub_board = Board.find(food_tile.predictive_board_id)
       expect(sub_board.settings["builder_child"]).to be(true)
       expect(sub_board.settings["builder_root"]).to be_falsey
@@ -232,8 +232,8 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
         }.to change { Board.where(user_id: owner.id).count }.by(1) # only the Food sub-board
 
         expect(returned.id).to eq(root.id)
-        expect(root.reload.board_images.map(&:label)).to contain_exactly("I", "Food")
-        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        expect(root.reload.board_images.map(&:display_label)).to contain_exactly("I", "Food")
+        food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
         expect(Board.find(food_tile.predictive_board_id).settings["builder_child"]).to be(true)
       end
 
@@ -289,7 +289,7 @@ RSpec.describe Boards::BoardTreeBuilder, type: :service do
         expect(root.user_id).to eq(owner.id)
         expect(root.settings["builder_root"]).to be(true)
 
-        food_tile = root.board_images.find { |bi| bi.label == "Food" }
+        food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
         food_board = Board.find(food_tile.predictive_board_id)
         expect(food_board.board_images.map(&:label)).to eq(["apple"])
         expect(food_board.settings["builder_child"]).to be(true)

--- a/spec/services/boards/image_resolver_spec.rb
+++ b/spec/services/boards/image_resolver_spec.rb
@@ -55,7 +55,11 @@ RSpec.describe Boards::ImageResolver do
     it "keeps the authored casing on an image it has to create" do
       resolved = described_class.resolve_all(["BrandNewCased"], owner: owner)
 
-      expect(resolved["brandnewcased"].label).to eq("BrandNewCased")
+      # The authored casing now lives on display_label; label is the lowercase
+      # matching key, so the next resolve for "brandnewcased" finds this row
+      # instead of creating a second one.
+      expect(resolved["brandnewcased"].display_label).to eq("BrandNewCased")
+      expect(resolved["brandnewcased"].label).to eq("brandnewcased")
     end
 
     it "does not scale its query count with the number of labels" do

--- a/spec/services/boards/screen_reflow_spec.rb
+++ b/spec/services/boards/screen_reflow_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Boards::ScreenReflow do
     end
 
     def labels_at(screen)
-      board.board_images.reload.map { |bi| [bi.label, bi.layout[screen]] }.to_h
+      board.board_images.reload.map { |bi| [bi.display_label, bi.layout[screen]] }.to_h
     end
 
     it "leaves the default path byte-identical" do

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Boards::SeededSetCloner do
       cloned_food = owner.boards.find_by(name: "Food")
       cloned_feelings = owner.boards.find_by(name: "Feelings")
 
-      food_tile = root.board_images.find_by(label: "Food")
+      food_tile = root.board_images.find_by(display_label: "Food")
       expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
       home_tile = cloned_feelings.board_images.find_by(label: "home")
@@ -135,7 +135,7 @@ RSpec.describe Boards::SeededSetCloner do
       expect(favorites.settings["builder_child"]).to be(true)
       expect(favorites.board_images.map(&:label)).to include("grandma")
 
-      fav_tile = root.board_images.find_by(label: "My Favorites")
+      fav_tile = root.board_images.find_by(display_label: "My Favorites")
       expect(fav_tile.predictive_board_id).to eq(favorites.id)
     end
 
@@ -170,7 +170,7 @@ RSpec.describe Boards::SeededSetCloner do
         expect(owner.boards.find_by(name: "Food")).to be_nil
         expect(owner.boards.find_by(name: "Feelings")).to be_present
 
-        food_tile = root.board_images.find_by(label: "Food")
+        food_tile = root.board_images.find_by(display_label: "Food")
         expect(food_tile.predictive_board_id).to be_nil
       end
 
@@ -224,10 +224,10 @@ RSpec.describe Boards::SeededSetCloner do
 
         expect(returned.id).to eq(root.id)
         root.reload
-        expect(root.board_images.map(&:label)).to include("I", "want", "help", "Food", "Feelings")
+        expect(root.board_images.map(&:display_label)).to include("I", "want", "help", "Food", "Feelings")
 
         cloned_food = owner.boards.find_by(name: "Food")
-        food_tile = root.board_images.find_by(label: "Food")
+        food_tile = root.board_images.find_by(display_label: "Food")
         expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
         cloned_feelings = owner.boards.find_by(name: "Feelings")
@@ -266,7 +266,7 @@ RSpec.describe Boards::SeededSetCloner do
 
         favorites = owner.boards.find_by(name: "My Favorites")
         expect(favorites.board_images.map(&:label)).to include("grandma")
-        fav_tile = root.reload.board_images.find_by(label: "My Favorites")
+        fav_tile = root.reload.board_images.find_by(display_label: "My Favorites")
         expect(fav_tile.predictive_board_id).to eq(favorites.id)
       end
 
@@ -300,7 +300,7 @@ RSpec.describe Boards::SeededSetCloner do
       expect(owner.boards.count).to eq(3)
 
       cloned_food = owner.boards.find_by(name: "Food")
-      expect(root.board_images.find_by(label: "Food").predictive_board_id).to eq(cloned_food.id)
+      expect(root.board_images.find_by(display_label: "Food").predictive_board_id).to eq(cloned_food.id)
     end
 
     it "routes interests into the cloned fringe pages and My Favorites" do
@@ -312,7 +312,7 @@ RSpec.describe Boards::SeededSetCloner do
 
       favorites = owner.boards.find_by(name: "My Favorites")
       expect(favorites.board_images.map(&:label)).to contain_exactly("grandma")
-      expect(root.board_images.find_by(label: "My Favorites")).to be_present
+      expect(root.board_images.find_by(display_label: "My Favorites")).to be_present
     end
 
     it "falls back to the owner's voice for boards it creates" do
@@ -351,7 +351,7 @@ RSpec.describe Boards::SeededSetCloner do
         expect(fringe.count).to be > 0
 
         fringe.each do |board|
-          self_tile = board.board_images.find_by(label: board.name)
+          self_tile = board.board_images.find_by(display_label: board.name)
           expect(self_tile).to be_present, "expected fringe '#{board.name}' to have a '#{board.name}' self tile"
           expect(self_tile.predictive_board_id).to eq(cloned_root.id),
             "expected '#{board.name}' self tile to link home to the cloned root"
@@ -376,7 +376,7 @@ RSpec.describe Boards::SeededSetCloner do
       { "I" => ["pronoun", "#FFEA75"],
         "want" => ["verb", "#A1F571"],
         "what" => ["question", "#A07AFF"] }.each do |label, (pos, hex)|
-        tile = cloned_root.board_images.find_by(label: label)
+        tile = cloned_root.board_images.find_by(display_label: label)
         expect(tile).to be_present, "expected a cloned '#{label}' tile"
         expect(tile.part_of_speech).to eq(pos)
         expect(tile.bg_color).to eq(hex)

--- a/spec/services/boards/set_graph_builder_spec.rb
+++ b/spec/services/boards/set_graph_builder_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Boards::SetGraphBuilder do
 
   it "exposes each tile's BoardImage id and image_url" do
     home = graph[:boards].find { |b| b[:id] == set[:home].id }
-    bi = set[:home].board_images.find_by(label: "I")
+    bi = set[:home].board_images.find_by(display_label: "I")
     tile = home[:tiles].find { |t| t[:label] == "I" }
     expect(tile[:id]).to eq(bi.id)
     expect(tile).to have_key(:image_url)

--- a/spec/services/boards/starter_blueprints_spec.rb
+++ b/spec/services/boards/starter_blueprints_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Boards::StarterBlueprints, type: :service do
         # The capitalized folder labels — folder names, never seeded vocabulary —
         # are exactly what used to blow up. They now resolve to created images.
         %w[Food Feelings Play].each do |folder_label|
-          expect(Image.find_by(label: folder_label, user_id: user.id)).to be_present
+          expect(Image.by_label(folder_label).find_by(user_id: user.id)).to be_present
         end
       end
     end

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe VocabSets do
 
     def expect_authored_colors(board)
       EXPECTED_TILES.each do |label, expected|
-        tile = board.board_images.find_by(label: label)
+        tile = board.board_images.find_by(display_label: label)
         expect(tile).to be_present, "expected a '#{label}' tile on #{board.name}"
         expect(tile.part_of_speech).to eq(expected[:pos]),
           "expected '#{label}' part_of_speech #{expected[:pos]}, got #{tile.part_of_speech}"

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -42,13 +42,13 @@ RSpec.describe VocabSets do
       expect(c60_boards.pluck(:name)).to contain_exactly(*CORE_60_BOARD_NAMES)
       expect(c60_boards.all? { |b| b.predefined && b.published }).to be(true)
 
-      food_tile = @c60_root.board_images.find_by(label: "Food")
+      food_tile = @c60_root.board_images.find_by(display_label: "Food")
       expect(food_tile.predictive_board_id).to be_present
       expect(Board.find(food_tile.predictive_board_id).name).to eq("Food")
     end
 
     it "does not create self-link folder tiles on fringe pages" do
-      food_board = Board.find(@c60_root.board_images.find_by(label: "Food").predictive_board_id)
+      food_board = Board.find(@c60_root.board_images.find_by(display_label: "Food").predictive_board_id)
       food_self_links = food_board.board_images.where(predictive_board_id: food_board.id)
       expect(food_self_links).to be_empty
     end
@@ -76,15 +76,15 @@ RSpec.describe VocabSets do
     # Each People page's way home is its own "People" self tile; it must resolve
     # to ITS set's root, never the other set's (the pre-namespacing bug).
     it "seeds disjoint fringe boards per set, each fringe's self tile resolving to its own root" do
-      c60_people = Board.find(@c60_root.board_images.find_by(label: "People").predictive_board_id)
-      c84_people = Board.find(@c84_root.board_images.find_by(label: "People").predictive_board_id)
+      c60_people = Board.find(@c60_root.board_images.find_by(display_label: "People").predictive_board_id)
+      c84_people = Board.find(@c84_root.board_images.find_by(display_label: "People").predictive_board_id)
 
       expect(c60_people.id).not_to eq(c84_people.id)
       expect(c60_people.obf_id).to eq("core-60:people")
       expect(c84_people.obf_id).to eq("core-84:people")
 
-      expect(c60_people.board_images.find_by(label: "People").predictive_board_id).to eq(@c60_root.id)
-      expect(c84_people.board_images.find_by(label: "People").predictive_board_id).to eq(@c84_root.id)
+      expect(c60_people.board_images.find_by(display_label: "People").predictive_board_id).to eq(@c60_root.id)
+      expect(c84_people.board_images.find_by(display_label: "People").predictive_board_id).to eq(@c84_root.id)
     end
 
     it "shares no fringe boards between the two seeded sets" do
@@ -324,7 +324,7 @@ RSpec.describe VocabSets do
     end
 
     it "restores authored colors on re-seed after a tile was mangled" do
-      tile = @c60_root.board_images.find_by(label: "I")
+      tile = @c60_root.board_images.find_by(display_label: "I")
       tile.update_columns(part_of_speech: "noun", bg_color: "#FFFFFF")
 
       VocabSets.seed_slug!("core-60")
@@ -332,24 +332,24 @@ RSpec.describe VocabSets do
     end
 
     it "heals a stale bg_color on re-seed even when part_of_speech is already right" do
-      tile = @c60_root.board_images.find_by(label: "I")
+      tile = @c60_root.board_images.find_by(display_label: "I")
       tile.update_columns(bg_color: "#FFFFFF")
 
       VocabSets.seed_slug!("core-60")
-      expect(@c60_root.reload.board_images.find_by(label: "I").bg_color).to eq("#FFEA75")
+      expect(@c60_root.reload.board_images.find_by(display_label: "I").bg_color).to eq("#FFEA75")
     end
 
     it "never overwrites a non-blank part_of_speech on the shared Image record" do
-      image = @c60_root.board_images.find_by(label: "I").image
+      image = @c60_root.board_images.find_by(display_label: "I").image
       image.update_column(:part_of_speech, "noun")
 
       VocabSets.seed_slug!("core-60")
       expect(image.reload.part_of_speech).to eq("noun")
-      expect(@c60_root.reload.board_images.find_by(label: "I").part_of_speech).to eq("pronoun")
+      expect(@c60_root.reload.board_images.find_by(display_label: "I").part_of_speech).to eq("pronoun")
     end
 
     it "backfills a blank Image part_of_speech from the authored OBF" do
-      image = @c60_root.board_images.find_by(label: "I").image
+      image = @c60_root.board_images.find_by(display_label: "I").image
       image.update_column(:part_of_speech, nil)
 
       VocabSets.seed_slug!("core-60")
@@ -392,7 +392,7 @@ RSpec.describe VocabSets do
     end
 
     it "wires the Drinks folder tile to the seeded Drinks board" do
-      drinks_tile = @c60_root.board_images.find_by(label: "Drinks")
+      drinks_tile = @c60_root.board_images.find_by(display_label: "Drinks")
       expect(drinks_tile).to be_present
       expect(drinks_tile.predictive_board_id).to be_present
       expect(Board.find(drinks_tile.predictive_board_id).name).to eq("Drinks")
@@ -418,7 +418,7 @@ RSpec.describe VocabSets do
     end
 
     it "wires the Drinks folder tile to the seeded Drinks board" do
-      drinks_tile = @c84_root.board_images.find_by(label: "Drinks")
+      drinks_tile = @c84_root.board_images.find_by(display_label: "Drinks")
       expect(drinks_tile).to be_present
       expect(drinks_tile.predictive_board_id).to be_present
       expect(Board.find(drinks_tile.predictive_board_id).name).to eq("Drinks")

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
       expect(root.status).to eq("complete")
       expect(root.board_images.count).to eq(CORE_84_GRID_CELLS)
       # No non-authored default folder was injected.
-      expect(root.board_images.map(&:label)).not_to include("Social")
+      expect(root.board_images.map(&:display_label)).not_to include("Social")
       # The authored question word stays in-grid (row index 4), never orphaned
       # onto a stray 8th row.
       who = root.board_images.find { |bi| bi.label == "who" }
@@ -172,7 +172,7 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     # The default applies across the whole built set, not just the home board —
     # except each page's SELF tile, the one folder tile that speaks its label
     # (it's the you-are-here anchor and the way home). See Boards::NavRowSync.
-    animals = Board.find(root.board_images.find { |bi| bi.label == "Animals" }.predictive_board_id)
+    animals = Board.find(root.board_images.find { |bi| bi.display_label == "Animals" }.predictive_board_id)
     animals.board_images.select(&:is_dynamic?).each do |bi|
       next if bi.label.to_s.strip.casecmp?(animals.name.to_s.strip)
 
@@ -224,12 +224,12 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
       { "word" => "tummy", "category" => "Health & Body" },
     ])
 
-    people = Board.find(root.board_images.find { |bi| bi.label == "People" }.predictive_board_id)
-    body   = Board.find(root.board_images.find { |bi| bi.label == "Body" }.predictive_board_id)
+    people = Board.find(root.board_images.find { |bi| bi.display_label == "People" }.predictive_board_id)
+    body   = Board.find(root.board_images.find { |bi| bi.display_label == "Body" }.predictive_board_id)
     expect(people.board_images.map { |bi| bi.label.to_s.downcase }).to include("grandma")
     expect(body.board_images.map { |bi| bi.label.to_s.downcase }).to include("tummy")
 
-    favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+    favorites_tile = root.board_images.find { |bi| bi.display_label == "My Favorites" }
     if favorites_tile
       fav = Board.find(favorites_tile.predictive_board_id)
       expect(fav.board_images.map { |bi| bi.label.to_s.downcase }).not_to include("grandma", "tummy")
@@ -263,8 +263,8 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
 
     root = build!([{ "word" => "dog", "category" => "Animals" }])
 
-    people_tile = root.board_images.find { |bi| bi.label == "People" }
-    animals_tile = root.board_images.find { |bi| bi.label == "Animals" }
+    people_tile = root.board_images.find { |bi| bi.display_label == "People" }
+    animals_tile = root.board_images.find { |bi| bi.display_label == "Animals" }
 
     expect(Boards::ImageResolver.art?(people_tile.image)).to be(true)
     expect(Boards::ImageResolver.art?(animals_tile.image)).to be(true)

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
   # carry a predictive link — a dead folder tile opens nothing when tapped.
   def dead_folder_tiles(board)
     board.board_images.select do |bi|
-      label = bi.label.to_s
+      label = bi.display_label.to_s
       label.length > 2 && label[0] == label[0].upcase && bi.predictive_board_id.nil?
     end
   end
@@ -106,10 +106,10 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     # authored folders the planner used to strip are intact.
     expect(dead_folder_tiles(root)).to be_empty
 
-    labels = root.board_images.map(&:label)
+    labels = root.board_images.map(&:display_label)
     expect(labels).to include("More", "School", "Time", "Describe")
     %w[More School Time Describe].each do |name|
-      tile = root.board_images.find { |bi| bi.label == name }
+      tile = root.board_images.find { |bi| bi.display_label == name }
       expect(tile.predictive_board_id).to be_present, "#{name} folder tile has no linked board"
     end
 

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe BuildBoardSetJob do
       expect(root.settings["builder_root"]).to be(true)
 
       # Core tiles landed on the SAME root the controller returned.
-      labels = root.board_images.map(&:label)
+      labels = root.board_images.map(&:display_label)
       expect(labels).to include("I", "want", "Food", "Feelings", "Play")
 
       # Folder tiles link to builder_child sub-boards.
@@ -400,7 +400,7 @@ RSpec.describe BuildBoardSetJob do
       # to a real board. None are left dead (excluding authored seed pages used
       # to strip the sub-board while leaving its tile behind).
       dead = root.board_images.select do |bi|
-        label = bi.label.to_s
+        label = bi.display_label.to_s
         label.length > 2 && label[0] == label[0].upcase && bi.predictive_board_id.nil?
       end
       expect(dead).to be_empty

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -98,14 +98,14 @@ RSpec.describe BuildBoardSetJob do
       expect(labels).to include("I", "want", "Food", "Feelings", "Play")
 
       # Folder tiles link to builder_child sub-boards.
-      play_tile = root.board_images.find { |bi| bi.label == "Play" }
+      play_tile = root.board_images.find { |bi| bi.display_label == "Play" }
       expect(play_tile.predictive_board_id).to be_present
       play_board = Board.find(play_tile.predictive_board_id)
       expect(play_board.settings["builder_child"]).to be(true)
       expect(play_board.board_images.map(&:label)).to include("dinosaurs", "ball")
 
       # Unmatched interest fell through to "My Favorites".
-      favorites_tile = root.board_images.find { |bi| bi.label == "My Favorites" }
+      favorites_tile = root.board_images.find { |bi| bi.display_label == "My Favorites" }
       favorites_board = Board.find(favorites_tile.predictive_board_id)
       expect(favorites_board.board_images.map(&:label)).to contain_exactly("grandma")
 
@@ -242,12 +242,12 @@ RSpec.describe BuildBoardSetJob do
       described_class.new.perform(root.id, communicator.id, "core-60", [])
 
       food = user.boards.find_by(name: "Food")
-      self_tile = food.board_images.find { |bi| bi.label == "Food" }
+      self_tile = food.board_images.find { |bi| bi.display_label == "Food" }
       expect(self_tile).to be_present
       expect(self_tile.predictive_board_id).to eq(root.id)
       expect(self_tile.data.to_h["mute_name"]).not_to be(true)
 
-      food_folder = root.board_images.find { |bi| bi.label == "Food" }
+      food_folder = root.board_images.find { |bi| bi.display_label == "Food" }
       expect(food_folder.data["mute_name"]).to be(true)
     end
 
@@ -272,7 +272,7 @@ RSpec.describe BuildBoardSetJob do
 
       root.reload
       expect(root.status).to eq("complete")
-      expect(root.board_images.map(&:label)).to include("I", "Food")
+      expect(root.board_images.map(&:display_label)).to include("I", "Food")
 
       cloned_food = user.boards.find_by(name: "Food")
       expect(cloned_food).to be_present
@@ -280,7 +280,7 @@ RSpec.describe BuildBoardSetJob do
       expect(cloned_food.board_images.map(&:label)).to include("apple", "pizza")
 
       # Folder tile points at the CLONED fringe, not the admin source.
-      food_tile = root.board_images.find { |bi| bi.label == "Food" }
+      food_tile = root.board_images.find { |bi| bi.display_label == "Food" }
       expect(food_tile.predictive_board_id).to eq(cloned_food.id)
 
       # Source set untouched; user's copy never surfaces as a pickable template.
@@ -321,7 +321,7 @@ RSpec.describe BuildBoardSetJob do
       root.reload
       expect(root.status).to eq("complete")
 
-      phrases_tile = root.board_images.find { |bi| bi.label == "Phrases" }
+      phrases_tile = root.board_images.find { |bi| bi.display_label == "Phrases" }
       expect(phrases_tile&.predictive_board_id).to be_present
 
       phrases_board = Board.find(phrases_tile.predictive_board_id)
@@ -332,7 +332,7 @@ RSpec.describe BuildBoardSetJob do
         .select { |bi| bi.predictive_board_id.present? }
       expect(function_tiles.size).to eq(6)
 
-      greetings = Board.find(function_tiles.find { |bi| bi.label == "Greetings & Social" }.predictive_board_id)
+      greetings = Board.find(function_tiles.find { |bi| bi.display_label == "Greetings & Social" }.predictive_board_id)
       expect(greetings.board_images.map(&:label)).to include("hi there!", "good morning")
       # Its own gestalt scripts are all phrases; the nav row it also carries is not.
       scripts = greetings.board_images.reject { |bi| bi.data&.dig("nav_tile") }
@@ -344,7 +344,7 @@ RSpec.describe BuildBoardSetJob do
 
       described_class.new.perform(root.id, communicator.id, "standard", [])
 
-      phrases_tile = root.reload.board_images.find { |bi| bi.label == "Phrases" }
+      phrases_tile = root.reload.board_images.find { |bi| bi.display_label == "Phrases" }
       phrases_board_id = phrases_tile.predictive_board_id
 
       expect(communicator.reload.settings["phrase_board_id"]).to eq(phrases_board_id)
@@ -382,7 +382,7 @@ RSpec.describe BuildBoardSetJob do
 
       root.reload
       expect(root.status).to eq("complete")
-      expect(root.board_images.map(&:label)).to include("I", "Food")
+      expect(root.board_images.map(&:display_label)).to include("I", "Food")
 
       cloned_food = user.boards.find_by(name: "Food")
       expect(cloned_food).to be_present
@@ -690,7 +690,7 @@ RSpec.describe BuildBoardSetJob do
       expect(root.status).to eq("complete")
       expect(root.board_images.count).to be > 0
 
-      play_tile = root.board_images.find { |bi| bi.label == "Play" }
+      play_tile = root.board_images.find { |bi| bi.display_label == "Play" }
       play_board = Board.find(play_tile.predictive_board_id)
       expect(play_board.board_images.map(&:label)).to include("dinosaurs")
     end
@@ -703,7 +703,7 @@ RSpec.describe BuildBoardSetJob do
 
       root.reload
       expect(root.status).to eq("complete")
-      expect(root.board_images.map(&:label)).to include("I", "Food")
+      expect(root.board_images.map(&:display_label)).to include("I", "Food")
       expect(ChildBoard.count).to eq(0)
     end
 

--- a/spec/tasks/board_builder_sync_nav_rows_spec.rb
+++ b/spec/tasks/board_builder_sync_nav_rows_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "board_builder:sync_nav_rows" do
     labels = food.board_images.reload.map(&:label)
     expect(labels).to include("Food", "this")
 
-    self_tile = food.board_images.find { |bi| bi.label == "Food" }
+    self_tile = food.board_images.find { |bi| bi.display_label == "Food" }
     expect(self_tile.predictive_board_id).to eq(root.id)
   end
 


### PR DESCRIPTION
## Why

`images.label` is documented everywhere as the **lowercase matching key** — it's what every `find_by(label:)` in the app keys on — but nothing enforced it. `Image#set_label` had its downcase/strip commented out, so `label` doubled as display text and drifted into whatever casing the creating path used.

Two defects fell out of that:

1. **Duplicate, art-less images.** A user typing "Swing" missed the curated `swing` symbol, and the calling site's very next line created a blank Image beside it — an empty tile on the board and a duplicate in the library. The internal API was fixed for this in #573 via `Boards::ImageResolver`; nothing else was.
2. **Inconsistent tile casing.** One board rendered "Higher" next to "swing" — cosmetic on screen, a visible defect in print.

Measured on a copy of the library (7,366 images): 452 rows carried uppercase, **217 had an exact lowercase twin**, **278 of the 452 had zero docs** (blank dupes from a case-sensitive miss), and 165 boards rendered mixed tile casing.

## The core change

**Split the two roles.** New `images.display_label` column carries the authored casing, so normalizing the key costs nothing renderable — `iPad`, `McDonald's`, `PE` survive intact. `Image#set_label` downcases and strips `label` on every write. Punctuation is deliberately *not* stripped (the old commented-out `gsub` would have turned `McDonald's` into `McDonalds`, splitting it from its own art).

**`Image.by_label` is now the only correct lookup**, matching on `LOWER(label)`. ~20 call sites converted. Added a plain and a functional `LOWER(label)` index — `images.label` had **no index at all** despite being the hottest lookup column in the app.

**Backfill** (`20260807120100`), three ordered passes: authored casing copied verbatim into `display_label`; then the single plain Title-Cased `category` folder tiles that already had a lowercase twin (`Animals`, `Play`, `Time` — 21 rows) are lowercased; then `label` is normalized. The twin test protects the 94 imported source-collection names (`CommuniKate weather`, `Core 24 - Small Words`) — none are single plain words. `board_images` rows are **not** backfilled, per the forward-only rule from #582.

## The knock-on work (most of this PR)

Making lookup case-insensitive means **two authored things can now legitimately share one Image** — Core 60/84 author both a `more` word button and a `More` folder. Several places assumed one-to-one, and each broke something real. These are not cleanup; without them this change regresses the flagship AAC boards.

| # | Defect | Cause |
|---|---|---|
| 1 | OBZ import minted a duplicate Image on **every re-seed** | `preload_image_cache` queried case-sensitively and keyed on the stored label while lookups used the raw OBF label — the exact duplication this PR removes, reintroduced in the importer |
| 2 | Core 60/84 home boards came out **58/82 tiles instead of 60/84** — the `play` and `more` word tiles silently vanished | the legacy `by_image_id` tile-adoption path handed the folder's tile to the word button |
| 3 | Core 84 folders rendered **`more`/`play`** instead of `More`/`Play` | tile display text defaulted from the shared Image, so whichever button imported first decided the casing for both |
| 4 | Keyboard `A` / `I` keys could render **vocabulary artwork** | letter images were looked up by label alone; the article `a` and pronoun `I` are real images with symbol art (the `i` image has 11 docs) |
| 5 | Keyboard re-seed **appended duplicate tiles** | tile upsert keyed on `label`, on a seed documented as idempotent |
| 6 | Native grid rendered **`q`, not `Q`** | `api_view_for_native_grid` sent the matching key |
| 7 | Board Builder template picker previewed **`["i", "food"]`** | `StarterBlueprints` sent the matching key |

Plus `Board#set_current_word_list` (surfaced as `word_list`) going lowercase — now `display_label`, which restores the pre-branch value exactly. `CloneBoardJob`'s dedup compares the same field on both sides, so matching is unaffected.

**The generalizable rule**, now recorded as a CLAUDE.md invariant: *anything that displays a tile reads `display_label`; only lookups use `label`.* That's the lens to review this diff through.

## Decisions worth a reviewer's eye

- **Duplicate rows are left in place.** 135 user+label groups differ only by casing. Once lookups are case-insensitive, `ImageResolver` always picks the art-bearing row, so the blank twins are dead weight rather than a bug. Merging them is a destructive migration over live user boards and deserves its own PR.
- **Existing tiles are untouched.** Backfilling `board_images.display_label` would have to distinguish deliberate casing from inherited casing on data where that signal is already lost.
- **The keyboard fix means the next production seed creates 26 fresh letter images** rather than adopting existing rows. Deliberate: adopting by label is precisely the collision being fixed. Existing keyboard tiles keep their current images, so nothing changes visually until re-seeded.
- **`board_images.label` is NOT normalized.** It's lowercase when `set_labels` derives it from the image, but `NavRowSync` / `PhrasesPageBuilder` / `SeededSetCloner` write it directly and keep their casing. Tile label casing is mixed by design — an earlier version of this description claimed otherwise, which is why several spec lookups broke asymmetrically.
- **Migration is irreversible by design.** Rolling back means dropping the column, not resurrecting the old casing.

## Test plan

New coverage:
- 15 model specs for the split and `Image.by_label`, including the regression itself: `find_by(label: "Swing")` returns nil where `by_label` finds the curated row.
- `spec/requests/api/images_label_casing_spec.rb` — the symptom through real endpoints (`find_or_create`, `add_image`, `find_by_label`): no duplicate on a casing or whitespace mismatch, and `iPad` casing reaches the tile.
- `board_from_obf_idempotency_spec` — three cases for defects 1–3 above; each fails without its fix.

Existing specs updated where they pinned the old behavior — notably `board_spec`'s "creates a new image for the differently-cased word", which asserted the bug itself.

Verified green locally:

```
bundle exec rspec spec/models                              # 839 examples, 0 failures
bundle exec rspec spec/services/boards spec/services/labels \
  spec/models/image_spec.rb spec/models/board_image_spec.rb # 473 examples, 0 failures
bundle exec rspec spec/requests/api/v1/board_builder_spec.rb # 55 examples, 0 failures
bundle exec rspec spec/lib/tasks/core_boards_rake_spec.rb \
  spec/db/seeds/keyboard_boards_seed_spec.rb                # 20 examples, 0 failures
bundle exec rspec spec/models/board_from_obf_idempotency_spec.rb # 6 examples, 0 failures
```

Direct probes on the real seeded sets: core-60 **60/60** tiles with no missing authored buttons; core-84 **84** tiles with folders `People/Feelings/Food/Play/Places/Body/More/School/Time/Describe/Drinks` all carrying authored casing.

**Note for CI:** this suite has a pre-existing `users_id_seq` desync — specs that create a user at an explicit `DEFAULT_ADMIN_ID` don't advance the sequence, so a later `create(:user)` collides. It reproduces on `main` with `rspec spec/models/board_spec.rb spec/requests/api/images_spec.rb` and is unrelated to this change. Several earlier local runs were also invalidated by a concurrent session resetting the shared test database; CI is the trustworthy signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
