### PR TITLE
fix(labels): make the lowercase tile default actually apply, + backfill task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Tiles stopped coming out Title Cased.** The lowercase tile default was a
+  no-op on the exact input it existed to fix: any capital at all counted as
+  deliberate styling, so a word that arrived "Fun" or "Giraffe" — however it was
+  created, admin or not — bailed out and stayed capitalized forever. Only a
+  capital past the first letter is deliberate now ("iPad", "TV", "McDonald's",
+  and the pronoun "I" are all still safe), and it's judged per word, so one
+  styled word no longer exempts a whole label. Category tiles keep their capital
+  on purpose — "Food" is a page you open, not a word you speak.
+- **New words no longer pollute the image library with a stuck capital.** The
+  fold now happens in the one place authored casing becomes an image's display
+  text, so every path that creates a word — the board editor, word lists, AI
+  drafts, imports — gets it, instead of the handful that had been patched
+  one at a time.
+- **Boards built before the fix can be corrected.** `bin/rails
+  labels:fold_casing_report` shows exactly what would change and writes nothing;
+  `labels:fold_casing APPLY=1` applies it. Scopeable to a single board or user,
+  skips category tiles by default, and only ever re-cases text — it can never
+  change what a tile says.
+
 - **Words made from the admin dashboard could permanently stick in Title Case.**
   Creating a tile for a brand-new word (no matching image in the library yet)
   baked in whatever casing it was authored with — a word-list line typed with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,22 @@ an explicit decision, not a drive-by edit.
   callback: it is lowercase when `set_labels` derives it from the image, but
   builders that write it directly (`NavRowSync`, `PhrasesPageBuilder`) keep
   their own casing — read `display_label` for tile text either way.
