### PR TITLE
test: park the users id sequence above hand-pinned admin ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,14 @@ permissions matrix lives in
   `VocabSets`) need the admin created with that specific ID in specs —
   `create(:admin_user)` assigns a random ID and the lookups return nil.
   Use: `User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)`
+- That pinned-id insert is safe **because** `spec/support/users_id_sequence.rb`
+  parks the `users` primary-key sequence above every hand-picked id (an
+  explicit-id INSERT doesn't advance the Postgres sequence, and sequences
+  aren't rolled back between examples, so without the guard the next
+  `create(:user)` in the process is handed the admin's id and dies on
+  `users_pkey`). Never "fix" an ordering collision by resetting the sequence
+  down to `MAX(id) + 1` in a spec — that reinstates the zero-slack state the
+  guard exists to avoid.
 
 ## Documentation rules (this file + the spokes)
 

--- a/spec/config/users_id_sequence_spec.rb
+++ b/spec/config/users_id_sequence_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+# Guards the invariant that keeps pinned-id admin specs from poisoning whatever
+# runs after them in the same process. See spec/support/users_id_sequence.rb.
+RSpec.describe UsersIdSequence do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  def sequence_value
+    connection.select_value(
+      "SELECT COALESCE(pg_sequence_last_value(pg_get_serial_sequence('users', 'id')::regclass), 0)"
+    ).to_i
+  end
+
+  def desync_sequence!(to)
+    connection.execute("SELECT setval(pg_get_serial_sequence('users', 'id'), #{to}, false)")
+  end
+
+  it "starts every example with the next id clear of DEFAULT_ADMIN_ID and of MAX(id)" do
+    expect(described_class.next_id).to be > User::DEFAULT_ADMIN_ID
+    expect(described_class.next_id).to be > (User.maximum(:id) || 0)
+  end
+
+  it "lets a spec pin the admin at DEFAULT_ADMIN_ID and still build users afterwards" do
+    admin = User.find_by(id: User::DEFAULT_ADMIN_ID) ||
+            FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+
+    expect(admin.id).to eq(User::DEFAULT_ADMIN_ID)
+    expect { FactoryBot.create(:user) }.not_to raise_error
+    expect(FactoryBot.create(:user).id).to be > User::DEFAULT_ADMIN_ID
+  end
+
+  describe ".ensure_clear!" do
+    it "repairs a sequence that would hand out an already-pinned id" do
+      FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      # What a fresh database looks like after an explicit-id insert: the
+      # sequence never advanced, so nextval would return DEFAULT_ADMIN_ID.
+      desync_sequence!(User::DEFAULT_ADMIN_ID)
+      expect(described_class.next_id).to eq(User::DEFAULT_ADMIN_ID)
+
+      described_class.ensure_clear!
+
+      expect(FactoryBot.create(:user).id).to be > User::DEFAULT_ADMIN_ID
+    end
+
+    it "leaves headroom above MAX(id) rather than sitting on it" do
+      FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      described_class.ensure_clear!
+
+      expect(described_class.next_id).to be > described_class::FLOOR
+    end
+
+    it "never moves the sequence backwards" do
+      described_class.ensure_clear!
+      high = sequence_value + 5_000
+      connection.execute("SELECT setval(pg_get_serial_sequence('users', 'id'), #{high}, true)")
+
+      described_class.ensure_clear!
+
+      expect(sequence_value).to eq(high)
+    end
+
+    it "is idempotent" do
+      described_class.ensure_clear!
+      before = sequence_value
+      described_class.ensure_clear!
+
+      expect(sequence_value).to eq(before)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,19 +61,9 @@ RSpec.configure do |config|
 
   config.before(:each) do
     ActiveStorage::Current.url_options = { host: "localhost", port: 4000, protocol: "http" }
