### PR TITLE
feat(admin): infer the board name too, and unblock drafting without one

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1114,19 +1114,26 @@ Its own invariants:
   radius. Publishing refuses a set with any empty page; delete removes pages
   before the root.
 
-- **Topic and audience are inferred, not typed.**
-  `Boards::AdminBuilder::ContextSuggester` reads the board name and any words
-  already in the form and returns `{ topic:, audience: }` in one OpenAI call —
-  same shape as `WordListDrafter`. `POST .../board_builds/suggest` fills both
-  fields on their own; `draft` calls it first whenever the topic is blank, so
-  "Draft with AI" works from a board name alone. A value the admin typed is
-  never overwritten.
-  - **Gated on the topic only.** Audience is optional to the drafter, so a blank
-    audience alongside a known topic is not worth a round trip; the topic call
-    answers both anyway.
-  - Both values are prompt fragments, not display copy — `topic` completes
-    "`<label>` in the context of ___" for every generated tile on the board — so
-    the response is stripped of a trailing full stop and length-capped. A
-    runaway answer would otherwise end up inside every art prompt.
+- **Name, topic and audience are inferred, not typed.**
+  `Boards::AdminBuilder::ContextSuggester` reads whichever of a name, a topic
+  and the words already in the form it is given, and returns
+  `{ name:, topic:, audience: }` in one OpenAI call — same shape as
+  `WordListDrafter`. `POST .../board_builds/suggest` fills every blank field;
+  `draft` calls it first whenever the name **or** topic is blank, so a build can
+  start from a name, a topic, or a pasted word list alone. A value the admin
+  typed is never overwritten, the name included.
+  - **Not gated on a blank audience.** Audience is optional to the drafter, so
+    it isn't worth a round trip of its own — but name and topic both are
+    (preview and build require a name; topic steers every art prompt), and the
+    one call answers all three anyway.
+  - Topic and audience are prompt fragments, not display copy — `topic`
+    completes "`<label>` in the context of ___" for every generated tile on the
+    board — so the response is stripped of a trailing full stop and
+    length-capped. A runaway answer would otherwise end up inside every art
+    prompt. `name` is capped too: it is user-facing and seeds the slug.
+  - The board name input is `required`, which is right for preview and build but
+    would have the browser block a draft before the server could infer one — so
+    the draft and suggest buttons both carry `formnovalidate`. A request spec
+    can't catch that; it bypasses HTML validation.
 
 AI drafting (Phase 2) fills the main word list only — pages are authored by hand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
-- **The board builder works out the topic and audience for you.** Name a board
-  and it infers what the board is about and who it's for — the two things that
+- **The board builder works out the name, topic and audience for you.** Give it
+  any one of them — or just paste a word list — and it fills in the rest: what
+  the board should be called, what it's about, and who it's for. The last two
   steer both the drafted word list and the art generated for words the library
-  doesn't cover. It runs on its own when you draft from a name alone, or on
-  demand from a button. Anything you've typed yourself is left alone.
+  doesn't cover. It runs on its own when you draft, or on demand from a button.
+  Anything you've typed yourself is left alone.
 - **The admin board builder can build a linked set of pages, not just one
   board.** Add pages to a build, give each one a key, and point a tile at it —
   that tile becomes a folder that opens the page, and a tile on a page can point

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -39,13 +39,15 @@ module Admin
     # it, then previews the art, then builds.
     def draft
       @form = submitted_form
-      # Topic steers the draft and, later, every art prompt, so infer it from
-      # the board rather than making it a prerequisite — "Draft with AI" then
-      # works from a name alone. Gated on the topic ONLY: audience is genuinely
-      # optional to the drafter, and spending a second API call to fill it in
-      # when the topic is already known buys nothing. It gets filled anyway when
-      # the topic call runs, since that answers both.
-      @form = @form.merge(suggested_context(@form)) if @form[:topic].blank?
+      # Neither a name nor a topic is a prerequisite for drafting: whichever is
+      # missing is inferred from whatever else the form has, so a draft can
+      # start from a name, a topic, or a pasted word list alone.
+      #
+      # Deliberately NOT gated on a blank audience. Audience is optional to the
+      # drafter, so it isn't worth a round trip of its own — but name and topic
+      # both are (preview and build require a name; topic steers every art
+      # prompt), and the one call answers all three anyway.
+      @form = @form.merge(suggested_context(@form)) if @form[:topic].blank? || @form[:name].blank?
       @problems = draft_problems(@form)
       return render(:new, status: :unprocessable_entity) if @problems.any?
 
