### PR TITLE
refactor(printables): make each printable file describe only itself

### DIFF
--- a/.claude-notes/board-printable-in-app-handoff.md
+++ b/.claude-notes/board-printable-in-app-handoff.md
@@ -320,15 +320,28 @@ Invariants a future change has to keep:
   overrides swap fills for outlines and never change sizes: if the two covers
   could disagree about layout they could disagree about page count, and the
   colour and low-ink files would stop being interchangeable.
+- **A wrapper page describes only the file it sits in.** The how-to-use page's
+  step 1 is the one claim it makes about its own document, and a set is emitted
+  as two separate files, so it is rendered per variant: the colour file says
+  it's colour, the low-ink file says it's low-ink, and **neither mentions the
+  other**. A reader holding one print doesn't need to be told another exists
+  somewhere — it just raises a question the page can't answer. Only a single
+  board, which is one file genuinely holding both halves, describes a pair.
+- **Nothing is justified and nothing hyphenates.** Body copy carries
+  `text-wrap: pretty` to kill orphans; short centred blocks (headings, intros,
+  captions) carry `text-wrap: balance`. Both are ignored by an older Chrome
+  rather than breaking. Where a break still lands badly, fix the copy or use
+  `&nbsp;` — don't reach for hyphenation.
 - **The QR is white-filled, not cream.** It sits inside a white card in both
   variants, and contrast is the whole job of that image.
 - **The public `pb` URL is printed as text beside every QR.** These get
   photocopied, laminated, and handed to people without a phone camera.
 
-`RenderWrappers#call` returns a fifth key, `cover_low_ink`, **only for a set** —
-a single board is one document holding both halves, so it has no low-ink file
-to give its own cover to. `MergePdf#cover_for` falls back to the colour cover
-rather than assuming the key is there.
+`RenderWrappers#call` returns two extra keys for a set — `cover_low_ink` and
+`how_to_use_low_ink` — and neither for a single board, which is one document
+holding both halves and has no low-ink identity to honour.
+`MergePdf#wrapper_for(key, variant)` picks the `_low_ink` render for the low-ink
+file and falls back rather than assuming the key is there.
 
 ## Wrap-up
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   typeface, numbered step cards in place of the how-to bullet list, and
   side-by-side "You may" / "Please don't" cards on the license page. The board's
   public URL is printed as text beside every QR code, so a photocopied or
-  laminated sheet still leads back to the board. The low-ink file now opens on
-  its own ink-light cover instead of a full-colour one.
+  laminated sheet still leads back to the board.
+- **Each printable file now describes only itself.** A set is delivered as two
+  files, and both used to carry the same cover and the same "this comes as two
+  files" instructions. The colour file now says it's the colour print and the
+  low-ink file says it's the low-ink print, each behind its own matching cover —
+  neither mentions the other. A single board, which really is one file holding
+  both a colour and a low-ink copy, still says so.
 
 ### Added
 

--- a/app/services/boards/printables/merge_pdf.rb
+++ b/app/services/boards/printables/merge_pdf.rb
@@ -53,8 +53,8 @@ module Boards
 
       def build(variant:, filename:, board_pages:)
         pdf = CombinePDF.new
-        pdf << CombinePDF.parse(cover_for(variant))
-        pdf << CombinePDF.parse(wrappers[:how_to_use])
+        pdf << CombinePDF.parse(wrapper_for(:cover, variant))
+        pdf << CombinePDF.parse(wrapper_for(:how_to_use, variant))
         board_pages.each { |page| pdf << CombinePDF.parse(page.pdf_bytes) }
         pdf << CombinePDF.parse(wrappers[:license])
         pdf << CombinePDF.parse(wrappers[:credits])
@@ -67,15 +67,18 @@ module Boards
         )
       end
 