-
-    # Keep the users id sequence above User::DEFAULT_ADMIN_ID. Several specs
-    # insert the admin with an explicit id (== DEFAULT_ADMIN_ID); an explicit
-    # id doesn't advance the Postgres sequence, and sequences aren't rolled back
-    # between examples — so depending on shard/run order, a later create(:user)
-    # could grab that same id and raise PG::UniqueViolation on users_pkey. This
-    # makes the next sequence id deterministically clear of the fixed admin id.
-    ActiveRecord::Base.connection.execute(<<~SQL)
-      SELECT setval(
-        pg_get_serial_sequence('users', 'id'),
-        GREATEST(COALESCE((SELECT MAX(id) FROM users), 0), #{User::DEFAULT_ADMIN_ID}),
-        true
-      )
-    SQL
   end
+
+  # The `users` primary-key sequence is parked above every hand-pinned id by
+  # spec/support/users_id_sequence.rb. Read that file before touching a spec
+  # that inserts a user at an explicit id.
 end

--- a/spec/requests/api/internal/profiles_spec.rb
+++ b/spec/requests/api/internal/profiles_spec.rb
@@ -5,13 +5,7 @@ RSpec.describe "API::Internal::Profiles", type: :request do
   let(:auth_headers) { { "Authorization" => "Bearer #{internal_key}" } }
   let(:json_headers) { auth_headers.merge("Content-Type" => "application/json") }
   let!(:admin_user) do
-    user = User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
-    # Inserting a row with an explicit primary key does not advance the
-    # `users` sequence, so the next factory-built user (e.g. via
-    # `create(:child_account)`'s `association :user`) would otherwise collide
-    # on id=1. Reset the sequence to MAX(id)+1.
-    ActiveRecord::Base.connection.reset_pk_sequence!("users")
-    user
+    User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
   end
   let(:profile_owner) { create(:child_account) }
   let!(:profile) do

--- a/spec/support/users_id_sequence.rb
+++ b/spec/support/users_id_sequence.rb
@@ -1,0 +1,69 @@
+# Keeps the Postgres `users` primary-key sequence clear of the ids specs pin
+# by hand.
+#
+# Several specs have to insert the seed admin at an explicit primary key
+# (`User::DEFAULT_ADMIN_ID`) because services look it up by that id. An
+# explicit-id INSERT does not advance `users_id_seq`, and sequences are not
+# rolled back with the surrounding transaction — so on a freshly prepared
+# database (CI, or a local `db:test:prepare`) the sequence still points at
+# DEFAULT_ADMIN_ID after the pinned insert, and the next factory-built user is
+# handed that same id:
+#
+#   PG::UniqueViolation: duplicate key value violates unique constraint
+#   "users_pkey" DETAIL: Key (id)=(1) already exists.
+#
+# Whether it blows up depends entirely on spec order, which makes it a
+# recurring, hard-to-place CI failure rather than a reproducible one.
+#
+# The fix is headroom, not bookkeeping at the call sites: park the sequence
+# far above every id a spec pins, so a hand-picked id and a sequence-issued id
+# can never be the same number. Two rails matter here:
+#
+#   * The floor is well above DEFAULT_ADMIN_ID, not one step above it. Sitting
+#     exactly at MAX(id) leaves zero slack, so any row the `MAX(id)` probe
+#     can't see — one inserted later in the same example, or from a
+#     `before(:all)` block — lands right back on the next sequence value.
+#   * The guard is monotonic. It never moves the sequence backwards, so it can
+#     only ever widen the gap, and re-running it is always safe.
+module UsersIdSequence
+  # Well clear of User::DEFAULT_ADMIN_ID (1) and of any id a spec pins by hand.
+  FLOOR = 10_000
+
+  # A single statement per call: leave the sequence at the highest of (where it
+  # already is, the largest id in the table, the floor). `pg_sequence_last_value`
+  # is NULL until the sequence has been advanced, which the COALESCE turns into
+  # 0 so a never-used sequence jumps straight to the floor.
+  ENSURE_SQL = <<~SQL.freeze
+    SELECT setval(
+      pg_get_serial_sequence('users', 'id'),
+      GREATEST(
+        COALESCE(pg_sequence_last_value(pg_get_serial_sequence('users', 'id')::regclass), 0),
+        COALESCE((SELECT MAX(id) FROM users), 0),
+        #{FLOOR}
+      ),
+      true
+    )
+  SQL
+
+  def self.ensure_clear!
+    ActiveRecord::Base.connection.execute(ENSURE_SQL)
+  end
+
+  # The id nextval would hand out right now, without consuming it. A sequence
+  # that has never been advanced (is_called = false) returns last_value itself.
+  def self.next_id
+    connection = ActiveRecord::Base.connection
+    sequence = connection.select_value("SELECT pg_get_serial_sequence('users', 'id')")
+    row = connection.select_one("SELECT last_value, is_called FROM #{sequence}")
+    row["is_called"] ? row["last_value"].to_i + 1 : row["last_value"].to_i
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) { UsersIdSequence.ensure_clear! }
+
+  # `before(:context)` covers test_prof's `before_all` / `let_it_be`, which
+  # create records before any example-level hook has run.
+  config.before(:context) { UsersIdSequence.ensure_clear! }
+  config.before(:each) { UsersIdSequence.ensure_clear! }
+end

--- a/spec/support/users_id_sequence.rb
+++ b/spec/support/users_id_sequence.rb
@@ -26,7 +26,9 @@
 #   * The guard is monotonic. It never moves the sequence backwards, so it can
 #     only ever widen the gap, and re-running it is always safe.
 module UsersIdSequence
-  # Well clear of User::DEFAULT_ADMIN_ID (1) and of any id a spec pins by hand.
+  # Must stay above every id a spec pins by hand: User::DEFAULT_ADMIN_ID (1)
+  # and the handful of literals in use (42, 4242, 9001). Raise it if a spec
+  # ever needs a larger one — `grep -rn "id: [0-9]" spec/` finds them.
   FLOOR = 10_000
 
   # A single statement per call: leave the sequence at the highest of (where it


