### PR TITLE
feat(admin): board build review — open in new tab, real column width, size in tiles

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1113,6 +1113,12 @@ Its own invariants:
   re-scoped through `builder_boards`, so a hand-edited id can't widen the blast
   radius. Publishing refuses a set with any empty page; delete removes pages
   before the root.
+- **The review page links out with `board_app_url`, not the `/pb/` page.**
+  `Admin::BoardBuildsHelper#board_app_url` points at `FRONT_END_URL/boards/:id`,
+  which resolves for an unpublished board — the whole point of the review step.
+  `board_published_page_url` (`/pb/<slug>`) is only rendered once
+  `board.published?`, because `Board#viewable_by?` gates the public page on that
+  flag and an unpublished link would 404 the admin who clicked it.
 
 - **Name, topic and audience are inferred, not typed.**
   `Boards::AdminBuilder::ContextSuggester` reads whichever of a name, a topic

--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1050,10 +1050,15 @@ Its own invariants:
   them. `resolve_all` runs only inside `Boards::AdminBuilder::Build`'s
   transaction, where creating blanks is the intended outcome. Asserted by spec
   on both `Board.count` and `Image.count`.
-- **Tile count must equal `columns × rows`.** Rows aren't stored
-  (`Board#rows_for_screen_size` derives them), so a short final row leaves dead
-  cells rather than a shorter board. `Boards::AdminBuilder::PlanValidator`
-  rejects it; an "allow a partial row" checkbox is the explicit escape hatch.
+- **A board is authored as columns + a tile count, never rows.** Rows aren't
+  stored anywhere — `Board#rows_for_screen_size` derives them from the tiles —
+  so `admin_board_builds.tile_count` (and a child page's `tile_count` override
+  inside `plan`) is the size. `Boards::AdminBuilder::PlanValidator` enforces two
+  separate things: the word list must be **exactly** `tile_count` long, and
+  `tile_count` must be a whole number of rows for the column count. Only the
+  second has an escape hatch ("allow a partial row") — a tile count that isn't a
+  multiple of the columns leaves dead cells at the right end of the last row.
+  Shrinking the board is the fix for a short word list, not ticking the box.
 - **Boards are marked `settings["admin_builder"] = true`** and every member
   action is scoped through `AdminBoardBuild.builder_boards`, the same rail
   `Admin::VideoBoardsController` runs on. Boards are created unpublished;
@@ -1113,6 +1118,11 @@ Its own invariants:
   re-scoped through `builder_boards`, so a hand-edited id can't widen the blast
   radius. Publishing refuses a set with any empty page; delete removes pages
   before the root.
+- **Both review grids render the authored column count**, via the `.builder-grid`
+  class in the admin layout plus an inline `--cols`. Tailwind can't compile a
+  class assembled at runtime, so a hardcoded six-across grid was showing every
+  board — 4-wide, 8-wide — at a width it would never be used at, which defeats
+  the point of reviewing before publishing.
 - **The review page links out with `board_app_url`, not the `/pb/` page.**
   `Admin::BoardBuildsHelper#board_app_url` points at `FRONT_END_URL/boards/:id`,
   which resolves for an unpublished board — the whole point of the review step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **The board builder asks for a tile count instead of rows.** The board never
+  stored a row count — it works out rows from how many tiles there are — so
+  "6 × 4" was really just "24 tiles" wearing a disguise. The field now says what
+  it does. The rail against dead cells moved with it: a tile count that doesn't
+  fill whole rows is flagged, with the two nearest counts that would, and
+  "allow a partial row" is still there for when you mean it.
+- **The board build preview shows the real layout.** The review grid was always
+  six tiles across no matter what you authored, so an 8-wide board was reviewed
+  at a width it would never be used at. Both the art preview and the built-board
+  page now draw the board at its own column count, and each page of a linked set
+  at its own.
+
 ### Added
 
 - **The board build review page opens the board in a new tab.** Every built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **The board build review page opens the board in a new tab.** Every built
+  board — and every page of a linked set — now has an "open" link straight into
+  the app, so you can try the real thing before publishing instead of judging it
+  from the tile grid. Once a board is published, the `/pb/` public URL becomes a
+  link too.
 - **The board builder works out the name, topic and audience for you.** Give it
   any one of them — or just paste a word list — and it fills in the rest: what
   the board should be called, what it's about, and who it's for. The last two

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -16,9 +16,10 @@ module Admin
   #      board this page didn't create.
   class BoardBuildsController < Admin::ApplicationController
     MAX_COLUMNS = 12
-    MAX_ROWS = 12
+    # 12x12, the old grid ceiling expressed as tiles.
+    MAX_TILES = 144
     DEFAULT_COLUMNS = 6
-    DEFAULT_ROWS = 4
+    DEFAULT_TILES = 24
     DEFAULT_VOICE = "polly:kevin".freeze
     # Marks the field in a word-list line that names the page a tile opens.
     LINK_TOKEN = ">".freeze
@@ -53,8 +54,7 @@ module Admin
 
       tiles = Boards::AdminBuilder::WordListDrafter.new(
         topic: @form[:topic],
-        columns: @form[:columns].to_i,
-        rows: @form[:rows].to_i,
+        tile_count: @form[:tile_count].to_i,
         audience: @form[:audience],
       ).call
 
@@ -116,7 +116,7 @@ module Admin
         topic: @form[:topic].presence,
         voice: @form[:voice],
         columns_count: @form[:columns].to_i,
-        rows_count: @form[:rows].to_i,
+        tile_count: @form[:tile_count].to_i,
         commercial_safe_only: @form[:commercial_safe_only],
         plan: {
           "tiles" => Boards::AdminBuilder::Plan.stringify_tiles(@form[:tiles]),
@@ -125,7 +125,7 @@ module Admin
               "key" => child[:key],
               "name" => child[:name],
               "columns" => child[:columns].presence&.to_i,
-              "rows" => child[:rows].presence&.to_i,
+              "tile_count" => child[:tile_count].presence&.to_i,
               "tiles" => Boards::AdminBuilder::Plan.stringify_tiles(child[:tiles]),
             }.compact
           end,
@@ -257,7 +257,7 @@ module Admin
       suggest_context(form)
     end
 
-    # Drafting needs something to draft about and a grid to size the list. The
+    # Drafting needs something to draft about and a size for the list. The
     # topic is inferred from the board first, so this only fires when there was
     # nothing to infer it from.
     def draft_problems(form)
@@ -265,9 +265,9 @@ module Admin
       problems << "Give the board a name or a topic to draft from." if form[:topic].blank?
 
       columns = form[:columns].to_i
-      rows = form[:rows].to_i
+      tiles = form[:tile_count].to_i
       problems << "Columns must be between 1 and #{MAX_COLUMNS}." unless columns.between?(1, MAX_COLUMNS)
-      problems << "Rows must be between 1 and #{MAX_ROWS}." unless rows.between?(1, MAX_ROWS)
+      problems << "Tiles must be between 1 and #{MAX_TILES}." unless tiles.between?(1, MAX_TILES)
       problems
     end
 
@@ -279,7 +279,7 @@ module Admin
     # survivable because this only fills the textarea — but say so rather than
     # letting the admin discover it at preview.
     def draft_notice(tiles, form)
-      wanted = form[:columns].to_i * form[:rows].to_i
+      wanted = form[:tile_count].to_i
       return "Drafted #{tiles.size} words. Edit them, then preview the art." if tiles.size == wanted
 
       "Drafted #{tiles.size} of #{wanted} words — add #{wanted - tiles.size} more before previewing."
@@ -292,7 +292,7 @@ module Admin
         audience: "",
         voice: DEFAULT_VOICE,
         columns: DEFAULT_COLUMNS.to_s,
-        rows: DEFAULT_ROWS.to_s,
+        tile_count: DEFAULT_TILES.to_s,
         words: "",
         tiles: [],
         children: [],
@@ -303,7 +303,7 @@ module Admin
     end
 
     def blank_child
-      { key: "", name: "", columns: "", rows: "", words: "", tiles: [] }
+      { key: "", name: "", columns: "", tile_count: "", words: "", tiles: [] }
     end
 
     # Keeps the raw submitted strings so a failed submit re-renders exactly what
