### PR TITLE
feat(admin): add-to word list, auto-snap tile count to full rows

### DIFF
--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -68,6 +68,40 @@ module Admin
       render :new, status: :unprocessable_entity
     end
 
+    # Additive form of `draft`: tops up whatever the admin already typed with
+    # only the words missing to reach tile_count, instead of replacing it.
+    def add_words
+      @form = submitted_form
+      @form = @form.merge(suggested_context(@form)) if @form[:topic].blank? || @form[:name].blank?
+      @problems = draft_problems(@form)
+
+      existing = @form[:tiles]
+      missing = @form[:tile_count].to_i - existing.size
+      if @problems.empty? && missing <= 0
+        @problems << "Already have #{existing.size} of #{@form[:tile_count]} words — " \
+                      "raise Tiles or remove some before adding more."
+      end
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      new_tiles = Boards::AdminBuilder::WordListDrafter.new(
+        topic: @form[:topic],
+        tile_count: missing,
+        audience: @form[:audience],
+        existing_labels: existing.map { |tile| tile[:label] },
+      ).call
+
+      all_tiles = existing + new_tiles
+      @form = @form.merge(words: tiles_to_words(all_tiles), tiles: all_tiles)
+      flash.now[:notice] = add_words_notice(new_tiles, missing, @form)
+      render :new
+    rescue Boards::AdminBuilder::WordListDrafter::GenerationError => e
+      @problems = ["Couldn't draft more words: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    rescue Boards::AdminBuilder::ContextSuggester::GenerationError => e
+      @problems = ["Couldn't work out the topic: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    end
+
     # Optional step zero, the multi-page form of `draft`. Drafts the whole set
     # — root word list with its folder tiles already linked, plus each page —
     # into the form and stops there. Nothing is previewed or built from it.
@@ -441,6 +475,20 @@ module Admin
       return "Drafted #{tiles.size} words. Edit them, then preview the art." if tiles.size == wanted
 
       "Drafted #{tiles.size} of #{wanted} words — add #{wanted - tiles.size} more before previewing."
+    end
+
+    # Same shortfall handling as draft_notice, but against the top-up ask
+    # (`wanted_new`) rather than the board's total tile_count.
+    def add_words_notice(new_tiles, wanted_new, form)
+      total = form[:tiles].size
+      target = form[:tile_count].to_i
+      if new_tiles.size == wanted_new
+        return "Added #{new_tiles.size} #{"word".pluralize(new_tiles.size)} " \
+               "(#{total} of #{target} so far). Edit them, then preview the art."
+      end
+
+      "Added #{new_tiles.size} of #{wanted_new} more words (#{total} of #{target} so far) — " \
+        "add #{target - total} more before previewing."
     end
 
     def blank_form

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -27,10 +27,14 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES = 144
 
-      def initialize(topic:, tile_count:, audience: nil)
+      # existing_labels switches the prompt from "draft a whole board" to "add
+      # N more tiles to one that already has these" — used when topping up a
+      # list an admin already started rather than replacing it.
+      def initialize(topic:, tile_count:, audience: nil, existing_labels: [])
         @topic = topic.to_s.strip
         @tile_count = tile_count.to_i.clamp(1, MAX_TILES)
         @audience = audience.to_s.strip
+        @existing_labels = Array(existing_labels).map(&:to_s)
       end
 
       def call
@@ -41,7 +45,7 @@ module Boards
 
       private
 
-      attr_reader :topic, :tile_count, :audience
+      attr_reader :topic, :tile_count, :audience, :existing_labels
 
       def generate_via_openai
         client = OpenAiClient.new(
@@ -63,6 +67,8 @@ module Boards
       end
 
       def build_prompt
+        return topup_prompt if existing_labels.any?
+
         <<~PROMPT
           You are building an AAC (Augmentative and Alternative Communication) board for a
           nonspeaking communicator. The board's topic is: #{topic}
@@ -105,6 +111,45 @@ module Boards
         PROMPT
       end
 
+      # Tops up a list the admin already started rather than drafting a whole
+      # board — no core spine recitation, since it may already be on the list
+      # (or the admin left it off on purpose).
+      def topup_prompt
+        <<~PROMPT
+          You are extending an existing AAC (Augmentative and Alternative Communication)
+          board for a nonspeaking communicator. The board's topic is: #{topic}
+          #{audience.present? ? "It is for: #{audience}" : ""}
+
+          The board already has these tiles — do not repeat any of them:
+          #{existing_labels.join(", ")}
+
+          Generate EXACTLY #{tile_count} NEW tiles that round out the existing list with
+          topic words the board doesn't have yet.
+
+          Rules:
+          - A board for talking, not a vocabulary list. Favour words that finish a
+            sentence over words that name a thing.
+          - No near-duplicates of each other or of the existing words ("happy" next to
+            "glad", "big" next to "large"). Each tile costs a cell.
+          - Keep each label short — 1-2 words.
+          - Concrete and age-appropriate.
+          - Give every tile a part_of_speech from exactly this list:
+            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
+          - Classify by communicative function, not strict grammar: "more", "yes" and
+            "please" are social; "no", "not" and "stop" are important_function.
+
+          Respond in JSON format:
+          {
+            "tiles": [
+              { "label": "swing", "part_of_speech": "noun" },
+              { "label": "push", "part_of_speech": "verb" }
+            ]
+          }
+
+          Return ONLY the JSON, no other text.
+        PROMPT
+      end
+
       def parse_response(raw)
         data = JSON.parse(raw)
         tiles = dedupe(Array(data["tiles"])).first(tile_count)
@@ -124,8 +169,12 @@ module Boards
       # PlanValidator: `images.label` is a lowercase matching key, so "Go" and
       # "go" are one symbol, and a draft that fails validation on arrival is
       # worse than a short one. Near-duplicates are the prompt's job.
+      #
+      # Seeded with existing_labels too, so a top-up drops anything the AI
+      # repeats from the list it was told to avoid, on top of repeats within
+      # its own response.
       def dedupe(raw_tiles)
-        seen = Set.new
+        seen = Set.new(existing_labels.map(&:downcase))
 
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -100,10 +100,18 @@
       <%# formnovalidate: the board name is `required` for preview and build,
           but drafting infers a missing one — without this the browser blocks
           the submit before the server ever gets to. %>
-      <button type="submit" id="draft-button" formaction="<%= draft_admin_dashboard_board_builds_path %>" formnovalidate
-              class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
-        Draft with AI
-      </button>
+      <div class="flex items-center gap-2">
+        <button type="submit" id="draft-button" formaction="<%= draft_admin_dashboard_board_builds_path %>" formnovalidate
+                class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+          Draft with AI
+        </button>
+        <%# Additive: tops up whatever's already typed with only the missing
+            words, so nothing here needs a confirm() before overwriting. %>
+        <button type="submit" id="add-words-button" formaction="<%= add_words_admin_dashboard_board_builds_path %>" formnovalidate
+                class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+          Add more
+        </button>
+      </div>
     </div>
 
     <div class="mb-3">
@@ -261,6 +269,7 @@
     var tileCount = document.getElementById("tile_count");
     var cellCount = document.getElementById("cell-count");
     var wordCount = document.getElementById("word-count");
+    var allowPartialRow = document.getElementById("allow_partial_row");
     if (!words || !columns || !tileCount) return;
 
     function update() {
@@ -271,7 +280,33 @@
       wordCount.style.color = cells && used !== cells ? "#f87171" : "";
     }
 
+    // Rounds up to the next full row for the given column count; if that
+    // overshoots the field's max, rounds down to the last full row instead
+    // so a full-grid ceiling (144) is never exceeded by rounding.
+    function snappedTileCount(tiles, cols, max) {
+      var remainder = tiles % cols;
+      var roundedUp = remainder === 0 ? tiles : tiles + (cols - remainder);
+      return roundedUp > max ? Math.floor(max / cols) * cols : roundedUp;
+    }
+
+    // "Rows have to be complete" is only relaxed by the partial-row checkbox
+    // — everywhere else, a tile count that isn't cols x rows leaves dead
+    // cells at the end of the grid, so snap it the moment either field
+    // settles (not on every keystroke, which would fight the admin's typing).
+    function snapTileCount() {
+      if (allowPartialRow && allowPartialRow.checked) return;
+      var cols = parseInt(columns.value, 10) || 0;
+      var tiles = parseInt(tileCount.value, 10) || 0;
+      if (!cols || !tiles) return;
+      var max = parseInt(tileCount.max, 10) || tiles;
+      var snapped = snappedTileCount(tiles, cols, max);
+      if (snapped !== tiles) tileCount.value = snapped;
+      update();
+    }
+
     [words, columns, tileCount].forEach(function (el) { el.addEventListener("input", update); });
+    [columns, tileCount].forEach(function (el) { el.addEventListener("change", snapTileCount); });
+    if (allowPartialRow) allowPartialRow.addEventListener("change", snapTileCount);
     update();
 
     // Page blocks are indexed, so every add/remove has to renumber the whole

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
       collection do
         post :suggest
         post :draft
+        post :add_words
         post :draft_set
         post :describe, to: "board_builds#describe_board"
         post :preview

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -467,6 +467,77 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  describe "POST /admin/board_builds/add_words" do
+    let(:new_tiles) do
+      [
+        { label: "slide", part_of_speech: "noun" },
+        { label: "go", part_of_speech: "verb" },
+      ]
+    end
+
+    before do
+      sign_in admin
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call).and_return(new_tiles)
+    end
+
+    # form_params already has 4 words; asking for 6 leaves 2 missing.
+    it "appends only the missing words and writes nothing" do
+      expect { post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "6") }
+        .to not_change(Board, :count)
+        .and not_change(Image, :count)
+        .and not_change(AdminBoardBuild, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("i | pronoun")
+      expect(response.body).to include("swing | noun")
+      expect(response.body).to include("slide | noun")
+      expect(response.body).to include("go | verb")
+      expect(response.body).to include("Added 2 words")
+    end
+
+    it "passes the missing count and the existing labels to the drafter, not the whole tile_count" do
+      expect(Boards::AdminBuilder::WordListDrafter).to receive(:new)
+        .with(topic: "the playground", tile_count: 2, audience: "", existing_labels: %w[i want more swing])
+        .and_call_original
+
+      post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "6")
+    end
+
+    it "refuses when the list already meets the tile count" do
+      expect(Boards::AdminBuilder::WordListDrafter).not_to receive(:new)
+
+      post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "4")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Already have 4 of 4 words")
+    end
+
+    it "says so when the top-up comes back short" do
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call).and_return(new_tiles.first(1))
+
+      post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "6")
+
+      expect(response.body).to include("Added 1 of 2 more words (5 of 6 so far)")
+    end
+
+    it "surfaces a generation failure without losing the form" do
+      allow_any_instance_of(Boards::AdminBuilder::WordListDrafter).to receive(:call)
+        .and_raise(Boards::AdminBuilder::WordListDrafter::GenerationError, "OpenAI returned no content")
+
+      post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "6")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Couldn&#39;t draft more words")
+      expect(response.body).to include("i | pronoun")
+    end
+
+    it "is closed to non-admins" do
+      sign_in create(:user)
+      post add_words_admin_dashboard_board_builds_path, params: form_params(tile_count: "6")
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
   describe "POST /admin/board_builds/preview" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/word_list_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/word_list_drafter_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     end
   end
 