-      # The low-ink FILE opens on an ink-light cover so its first page doesn't
-      # contradict its filename. RenderWrappers only produces one for a set, so
-      # fall back to the colour cover rather than assuming the key is there —
-      # the single-board file is one document holding both halves and has no
-      # low-ink identity to honour.
-      def cover_for(variant)
-        return wrappers[:cover] unless variant == BoardPrintable::VARIANT_LOW_INK
+      # The cover and the how-to-use page both make claims about the file they
+      # sit in, so the low-ink FILE gets its own render of each: an ink-light
+      # cover, and instructions that describe a low-ink print rather than the
+      # colour one it doesn't contain.
+      #
+      # RenderWrappers only produces those for a set, so fall back rather than
+      # assuming the key is there — the single-board file is one document
+      # holding both halves and has no low-ink identity to honour.
+      def wrapper_for(key, variant)
+        return wrappers[key] unless variant == BoardPrintable::VARIANT_LOW_INK
 
-        wrappers[:cover_low_ink] || wrappers[:cover]
+        wrappers[:"#{key}_low_ink"] || wrappers[key]
       end
     end
   end

--- a/app/services/boards/printables/render_wrappers.rb
+++ b/app/services/boards/printables/render_wrappers.rb
@@ -26,14 +26,17 @@ module Boards
       end
 
       # => { cover:, how_to_use:, license:, credits: } of PDF bytes, plus
-      #    cover_low_ink: for a set.
+      #    cover_low_ink: and how_to_use_low_ink: for a set.
       #
-      # The low-ink cover is a second render of the same template with
-      # `ink_light` set, which the layout turns into fills-become-outlines. It
-      # exists only for a set, where MergePdf emits a separate low-ink FILE that
-      # would otherwise open on a full-bleed gradient — a cover that contradicts
-      # the promise its filename makes. A single board is one file containing
-      # both halves, so it keeps the one colour cover.
+      # A set is emitted as two separate FILES (MergePdf), so the two pages that
+      # make claims about the document they sit in get rendered twice — once per
+      # variant — and MergePdf binds the matching one into each file. Without
+      # that, the low-ink file opens on a full-bleed gradient cover and then
+      # explains a colour print it doesn't contain.
+      #
+      # A single board is ONE file holding both a colour and a low-ink half, so
+      # it has no per-variant identity: one cover, one how-to-use, and the copy
+      # describes the pair of halves.
       def call
         wrappers = {
           cover: render("cover", assigns: cover_assigns),
@@ -46,6 +49,7 @@ module Boards
 
         wrappers.merge(
           cover_low_ink: render("cover", assigns: cover_assigns.merge(ink_light: true)),
+          how_to_use_low_ink: render("how_to_use", assigns: how_to_use_assigns(low_ink: true)),
         )
       end
 
@@ -65,9 +69,12 @@ module Boards
         }
       end
 
-      def how_to_use_assigns
+      # `low_ink` is only ever true for a set, where this page is bound into the
+      # low-ink file alone and must describe that file rather than the pair.
+      def how_to_use_assigns(low_ink: false)
         {
           is_set: set?,
+          low_ink: low_ink,
           topic: topic,
           noun: set? ? "set of #{board_count} communication boards" : "communication board",
         }

--- a/app/views/api/board_printables/how_to_use.html.erb
+++ b/app/views/api/board_printables/how_to_use.html.erb
@@ -2,10 +2,16 @@
     (speakanyway-printables/src/plugins/aac/product-types/existing-board.ts) so
     an in-app printable and a pipeline printable read identically.
 
-    Exception — the set branch. The pipeline merges a set into ONE PDF with a
-    colour half then a low-ink half; MergePdf here emits TWO fully-wrapped
-    files instead. This same page is bound into both, so the copy has to
-    describe the pair, not halves of one document.
+    Exception — step 1, which is the one claim this page makes about the
+    document it sits in, so it can only ever describe THAT document:
+
+      single board  → one file holding a colour half and a low-ink half
+      set, colour   → this file is all colour
+      set, low-ink  → this file is all low-ink
+
+    Neither set variant mentions the other file. A reader holding the low-ink
+    print doesn't need to be told a colour one exists somewhere; being told so
+    just raises a question the page can't answer.
 
     Steps 1 and 6 span both columns because they carry the longest copy; the
     four short ones sit in a 2×2 block between them. %>
@@ -30,18 +36,26 @@
       <div class="step wide">
         <span class="num">1</span>
         <div>