@@ -318,7 +318,7 @@ module Admin
         audience: params[:audience].to_s.strip,
         voice: params[:voice].to_s.strip.presence || DEFAULT_VOICE,
         columns: params[:columns].to_s.strip,
-        rows: params[:rows].to_s.strip,
+        tile_count: params[:tile_count].to_s.strip,
         words: words,
         tiles: parse_tiles(words),
         children: submitted_children,
@@ -338,7 +338,7 @@ module Admin
           key: child[:key].to_s.strip.downcase,
           name: child[:name].to_s.strip,
           columns: child[:columns].to_s.strip,
-          rows: child[:rows].to_s.strip,
+          tile_count: child[:tile_count].to_s.strip,
           words: words,
           tiles: parse_tiles(words),
         }
@@ -386,9 +386,9 @@ module Admin
       problems << "Pick a voice from the list." unless voice_values.include?(form[:voice])
 
       columns = form[:columns].to_i
-      rows = form[:rows].to_i
+      tiles = form[:tile_count].to_i
       problems << "Columns must be between 1 and #{MAX_COLUMNS}." unless columns.between?(1, MAX_COLUMNS)
-      problems << "Rows must be between 1 and #{MAX_ROWS}." unless rows.between?(1, MAX_ROWS)
+      problems << "Tiles must be between 1 and #{MAX_TILES}." unless tiles.between?(1, MAX_TILES)
       problems.concat(child_grid_range_problems(form))
       return problems if problems.any?
 
@@ -409,8 +409,8 @@ module Admin
         if child[:columns].present? && !child[:columns].to_i.between?(1, MAX_COLUMNS)
           problems << "#{label}: columns must be between 1 and #{MAX_COLUMNS}."
         end
-        if child[:rows].present? && !child[:rows].to_i.between?(1, MAX_ROWS)
-          problems << "#{label}: rows must be between 1 and #{MAX_ROWS}."
+        if child[:tile_count].present? && !child[:tile_count].to_i.between?(1, MAX_TILES)
+          problems << "#{label}: tiles must be between 1 and #{MAX_TILES}."
         end
         problems
       end
@@ -421,7 +421,7 @@ module Admin
         root: {
           name: form[:name],
           columns: form[:columns].to_i,
-          rows: form[:rows].to_i,
+          tile_count: form[:tile_count].to_i,
           tiles: form[:tiles],
         },
         children: form[:children],

--- a/app/helpers/admin/board_builds_helper.rb
+++ b/app/helpers/admin/board_builds_helper.rb
@@ -1,0 +1,21 @@
+module Admin
+  module BoardBuildsHelper
+    # The board as it opens in the app. Unlike the /pb/ public page this works
+    # before the board is published, which is exactly when an admin is
+    # reviewing a fresh build.
+    def board_app_url(board)
+      "#{front_end_base_url}/boards/#{board.id}"
+    end
+
+    # Only meaningful once the board is published — /pb/ 404s before that.
+    def board_published_page_url(board)
+      "#{front_end_base_url}/pb/#{board.slug}"
+    end
+
+    private
+
+    def front_end_base_url
+      ENV["FRONT_END_URL"] || "http://localhost:8100"
+    end
+  end
+end

--- a/app/models/admin_board_build.rb
+++ b/app/models/admin_board_build.rb
@@ -18,7 +18,7 @@ class AdminBoardBuild < ApplicationRecord
 
   validates :status, inclusion: { in: STATUSES }
   validates :name, presence: true
-  validates :columns_count, :rows_count, numericality: { greater_than: 0 }
+  validates :columns_count, :tile_count, numericality: { greater_than: 0 }
 
   scope :recent, -> { order(created_at: :desc) }
 
@@ -31,7 +31,7 @@ class AdminBoardBuild < ApplicationRecord
 
   # The root page plus any child pages, normalized into one iterable list.
   def pages
-    Boards::AdminBuilder::Plan.from_stored(plan, name: name, columns: columns_count, rows: rows_count)
+    Boards::AdminBuilder::Plan.from_stored(plan, name: name, columns: columns_count, tile_count: tile_count)
   end
 
   def tiles
@@ -57,10 +57,6 @@ class AdminBoardBuild < ApplicationRecord
 
     ordered = self.class.builder_boards.where(id: ids).index_by(&:id)
     [board_id, *ids].uniq.filter_map { |id| ordered[id] }
-  end
-
-  def cell_count
-    columns_count.to_i * rows_count.to_i
   end
 
   def complete? = status == "complete"

--- a/app/services/boards/admin_builder/art_preview.rb
+++ b/app/services/boards/admin_builder/art_preview.rb
@@ -42,7 +42,16 @@ module Boards
 
       def call
         previewed = pages.map do |page|
-          { key: page[:key], name: page[:name], rows: page[:tiles].map { |tile| row_for(tile) } }
+          # `columns`/`tile_count` carry the page's OWN grid through to the view:
+          # with mixed grids a page needn't match the main board, so the review
+          # grid can't be drawn from the form's top-level columns.
+          {
+            key: page[:key],
+            name: page[:name],
+            columns: page[:columns].to_i,
+            tile_count: page[:tile_count].to_i,
+            rows: page[:tiles].map { |tile| row_for(tile) },
+          }
         end
 
         # Coverage is over distinct labels: the same word on two pages is one

--- a/app/services/boards/admin_builder/plan.rb
+++ b/app/services/boards/admin_builder/plan.rb
@@ -4,9 +4,14 @@ module Boards
     # all in the same shape so validation, preview and build can iterate one
     # list instead of special-casing the root everywhere.
     #
-    # A page is `{ key:, name:, columns:, rows:, tiles: }`; a tile is
+    # A page is `{ key:, name:, columns:, tile_count:, tiles: }`; a tile is
     # `{ label:, part_of_speech:, display_label:, links_to: }`. The root's key
     # is ROOT_KEY, which is also what a child's "back to home" tile links to.
+    #
+    # `tile_count` is the authored SIZE of the page; `tiles` is what was written
+    # for it. Validation is what makes them agree. A row count is deliberately
+    # not part of the shape — `Board#rows_for_screen_size` derives rows from the
+    # tiles, so a stored one would be fiction.
     #
     # Children inherit the root's grid unless they carry their own — every board
     # in a set shares the root's grid, so a communicator moving into a folder
@@ -16,14 +21,14 @@ module Boards
 
       module_function
 
-      # `root` is `{ name:, columns:, rows:, tiles: }`; each child adds `key:`
-      # and may override `columns`/`rows`.
+      # `root` is `{ name:, columns:, tile_count:, tiles: }`; each child adds
+      # `key:` and may override `columns`/`tile_count`.
       def pages(root:, children: [])
         root_page = {
           key: ROOT_KEY,
           name: root[:name].to_s,
           columns: root[:columns].to_i,
-          rows: root[:rows].to_i,
+          tile_count: root[:tile_count].to_i,
           tiles: Array(root[:tiles]),
         }
 
@@ -35,11 +40,11 @@ module Boards
           key: child[:key].to_s.strip,
           name: child[:name].to_s,
           columns: child[:columns].presence&.to_i || root_page[:columns],
-          rows: child[:rows].presence&.to_i || root_page[:rows],
+          tile_count: child[:tile_count].presence&.to_i || root_page[:tile_count],
           tiles: Array(child[:tiles]),
           # Whether the grid was authored on this page or inherited — the
           # mixed-grid check only has something to say about an authored one.
-          inherits_grid: child[:columns].blank? && child[:rows].blank?,
+          inherits_grid: child[:columns].blank? && child[:tile_count].blank?,
         }
       end
 
@@ -56,17 +61,17 @@ module Boards
       end
 
       # Round-trips a stored `plan` jsonb back into page hashes.