@@ -71,13 +73,13 @@ module Admin
     # before a whole word list is drafted from them.
     def suggest
       @form = submitted_form
-      if @form[:name].blank? && @form[:words].strip.blank?
-        @problems = ["Give the board a name, or some words, to work the topic out from."]
+      if nothing_to_infer_from?(@form)
+        @problems = ["Give the board a name, a topic, or some words to work from."]
         return render(:new, status: :unprocessable_entity)
       end
 
       @form = @form.merge(suggest_context(@form))
-      flash.now[:notice] = "Suggested a topic and audience — edit them, or draft a word list."
+      flash.now[:notice] = "Filled in what was blank — edit it, or draft a word list."
       render :new
     rescue Boards::AdminBuilder::ContextSuggester::GenerationError => e
       @problems = ["Couldn't suggest a topic: #{e.message}"]
@@ -229,21 +231,28 @@ module Admin
       @voice_values ||= VoiceService::VOICES.map { |voice| voice[:value] }
     end
 
-    # The whole suggestion, so a partially-filled form only has the blank half
-    # replaced — an explicitly typed topic or audience is never overwritten.
+    def nothing_to_infer_from?(form)
+      form[:name].blank? && form[:topic].blank? && form[:words].strip.blank?
+    end
+
+    # Only the blanks are filled — anything the admin typed is never
+    # overwritten, including the name.
     def suggest_context(form)
-      context = Boards::AdminBuilder::ContextSuggester.new(name: form[:name], words: form[:words]).call
+      context = Boards::AdminBuilder::ContextSuggester.new(
+        name: form[:name], topic: form[:topic], words: form[:words],
+      ).call
 
       {
+        name: form[:name].presence || context[:name],
         topic: form[:topic].presence || context[:topic],
         audience: form[:audience].presence || context[:audience],
       }
     end
 
-    # Same, but a failure here is not fatal: drafting can still go ahead if the
-    # admin typed a topic themselves, and `draft_problems` reports it if not.
+    # Same, but skipped rather than raised when there is nothing to work from —
+    # `draft_problems` reports that more usefully than a generation error would.
     def suggested_context(form)
-      return {} if form[:name].blank? && form[:words].strip.blank?
+      return {} if nothing_to_infer_from?(form)
 
       suggest_context(form)
     end

--- a/app/services/boards/admin_builder/context_suggester.rb
+++ b/app/services/boards/admin_builder/context_suggester.rb
@@ -1,14 +1,15 @@
 module Boards
   module AdminBuilder
-    # Infers a board's topic and audience from its name — and from the words
-    # already on it, when there are any. One OpenAI call returning
-    # `{ topic:, audience: }`.
+    # Infers a board's name, topic and audience from whatever the admin has
+    # given so far — any of a name, a topic, or the words already on the board.
+    # One OpenAI call returning `{ name:, topic:, audience: }`.
     #
-    # Both fields exist to be fed to other prompts rather than to be stored
-    # prose: `topic` is what completes "<label> in the context of ___" when art
-    # is generated (the difference between a playground *swing* and a mood
-    # swing), and `audience` steers the word-list draft. So the prompt asks for
-    # a short noun phrase in each, not a sentence.
+    # Two of the three exist to be fed to other prompts rather than to be
+    # stored prose: `topic` is what completes "<label> in the context of ___"
+    # when art is generated (the difference between a playground *swing* and a
+    # mood swing), and `audience` steers the word-list draft. So the prompt asks
+    # for a short noun phrase in each, not a sentence. `name` is different — it
+    # is user-facing, and it seeds the board's slug.
     #
     # ONLY EVER POPULATES THE FORM — like WordListDrafter, this is a starting
     # point a human edits before anything is previewed or built.
