### PR TITLE
feat(admin): board builder phases 1 + 2 — word list, AI drafting, art preview, build

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -1,0 +1,405 @@
+# Handoff: Admin Board Builder (backend)
+
+**Date:** 2026-08-07 · **Status:** not started
+**Full plan:** `../drafts/admin-board-builder-plan.md` (this doc is self-contained; the plan adds context)
+**Counterpart:** none — this is backend-only, server-rendered `/admin`
+**Issue:** none filed
+
+## Baseline
+
+Planned against `origin/main` as of 2026-08-07. Four merged PRs are load-bearing
+for the decisions below — `#570` (`predictive_board_id` permitted on internal
+board_images), `#573` (`ImageResolver` on the bulk path), `#584` (`board_images`
+update/destroy), `#585` (label search tiers). If you're on anything older, these
+notes will read as wrong.
+
+## What we're building
+
+An admin page at `/admin/board_builds` that authors a **dense** AAC board — every
+grid cell filled, real symbol art on every tile, Fitzgerald colors, `polly:kevin`
+— with a **mandatory art-review step before anything is written**.
+
+This ports the `speakanyway-board-build` skill
+(`marketing/skills/speakanyway-board-build/scripts/build_board.py` in the
+workspace, ~816 lines) out of a Python script that drives the internal HTTP API
+and into the app itself.
+
+**The key insight: don't port the HTTP client.** The script pins `image_id`s,
+double-searches labels, tolerates 500-after-commit, and reports unlinked tiles
+because it is a remote client working around API limits that no longer exist.
+This page is in-process Rails. Call `Boards::ImageResolver`, `Images::LabelSearch`
+and the models directly. Do **not** have Rails HTTP-call `/api/internal/*`.
+
+## Decisions (already made — don't re-litigate)
+
+1. **Server-rendered ERB admin**, not the React admin. `Admin::VideoBoardsController`
+   and `Admin::BoardPrintablesController` both live there; this is the third.
+2. **Two-step build: preview, then confirm.** Submitting the form resolves art
+   and shows coverage, fuzzy matches, and license flags. **Nothing is written
+   until a second, explicit Build click.** This is the single most valuable
+   behaviour being ported — a wrong symbol is expensive to fix after the fact.
+3. **Boards are created unpublished.** Publishing is a separate confirmed action,
+   never chained onto a build.
+4. **Boards are owned by `User::DEFAULT_ADMIN_ID`**, not `current_user` — same as
+   `Admin::VideoBoardsController#seed_admin`.
+5. **Phase 1 is a single board. Phase 3 adds linked child pages.** Build them in
+   that order.
+6. **AI word-list drafting (Phase 2) only ever populates the form.** It never
+   feeds the build directly; a human edits before preview.
+7. No new gems, no new ENV vars.
+
+## Current state — what already exists
+
+### The pattern to copy: `Admin::VideoBoardsController`
+
+`app/controllers/admin/video_boards_controller.rb` (~176 lines) is the closest
+precedent and its two rails are stated in its own class comment. Copy both:
+
+- **A `SEEDER_SETTING` marker + a scoped finder.** It sets
+  `settings["video_seeder"] = true` and every member action goes through
+  `seeded_boards` (`Board.where("(settings ->> :key) = 'true'", key: SEEDER_SETTING)`),
+  so `destroy`/`publish` can never reach an unrelated board by id. Use
+  `settings["admin_builder"] = true` the same way.
+- **Nothing is written until every row parses.** `validation_error(form)` returns
+  a string or nil; `create` renders `:new` with `:unprocessable_entity` and the
+  raw submitted values preserved (`submitted_form`) so the admin doesn't retype.
+  It reads raw `params[:...]` rather than strong params — match that.
+
+Its service, `app/services/video_boards/board_seeder.rb`, is `module_function`
+style with a `build_board!(cfg, admin:)` entry point. Same shape here.
+
+### The pattern for a long job from ERB admin: `Admin::BoardPrintablesController`
+
+`create` builds a status record, calls `GenerateBoardPrintableJob.perform_async(id)`,
+and redirects to `show`, which renders status. Jobs live in **`app/sidekiq/`**
+(not `app/jobs/`), plain classes with `include Sidekiq::Job`.
+
+### Image resolution — all of it already exists
+
+- **`Boards::ImageResolver`** (`app/services/boards/image_resolver.rb`).
+  `resolve_all(labels, owner:)` batches in 2 queries; `best_arted_for(label, owner)`
+  prefers art-bearing images, case-insensitively, owner's first then
+  `Image.public_img.where(user_id: [User::DEFAULT_ADMIN_ID, nil])`.
+- **🚨 `resolve` and `resolve_all` CREATE a blank `Image` row for any label with
+  no match.** The source says so explicitly: *"never call it from a read-only
+  path."* **Your preview step must not use them.** Use `Images::LabelSearch` (or
+  `best_arted_for`, which is read-only) for the preview, and `resolve_all` only
+  inside the build transaction.
+- **`Images::LabelSearch`** (`app/services/images/label_search.rb`).
+  `new(match:, limit:, commercial_safe:, include_share_alike:, resolve:)`.
+  Its `tiers` are lazy and best-first: `resolve` → `literal_matches`
+  (`LOWER(label) = LOWER(?)`, ordered by doc count) → `search_by_exact_label` →
+  `search_by_label`.
+  - **`resolve: true` is exactly what you want for the preview** — it prepends
+    "what the resolver would actually attach," and a resolve row is never dropped
+    by the `commercial_safe` filter (deliberate: it answers "does art exist at
+    all", separately from "may we sell it").
+  - `serialize` returns `source_type, license, commercial_safe,
+    attribution_required, share_alike, src, original_url, match`.
+  - **`src` is nil until the 288px variant is processed.** Never treat nil `src`
+    as "no art" — check `original_url`.
+
+The skill's belief that bulk POST and GET search disagree on exact matches is
+**stale**; `#585` routed both through `tiers`. Don't port the second-pass loop.
+
+### Colors
+
+`app/helpers/color_helper.rb` — `PRESET_DATA` is the Modified Fitzgerald key
+(`part_of_speech` → hex), `PARTS_OF_SPEECH` is the canonical 12-value list, and
+`ColorHelper.to_hex(value, default:)` normalizes. `module_function`, so call
+`ColorHelper.to_hex(...)`.
+
+**Don't port the script's `bg_color` computation.** It builds Fitzgerald hexes
+by hand only because the internal API won't accept `part_of_speech`. In-process
+you can set the real attribute and get the color for free — but the timing
+matters:
+
+```ruby
+board_image = board.add_image(image_id)
+raise "image #{image_id} not found" if board_image.nil?   # add_image returns nil on failure
+board_image.update!(part_of_speech: pos)                  # fires set_colors
+```
+
+`BoardImage#set_colors` is declared `before_update :set_colors, if:
+:part_of_speech_changed?` — **`before_update`, so it does not fire on create.**
+On the create path colors come from `before_create :set_defaults`, which uses the
+*Image's* `bg_color`, not the part of speech. (`Board#add_image` works around
+this by calling `set_colors` explicitly before save.) So setting
+`part_of_speech` as a separate `update!` after the tile exists is what actually
+applies the Modified Fitzgerald color. Don't also pass `bg_color` — the callback
+would overwrite it.
+
+Note `Board#add_image(image_id, layout = nil)` returns `nil` rather than raising
+on a missing image or a failed save. `Boards::BoardTreeBuilder` guards this with
+a raise; do the same, inside the transaction, so a bad id aborts the build
+instead of silently producing a short board.
+
+### Columns, rows, layout
+
+- **Rows are never stored.** `Board#rows_for_screen_size` returns `max(y + h)`
+  across tiles. So a short final row doesn't create an empty row — it creates
+  conspicuous empty cells at the right end of the last one. That is the entire
+  reason for the tile-count rule below.
+- `Boards::ScreenColumns.derive(lg, screen_size)` — `md ≈ round(lg × 2/3)`,
+  `sm ≈ round(lg / 3)` floored at 2. **Set only `large_screen_columns`.** Hand-
+  setting md/sm writes `settings["custom_screen_layouts"]` and permanently stops
+  reflow. (Note `VideoBoards::BoardSeeder` sets all four equal — do *not* copy
+  that part.)
+- `Board#set_screen_sizes` (`before_create`) defaults `large_screen_columns` to
+  **8** when nil. Always set it explicitly.
+- `Board#apply_layout!(layout:, screen_size:, columns:, margins:, settings:)` —
+  `layout` items are **string-keyed** (`"i"`, `"x"`, `"y"`, `"w"`, `"h"`) where
+  `"i"` is the **BoardImage** id, but `columns:`/`margins:` are read with
+  **symbol** keys. It sorts by `[y, x]` and rewrites each tile's `position`, so
+  the layout — not creation order — determines final tile order.
+- `Board#open_grid_cells(screen_size)` is the existing density primitive.
+
+### Other behaviour worth knowing before it surprises you
+
+- **Linked children drop out of internal board search.** Setting
+  `predictive_board_id` flips `Board#check_is_sub_board`, and
+  `Boards::AdminSearch.base_scope` filters both `sub_board: [false, nil]` and
+  `.not_builder_child`. Expected; fetch children by id, and don't build the
+  admin index page on top of `AdminSearch` or Phase 3's children will vanish
+  from it.
+- **Slug collisions get a hex suffix** — `generate_unique_slug` appends
+  `SecureRandom.hex(4)` rather than erroring, so building "At the Park" twice
+  silently produces `at-the-park-a1b2c3d4`. Surface the final slug in the UI;
+  a printed QR target depends on it. (It assigns only — the caller saves.)
+- **`VoiceService.normalize_voice` passes through any string containing a colon
+  without validating it.** `polly:kevn` saves fine and only fails later at audio
+  synthesis. Constrain voice to a select box; don't take free text.
+- Setting `voice` on a Board cascades to tiles and re-queues audio — set it at
+  create time rather than patching after.
+
+## Work items
+
+### Phase 1 — single board, manual word list
+
+#### 1. `AdminBoardBuild` model + migration
+
+```ruby
+create_table :admin_board_builds do |t|
+  t.references :board, foreign_key: true                 # null until built
+  t.references :created_by, foreign_key: { to_table: :users }
+  t.string  :status, null: false, default: "pending"     # pending/building/complete/failed
+  t.string  :name, null: false
+  t.string  :topic
+  t.integer :columns_count, null: false
+  t.integer :rows_count, null: false
+  t.boolean :commercial_safe_only, null: false, default: true
+  t.jsonb   :plan, null: false, default: {}              # the authored tiles
+  t.jsonb   :art_report, null: false, default: {}        # coverage at build time
+  t.text    :error_message
+  t.timestamps
+end
+add_index :admin_board_builds, [:status, :created_at]
+```
+
+Persisting `plan` and `art_report` is what makes a failed build re-runnable
+without re-authoring, and gives the `show` page something to render.
+
+#### 2. `Boards::AdminBuilder::PlanValidator`
+
+Port of the script's `validate()` (build_board.py:103–173). Returns an array of
+human-readable problem strings; empty means safe to build.
+
+- **`tiles.length` must equal `columns × rows`.** Reject otherwise with a message
+  naming how many to add or remove. This is the rule the whole feature exists
+  for — a partial final row reads as broken on a classroom TV. Provide an
+  explicit "allow a partial row" checkbox as the escape hatch, unchecked.
+- Every tile needs a non-empty label.
+- Duplicate labels are an error, not a warning — each one costs a cell and buys
+  nothing.
+- `part_of_speech` must be in `ColorHelper::PARTS_OF_SPEECH`.
+
+#### 3. `Boards::AdminBuilder::ArtPreview` — **read-only**
+
+Input: labels + `commercial_safe_only`. Output per label:
+`{ label, image_id, matched_label, exact:, license:, commercial_safe:, src: }`
+plus aggregate `coverage_pct`, `missing[]`, `inexact[]`.
+
+- Use `Images::LabelSearch.new(commercial_safe:, resolve: true).call(label)`.
+- **Exact vs. fuzzy is the point.** A hit whose own label differs from the
+  requested word is a judgment call, not a match — the classic failure is `my`
+  resolving to art labeled *"too tired to speak as it uses a lot of my energy…"*.
+  Surface every one for review; don't silently accept.
+- **Write nothing.** No `ImageResolver.resolve`, no `Image.create`.
+- Render the resolved symbols as an actual image grid, not just a table of
+  labels. Coverage numbers don't show that a symbol is technically correct and
+  visually wrong.
+
+#### 4. `Boards::AdminBuilder::Build` + `BuildAdminBoardJob`
+
+Inside one transaction:
+
+1. `Boards::ImageResolver.resolve_all(labels, owner: seed_admin)` — here it's
+   correct that misses create blank Images; those are what generation targets.
+2. Create the board: `board_type: "static"`, `voice`, `large_screen_columns`,
+   `settings: { "admin_builder" => true, "disable_scroll" => true }`,
+   `user: seed_admin`, `published: false`.
+3. Add tiles in authored order via `Board#add_image(image_id)` (guarding the nil
+   return), then `update!(part_of_speech:)` per the Colors section above, plus
+   `display_label` when given.
+4. `apply_layout!` with reading-order coordinates:
+   `{ "i" => board_image.id.to_s, "x" => idx % cols, "y" => idx / cols, "w" => 1, "h" => 1 }`.
+
+After commit (not inside it), queue art for labels that resolved to a blank
+Image: `Image.where(id: ids).where.missing(:docs)`, in slices of 3, via
+`GenerateImagesJob.perform_async(batch, board.id)` — matching
+`API::Internal::BoardImagesController#queue_missing_art!`.
+
+**Use a topic-aware prompt**, not a bare label. This is the difference between
+*swing* on a playground board and a mood swing. The script's prompt
+(build_board.py:424–428) is worth lifting near-verbatim.
+
+Set `status: "failed"` with `error_message` on rescue, then re-raise so Sidekiq
+retries.
+
+#### 5. `Admin::BoardBuildsController`
+
+Routes go inside the existing `namespace :admin` block, following the local
+`as: :dashboard_*` convention:
+
+```ruby
+resources :board_builds, only: [:index, :new, :create, :show, :destroy],
+          as: :dashboard_board_builds do
+  collection { post :preview }
+  member     { post :publish; post :unpublish }
+end
+```
+
+| Action | Does |
+|---|---|
+| `new` | blank form: name, topic, columns select, voice select, word rows |
+| `preview` | validate → resolve art read-only → render the review screen. **No writes.** |
+| `create` | re-validate, create the `AdminBoardBuild`, `perform_async`, redirect to `show` |
+| `show` | status, resulting board link + slug, art coverage |
+| `publish` | separate + confirmed; refuse if the board has no tiles |
+
+Re-validate in `create`. The preview round-trip is a hidden-field resubmit and
+must not be trusted.
+
+Add a nav link in `app/views/layouts/admin.html.erb` and a card on
+`app/views/admin/dashboard/index.html.erb`. Design tokens are already defined in
+the admin layout: `admin-card`, `admin-card-alt`, `admin-input`, `text-t1/t2/t3`,
+`text-accent`, `admin-hover-row`, `admin-flash-ok/err`. Active nav state idiom is
+`request.path.start_with?("/admin/…")`.
+
+### Phase 2 — `Boards::AdminBuilder::WordListDrafter`
+
+Topic + `columns × rows` + optional audience → `[{ label:, part_of_speech: }]`.
+
+**Write a new prompt; don't compose the existing pieces.**
+`Board#get_words_for_scenario` needs a persisted Board and returns bare strings,
+and `AacWordCategorizer.categorize` is one OpenAI call *per word* — composing
+them is an N+1 against an API. One call returning both fields is the whole job.
+
+Use `OpenAiClient` (it's at **`app/models/open_ai_client.rb`**, not
+`app/services/`) with `GTP_MODEL`. Follow `Boards::AiPageGenerator`'s shape
+exactly — `OpenAiClient.new(messages: [...])`, `create_chat(true)` for a JSON
+response, `JSON.parse`, and a `GenerationError` raised on both a blank response
+and a parse failure. Tolerate `"word"` as an alias for `"label"` in the response
+the way its `parse_response` does.
+
+The prompt must carry the skill's actual authoring rules, or the output will be
+a noun list: the core spine (`I, you, it, want, go, stop, more, help, like, not,
+yes, all done, look, my turn, what, where`) placed first; a rough balance of
+30–40% verbs and core function words, 15–20% pronouns/determiners, 15–20%
+describing words, 25–35% topic nouns; no near-duplicates; and **exactly**
+`columns × rows` entries.
+
+No credit charge — admin-owned. Populate the form; never build from it directly.
+
+### Phase 3 — linked child pages
+
+- Plan gains `children: [{ key, name, tiles }]` and tiles gain `links_to`.
+- **Every board in the set shares the root's grid.** A communicator shouldn't
+  have cell size change under their finger mid-navigation. `--allow-mixed-grids`
+  becomes a checkbox needing an explicit tick.
+- Build order: create a board only after everything it links to exists. Cycles
+  are normal — a child usually has a "back to home" tile. Break cycles at the
+  **back** edge, never at a root→child edge. Port `build_order()`
+  (build_board.py:176–215) rather than re-deriving it.
+- Set the link with `board_image.update!(predictive_board_id: child.id)` —
+  `Boards::BoardTreeBuilder` already does exactly this.
+
+### Phase 4 — verify + publish
+
+`status: "complete"` means the board record finished writing. It says nothing
+about whether any tile has a picture, which is the failure this whole feature
+exists to prevent. On `show`, report tiles whose Image has no doc
+(`Image.where(id: board.board_images.select(:image_id)).where.missing(:docs)`)
+and surface `Board#has_generating_images?` so a half-generated board is
+obviously mid-flight rather than broken.
+
+## Testing
+
+Request specs in `spec/requests/admin/`. **`spec/requests/admin/video_boards_spec.rb`
+is the direct precedent — read it first.** Note its required setup:
+
+```ruby
+include Devise::Test::IntegrationHelpers
+let!(:seed_admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+before do
+  allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+  allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+end
+```
+
+(The asset stubbing is required — the admin layout calls `stylesheet_link_tag`.)
+
+Authorization matrix — prove every row:
+
+| Caller | Expect |
+|---|---|
+| signed out | redirect to sign-in, nothing written |
+| `role: "user"` | redirect to `root_path`, nothing written |
+| `role: "admin"` | 200 |
+| admin, `publish` on a board this page didn't create | not found / redirect — prove the `admin_builder` scoping holds |
+
+Behaviour to prove:
+
+- **`preview` writes nothing** — assert `.not_to change(Board, :count)` *and*
+  `.not_to change(Image, :count)`. The `Image` half is the one that will actually
+  catch a regression, since `ImageResolver.resolve_all` creates rows.
+- tile count ≠ `columns × rows` → re-renders `:new`, 422, nothing written, and
+  the submitted values are still in the form
+- duplicate labels rejected; unknown `part_of_speech` rejected
+- happy path → `published == false`, `user_id == DEFAULT_ADMIN_ID`,
+  `settings["admin_builder"] == true`, `large_screen_columns` as chosen, and
+  md/sm derived by `ScreenColumns` rather than set equal to lg
+- tiles land in authored reading order after `apply_layout!`
+- a label with no art → blank Image created, generation queued **after** commit,
+  in slices of 3
+- job failure → `status: "failed"` with `error_message`
+- publish refuses a board with no tiles
+- Phase 3: children created before root; a back-edge to root doesn't deadlock;
+  child grid ≠ root grid rejected unless the override is ticked
+
+Add a service spec for `PlanValidator` and for the Phase 3 build ordering
+specifically — both are pure, cheap to test in isolation, and the likeliest to
+regress.
+
+Stub OpenAI in Phase 2 specs; never let a spec make a real call.
+
+Run `bundle exec rspec spec/requests/admin spec/services/boards` before opening
+the PR.
+
+## Deploy notes
+
+- One migration (`admin_board_builds`). No backfill.
+- No new gems. No new ENV vars.
+- Ships in phases; Phase 1 is independently useful and independently
+  releasable.
+- Requires `User::DEFAULT_ADMIN_ID` to exist in every environment it runs in —
+  `Admin::VideoBoardsController#require_seed_admin!` already guards this; copy it.
+
+## Wrap-up
+
+Follow this repo's CLAUDE.md for git workflow and conventions. Open the PR and
+stop — never merge. Commit this doc in the PR so it survives the session.
+Consider a short entry in `.claude-notes/board-builder.md` noting that an
+admin-side builder now exists alongside the user-facing wizard, so the two don't
+get confused later.