-      def from_stored(stored, name:, columns:, rows:)
+      def from_stored(stored, name:, columns:, tile_count:)
         stored = stored || {}
 
         pages(
-          root: { name: name, columns: columns, rows: rows, tiles: symbolize_tiles(stored["tiles"]) },
+          root: { name: name, columns: columns, tile_count: tile_count, tiles: symbolize_tiles(stored["tiles"]) },
           children: Array(stored["children"]).map do |child|
             {
               key: child["key"],
               name: child["name"],
               columns: child["columns"],
-              rows: child["rows"],
+              tile_count: child["tile_count"],
               tiles: symbolize_tiles(child["tiles"]),
             }
           end,

--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -6,8 +6,9 @@ module Boards
     #
     # Two rules carry the weight:
     #
-    #   * **Tile count must equal columns × rows on every page.** Rows are never
-    #     stored (`Board#rows_for_screen_size` derives them from the tiles), so a
+    #   * **The word list must be exactly the page's tile count, and that count
+    #     must fill whole rows.** Rows are never stored
+    #     (`Board#rows_for_screen_size` derives them from the tiles), so a
     #     partial final row doesn't shorten the board — it leaves conspicuous
     #     empty cells at the right end of the last row, which reads as broken on
     #     a classroom TV.
@@ -95,26 +96,33 @@ module Boards
 
       def count_problems(page)
         columns = page[:columns].to_i
-        rows = page[:rows].to_i
-        return [prefixed(page, "set both a column count and a row count.")] if columns < 1 || rows < 1
+        wanted = page[:tile_count].to_i
+        return [prefixed(page, "set both a column count and a tile count.")] if columns < 1 || wanted < 1
 
         tiles = page[:tiles]
         return [prefixed(page, "add at least one word.")] if tiles.empty?
 
-        cells = columns * rows
+        count_mismatch(page, tiles.size, wanted) + partial_row_problems(page, columns, wanted)
+      end
 
-        # Overflow is always an error: there is no cell for the extra tiles, so
-        # "allow a partial row" can't rescue it.
-        if tiles.size > cells
-          return [prefixed(page, "#{tiles.size} words won't fit a #{columns}×#{rows} grid " \
-                                 "(#{cells} cells). Remove #{tiles.size - cells}.")]
-        end
+      def count_mismatch(page, written, wanted)
+        return [] if written == wanted
 
-        return [] if tiles.size == cells || allow_partial_row
+        verb = written > wanted ? "Remove #{written - wanted}" : "Add #{wanted - written}"
+        [prefixed(page, "#{written} words for a #{wanted}-tile board (needs exactly #{wanted}). #{verb}. " \
+                        "Change the tile count if the board should be a different size.")]
+      end
 
-        [prefixed(page, "#{tiles.size} words for a #{columns}×#{rows} grid (needs exactly #{cells}). " \
-                        "Add #{cells - tiles.size}. A partial row leaves dead cells at the end of the " \
-                        "last row — tick “allow a partial row” if you meant it.")]
+      # The dead-cell rail, moved off the word list and onto the size itself: a
+      # tile count that isn't a whole number of rows leaves empty cells at the
+      # right end of the last row no matter how well the words are chosen.
+      def partial_row_problems(page, columns, wanted)
+        return [] if allow_partial_row || (wanted % columns).zero?
+
+        full = (wanted / columns) * columns
+        [prefixed(page, "#{wanted} tiles across #{columns} columns leaves #{wanted - full} in a partial " \
+                        "last row, which reads as dead cells. Use #{full} or #{full + columns} — or tick " \
+                        "“allow a partial row” if you meant it.")]
       end
 
       def label_problems(page)
@@ -147,16 +155,16 @@ module Boards
       def grid_problems
         return [] if allow_mixed_grids || !multi_page?
 
-        root_grid = [root_page[:columns].to_i, root_page[:rows].to_i]
+        root_grid = [root_page[:columns].to_i, root_page[:tile_count].to_i]
 
         pages.drop(1).filter_map do |page|
           next if page[:inherits_grid]
 
-          grid = [page[:columns].to_i, page[:rows].to_i]
+          grid = [page[:columns].to_i, page[:tile_count].to_i]
           next if grid == root_grid
 
-          "#{label_for(page)}: grid #{grid[0]}×#{grid[1]} differs from the main board's " \
-            "#{root_grid[0]}×#{root_grid[1]}. Every page in a set shares the main board's grid. " \
+          "#{label_for(page)}: grid #{grid[0]} columns / #{grid[1]} tiles differs from the main board's " \
+            "#{root_grid[0]} columns / #{root_grid[1]} tiles. Every page in a set shares the main board's grid. " \
             "If this page can't fill it on good words, widen its remit, merge it into a sibling, or " \
             "cut the folder tile — don't shrink it. Tick “allow mixed grids” only if you meant it."
         end

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -27,9 +27,9 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES = 144
 
-      def initialize(topic:, columns:, rows:, audience: nil)
+      def initialize(topic:, tile_count:, audience: nil)
         @topic = topic.to_s.strip
-        @tile_count = (columns.to_i * rows.to_i).clamp(1, MAX_TILES)
+        @tile_count = tile_count.to_i.clamp(1, MAX_TILES)
         @audience = audience.to_s.strip
       end
 

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -42,8 +42,8 @@
                 class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
         </div>
         <div>
-          <label class="block text-xs font-medium text-t2 mb-1" for="rows">Rows</label>
-          <%= number_field_tag :rows, @form[:rows], id: "rows", min: 1, max: Admin::BoardBuildsController::MAX_ROWS,
+          <label class="block text-xs font-medium text-t2 mb-1" for="tile_count">Tiles</label>
+          <%= number_field_tag :tile_count, @form[:tile_count], id: "tile_count", min: 1, max: Admin::BoardBuildsController::MAX_TILES,
                 class: "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
         </div>
       </div>
@@ -86,7 +86,7 @@
       <p class="text-[11px] text-t3 mt-1">
         You need exactly <span id="cell-count" class="text-t1 font-medium">—</span> words
         (<span id="word-count" class="text-t1 font-medium">0</span> so far).
-        A partial row leaves dead cells at the end of the last row.
+        A tile count that isn’t a whole number of rows leaves dead cells at the end of the last row.
       </p>
     </div>
 
@@ -147,9 +147,9 @@
             </div>
             <div class="col-span-2 flex items-end gap-2">
               <div class="flex-1">
-                <label class="block text-[11px] font-medium text-t2 mb-1">Rows</label>
-                <input type="number" min="1" max="<%= Admin::BoardBuildsController::MAX_ROWS %>"
-                       name="children[<%= index %>][rows]" value="<%= child[:rows] %>" placeholder="—"
+                <label class="block text-[11px] font-medium text-t2 mb-1">Tiles</label>
+                <input type="number" min="1" max="<%= Admin::BoardBuildsController::MAX_TILES %>"
+                       name="children[<%= index %>][tile_count]" value="<%= child[:tile_count] %>" placeholder="—"
                        class="admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none">
               </div>
               <button type="button" class="remove-page text-t3 hover:text-t1 text-sm leading-none px-1 pb-2 cursor-pointer" title="Remove page">&times;</button>
@@ -188,9 +188,9 @@
         </div>
         <div class="col-span-2 flex items-end gap-2">
           <div class="flex-1">
-            <label class="block text-[11px] font-medium text-t2 mb-1">Rows</label>
-            <input type="number" min="1" max="<%= Admin::BoardBuildsController::MAX_ROWS %>"
-                   name="children[IDX][rows]" value="" placeholder="—"
+            <label class="block text-[11px] font-medium text-t2 mb-1">Tiles</label>
+            <input type="number" min="1" max="<%= Admin::BoardBuildsController::MAX_TILES %>"
+                   name="children[IDX][tile_count]" value="" placeholder="—"
                    class="admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none">
           </div>
           <button type="button" class="remove-page text-t3 hover:text-t1 text-sm leading-none px-1 pb-2 cursor-pointer" title="Remove page">&times;</button>
@@ -212,20 +212,20 @@
   (function () {
     var words = document.getElementById("words");
     var columns = document.getElementById("columns");
-    var rows = document.getElementById("rows");
+    var tileCount = document.getElementById("tile_count");
     var cellCount = document.getElementById("cell-count");
     var wordCount = document.getElementById("word-count");
-    if (!words || !columns || !rows) return;
+    if (!words || !columns || !tileCount) return;
 
     function update() {
-      var cells = (parseInt(columns.value, 10) || 0) * (parseInt(rows.value, 10) || 0);
+      var cells = parseInt(tileCount.value, 10) || 0;
       var used = words.value.split("\n").filter(function (line) { return line.trim() !== ""; }).length;
       cellCount.textContent = cells || "—";
       wordCount.textContent = used;
       wordCount.style.color = cells && used !== cells ? "#f87171" : "";
     }
 
-    [words, columns, rows].forEach(function (el) { el.addEventListener("input", update); });
+    [words, columns, tileCount].forEach(function (el) { el.addEventListener("input", update); });
     update();
 
     // Page blocks are indexed, so every add/remove has to renumber the whole

--- a/app/views/admin/board_builds/index.html.erb
+++ b/app/views/admin/board_builds/index.html.erb
@@ -27,7 +27,7 @@
               <div class="text-[10px] text-t3"><%= build.topic %></div>
             <% end %>
           </td>
-          <td class="px-5 py-3 text-xs text-t2 whitespace-nowrap"><%= build.columns_count %>×<%= build.rows_count %></td>
+          <td class="px-5 py-3 text-xs text-t2 whitespace-nowrap"><%= build.columns_count %> cols · <%= build.tile_count %> tiles</td>
           <td class="px-5 py-3 whitespace-nowrap">
             <% case build.status %>
             <% when "complete" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -5,7 +5,7 @@
     <h1 class="text-2xl font-semibold text-t1 tracking-tight">Review the art — <%= @form[:name] %></h1>
     <p class="text-sm text-t3 mt-0.5">
       Nothing has been written yet. <%= @preview[:total] %> distinct <%= "word".pluralize(@preview[:total]) %> ·
-      <%= @form[:columns] %>×<%= @form[:rows] %> grid<%= " · #{@preview[:pages].size} pages" if @preview[:pages].size > 1 %>.
+      <%= @form[:columns] %> columns · <%= @form[:tile_count] %> tiles<%= " · #{@preview[:pages].size} pages" if @preview[:pages].size > 1 %>.
     </p>
   </div>
   <%= link_to "← All board builds", admin_dashboard_board_builds_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
@@ -54,10 +54,12 @@
     <% else %>
       Page “<%= page[:key] %>” — <%= page[:name] %>
     <% end %>
-    <span class="text-t3 font-normal normal-case tracking-normal">· <%= page[:rows].size %> tiles, in reading order</span>
+    <span class="text-t3 font-normal normal-case tracking-normal">
+      · <%= page[:columns] %> columns · <%= page[:rows].size %> of <%= page[:tile_count] %> tiles, in reading order
+    </span>
   </h2>
 
-  <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3 mb-8">
+  <div class="builder-grid mb-8" style="--cols: <%= page[:columns] %>;">
     <% page[:rows].each do |row| %>
       <div class="admin-card border rounded-xl overflow-hidden <%= "border-amber-500" if row.found? && !row.exact %><%= "border-red-500" unless row.found? %>">
         <div class="aspect-square admin-card-alt flex items-center justify-center overflow-hidden">
@@ -101,13 +103,13 @@
     <%= hidden_field_tag :audience, @form[:audience] %>
     <%= hidden_field_tag :voice, @form[:voice] %>
     <%= hidden_field_tag :columns, @form[:columns] %>
-    <%= hidden_field_tag :rows, @form[:rows] %>
+    <%= hidden_field_tag :tile_count, @form[:tile_count] %>
     <%= hidden_field_tag :words, @form[:words] %>
     <%= hidden_field_tag :commercial_safe_only, @form[:commercial_safe_only] ? "1" : "0" %>
     <%= hidden_field_tag :allow_partial_row, @form[:allow_partial_row] ? "1" : "0" %>
     <%= hidden_field_tag :allow_mixed_grids, @form[:allow_mixed_grids] ? "1" : "0" %>
     <% @form[:children].each_with_index do |child, index| %>
-      <% %i[key name columns rows words].each do |field| %>
+      <% %i[key name columns tile_count words].each do |field| %>
         <%= hidden_field_tag "children[#{index}][#{field}]", child[field], id: nil %>
       <% end %>
     <% end %>

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -47,15 +47,26 @@
           <%= @board.board_images.size %> tiles ·
           lg <%= @board.large_screen_columns %> / md <%= @board.medium_screen_columns %> / sm <%= @board.small_screen_columns %> columns
         </p>
-        <p class="text-xs text-t2 mt-1">
-          Public URL when published: <span class="font-mono">/pb/<%= @board.slug %></span> —
-          a published slug is frozen, so check it now.
-        </p>
+        <% if @board.published? %>
+          <p class="text-xs text-t2 mt-1">
+            Public URL:
+            <%= link_to "/pb/#{@board.slug}", board_published_page_url(@board), target: "_blank", rel: "noopener",
+                  class: "font-mono text-accent hover:underline", title: "Open the public page in a new tab" %>
+          </p>
+        <% else %>
+          <p class="text-xs text-t2 mt-1">
+            Public URL when published: <span class="font-mono">/pb/<%= @board.slug %></span> —
+            a published slug is frozen, so check it now.
+          </p>
+        <% end %>
       <% end %>
     </div>
 
     <div class="flex items-center gap-2">
       <% if @board %>
+        <%= link_to "Open board ↗", board_app_url(@board), target: "_blank", rel: "noopener",
+              class: "text-xs font-medium px-3 py-2 rounded border admin-input text-t1 hover:text-accent transition-colors",
+              title: "Open this board in the app in a new tab" %>
         <% if @board.published? %>
           <%= button_to "Unpublish", unpublish_admin_dashboard_board_build_path(@build), method: :post,
                 class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1",
@@ -103,6 +114,9 @@
       <span class="text-t3 font-normal normal-case tracking-normal">
         · <span class="font-mono"><%= page.slug %></span>
         · <%= page.published? ? "published" : "unpublished" %>
+        · <%= link_to "open ↗", board_app_url(page), target: "_blank", rel: "noopener",
+                class: "text-t2 hover:text-accent underline transition-colors",
+                title: "Open this page in the app in a new tab" %>
       </span>
     </h2>
 

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -4,7 +4,7 @@
   <div>
     <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @build.name %></h1>
     <p class="text-sm text-t3 mt-0.5">
-      <%= @build.columns_count %>×<%= @build.rows_count %> · <%= @build.tiles.size %> tiles<%= " · #{@build.children.size} #{"page".pluralize(@build.children.size)}" if @build.multi_page? %>
+      <%= @build.columns_count %> columns · <%= @build.tiles.size %> tiles<%= " · #{@build.children.size} #{"page".pluralize(@build.children.size)}" if @build.multi_page? %>
       <% if @build.topic.present? %> · topic: <%= @build.topic %><% end %>
       <% if @board %> · <span class="font-mono text-xs"><%= @board.slug %></span><% end %>
     </p>
@@ -113,6 +113,7 @@
       <%= page.id == @board.id ? "Main board" : "Page" %> — <%= page.name %>
       <span class="text-t3 font-normal normal-case tracking-normal">
         · <span class="font-mono"><%= page.slug %></span>
+        · <%= page.large_screen_columns %> columns
         · <%= page.published? ? "published" : "unpublished" %>
         · <%= link_to "open ↗", board_app_url(page), target: "_blank", rel: "noopener",
                 class: "text-t2 hover:text-accent underline transition-colors",
@@ -120,7 +121,7 @@
       </span>
     </h2>
 
-    <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 gap-3 mb-8">
+    <div class="builder-grid mb-8" style="--cols: <%= page.large_screen_columns %>;">
       <% @tiles_by_board[page].each do |tile| %>
         <div class="admin-card border rounded-xl overflow-hidden">
           <div class="aspect-square flex items-center justify-center overflow-hidden" style="background-color: <%= tile.bg_color || "transparent" %>;">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -64,6 +64,17 @@
       color: var(--text-primary);
     }
     .admin-hover-row:hover { background: var(--hover-row); }
+
+    /* Board-build review grids render the AUTHORED column count, not a fixed
+       one — the point of the review step is seeing the layout you'll get, so a
+       fixed six-across Tailwind class would lie about an 8-wide board. The
+       count comes in as an inline `--cols`; Tailwind can't compile a class
+       built at runtime. */
+    .builder-grid {
+      display: grid;
+      gap: 0.75rem;
+      grid-template-columns: repeat(var(--cols, 6), minmax(0, 1fr));
+    }
     .admin-flash-ok { background: rgba(34,197,94,0.08); border-color: rgba(34,197,94,0.2); color: #16a34a; }
     .admin-flash-err { background: rgba(239,68,68,0.08); border-color: rgba(239,68,68,0.2); color: #dc2626; }
     html.dark .admin-flash-ok { background: rgba(34,197,94,0.15); color: #86efac; }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -21,7 +21,7 @@
       "cwe_id": [
         915
       ],
-      "user_note": "False positive: Admin::UsersController is gated by require_admin! (admins only), and :role is validated against the EDITABLE_ROLES allowlist (%w[user admin partner vendor]) before assignment \u2014 a non-listed role is ignored."
+      "user_note": "False positive: Admin::UsersController is gated by require_admin! (admins only), and :role is validated against the EDITABLE_ROLES allowlist (%w[user admin partner vendor]) before assignment — a non-listed role is ignored."
     },
     {
       "warning_type": "SQL Injection",
@@ -67,7 +67,7 @@
       "cwe_id": [
         22
       ],
-      "user_note": "False positive: the path is a Tempfile created by the job itself. The model attribute (doc.id, an integer PK) is used only as part of a temp filename prefix \u2014 no user-supplied path traversal is possible."
+      "user_note": "False positive: the path is a Tempfile created by the job itself. The model attribute (doc.id, an integer PK) is used only as part of a temp filename prefix — no user-supplied path traversal is possible."
     },
     {
       "warning_type": "SQL Injection",
@@ -137,6 +137,25 @@
         89
       ],
       "user_note": "False positive: @board_sort and @board_dir are both validated against explicit allowlists (SORTABLE_BOARD_COLUMNS and %w[asc desc]) via presence_in before being used in Arel.sql. No user input reaches this interpolation unchecked."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 8.0.5 ends on 2026-10-07",
+      "file": "Gemfile.lock",
+      "line": 439,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "user_note": "Not a vulnerability — Brakeman warns 60 days before a Rails series goes EOL, so this fired on its own on 2026-08-08 and turned the Security workflow red on main. Rails 8.0 support ends 2026-10-07; the fix is the 8.1 upgrade, tracked separately. Remove this entry with that upgrade — the fingerprint is version-specific, so it will not silence the next series' warning."
     }
   ],
   "updated": null,

--- a/db/migrate/20260808120000_rename_rows_count_to_tile_count_on_admin_board_builds.rb
+++ b/db/migrate/20260808120000_rename_rows_count_to_tile_count_on_admin_board_builds.rb
@@ -1,0 +1,44 @@
+# The builder never stored a row count on the board it made —
+# `Board#rows_for_screen_size` derives rows from the tile count — so "rows" only
+# ever meant "columns × rows tiles". Storing the tile count directly says what
+# the number actually does and lets a board be sized without pretending its
+# height is fixed.
+#
+# Existing rows hold a ROW count, so the value (and every child page's grid
+# override inside `plan`) is converted rather than reinterpreted.
+class RenameRowsCountToTileCountOnAdminBoardBuilds < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :admin_board_builds, :rows_count, :tile_count
+    execute("UPDATE admin_board_builds SET tile_count = GREATEST(columns_count * tile_count, 1)")
+    convert_child_grids!("rows", "tile_count") { |columns, rows| columns * rows }
+  end
+
+  def down
+    convert_child_grids!("tile_count", "rows") { |columns, tiles| tiles / [columns, 1].max }
+    execute("UPDATE admin_board_builds SET tile_count = GREATEST(tile_count / GREATEST(columns_count, 1), 1)")
+    rename_column :admin_board_builds, :tile_count, :rows_count
+  end
+
+  private
+
+  # A child page's grid override lives in the `plan` jsonb, not in a column, so
+  # it has to be rewritten row by row. The table is admin-authored builds — tens
+  # of rows, not millions.
+  def convert_child_grids!(from_key, to_key)
+    select_all("SELECT id, columns_count, plan FROM admin_board_builds").each do |row|
+      plan = row["plan"].is_a?(String) ? JSON.parse(row["plan"].presence || "{}") : (row["plan"] || {})
+      # Only an authored override is converted — a blank one inherits the root's
+      # grid and must stay blank, or every page becomes independently sized.
+      overrides = Array(plan["children"]).select { |child| child[from_key].present? }
+      next if overrides.empty?
+
+      root_columns = row["columns_count"].to_i
+      overrides.each do |child|
+        columns = child["columns"].presence&.to_i || root_columns
+        child[to_key] = [yield(columns, child.delete(from_key).to_i), 1].max
+      end
+
+      execute("UPDATE admin_board_builds SET plan = #{quote(plan.to_json)}::jsonb WHERE id = #{row["id"].to_i}")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_07_150000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -65,7 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_07_150000) do
     t.string "topic"
     t.string "voice", default: "polly:kevin", null: false
     t.integer "columns_count", null: false
-    t.integer "rows_count", null: false
+    t.integer "tile_count", null: false
     t.boolean "commercial_safe_only", default: true, null: false
     t.jsonb "plan", default: {}, null: false
     t.jsonb "art_report", default: {}, null: false

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       topic: "the playground",
       voice: "polly:kevin",
       columns: "2",
-      rows: "2",
+      tile_count: "4",
       words: "i | pronoun\nwant | verb\nmore | important_function\nswing | noun",
       commercial_safe_only: "1",
     }.merge(overrides)