@@ -25,15 +26,18 @@ module Boards
       # end up inside every art prompt for the board.
       MAX_TOPIC_LENGTH = 120
       MAX_AUDIENCE_LENGTH = 120
+      # A board name is user-facing and seeds the slug, so it stays short.
+      MAX_NAME_LENGTH = 60
 
-      def initialize(name:, words: nil)
+      def initialize(name: nil, topic: nil, words: nil)
         @name = name.to_s.strip
+        @topic = topic.to_s.strip
         @words = word_sample(words)
       end
 
       def call
-        if name.blank? && words.empty?
-          raise GenerationError, "give the board a name, or some words, to work from"
+        if name.blank? && topic.blank? && words.empty?
+          raise GenerationError, "give the board a name, a topic, or some words to work from"
         end
 
         parse_response(generate_via_openai)
@@ -41,7 +45,7 @@ module Boards
 
       private
 
-      attr_reader :name, :words
+      attr_reader :name, :topic, :words
 
       def word_sample(words)
         words.to_s.split("\n").filter_map do |line|
@@ -52,7 +56,7 @@ module Boards
 
       def generate_via_openai
         client = OpenAiClient.new(
-          prompt: name.presence || words.first.to_s,
+          prompt: name.presence || topic.presence || words.first.to_s,
           messages: [{ role: "user", content: build_prompt }],
         )
         client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
@@ -69,9 +73,15 @@ module Boards
           nonspeaking communicator.
 
           #{name.present? ? "The board is called: #{name}" : "The board has no name yet."}
+          #{topic.present? ? "It is about: #{topic}" : ""}
           #{words.any? ? "Words already on it: #{words.join(", ")}" : ""}
 
-          Infer two things about it.
+          Infer three things about it.
+
+          "name" — a short, plain title for the board, the kind a teacher or parent would
+          recognize in a list: "At the Playground", "Getting Dressed", "Snack Time". Title
+          case, no punctuation, at most six words. If the board already has a name, repeat it
+          back unchanged rather than improving it.
 
           "topic" — the subject or setting of the board, as a short noun phrase that can be
           dropped into the sentence "a picture of <word> in the context of ___". Write it so
@@ -85,7 +95,7 @@ module Boards
           answer "an early communicator" rather than guessing something specific.
 
           Respond in JSON format:
-          { "topic": "the playground", "audience": "an early communicator" }
+          { "name": "At the Playground", "topic": "the playground", "audience": "an early communicator" }
 
           Return ONLY the JSON, no other text.
         PROMPT
@@ -93,12 +103,13 @@ module Boards
 
       def parse_response(raw)
         data = JSON.parse(raw)
-        topic = clean(data["topic"], MAX_TOPIC_LENGTH)
+        suggested_name = clean(data["name"], MAX_NAME_LENGTH)
+        suggested_topic = clean(data["topic"], MAX_TOPIC_LENGTH)
         audience = clean(data["audience"], MAX_AUDIENCE_LENGTH)
 
-        raise GenerationError, "AI returned no usable topic" if topic.blank?
+        raise GenerationError, "AI returned no usable topic" if suggested_topic.blank?
 
-        { topic: topic, audience: audience }
+        { name: suggested_name, topic: suggested_topic, audience: audience }
       rescue JSON::ParserError => e
         raise GenerationError, "Failed to parse AI response: #{e.message}"
       end

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -13,9 +13,9 @@
             name and any words already typed in this same form. %>
         <button type="submit" formaction="<%= suggest_admin_dashboard_board_builds_path %>" formnovalidate
                 class="text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
-          Work out topic &amp; audience
+          Fill in the blanks
         </button>
-        <p class="text-[11px] text-t3 ml-3">Reads the board name and any words you've typed. Drafting does this on its own if they're blank.</p>
+        <p class="text-[11px] text-t3 ml-3">Works out the name, topic and audience from whichever of them you've given — or from a pasted word list. Drafting does it on its own too.</p>
       </div>
       <div>
         <label class="block text-xs font-medium text-t2 mb-1" for="topic">Topic <span class="text-t3">(optional)</span></label>