+  describe "topping up an existing list" do
+    it "drops a word the model repeats from existing_labels" do
+      stub_ai(ai_tiles(["I", "pronoun"], ["slide", "noun"]))
+
+      result = described_class.new(topic: "the playground", tile_count: 2, existing_labels: %w[i want]).call
+      expect(result.map { |tile| tile[:label] }).to eq(["slide"])
+    end
+
+    it "matches existing_labels case-insensitively" do
+      stub_ai(ai_tiles(["Swing", "noun"], ["push", "verb"]))
+
+      result = described_class.new(topic: "the playground", tile_count: 2, existing_labels: %w[swing]).call
+      expect(result.map { |tile| tile[:label] }).to eq(["push"])
+    end
+  end
+
   describe "failures" do
     it "raises when OpenAI returns nothing" do
       stub_ai("")
@@ -162,6 +178,22 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       expect(prompt_for(topic: "the playground", tile_count: 4, audience: "a preschooler"))
         .to include("It is for: a preschooler")
       expect(prompt_for(topic: "the playground", tile_count: 4)).not_to include("It is for:")
+    end
+
+    context "with existing_labels" do
+      it "switches to the top-up prompt and lists the words to avoid" do
+        prompt = prompt_for(topic: "the playground", tile_count: 2, existing_labels: %w[i want])
+
+        expect(prompt).to include("do not repeat any of them")
+        expect(prompt).to include("i, want")
+        expect(prompt).to include("EXACTLY 2 NEW tiles")
+      end
+
+      it "drops the mandatory core-spine recitation" do
+        prompt = prompt_for(topic: "the playground", tile_count: 2, existing_labels: %w[i want])
+
+        expect(prompt).not_to include("before any topic words")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Board Builds admin: "Draft with AI" always replaced the whole word list wholesale. Added a separate **"Add more"** button that tops up an existing list — asks `WordListDrafter` only for the words still missing (`tile_count` minus what's typed), excludes the existing labels from the prompt and dedup, and appends the result without touching what's already there.
- Tile-count field now **auto-snaps** to the next full row of `Columns` the moment either field settles (`change` event, not mid-keystroke), unless "Allow a partial last row" is checked. Previously a mismatch (e.g. 42 tiles at 8 columns) only surfaced as a server-side validation error after a full Preview round trip.

## Changes
- `app/services/boards/admin_builder/word_list_drafter.rb` — new `existing_labels:` option, a top-up prompt variant, dedup seeded from existing labels
- `app/controllers/admin/board_builds_controller.rb` — new `add_words` action + `add_words_notice`
- `config/routes.rb` — new `add_words` collection route
- `app/views/admin/board_builds/_form.html.erb` — "Add more" button + tile-count snap JS
- Specs added/updated in `spec/services/boards/admin_builder/word_list_drafter_spec.rb` and `spec/requests/admin/board_builds_spec.rb`

## Test plan
- `bundle exec rspec spec/services/boards/admin_builder/word_list_drafter_spec.rb spec/requests/admin/board_builds_spec.rb` — 128 examples, 0 failures
- Manually verified in the browser: Columns=8 with Tiles=42 snapped to 48 before submit; "Add more" appended AI-drafted words to an existing 2-word list without touching them, reaching the target tile count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)