@@ -31,7 +31,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
         name: "Playground",
         voice: "polly:kevin",
         columns_count: 2,
-        rows_count: 2,
+        tile_count: 4,
         plan: { "tiles" => [{ "label" => "i", "part_of_speech" => "pronoun" }] },
       }.merge(overrides),
     )
@@ -115,7 +115,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
         words: "i | pronoun\nwant | verb\nmore | social\nFood | noun | >food",
         children: {
           "0" => {
-            key: "food", name: "Food", columns: "", rows: "",
+            key: "food", name: "Food", columns: "", tile_count: "",
             words: "apple | noun\nbanana | noun\nhungry | adjective\nback | social | >__root__",
           },
         },
@@ -168,7 +168,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
 
     it "drops a wholly blank page block rather than failing on it" do
       params = set_params
-      params[:children]["1"] = { key: "", name: "", columns: "", rows: "", words: "  " }
+      params[:children]["1"] = { key: "", name: "", columns: "", tile_count: "", words: "  " }
 
       expect { post admin_dashboard_board_builds_path, params: params }
         .to change(AdminBoardBuild, :count).by(1)
@@ -185,7 +185,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
 
     it "rejects a page whose grid differs from the main board's" do
       params = set_params
-      params[:children]["0"] = params[:children]["0"].merge(columns: "3", rows: "3",
+      params[:children]["0"] = params[:children]["0"].merge(columns: "3", tile_count: "9",
                                                             words: (1..9).map { |i| "word#{i} | noun" }.join("\n"))
 
       expect { post admin_dashboard_board_builds_path, params: params }.not_to change(AdminBoardBuild, :count)
@@ -194,7 +194,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
 
     it "allows a different grid when the escape hatch is ticked" do
       params = set_params(allow_mixed_grids: "1")
-      params[:children]["0"] = params[:children]["0"].merge(columns: "3", rows: "3",
+      params[:children]["0"] = params[:children]["0"].merge(columns: "3", tile_count: "9",
                                                             words: (1..9).map { |i| "word#{i} | noun" }.join("\n"))
 
       expect { post admin_dashboard_board_builds_path, params: params }.to change(AdminBoardBuild, :count).by(1)
@@ -350,9 +350,9 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response.body).to include("a preschooler")
     end
 
-    it "passes the topic, grid and audience to the drafter" do
+    it "passes the topic, tile count and audience to the drafter" do
       expect(Boards::AdminBuilder::WordListDrafter).to receive(:new)
-        .with(topic: "the playground", columns: 2, rows: 2, audience: "a preschooler")
+        .with(topic: "the playground", tile_count: 4, audience: "a preschooler")
         .and_call_original
 
       post draft_admin_dashboard_board_builds_path, params: form_params(audience: "a preschooler")
@@ -495,13 +495,38 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response.body).to include("will be generated")
       expect(response.body).to include("0%")
     end