-          <p class="lead"><%= @is_set ? "Two files, same boards" : "Printed twice" %></p>
-          <p>
-            <% if @is_set %>
-              This printable comes as two files, each with all the same boards: one in
-              full color, and one with white tile backgrounds for a cleaner, lower-ink
-              print. Use whichever fits your printer.
-            <% else %>
-              This printable includes the board twice: once in full color, then again
+          <% if !@is_set %>
+            <p class="lead">Printed twice</p>
+            <p>
+              This file includes the board twice: once in full color, then again
               with white tile backgrounds for a cleaner, lower-ink print. Use
               whichever fits your printer.
-            <% end %>
-          </p>
+            </p>
+          <% elsif @low_ink %>
+            <p class="lead">Printed low-ink</p>
+            <p>
+              Every board in this file uses white tile backgrounds, so it prints
+              cleanly and goes easy on your ink.
+            </p>
+          <% else %>
+            <p class="lead">Printed in full color</p>
+            <p>
+              Every board in this file uses the same tile colors your
+              communicator sees on screen.
+            </p>
+          <% end %>
         </div>
       </div>
 
@@ -57,9 +71,11 @@
         <span class="num">3</span>
         <div>
           <p class="lead">Hear it out loud</p>
+          <%# Full stop rather than an em dash: at this measure the dash kept
+              landing at the start of a line, where it reads as a stray mark. %>
           <p>
             Scan the QR code on the cover<%= " or any page" if @is_set %> to open the
-            board<%= "s" if @is_set %> online — every word speaks out loud when you
+            board<%= "s" if @is_set %> online. Every word speaks out loud when you
             tap it. Nothing to install.
           </p>
         </div>
@@ -69,7 +85,9 @@
         <span class="num">4</span>
         <div>
           <p class="lead">Practice first</p>
-          <p>Practice with your communicator before you need it. Familiarity helps.</p>
+          <%# Kept short deliberately. This card sits beside step 5 in the grid
+              and any third line makes the pair visibly uneven. %>
+          <p>Practice together before you need&nbsp;it. Familiarity helps.</p>
         </div>
       </div>
 

--- a/app/views/api/board_printables/license.html.erb
+++ b/app/views/api/board_printables/license.html.erb
@@ -1,4 +1,8 @@
-<%# Check and cross marks are inline SVG rather than ✓/✕ glyphs so they can't
+<%# One list, not two boxes. The mark carries the yes/no — a blue check or a
+    magenta cross — so the terms read as a single set of rules rather than a
+    permissions matrix the reader has to cross-reference.
+
+    Check and cross marks are inline SVG rather than ✓/✕ glyphs so they can't
     fall back to a different face — or to nothing — on the render box. %>
 <div class="sheet license">
   <div class="sheet-body">
@@ -11,47 +15,28 @@
       </p>
     </div>
 
-    <div class="terms">
-      <div class="card yes">
-        <h3>You may</h3>
-        <ul>
-          <li>
-            <span class="mark yes"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg></span>
-            <span>Print as many copies as you need for your family or classroom.</span>
-          </li>
-          <li>
-            <span class="mark yes"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg></span>
-            <span>Share with your communicator's full team — therapists, teachers, caregivers.</span>
-          </li>
-        </ul>
-      </div>
-
-      <div class="card no">
-        <h3>Please don't</h3>
-        <ul>
-          <li>
-            <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
-            <span>Resell or redistribute this file.</span>
-          </li>
-          <li>
-            <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
-            <span>Share the digital file outside that team.</span>
-          </li>
-          <li>
-            <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
-            <span>Modify and republish as your own work.</span>
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="callout">
-      <p>
-        Using this with a school, clinic, or caseload and not sure whether it's
-        covered? Ask us at speakanyway.com — we'd rather say yes than have you
-        guess.
-      </p>
-    </div>
+    <ul class="terms">
+      <li>
+        <span class="mark yes"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg></span>
+        <span>Print as many copies as you need for your family or classroom.</span>
+      </li>
+      <li>
+        <span class="mark yes"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7" /></svg></span>
+        <span>Share it with your communicator's full team — therapists, teachers, caregivers.</span>
+      </li>
+      <li>
+        <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
+        <span>Don't resell or redistribute this file.</span>
+      </li>
+      <li>
+        <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
+        <span>Don't share the digital file outside that team.</span>
+      </li>
+      <li>
+        <span class="mark no"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6L6 18" /></svg></span>
+        <span>Don't modify it and republish it as your own work.</span>
+      </li>
+    </ul>
 
     <div class="license-foot">
       <div class="rule"></div>