--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1028,3 +1028,45 @@ doesn't replace it; both can be set independently. Wiring:
 - **Publishing:** a built set publishes and unpublishes as a unit, behind a 409
   warn+confirm. See "Publish cascade (warn + confirm)" in
   `.claude-notes/boards-and-teams.md`.
+
+## Not this: the admin Board Builder (`/admin/board_builds`)
+
+Everything above is the **user-facing wizard** — communicator-scoped, template
+plus interest words, `POST /api/v1/board_builder`. There is a second, unrelated
+builder in the ERB admin, added in Phase 1 of
+`.claude-notes/admin-board-builder-handoff.md`. Don't confuse them.
+
+`Admin::BoardBuildsController` authors a single **dense public board** from a
+typed word list, owned by `User::DEFAULT_ADMIN_ID`. It shares the wizard's
+image-resolution seam (`Boards::ImageResolver`) and nothing else — no
+communicator, no templates, no interest routing, no `ChildBoard`.
+
+Its own invariants:
+
+- **Preview writes nothing.** `Boards::AdminBuilder::ArtPreview` resolves art
+  through `Images::LabelSearch` (whose `resolve` tier calls the read-only
+  `best_arted_for`), never `ImageResolver.resolve`/`resolve_all` — those create
+  a blank `Image` for any unmatched label, so a read-only path must not call
+  them. `resolve_all` runs only inside `Boards::AdminBuilder::Build`'s
+  transaction, where creating blanks is the intended outcome. Asserted by spec
+  on both `Board.count` and `Image.count`.
+- **Tile count must equal `columns × rows`.** Rows aren't stored
+  (`Board#rows_for_screen_size` derives them), so a short final row leaves dead
+  cells rather than a shorter board. `Boards::AdminBuilder::PlanValidator`
+  rejects it; an "allow a partial row" checkbox is the explicit escape hatch.
+- **Boards are marked `settings["admin_builder"] = true`** and every member
+  action is scoped through `AdminBoardBuild.builder_boards`, the same rail
+  `Admin::VideoBoardsController` runs on. Boards are created unpublished;
+  publishing is a separate confirmed POST that refuses an empty board.
+- **md/sm column counts are derived** via `Boards::ScreenColumns`, explicitly —
+  `Board#set_screen_sizes` only fills them when nil, and
+  `boards.medium/small_screen_columns` carry non-nil database defaults (8 and
+  3), so "set lg and let Rails handle it" silently gives a 6-column board an
+  8-column tablet layout.
+- **AI art for uncovered labels is queued after the commit**, in slices of 3,
+  matching `API::Internal::BoardImagesController#queue_missing_art!`. The
+  board's topic is written to `Image#image_prompt` as intent only — "swing in
+  the context of the playground" — because `Images::PromptBuilder` composes the
+  house style envelope at generation time and must not have it baked in twice.
+
+Phases 2 (AI word-list drafting) and 3 (linked child pages) are not built.

--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1069,4 +1069,15 @@ Its own invariants:
   the context of the playground" — because `Images::PromptBuilder` composes the
   house style envelope at generation time and must not have it baked in twice.
 
-Phases 2 (AI word-list drafting) and 3 (linked child pages) are not built.
+- **AI drafting only ever populates the form.** `POST .../board_builds/draft`
+  runs `Boards::AdminBuilder::WordListDrafter` and re-renders `new` with the
+  textarea filled — it never feeds a preview or a build. The draft is a starting
+  point a human edits; everything downstream still validates it from scratch.
+  Deliberately one new prompt rather than a composition of the existing pieces:
+  `Board#get_words_for_scenario` needs a persisted Board and returns bare
+  strings, and `AacWordCategorizer.categorize` is one OpenAI call *per word*, so
+  chaining them is an N+1 against a paid API. No credit charge — the boards are
+  admin-owned. Short drafts are returned rather than raised on, since the form
+  can absorb them; only an unusable response is an error.
+
+Phase 3 (linked child pages) is not built.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   unpublished; publishing stays a separate, confirmed step. The word list has to
   fill the grid exactly, because a partial last row leaves visible dead cells on
   a classroom screen — there's a checkbox to override it when you mean to.
+- **The word list can be drafted by AI.** Give the builder a topic — and
+  optionally who the board is for — and it fills the list with a board's worth
+  of words, colour-coded by part of speech, leading with the core words that let
+  a communicator say something rather than just name things. It's a starting
+  point, not a result: the draft lands in the editable list, and still has to be
+  reviewed and previewed like anything typed by hand.
 - **Cover-wrapped board printables can be generated in the app.** A sellable,
   print-ready PDF for a board previously required running the
   `speakanyway-printables` GitHub Actions pipeline; its PDF-producing core now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Admins can build a dense board from a word list, and see the symbols before
+  anything is created.** A new admin page takes a board name, a grid size, and a
+  typed word list, then shows the actual picture that would land on every tile —
+  flagging words the library has no art for, and words where it returned art
+  labelled with a different word. Nothing is written until you press Build, so a
+  wrong symbol is caught while it's still free to fix. Boards are created
+  unpublished; publishing stays a separate, confirmed step. The word list has to
+  fill the grid exactly, because a partial last row leaves visible dead cells on
+  a classroom screen — there's a checkbox to override it when you mean to.
 - **Cover-wrapped board printables can be generated in the app.** A sellable,
   print-ready PDF for a board previously required running the
   `speakanyway-printables` GitHub Actions pipeline; its PDF-producing core now

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -32,6 +32,29 @@ module Admin
       @form = blank_form
     end
 
