### PR TITLE
fix(boards): nullify admin_board_builds.board_id on board delete

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -88,6 +88,10 @@ class Board < ApplicationRecord
   has_many :word_events
   has_many :subgroups, class_name: "BoardGroup", foreign_key: "root_board_id", dependent: :nullify
   has_many :predictive_board_images, class_name: "BoardImage", foreign_key: "predictive_board_id", dependent: :nullify
+  # AdminBoardBuild is a build-run record (audit trail), not board content —
+  # it must survive board deletion, so the back-pointer is nullified
+  # (AdminBoardBuild#board is belongs_to optional).
+  has_many :admin_board_builds, dependent: :nullify
 
   include WordEventsHelper
 

--- a/spec/models/admin_board_build_spec.rb
+++ b/spec/models/admin_board_build_spec.rb
@@ -20,4 +20,13 @@ RSpec.describe AdminBoardBuild do
     expect(build.description).to eq("A board for the playground.")
     expect(build.audience).to eq("an early communicator")
   end
+
+  it "survives its board being destroyed, with board_id nullified" do
+    board = FactoryBot.create(:board)
+    build = described_class.create!(name: "Playground", columns_count: 2, tile_count: 4, board: board)
+
+    expect { board.destroy! }.not_to raise_error
+
+    expect(build.reload.board_id).to be_nil
+  end
 end


### PR DESCRIPTION
## Summary
- Deleting a board that had ever gone through the admin Board Builder raised `ActiveRecord::InvalidForeignKey` (`PG::ForeignKeyViolation` on `fk_rails_dd28c9b136`) because `AdminBoardBuild#board_id` has a DB-level FK but `Board` had no matching `has_many` to nullify it before destroy.
- Adds `has_many :admin_board_builds, dependent: :nullify` on `Board`, matching the existing pattern for `docs`, `subgroups`, and `predictive_board_images` — build records are an audit trail, not board content, so they survive with `board_id` cleared.

## Test plan
- [x] `bundle exec rspec spec/models/admin_board_build_spec.rb spec/models/board_spec.rb` — 96 examples, 0 failures
- [x] Reverted the fix locally and reran the new spec to confirm it reproduces the exact reported `PG::ForeignKeyViolation`
- [x] `bundle exec rails zeitwerk:check` — no load errors

Filed a separate follow-up for a latent twin of this bug in `BoardPrintable` (same missing-association shape, different fix since its `belongs_to :board` is required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)