@@ -57,7 +57,10 @@
       <h2 class="text-sm font-medium text-t1">Word list</h2>
       <%# formaction, not a second form: drafting has to see the topic, audience
           and grid the admin just typed above. %>
-      <button type="submit" id="draft-button" formaction="<%= draft_admin_dashboard_board_builds_path %>"
+      <%# formnovalidate: the board name is `required` for preview and build,
+          but drafting infers a missing one — without this the browser blocks
+          the submit before the server ever gets to. %>
+      <button type="submit" id="draft-button" formaction="<%= draft_admin_dashboard_board_builds_path %>" formnovalidate
               class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
         Draft with AI
       </button>

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -210,10 +210,10 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     before do
       sign_in admin
       allow_any_instance_of(Boards::AdminBuilder::ContextSuggester).to receive(:call)
-        .and_return({ topic: "the playground", audience: "a preschooler" })
+        .and_return({ name: "At the Playground", topic: "the playground", audience: "a preschooler" })
     end
 
-    it "fills in both fields and writes nothing" do
+    it "fills in every blank field and writes nothing" do
       expect { post suggest_admin_dashboard_board_builds_path, params: form_params(topic: "", audience: "") }
         .to not_change(Board, :count)
         .and not_change(Image, :count)
@@ -222,7 +222,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("the playground")
       expect(response.body).to include("a preschooler")
-      expect(response.body).to include("Suggested a topic and audience")
+      expect(response.body).to include("Filled in what was blank")
     end
 
     it "keeps the rest of the form" do
@@ -233,12 +233,28 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response.body).to include("swing | noun")
     end
 
-    it "reads the board name and the words already typed" do
+    it "reads the name, topic and words already typed" do
       expect(Boards::AdminBuilder::ContextSuggester).to receive(:new)
-        .with(name: "Playground", words: a_string_including("swing"))
+        .with(name: "Playground", topic: "", words: a_string_including("swing"))
         .and_call_original
 
       post suggest_admin_dashboard_board_builds_path, params: form_params(name: "Playground", topic: "", audience: "")
+    end
+
+    # The whole point: an admin shouldn't have to invent a board name first.
+    it "names a board that has only a topic" do
+      post suggest_admin_dashboard_board_builds_path,
+           params: form_params(name: "", audience: "", words: "")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("At the Playground")
+    end
+
+    it "leaves a name the admin typed alone" do
+      post suggest_admin_dashboard_board_builds_path, params: form_params(name: "My Board", topic: "", audience: "")
+
+      expect(response.body).to include("My Board")
+      expect(response.body).not_to include("At the Playground")
     end
 
     it "leaves a value the admin already typed alone" do
@@ -248,11 +264,11 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response.body).not_to include("a preschooler")
     end
 
-    it "refuses when there is nothing to work from" do
-      post suggest_admin_dashboard_board_builds_path, params: form_params(name: "", words: "")
+    it "refuses when there is nothing at all to work from" do
+      post suggest_admin_dashboard_board_builds_path, params: form_params(name: "", topic: "", words: "")
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("Give the board a name, or some words")
+      expect(response.body).to include("Give the board a name, a topic, or some words")
     end
 
     it "surfaces a generation failure without losing the form" do
@@ -286,6 +302,10 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     before do
       sign_in admin
       allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call).and_return(drafted)
+      # A blank name or topic makes draft infer first, so nothing here can
+      # reach the real API by accident.
+      allow_any_instance_of(Boards::AdminBuilder::ContextSuggester).to receive(:call)
+        .and_return({ name: "At the Playground", topic: "the playground", audience: "an early communicator" })
     end
 
     # The draft only ever populates the form — it is never fed to a preview or
@@ -330,7 +350,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     # blank one is inferred rather than being a prerequisite.
     it "works out a blank topic and audience before drafting" do
       allow_any_instance_of(Boards::AdminBuilder::ContextSuggester).to receive(:call)
