### PR TITLE
fix(images): stop plain leading-capital words from sticking as Title Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable user-facing changes to this project will be documented here.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Words made from the admin dashboard could permanently stick in Title Case.**
+  Creating a tile for a brand-new word (no matching image in the library yet)
+  baked in whatever casing it was authored with — a word-list line typed with
+  a capital, or an AI-drafted label — as that image's display text forever,
+  since any existing capital reads as deliberate styling ("iPad", "TV") to the
+  tile-casing default. New images now fold a plain leading capital down before
+  it's captured, so a first-time word defaults to lowercase like the rest of
+  the board; genuinely stylized casing is untouched. Same underlying path the
+  regular board editor uses, so it's fixed there too.
+
 ## [1.4.1] — 2026-08-08
 
 ### Changed

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -18,6 +18,13 @@ module Boards
   module ImageResolver
     module_function
 
+    # Matches a word that is capitalized ONLY on its first letter ("Zorblequax",
+    # "Swing") — the shape a word-list line or an LLM's JSON label naturally
+    # comes out in, not a deliberate stylistic choice. An uppercase letter
+    # anywhere past the first ("iPad", "TV", "McDonald's") reads as genuinely
+    # stylized and doesn't match.
+    PLAIN_LEADING_CAP = /\A\p{Upper}[^\p{Upper}]*\z/
+
     # Returns a persisted Image for `label`. `owner` is the User who owns any
     # newly-created image and whose private images are preferred.
     #
@@ -35,9 +42,22 @@ module Boards
       return arted if arted
 
       # 3. No art anywhere — keep an existing (blank) image, else create one.
+      #
+      # A plain leading capital is folded down before it's captured as
+      # display_label: Labels::CaseNormalizer treats ANY existing uppercase as
+      # deliberate when a tile later defaults its text from this image, so
+      # baking in an accidental capital here would permanently exempt every
+      # future tile for this word from the AAC lowercase convention — the same
+      # "Higher" next to "swing" defect #583/#617 fixed, just re-opened at
+      # image-creation time instead of tile-default time.
       owner.images.where(ci_label, word).first ||
         default_public_scope.where(ci_label, word).first ||
-        Image.create!(label: word, user_id: owner.id)
+        Image.create!(label: fold_accidental_leading_cap(word), user_id: owner.id)
+    end
+
+    def fold_accidental_leading_cap(word)
+      text = word.to_s
+      text.match?(PLAIN_LEADING_CAP) ? text.sub(/\A\p{Upper}/) { |char| char.downcase } : text
     end
 
     # Batch form of `resolve` for a whole request's worth of labels. Returns a

--- a/spec/services/boards/image_resolver_spec.rb
+++ b/spec/services/boards/image_resolver_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Boards::ImageResolver do
       expect(resolved["brand_new_batch_word"].label).to eq("brand_new_batch_word")
     end
 
-    it "keeps the authored casing on an image it has to create" do
+    it "keeps genuinely stylized casing on an image it has to create" do
       resolved = described_class.resolve_all(["BrandNewCased"], owner: owner)
 
       # The authored casing now lives on display_label; label is the lowercase
@@ -60,6 +60,19 @@ RSpec.describe Boards::ImageResolver do
       # instead of creating a second one.
       expect(resolved["brandnewcased"].display_label).to eq("BrandNewCased")
       expect(resolved["brandnewcased"].label).to eq("brandnewcased")
+    end
+
+    # A plain leading capital is indistinguishable from someone just typing a
+    # word-list line normally, or an LLM defaulting to Title Case in its JSON
+    # — not a deliberate stylistic choice like "iPad" or "TV". Baking it in as
+    # the image's display_label would permanently exempt every future tile for
+    # this word from the AAC lowercase convention, since
+    # Labels::CaseNormalizer treats any existing uppercase as deliberate.
+    it "folds a plain leading capital down when it has to create the image" do
+      resolved = described_class.resolve_all(["Zorblequax"], owner: owner)
+
+      expect(resolved["zorblequax"].display_label).to eq("zorblequax")
+      expect(resolved["zorblequax"].label).to eq("zorblequax")
     end
 
     it "does not scale its query count with the number of labels" do
@@ -121,6 +134,16 @@ RSpec.describe Boards::ImageResolver do
         expect(result.label).to eq("brand_new_word")
         expect(result.user_id).to eq(owner.id)
       }.to change(Image, :count).by(1)
+    end
+
+    it "folds a plain leading capital down on a brand-new image, but leaves stylized casing alone" do
+      plain = described_class.resolve("Swing", owner: owner)
+      stylized = described_class.resolve("iPad", owner: owner)
+      shouty = described_class.resolve("TV", owner: owner)
+
+      expect(plain.display_label).to eq("swing")
+      expect(stylized.display_label).to eq("iPad")
+      expect(shouty.display_label).to eq("TV")
     end
 
     it "normalizes the label before resolving" do


### PR DESCRIPTION
## Summary

- Words made from the admin dashboard (and, more rarely, the regular board editor) could come out permanently Title Cased instead of the AAC lowercase convention.
- Root cause: `Boards::ImageResolver.resolve` creates a brand-new `Image` for a never-before-seen word and captures whatever casing it was authored with as the permanent `display_label`. `Labels::CaseNormalizer` treats *any* existing uppercase as deliberate styling ("iPad", "TV"), so a word typed or AI-drafted with just a leading capital ("Zorblequax") locked into Title Case for every future tile that word ever appears on — anywhere in the library, on any board.
- This isn't admin-only: the same `ImageResolver` path backs the internal API the regular board editor uses. The admin dashboard just hits it constantly (AI-drafted word lists, brand-new topics), so it's where it was visible.
- Fix: fold a plain leading capital down before it's captured as `display_label`. Genuinely stylized casing (an uppercase letter anywhere past the first — "iPad", "TV", "McDonald's") is left untouched.
- Confirmed unaffected: `StarterBlueprints` (separate `Image.create!` call, not through `ImageResolver`), and `NavRowSync`/`PhrasesPageBuilder`/`SeededSetCloner` (all pin `display_label` explicitly rather than defaulting from the image).

## Test plan

- Added failing-then-passing specs in `spec/services/boards/image_resolver_spec.rb` covering both `.resolve` and `.resolve_all`: a plain leading capital folds to lowercase on a new image; genuinely stylized casing ("iPad", "TV", "BrandNewCased") survives untouched.
- Reproduced the bug live via `bin/rails runner` through `Boards::AdminBuilder::Build` before the fix (`display_label="Zorblequax"`) and confirmed it's gone after (`display_label="zorblequax"`).
- Ran the full set of specs downstream of `ImageResolver` — admin builder, blueprint assembler, nav row sync, phrases page builder, seeded set cloner, starter blueprints, the internal board_images API, `Image`, `Labels::CaseNormalizer`, `BoardImage`, and the label-casing request spec — 254 examples, 0 failures.
- `bin/rails zeitwerk:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)