### PR TITLE
fix(admin): stop AI board drafts from snake_casing tile labels

### DIFF
--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -553,7 +553,7 @@ class OpenAiClient
   def get_word_suggestions_from_prompt(prompt, language: "en", profile: nil)
     @model = GTP_MODEL
     text = prompt
-    format_instructions = "Respond with a JSON object in the following format: {\"words\": [\"word_or_phrase_1\", \"word_or_phrase_2\", \"word_or_phrase_3\", ...]}"
+    format_instructions = "Respond with a JSON object in the following format: {\"words\": [\"word or phrase 1\", \"word or phrase 2\", \"word or phrase 3\", ...]}. Use spaces between words in a phrase, never underscores."
     text += format_instructions
     text = append_language_instruction(text, language)
     text = append_profile_guidance(text, profile)

--- a/app/services/boards/admin_builder/set_drafter.rb
+++ b/app/services/boards/admin_builder/set_drafter.rb
@@ -96,6 +96,9 @@ module Boards
             and words like "more", "stop", "help". Pages carry their own subject's words.
           - No near-duplicates within a board ("happy" and "glad"). Each tile costs a cell.
           - Keep each label short — 1-2 words.
+          - A label is display text, not an identifier: separate words with a plain
+            space, never an underscore. (Page "key" values are the one exception —
+            those are underscored on purpose, per the structure rules above.)
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -175,7 +178,7 @@ module Boards
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)
 
-          label = (tile["label"] || tile["word"]).to_s.strip
+          label = sanitize_label(tile["label"] || tile["word"])
           next if label.blank?
           next unless seen.add?(label.downcase)
 
@@ -185,6 +188,15 @@ module Boards
             links_to: link_for(tile, known_keys),
           }.compact
         end.first(tile_count)
+      end
+
+      # The model occasionally answers a multi-word label snake_cased, like an
+      # identifier rather than the tile text it's meant to be — underscores
+      # have no legitimate place in display text, so they're folded to spaces
+      # rather than left for the admin to notice and retype. Distinct from
+      # normalize_key: a page "key" is meant to be underscored.
+      def sanitize_label(raw)
+        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
       end
 
       def part_of_speech_for(tile)

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -94,6 +94,8 @@ module Boards
             cell.
           - Keep each label short — 1-2 words.
           - Concrete and age-appropriate.
+          - A label is display text, not an identifier: separate words with a plain
+            space, never an underscore.
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -133,6 +135,8 @@ module Boards
             "glad", "big" next to "large"). Each tile costs a cell.
           - Keep each label short — 1-2 words.
           - Concrete and age-appropriate.
+          - A label is display text, not an identifier: separate words with a plain
+            space, never an underscore.
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -179,12 +183,20 @@ module Boards
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)
 
-          label = (tile["label"] || tile["word"]).to_s.strip
+          label = sanitize_label(tile["label"] || tile["word"])
           next if label.blank?
           next unless seen.add?(label.downcase)
 
           { label: label, part_of_speech: part_of_speech_for(tile) }
         end
+      end
+
+      # The model occasionally answers a multi-word label snake_cased, like an
+      # identifier rather than the tile text it's meant to be — underscores
+      # have no legitimate place in display text, so they're folded to spaces
+      # rather than left for the admin to notice and retype.
+      def sanitize_label(raw)
+        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
       end
 
       # An unrecognized value would be rejected by PlanValidator on preview, so

--- a/spec/services/boards/admin_builder/set_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/set_drafter_spec.rb
@@ -138,6 +138,22 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
       expect(draft(columns: 1, tile_count: 1)[:root_tiles].first[:part_of_speech]).to eq("default")
     end
 