-        .and_return({ topic: "the playground", audience: "a preschooler" })
+        .and_return({ name: "At the Playground", topic: "the playground", audience: "a preschooler" })
 
       expect(Boards::AdminBuilder::WordListDrafter).to receive(:new)
         .with(hash_including(topic: "the playground", audience: "a preschooler"))
@@ -340,6 +360,19 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
            params: form_params(topic: "", audience: "", name: "At the Playground", words: "")
 
       expect(response).to have_http_status(:ok)
+    end
+
+    # Preview and build require a name, so drafting fills a blank one rather
+    # than handing back a word list that can't be submitted.
+    it "names an unnamed board while drafting it" do
+      allow_any_instance_of(Boards::AdminBuilder::ContextSuggester).to receive(:call)
+        .and_return({ name: "At the Playground", topic: "the playground", audience: "a preschooler" })
+
+      post draft_admin_dashboard_board_builds_path, params: form_params(name: "", words: "")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("At the Playground")
+      expect(response.body).to include("I | pronoun")
     end
 
     it "never overwrites a topic the admin typed" do
@@ -353,7 +386,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
 
     it "fills a blank topic but keeps an audience the admin typed" do
       allow_any_instance_of(Boards::AdminBuilder::ContextSuggester).to receive(:call)
-        .and_return({ topic: "the playground", audience: "someone else" })
+        .and_return({ name: "Playground", topic: "the playground", audience: "someone else" })
 
       expect(Boards::AdminBuilder::WordListDrafter).to receive(:new)
         .with(hash_including(topic: "the playground", audience: "a teenager"))

--- a/spec/services/boards/admin_builder/context_suggester_spec.rb
+++ b/spec/services/boards/admin_builder/context_suggester_spec.rb
@@ -6,15 +6,24 @@ RSpec.describe Boards::AdminBuilder::ContextSuggester do
       .and_return({ role: "assistant", content: content })
   end
 
-  let(:valid) { { "topic" => "the playground", "audience" => "an early communicator" }.to_json }
+  let(:valid) do
+    { "name" => "At the Playground", "topic" => "the playground",
+      "audience" => "an early communicator" }.to_json
+  end
 
   # Never let a spec reach the real API.
   before { stub_ai(valid) }
 
   describe "#call" do
-    it "returns a topic and an audience" do
+    it "returns a name, a topic and an audience" do
       expect(described_class.new(name: "At the Playground").call)
-        .to eq({ topic: "the playground", audience: "an early communicator" })
+        .to eq({ name: "At the Playground", topic: "the playground", audience: "an early communicator" })
+    end
+
+    # The point of naming the board: an admin shouldn't have to invent one
+    # before the AI will do anything.
+    it "works from a topic alone, with no name" do
+      expect(described_class.new(topic: "the playground").call[:name]).to eq("At the Playground")
     end
 
     it "works from words alone when the board has no name" do
@@ -22,9 +31,9 @@ RSpec.describe Boards::AdminBuilder::ContextSuggester do
         .to eq("the playground")
     end
 
-    it "refuses when there is nothing to work from" do
-      expect { described_class.new(name: "  ", words: "  ").call }
-        .to raise_error(described_class::GenerationError, /name, or some words/)
+    it "refuses when there is nothing at all to work from" do
+      expect { described_class.new(name: "  ", topic: "  ", words: "  ").call }
+        .to raise_error(described_class::GenerationError, /name, a topic, or some words/)
     end
   end
 
@@ -39,18 +48,20 @@ RSpec.describe Boards::AdminBuilder::ContextSuggester do
       expect(result[:audience]).to eq("an early communicator")
     end
 
-    it "caps a runaway topic" do
-      stub_ai({ "topic" => "x" * 500, "audience" => "y" * 500 }.to_json)
+    it "caps a runaway response" do
+      stub_ai({ "name" => "n" * 500, "topic" => "x" * 500, "audience" => "y" * 500 }.to_json)
 
       result = described_class.new(name: "Playground").call