--- a/app/views/layouts/pdf_printable.html.erb
+++ b/app/views/layouts/pdf_printable.html.erb
@@ -64,6 +64,30 @@
         size: letter;
       }
 
+      /* Typesetting. Nothing is justified and nothing hyphenates — both produce
+         rivers and broken words at these short measures.
+         `pretty` costs Chrome a slower line-breaking pass in exchange for
+         killing orphans (a stranded last word); `balance` evens the line
+         lengths of the short centred blocks — headings, intros, captions —
+         where a long-then-tiny break is most obvious. Both are ignored by an
+         older Chrome rather than breaking, so the render degrades to the
+         default greedy wrap. */
+      p, li {
+        text-wrap: pretty;
+        hyphens: none;
+      }
+
+      .cover .title,
+      .page-head h2,
+      .page-head .intro,
+      .about h2,
+      .about .quote,
+      .pill,
+      .qr-card .qr-caption,
+      .license-foot p {
+        text-wrap: balance;
+      }
+
       /* ── Sheet: the shared 8.5×11 page every wrapper builds on ────────── */
       .sheet {
         width: 8.5in;
@@ -350,60 +374,34 @@
       }
 
       /* ── License ─────────────────────────────────────────────────────── */
-      /* flex: 1 + align-content: center so the two cards float in the middle of
-         the page rather than clinging to the heading with six dead inches
-         underneath. Rows stay content-sized. */
+      /* One centred column. Each term is a whole sentence, so a narrow
+         side-by-side column squeezed them to three and four lines each with
+         a stranded last word; at full measure they all fit on one or two. */
       .terms {
         flex: 1;
         min-height: 0;
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.25in;
-        align-content: center;
-      }
-
-      .terms .card {
-        padding: 24pt 22pt 26pt;
-      }
-
-      .terms .card.yes {
-        background: var(--cyan-tint);
-      }
-
-      .terms .card.no {
-        background: var(--magenta-tint);
-      }
-
-      .terms h3 {
-        font-size: 16pt;
-        font-weight: 800;
-        color: var(--navy);
-        margin-bottom: 16pt;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 26pt;
+        width: 5.9in;
+        margin: 0 auto;
       }
 
       .terms li {
         list-style: none;
         display: flex;
-        gap: 10pt;
+        gap: 14pt;
         align-items: flex-start;
-        font-size: 11.5pt;
+        font-size: 14pt;
         line-height: 1.45;
-        margin-bottom: 14pt;
+        text-align: left;
       }
 