+    # Optional step zero. Drafts a word list into the form and stops there —
+    # the draft is never fed to a preview or a build on its own. A human edits
+    # it, then previews the art, then builds.
+    def draft
+      @form = submitted_form
+      @problems = draft_problems(@form)
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      tiles = Boards::AdminBuilder::WordListDrafter.new(
+        topic: @form[:topic],
+        columns: @form[:columns].to_i,
+        rows: @form[:rows].to_i,
+        audience: @form[:audience],
+      ).call
+
+      @form = @form.merge(words: tiles_to_words(tiles), tiles: tiles)
+      flash.now[:notice] = draft_notice(tiles, @form)
+      render :new
+    rescue Boards::AdminBuilder::WordListDrafter::GenerationError => e
+      @problems = ["Couldn't draft a word list: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    end
+
     # Step one. Read-only: resolves what the library would attach to each tile
     # and renders it for a human to look at. Asserted by spec to change neither
     # Board.count nor Image.count.
@@ -149,10 +172,38 @@ module Admin
       @voice_values ||= VoiceService::VOICES.map { |voice| voice[:value] }
     end
 
+    # Drafting needs a topic and a grid to size the list, and nothing else —
+    # a board can be drafted before it has a name.
+    def draft_problems(form)
+      problems = []
+      problems << "Give the board a topic to draft from." if form[:topic].blank?
+
+      columns = form[:columns].to_i
+      rows = form[:rows].to_i
+      problems << "Columns must be between 1 and #{MAX_COLUMNS}." unless columns.between?(1, MAX_COLUMNS)
+      problems << "Rows must be between 1 and #{MAX_ROWS}." unless rows.between?(1, MAX_ROWS)
+      problems
+    end
+
+    def tiles_to_words(tiles)
+      tiles.map { |tile| "#{tile[:label]} | #{tile[:part_of_speech]}" }.join("\n")
+    end
+
+    # The drafter can come back short (near-duplicates get dropped), which is
+    # survivable because this only fills the textarea — but say so rather than
+    # letting the admin discover it at preview.
+    def draft_notice(tiles, form)
+      wanted = form[:columns].to_i * form[:rows].to_i
+      return "Drafted #{tiles.size} words. Edit them, then preview the art." if tiles.size == wanted
+
+      "Drafted #{tiles.size} of #{wanted} words — add #{wanted - tiles.size} more before previewing."
+    end
+
     def blank_form
       {
         name: "",
         topic: "",
+        audience: "",
         voice: DEFAULT_VOICE,
         columns: DEFAULT_COLUMNS.to_s,
         rows: DEFAULT_ROWS.to_s,
@@ -172,6 +223,7 @@ module Admin
       {
         name: params[:name].to_s.strip,
         topic: params[:topic].to_s.strip,
+        audience: params[:audience].to_s.strip,
         voice: params[:voice].to_s.strip.presence || DEFAULT_VOICE,
         columns: params[:columns].to_s.strip,
         rows: params[:rows].to_s.strip,

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -1,0 +1,228 @@
+module Admin
+  # Admin Board Builder: author a dense AAC board from a word list, review the
+  # symbol art, then build it.
+  #
+  # Three rails are load-bearing and must stay:
+  #   1. Preview writes NOTHING. It resolves art through Images::LabelSearch,
+  #      never Boards::ImageResolver.resolve/resolve_all — those create a blank
+  #      Image row for any label with no match, so a read-only path must not
+  #      touch them. A wrong symbol is expensive to fix after the fact, which is
+  #      the whole reason the build is two steps.
+  #   2. Nothing is written until the plan validates. A bad word list re-renders
+  #      the form with exactly what the admin typed.
+  #   3. Boards are created unpublished and owned by User::DEFAULT_ADMIN_ID.
+  #      Publishing is a separate, confirmed POST, and every member action is
+  #      scoped through AdminBoardBuild.builder_boards so it can never reach a
+  #      board this page didn't create.
+  class BoardBuildsController < Admin::ApplicationController
+    MAX_COLUMNS = 12
+    MAX_ROWS = 12
+    DEFAULT_COLUMNS = 6
+    DEFAULT_ROWS = 4
+    DEFAULT_VOICE = "polly:kevin".freeze
+
+    before_action :require_seed_admin!
+    before_action :set_build, only: %i[show destroy publish unpublish]
+
+    def index
+      @builds = AdminBoardBuild.includes(:board, :created_by).recent.limit(100)
+    end
+
+    def new
+      @form = blank_form
+    end
+
+    # Step one. Read-only: resolves what the library would attach to each tile
+    # and renders it for a human to look at. Asserted by spec to change neither
+    # Board.count nor Image.count.
+    def preview
+      @form = submitted_form
+      @problems = validation_problems(@form)
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      @preview = Boards::AdminBuilder::ArtPreview.new(
+        labels: @form[:tiles].map { |tile| tile[:label] },
+        commercial_safe_only: @form[:commercial_safe_only],
+      ).call
+
+      render :preview
+    end
+
+    # Step two. The preview round-trip is a hidden-field resubmit, so the plan
+    # is parsed and validated again from scratch — never trusted.
+    def create
+      @form = submitted_form
+      @problems = validation_problems(@form)
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      build = AdminBoardBuild.create!(
+        created_by: current_user,
+        status: "pending",
+        name: @form[:name],
+        topic: @form[:topic].presence,
+        voice: @form[:voice],
+        columns_count: @form[:columns].to_i,
+        rows_count: @form[:rows].to_i,
+        commercial_safe_only: @form[:commercial_safe_only],
+        plan: { "tiles" => @form[:tiles].map { |tile| tile.transform_keys(&:to_s) } },
+      )
+      BuildAdminBoardJob.perform_async(build.id)
+
+      redirect_to admin_dashboard_board_build_path(build),
+                  notice: "Building “#{build.name}” — it lands unpublished for review."
+    end
+
+    def show
+      @board = builder_board_for(@build)
+      @tiles = @board ? @board.board_images.includes(:image).order(:position) : []
+      @missing_art_count = @board ? missing_art_count(@board) : 0
+    end
+
+    def publish
+      board = builder_board_for(@build)
+      return redirect_to(admin_dashboard_board_build_path(@build), alert: "No board to publish yet.") if board.nil?
+
+      if board.board_images.empty?
+        return redirect_to admin_dashboard_board_build_path(@build),
+                           alert: "This board has no tiles — refusing to publish an empty board."
+      end
+
+      board.update!(published: true)
+      redirect_to admin_dashboard_board_build_path(@build), notice: "“#{board.name}” is now public."
+    end
+
+    def unpublish
+      board = builder_board_for(@build)
+      return redirect_to(admin_dashboard_board_build_path(@build), alert: "No board to unpublish.") if board.nil?
+
+      board.update!(published: false)
+      redirect_to admin_dashboard_board_build_path(@build), notice: "“#{board.name}” is no longer public."
+    end
+
+    def destroy
+      board = builder_board_for(@build)
+      if board&.published?
+        return redirect_to admin_dashboard_board_builds_path,
+                           alert: "“#{board.name}” is published — unpublish it before deleting."
+      end
+
+      name = @build.name
+      # The build row first: admin_board_builds.board_id carries a foreign key,
+      # so destroying the board while the build still points at it violates it.
+      @build.destroy
+      board&.destroy
+      redirect_to admin_dashboard_board_builds_path, notice: "Deleted “#{name}”."
+    end
+
+    private
+
+    def set_build
+      @build = AdminBoardBuild.find_by(id: params[:id])
+      redirect_to admin_dashboard_board_builds_path, alert: "Board build not found." unless @build
+    end
+
+    # A board is only reachable from here if it carries this page's marker, so
+    # a hand-edited board_id can't turn publish into a lever on any board.
+    def builder_board_for(build)
+      return nil if build.board_id.blank?
+
+      AdminBoardBuild.builder_boards.find_by(id: build.board_id)
+    end
+
+    # Built boards are owned by the canonical admin (parity with
+    # Admin::VideoBoardsController), not whichever admin is signed in.
+    def seed_admin
+      @seed_admin ||= User.find_by(id: User::DEFAULT_ADMIN_ID)
+    end
+
+    def require_seed_admin!
+      return if seed_admin
+
+      redirect_to admin_root_path, alert: "No default admin user configured — cannot build boards."
+    end
+
+    def missing_art_count(board)
+      Image.where(id: board.board_images.select(:image_id)).where.missing(:docs).count
+    end
+
+    def voice_values
+      @voice_values ||= VoiceService::VOICES.map { |voice| voice[:value] }
+    end
+
+    def blank_form
+      {
+        name: "",
+        topic: "",
+        voice: DEFAULT_VOICE,
+        columns: DEFAULT_COLUMNS.to_s,
+        rows: DEFAULT_ROWS.to_s,
+        words: "",
+        tiles: [],
+        commercial_safe_only: true,
+        allow_partial_row: false,
+      }
+    end
+
+    # Keeps the raw submitted strings so a failed submit re-renders exactly what
+    # the admin typed. Reads raw params rather than strong params, matching
+    # Admin::VideoBoardsController.
+    def submitted_form
+      words = params[:words].to_s
+
+      {
+        name: params[:name].to_s.strip,
+        topic: params[:topic].to_s.strip,
+        voice: params[:voice].to_s.strip.presence || DEFAULT_VOICE,
+        columns: params[:columns].to_s.strip,
+        rows: params[:rows].to_s.strip,
+        words: words,
+        tiles: parse_tiles(words),
+        commercial_safe_only: checked?(params[:commercial_safe_only]),
+        allow_partial_row: checked?(params[:allow_partial_row]),
+      }
+    end
+
+    def checked?(value)
+      ActiveModel::Type::Boolean.new.cast(value) || false
+    end
+
+    # One tile per line: `word`, `word | part_of_speech`, or
+    # `word | part_of_speech | tile text`. A textarea rather than N inputs
+    # because a dense board is 24-84 words and pasting a list is the job.
+    def parse_tiles(words)
+      words.to_s.split("\n").filter_map do |line|
+        line = line.strip
+        next if line.blank?
+
+        label, part_of_speech, display_label = line.split("|", 3).map { |part| part.to_s.strip }
+        {
+          label: label.to_s,
+          part_of_speech: part_of_speech.presence || "default",
+          display_label: display_label.presence,
+        }.compact
+      end
+    end
+
+    def validation_problems(form)
+      problems = []
+      problems << "Give the board a name." if form[:name].blank?
+      # VoiceService.normalize_voice passes through any string containing a
+      # colon without validating it, so "polly:kevn" would save fine and only
+      # fail later at audio synthesis. Constrain to the list.
+      problems << "Pick a voice from the list." unless voice_values.include?(form[:voice])
+
+      columns = form[:columns].to_i
+      rows = form[:rows].to_i
+      problems << "Columns must be between 1 and #{MAX_COLUMNS}." unless columns.between?(1, MAX_COLUMNS)
+      problems << "Rows must be between 1 and #{MAX_ROWS}." unless rows.between?(1, MAX_ROWS)
+      return problems if problems.any?
+
+      problems + Boards::AdminBuilder::PlanValidator.new(
+        tiles: form[:tiles],
+        columns: columns,
+        rows: rows,
+        allow_partial_row: form[:allow_partial_row],
+      ).call
+    end
+  end
+end

--- a/app/models/admin_board_build.rb
+++ b/app/models/admin_board_build.rb
@@ -1,0 +1,53 @@
+# One run of the admin Board Builder (`/admin/board_builds`): an authored plan
+# plus the board it produced.
+#
+# The record exists before the board does. `plan` is written at request time so
+# a failed build can be inspected and re-run without the admin re-typing the
+# word list, and `art_report` is written after the build so `show` can say what
+# actually got a picture — which is the failure this whole page exists to catch.
+class AdminBoardBuild < ApplicationRecord
+  STATUSES = %w[pending building complete failed].freeze
+
+  # Marks every board this page creates. Publish/destroy are scoped to it so a
+  # member action can never reach an unrelated board, the same rail
+  # Admin::VideoBoardsController runs on.
+  BUILDER_SETTING = "admin_builder".freeze
+
+  belongs_to :board, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :name, presence: true
+  validates :columns_count, :rows_count, numericality: { greater_than: 0 }
+
+  scope :recent, -> { order(created_at: :desc) }
+
+  # Boards created by this page. Everything that mutates a board goes through
+  # it, so a hand-edited `board_id` can't turn publish into a lever on an
+  # arbitrary board.
+  def self.builder_boards
+    Board.where("(settings ->> :key) = 'true'", key: BUILDER_SETTING)
+  end
+
+  def tiles
+    Array((plan || {})["tiles"])
+  end
+
+  def labels
+    tiles.map { |tile| tile["label"].to_s }
+  end
+
+  def cell_count
+    columns_count.to_i * rows_count.to_i
+  end
+
+  def complete? = status == "complete"
+  def failed? = status == "failed"
+  def in_flight? = %w[pending building].include?(status)
+
+  def mark_building! = update!(status: "building", error_message: nil)
+
+  def mark_failed!(message)
+    update!(status: "failed", error_message: message.to_s.truncate(1000))
+  end
+end

--- a/app/services/boards/admin_builder/art_preview.rb
+++ b/app/services/boards/admin_builder/art_preview.rb
@@ -1,0 +1,100 @@
+module Boards
+  module AdminBuilder
+    # What the library would put on each tile, resolved WITHOUT WRITING ANYTHING.
+    #
+    # 🚨 This is the reason the builder is two steps, and the one rule that must
+    # not be relaxed: `Boards::ImageResolver.resolve` / `.resolve_all` CREATE a
+    # blank Image row for any label with no match. Calling either from here
+    # would litter the library with blanks every time an admin pressed Preview
+    # — and would report "art exists" for a row it had just invented. Resolution
+    # here goes through Images::LabelSearch, whose `resolve` tier calls the
+    # read-only `best_arted_for`. `resolve_all` belongs in Build, inside the
+    # transaction, where creating blanks is the intended outcome.
+    #
+    # Exact vs. fuzzy is the point of the review screen. A hit whose own label
+    # differs from the requested word is a judgment call, not a match: "my" has
+    # resolved to art labelled "too tired to speak as it uses a lot of my
+    # energy…". Every one of those is surfaced for a human to look at.
+    class ArtPreview
+      Row = Struct.new(
+        :label, :image_id, :matched_label, :exact, :src, :original_url,
+        :source_type, :license, :commercial_safe, :attribution_required, :share_alike,
+        keyword_init: true,
+      ) do
+        def found? = image_id.present?
+
+        def exact? = exact.present?
+
+        # `src` is nil until the 288px variant is processed — that is not the
+        # same as "no art". Fall back to the full-resolution original so the
+        # review grid still shows a picture.
+        def display_url = src.presence || original_url.presence
+      end
+
+      def initialize(labels:, commercial_safe_only: true)
+        @labels = Array(labels).map { |label| label.to_s.strip }.reject(&:blank?)
+        @commercial_safe_only = commercial_safe_only
+      end
+
+      def call
+        rows = labels.map { |label| row_for(label) }
+
+        {
+          rows: rows,
+          total: rows.size,
+          found: rows.count(&:found?),
+          coverage_pct: coverage_pct(rows),
+          missing: rows.reject(&:found?).map(&:label),
+          inexact: rows.select { |row| row.found? && !row.exact }.map(&:label),
+          unsafe: rows.select { |row| row.found? && row.commercial_safe == false }.map(&:label),
+        }
+      end
+
+      private
+
+      attr_reader :labels, :commercial_safe_only
+
+      def searcher
+        # limit: 1 — the review grid shows what will actually be attached, not a
+        # menu of alternatives. `resolve: true` prepends exactly that pick.
+        @searcher ||= Images::LabelSearch.new(
+          match: "exact",
+          limit: 1,
+          commercial_safe: commercial_safe_only,
+          resolve: true,
+        )
+      end
+
+      def row_for(label)
+        result = searcher.call(label).first
+        return Row.new(label: label, exact: false) if result.nil?
+
+        Row.new(
+          label: label,
+          image_id: result[:id],
+          matched_label: result[:label],
+          exact: exact?(label, result[:label]),
+          src: result[:src],
+          original_url: result[:original_url],
+          source_type: result[:source_type],
+          license: result[:license],
+          commercial_safe: result[:commercial_safe],
+          attribution_required: result[:attribution_required],
+          share_alike: result[:share_alike],
+        )
+      end
+
+      # `images.label` is the lowercase matching key, so casing never makes a
+      # match inexact — a different *word* does.
+      def exact?(requested, matched)
+        Boards::ImageResolver.normalize(requested) == Boards::ImageResolver.normalize(matched)
+      end
+
+      def coverage_pct(rows)
+        return 0 if rows.empty?
+
+        ((rows.count(&:found?) / rows.size.to_f) * 100).round
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -1,0 +1,196 @@
+module Boards
+  module AdminBuilder
+    # Writes the board an AdminBoardBuild describes. Runs from
+    # BuildAdminBoardJob, after a human has looked at the art preview.
+    #
+    # Everything that touches the database happens in one transaction, so a bad
+    # image id aborts the whole build rather than silently producing a short
+    # board. AI generation is queued AFTER the commit — Sidekiq can otherwise
+    # pick the job up before the rows it references exist.
+    class Build
+      class BuildError < StandardError; end
+
+      # Matches API::Internal::BoardImagesController's slicing: the job fans out
+      # to an image API and a whole 48-tile board in one call would stampede it.
+      GENERATE_BATCH_SIZE = 3
+
+      def initialize(admin_board_build:)
+        @build = admin_board_build
+      end
+
+      def call
+        return build.board if build.board_id.present?
+
+        build.mark_building!
+        board = ActiveRecord::Base.transaction { create_board! }
+
+        blank_image_ids = art_less_image_ids
+        build.update!(board: board, status: "complete", art_report: art_report(board, blank_image_ids))
+        queue_missing_art!(board, blank_image_ids)
+
+        board
+      rescue StandardError => e
+        build.mark_failed!(e.message)
+        raise
+      end
+
+      private
+
+      attr_reader :build
+
+      def admin
+        @admin ||= User.find_by(id: User::DEFAULT_ADMIN_ID) ||
+                   raise(BuildError, "No default admin user configured — cannot build.")
+      end
+
+      def tiles = build.tiles
+
+      def columns = build.columns_count.to_i
+
+      # Keyed by the resolver's own normalized key, so a label looks up the same
+      # way regardless of the casing it was authored in. Here it is correct that
+      # a miss creates a blank Image — those blanks are what generation targets.
+      def resolved
+        @resolved ||= Boards::ImageResolver.resolve_all(build.labels, owner: admin)
+      end
+
+      def create_board!
+        board = new_board
+        board_images = tiles.map { |tile| add_tile!(board, tile) }
+        apply_reading_order!(board, board_images)
+        board.set_current_word_list
+        board.save!
+        board
+      end
+
+      def new_board
+        board = Board.new(
+          name: build.name,
+          user: admin,
+          parent: admin,
+          predefined: true,
+          published: false,
+          board_type: "static",
+          # Set at create time: assigning `voice` later cascades to every tile
+          # and re-queues all their audio.
+          voice: build.voice,
+          # lg is authored; md and sm are DERIVED from it through the single
+          # source of truth. `Board#set_screen_sizes` would do this itself, but
+          # only when the column is nil — and boards.medium/small_screen_columns
+          # carry non-nil database defaults (8 and 3), so leaving them alone
+          # gives a 6-column board an 8-column tablet layout. Deriving here is
+          # not the same as hand-authoring a md/sm *layout*, which is what marks
+          # a screen customized and stops reflow for good.
+          large_screen_columns: columns,
+          medium_screen_columns: Boards::ScreenColumns.derive(columns, "md"),
+          small_screen_columns: Boards::ScreenColumns.derive(columns, "sm"),
+          number_of_columns: columns,
+          settings: { AdminBoardBuild::BUILDER_SETTING => true, "disable_scroll" => true },
+        )
+        # Assigns only — a collision gets a hex suffix rather than an error, so
+        # the final slug is worth surfacing in the UI.
+        board.generate_unique_slug if board.slug.blank?
+        board.save!
+        board
+      end
+
+      def add_tile!(board, tile)
+        label = tile["label"].to_s
+        image = resolved[Boards::ImageResolver.normalize(label)]
+        raise BuildError, "no image resolved for #{label.inspect}" if image.nil?
+
+        # Board#add_image returns nil on a missing image or a failed save rather
+        # than raising, which would leave a short board behind.
+        board_image = board.add_image(image.id)
+        raise BuildError, "could not add a tile for #{label.inspect}" if board_image.nil?
+
+        apply_tile_attributes!(board_image, tile)
+        board_image
+      end
+
+      # `BoardImage#set_colors` is `before_update ... if: :part_of_speech_changed?`
+      # — before_update, so it does not fire on create. On the create path colors
+      # come from the Image's own bg_color, not the part of speech, so applying
+      # the authored part of speech as a separate update after the tile exists is
+      # what actually lands the Modified Fitzgerald colour. Don't also pass
+      # bg_color; the callback would overwrite it.
+      def apply_tile_attributes!(board_image, tile)
+        attrs = {}
+        pos = tile["part_of_speech"].to_s
+        attrs[:part_of_speech] = pos if pos.present? && pos != "default"
+
+        display_label = tile["display_label"].to_s
+        attrs[:display_label] = display_label if display_label.present?
+
+        board_image.update!(attrs) if attrs.any?
+      end
+
+      # Reading order: left to right, top to bottom, in the order the words were
+      # authored. apply_layout! sorts by [y, x] and rewrites every tile's
+      # position, so the layout — not creation order — decides the final order.
+      def apply_reading_order!(board, board_images)
+        layout = board_images.each_with_index.map do |board_image, index|
+          {
+            "i" => board_image.id.to_s,
+            "x" => index % columns,
+            "y" => index / columns,
+            "w" => 1,
+            "h" => 1,
+          }
+        end
+        return if layout.empty?
+
+        board.apply_layout!(layout: layout, screen_size: "lg", columns: { large_screen_columns: columns })
+      end
+
+      # Labels that resolved to a blank Image — the ones generation targets.
+      def art_less_image_ids
+        Image.where(id: resolved.values.map(&:id).uniq).where.missing(:docs).pluck(:id)
+      end
+
+      def art_report(board, blank_image_ids)
+        total = tiles.size
+        missing = resolved.select { |_, image| blank_image_ids.include?(image.id) }.keys
+
+        {
+          "tile_count" => total,
+          "with_art" => total - missing.size,
+          "coverage_pct" => total.zero? ? 0 : (((total - missing.size) / total.to_f) * 100).round,
+          "missing_labels" => missing,
+          "queued_image_ids" => blank_image_ids,
+          "slug" => board.slug,
+        }
+      end
+
+      # Queued after commit, in slices of 3, mirroring
+      # API::Internal::BoardImagesController#queue_missing_art!.
+      def queue_missing_art!(board, image_ids)
+        return if image_ids.empty?
+
+        seed_art_prompts!(image_ids)
+        image_ids.each_slice(GENERATE_BATCH_SIZE) do |batch|
+          GenerateImagesJob.perform_async(batch, board.id)
+        end
+      end
+
+      # The board's topic is what keeps "swing" on a playground board from
+      # coming back as a mood swing. `image_prompt` carries the INTENT only —
+      # Images::PromptBuilder composes the house style envelope at generation
+      # time and must never have it baked in here, or it gets wrapped twice.
+      def seed_art_prompts!(image_ids)
+        Image.where(id: image_ids).each do |image|
+          next if image.image_prompt.present?
+
+          image.update_column(:image_prompt, art_intent_for(image.label))
+        end
+      end
+
+      def art_intent_for(label)
+        topic = build.topic.to_s.strip
+        return label.to_s if topic.blank?
+
+        "#{label} in the context of #{topic}"
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -1,0 +1,81 @@
+module Boards
+  module AdminBuilder
+    # Rejects the authoring mistakes that produce a sparse or broken board,
+    # before anything is resolved or written. Returns an array of
+    # human-readable problems; empty means the plan is safe to build.
+    #
+    # The tile-count rule is the reason the page exists. Rows are never stored
+    # (`Board#rows_for_screen_size` derives them from the tiles), so a partial
+    # final row doesn't shorten the board — it leaves conspicuous empty cells at
+    # the right end of the last row, which reads as broken on a classroom TV.
+    class PlanValidator
+      def initialize(tiles:, columns:, rows:, allow_partial_row: false)
+        @tiles = Array(tiles)
+        @columns = columns.to_i
+        @rows = rows.to_i
+        @allow_partial_row = allow_partial_row
+      end
+
+      def call
+        return ["Set both a column count and a row count."] if columns < 1 || rows < 1
+
+        problems = []
+        problems.concat(count_problems)
+        problems.concat(label_problems)
+        problems.concat(part_of_speech_problems)
+        problems
+      end
+
+      private
+
+      attr_reader :tiles, :columns, :rows, :allow_partial_row
+
+      def cells = columns * rows
+
+      def count_problems
+        return ["Add at least one word."] if tiles.empty?
+
+        # Overflow is always an error: there is no cell for the extra tiles, so
+        # "allow a partial row" can't rescue it.
+        if tiles.size > cells
+          return ["#{tiles.size} words won't fit a #{columns}×#{rows} grid (#{cells} cells). " \
+                  "Remove #{tiles.size - cells}."]
+        end
+
+        return [] if tiles.size == cells || allow_partial_row
+
+        ["#{tiles.size} words for a #{columns}×#{rows} grid (needs exactly #{cells}). " \
+         "Add #{cells - tiles.size}. A partial row leaves dead cells at the end of the last row — " \
+         "tick “allow a partial row” if you meant it."]
+      end
+
+      def label_problems
+        problems = []
+        problems << "Every tile needs a word — one line is empty." if labels.any?(&:blank?)
+
+        keys = labels.reject(&:blank?).map(&:downcase)
+        dupes = keys.tally.select { |_, count| count > 1 }.keys.sort
+        if dupes.any?
+          problems << "Duplicate words: #{dupes.join(", ")}. Each one costs a cell and buys nothing."
+        end
+
+        problems
+      end
+
+      def part_of_speech_problems
+        bad = tiles.filter_map do |tile|
+          pos = tile[:part_of_speech].presence || tile["part_of_speech"].presence || "default"
+          pos unless ColorHelper::PARTS_OF_SPEECH.include?(pos.to_s)
+        end.uniq.sort
+
+        return [] if bad.empty?
+
+        ["Unknown part of speech: #{bad.join(", ")}. Use one of: #{ColorHelper::PARTS_OF_SPEECH.join(", ")}."]
+      end
+
+      def labels
+        @labels ||= tiles.map { |tile| (tile[:label] || tile["label"]).to_s.strip }
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -1,0 +1,150 @@
+module Boards
+  module AdminBuilder
+    # Drafts a word list for a board of a given size and topic: one OpenAI call
+    # returning `[{ label:, part_of_speech: }]`.
+    #
+    # The output ONLY EVER POPULATES THE FORM. It is never fed to a build
+    # directly — a human edits it, then previews the art, then builds. That is
+    # the whole reason this returns plain data and touches nothing.
+    #
+    # Deliberately a new prompt rather than a composition of the pieces that
+    # already exist: `Board#get_words_for_scenario` needs a persisted Board and
+    # returns bare strings with no part of speech, and
+    # `AacWordCategorizer.categorize` is one OpenAI call PER WORD — chaining
+    # them is an N+1 against a paid API for something one call answers.
+    #
+    # No credit charge: the boards this drafts are admin-owned.
+    class WordListDrafter
+      class GenerationError < StandardError; end
+
+      # The words that make a board usable for something other than labelling.
+      # Placed first so they land in the top-left, where they are reachable.
+      CORE_SPINE = [
+        "I", "you", "it", "want", "go", "stop", "more", "help",
+        "like", "not", "yes", "all done", "look", "my turn", "what", "where"
+      ].freeze
+
+      # 12x12, matching the controller's grid ceiling.
+      MAX_TILES = 144
+
+      def initialize(topic:, columns:, rows:, audience: nil)
+        @topic = topic.to_s.strip
+        @tile_count = (columns.to_i * rows.to_i).clamp(1, MAX_TILES)
+        @audience = audience.to_s.strip
+      end
+
+      def call
+        raise GenerationError, "give the board a topic to draft from" if topic.blank?
+
+        parse_response(generate_via_openai)
+      end
+
+      private
+
+      attr_reader :topic, :tile_count, :audience
+
+      def generate_via_openai
+        client = OpenAiClient.new(
+          prompt: topic,
+          messages: [{ role: "user", content: build_prompt }],
+        )
+        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
+        result = client.create_chat(true)
+
+        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
+
+        result[:content]
+      end
+
+      # A small grid can't carry the whole spine, so ask for as much of it as
+      # fits rather than for words that were never going to be there.
+      def spine_for_size
+        CORE_SPINE.first([tile_count, CORE_SPINE.size].min)
+      end
+
+      def build_prompt
+        <<~PROMPT
+          You are building an AAC (Augmentative and Alternative Communication) board for a
+          nonspeaking communicator. The board's topic is: #{topic}
+          #{audience.present? ? "It is for: #{audience}" : ""}
+
+          Generate EXACTLY #{tile_count} tiles — the board is a fixed grid and a partial
+          last row leaves visible dead cells.
+
+          Start with these core words, in this order, before any topic words:
+          #{spine_for_size.join(", ")}
+
+          Then fill the rest with topic words, aiming for roughly this balance across the
+          whole list:
+          - 30-40% verbs and core function words (the words that do the communicating)
+          - 15-20% pronouns and determiners
+          - 15-20% describing words
+          - 25-35% topic nouns
+
+          Rules:
+          - A board for talking, not a vocabulary list. Favour words that finish a
+            sentence over words that name a thing.
+          - No near-duplicates ("happy" and "glad", "big" and "large"). Each tile costs a
+            cell.
+          - Keep each label short — 1-2 words.
+          - Concrete and age-appropriate.
+          - Give every tile a part_of_speech from exactly this list:
+            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
+          - Classify by communicative function, not strict grammar: "more", "yes" and
+            "please" are social; "no", "not" and "stop" are important_function.
+
+          Respond in JSON format:
+          {
+            "tiles": [
+              { "label": "I", "part_of_speech": "pronoun" },
+              { "label": "want", "part_of_speech": "verb" }
+            ]
+          }
+
+          Return ONLY the JSON, no other text.
+        PROMPT
+      end
+
+      def parse_response(raw)
+        data = JSON.parse(raw)
+        tiles = dedupe(Array(data["tiles"])).first(tile_count)
+
+        # Unlike Boards::AiPageGenerator — which builds from its response — this
+        # only fills a textarea, so a short draft is survivable: the form's
+        # counter shows the gap and the admin types the rest. Only a response
+        # with nothing usable in it is an error.
+        raise GenerationError, "AI returned no usable words" if tiles.empty?
+
+        tiles
+      rescue JSON::ParserError => e
+        raise GenerationError, "Failed to parse AI response: #{e.message}"
+      end
+
+      # Exact and casing-only repeats are dropped here rather than left for
+      # PlanValidator: `images.label` is a lowercase matching key, so "Go" and
+      # "go" are one symbol, and a draft that fails validation on arrival is
+      # worse than a short one. Near-duplicates are the prompt's job.
+      def dedupe(raw_tiles)
+        seen = Set.new
+
+        raw_tiles.filter_map do |tile|
+          next unless tile.is_a?(Hash)
+
+          label = (tile["label"] || tile["word"]).to_s.strip
+          next if label.blank?
+          next unless seen.add?(label.downcase)
+
+          { label: label, part_of_speech: part_of_speech_for(tile) }
+        end
+      end
+
+      # An unrecognized value would be rejected by PlanValidator on preview, so
+      # fall back to "default" (grey) and let the admin re-colour it rather than
+      # handing back a list that can't be submitted.
+      def part_of_speech_for(tile)
+        value = tile["part_of_speech"].to_s.strip.downcase
+        ColorHelper::PARTS_OF_SPEECH.include?(value) ? value : "default"
+      end
+    end
+  end
+end

--- a/app/sidekiq/build_admin_board_job.rb
+++ b/app/sidekiq/build_admin_board_job.rb
@@ -1,0 +1,11 @@
+class BuildAdminBoardJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :default
+
+  def perform(admin_board_build_id)
+    build = AdminBoardBuild.find_by(id: admin_board_build_id)
+    return unless build
+
+    Boards::AdminBuilder::Build.new(admin_board_build: build).call
+  end
+end

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -1,0 +1,99 @@
+<%# The authoring form. Rendered by `new` and again at the bottom of `preview`
+    so "change something and look again" is one round trip, not a re-type. %>
+<%= form_tag preview_admin_dashboard_board_builds_path, method: :post do %>
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="name">Board name</label>
+        <%= text_field_tag :name, @form[:name], id: "name", required: true,
+              class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="topic">Topic <span class="text-t3">(optional)</span></label>
+        <%= text_field_tag :topic, @form[:topic], id: "topic", placeholder: "the playground",
+              class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+        <p class="text-[11px] text-t3 mt-1">Steers AI art for words the library doesn't cover — “swing” on a playground board, not a mood swing.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-xs font-medium text-t2 mb-1" for="columns">Columns</label>
+          <%= number_field_tag :columns, @form[:columns], id: "columns", min: 1, max: Admin::BoardBuildsController::MAX_COLUMNS,
+                class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-t2 mb-1" for="rows">Rows</label>
+          <%= number_field_tag :rows, @form[:rows], id: "rows", min: 1, max: Admin::BoardBuildsController::MAX_ROWS,
+                class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+        </div>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="voice">Voice</label>
+        <%= select_tag :voice,
+              options_for_select(VoiceService::VOICES.map { |v| ["#{v[:label]} (#{v[:value]})", v[:value]] }, @form[:voice]),
+              id: "voice",
+              class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+        <p class="text-[11px] text-t3 mt-1">Set at creation — changing it later re-queues audio for every tile.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <div class="mb-3">
+      <h2 class="text-sm font-medium text-t1">Word list</h2>
+      <p class="text-[11px] text-t3 mt-0.5">
+        One tile per line. <span class="font-mono">word</span>,
+        <span class="font-mono">word | part_of_speech</span>, or
+        <span class="font-mono">word | part_of_speech | tile text</span>.
+        Parts of speech: <span class="font-mono"><%= ColorHelper::PARTS_OF_SPEECH.join(", ") %></span>.
+      </p>
+      <p class="text-[11px] text-t3 mt-1">
+        You need exactly <span id="cell-count" class="text-t1 font-medium">—</span> words
+        (<span id="word-count" class="text-t1 font-medium">0</span> so far).
+        A partial row leaves dead cells at the end of the last row.
+      </p>
+    </div>
+
+    <%= text_area_tag :words, @form[:words], id: "words", rows: 14, spellcheck: false,
+          placeholder: "I | pronoun\nwant | verb\nmore | important_function\nswing | noun",
+          class: "admin-input border rounded px-3 py-2 text-sm w-full font-mono focus:border-indigo-500 focus:outline-none" %>
+
+    <div class="flex flex-col gap-2 mt-4">
+      <label class="flex items-center gap-2 text-xs text-t2">
+        <%= check_box_tag :commercial_safe_only, "1", @form[:commercial_safe_only] %>
+        Prefer commercially-safe art only
+      </label>
+      <label class="flex items-center gap-2 text-xs text-t2">
+        <%= check_box_tag :allow_partial_row, "1", @form[:allow_partial_row] %>
+        Allow a partial last row (leaves empty cells — tick only if you mean it)
+      </label>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-3">
+    <%= submit_tag "Preview the art",
+          class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>
+    <span class="text-[11px] text-t3">Preview writes nothing — no board, no images.</span>
+  </div>
+<% end %>
+
+<script>
+  (function () {
+    var words = document.getElementById("words");
+    var columns = document.getElementById("columns");
+    var rows = document.getElementById("rows");
+    var cellCount = document.getElementById("cell-count");
+    var wordCount = document.getElementById("word-count");
+    if (!words || !columns || !rows) return;
+
+    function update() {
+      var cells = (parseInt(columns.value, 10) || 0) * (parseInt(rows.value, 10) || 0);
+      var used = words.value.split("\n").filter(function (line) { return line.trim() !== ""; }).length;
+      cellCount.textContent = cells || "—";
+      wordCount.textContent = used;
+      wordCount.style.color = cells && used !== cells ? "#f87171" : "";
+    }
+
+    [words, columns, rows].forEach(function (el) { el.addEventListener("input", update); });
+    update();
+  })();
+</script>

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -12,7 +12,13 @@
         <label class="block text-xs font-medium text-t2 mb-1" for="topic">Topic <span class="text-t3">(optional)</span></label>
         <%= text_field_tag :topic, @form[:topic], id: "topic", placeholder: "the playground",
               class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
-        <p class="text-[11px] text-t3 mt-1">Steers AI art for words the library doesn't cover — “swing” on a playground board, not a mood swing.</p>
+        <p class="text-[11px] text-t3 mt-1">Steers AI art for words the library doesn't cover — “swing” on a playground board, not a mood swing. Also what the AI drafts a word list from.</p>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="audience">Audience <span class="text-t3">(optional)</span></label>
+        <%= text_field_tag :audience, @form[:audience], id: "audience", placeholder: "an early communicator, preschool age",
+              class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+        <p class="text-[11px] text-t3 mt-1">Used only when drafting. Not saved on the board.</p>
       </div>
       <div class="grid grid-cols-2 gap-4">
         <div>
@@ -38,8 +44,17 @@
   </div>
 
   <div class="admin-card border rounded-xl p-5 mb-6">
-    <div class="mb-3">
+    <div class="flex items-start justify-between gap-4 mb-3">
       <h2 class="text-sm font-medium text-t1">Word list</h2>
+      <%# formaction, not a second form: drafting has to see the topic, audience
+          and grid the admin just typed above. %>
+      <button type="submit" id="draft-button" formaction="<%= draft_admin_dashboard_board_builds_path %>"
+              class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+        Draft with AI
+      </button>
+    </div>
+
+    <div class="mb-3">
       <p class="text-[11px] text-t3 mt-0.5">
         One tile per line. <span class="font-mono">word</span>,
         <span class="font-mono">word | part_of_speech</span>, or
@@ -95,5 +110,17 @@
 
     [words, columns, rows].forEach(function (el) { el.addEventListener("input", update); });
     update();
+
+    // Drafting replaces the textarea wholesale, so only confirm when there is
+    // something to lose.
+    var draftButton = document.getElementById("draft-button");
+    if (draftButton) {
+      draftButton.addEventListener("click", function (event) {
+        if (words.value.trim() === "") return;
+        if (!window.confirm("Replace the word list you've typed with an AI draft?")) {
+          event.preventDefault();
+        }
+      });
+    }
   })();
 </script>

--- a/app/views/admin/board_builds/index.html.erb
+++ b/app/views/admin/board_builds/index.html.erb
@@ -1,0 +1,71 @@
+<% content_for :page_title, "Board Builds" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Board Builds</h1>
+    <p class="text-sm text-t3 mt-0.5">Dense AAC boards built from a word list. Art is reviewed before anything is written; boards land unpublished.</p>
+  </div>
+  <%= link_to "New board build", new_admin_dashboard_board_build_path,
+        class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors" %>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Build", "Grid", "Status", "Board", "Coverage", "Created", ""].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @builds.each do |build| %>
+        <tr class="admin-hover-row transition-colors align-top" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3">
+            <%= link_to build.name, admin_dashboard_board_build_path(build), class: "text-xs text-t1 hover:text-accent transition-colors font-medium" %>
+            <% if build.topic.present? %>
+              <div class="text-[10px] text-t3"><%= build.topic %></div>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2 whitespace-nowrap"><%= build.columns_count %>×<%= build.rows_count %></td>
+          <td class="px-5 py-3 whitespace-nowrap">
+            <% case build.status %>
+            <% when "complete" %>
+              <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">built</span>
+            <% when "failed" %>
+              <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5">failed</span>
+            <% else %>
+              <span class="admin-card-alt text-t2 inline-block text-xs rounded px-2 py-0.5"><%= build.status %></span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2">
+            <% if build.board %>
+              <div class="font-mono text-[10px] text-t3"><%= build.board.slug %></div>
+              <% if build.board.published? %>
+                <span class="text-green-400 text-[10px]">published</span>
+              <% else %>
+                <span class="text-t3 text-[10px]">unpublished</span>
+              <% end %>
+            <% else %>
+              <span class="text-t3">—</span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2 whitespace-nowrap">
+            <%= build.art_report["coverage_pct"] ? "#{build.art_report["coverage_pct"]}%" : "—" %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= build.created_at.strftime("%b %-d, %Y") %></td>
+          <td class="px-5 py-3 whitespace-nowrap">
+            <%= link_to "Open", admin_dashboard_board_build_path(build),
+                  class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @builds.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">
+      No board builds yet. <%= link_to "Build one", new_admin_dashboard_board_build_path, class: "text-accent hover:underline" %>.
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/board_builds/new.html.erb
+++ b/app/views/admin/board_builds/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "New Board Build" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">New Board Build</h1>
+    <p class="text-sm text-t3 mt-0.5">Author a dense board, review every symbol, then build. The board lands unpublished.</p>
+  </div>
+  <%= link_to "← All board builds", admin_dashboard_board_builds_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<% if @problems.present? %>
+  <div class="admin-flash-err border rounded-lg px-4 py-3 mb-6 text-sm">
+    <ul class="list-disc pl-4 flex flex-col gap-1">
+      <% @problems.each do |problem| %>
+        <li><%= problem %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= render "form" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -1,0 +1,103 @@
+<% content_for :page_title, "Review art — #{@form[:name]}" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Review the art — <%= @form[:name] %></h1>
+    <p class="text-sm text-t3 mt-0.5">
+      Nothing has been written yet. <%= @preview[:total] %> tiles ·
+      <%= @form[:columns] %>×<%= @form[:rows] %> grid.
+    </p>
+  </div>
+  <%= link_to "← All board builds", admin_dashboard_board_builds_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <div class="flex flex-wrap items-center gap-6">
+    <div>
+      <p class="text-2xl font-semibold text-t1"><%= @preview[:coverage_pct] %>%</p>
+      <p class="text-[11px] text-t3">library coverage (<%= @preview[:found] %>/<%= @preview[:total] %>)</p>
+    </div>
+    <div>
+      <p class="text-2xl font-semibold text-t1"><%= @preview[:missing].size %></p>
+      <p class="text-[11px] text-t3">no art — AI will generate these</p>
+    </div>
+    <div>
+      <p class="text-2xl font-semibold text-t1"><%= @preview[:inexact].size %></p>
+      <p class="text-[11px] text-t3">fuzzy matches — check these by eye</p>
+    </div>
+    <% if @form[:commercial_safe_only] && @preview[:unsafe].any? %>
+      <div>
+        <p class="text-2xl font-semibold text-t1"><%= @preview[:unsafe].size %></p>
+        <p class="text-[11px] text-t3">not commercially safe</p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @preview[:inexact].any? %>
+    <p class="text-xs text-t2 mt-4">
+      <span class="text-t1 font-medium">Fuzzy:</span> <%= @preview[:inexact].join(", ") %> —
+      the library returned art whose own label is a different word. Look at the picture, not the percentage.
+    </p>
+  <% end %>
+  <% if @preview[:missing].any? %>
+    <p class="text-xs text-t2 mt-2">
+      <span class="text-t1 font-medium">No art:</span> <%= @preview[:missing].join(", ") %> —
+      these get a blank image and queued AI art after the build.
+    </p>
+  <% end %>
+</div>
+
+<h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Every tile — in reading order</h2>
+
+<div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3 mb-8">
+  <% @preview[:rows].each do |row| %>
+    <div class="admin-card border rounded-xl overflow-hidden <%= "border-amber-500" if row.found? && !row.exact %><%= "border-red-500" unless row.found? %>">
+      <div class="aspect-square admin-card-alt flex items-center justify-center overflow-hidden">
+        <% if row.display_url.present? %>
+          <img src="<%= row.display_url %>" alt="<%= row.label %>" loading="lazy" class="w-full h-full object-contain">
+        <% else %>
+          <span class="text-[11px] text-t3 px-2 text-center">no art</span>
+        <% end %>
+      </div>
+      <div class="p-2">
+        <p class="text-xs font-medium text-t1 truncate" title="<%= row.label %>"><%= row.label %></p>
+        <% if row.found? && !row.exact %>
+          <p class="text-[10px] text-amber-500 truncate" title="<%= row.matched_label %>">matched “<%= row.matched_label %>”</p>
+        <% elsif !row.found? %>
+          <p class="text-[10px] text-red-400">will be generated</p>
+        <% end %>
+        <% if row.found? && row.commercial_safe == false %>
+          <p class="text-[10px] text-t3 truncate" title="<%= row.license %>">not commercial-safe</p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-8">
+  <h2 class="text-sm font-medium text-t1 mb-1">Happy with it?</h2>
+  <p class="text-xs text-t2 mb-4">
+    Building creates the board unpublished, owned by the default admin, and queues AI art for anything the library
+    didn't cover. Publishing is a separate step.
+  </p>
+
+  <%# Hidden-field resubmit of exactly what was previewed. `create` re-parses
+      and re-validates it from scratch — the round trip is not trusted. %>
+  <%= form_tag admin_dashboard_board_builds_path, method: :post do %>
+    <%= hidden_field_tag :name, @form[:name] %>
+    <%= hidden_field_tag :topic, @form[:topic] %>
+    <%= hidden_field_tag :voice, @form[:voice] %>
+    <%= hidden_field_tag :columns, @form[:columns] %>
+    <%= hidden_field_tag :rows, @form[:rows] %>
+    <%= hidden_field_tag :words, @form[:words] %>
+    <%= hidden_field_tag :commercial_safe_only, @form[:commercial_safe_only] ? "1" : "0" %>
+    <%= hidden_field_tag :allow_partial_row, @form[:allow_partial_row] ? "1" : "0" %>
+    <%= submit_tag "Build this board",
+          class: "text-xs font-medium px-4 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer border-0",
+          data: { turbo_confirm: "Build “#{@form[:name]}”? This creates the board and queues AI art for missing symbols." } %>
+  <% end %>
+</div>
+
+<h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Or change something and look again</h2>
+
+<%= render "form" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -86,6 +86,7 @@
   <%= form_tag admin_dashboard_board_builds_path, method: :post do %>
     <%= hidden_field_tag :name, @form[:name] %>
     <%= hidden_field_tag :topic, @form[:topic] %>
