### PR TITLE
fix(boards): destroy board_printables when their board is deleted

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -88,6 +88,11 @@ class Board < ApplicationRecord
   has_many :word_events
   has_many :subgroups, class_name: "BoardGroup", foreign_key: "root_board_id", dependent: :nullify
   has_many :predictive_board_images, class_name: "BoardImage", foreign_key: "predictive_board_id", dependent: :nullify
+  # A BoardPrintable is a rendered PDF derived from the board's content, not
+  # independent content of its own — unlike AdminBoardBuild (nullified, an
+  # audit trail) it has no reason to outlive the board, and its belongs_to
+  # is required so nullify would raise NOT NULL anyway.
+  has_many :board_printables, dependent: :destroy
 
   include WordEventsHelper
 

--- a/spec/models/board_printable_spec.rb
+++ b/spec/models/board_printable_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe BoardPrintable do
+  it "is destroyed along with its board" do
+    board = FactoryBot.create(:board)
+    printable = described_class.create!(board: board, board_ids: [board.id])
+
+    expect { board.destroy! }.not_to raise_error
+    expect(described_class.exists?(printable.id)).to be false
+  end
+end


### PR DESCRIPTION
## Summary
- `BoardPrintable#board` (`app/models/board_printable.rb`) is a required `belongs_to` backed by a DB-level FK, but `Board` had no reverse `has_many :board_printables` — so `Board#destroy!` raised `ActiveRecord::InvalidForeignKey` for any board with a generated printable.
- Unlike `AdminBoardBuild` (an audit-trail record, correctly `dependent: :nullify`'d in a sibling branch), a `BoardPrintable` is a rendered PDF derived from the board's own content with no reason to outlive it — and its `belongs_to` is required, so `nullify` would itself raise a NOT NULL violation. `dependent: :destroy` is the right semantics.

## Test plan
- Added `spec/models/board_printable_spec.rb`: creates a board + printable, destroys the board, asserts no error and the printable is gone.
- Verified the regression: reverted the model change locally and confirmed the new spec fails with the exact `PG::ForeignKeyViolation` this PR fixes, then confirmed it passes with the fix.
- Ran the fix + surrounding board/printable coverage: `bundle exec rspec spec/models/board_printable_spec.rb spec/requests/admin/board_printables_spec.rb spec/requests/api/admin/board_printables_spec.rb spec/models/board_spec.rb spec/requests/api/boards_spec.rb spec/requests/api/boards_destroy_spec.rb` — 215 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)