+
+    # The review grid used to be a hardcoded 6 columns, so a 4-wide board was
+    # reviewed at a width it would never be used at.
+    it "draws the review grid at the authored column count" do
+      params = form_params(columns: "4", tile_count: "4", words: "i | pronoun\nwant | verb\nmore | important_function\nswing | noun")
+
+      post preview_admin_dashboard_board_builds_path, params: params
+
+      expect(response.body).to include("--cols: 4")
+      expect(response.body).not_to include("lg:grid-cols-6")
+    end
+
+    it "draws each page of a mixed-grid set at its own column count" do
+      params = form_params(
+        columns: "2", tile_count: "4",
+        words: "i | pronoun\nwant | verb\nmore | important_function\nFood | noun | >food",
+        allow_mixed_grids: "1",
+        children: { "0" => { key: "food", name: "Food", columns: "3", tile_count: "3", words: "apple\nbanana\nhungry" } },
+      )
+
+      post preview_admin_dashboard_board_builds_path, params: params
+
+      expect(response.body).to include("--cols: 2")
+      expect(response.body).to include("--cols: 3")
+    end
   end
 
   describe "validation" do
     before { sign_in admin }
 
-    it "rejects a tile count that doesn't fill the grid and preserves what was typed" do
-      params = form_params(rows: "3")
+    it "rejects a word list that doesn't match the tile count and preserves what was typed" do
+      params = form_params(tile_count: "6")
 
       expect { post preview_admin_dashboard_board_builds_path, params: params }
         .to not_change(Board, :count).and not_change(Image, :count)
