### PR TITLE
fix(admin): the board builder form must opt out of Turbo

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -171,6 +171,13 @@ instead of silently producing a short board.
   synthesis. Constrain voice to a select box; don't take free text.
 - Setting `voice` on a Board cascades to tiles and re-queues audio — set it at
   create time rather than patching after.
+- **The authoring form must stay `data: { turbo: false }`.** `suggest`, `draft`
+  and `preview` all answer a POST with a rendered 200, because each hands the
+  admin's own submission back to them. Turbo Drive refuses a 2xx form response
+  that isn't a redirect (`Form responses must redirect to another location`),
+  throws, and leaves the page untouched — so with Turbo on, every button on the
+  form is a silent no-op. Request specs can't see this: they assert the rendered
+  body and never run Turbo. A spec asserts the attribute is present instead.
 
 ## Work items
 

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -1,6 +1,12 @@
 <%# The authoring form. Rendered by `new` and again at the bottom of `preview`
     so "change something and look again" is one round trip, not a re-type. %>
-<%= form_tag preview_admin_dashboard_board_builds_path, method: :post do %>
+<%# turbo: false is load-bearing. Every action this form posts to — suggest,
+    draft, preview — answers with a rendered 200, not a redirect, because each
+    one hands the admin's own submission back to them. Turbo Drive refuses a
+    2xx form response that isn't a redirect ("Form responses must redirect to
+    another location"), throws, and leaves the page untouched — so with Turbo
+    on, every button here is a no-op. %>
+<%= form_tag preview_admin_dashboard_board_builds_path, method: :post, data: { turbo: false } do %>
   <div class="admin-card border rounded-xl p-5 mb-6">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -87,6 +87,26 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  # Turbo Drive discards a 2xx form response that isn't a redirect ("Form
+  # responses must redirect to another location") — so every action this form
+  # posts to that renders instead of redirecting (suggest, draft, preview)
+  # silently does nothing in a browser unless the form opts out.
+  describe "the authoring form opts out of Turbo" do
+    before { sign_in admin }
+
+    it "marks the form on the new page" do
+      get new_admin_dashboard_board_build_path
+
+      expect(response.body).to include('data-turbo="false"')
+    end
+
+    it "marks the form re-rendered under the art preview" do
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response.body).to include('data-turbo="false"')
+    end
+  end
+
   describe "child pages" do
     before { sign_in admin }
 


### PR DESCRIPTION
## The bug

Nothing on **New Board Build** did anything. "Fill in the blanks", "Draft with AI" and "Preview the art" all posted, got a 200 back, and left the page exactly as it was. The console showed:

> `Error: Form responses must redirect to another location` at `_FormSubmission.requestSucceededWithResponse`

## Root cause

All three of those actions answer a POST with a **rendered 200**, not a redirect — by design, since each one hands the admin's own submission back to them with something filled in. Turbo Drive refuses a 2xx form response that isn't a redirect, throws, and discards the response. The page never updates.

Only the *error* paths appeared to work, because those render `422` and Turbo happily renders a non-2xx.

The server side was always correct. Request specs never caught this because they assert the rendered body and never run Turbo.

## The fix

`data: { turbo: false }` on the authoring form, with a comment saying why it can't be dropped.

Every other render-instead-of-redirect form in the admin dashboard — `users`, `feedback`, `board_printables`, `mission_control` — already carried this. The board builder form was the outlier.

The "Build this board" form on the preview page is untouched: `create` redirects, so Turbo is correct there, and its `turbo_confirm` needs Turbo on.

## Test plan

- Two new regression specs assert the form carries `data-turbo="false"` on the `new` page **and** on the copy re-rendered under the art preview. Both fail without the fix.
- `bundle exec rspec spec/requests/admin/board_builds_spec.rb` → **68 examples, 0 failures**

## Docs

Added the trap to `.claude-notes/admin-board-builder-handoff.md` under "Other behaviour worth knowing before it surprises you" — removing the attribute silently breaks the whole page, and no request spec will tell you.

No CHANGELOG entry: the features this unblocks are still under `[Unreleased]`, so they never shipped in a working state to log a fix against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)