+- **Tile casing defaults to lowercase, and only a capital PAST the first letter
+  counts as deliberate.** `Labels::CaseNormalizer` is the single authority, and
+  `Image#set_label` is the single place authored casing becomes display text —
+  fold there, never at the ~20 call sites that build an `Image` from a raw
+  label. A plain leading capital ("Fun", "Giraffe") carries no intent and is
+  folded down; "iPad", "TV", "McDonald's", "HELP" and the standalone pronoun
+  "I" are preserved. Judged **per word**, so one styled word can't exempt a
+  whole label. Treating any capital as deliberate is what made the lowercase
+  default a no-op on exactly the input it exists to fix.
+- **A category tile's label is authored, not defaulted.** Folder tiles keep
+  their capital ("Food", "Play") — an AAC board leans on it to separate a page
+  you open from a word you speak. The OBF importer pins the authored button
+  label and `Boards::BoardTreeBuilder` pins the blueprint's folder label; both
+  bypass the lowercase default by design. `predictive_board_id` alone does NOT
+  identify a folder (predictive/dynamic word tiles carry it too), so never use
+  it to infer that a tile's casing was intentional.
 - **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
   and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
   silently reverts a slug change on a published board (reverts, never raises —

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1149,8 +1149,17 @@ class Image < ApplicationRecord
 
     # Track the authored casing on create, and re-derive it on a rename — but
     # never clobber a display_label the caller set explicitly in the same write.
+    #
+    # Folded through Labels::CaseNormalizer on the way in. This is the ONE place
+    # authored casing becomes an image's display text, so it is the only place
+    # the fold belongs: ~20 call sites build an Image straight from a raw
+    # user/AI/import label (`api/boards_controller#add_image`, the images
+    # controllers, board word lists, scenarios, clones), and patching them one
+    # at a time is how a plain "Giraffe" kept getting into the library. The
+    # normalizer keeps deliberate casing ("iPad", "TV", "McDonald's") and the
+    # standalone pronoun "I" intact.
     if self[:display_label].blank? || (will_save_change_to_label? && !will_save_change_to_display_label?)
-      self.display_label = item_name
+      self.display_label = Labels::CaseNormalizer.normalize(item_name, part_of_speech: part_of_speech)
     end
 
     self.label = Image.normalize_label(item_name)

--- a/app/services/boards/board_tree_builder.rb
+++ b/app/services/boards/board_tree_builder.rb
@@ -83,6 +83,8 @@ module Boards
         board_image = board.add_image(tile[:image_id])
         raise BuildError, "image #{tile[:image_id].inspect} not found" if board_image.nil?
 
+        pin_folder_label!(board_image, tile)
+
         if tile[:children] && depth < MAX_DEPTH
           child = build_board(tile[:children], depth: depth + 1)
           board_image.update!(predictive_board_id: child.id) # link folder -> child
@@ -90,6 +92,23 @@ module Boards
       end
 
       board
+    end
+
+    # A category tile's label is AUTHORED, not defaulted: the blueprint names
+    # these folders "Food"/"Feelings"/"Play" on purpose, and an AAC board leans
+    # on that capital to separate a category you open from a word you speak.
+    # Pin it so it takes the authored path rather than the lowercase default
+    # every vocabulary tile gets — the same rule the OBF importer already
+    # applies to an authored button label.
+    #
+    # Pinned whenever the blueprint declares children, including past MAX_DEPTH
+    # where the folder stays a leaf: the label was authored either way.
+    def pin_folder_label!(board_image, tile)
+      label = tile[:label].to_s
+      return if tile[:children].blank? || label.blank?
+      return if board_image.display_label == label
+
+      board_image.update!(display_label: label)
     end
 
     # The Board a node persists into: a fresh Board for every node in the sync

--- a/app/services/boards/image_resolver.rb
+++ b/app/services/boards/image_resolver.rb
@@ -18,13 +18,6 @@ module Boards
   module ImageResolver
     module_function
 
-    # Matches a word that is capitalized ONLY on its first letter ("Zorblequax",
-    # "Swing") — the shape a word-list line or an LLM's JSON label naturally
-    # comes out in, not a deliberate stylistic choice. An uppercase letter
-    # anywhere past the first ("iPad", "TV", "McDonald's") reads as genuinely
-    # stylized and doesn't match.
-    PLAIN_LEADING_CAP = /\A\p{Upper}[^\p{Upper}]*\z/
-
     # Returns a persisted Image for `label`. `owner` is the User who owns any
     # newly-created image and whose private images are preferred.
     #
@@ -42,22 +35,11 @@ module Boards
       return arted if arted
 
       # 3. No art anywhere — keep an existing (blank) image, else create one.
-      #
-      # A plain leading capital is folded down before it's captured as
-      # display_label: Labels::CaseNormalizer treats ANY existing uppercase as
-      # deliberate when a tile later defaults its text from this image, so
-      # baking in an accidental capital here would permanently exempt every
-      # future tile for this word from the AAC lowercase convention — the same
-      # "Higher" next to "swing" defect #583/#617 fixed, just re-opened at
-      # image-creation time instead of tile-default time.
+      #    `Image#set_label` folds an accidental leading capital out of the
+      #    authored casing for every creation path, this one included.
       owner.images.where(ci_label, word).first ||
         default_public_scope.where(ci_label, word).first ||
-        Image.create!(label: fold_accidental_leading_cap(word), user_id: owner.id)
-    end
-
-    def fold_accidental_leading_cap(word)
-      text = word.to_s
-      text.match?(PLAIN_LEADING_CAP) ? text.sub(/\A\p{Upper}/) { |char| char.downcase } : text
+        Image.create!(label: word, user_id: owner.id)
     end
 
     # Batch form of `resolve` for a whole request's worth of labels. Returns a

--- a/app/services/labels/case_normalizer.rb
+++ b/app/services/labels/case_normalizer.rb
@@ -14,9 +14,16 @@ module Labels
   # This normalizes the **defaulted** case only. Callers that explicitly supply
   # a `display_label` never route through here — their casing wins.
   #
-  # The transform only ever upcases the first letter of a word (and only for
-  # the standalone pronoun "I"). It never downcases, so nothing that slips past
-  # `deliberate_casing?` can be mangled.
+  # "Deliberate casing" is judged PER WORD, and means a capital the author could
+  # only have typed on purpose: one past the first letter ("iPad", "TV",
+  # "McDonald's", "HELP"). Those words are returned untouched.
+  #
+  # A plain LEADING capital is not evidence of intent — it is what a word-list
+  # line, an LLM's JSON label, or ordinary typing produces — so it is folded
+  # down to the lowercase default. Treating it as deliberate is what made this
+  # service a no-op on the input it exists to fix: every tile that arrived
+  # "Fun"/"Giraffe"/"Go" bailed out and stayed Title Cased, so a board rendered
+  # "Fun" next to "spot" (#583 only ever worked on already-lowercase input).
   module CaseNormalizer
     # Whole-utterance tiles (gestalt / GLP) read as sentences, not headlines.
     PHRASE_PART_OF_SPEECH = "phrase".freeze
@@ -33,7 +40,6 @@ module Labels
     def normalize(text, language: nil, part_of_speech: nil)
       text = text.to_s
       return text if text.strip.empty?
-      return text if deliberate_casing?(text)
 
       english = english?(language)
       if english && part_of_speech.to_s != PHRASE_PART_OF_SPEECH
@@ -43,11 +49,15 @@ module Labels
       end
     end
 
-    # Any existing uppercase letter means the text was cased on purpose —
-    # "iPad", "TV", "McDonald's". A naive titleize would wreck all three, and an
-    # exception list would have to be maintained forever. Leave it alone.
-    def deliberate_casing?(text)
-      text.to_s.match?(/\p{Upper}/)
+    # A capital PAST the first letter is one the author could only have typed on
+    # purpose — "iPad", "TV", "McDonald's", "HELP". A naive titleize would wreck
+    # all of those, and an exception list would have to be maintained forever.
+    # Leave such a word alone.
+    #
+    # Judged per word, so one styled word doesn't exempt the whole label: "My
+    # iPad" folds to "my iPad" rather than staying Title Cased throughout.
+    def deliberate_casing?(word)
+      word.to_s.sub(/\A\P{Alpha}*\p{Alpha}/, "").match?(/\p{Upper}/)
     end
 
     # Title Case is an English convention; Spanish wants "Todo listo", not
@@ -63,23 +73,39 @@ module Labels
     # pronoun "I" is the one grammar rule that survives regardless of style or
     # position in the tile text.
     def lowercase_case(text)
-      transform_words(text) { |word| word.match?(STANDALONE_I) ? upcase_first(word) : word }
+      transform_words(text) do |word|
+        if word.match?(STANDALONE_I)
+          upcase_first(word)
+        else
+          fold_first(word)
+        end
+      end
     end
 
-    # First word capitalized, the rest left as authored — except a standalone
-    # "i", which stays capitalized wherever it lands.
+    # First word capitalized, the rest folded to the lowercase default — except
+    # a standalone "i", which stays capitalized wherever it lands, and a word
+    # whose casing was deliberate, which is never touched.
     def sentence_case(text, english: true)
       first = true
       transform_words(text) do |word|
         if first
           first = false
-          upcase_first(word)
+          # "iPad is broken" must not become "IPad is broken".
+          deliberate_casing?(word) ? word : upcase_first(word)
         elsif english && word.match?(STANDALONE_I)
           upcase_first(word)
         else
-          word
+          fold_first(word)
         end
       end
+    end
+
+    # Downcase an accidental leading capital, leaving a deliberately cased word
+    # ("iPad", "TV") exactly as authored.
+    def fold_first(word)
+      return word if deliberate_casing?(word)
+
+      word.sub(/\p{Alpha}/) { |char| char.downcase }
     end
 
     # Upcase the first alphabetic character, leaving leading punctuation and

--- a/lib/tasks/tile_label_casing.rake
+++ b/lib/tasks/tile_label_casing.rake
@@ -1,0 +1,165 @@
+namespace :labels do
+  # Backfill for the casing defect fixed in Labels::CaseNormalizer: a plain
+  # leading capital ("Fun", "Giraffe") used to be read as DELIBERATE styling, so
+  # the lowercase default never applied and the capital stuck permanently — on
+  # the tile AND on the Image it defaulted from. Boards built before the fix
+  # still render that way, because tile text is written once at creation.
+  #
+  # Only ever folds a leading capital down. A word whose casing was deliberate
+  # ("iPad", "TV", "McDonald's", "HELP") and the standalone pronoun "I" are left
+  # exactly as they are — the same judgement Labels::CaseNormalizer makes, reused
+  # here rather than re-implemented, so the backfill and the live path can't drift.
+  #
+  # LINKED (folder / predictive) TILES ARE SKIPPED BY DEFAULT. A category tile's
+  # capital is authored on purpose — "Food" is a folder you open, not a word you
+  # speak — and `predictive_board_id` cannot tell a curated folder apart from a
+  # predictive word tile, so the conservative default is to leave every linked
+  # tile alone. INCLUDE_LINKED=1 folds them too.
+  #
+  #   bin/rails labels:fold_casing_report              # dry run, whole database
+  #   bin/rails labels:fold_casing_report BOARD_ID=5827
+  #   bin/rails labels:fold_casing APPLY=1 BOARD_ID=5827
+  #   bin/rails labels:fold_casing APPLY=1             # everything
+  #
+  # Env: BOARD_ID, USER_ID (scope) · INCLUDE_LINKED=1 · IMAGES=0 (tiles only)
+  #      LIMIT (cap rows touched) · SAMPLE (rows to print, default 25)
+  #      ONLY=down (just fold stuck capitals) | up | both (default)
+
+  # A rewrite is only ever a re-casing: same letters, different capitals.
+  # Anything else means the normalizer would change the word itself, so we
+  # refuse it — this must never edit what a tile SAYS, only how it's cased.
+  recase_only = lambda do |old, new|
+    new.present? && new != old && new.casecmp(old).zero?
+  end
+
+  # Which way a rewrite moves. Folding a stuck capital down ("Fun" -> "fun") is
+  # the defect being repaired; the normalizer ALSO capitalizes the standalone
+  # pronoun "i" ("i need" -> "I need"), which is a grammar rule moving the other
+  # way. Both converge on what the live path now produces, but they are
+  # different edits and are reported — and can be run — separately.
+  direction = lambda do |old, new|
+    new.count("A-Z") < old.count("A-Z") ? :down : :up
+  end
+
+  # Read inside the lambda, not at file-load time: a rake file is loaded once
+  # per process, so a local captured out here would freeze whatever ENV held
+  # before the task ran and silently ignore ONLY=.
+  keep_direction = lambda do |dir|
+    wanted = (ENV["ONLY"].presence || "both").downcase
+    wanted == "both" || wanted == dir.to_s
+  end
+
+  scope_tiles = lambda do
+    # reorder(nil): board_images carries a default position order, and find_each
+    # overrides it — without this every batch logs "Scoped order is ignored".
+    # Order is irrelevant here; each row is folded independently.
+    rel = BoardImage.reorder(nil).where.not(display_label: [nil, ""])
+    rel = rel.where(board_id: ENV["BOARD_ID"]) if ENV["BOARD_ID"].present?
+    rel = rel.joins(:board).where(boards: { user_id: ENV["USER_ID"] }) if ENV["USER_ID"].present?
+    rel = rel.where(predictive_board_id: nil) unless ENV["INCLUDE_LINKED"] == "1"
+    rel
+  end
+
+  scope_images = lambda do
+    rel = Image.where.not(display_label: [nil, ""])
+    rel = rel.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+    # An image is not board-scoped; when a single board is named, only the
+    # images that board's tiles actually point at are in play.
+    rel = rel.where(id: BoardImage.where(board_id: ENV["BOARD_ID"]).select(:image_id)) if ENV["BOARD_ID"].present?
+    rel
+  end
+
+  # Yields [record, old_text, new_text] for every row the fold would rewrite.
+  collect = lambda do |apply:|
+    limit = ENV["LIMIT"].presence&.to_i
+    changes = { tiles: [], images: [] }
+
+    scope_tiles.call.includes(:image).find_each do |bi|
+      break if limit && changes[:tiles].size >= limit
+
+      old = bi.display_label.to_s
+      new = Labels::CaseNormalizer.normalize(
+        old, language: bi.language, part_of_speech: bi.effective_part_of_speech,
+      )
+      next unless recase_only.call(old, new)
+
+      dir = direction.call(old, new)
+      next unless keep_direction.call(dir)
+
+      changes[:tiles] << [bi, old, new, dir]
+      bi.update_columns(display_label: new) if apply
+    end
+
+    unless ENV["IMAGES"] == "0"
+      scope_images.call.find_each do |img|
+        break if limit && changes[:images].size >= limit
+
+        old = img.display_label.to_s
+        new = Labels::CaseNormalizer.normalize(old, part_of_speech: img.part_of_speech)
+        next unless recase_only.call(old, new)
+
+        dir = direction.call(old, new)
+        next unless keep_direction.call(dir)
+
+        changes[:images] << [img, old, new, dir]
+        # update_columns, not update!: this must not fire set_label, the audio
+        # re-render hooks, or touch updated_at across the library.
+        img.update_columns(display_label: new) if apply
+      end
+    end
+
+    changes
+  end
+
+  report = lambda do |changes, applied:|
+    sample = (ENV["SAMPLE"].presence || 25).to_i
+    verb = applied ? "rewrote" : "would rewrite"
+
+    %i[tiles images].each do |kind|
+      rows = changes[kind]
+      down, up = rows.partition { |row| row[3] == :down }
+      puts "\n#{kind.to_s.capitalize}: #{verb} #{rows.size} " \
+           "(#{down.size} stuck capital folded down, #{up.size} standalone \"i\" capitalized)"
+      next if rows.empty?
+
+      { "fold down" => down, "capitalize i" => up }.each do |heading, group|
+        next if group.empty?
+
+        puts "  #{heading}:"
+        group.first(sample).each do |record, old, new, _dir|
+          where = kind == :tiles ? "board #{record.board_id}" : "image #{record.id}"
+          puts format("    %-20s %-18s -> %s", where, old.inspect, new.inspect)
+        end
+        puts "    … #{group.size - sample} more" if group.size > sample
+      end
+    end
+
+    scope = []
+    scope << "board #{ENV['BOARD_ID']}" if ENV["BOARD_ID"].present?
+    scope << "user #{ENV['USER_ID']}" if ENV["USER_ID"].present?
+    scope << (ENV["INCLUDE_LINKED"] == "1" ? "including linked tiles" : "skipping linked tiles")
+    scope << "direction=#{ENV['ONLY'].presence || 'both'}"
+    puts "\nScope: #{scope.join(', ')}"
+  end
+
+  desc "Report tile/image display text with a stuck accidental capital (writes nothing)"
+  task fold_casing_report: :environment do
+    puts "DRY RUN — nothing is written."
+    report.call(collect.call(apply: false), applied: false)
+    puts "\nRe-run with APPLY=1 on labels:fold_casing to write these changes."
+  end
+
+  desc "Fold accidental leading capitals out of tile/image display text (APPLY=1 to write)"
+  task fold_casing: :environment do
+    apply = ENV["APPLY"] == "1"
+    puts apply ? "APPLYING changes." : "DRY RUN — nothing is written (pass APPLY=1 to write)."
+
+    changes = collect.call(apply: apply)
+    report.call(changes, applied: apply)
+
+    if apply
+      total = changes[:tiles].size + changes[:images].size
+      puts "\nDone. #{total} row(s) updated."
+    end
+  end
+end

--- a/spec/lib/tasks/tile_label_casing_rake_spec.rb
+++ b/spec/lib/tasks/tile_label_casing_rake_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "labels rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+
+  def run(name, **env)
+    env.each { |k, v| ENV[k.to_s] = v.to_s }
+    task = Rake::Task["labels:#{name}"]
+    task.reenable
+    task.invoke
+  ensure
+    env.each_key { |k| ENV.delete(k.to_s) }
+  end
+
+  # display_label is written directly: these rows stand in for tiles created
+  # BEFORE the normalizer fix, which is the only thing the backfill exists for.
+  def tile(display_label, predictive_board_id: nil, part_of_speech: "noun")
+    bi = create(:board_image, board: board, part_of_speech: part_of_speech,
+                              predictive_board_id: predictive_board_id,
+                              image: create(:image, label: display_label.downcase, user_id: user.id))
+    bi.update_columns(display_label: display_label)
+    bi
+  end
+
+  describe "labels:fold_casing_report" do
+    it "writes nothing" do
+      stuck = tile("Fun")
+
+      expect { run("fold_casing_report") }.to output(/DRY RUN/).to_stdout
+      expect(stuck.reload.display_label).to eq("Fun")
+    end
+  end
+
+  describe "labels:fold_casing" do
+    it "is a dry run unless APPLY=1 is passed" do
+      stuck = tile("Fun")
+
+      expect { run("fold_casing") }.to output(/DRY RUN/).to_stdout
+      expect(stuck.reload.display_label).to eq("Fun")
+    end
+
+    it "folds a stuck capital down when applied" do
+      stuck = tile("Fun")
+      phrase = tile("All Done")
+
+      run("fold_casing", APPLY: 1)
+
+      expect(stuck.reload.display_label).to eq("fun")
+      expect(phrase.reload.display_label).to eq("all done")
+    end
+
+    it "leaves deliberate casing and the standalone pronoun alone" do
+      brand = tile("iPad")
+      acronym = tile("TV")
+      pronoun = tile("I", part_of_speech: "pronoun")
+
+      run("fold_casing", APPLY: 1)
+
+      expect(brand.reload.display_label).to eq("iPad")
+      expect(acronym.reload.display_label).to eq("TV")
+      expect(pronoun.reload.display_label).to eq("I")
+    end
+
+    # A category tile's capital is authored on purpose, and predictive_board_id
+    # can't tell a curated folder from a predictive word tile — so linked tiles
+    # are left alone unless explicitly asked for.
+    it "skips a linked tile by default and folds it with INCLUDE_LINKED" do
+      folder = tile("Food", predictive_board_id: create(:board, user: user).id)
+
+      run("fold_casing", APPLY: 1)
+      expect(folder.reload.display_label).to eq("Food")
+
+      run("fold_casing", APPLY: 1, INCLUDE_LINKED: 1)
+      expect(folder.reload.display_label).to eq("food")
+    end
+
+    it "restricts to folding down when ONLY=down" do
+      stuck = tile("Fun")
+      lower_i = tile("i", part_of_speech: "pronoun")
+      lower_i.update_columns(display_label: "i")
+
+      run("fold_casing", APPLY: 1, ONLY: "down")
+
+      expect(stuck.reload.display_label).to eq("fun")
+      expect(lower_i.reload.display_label).to eq("i")
+    end
+
+    it "confines itself to one board when BOARD_ID is given" do
+      other_board = create(:board, user: user)
+      mine = tile("Fun")
+      theirs = create(:board_image, board: other_board,
+                                    image: create(:image, label: "swing", user_id: user.id))
+      theirs.update_columns(display_label: "Swing")
+
+      run("fold_casing", APPLY: 1, BOARD_ID: board.id)
+
+      expect(mine.reload.display_label).to eq("fun")
+      expect(theirs.reload.display_label).to eq("Swing")
+    end
+
+    it "never changes what a tile says, only how it is cased" do
+      stuck = tile("Eat Breakfast")
+
+      run("fold_casing", APPLY: 1)
+
+      expect(stuck.reload.display_label.downcase).to eq("eat breakfast")
+    end
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -537,12 +537,16 @@ RSpec.describe Board, type: :model do
         }.to change(Image, :count).by(2)
       end
 