@@ -512,11 +537,25 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response.body).to include("swing | noun")
     end
 
-    it "accepts a partial last row when the escape hatch is ticked" do
-      post preview_admin_dashboard_board_builds_path, params: form_params(rows: "3", allow_partial_row: "1")
+    # The escape hatch now governs the SIZE, not the word list: 3 tiles across
+    # 2 columns is a partial last row, and the words still have to match it.
+    it "accepts a tile count that doesn't fill whole rows when the escape hatch is ticked" do
+      params = form_params(tile_count: "3", words: "i | pronoun\nwant | verb\nmore | important_function",
+                           allow_partial_row: "1")
+
+      post preview_admin_dashboard_board_builds_path, params: params
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Review the art")
+    end
+
+    it "rejects a tile count that leaves a partial last row without the escape hatch" do
+      params = form_params(tile_count: "3", words: "i | pronoun\nwant | verb\nmore | important_function")
+
+      post preview_admin_dashboard_board_builds_path, params: params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("partial last row")
     end
 
     it "rejects duplicate words" do
@@ -569,7 +608,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(build.name).to eq("Playground")
       expect(build.topic).to eq("the playground")
       expect(build.columns_count).to eq(2)
-      expect(build.rows_count).to eq(2)
+      expect(build.tile_count).to eq(4)
       expect(build.labels).to eq(%w[i want more swing])
       expect(build.tiles.map { |t| t["part_of_speech"] }).to eq(%w[pronoun verb important_function noun])
       expect(BuildAdminBoardJob.jobs.map { |job| job["args"].first }).to eq([build.id])
@@ -658,6 +697,20 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       get admin_dashboard_board_build_path(build)
 
       expect(response.body).to include("http://localhost:8100/boards/#{page.id}")
+    end
+
+    # The tile grid mirrors the board's own lg layout, so what the review page
+    # shows is what a communicator gets.
+    it "draws the tile grid at the board's own column count" do
+      board = built_board
+      board.update!(large_screen_columns: 8)
+      board.add_image(Image.create!(label: "i", user_id: seed_admin.id).id)
+      build = create_build(status: "complete", board: board)
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include("--cols: 8")
+      expect(response.body).not_to include("lg:grid-cols-6")
     end
   end
 

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -626,6 +626,39 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
 
       expect(response.body).to include(board.slug)
     end
+
+    # The app URL works before publishing; /pb/ does not, so an unpublished
+    # build must not offer a public link that 404s.
+    it "links the built board into the app in a new tab" do
+      board = built_board
+      build = create_build(status: "complete", board: board)
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include("http://localhost:8100/boards/#{board.id}")
+      expect(response.body).to include('target="_blank"')
+      expect(response.body).not_to include("http://localhost:8100/pb/#{board.slug}")
+    end
+
+    it "links the public page too once the board is published" do
+      board = built_board(published: true)
+      build = create_build(status: "complete", board: board)
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include("http://localhost:8100/pb/#{board.slug}")
+    end
+
+    it "links every page of a linked set" do
+      root = built_board
+      page = built_board(name: "Food page")
+      build = create_build(status: "complete", board: root)
+      build.update!(art_report: { "boards" => { "__root__" => root.id, "food" => page.id } })
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include("http://localhost:8100/boards/#{page.id}")
+    end
   end
 
   describe "publish / unpublish" do

--- a/spec/services/boards/admin_builder/art_preview_spec.rb
+++ b/spec/services/boards/admin_builder/art_preview_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Boards::AdminBuilder::ArtPreview do
 
   def pages_for(labels, children: [])
     Boards::AdminBuilder::Plan.pages(
-      root: { name: "Board", columns: 2, rows: 2, tiles: labels.map { |label| { label: label } } },
+      root: { name: "Board", columns: 2, tile_count: 4, tiles: labels.map { |label| { label: label } } },
       children: children,
     )
   end
@@ -131,6 +131,20 @@ RSpec.describe Boards::AdminBuilder::ArtPreview do
 
       expect(root_rows.last).not_to be_folder
       expect(root_rows.map(&:links_to)).to eq([nil, nil, nil, nil])
+    end
+
+    # The review grid is drawn from these, not from the form's top-level
+    # columns — with mixed grids a page needn't match the main board.
+    it "carries each page's own grid through" do
+      pages = pages_for(
+        %w[i want more Food],
+        children: [{ key: "food", name: "Food", columns: 3, tile_count: 3, tiles: %w[apple banana more].map { |l| { label: l } } }],
+      )
+
+      result = described_class.new(pages: pages, commercial_safe_only: false).call
+
+      expect(result[:pages].first).to include(columns: 2, tile_count: 4)
+      expect(result[:pages].last).to include(columns: 3, tile_count: 3)
     end
 
     it "carries links_to through to the row" do

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Boards::AdminBuilder::Build do
     image
   end
 
-  def build_record(tiles:, columns: 2, rows: 2, children: [], **overrides)
+  def build_record(tiles:, columns: 2, tile_count: 4, children: [], **overrides)
     AdminBoardBuild.create!(
       {
         created_by: requester,
@@ -23,7 +23,7 @@ RSpec.describe Boards::AdminBuilder::Build do
         topic: "the playground",
         voice: "polly:kevin",
         columns_count: columns,
-        rows_count: rows,
+        tile_count: tile_count,
         plan: { "tiles" => tiles, "children" => children },
       }.merge(overrides),
     )
@@ -61,7 +61,7 @@ RSpec.describe Boards::AdminBuilder::Build do
     # Hand-setting md/sm writes settings["custom_screen_layouts"] and
     # permanently stops reflow — only the authored lg count may be set.
     it "sets only the large column count and lets md/sm derive from it" do
-      board = described_class.new(admin_board_build: build_record(tiles: four_tiles, columns: 6, rows: 1)).call
+      board = described_class.new(admin_board_build: build_record(tiles: four_tiles, columns: 6, tile_count: 6)).call
 
       expect(board.large_screen_columns).to eq(6)
       expect(board.medium_screen_columns).to eq(Boards::ScreenColumns.derive(6, "md"))
@@ -219,7 +219,7 @@ RSpec.describe Boards::AdminBuilder::Build do
 
     it "gives every page the root's grid" do
       root = described_class.new(admin_board_build: build_record(
-        tiles: root_with_folder, columns: 4, rows: 1, children: [food_page],
+        tiles: root_with_folder, columns: 4, tile_count: 4, children: [food_page],
       )).call
       child = Board.find(root.board_images.find { |bi| bi.predictive_board_id }.predictive_board_id)
 