+    <%= hidden_field_tag :audience, @form[:audience] %>
     <%= hidden_field_tag :voice, @form[:voice] %>
     <%= hidden_field_tag :columns, @form[:columns] %>
     <%= hidden_field_tag :rows, @form[:rows] %>

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -1,0 +1,126 @@
+<% content_for :page_title, @build.name %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @build.name %></h1>
+    <p class="text-sm text-t3 mt-0.5">
+      <%= @build.columns_count %>×<%= @build.rows_count %> · <%= @build.tiles.size %> tiles
+      <% if @build.topic.present? %> · topic: <%= @build.topic %><% end %>
+      <% if @board %> · <span class="font-mono text-xs"><%= @board.slug %></span><% end %>
+    </p>
+  </div>
+  <%= link_to "← All board builds", admin_dashboard_board_builds_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <div class="flex items-start justify-between gap-4 flex-wrap">
+    <div>
+      <% case @build.status %>
+      <% when "complete" %>
+        <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">built</span>
+      <% when "failed" %>
+        <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5">failed</span>
+      <% else %>
+        <span class="admin-card-alt text-t2 inline-block text-xs rounded px-2 py-0.5"><%= @build.status %></span>
+      <% end %>
+
+      <% if @board %>
+        <% if @board.published? %>
+          <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5 ml-1">published</span>
+        <% else %>
+          <span class="admin-card-alt text-t2 inline-block text-xs rounded px-2 py-0.5 ml-1">unpublished</span>
+        <% end %>
+      <% end %>
+
+      <% if @build.in_flight? %>
+        <p class="text-xs text-t2 mt-2">The build is queued — reload in a moment.</p>
+      <% end %>
+
+      <% if @build.failed? %>
+        <p class="text-xs text-red-400 mt-2 max-w-xl font-mono"><%= @build.error_message %></p>
+        <p class="text-xs text-t2 mt-1">The word list is saved below — nothing needs re-typing.</p>
+      <% end %>
+
+      <% if @board %>
+        <p class="text-xs text-t2 mt-2">
+          Board <span class="font-mono">#<%= @board.id %></span> ·
+          <%= @board.board_images.size %> tiles ·
+          lg <%= @board.large_screen_columns %> / md <%= @board.medium_screen_columns %> / sm <%= @board.small_screen_columns %> columns
+        </p>
+        <p class="text-xs text-t2 mt-1">
+          Public URL when published: <span class="font-mono">/pb/<%= @board.slug %></span> —
+          a published slug is frozen, so check it now.
+        </p>
+      <% end %>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <% if @board %>
+        <% if @board.published? %>
+          <%= button_to "Unpublish", unpublish_admin_dashboard_board_build_path(@build), method: :post,
+                class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1",
+                form: { data: { turbo_confirm: "Unpublish “#{@board.name}”? It will no longer be public." } } %>
+        <% else %>
+          <%= button_to "Publish", publish_admin_dashboard_board_build_path(@build), method: :post,
+                class: "text-xs font-medium px-3 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
+                form: { data: { turbo_confirm: "Publish “#{@board.name}”? This makes it public to everyone. Have you looked at every tile?" } } %>
+        <% end %>
+      <% end %>
+      <% unless @board&.published? %>
+        <%= button_to "Delete", admin_dashboard_board_build_path(@build), method: :delete,
+              class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1",
+              form: { data: { turbo_confirm: "Delete this build and its board? This can't be undone." } } %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<% if @board %>
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <h2 class="text-sm font-medium text-t1 mb-1">Art coverage</h2>
+    <p class="text-xs text-t2">
+      <%= @build.art_report["coverage_pct"] || 0 %>% of tiles had library art at build time.
+      <% if @missing_art_count.positive? %>
+        <span class="text-amber-500"><%= @missing_art_count %> <%= "tile".pluralize(@missing_art_count) %> still have no picture</span> —
+        AI generation was queued for them.
+      <% else %>
+        Every tile has a picture.
+      <% end %>
+      <% if @board.has_generating_images? %>
+        <span class="text-t1">Art is still generating.</span>
+      <% end %>
+    </p>
+    <% if Array(@build.art_report["missing_labels"]).any? %>
+      <p class="text-[11px] text-t3 mt-2">
+        Generated: <%= Array(@build.art_report["missing_labels"]).join(", ") %>
+      </p>
+    <% end %>
+  </div>
+
+  <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Tiles — in board order</h2>
+
+  <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+    <% @tiles.each do |tile| %>
+      <div class="admin-card border rounded-xl overflow-hidden">
+        <div class="aspect-square flex items-center justify-center overflow-hidden" style="background-color: <%= tile.bg_color || "transparent" %>;">
+          <% if tile.display_image_url.present? %>
+            <img src="<%= tile.display_image_url %>" alt="<%= tile.display_label %>" loading="lazy" class="w-full h-full object-contain">
+          <% else %>
+            <span class="text-[11px] text-t3 px-2 text-center">no picture yet</span>
+          <% end %>
+        </div>
+        <div class="p-2">
+          <p class="text-xs font-medium text-t1 truncate" title="<%= tile.display_label %>"><%= tile.display_label %></p>
+          <p class="text-[10px] text-t3"><%= tile.effective_part_of_speech %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<div class="admin-card border rounded-xl p-5 mt-6">
+  <h2 class="text-sm font-medium text-t1 mb-2">The word list that was built</h2>
+  <pre class="text-[11px] text-t2 font-mono whitespace-pre-wrap"><%= @build.tiles.map { |tile|
+        [tile["label"], tile["part_of_speech"], tile["display_label"]].compact.reject(&:blank?).join(" | ")
+      }.join("\n") %></pre>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -49,6 +49,12 @@
       <p class="text-xs text-t2 mt-1">Build video demo boards from YouTube clips, review, and publish</p>
     <% end %>
 
