### PR TITLE
feat(admin): loosen board-builder tile count validation to a 2-tile tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Board builder word-count validation now allows a small margin.** A word
+  list within 2 tiles of the page's tile count is accepted instead of
+  requiring an exact match — the message and the live word-count hint on the
+  form now say "within 2" rather than "exactly." A gap larger than that still
+  blocks preview/build with the same "Add N" / "Remove N" guidance.
+
 ### Fixed
 
 - **Words made from the admin dashboard could permanently stick in Title Case.**

--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -6,8 +6,8 @@ module Boards
     #
     # Two rules carry the weight:
     #
-    #   * **The word list must be exactly the page's tile count, and that count
-    #     must fill whole rows.** Rows are never stored
+    #   * **The word list must be within `TILE_COUNT_TOLERANCE` of the page's
+    #     tile count, and that count must fill whole rows.** Rows are never stored
     #     (`Board#rows_for_screen_size` derives them from the tiles), so a
     #     partial final row doesn't shorten the board — it leaves conspicuous
     #     empty cells at the right end of the last row, which reads as broken on
@@ -20,6 +20,11 @@ module Boards
     #
     # Both have an explicit, unticked escape hatch rather than being advisory.
     class PlanValidator
+      # A word list within this many tiles of the target is accepted as-is —
+      # close enough to not fuss over, without opening the door to a board
+      # that's meaningfully sparse or overflowing.
+      TILE_COUNT_TOLERANCE = 2
+
       def initialize(pages:, allow_partial_row: false, allow_mixed_grids: false)
         @pages = Array(pages)
         @allow_partial_row = allow_partial_row
@@ -106,10 +111,12 @@ module Boards
       end
 
       def count_mismatch(page, written, wanted)
-        return [] if written == wanted
+        diff = written - wanted
+        return [] if diff.abs <= TILE_COUNT_TOLERANCE
 
-        verb = written > wanted ? "Remove #{written - wanted}" : "Add #{wanted - written}"
-        [prefixed(page, "#{written} words for a #{wanted}-tile board (needs exactly #{wanted}). #{verb}. " \
+        verb = diff.positive? ? "Remove #{diff}" : "Add #{-diff}"
+        [prefixed(page, "#{written} words for a #{wanted}-tile board (needs to be within " \
+                        "#{TILE_COUNT_TOLERANCE} of #{wanted}). #{verb} to land on #{wanted} exactly. " \
                         "Change the tile count if the board should be a different size.")]
       end
 

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -126,8 +126,9 @@
         <span class="font-mono">Food | noun | &gt;food</span>. From a page, <span class="font-mono">&gt;<%= Boards::AdminBuilder::Plan::ROOT_KEY %></span> goes back to the main board.
       </p>
       <p class="text-[11px] text-t3 mt-1">
-        You need exactly <span id="cell-count" class="text-t1 font-medium">—</span> words
-        (<span id="word-count" class="text-t1 font-medium">0</span> so far).
+        You need about <span id="cell-count" class="text-t1 font-medium">—</span> words
+        (within <%= Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE %>) —
+        <span id="word-count" class="text-t1 font-medium">0</span> so far.
         A tile count that isn’t a whole number of rows leaves dead cells at the end of the last row.
       </p>
     </div>
@@ -272,12 +273,15 @@
     var allowPartialRow = document.getElementById("allow_partial_row");
     if (!words || !columns || !tileCount) return;
 
+    // Kept in sync with Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE.
+    var TILE_COUNT_TOLERANCE = <%= Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE %>;
+
     function update() {
       var cells = parseInt(tileCount.value, 10) || 0;
       var used = words.value.split("\n").filter(function (line) { return line.trim() !== ""; }).length;
       cellCount.textContent = cells || "—";
       wordCount.textContent = used;
-      wordCount.style.color = cells && used !== cells ? "#f87171" : "";
+      wordCount.style.color = cells && Math.abs(used - cells) > TILE_COUNT_TOLERANCE ? "#f87171" : "";
     }
 
     // Rounds up to the next full row for the given column count; if that

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -614,15 +614,25 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     before { sign_in admin }
 
     it "rejects a word list that doesn't match the tile count and preserves what was typed" do
-      params = form_params(tile_count: "6")
+      params = form_params(tile_count: "8")
 
       expect { post preview_admin_dashboard_board_builds_path, params: params }
         .to not_change(Board, :count).and not_change(Image, :count)
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("needs exactly 6")
+      expect(response.body).to include("needs to be within 2 of 8")
       expect(response.body).to include("Playground")
       expect(response.body).to include("swing | noun")
+    end
+
+    # A word list a tile or two off the target is close enough to not fuss over.
+    it "accepts a word list within tolerance of the tile count" do
+      params = form_params(tile_count: "6")
+
+      post preview_admin_dashboard_board_builds_path, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Review the art")
     end
 
     # The escape hatch now governs the SIZE, not the word list: 3 tiles across

--- a/spec/services/boards/admin_builder/plan_validator_spec.rb
+++ b/spec/services/boards/admin_builder/plan_validator_spec.rb
@@ -24,14 +24,24 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     end
 
     it "rejects a short plan and says how many to add" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more")))
-      expect(problems.first).to include("3 words for a 4-tile board (needs exactly 4)")
-      expect(problems.first).to include("Add 1")
+      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more"), tile_count: 8))
+      expect(problems.first).to include("3 words for a 8-tile board (needs to be within 2 of 8)")
+      expect(problems.first).to include("Add 5")
+    end
+
+    it "accepts a plan within tolerance of the tile count" do
+      expect(validate(pages: pages(root_tiles: tiles("i", "want"), tile_count: 4))).to eq([])
+    end
+
+    it "rejects a plan just past the tolerance" do
+      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4))
+      expect(problems.first).to include("1 words for a 4-tile board")
+      expect(problems.first).to include("Add 3")
     end
 
     # A one-board build must read exactly as it did before pages existed.
     it "does not prefix messages with a page name" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more")))
