### PR TITLE
fix(admin): warn instead of claiming success when AI drafts fewer pages than asked

### DIFF
--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -421,16 +421,27 @@ module Admin
     end
 
     def draft_set_notice(set, form)
-      wanted = form[:tile_count].to_i
+      wanted_tiles = form[:tile_count].to_i
+      wanted_pages = form[:page_count].to_i
       pages = set[:children].size
-      short = ([set[:root_tiles]] + set[:children].map { |child| child[:tiles] })
-              .count { |tiles| tiles.size != wanted }
+      short_boards = ([set[:root_tiles]] + set[:children].map { |child| child[:tiles] })
+                     .count { |tiles| tiles.size != wanted_tiles }
 
       base = "Drafted the main board and #{pages} #{"page".pluralize(pages)}."
-      return "#{base} Edit them, then preview the art." if short.zero?
+      return "#{base} Edit them, then preview the art." if short_boards.zero? && pages == wanted_pages
 
-      "#{base} #{short} #{"board".pluralize(short)} didn't come back with exactly #{wanted} words — " \
-        "check the counts before previewing."
+      warnings = []
+      if pages < wanted_pages
+        missing = wanted_pages - pages
+        warnings << "the AI came back #{missing} #{"page".pluralize(missing)} short of the #{wanted_pages} " \
+                     "you asked for"
+      end
+      if short_boards.positive?
+        warnings << "#{short_boards} #{"board".pluralize(short_boards)} didn't come back with exactly " \
+                     "#{wanted_tiles} words"
+      end
+
+      "#{base} #{warnings.join("; ").capitalize} — check the counts before previewing."
     end
 
     # The drafter can come back short (near-duplicates get dropped), which is

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -926,6 +926,17 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("draft from")
     end
+
+    it "warns rather than claiming success when the AI comes back short on pages" do
+      stub_set_drafter(root_tiles: drafted[:root_tiles], children: [])
+
+      post draft_set_admin_dashboard_board_builds_path,
+           params: form_params(words: "", page_count: "2", columns: "1", tile_count: "2")
+
+      expect(response).to have_http_status(:ok)
+      expect(flash[:notice]).to match(/short|didn.t come back|asked for 2/i)
+      expect(flash[:notice]).not_to eq("Drafted the main board and 0 pages. Edit them, then preview the art.")
+    end
   end
 
   describe "POST describe" do


### PR DESCRIPTION
## Summary
- The board builder's "Draft the whole set with AI" button reported success ("Drafted the main board and 0 pages... Edit them, then preview the art.") even when the AI came back with fewer pages than requested — including zero. `draft_set_notice` only compared each board's *tile count* to what was asked for; it never compared the *number of pages returned* against `page_count`.
- Root cause: `SetDrafter`'s page structure isn't schema-enforced on the OpenAI response, so a real call can legitimately come back short on pages. The controller had no way to signal that to the admin.
- Fix: `draft_set_notice` now also checks `set[:children].size` against the requested `page_count` and folds a "came back N pages short of the M you asked for" warning into the flash alongside the existing tile-count check, instead of silently reporting a clean success.

## Test plan
- Added a regression spec (`spec/requests/admin/board_builds_spec.rb`) that stubs `SetDrafter` returning zero children for a `page_count: "2"` request and asserts the flash warns rather than claiming plain success.
- `bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder/set_drafter_spec.rb` — 125 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)