@@ -230,7 +230,7 @@ RSpec.describe Boards::AdminBuilder::Build do
     it "lets a page override the grid when one was authored" do
       root = described_class.new(admin_board_build: build_record(
         tiles: root_with_folder,
-        children: [food_page.merge("columns" => 2, "rows" => 2)],
+        children: [food_page.merge("columns" => 2, "tile_count" => 4)],
       )).call
       child = Board.find(root.board_images.find { |bi| bi.predictive_board_id }.predictive_board_id)
 

--- a/spec/services/boards/admin_builder/plan_validator_spec.rb
+++ b/spec/services/boards/admin_builder/plan_validator_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     labels.map { |label| { label: label, part_of_speech: "noun" } }
   end
 
-  def pages(root_tiles:, columns: 2, rows: 2, children: [])
+  def pages(root_tiles:, columns: 2, tile_count: 4, children: [])
     Boards::AdminBuilder::Plan.pages(
-      root: { name: "Playground", columns: columns, rows: rows, tiles: root_tiles },
+      root: { name: "Playground", columns: columns, tile_count: tile_count, tiles: root_tiles },
       children: children,
     )
   end
@@ -25,7 +25,7 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
 
     it "rejects a short plan and says how many to add" do
       problems = validate(pages: pages(root_tiles: tiles("i", "want", "more")))
-      expect(problems.first).to include("3 words for a 2×2 grid (needs exactly 4)")
+      expect(problems.first).to include("3 words for a 4-tile board (needs exactly 4)")
       expect(problems.first).to include("Add 1")
     end
 
@@ -35,23 +35,41 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
       expect(problems.first).not_to include("Playground:")
     end
 
-    it "allows a short plan when the partial-row escape hatch is ticked" do
-      expect(validate(pages: pages(root_tiles: tiles("i", "want", "more")), allow_partial_row: true)).to eq([])
+    # The word list is measured against the authored tile count now, not against
+    # columns × rows, so "allow a partial row" no longer excuses a short list —
+    # it excuses a tile count that doesn't fill whole rows.
+    it "rejects a short plan even with the partial-row escape hatch ticked" do
+      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more")), allow_partial_row: true)
+      expect(problems.first).to include("needs exactly 4")
     end
 
-    it "rejects an over-full plan even with the escape hatch ticked" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more", "help", "stop")), allow_partial_row: true)
-      expect(problems.first).to include("won't fit")
+    it "accepts a short list once the tile count is lowered to match" do
+      expect(validate(
+        pages: pages(root_tiles: tiles("i", "want", "more"), tile_count: 3),
+        allow_partial_row: true,
+      )).to eq([])
+    end
+
+    it "rejects an over-full plan and says how many to remove" do
+      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more", "help", "stop")))
+      expect(problems.first).to include("5 words for a 4-tile board")
       expect(problems.first).to include("Remove 1")
+    end
+
+    # The dead-cell rail, now stated on the size rather than on the word list.
+    it "rejects a tile count that doesn't fill whole rows" do
+      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more"), tile_count: 3))
+      expect(problems.first).to include("3 tiles across 2 columns leaves 1 in a partial last row")
+      expect(problems.first).to include("Use 2 or 4")
     end
 
     it "rejects an empty word list" do
       expect(validate(pages: pages(root_tiles: []))).to eq(["Add at least one word."])
     end
 
-    it "rejects a grid with no columns or rows" do
+    it "rejects a grid with no columns or no tile count" do
       expect(validate(pages: pages(root_tiles: tiles("i"), columns: 0)))
-        .to eq(["Set both a column count and a row count."])
+        .to eq(["Set both a column count and a tile count."])
     end
 
     it "rejects a blank label" do
@@ -78,13 +96,13 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
 
     it "accepts every canonical part of speech" do
       ColorHelper::PARTS_OF_SPEECH.each do |pos|
-        problems = validate(pages: pages(root_tiles: [{ label: "word", part_of_speech: pos }], columns: 1, rows: 1))
+        problems = validate(pages: pages(root_tiles: [{ label: "word", part_of_speech: pos }], columns: 1, tile_count: 1))
         expect(problems).to eq([]), "expected #{pos} to be accepted"
       end
     end
 
     it "defaults a missing part of speech rather than rejecting it" do
-      expect(validate(pages: pages(root_tiles: [{ label: "word" }], columns: 1, rows: 1))).to eq([])
+      expect(validate(pages: pages(root_tiles: [{ label: "word" }], columns: 1, tile_count: 1))).to eq([])
     end
   end
 
@@ -103,7 +121,7 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
 
     it "names the page in its own problems" do
       problems = validate(pages: pages(root_tiles: root_with_folder, children: [child(tiles_list: tiles("apple"))]))
-      expect(problems).to include(a_string_including("Food: 1 words for a 2×2 grid"))
+      expect(problems).to include(a_string_including("Food: 1 words for a 4-tile board"))
     end
 
     it "rejects a tile pointing at a page that doesn't exist" do
@@ -163,9 +181,9 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
       tiles("i", "want", "more") + [{ label: "Food", part_of_speech: "noun", links_to: "food" }]
     end
 
-    def sized_child(columns:, rows:, count:)
+    def sized_child(columns:, tile_count:, count:)
       {
-        key: "food", name: "Food", columns: columns, rows: rows,
+        key: "food", name: "Food", columns: columns, tile_count: tile_count,
         tiles: Array.new(count) { |i| { label: "word#{i}", part_of_speech: "noun" } },
       }
     end
@@ -173,13 +191,13 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     # A communicator moving into a folder page shouldn't have the cell size
     # change under their finger.
     it "rejects a page whose authored grid differs from the main board's" do
-      problems = validate(pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 3, rows: 3, count: 9)]))
-      expect(problems).to include(a_string_including("grid 3×3 differs from the main board's 2×2"))
+      problems = validate(pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 3, tile_count: 9, count: 9)]))
+      expect(problems).to include(a_string_including("grid 3 columns / 9 tiles differs from the main board's 2 columns / 4 tiles"))
     end
 
     it "allows a different grid when the escape hatch is ticked" do
       problems = validate(
-        pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 3, rows: 3, count: 9)]),
+        pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 3, tile_count: 9, count: 9)]),
         allow_mixed_grids: true,
       )
       expect(problems).to eq([])
@@ -195,7 +213,7 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
 
     # Matching the root explicitly is the same board as inheriting it.
     it "accepts a page that restates the main board's grid" do
-      problems = validate(pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 2, rows: 2, count: 4)]))
+      problems = validate(pages: pages(root_tiles: root_with_folder, children: [sized_child(columns: 2, tile_count: 4, count: 4)]))
       expect(problems).to eq([])
     end
   end

--- a/spec/services/boards/admin_builder/word_list_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/word_list_drafter_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
 
   describe "#call" do
     it "returns labels with parts of speech" do