-      it "keeps the authored casing available as display text" do
+      # A bare leading capital carries no intent — it's just how a word-list
+      # line gets typed — so it is folded to the lowercase AAC default rather
+      # than becoming this image's permanent display text. Deliberate casing
+      # ("iPad", "TV") is what survives; see Labels::CaseNormalizer.
+      it "folds an accidental leading capital out of the display text" do
         board.find_or_create_images_from_word_list(["apple"])
 
         apple = Image.by_label("apple").first
         expect(apple.label).to eq("apple")
-        expect(apple.display_label).to eq("Apple")
+        expect(apple.display_label).to eq("apple")
       end
     end
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -165,7 +165,9 @@ RSpec.describe Image, type: :model do
       image.update!(label: "Slide")
 
       expect(image.label).to eq("slide")
-      expect(image.display_label).to eq("Slide")
+      # Folded, not preserved: a plain leading capital is accidental. The
+      # example above this one covers the casing that IS deliberate ("TV").
+      expect(image.display_label).to eq("slide")
     end
 
     it "keeps an explicit display_label set in the same write as a rename" do

--- a/spec/requests/api/board_groups_graph_spec.rb
+++ b/spec/requests/api/board_groups_graph_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe "API::BoardGroups graph", type: :request do
   def build_group_for(owner)
     home  = FactoryBot.create(:board, user: owner, name: "Home")
     food  = FactoryBot.create(:board, user: owner, name: "Food")