-      .terms li:last-child {
-        margin-bottom: 0;
-      }
-
-      .license .callout {
-        flex: 0 0 auto;
-        margin-bottom: 0.35in;
-      }
-
-      .license .callout p {
-        font-size: 11pt;
-        line-height: 1.45;
-        color: var(--navy);
+      .terms .mark {
+        /* Optical alignment with the cap height of the first line, not the
+           line box — a flex-start mark sits visibly high next to 13pt text. */
+        margin-top: 2.5pt;
       }
 
       .license-foot {

--- a/spec/services/boards/printables/merge_pdf_spec.rb
+++ b/spec/services/boards/printables/merge_pdf_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Boards::Printables::MergePdf do
   let(:license) { 603 }
   let(:credits) { 604 }
   let(:cover_low_ink) { 605 }
+  let(:how_to_low_ink) { 606 }
 
   let(:wrappers) do
     {
@@ -24,6 +25,7 @@ RSpec.describe Boards::Printables::MergePdf do
       license: page_pdf(license),
       credits: page_pdf(credits),
       cover_low_ink: page_pdf(cover_low_ink),
+      how_to_use_low_ink: page_pdf(how_to_low_ink),
     }
   end
 
@@ -56,13 +58,13 @@ RSpec.describe Boards::Printables::MergePdf do
       described_class.new(wrappers: wrappers, pages: pages, boards: boards, slug: "core-words").call
     end
 
-    it "opens the low-ink file on the ink-light cover" do
+    it "gives the low-ink file its own cover and instructions" do
       low_ink = files.find { |f| f.variant == BoardPrintable::VARIANT_LOW_INK }
 
-      expect(widths(low_ink)).to eq([cover_low_ink, how_to, 201, 202, license, credits])
+      expect(widths(low_ink)).to eq([cover_low_ink, how_to_low_ink, 201, 202, license, credits])
     end
 
-    it "opens the colour file on the colour cover" do
+    it "gives the colour file the colour cover and instructions" do
       colour = files.find { |f| f.variant == BoardPrintable::VARIANT_COLOR }
 
       expect(widths(colour)).to eq([cover, how_to, 101, 102, license, credits])
@@ -77,18 +79,19 @@ RSpec.describe Boards::Printables::MergePdf do
     # RenderWrappers only produces an ink-light cover for a set, but MergePdf
     # must not assume the key is present — a missing one falls back rather than
     # merging nil and blowing up mid-job.
-    it "falls back to the colour cover when no ink-light cover was rendered" do
+    it "falls back to the colour pages when no low-ink variants were rendered" do
       wrappers.delete(:cover_low_ink)
+      wrappers.delete(:how_to_use_low_ink)
       low_ink = files.find { |f| f.variant == BoardPrintable::VARIANT_LOW_INK }
 
-      expect(widths(low_ink).first).to eq(cover)
+      expect(widths(low_ink).take(2)).to eq([cover, how_to])
     end
   end
 
   # One document holding both halves: there is no low-ink FILE to give its own
   # identity to, so it keeps the one colour cover.
   describe "a single board" do
-    it "wraps both halves in one file behind the colour cover" do
+    it "wraps both halves in one file behind the colour cover and instructions" do
       pages = [
         board_page(BoardPrintable::VARIANT_COLOR, 101),
         board_page(BoardPrintable::VARIANT_LOW_INK, 201),

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Boards::Printables::RenderWrappers do
   let(:rendered) { {} }
 
   before do
-    order = %i[cover how_to_use license credits cover_low_ink]
+    order = %i[cover how_to_use license credits cover_low_ink how_to_use_low_ink]
     index = 0
     allow(Grover).to receive(:new) do |html, **_opts|
       rendered[order[index]] = html
@@ -110,15 +110,39 @@ RSpec.describe Boards::Printables::RenderWrappers do
       expect(rendered[:how_to_use]).to include("The same board")
     end
 
-    # A set ships as two separate files (MergePdf#call), not one document with
-    # a colour half and a low-ink half — the copy must not promise otherwise.
-    it "describes a set as two files rather than one two-part document" do
-      render(board_count: 4)
+    # A set ships as two separate FILES (MergePdf#call), and this page is bound
+    # into each one, so it describes the file it's in and nothing else. Naming
+    # the other file would raise a question this page can't answer — the reader
+    # is holding one print, not a pair.
+    describe "for a set" do
+      it "tells the colour file it is the colour print" do
+        render(board_count: 4)
 
-      expect(rendered[:how_to_use]).to include("set of 4 communication boards")
-      expect(rendered[:how_to_use]).to include("comes as two files")
-      expect(rendered[:how_to_use]).not_to include("prints every board twice")
-      expect(rendered[:how_to_use]).to include("Every board")
+        expect(rendered[:how_to_use]).to include("set of 4 communication boards")
+        expect(rendered[:how_to_use]).to include("Printed in full color")
+        expect(rendered[:how_to_use]).to include("Every board")
+      end
+
+      it "tells the low-ink file it is the low-ink print" do
+        render(board_count: 4)
+
+        expect(rendered[:how_to_use_low_ink]).to include("Printed low-ink")
+        expect(rendered[:how_to_use_low_ink]).to include("white tile backgrounds")
+      end
+
+      it "never mentions the other file from either one" do
+        render(board_count: 4)
+
+        [rendered[:how_to_use], rendered[:how_to_use_low_ink]].each do |html|
+          expect(html).not_to include("two files")
+          expect(html).not_to include("twice")
+        end
+      end
+
+      it "renders a low-ink how-to only for a set" do
+        expect(render(board_count: 4)).to have_key(:how_to_use_low_ink)
+        expect(render).not_to have_key(:how_to_use_low_ink)
+      end
     end
 
     it "names the topic when one was given" do
@@ -153,12 +177,16 @@ RSpec.describe Boards::Printables::RenderWrappers do
     end
   end
 
-  it "renders the personal-use license terms" do
+  # One list, not two boxes: the check/cross mark carries the yes/no, so both
+  # the permissions and the restrictions sit in a single <ul class="terms">.
+  it "renders the personal-use license terms as one list" do
     render
 
     expect(rendered[:license]).to include("License")
     expect(rendered[:license]).to include("personal and classroom use")
-    expect(rendered[:license]).to include("Resell or redistribute")
+    expect(rendered[:license]).to include("Print as many copies as you need")
+    expect(rendered[:license]).to include("resell or redistribute")
+    expect(rendered[:license].scan('<ul class="terms">').length).to eq(1)
   end
 
   it "renders the credits page with a QR back to the board" do


### PR DESCRIPTION
Stacked on #614 — **base is `claude/board-printables-pages-design-698a2a`, not `main`.** Merge #614 first, then this retargets to `main` automatically.

Three refinements to the redesigned wrapper pages.

## Each file describes only itself

The how-to-use page made a claim about a document it wasn't always in. A set is emitted as two separate files, but both carried the same *"this printable comes as two files"* copy — so someone holding the low-ink print was told about a colour file they didn't have, which raises a question the page can't answer.

Step 1 is now rendered per variant:

| File | Step 1 |
|---|---|
| Set, colour | **Printed in full color** — "Every board in this file uses the same tile colors your communicator sees on screen." |
| Set, low-ink | **Printed low-ink** — "Every board in this file uses white tile backgrounds, so it prints cleanly and goes easy on your ink." |
| Single board | **Printed twice** — unchanged; that file really does hold both halves |

Neither set variant mentions the other file.

`RenderWrappers` gains `how_to_use_low_ink` alongside `cover_low_ink`, both only for a set. `MergePdf#cover_for` generalises to `wrapper_for(key, variant)` with the same fall-back-if-absent behaviour for either page.

## License is one list

The check and cross marks already carried the yes/no, so the two boxes were splitting five sentences into a permissions matrix the reader had to cross-reference — and the narrow columns squeezed each term onto three and four lines with a stranded last word. At full measure they fit on one or two. Colours and marks are unchanged.

Also drops the "not sure whether it's covered? Ask us at speakanyway.com" callout.

## Typesetting

`text-wrap: pretty` on body copy to kill orphans, `text-wrap: balance` on the short centred blocks (headings, intros, captions), `hyphens: none`, and nothing justified. Both `text-wrap` values are ignored by an older Chrome rather than breaking, so the render degrades to the default greedy wrap.

Three breaks survived that and were fixed in the copy instead, since CSS can't fix bad sentences:

- Step 3's em dash kept landing at the *start* of a line, where it reads as a stray mark → full stop.
- Step 4's "Familiarity helps." was stranded on a line of its own, making that card visibly taller than the one beside it → shortened so the pair matches.
- "…before you need / it." orphaned a two-letter word from its verb → `&nbsp;`.

## Test plan

- `bundle exec rspec spec/services/boards/printables` — **52 examples, 0 failures.**
- New coverage: the colour and low-ink how-to pages each name their own print; **neither contains "two files" or "twice"**; `how_to_use_low_ink` is present for a set and absent for a single board; the license renders exactly one `<ul class="terms">`.
- `merge_pdf_spec` extended — it fingerprints every wrapper by MediaBox width, so it now proves the low-ink file gets *both* the ink-light cover and the low-ink instructions, and that dropping both keys falls back to the colour pair rather than merging `nil`.
- Rendered all seven pages (set colour, set low-ink, single) through real Grover: each is exactly one Letter sheet, and the two how-to variants differ only in step 1.

## Reviewer notes

- Step 1 is the only copy that changed for reasons other than typesetting. Steps 2–6 and the closing callout are untouched apart from the three line-break fixes above.
- The single-board path is unchanged in output — same one cover, one how-to, same "includes the board twice" copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)