-      result = described_class.new(topic: "the playground", columns: 2, rows: 2).call
+      result = described_class.new(topic: "the playground", tile_count: 4).call
 
       expect(result).to eq([
         { label: "I", part_of_speech: "pronoun" },
@@ -30,14 +30,14 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     end
 
     it "refuses to draft without a topic" do
-      expect { described_class.new(topic: "  ", columns: 2, rows: 2).call }
+      expect { described_class.new(topic: "  ", tile_count: 4).call }
         .to raise_error(described_class::GenerationError, /topic/)
     end
 
     it "trims a response longer than the grid" do
       stub_ai(ai_tiles(["I", "pronoun"], ["want", "verb"], ["more", "social"], ["swing", "noun"], ["slide", "noun"]))
 
-      expect(described_class.new(topic: "the playground", columns: 2, rows: 2).call.size).to eq(4)
+      expect(described_class.new(topic: "the playground", tile_count: 4).call.size).to eq(4)
     end
 
     # Unlike Boards::AiPageGenerator this only fills a textarea, so a short
@@ -45,13 +45,13 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     it "returns a short draft rather than raising" do
       stub_ai(ai_tiles(["I", "pronoun"], ["want", "verb"]))
 
-      expect(described_class.new(topic: "the playground", columns: 3, rows: 3).call.size).to eq(2)
+      expect(described_class.new(topic: "the playground", tile_count: 9).call.size).to eq(2)
     end
 
     it "tolerates 'word' as an alias for 'label'" do
       stub_ai({ "tiles" => [{ "word" => "swing", "part_of_speech" => "noun" }] }.to_json)
 
-      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call)
+      expect(described_class.new(topic: "the playground", tile_count: 1).call)
         .to eq([{ label: "swing", part_of_speech: "noun" }])
     end
   end
@@ -62,28 +62,28 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     it "drops a casing-only duplicate" do
       stub_ai(ai_tiles(["go", "verb"], ["Go", "verb"], ["stop", "important_function"]))
 
-      result = described_class.new(topic: "the playground", columns: 3, rows: 1).call
+      result = described_class.new(topic: "the playground", tile_count: 3).call
       expect(result.map { |tile| tile[:label] }).to eq(%w[go stop])
     end
 
     it "falls back to default for a part of speech outside the Fitzgerald key" do
       stub_ai(ai_tiles(["swing", "gerund"]))
 
-      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call)
+      expect(described_class.new(topic: "the playground", tile_count: 1).call)
         .to eq([{ label: "swing", part_of_speech: "default" }])
     end
 
     it "normalizes casing on the part of speech" do
       stub_ai(ai_tiles(["swing", "Noun"]))
 
-      expect(described_class.new(topic: "the playground", columns: 1, rows: 1).call.first[:part_of_speech])
+      expect(described_class.new(topic: "the playground", tile_count: 1).call.first[:part_of_speech])
         .to eq("noun")
     end
 
     it "skips blank labels and non-hash entries" do
       stub_ai({ "tiles" => [{ "label" => "  " }, "nonsense", { "label" => "swing" }] }.to_json)
 
-      expect(described_class.new(topic: "the playground", columns: 3, rows: 1).call)
+      expect(described_class.new(topic: "the playground", tile_count: 3).call)
         .to eq([{ label: "swing", part_of_speech: "default" }])
     end
   end
@@ -92,21 +92,21 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     it "raises when OpenAI returns nothing" do
       stub_ai("")
 
-      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+      expect { described_class.new(topic: "the playground", tile_count: 4).call }
         .to raise_error(described_class::GenerationError, /no content/)
     end
 
     it "raises on unparseable JSON" do
       stub_ai("not json")
 
-      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+      expect { described_class.new(topic: "the playground", tile_count: 4).call }
         .to raise_error(described_class::GenerationError, /Failed to parse/)
     end
 
     it "raises when nothing in the response is usable" do
       stub_ai({ "tiles" => [] }.to_json)
 
-      expect { described_class.new(topic: "the playground", columns: 2, rows: 2).call }
+      expect { described_class.new(topic: "the playground", tile_count: 4).call }
         .to raise_error(described_class::GenerationError, /no usable words/)
     end
   end
@@ -124,11 +124,11 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     end
 
     it "asks for exactly the grid's worth of tiles" do
-      expect(prompt_for(topic: "the playground", columns: 6, rows: 4)).to include("EXACTLY 24 tiles")
+      expect(prompt_for(topic: "the playground", tile_count: 24)).to include("EXACTLY 24 tiles")
     end
 
     it "carries the core spine, in order, ahead of topic words" do
-      prompt = prompt_for(topic: "the playground", columns: 6, rows: 4)
+      prompt = prompt_for(topic: "the playground", tile_count: 24)
 
       expect(prompt).to include(described_class::CORE_SPINE.join(", "))
       expect(prompt).to include("before any topic words")
@@ -137,14 +137,14 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     # A 2x2 board can't carry sixteen core words; asking for them would
     # guarantee the balance is wrong.
     it "asks only for as much of the spine as the grid can hold" do
-      prompt = prompt_for(topic: "the playground", columns: 2, rows: 2)
+      prompt = prompt_for(topic: "the playground", tile_count: 4)
 
       expect(prompt).to include("I, you, it, want")
       expect(prompt).not_to include("my turn")
     end
 
     it "carries the balance targets and the no-near-duplicates rule" do
-      prompt = prompt_for(topic: "the playground", columns: 6, rows: 4)
+      prompt = prompt_for(topic: "the playground", tile_count: 24)
 
       expect(prompt).to include("30-40% verbs and core function words")
       expect(prompt).to include("15-20% pronouns and determiners")
@@ -154,14 +154,14 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     end
 
     it "constrains the part of speech to the Fitzgerald key" do
-      expect(prompt_for(topic: "the playground", columns: 2, rows: 2))
+      expect(prompt_for(topic: "the playground", tile_count: 4))
         .to include(ColorHelper::PARTS_OF_SPEECH.join(", "))
     end
 
     it "includes the audience only when one is given" do
-      expect(prompt_for(topic: "the playground", columns: 2, rows: 2, audience: "a preschooler"))
+      expect(prompt_for(topic: "the playground", tile_count: 4, audience: "a preschooler"))
         .to include("It is for: a preschooler")
-      expect(prompt_for(topic: "the playground", columns: 2, rows: 2)).not_to include("It is for:")
+      expect(prompt_for(topic: "the playground", tile_count: 4)).not_to include("It is for:")
     end
   end
 end


### PR DESCRIPTION
Three fixes to the admin board build pages, all the same shape: the review step wasn't showing you the board you're about to publish.

## 1. Open the board in a new tab

The review page showed the tile grid and the slug but no way to open the actual board — you had to hand-assemble a URL to try a build before publishing it.

- New `Admin::BoardBuildsHelper` with `board_app_url(board)` → `FRONT_END_URL/boards/:id` and `board_published_page_url(board)` → `FRONT_END_URL/pb/<slug>`.
- **"Open board ↗"** button in the action row; **"open ↗"** on every page of a linked set; the `Public URL` line becomes a link once published.

`Board#viewable_by?` gates `/pb/` on `published`, and review happens *before* publishing — so the app URL is what's always live, and `/pb/` only renders once `published?`.

## 2. The preview drew the wrong layout

Both review grids were a hardcoded six across regardless of what you authored, so an 8-wide board was reviewed at a width it will never be used at — with "8×4 grid" written above it.

Both now render the authored column count via a `.builder-grid` class in the admin layout plus an inline `--cols`, and each page of a mixed-grid set draws at its own. Tailwind can't compile a class assembled at runtime, hence the custom property rather than `lg:grid-cols-N`.

## 3. "Rows" is now "Tiles"

Rows were never stored on the board — `Board#rows_for_screen_size` derives them from the tile count — so `columns × rows` only ever meant "this many tiles". The field now says what it does.

- `admin_board_builds.rows_count` → `tile_count`. The migration converts existing values (`columns × rows`) and every child page's grid override inside the `plan` jsonb; `down` converts back.
- `Plan` pages carry `tile_count:` instead of `rows:`; `WordListDrafter` takes `tile_count:` directly.
- Form field, live counter, child-page inputs, index and show all speak in columns + tiles.

**The dead-cell rail moved and got sharper.** Two separate checks now: the word list must be exactly `tile_count` long, and `tile_count` must be a whole number of rows for the column count. Only the second has the "allow a partial row" escape hatch, and the message names the two nearest counts that would fill whole rows. Previously the checkbox quietly excused a *short word list*, which is the case where shrinking the board is the right fix.

## Test plan

```
bundle exec rspec spec/requests/admin/ spec/services/boards/admin_builder/ spec/models/
1161 examples, 0 failures, 6 pending
```

New coverage: app/public link rendering on the review page (unpublished vs published, and per page of a set); the review grid drawn at the authored column count and per-page for a mixed-grid set; each page's own grid carried through `ArtPreview`; the word-count and partial-row checks under the new semantics.

Migration verified both ways — `db:migrate`, `db:rollback`, `db:migrate`.

## Docs

- `CHANGELOG.md` — entries under Changed and Added.
- `.claude-notes/board-builder.md` — the tile-count invariant replaces the old `columns × rows` one; notes on the runtime column count and on why the review link is the app URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)