+    <%= link_to admin_dashboard_board_builds_path,
+          class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
+      <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Board Builds</p>
+      <p class="text-xs text-t2 mt-1">Build a dense AAC board from a word list — review the symbol art, then publish</p>
+    <% end %>
+
     <%= link_to admin_dashboard_feedback_path,
           class: "group admin-card border hover:border-indigo-500 rounded-xl p-5 transition-colors" do %>
       <p class="text-sm font-medium text-t1 group-hover:text-accent transition-colors">Feedback</p>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -113,6 +113,8 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Board Builds", admin_dashboard_board_builds_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_builds") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Feedback", admin_dashboard_feedback_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/feedback") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Word Events", admin_dashboard_word_events_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
     end
     resources :board_builds, only: [:index, :new, :create, :show, :destroy], as: :dashboard_board_builds do
       collection do
+        post :draft
         post :preview
       end
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,15 @@ Rails.application.routes.draw do
         post :unpublish
       end
     end
+    resources :board_builds, only: [:index, :new, :create, :show, :destroy], as: :dashboard_board_builds do
+      collection do
+        post :preview
+      end
+      member do
+        post :publish
+        post :unpublish
+      end
+    end
     get "feedback", to: "feedback#index", as: :dashboard_feedback
     get "word_events", to: "word_events#index", as: :dashboard_word_events
     resources :board_printables, only: [:index, :show, :create], as: :dashboard_board_printables