### PR DESCRIPTION
## Summary

Fixes the order-dependent `PG::UniqueViolation` on `users_pkey` that shows up in RSpec whenever a spec that pins an explicit primary key runs before a spec that builds users from factories.

Several specs must insert the seed admin at `User::DEFAULT_ADMIN_ID` because services look it up by that id. An explicit-id `INSERT` does not advance `users_id_seq`, and sequences are not rolled back with the surrounding transaction — so on a freshly loaded schema the sequence still points at `DEFAULT_ADMIN_ID` after the pinned insert, and the next factory-built user is handed the same id:

```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: duplicate key value violates unique constraint "users_pkey"
DETAIL:  Key (id)=(1) already exists.
```

Reduced to a three-line repro outside RSpec, which is where the `is_called => false` detail became visible:

```
admin id=1  seq=[{"last_value"=>1, "is_called"=>false}]
RAISED: ActiveRecord::RecordNotUnique: PG::UniqueViolation: duplicate key value violates unique constraint "users_pkey"
```

**Why it reads as random.** CI creates a new database and runs `db:schema:load` per shard, then splits spec files with `awk "NR % 3 == index"`. Every shard therefore starts in exactly the vulnerable state (`last_value = 1, is_called = false`), and whether a pinned-id spec lands before any factory user is down to the shard split. Locally it hides, because after one run the sequence has drifted out of the vulnerable range and stays there.

**It is not always loud.** The pinned-id idiom is `User.find_by(id: DEFAULT_ADMIN_ID) || create(:admin_user, id: ...)`. When the desynced sequence had already handed id 1 to an ordinary factory user, `find_by` returns *that* user and the spec proceeds with a non-admin standing in for the seed admin. That is what `spec/sidekiq/build_board_set_job_grid_spec.rb` was hitting: `RuntimeError: Import produced no root board for "core-84"`, six failures on `main`, zero here.

## Approach

Fix the sequence, not the call sites — the pinned-id pattern is documented in `CLAUDE.md` and has to stay.

There was already a guard in `spec/rails_helper.rb` (added in #530), but it parked the sequence at exactly `GREATEST(MAX(id), DEFAULT_ADMIN_ID)` on every example. That leaves zero slack: any row the `MAX(id)` probe can't see lands straight back on the next sequence value.

`spec/support/users_id_sequence.rb` replaces it with a guard built on two rails:

* **Headroom, not bookkeeping.** One `setval` raises the sequence to `GREATEST(current, MAX(id), 10_000)`. The floor clears every id the suite pins by hand — `1` (`DEFAULT_ADMIN_ID`), `42`, `4242`, `9001` — so a hand-picked id and a sequence-issued id can never be the same number.
* **Monotonic.** It never moves the sequence backwards, so re-running it can only widen the gap and is always safe.

Applied at `before(:suite)`, `before(:context)` (covers test_prof's `before_all` / `let_it_be`, which create records before any example-level hook runs) and `before(:each)` — the same one-query-per-example cost as the guard it replaces, so no suite slowdown.

Also drops the `reset_pk_sequence!("users")` workaround from `spec/requests/api/internal/profiles_spec.rb`: it pulled the sequence back down to the zero-slack state the guard exists to avoid.

## Test plan

`spec/config/users_id_sequence_spec.rb` (new, 6 examples) covers the invariant, the repair, the headroom, monotonicity, and idempotence.

Every ordering below was started from the vulnerable state (`setval('users_id_seq', 1, false)`) rather than whatever the local database had drifted to:

| Ordering | Result |
|---|---|
| `board_spec` → `images_spec` (seed 19171 — the reported repro) | 114 examples, 0 failures |
| `images_spec` → `board_spec` (seed 4242) | 114 examples, 0 failures |
| `requests/api/internal` → `images_spec` (seed 7) | 180 examples, 0 failures |
| `profiles_spec` → `image_spec` → `doc_spec` (seed 99) | 45 examples, 0 failures |
| `build_board_set_job_grid_spec` → `images_spec` (seed 5) | 31 examples, 0 failures (**6 failures on `main`**) |
| `build_board_set_job_grid_spec` alone | 9 examples, 0 failures |
| `spec/config/users_id_sequence_spec.rb` | 6 examples, 0 failures |
| `board_spec` → `images_spec`, seeds 1–10 | 114 examples, 0 failures each |

The full suite was **not** run locally — `build_board_set_job_grid_spec.rb` alone takes 7 minutes — so CI's three shards are the full-suite check here. They are also the more meaningful test: each shard starts from a freshly loaded schema, which is the exact condition that triggers the bug.

No `CHANGELOG.md` entry: test-infrastructure only, nothing user-facing.

## Docs

`CLAUDE.md` gains a note under Testing explaining why the pinned-id pattern is safe, and that an ordering collision must never be "fixed" by resetting the sequence down to `MAX(id) + 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)