-    FactoryBot.create(:board_image, board: home, image: FactoryBot.create(:image, label: "Food"), predictive_board_id: food.id)
+    # A category tile pins its authored display_label, the way the OBF importer
+    # and Boards::BoardTreeBuilder do for a real folder; the word tile below is
+    # left to default, which lowercases it.
+    FactoryBot.create(:board_image, board: home, display_label: "Food",
+                                    image: FactoryBot.create(:image, label: "Food"), predictive_board_id: food.id)
     FactoryBot.create(:board_image, board: food, image: FactoryBot.create(:image, label: "apple"))
 
     group = FactoryBot.create(:board_group, user: owner, builder: true, layout: {})

--- a/spec/requests/api/images_label_casing_spec.rb
+++ b/spec/requests/api/images_label_casing_spec.rb
@@ -59,7 +59,11 @@ RSpec.describe "Images label casing", type: :request do
 
       created = Image.by_label("trampoline").first
       expect(created.label).to eq("trampoline")
-      expect(created.display_label).to eq("Trampoline")
+      # The capital a user happens to type carries no intent, so it is folded to
+      # the lowercase AAC default rather than becoming this word's permanent
+      # display text. Deliberate casing survives — see the "iPad" examples in
+      # spec/services/labels/case_normalizer_spec.rb.
+      expect(created.display_label).to eq("trampoline")
     end
   end
 

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -527,6 +527,14 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
         queries
       end
 