--- a/db/migrate/20260807150000_create_admin_board_builds.rb
+++ b/db/migrate/20260807150000_create_admin_board_builds.rb
@@ -1,0 +1,27 @@
+class CreateAdminBoardBuilds < ActiveRecord::Migration[8.0]
+  def change
+    create_table :admin_board_builds do |t|
+      # Null until the build actually writes a board.
+      t.references :board, foreign_key: true
+      t.references :created_by, foreign_key: { to_table: :users }
+      t.string :status, null: false, default: "pending"
+      t.string :name, null: false
+      t.string :topic
+      t.string :voice, null: false, default: "polly:kevin"
+      t.integer :columns_count, null: false
+      t.integer :rows_count, null: false
+      t.boolean :commercial_safe_only, null: false, default: true
+      # The authored tiles. Persisted so a failed build is re-runnable without
+      # re-authoring, and so `show` has something to render.
+      t.jsonb :plan, null: false, default: {}
+      # What the build actually resolved: coverage, labels with no art, and the
+      # images it queued generation for.
+      t.jsonb :art_report, null: false, default: {}
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :admin_board_builds, [:status, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_07_120100) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_07_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -55,6 +55,26 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_07_120100) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "admin_board_builds", force: :cascade do |t|
+    t.bigint "board_id"
+    t.bigint "created_by_id"
+    t.string "status", default: "pending", null: false
+    t.string "name", null: false
+    t.string "topic"
+    t.string "voice", default: "polly:kevin", null: false
+    t.integer "columns_count", null: false
+    t.integer "rows_count", null: false
+    t.boolean "commercial_safe_only", default: true, null: false
+    t.jsonb "plan", default: {}, null: false
+    t.jsonb "art_report", default: {}, null: false
+    t.text "error_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_id"], name: "index_admin_board_builds_on_board_id"
+    t.index ["created_by_id"], name: "index_admin_board_builds_on_created_by_id"
+    t.index ["status", "created_at"], name: "index_admin_board_builds_on_status_and_created_at"
   end
 
   create_table "analytics_events", force: :cascade do |t|