+      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4))
       expect(problems.first).not_to include("Playground:")
     end
 
@@ -39,8 +49,8 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     # columns × rows, so "allow a partial row" no longer excuses a short list —
     # it excuses a tile count that doesn't fill whole rows.
     it "rejects a short plan even with the partial-row escape hatch ticked" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more")), allow_partial_row: true)
-      expect(problems.first).to include("needs exactly 4")
+      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4), allow_partial_row: true)
+      expect(problems.first).to include("needs to be within 2 of 4")
     end
 
     it "accepts a short list once the tile count is lowered to match" do
@@ -51,9 +61,11 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     end
 
     it "rejects an over-full plan and says how many to remove" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more", "help", "stop")))
-      expect(problems.first).to include("5 words for a 4-tile board")
-      expect(problems.first).to include("Remove 1")
+      problems = validate(pages: pages(
+        root_tiles: tiles("i", "want", "more", "help", "stop", "go", "yes", "no"), tile_count: 4,
+      ))
+      expect(problems.first).to include("8 words for a 4-tile board")
+      expect(problems.first).to include("Remove 4")
     end
 
     # The dead-cell rail, now stated on the size rather than on the word list.


### PR DESCRIPTION
## Summary

- The board builder's word-list validation required an exact match against
  the page's tile count. Now a word list within 2 tiles of the target is
  accepted as-is; anything further off still blocks with the same
  "Add N" / "Remove N" guidance.
- The build itself already lays out from the actual written tile count (not
  the target `tile_count`), so a board landing a couple tiles off doesn't
  produce a broken grid — this only loosens the preview-time gate.
- Updated the live word-count hint and its JS red-flag threshold on the form
  to match ("within 2" instead of "exactly").
- Added a `Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE`
  constant as the single source of truth, referenced from both the Ruby
  validator and the ERB/JS hint.

## Test plan

- `bundle exec rspec spec/services/boards/admin_builder/plan_validator_spec.rb spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder/word_list_drafter_spec.rb` — 161 examples, 0 failures.
- Added specs covering: accepted within tolerance, rejected just past tolerance, and updated existing exact-match fixtures that are now within tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)