+      # Warm up first. The FIRST request in a process pays one-time costs the
+      # comparison isn't about — Devise/JWT setup, association and schema caches
+      # — and they all land on whichever side is measured first. That made the
+      # result depend on what else had already run in the same process, so the
+      # example passed or failed on shard composition rather than on the code.
+      warmup = create(:image, label: "flat-warmup", user_id: admin_user.id)
+      count_queries.call([{ image_id: warmup.id }], {})
+
       lean = count_queries.call(images.first(3).map { |i| { image_id: i.id } }, {})
       full = count_queries.call(images.last(3).map { |i| { image_id: i.id } }, { view: "full" })
 

--- a/spec/requests/api/v1/board_builder_spec.rb
+++ b/spec/requests/api/v1/board_builder_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe "API::V1::BoardBuilder", type: :request do
     root  = create(:board, user: admin, name: "Core 60", predefined: true, published: true)
     food  = create(:board, user: admin, name: "Food", predefined: true, published: true)
     create(:board_image, board: root, label: "I", image: create(:image, label: "I", user_id: admin.id))
-    food_tile = create(:board_image, board: root, label: "Food",
+    # The category tile pins its authored display_label, exactly as the OBZ
+    # import this fixture stands in for does — a folder label is authored, not
+    # defaulted, so it keeps its capital while vocabulary tiles lowercase.
+    food_tile = create(:board_image, board: root, label: "Food", display_label: "Food",
                                      image: create(:image, label: "Food", user_id: admin.id))
     food_tile.update!(predictive_board_id: food.id)
     create(:board_image, board: food, label: "apple", image: create(:image, label: "apple", user_id: admin.id))

--- a/spec/services/boards/screen_reflow_spec.rb
+++ b/spec/services/boards/screen_reflow_spec.rb
@@ -10,8 +10,11 @@ RSpec.describe Boards::ScreenReflow do
   end
 
   # A tile with an explicit lg cell (callbacks bypassed so x/y/w/h are exact).
+  # display_label is pinned so tiles stay addressable by the exact text these
+  # layout examples look them up with. This spec is about geometry; the
+  # lowercase default that Labels::CaseNormalizer applies is covered elsewhere.
   def tile(label, x:, y:, position:, w: 1, h: 1)
-    bi = create(:board_image, board: board, position: position,
+    bi = create(:board_image, board: board, position: position, display_label: label,
                               image: create(:image, label: label, user_id: user.id))
     bi.update_column(:layout, { "lg" => { "i" => bi.id.to_s, "x" => x, "y" => y, "w" => w, "h" => h } })
     bi

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -21,10 +21,14 @@ RSpec.describe Boards::SeededSetCloner do
     %w[I want help].each do |label|
       create(:board_image, board: root, label: label, image: create(:image, label: label, user_id: admin_user.id))
     end
-    food_tile = create(:board_image, board: root, label: "Food",
+    # Category tiles carry a PINNED display_label, the way a curated seeded set
+    # really does (the OBF importer pins the authored button label;
+    # Boards::BoardTreeBuilder pins the blueprint's folder label). Vocabulary
+    # tiles above are left to default, which is what lowercases them.
+    food_tile = create(:board_image, board: root, label: "Food", display_label: "Food",
                                      image: create(:image, label: "Food", user_id: admin_user.id))
     food_tile.update!(predictive_board_id: food.id)
-    feelings_tile = create(:board_image, board: root, label: "Feelings",
+    feelings_tile = create(:board_image, board: root, label: "Feelings", display_label: "Feelings",
                                          image: create(:image, label: "Feelings", user_id: admin_user.id))
     feelings_tile.update!(predictive_board_id: feelings.id)
 

--- a/spec/services/boards/set_graph_builder_spec.rb
+++ b/spec/services/boards/set_graph_builder_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Boards::SetGraphBuilder do
 
   # Build a tile on `board`. A folder tile links to `links_to` (a Board);
   # a word tile passes links_to: nil. The label drives duplicate-word stats.
+  # A category tile pins its authored display_label, the way the OBF importer
+  # and Boards::BoardTreeBuilder do for a real folder; a word tile is left to
+  # default, which lowercases it.
   def add_tile(board, label:, links_to: nil)
     image = FactoryBot.create(:image, label: label)
     FactoryBot.create(
@@ -12,6 +15,7 @@ RSpec.describe Boards::SetGraphBuilder do
       board: board,
       image: image,
       predictive_board_id: links_to&.id,
+      **(links_to ? { display_label: label } : {}),
     )
   end
 

--- a/spec/services/labels/case_normalizer_spec.rb
+++ b/spec/services/labels/case_normalizer_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Labels::CaseNormalizer do
       expect(described_class.normalize("was it i")).to eq("was it I")
     end
 
+    # "Deliberate" means a capital the author could only have typed on purpose —
+    # one PAST the first letter. A plain leading capital is what a word-list
+    # line, an LLM's JSON label, or ordinary typing produces, so it carries no
+    # intent and must not exempt a tile from the lowercase default.
     context "when the text already carries deliberate casing" do
       it "leaves brand casing alone" do
         expect(described_class.normalize("iPad")).to eq("iPad")
@@ -31,8 +35,26 @@ RSpec.describe Labels::CaseNormalizer do
         expect(described_class.normalize("McDonald's")).to eq("McDonald's")
       end
 
-      it "leaves an already Title Cased phrase alone" do
-        expect(described_class.normalize("All Done")).to eq("All Done")
+      it "judges each word on its own, so styling survives beside a folded word" do
+        expect(described_class.normalize("My iPad")).to eq("my iPad")
+      end
+    end
+
+    context "when the text carries only an accidental leading capital" do
+      it "folds a single Title Cased word down to the lowercase default" do
+        expect(described_class.normalize("Fun")).to eq("fun")
+      end
+
+      it "folds every word of a Title Cased label" do
+        expect(described_class.normalize("All Done")).to eq("all done")
+      end
+
+      it "still capitalizes a standalone I" do
+        expect(described_class.normalize("Me And I")).to eq("me and I")
+      end
+
+      it "preserves the original spacing while folding" do
+        expect(described_class.normalize("All  Done")).to eq("all  done")
       end
     end
 
@@ -55,6 +77,21 @@ RSpec.describe Labels::CaseNormalizer do
       it "does not capitalize words that merely start with i" do
         expect(described_class.normalize("put it in there", part_of_speech: "phrase"))
           .to eq("Put it in there")
+      end
+
+      it "folds a Title Cased phrase down to sentence case" do
+        expect(described_class.normalize("All Done Now", part_of_speech: "phrase"))
+          .to eq("All done now")
+      end
+
+      it "keeps a styled word styled mid-phrase" do
+        expect(described_class.normalize("i want my iPad", part_of_speech: "phrase"))
+          .to eq("I want my iPad")
+      end
+
+      it "does not force a sentence capital onto a styled leading word" do
+        expect(described_class.normalize("iPad is broken", part_of_speech: "phrase"))
+          .to eq("iPad is broken")
       end
     end
 
@@ -85,8 +122,9 @@ RSpec.describe Labels::CaseNormalizer do
       expect(described_class.normalize("was  it  i")).to eq("was  it  I")
     end
 
-    it "never downcases" do
+    it "never downcases a word whose casing was deliberate" do
       expect(described_class.normalize("HELP", part_of_speech: "phrase")).to eq("HELP")
+      expect(described_class.normalize("HELP")).to eq("HELP")
     end
   end
 end

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -34,11 +34,15 @@ RSpec.describe BuildBoardSetJob do
     create(:board_image, board: source_root, label: "I",
                          image: create(:image, label: "I", user_id: admin.id))
     food_image = create(:image, label: "Food", user_id: admin.id)
-    food_tile = create(:board_image, board: source_root, label: "Food", image: food_image)
+    # Category and self tiles pin their authored display_label, as the OBZ
+    # import this fixture stands in for does — a folder label is authored, not
+    # defaulted, so it keeps its capital while vocabulary tiles lowercase.
+    food_tile = create(:board_image, board: source_root, label: "Food", display_label: "Food",
+                                     image: food_image)
     food_tile.update!(predictive_board_id: food.id)
     create(:board_image, board: food, label: "apple",
                          image: create(:image, label: "apple", user_id: admin.id))
-    self_tile = create(:board_image, board: food, label: "Food", image: food_image)
+    self_tile = create(:board_image, board: food, label: "Food", display_label: "Food", image: food_image)
     self_tile.update!(predictive_board_id: source_root.id)
     Boards::RobustSets.mark_root!(source_root, slug)
     source_root


### PR DESCRIPTION
## Summary

Follow-up to #631, which fixed a symptom. This fixes the rule.

`Labels::CaseNormalizer` treated **any** uppercase letter as deliberate styling and bailed out entirely — so the lowercase tile default was a no-op on exactly the input it exists to fix. A word that arrived `"Fun"` or `"Giraffe"` stayed Title Cased permanently, on *every* creation path, not just the admin dashboard. That's why boards like `/boards/5827` still rendered `"Fun"` next to `"spot"` after #631, and why adding a new image as a non-admin still capitalized.

**The rule now:** only a capital **past the first letter** is deliberate, judged **per word**.

| input | before | after |
|---|---|---|
| `Fun`, `Giraffe`, `All Done` | unchanged | `fun`, `giraffe`, `all done` |
| `iPad`, `TV`, `McDonald's`, `HELP` | unchanged | unchanged |
| `I` (standalone pronoun) | `I` | `I` |
| `i want my iPad` (phrase) | `i want my iPad` — *no sentence capital* | `I want my iPad` |

That last row was a second bug the per-word change fixes: one styled word downstream suppressed the sentence capital for the whole label.

### Where the fold lives

Moved into `Image#set_label` — the single place authored casing becomes an image's display text. ~20 call sites build an `Image` straight from a raw user/AI/import label (`api/boards_controller#add_image`, the images controllers, board word lists, scenarios, clones); patching them one at a time is exactly how `"Giraffe"` kept reaching the library. This supersedes the narrower `ImageResolver` special-case from #631, which is removed.

### Category tiles keep their capital

Confirmed with @brittanyjohns: `"Food"` is a page you open, not a word you speak, so folders stay Title Case. `Boards::BoardTreeBuilder` now pins the blueprint's folder label, matching what the OBF importer already does for an authored button. Note `predictive_board_id` does **not** identify a folder — predictive/dynamic word tiles carry it too — so it's never used to infer intent.

### Backfill for existing boards

Tile text is written once at creation, so boards built before this keep their casing. New rake task, dry run by default:

```bash
bin/rails labels:fold_casing_report BOARD_ID=5827   # writes nothing
bin/rails labels:fold_casing APPLY=1 BOARD_ID=5827
```

Scopeable by `BOARD_ID`/`USER_ID`, skips category tiles unless `INCLUDE_LINKED=1`, `ONLY=down|up|both`, and it **only ever re-cases** — a rewrite whose letters differ is refused, so it can never change what a tile says.

**Two things to look at before running it broadly** (both visible in the dry run, neither blocks this PR):
- On *images* it mostly runs the other direction — capitalizing standalone `"i"` (`"i need"` → `"I need"`). Correct per the rule, but it's a different edit, so it's reported and runnable separately via `ONLY=`.
- Image rows include proper nouns and board-name-ish titles (`"Joshua"`, `"Home - Sequoia 15 - Calloway"`) that the fold would lowercase. Recommend starting with `IMAGES=0 ONLY=down` — tiles are what actually render on a board.

## Test plan

- Rewrote `spec/services/labels/case_normalizer_spec.rb` around the corrected contract; the old `"All Done"` stays `"All Done"` and blanket `"never downcases"` assertions encoded the bug and were replaced with per-word ones.
- New `spec/lib/tasks/tile_label_casing_rake_spec.rb` (8 examples): dry-run-by-default, fold, deliberate casing and `"I"` preserved, linked-tile skip + `INCLUDE_LINKED`, `ONLY=down`, `BOARD_ID` scoping, and never-changes-the-word. It caught a real bug — `ONLY` was read at rake-file load time and silently ignored.
- Fixture updates where specs stood in for curated folders (`seeded_set_cloner`, `set_graph_builder`, `screen_reflow`) now pin `display_label`, matching how those tiles are really created.
- Full run over `spec/models`, `spec/services`, `spec/lib/tasks`, `spec/requests/api/internal`, plus the label-casing request spec: **2289 examples, 0 failures**, and 256 re-verified after rebasing onto #635.
- Verified end-to-end through the real non-admin path (`api/boards_controller#add_image`): word tile → `"giraffe77"`, styled tile → `"iPad77"`.
- `bin/rails zeitwerk:check` clean.

Docs: CHANGELOG entries + two new invariants in CLAUDE.md (the casing rule and its single choke point; category labels being authored, and the `predictive_board_id` trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)