@@ -1110,6 +1130,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_07_120100) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "admin_board_builds", "boards"
+  add_foreign_key "admin_board_builds", "users", column: "created_by_id"
   add_foreign_key "board_exports", "users"
   add_foreign_key "board_gallery_listings", "boards"
   add_foreign_key "board_gallery_reports", "board_gallery_listings"

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1,0 +1,332 @@
+require "rails_helper"
+
+RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let!(:seed_admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let(:admin) { create(:admin_user) }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+    BuildAdminBoardJob.jobs.clear
+  end
+
+  def form_params(overrides = {})
+    {
+      name: "Playground",
+      topic: "the playground",
+      voice: "polly:kevin",
+      columns: "2",
+      rows: "2",
+      words: "i | pronoun\nwant | verb\nmore | important_function\nswing | noun",
+      commercial_safe_only: "1",
+    }.merge(overrides)
+  end
+
+  def create_build(**overrides)
+    AdminBoardBuild.create!(
+      {
+        created_by: admin,
+        name: "Playground",
+        voice: "polly:kevin",
+        columns_count: 2,
+        rows_count: 2,
+        plan: { "tiles" => [{ "label" => "i", "part_of_speech" => "pronoun" }] },
+      }.merge(overrides),
+    )
+  end
+
+  def built_board(published: false)
+    Board.create!(
+      name: "Built Board",
+      user: seed_admin,
+      published: published,
+      settings: { AdminBoardBuild::BUILDER_SETTING => true },
+    )
+  end
+
+  describe "authorization" do
+    it "redirects a signed-out visitor and writes nothing" do
+      get admin_dashboard_board_builds_path
+      expect(response).to redirect_to(new_user_session_path)
+
+      expect { post preview_admin_dashboard_board_builds_path, params: form_params }
+        .to not_change(AdminBoardBuild, :count).and not_change(Image, :count)
+      expect(response).to redirect_to(new_user_session_path)
+
+      expect { post admin_dashboard_board_builds_path, params: form_params }.not_to change(AdminBoardBuild, :count)
+    end
+
+    it "redirects a non-admin away from every action" do
+      sign_in create(:user)
+      build = create_build(board: built_board)
+
+      get admin_dashboard_board_builds_path
+      expect(response).to redirect_to(root_path)
+
+      get new_admin_dashboard_board_build_path
+      expect(response).to redirect_to(root_path)
+
+      expect { post preview_admin_dashboard_board_builds_path, params: form_params }.not_to change(Image, :count)
+      expect(response).to redirect_to(root_path)
+
+      expect { post admin_dashboard_board_builds_path, params: form_params }.not_to change(AdminBoardBuild, :count)
+      expect(response).to redirect_to(root_path)
+
+      post publish_admin_dashboard_board_build_path(build)
+      expect(response).to redirect_to(root_path)
+      expect(build.board.reload.published).to be(false)
+    end
+
+    it "lets an admin in" do
+      sign_in admin
+      get new_admin_dashboard_board_build_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /admin/board_builds/preview" do
+    before { sign_in admin }
+
+    # The rail this whole two-step flow exists for. ImageResolver.resolve_all
+    # creates a blank Image for any unmatched label, so the Image assertion is
+    # the one that actually catches a regression.
+    it "writes nothing at all" do
+      expect { post preview_admin_dashboard_board_builds_path, params: form_params }
+        .to not_change(Board, :count)
+        .and not_change(Image, :count)
+        .and not_change(AdminBoardBuild, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Review the art")
+    end
+
+    it "shows every authored word in the review grid" do
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      %w[i want more swing].each { |label| expect(response.body).to include(label) }
+    end
+
+    it "reports labels with no library art as needing generation" do
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response.body).to include("will be generated")
+      expect(response.body).to include("0%")
+    end
+  end
+
+  describe "validation" do
+    before { sign_in admin }
+
+    it "rejects a tile count that doesn't fill the grid and preserves what was typed" do
+      params = form_params(rows: "3")
+
+      expect { post preview_admin_dashboard_board_builds_path, params: params }
+        .to not_change(Board, :count).and not_change(Image, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("needs exactly 6")
+      expect(response.body).to include("Playground")
+      expect(response.body).to include("swing | noun")
+    end
+
+    it "accepts a partial last row when the escape hatch is ticked" do
+      post preview_admin_dashboard_board_builds_path, params: form_params(rows: "3", allow_partial_row: "1")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Review the art")
+    end
+
+    it "rejects duplicate words" do
+      post preview_admin_dashboard_board_builds_path,
+           params: form_params(words: "i | pronoun\nwant | verb\nwant | verb\nswing | noun")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Duplicate words: want")
+    end
+
+    it "rejects an unknown part of speech" do
+      post preview_admin_dashboard_board_builds_path,
+           params: form_params(words: "i | pronoun\nwant | gerund\nmore | verb\nswing | noun")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Unknown part of speech: gerund")
+    end
+
+    it "rejects a blank name" do
+      expect { post admin_dashboard_board_builds_path, params: form_params(name: "") }
+        .not_to change(AdminBoardBuild, :count)
+      expect(response.body).to include("Give the board a name")
+    end
+
+    # VoiceService.normalize_voice waves through any string containing a colon,
+    # so a typo would only fail later at audio synthesis.
+    it "rejects a voice that isn't in the list" do
+      expect { post admin_dashboard_board_builds_path, params: form_params(voice: "polly:kevn") }
+        .not_to change(AdminBoardBuild, :count)
+      expect(response.body).to include("Pick a voice from the list")
+    end
+
+    it "rejects an out-of-range grid" do
+      post preview_admin_dashboard_board_builds_path, params: form_params(columns: "99")
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Columns must be between 1 and 12")
+    end
+  end
+
+  describe "POST /admin/board_builds" do
+    before { sign_in admin }
+
+    it "records the plan, queues the build, and still writes no board yet" do
+      expect { post admin_dashboard_board_builds_path, params: form_params }
+        .to change(AdminBoardBuild, :count).by(1)
+        .and not_change(Board, :count)
+
+      build = AdminBoardBuild.last
+      expect(build.status).to eq("pending")
+      expect(build.name).to eq("Playground")
+      expect(build.topic).to eq("the playground")
+      expect(build.columns_count).to eq(2)
+      expect(build.rows_count).to eq(2)
+      expect(build.labels).to eq(%w[i want more swing])
+      expect(build.tiles.map { |t| t["part_of_speech"] }).to eq(%w[pronoun verb important_function noun])
+      expect(BuildAdminBoardJob.jobs.map { |job| job["args"].first }).to eq([build.id])
+      expect(response).to redirect_to(admin_dashboard_board_build_path(build))
+    end
+
+    # The preview round trip is a hidden-field resubmit — create must re-derive
+    # the plan rather than trusting it.
+    it "re-validates the resubmitted plan instead of trusting the preview" do
+      expect { post admin_dashboard_board_builds_path, params: form_params(words: "i | pronoun") }
+        .not_to change(AdminBoardBuild, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(BuildAdminBoardJob.jobs).to be_empty
+    end
+
+    it "keeps a plain word with no part of speech" do
+      post admin_dashboard_board_builds_path, params: form_params(words: "i\nwant\nmore\nswing")
+
+      expect(AdminBoardBuild.last.tiles.map { |t| t["part_of_speech"] }).to eq(%w[default default default default])
+    end
+  end
+
+  describe "GET /admin/board_builds" do
+    it "lists builds" do
+      create_build(name: "Listed Build")
+      sign_in admin
+
+      get admin_dashboard_board_builds_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Listed Build")
+    end
+  end
+
+  describe "GET /admin/board_builds/:id" do
+    before { sign_in admin }
+
+    it "shows a failed build with its error and the word list intact" do
+      build = create_build(status: "failed", error_message: "boom")
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("failed")
+      expect(response.body).to include("boom")
+      expect(response.body).to include("i | pronoun")
+    end
+
+    it "surfaces the slug of the board it built" do
+      board = built_board
+      build = create_build(status: "complete", board: board)
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include(board.slug)
+    end
+  end
+
+  describe "publish / unpublish" do
+    before { sign_in admin }
+
+    it "publishes a board that has tiles" do
+      board = built_board
+      board.add_image(Image.create!(label: "i", user_id: seed_admin.id).id)
+      build = create_build(status: "complete", board: board)
+
+      post publish_admin_dashboard_board_build_path(build)
+
+      expect(board.reload.published).to be(true)
+      expect(response).to redirect_to(admin_dashboard_board_build_path(build))
+    end
+
+    it "refuses to publish an empty board" do
+      build = create_build(status: "complete", board: built_board)
+
+      post publish_admin_dashboard_board_build_path(build)
+
+      expect(build.board.reload.published).to be(false)
+      expect(flash[:alert]).to include("no tiles")
+    end
+
+    it "unpublishes a published board" do
+      build = create_build(status: "complete", board: built_board(published: true))
+
+      post unpublish_admin_dashboard_board_build_path(build)
+
+      expect(build.board.reload.published).to be(false)
+    end
+
+    # The admin_builder marker is the scoping rail: a board this page didn't
+    # create must be unreachable even if the build points at it.
+    it "does not reach a board that wasn't created here" do
+      other = create(:board, name: "Not A Built Board")
+      build = create_build(status: "complete", board: other)
+
+      post publish_admin_dashboard_board_build_path(build)
+
+      expect(other.reload.published).to be_falsey
+      expect(flash[:alert]).to include("No board to publish")
+    end
+
+    it "redirects when the build id is unknown" do
+      post publish_admin_dashboard_board_build_path(id: 0)
+
+      expect(response).to redirect_to(admin_dashboard_board_builds_path)
+      expect(flash[:alert]).to include("not found")
+    end
+  end
+
+  describe "DELETE /admin/board_builds/:id" do
+    before { sign_in admin }
+
+    it "deletes an unpublished build and its board" do
+      build = create_build(status: "complete", board: built_board)
+
+      expect { delete admin_dashboard_board_build_path(build) }
+        .to change(AdminBoardBuild, :count).by(-1)
+        .and change(Board, :count).by(-1)
+      expect(response).to redirect_to(admin_dashboard_board_builds_path)
+    end
+
+    it "refuses to delete a published board" do
+      build = create_build(status: "complete", board: built_board(published: true))
+
+      expect { delete admin_dashboard_board_build_path(build) }.not_to change(AdminBoardBuild, :count)
+      expect(flash[:alert]).to include("unpublish")
+    end
+  end
+
+  describe "when no default admin exists" do
+    it "refuses to build rather than seeding a board under the wrong owner" do
+      seed_admin.destroy
+      sign_in admin
+
+      get new_admin_dashboard_board_build_path
+
+      expect(response).to redirect_to(admin_root_path)
+      expect(flash[:alert]).to include("No default admin user configured")
+    end
+  end
+end

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -86,6 +86,91 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  describe "POST /admin/board_builds/draft" do
+    let(:drafted) do
+      [
+        { label: "I", part_of_speech: "pronoun" },
+        { label: "want", part_of_speech: "verb" },
+        { label: "more", part_of_speech: "social" },
+        { label: "swing", part_of_speech: "noun" },
+      ]
+    end
+
+    before do
+      sign_in admin
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call).and_return(drafted)
+    end
+
+    # The draft only ever populates the form — it is never fed to a preview or
+    # a build on its own.
+    it "fills the word list and writes nothing" do
+      expect { post draft_admin_dashboard_board_builds_path, params: form_params(words: "") }
+        .to not_change(Board, :count)
+        .and not_change(Image, :count)
+        .and not_change(AdminBoardBuild, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("I | pronoun")
+      expect(response.body).to include("swing | noun")
+      expect(response.body).to include("Drafted 4 words")
+    end
+
+    it "keeps everything else the admin already typed" do
+      post draft_admin_dashboard_board_builds_path,
+           params: form_params(words: "", name: "Playtime", audience: "a preschooler")
+
+      expect(response.body).to include("Playtime")
+      expect(response.body).to include("a preschooler")
+    end
+
+    it "passes the topic, grid and audience to the drafter" do
+      expect(Boards::AdminBuilder::WordListDrafter).to receive(:new)
+        .with(topic: "the playground", columns: 2, rows: 2, audience: "a preschooler")
+        .and_call_original
+
+      post draft_admin_dashboard_board_builds_path, params: form_params(audience: "a preschooler")
+    end
+
+    it "says so when the draft comes back short of the grid" do
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call).and_return(drafted.first(2))
+
+      post draft_admin_dashboard_board_builds_path, params: form_params(words: "")
+
+      expect(response.body).to include("Drafted 2 of 4 words")
+    end
+
+    it "refuses to draft without a topic" do
+      post draft_admin_dashboard_board_builds_path, params: form_params(topic: "")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Give the board a topic to draft from")
+    end
+
+    it "does not require a name — a board can be drafted before it is named" do
+      post draft_admin_dashboard_board_builds_path, params: form_params(name: "", words: "")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("I | pronoun")
+    end
+
+    it "surfaces a generation failure without losing the form" do
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call)
+        .and_raise(Boards::AdminBuilder::WordListDrafter::GenerationError, "OpenAI returned no content")
+
+      post draft_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Couldn&#39;t draft a word list")
+      expect(response.body).to include("Playground")
+    end
+
+    it "is closed to non-admins" do
+      sign_in create(:user)
+      post draft_admin_dashboard_board_builds_path, params: form_params
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
   describe "POST /admin/board_builds/preview" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/art_preview_spec.rb
+++ b/spec/services/boards/admin_builder/art_preview_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::ArtPreview do
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  def image_with_doc(label:, license: nil, source_type: "OpenAI")
+    image = Image.create!(label: label, user_id: admin.id)
+    doc = image.docs.create!(user_id: admin.id, license: license, source_type: source_type, raw: label)
+    doc.image.attach(
+      io: StringIO.new(file_fixture("sample.png").read),
+      filename: "#{label}.png",
+      content_type: "image/png",
+    )
+    image
+  end
+
+  before { admin }
+
+  # The single most important property of this service: Preview is a read-only
+  # path, and Boards::ImageResolver.resolve/resolve_all create a blank Image for
+  # any label with no match. A regression here silently litters the library.
+  it "writes nothing, for labels with art and labels without" do
+    image_with_doc(label: "apple")
+
+    expect {
+      described_class.new(labels: %w[apple nonexistentwordxyz], commercial_safe_only: false).call
+    }.to not_change(Image, :count).and not_change(Doc, :count)
+  end
+
+  it "reports an exact match with its image and a display url" do
+    image = image_with_doc(label: "apple")
+
+    row = described_class.new(labels: ["apple"], commercial_safe_only: false).call[:rows].first
+
+    expect(row.image_id).to eq(image.id)
+    expect(row.matched_label).to eq("apple")
+    expect(row).to be_exact
+    expect(row.display_url).to be_present
+  end
+
+  it "matches case-insensitively without calling it fuzzy" do
+    image_with_doc(label: "apple")
+
+    row = described_class.new(labels: ["Apple"], commercial_safe_only: false).call[:rows].first
+
+    expect(row).to be_found
+    expect(row).to be_exact
+  end
+
+  # The classic failure: "my" resolving to art labelled with a whole sentence.
+  # A hit whose own label is a different word is a judgment call, not a match.
+  it "flags a hit whose own label is a different word as inexact" do
+    image_with_doc(label: "applesauce")
+
+    result = described_class.new(labels: ["apple"], commercial_safe_only: false).call
+
+    expect(result[:rows].first).to be_found
+    expect(result[:rows].first).not_to be_exact
+    expect(result[:inexact]).to eq(["apple"])
+  end
+
+  it "reports a label with no art as missing" do
+    result = described_class.new(labels: ["nonexistentwordxyz"], commercial_safe_only: false).call
+
+    expect(result[:missing]).to eq(["nonexistentwordxyz"])
+    expect(result[:rows].first).not_to be_found
+    expect(result[:coverage_pct]).to eq(0)
+  end
+
+  it "computes coverage across the whole list" do
+    image_with_doc(label: "apple")
+    image_with_doc(label: "banana")
+
+    result = described_class.new(labels: %w[apple banana nonexistentwordxyz], commercial_safe_only: false).call
+
+    expect(result[:total]).to eq(3)
+    expect(result[:found]).to eq(2)
+    expect(result[:coverage_pct]).to eq(67)
+  end
+
+  it "surfaces licensing so an unsafe pick can be judged rather than hidden" do
+    image_with_doc(label: "apple", license: "CC BY-NC", source_type: "OpenSymbols")
+
+    row = described_class.new(labels: ["apple"], commercial_safe_only: true).call[:rows].first
+
+    expect(row).to be_found
+    expect(row.commercial_safe).to be(false)
+  end
+
+  it "ignores blank lines in the label list" do
+    result = described_class.new(labels: ["apple", "", "  "], commercial_safe_only: false).call
+    expect(result[:total]).to eq(1)
+  end
+end

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -1,0 +1,194 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::Build do
+  let!(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+  let(:requester) { create(:admin_user) }
+
+  # "Has art" is a Doc row — Boards::ImageResolver and `where.missing(:docs)`
+  # both key on that, not on an attached blob. No attachment here on purpose:
+  # ActiveStorage defers the upload to after_commit, and this service opens its
+  # own transaction, so attaching in setup makes the deferred upload fire mid-
+  # build against an already-consumed IO.
+  def image_with_art(label:)
+    image = Image.create!(label: label, user_id: admin.id)
+    image.docs.create!(user_id: admin.id, source_type: "OpenAI", raw: label)
+    image
+  end
+
+  def build_record(tiles:, columns: 2, rows: 2, **overrides)
+    AdminBoardBuild.create!(
+      {
+        created_by: requester,
+        name: "Playground",
+        topic: "the playground",
+        voice: "polly:kevin",
+        columns_count: columns,
+        rows_count: rows,
+        plan: { "tiles" => tiles },
+      }.merge(overrides),
+    )
+  end
+
+  def four_tiles
+    [
+      { "label" => "i", "part_of_speech" => "pronoun" },
+      { "label" => "want", "part_of_speech" => "verb" },
+      { "label" => "more", "part_of_speech" => "important_function" },
+      { "label" => "swing", "part_of_speech" => "noun" },
+    ]
+  end
+
+  around { |example| Sidekiq::Testing.fake! { example.run } }
+  before { GenerateImagesJob.jobs.clear }
+
+  describe "the board it writes" do
+    let(:build) { build_record(tiles: four_tiles) }
+
+    it "creates an unpublished board owned by the default admin and marked as ours" do
+      board = described_class.new(admin_board_build: build).call
+
+      expect(board.published).to be(false)
+      expect(board.user_id).to eq(admin.id)
+      expect(board.predefined).to be(true)
+      expect(board.board_type).to eq("static")
+      expect(board.settings["admin_builder"]).to be(true)
+      expect(board.settings["disable_scroll"]).to be(true)
+      expect(board.voice).to eq("polly:kevin")
+      expect(build.reload.status).to eq("complete")
+      expect(build.board_id).to eq(board.id)
+    end
+
+    # Hand-setting md/sm writes settings["custom_screen_layouts"] and
+    # permanently stops reflow — only the authored lg count may be set.
+    it "sets only the large column count and lets md/sm derive from it" do
+      board = described_class.new(admin_board_build: build_record(tiles: four_tiles, columns: 6, rows: 1)).call
+
+      expect(board.large_screen_columns).to eq(6)
+      expect(board.medium_screen_columns).to eq(Boards::ScreenColumns.derive(6, "md"))
+      expect(board.small_screen_columns).to eq(Boards::ScreenColumns.derive(6, "sm"))
+      expect(Array(board.settings["custom_screen_layouts"])).to be_empty
+    end
+
+    it "lays tiles out in authored reading order" do
+      board = described_class.new(admin_board_build: build).call
+
+      expect(board.board_images.order(:position).map(&:label)).to eq(%w[i want more swing])
+    end
+
+    it "applies the authored part of speech, which is what lands the Fitzgerald colour" do
+      board = described_class.new(admin_board_build: build).call
+      tile = board.board_images.order(:position).find { |bi| bi.label == "want" }
+
+      expect(tile.part_of_speech).to eq("verb")
+      expect(tile.bg_color).to eq(ColorHelper::PRESET_HEX["green"])
+    end
+
+    it "uses the tile text when a display_label is authored" do
+      tiles = four_tiles
+      tiles[0] = tiles[0].merge("display_label" => "Me")
+      board = described_class.new(admin_board_build: build_record(tiles: tiles)).call
+
+      expect(board.board_images.order(:position).first.display_label).to eq("Me")
+    end
+
+    it "surfaces the final slug, which a hex suffix may have changed" do
+      Board.create!(name: "Playground", slug: "playground", user: admin)
+      board = described_class.new(admin_board_build: build).call
+
+      expect(board.slug).to start_with("playground")
+      expect(build.reload.art_report["slug"]).to eq(board.slug)
+    end
+  end
+
+  describe "art" do
+    it "reuses library art and doesn't queue generation for a covered label" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      build = build_record(tiles: four_tiles)
+
+      described_class.new(admin_board_build: build).call
+
+      expect(GenerateImagesJob.jobs).to be_empty
+      expect(build.reload.art_report["coverage_pct"]).to eq(100)
+      expect(build.art_report["missing_labels"]).to be_empty
+    end
+
+    it "creates a blank image for an uncovered label and queues generation in slices of 3" do
+      build = build_record(tiles: four_tiles)
+
+      expect { described_class.new(admin_board_build: build).call }.to change(Image, :count).by(4)
+
+      queued = GenerateImagesJob.jobs.map { |job| job["args"].first }
+      expect(queued.map(&:size)).to eq([3, 1])
+      expect(queued.flatten.size).to eq(4)
+      expect(build.reload.art_report["coverage_pct"]).to eq(0)
+      expect(build.art_report["missing_labels"]).to match_array(%w[i want more swing])
+    end
+
+    # The topic is what keeps "swing" on a playground board from coming back as
+    # a mood swing. image_prompt carries intent only — Images::PromptBuilder
+    # composes the house envelope at generation time.
+    it "seeds a topic-aware prompt on generated images without baking in the house style" do
+      described_class.new(admin_board_build: build_record(tiles: four_tiles)).call
+
+      prompt = Image.find_by(label: "swing").image_prompt
+      expect(prompt).to eq("swing in the context of the playground")
+      expect(prompt).not_to include("flat vector")
+    end
+
+    it "falls back to a bare label when no topic was given" do
+      described_class.new(admin_board_build: build_record(tiles: four_tiles, topic: nil)).call
+
+      expect(Image.find_by(label: "swing").image_prompt).to eq("swing")
+    end
+
+    # Sidekiq can pick a job up before the rows it references exist, so
+    # generation must be queued after the transaction closes. The build's
+    # board_id is only assigned once it has, which makes it a usable probe.
+    it "queues generation only after the transaction has closed" do
+      build = build_record(tiles: four_tiles)
+      board_id_when_queued = :never_queued
+      allow(GenerateImagesJob).to receive(:perform_async) do |_ids, board_id|
+        board_id_when_queued = build.reload.board_id
+        expect(Board.find_by(id: board_id)).to be_present
+      end
+
+      described_class.new(admin_board_build: build).call
+
+      expect(board_id_when_queued).to eq(build.reload.board_id)
+      expect(board_id_when_queued).to be_present
+    end
+  end
+
+  describe "failure" do
+    it "records the error, writes no board, and re-raises so Sidekiq retries" do
+      build = build_record(tiles: four_tiles)
+      allow(Board).to receive(:new).and_raise(ActiveRecord::RecordInvalid.new(Board.new))
+
+      expect { described_class.new(admin_board_build: build).call }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect(build.reload.status).to eq("failed")
+      expect(build.error_message).to be_present
+      expect(build.board_id).to be_nil
+      expect(Board.where(name: "Playground")).to be_empty
+    end
+
+    it "aborts the whole build when a tile can't be added, leaving no short board" do
+      build = build_record(tiles: four_tiles)
+      allow_any_instance_of(Board).to receive(:add_image).and_return(nil)
+
+      expect { described_class.new(admin_board_build: build).call }
+        .to raise_error(Boards::AdminBuilder::Build::BuildError, /could not add a tile/)
+
+      expect(Board.where(name: "Playground")).to be_empty
+      expect(build.reload.status).to eq("failed")
+    end
+
+    it "is a no-op when the build already produced a board" do
+      build = build_record(tiles: four_tiles)
+      board = described_class.new(admin_board_build: build).call
+
+      expect { described_class.new(admin_board_build: build.reload).call }.not_to change(Board, :count)
+      expect(build.reload.board_id).to eq(board.id)
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/plan_validator_spec.rb
+++ b/spec/services/boards/admin_builder/plan_validator_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::PlanValidator do
+  def tiles(*labels)
+    labels.map { |label| { label: label, part_of_speech: "noun" } }
+  end
+
+  def validate(tiles:, columns: 2, rows: 2, allow_partial_row: false)
+    described_class.new(tiles: tiles, columns: columns, rows: rows, allow_partial_row: allow_partial_row).call
+  end
+
+  it "accepts a plan that exactly fills the grid" do
+    expect(validate(tiles: tiles("i", "want", "more", "help"))).to eq([])
+  end
+
+  describe "tile count" do
+    it "rejects a short plan and says how many to add" do
+      problems = validate(tiles: tiles("i", "want", "more"))
+      expect(problems.first).to include("3 words for a 2×2 grid (needs exactly 4)")
+      expect(problems.first).to include("Add 1")
+    end
+
+    it "allows a short plan when the partial-row escape hatch is ticked" do
+      expect(validate(tiles: tiles("i", "want", "more"), allow_partial_row: true)).to eq([])
+    end
+
+    it "rejects an over-full plan even with the escape hatch ticked" do
+      problems = validate(tiles: tiles("i", "want", "more", "help", "stop"), allow_partial_row: true)
+      expect(problems.first).to include("won't fit")
+      expect(problems.first).to include("Remove 1")
+    end
+
+    it "rejects an empty word list" do
+      expect(validate(tiles: [])).to eq(["Add at least one word."])
+    end
+
+    it "rejects a grid with no columns or rows" do
+      expect(validate(tiles: tiles("i"), columns: 0, rows: 2)).to eq(["Set both a column count and a row count."])
+    end
+  end
+
+  describe "labels" do
+    it "rejects a blank label" do
+      plan = tiles("i", "want", "more") + [{ label: "", part_of_speech: "noun" }]
+      expect(validate(tiles: plan)).to include(a_string_including("Every tile needs a word"))
+    end
+
+    it "rejects duplicate labels" do
+      problems = validate(tiles: tiles("i", "want", "want", "help"))
+      expect(problems).to include(a_string_including("Duplicate words: want"))
+    end
+
+    # images.label is a lowercase matching key, so "Want" and "want" resolve to
+    # the same symbol — two cells spent on one tile.
+    it "treats a casing-only difference as a duplicate" do
+      problems = validate(tiles: tiles("i", "Want", "want", "help"))
+      expect(problems).to include(a_string_including("Duplicate words: want"))
+    end
+  end
+
+  describe "part of speech" do
+    it "rejects a value outside the Fitzgerald key" do
+      plan = tiles("i", "want", "more") + [{ label: "help", part_of_speech: "gerund" }]
+      expect(validate(tiles: plan)).to include(a_string_including("Unknown part of speech: gerund"))
+    end
+
+    it "accepts every canonical value" do
+      ColorHelper::PARTS_OF_SPEECH.each do |pos|
+        problems = validate(tiles: [{ label: "word", part_of_speech: pos }], columns: 1, rows: 1)
+        expect(problems).to eq([]), "expected #{pos} to be accepted"
+      end
+    end
+
+    it "defaults a missing part of speech rather than rejecting it" do
+      expect(validate(tiles: [{ label: "word" }], columns: 1, rows: 1)).to eq([])
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/word_list_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/word_list_drafter_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::WordListDrafter do
+  def ai_tiles(*pairs)
+    { "tiles" => pairs.map { |label, pos| { "label" => label, "part_of_speech" => pos } } }.to_json
+  end
+
+  def stub_ai(content)
+    allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+      .and_return({ role: "assistant", content: content })
+  end
+
+  let(:four_tiles) do
+    ai_tiles(["I", "pronoun"], ["want", "verb"], ["more", "social"], ["swing", "noun"])
+  end
+
+  # Never let a spec reach the real API.
+  before { stub_ai(four_tiles) }
+
+  describe "#call" do
+    it "returns labels with parts of speech" do
+      result = described_class.new(topic: "the playground", columns: 2, rows: 2).call
+
+      expect(result).to eq([
+        { label: "I", part_of_speech: "pronoun" },
+        { label: "want", part_of_speech: "verb" },
+        { label: "more", part_of_speech: "social" },
+        { label: "swing", part_of_speech: "noun" },
+      ])
+    end
+
+    it "refuses to draft without a topic" do
+      expect { described_class.new(topic: "  ", columns: 2, rows: 2).call }
+        .to raise_error(described_class::GenerationError, /topic/)
+    end
+
+    it "trims a response longer than the grid" do
+      stub_ai(ai_tiles(["I", "pronoun"], ["want", "verb"], ["more", "social"], ["swing", "noun"], ["slide", "noun"]))
+
+      expect(described_class.new(topic: "the playground", columns: 2, rows: 2).call.size).to eq(4)
+    end
+
+    # Unlike Boards::AiPageGenerator this only fills a textarea, so a short
+    # draft is survivable — the admin types the rest.
+    it "returns a short draft rather than raising" do
+      stub_ai(ai_tiles(["I", "pronoun"], ["want", "verb"]))
+
+      expect(described_class.new(topic: "the playground", columns: 3, rows: 3).call.size).to eq(2)
+    end
+
+    it "tolerates 'word' as an alias for 'label'" do
+      stub_ai({ "tiles" => [{ "word" => "swing", "part_of_speech" => "noun" }] }.to_json)
+
+      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call)
+        .to eq([{ label: "swing", part_of_speech: "noun" }])
+    end
+  end
+
+  describe "cleanup of what the model returns" do
+    # A draft that PlanValidator would reject on arrival is worse than a short
+    # one, so exact and casing-only repeats are dropped here.
+    it "drops a casing-only duplicate" do
+      stub_ai(ai_tiles(["go", "verb"], ["Go", "verb"], ["stop", "important_function"]))
+
+      result = described_class.new(topic: "the playground", columns: 3, rows: 1).call
+      expect(result.map { |tile| tile[:label] }).to eq(%w[go stop])
+    end
+
+    it "falls back to default for a part of speech outside the Fitzgerald key" do
+      stub_ai(ai_tiles(["swing", "gerund"]))
+
+      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call)
+        .to eq([{ label: "swing", part_of_speech: "default" }])
+    end
+
+    it "normalizes casing on the part of speech" do
+      stub_ai(ai_tiles(["swing", "Noun"]))
+
+      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call.first[:part_of_speech])
+        .to eq("noun")
+    end
+
+    it "skips blank labels and non-hash entries" do
+      stub_ai({ "tiles" => [{ "label" => "  " }, "nonsense", { "label" => "swing" }] }.to_json)
+
+      expect(described_class.new(topic: "the playground", columns: 3, rows: 1).call)
+        .to eq([{ label: "swing", part_of_speech: "default" }])
+    end
+  end
+
+  describe "failures" do
+    it "raises when OpenAI returns nothing" do
+      stub_ai("")
+
+      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+        .to raise_error(described_class::GenerationError, /no content/)
+    end
+
+    it "raises on unparseable JSON" do
+      stub_ai("not json")
+
+      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+        .to raise_error(described_class::GenerationError, /Failed to parse/)
+    end
+
+    it "raises when nothing in the response is usable" do
+      stub_ai({ "tiles" => [] }.to_json)
+
+      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+        .to raise_error(described_class::GenerationError, /no usable words/)
+    end
+  end
+
+  describe "the prompt" do
+    def prompt_for(**args)
+      captured = nil
+      allow(OpenAiClient).to receive(:new) do |opts|
+        captured = opts[:messages].first[:content]
+        instance_double(OpenAiClient, create_chat: { role: "assistant", content: four_tiles })
+          .tap { |double| allow(double).to receive(:instance_variable_set) }
+      end
+      described_class.new(**args).call
+      captured
+    end
+
+    it "asks for exactly the grid's worth of tiles" do
+      expect(prompt_for(topic: "the playground", columns: 6, rows: 4)).to include("EXACTLY 24 tiles")
+    end
+
+    it "carries the core spine, in order, ahead of topic words" do
+      prompt = prompt_for(topic: "the playground", columns: 6, rows: 4)
+
+      expect(prompt).to include(described_class::CORE_SPINE.join(", "))
+      expect(prompt).to include("before any topic words")
+    end
+
+    # A 2x2 board can't carry sixteen core words; asking for them would
+    # guarantee the balance is wrong.
+    it "asks only for as much of the spine as the grid can hold" do
+      prompt = prompt_for(topic: "the playground", columns: 2, rows: 2)
+
+      expect(prompt).to include("I, you, it, want")
+      expect(prompt).not_to include("my turn")
+    end
+
+    it "carries the balance targets and the no-near-duplicates rule" do
+      prompt = prompt_for(topic: "the playground", columns: 6, rows: 4)
+
+      expect(prompt).to include("30-40% verbs and core function words")
+      expect(prompt).to include("15-20% pronouns and determiners")
+      expect(prompt).to include("15-20% describing words")
+      expect(prompt).to include("25-35% topic nouns")
+      expect(prompt).to include("No near-duplicates")
+    end
+
+    it "constrains the part of speech to the Fitzgerald key" do
+      expect(prompt_for(topic: "the playground", columns: 2, rows: 2))
+        .to include(ColorHelper::PARTS_OF_SPEECH.join(", "))
+    end
+
+    it "includes the audience only when one is given" do
+      expect(prompt_for(topic: "the playground", columns: 2, rows: 2, audience: "a preschooler"))
+        .to include("It is for: a preschooler")
+      expect(prompt_for(topic: "the playground", columns: 2, rows: 2)).not_to include("It is for:")
+    end
+  end
+end

