### PR TITLE
chore(release): stamp CHANGELOG as v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable user-facing changes to this project will be documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.4.1] — 2026-08-08
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- Stamp `CHANGELOG.md`'s `[Unreleased]` section as `[1.4.1] — 2026-08-08`, aligning with the frontend's v1.4.1 patch release (brittanyjohns/itty-bitty-frontend#650)

Backend deploys continuously and has no version number of its own, but
the changelog is stamped to match the frontend release for alignment,
per repo convention. Entries are unchanged — header rename only.

## Test plan
- Doc-only change; no test suite run needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)