+    # The model sometimes answers a multi-word label snake_cased, like an
+    # identifier, instead of the tile text it's meant to be — in both the root
+    # board and a child page. The page "key" itself is untouched: underscores
+    # are correct there.
+    it "folds underscores in a label to spaces, root and page alike" do
+      stub_ai(ai_set(
+        root: [tile("please_wait", "social", "food")],
+        pages: [{ "key" => "food", "name" => "Food", "tiles" => [tile("all__done", "important_function")] }],
+      ))
+
+      result = draft(columns: 1, tile_count: 1, page_count: 1)
+      expect(result[:root_tiles].first[:label]).to eq("please wait")
+      expect(result[:children].first[:key]).to eq("food")
+      expect(result[:children].first[:tiles].first[:label]).to eq("all done")
+    end
+
     it "trims a page longer than the requested tile count" do
       stub_ai(ai_set(root: [tile("I", "pronoun"), tile("want", "verb"), tile("more", "social")], pages: []))
 
@@ -200,6 +216,10 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
 
     it "constrains the part of speech to the Fitzgerald key" do
       expect(prompt_for).to include(ColorHelper::PARTS_OF_SPEECH.join(", "))
+    end
+
+    it "tells the model a label is display text, never underscored" do
+      expect(prompt_for).to include("never an underscore")
     end
 
     it "includes the audience only when one is given" do

--- a/spec/services/boards/admin_builder/word_list_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/word_list_drafter_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       expect(described_class.new(topic: "the playground", tile_count: 3).call)
         .to eq([{ label: "swing", part_of_speech: "default" }])
     end
+
+    # The model sometimes answers a multi-word label snake_cased, like an
+    # identifier, instead of the tile text it's meant to be.
+    it "folds underscores in a label to spaces" do
+      stub_ai(ai_tiles(["please_wait", "social"], ["all__done", "important_function"]))
+
+      expect(described_class.new(topic: "the playground", tile_count: 2).call)
+        .to eq([
+          { label: "please wait", part_of_speech: "social" },
+          { label: "all done", part_of_speech: "important_function" },
+        ])
+    end
   end
 
   describe "topping up an existing list" do
@@ -172,6 +184,11 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     it "constrains the part of speech to the Fitzgerald key" do
       expect(prompt_for(topic: "the playground", tile_count: 4))
         .to include(ColorHelper::PARTS_OF_SPEECH.join(", "))
+    end
+
+    it "tells the model a label is display text, never underscored" do
+      expect(prompt_for(topic: "the playground", tile_count: 4))
+        .to include("never an underscore")
     end
 
     it "includes the audience only when one is given" do


### PR DESCRIPTION
## Summary
- Board 5832 (`https://app.speakanyway.com/pb/at-the-hair-salon-09e0832a`) built via the Admin Board Builder showed tiles with underscores instead of spaces (`want_hair_salon`, `please_wait`, `all_done`, `thank_you`).
- Root cause: `WordListDrafter#dedupe` and `SetDrafter#clean_tiles` took OpenAI's `"label"` JSON field verbatim (`.strip` only) — nothing rejected underscores, and neither prompt told the model a label is display text rather than an identifier.
- Fix: sanitize the extracted label (underscores → spaces, collapsed) at the drafter boundary, and add an explicit prompt rule against underscores in both drafters. `key`/`links_to` routing tokens (`SetDrafter#normalize_key`) are untouched — underscores are correct there.
- Also fixed the same priming pattern in `OpenAiClient#get_word_suggestions_from_prompt` (used by the frontend "Tell a situation" wizard): its JSON format example alone used `word_or_phrase_1`/`word_or_phrase_2` instead of `word1`/`word2` like every sibling prompt in the file, which plausibly primed the model to mimic underscore-joined output.
- Board 5832's already-built tiles are left as-is per request — this only prevents new drafts from reproducing the bug.

## Test plan
- `bundle exec rspec spec/services/boards/admin_builder/word_list_drafter_spec.rb spec/services/boards/admin_builder/set_drafter_spec.rb spec/services/boards/admin_builder/word_list_spec.rb` — 61 examples, 0 failures (includes new regression tests for underscore-folding in both root and child-page labels).
- `bundle exec rspec spec/models/open_ai_client_spec.rb -e get_word_suggestions_from_prompt` — 2 examples, 0 failures.
- `bin/rails zeitwerk:check` — passes (pre-existing unrelated warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)