--- a/spec/support/negated_matchers.rb
+++ b/spec/support/negated_matchers.rb
@@ -1,0 +1,7 @@
+# Composable negations, so "this writes nothing" can be asserted across several
+# tables in one block:
+#
+#   expect { preview }.to not_change(Board, :count).and not_change(Image, :count)
+#
+# `expect { }.not_to change(...)` can't be chained with `.and`.
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
Phases 1 and 2 of `.claude-notes/admin-board-builder-handoff.md`. Phase 3 (linked child pages) is **not** in this PR.

New admin page at `/admin/board_builds`, alongside Video Boards and Board Printables in the ERB admin. The flow is **draft (optional) → edit → preview the art → build → publish**.

## The rail that matters

**Preview writes nothing.** `Boards::ImageResolver.resolve` / `.resolve_all` create a blank `Image` row for any label with no match, so the preview resolves through `Images::LabelSearch` instead — its `resolve` tier calls the read-only `best_arted_for`. `resolve_all` runs only inside `Boards::AdminBuilder::Build`'s transaction, where creating blanks is the intended outcome and is what AI generation targets.

Asserted directly, on both the draft and preview steps:

```ruby
expect { post preview_admin_dashboard_board_builds_path, params: form_params }
  .to not_change(Board, :count)
  .and not_change(Image, :count)
  .and not_change(AdminBoardBuild, :count)
```

The `Image` half is the one that would actually catch a regression.

## What's here

| Piece | Does |
|---|---|
| `AdminBoardBuild` + migration | persists the authored `plan` and the resulting `art_report`, so a failed build is inspectable and re-runnable without re-typing the word list |
| `Boards::AdminBuilder::WordListDrafter` | **Phase 2.** topic (+ optional audience) + grid → `[{ label:, part_of_speech: }]` in one OpenAI call |
| `Boards::AdminBuilder::PlanValidator` | pure; rejects a tile count that doesn't fill `columns × rows`, duplicate labels (case-insensitively — `label` is a lowercase matching key), and parts of speech outside `ColorHelper::PARTS_OF_SPEECH` |
| `Boards::AdminBuilder::ArtPreview` | read-only; per-label resolved symbol, exact vs. fuzzy, licensing, coverage |
| `Boards::AdminBuilder::Build` + `BuildAdminBoardJob` | one transaction; resolve → board → tiles → `apply_layout!`; art queued after commit |
| `Admin::BoardBuildsController` + views | `new` → `draft` → `preview` → `create` → `show`, plus `publish` / `unpublish` / `destroy` |

The word list is a textarea (`word`, `word | part_of_speech`, or `word | part_of_speech | tile text`) rather than N indexed row inputs — a dense board is 24–84 words, pasting a list is the job, and it makes preserving exactly what was typed on a failed submit trivial. It's also what the AI draft writes into.

## Phase 2 — AI drafting

**The draft only ever populates the form.** `POST .../board_builds/draft` re-renders `new` with the textarea filled and stops. It never feeds a preview or a build; everything downstream still validates from scratch.

Deliberately one new prompt rather than a composition of what already exists — `Board#get_words_for_scenario` needs a persisted Board and returns bare strings with no part of speech, and `AacWordCategorizer.categorize` is one OpenAI call *per word*, so chaining them is an N+1 against a paid API for something a single call answers. Shape follows `Boards::AiPageGenerator` exactly: `OpenAiClient.new(messages:)`, `GTP_MODEL`, `create_chat(true)`, `GenerationError` on both a blank response and a parse failure, `"word"` tolerated as an alias for `"label"`.

The prompt carries the authoring rules that stop the output being a noun list: the core spine placed first, the 30-40 / 15-20 / 15-20 / 25-35 balance, no near-duplicates, exactly `columns × rows` entries. The spine is trimmed to what the grid can hold — a 2×2 board can't carry sixteen core words, and asking for them would guarantee the balance is wrong.

On arrival the draft is cleaned up: casing-only duplicates dropped, unrecognized parts of speech folded to `default`. A draft that `PlanValidator` would reject on sight is worse than a short one. **Short drafts are returned rather than raised on** — this fills a textarea, so the admin types the rest, and the flash says how many are missing. Only a response with nothing usable in it is an error.

No credit charge (admin-owned boards). Every spec stubs OpenAI; none can reach the real API.

The Draft button uses `formaction` rather than a second form, so it submits the topic, audience and grid the admin just typed above it, and it confirms before overwriting a non-empty word list.

## Decisions worth flagging

- **Tile count must equal `columns × rows`.** Rows are never stored (`Board#rows_for_screen_size` derives them from the tiles), so a partial final row doesn't shorten the board — it leaves dead cells at the right end of the last row. An "allow a partial row" checkbox is the explicit, unchecked escape hatch. Overflow is rejected regardless.
- **md/sm columns are derived explicitly** via `Boards::ScreenColumns`. The handoff said to set only `large_screen_columns` and let `Board#set_screen_sizes` derive the rest — but that callback only fills a column when it's `nil`, and `boards.medium_screen_columns` / `small_screen_columns` carry non-nil database defaults (8 and 3). Setting lg alone gives a 6-column board an 8-column tablet layout. Deriving here is not the same as authoring a md/sm *layout*, which is what marks a screen customized and stops reflow.
- **Part of speech is applied as a separate `update!` after the tile exists.** `BoardImage#set_colors` is `before_update ... if: :part_of_speech_changed?` — before_update, so it doesn't fire on create. That second write is what actually lands the Modified Fitzgerald colour.
- **Topic goes into `image_prompt` as intent only** — `"swing in the context of the playground"` — because `Images::PromptBuilder` composes the house style envelope at generation time and must not have it baked in twice. This is what keeps a playground *swing* from coming back as a mood swing.
- **Boards carry `settings["admin_builder"] = true`**, and every member action resolves through `AdminBoardBuild.builder_boards`, so publish/destroy can never reach a board this page didn't create. Boards are created unpublished; publishing is separate, confirmed, and refuses an empty board.
- `destroy` removes the build row before the board — `admin_board_builds.board_id` has a foreign key.

## Test plan

```
bundle exec rspec spec/requests/admin spec/services/boards
```

**630 examples, 0 failures.** That's the scope the handoff asked for, and it covers the existing admin and boards suites alongside the new specs.

New specs (87 examples):

- `spec/requests/admin/board_builds_spec.rb` — full authorization matrix (signed out / `role: "user"` / admin / publish against a board this page didn't create); draft and preview both write nothing; draft preserves the rest of the form, passes topic/grid/audience through, reports a short draft, doesn't require a name, and surfaces a generation failure without losing the form; grid-count, duplicate, part-of-speech, voice and range rejections each re-render 422 with the submitted values intact; `create` re-validates the hidden-field resubmit rather than trusting it; publish refuses an empty board; delete refuses a published one.
- `spec/services/boards/admin_builder/word_list_drafter_spec.rb` — output shape, over-long and short responses, `word`/`label` alias, casing-duplicate and bad-part-of-speech cleanup, all three failure modes, and the prompt itself (exact tile count, spine present and trimmed to grid size, balance targets, Fitzgerald constraint, audience only when given).
- `spec/services/boards/admin_builder/plan_validator_spec.rb`
- `spec/services/boards/admin_builder/art_preview_spec.rb` — including the no-writes assertion for a label with art and one without.
- `spec/services/boards/admin_builder/build_spec.rb` — unpublished, `DEFAULT_ADMIN_ID`-owned, marked; md/sm derived rather than set equal to lg; authored reading order; Fitzgerald colour; generation queued after the transaction closes, in slices of 3; a failed build records `status: "failed"` + `error_message`, writes no board, and re-raises so Sidekiq retries.

One shared addition: `spec/support/negated_matchers.rb` defines `not_change`, so "this writes nothing" can be asserted across several tables in a single chained block.

## Docs

- `CHANGELOG.md` entries for both phases.
- `.claude-notes/board-builder.md` gains a "Not this: the admin Board Builder" section, so the admin-side builder and the user-facing wizard don't get confused later.
- The handoff doc is committed (`git add -f`, since `.claude-notes/` is gitignored).

## Deploy

One migration (`admin_board_builds`), no backfill. No new gems, no new ENV vars. Requires `User::DEFAULT_ADMIN_ID` to exist — the controller redirects with an explanation rather than seeding under the wrong owner if it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)