+      expect(result[:name].length).to eq(described_class::MAX_NAME_LENGTH)
       expect(result[:topic].length).to eq(described_class::MAX_TOPIC_LENGTH)
       expect(result[:audience].length).to eq(described_class::MAX_AUDIENCE_LENGTH)
     end
 
-    it "tolerates a missing audience" do
+    it "tolerates a missing name and audience" do
       stub_ai({ "topic" => "the playground" }.to_json)
 
-      expect(described_class.new(name: "Playground").call).to eq({ topic: "the playground", audience: "" })
+      expect(described_class.new(name: "Playground").call)
+        .to eq({ name: "", topic: "the playground", audience: "" })
     end
   end
 
@@ -99,6 +110,14 @@ RSpec.describe Boards::AdminBuilder::ContextSuggester do
 
     it "says so when the board has no name" do
       expect(prompt_for(name: "", words: "swing")).to include("no name yet")
+    end
+
+    it "carries a topic the admin already typed" do
+      expect(prompt_for(topic: "the playground")).to include("It is about: the playground")
+    end
+
+    it "asks for a short, recognizable board name" do
+      expect(prompt_for(name: "Playground")).to include("at most six words")
     end
 
     # The topic's whole job is to complete the art prompt's sentence.


### PR DESCRIPTION
Follow-up to [#622](https://github.com/brittanyjohns/itty_bitty_boards/pull/622). Answering "do I still have to come up with the board name first?" — you did, and now you don't.

## What was wrong

Two things, one of them a real defect:

1. **`ContextSuggester` inferred topic and audience, but not the name** — and preview and build both require a name. So the AI could tell you what your board was about, but you still had to name it before you could build it.
2. **The Draft button was blocked by HTML validation.** The name input is `required: true`, which is correct for preview and build. `formnovalidate` was on the Suggest button but not the Draft button, so in a real browser the name field blocked drafting *before the request was ever sent* — even though the server was perfectly willing to draft without one.

The second is worth calling out because the request spec asserting "a board can be drafted from a topic alone" **passed the whole time**. Request specs post directly and never run HTML validation, so the browser-only failure was invisible to them. I found it by reading the form, not by running tests.

## The change

- `ContextSuggester` takes any of a **name**, a **topic**, or the **word list**, and returns `{ name:, topic:, audience: }`. A build can now start from any one of the three — including pasting a word list into an otherwise empty form.
- `draft` infers when the name **or** topic is blank (was: topic only), so a drafted board comes back already named and ready to preview.
- Still **not** gated on a blank audience. That one is genuinely optional to the drafter and isn't worth a round trip of its own — and the single call answers all three anyway. Name and topic both are worth it: preview and build require a name, and topic steers every art prompt on the board.
- Both the Draft and Suggest buttons now carry `formnovalidate`.
- Anything the admin typed is still never overwritten, the name included — if the board already has a name the prompt is told to repeat it back unchanged rather than improve it.
- `name` is length-capped like the other two. It is user-facing and seeds the board's slug, so a runaway answer matters more here than elsewhere.

The Suggest button is relabelled "Fill in the blanks", since it now does three fields rather than two.

## Test plan

```
bundle exec rspec spec/requests/admin spec/services/boards
```

**708 examples, 0 failures.**

New coverage:

- `context_suggester_spec.rb` — works from a topic alone with no name; refuses only when name, topic *and* words are all empty; the name is length-capped; a missing name in the response is tolerated; the prompt carries a typed topic and asks for a short, recognizable board name.
- `board_builds_spec.rb` — `suggest` names a board that has only a topic, leaves a typed name alone, and reads all three inputs; `draft` names an unnamed board while drafting it.

The draft describe block now stubs `ContextSuggester` by default, so no spec in it can reach the real API by accident once a blank name started triggering inference.

## Note on branching

The first version of this commit was written on `claude/admin-board-builder-phase-3` before I noticed #622 had been merged mid-session. The pre-push hook caught it — pushing there would have stranded the work off `main`. This branch is cut fresh from `origin/main` at `be1fafc6` and the change re-applied; nothing was lost.

## Deploy

No migration. No new gems, no new ENV vars. One extra OpenAI call only in the case that previously errored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)