### PR TITLE
feat(boards): optional cascade delete of a board's subboards

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -654,8 +654,20 @@ communicator dashboards (`child_boards`), team shares (`team_boards`), and
 whether it's a Board Builder root. When anything matches and the request lacks
 `confirm=true`, destroy returns **409** `{ error: "board_in_use", message,
 board: { id, name }, usage: { referencing_boards, communicators, teams,
-builder_set } }` (counts exact, name lists capped at 10). Unreferenced boards
-delete in one step as before.
+builder_set, subboards } }` (counts exact, name lists capped at 10).
+Unreferenced boards delete in one step as before.
+
+- **Subboards count as usage, and the cascade is opt-in.** `Boards::SubboardTree`
+  walks the board's *outbound* folder links (`Boards::LinkedBoardsFinder`, which
+  handles cycles and caps the walk) and splits the tree into boards safe to
+  cascade and boards that must be kept — kept when predefined/template, owned by
+  someone else, on a communicator dashboard, shared with a team, or reachable
+  from a folder tile outside the deleted set. The summary
+  (`{ total, deletable_count, kept_count, names, kept_names }`) rides in the 409,
+  and `delete_subboards=true` alongside `confirm=true` destroys `deletable_ids`
+  and the root in one transaction. Without that param a confirmed delete still
+  takes only the board itself — the cascade never happens silently. The tree is
+  `nil` for builder roots, whose set already cascades through the group below.
 
 - **Builder roots cascade the whole set.** A confirmed delete of a
   `builder_root` board routes through its builder BoardGroup
@@ -679,7 +691,9 @@ delete in one step as before.
   a detached template that another board's folder tile still opens
   (`predictive_board_id` reference check) — detach-only in that case.
 - Frontend companion: handle the 409 with a confirm dialog and re-send with
-  `confirm=true` (special copy for builder roots — it deletes the whole set).
+  `confirm=true` (special copy for builder roots — it deletes the whole set),
+  plus an unchecked "Also delete its N subboards" checkbox that adds
+  `delete_subboards=true`.
 
 ### Publish cascade (warn + confirm)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Deleting a board can now take its subboards with it.** A board whose
+  buttons open other boards asks before deleting, and offers an optional
+  "Also delete its N subboards" that removes the whole linked set in one go.
+  Subboards that something else still uses — another board's button, a
+  communicator's dashboard, a team share — are kept and named in the warning.
+  The option is off by default: confirming without it deletes only the board
+  you asked for.
+
 ### Changed
 
 - **Board builder word-count validation now allows a small margin.** A word

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1192,6 +1192,10 @@ class API::BoardsController < API::ApplicationController
   # are nullified by the predictive_board_images dependent: :nullify
   # association (all board types — the old manual loop here only covered
   # board_type "predictive" and was redundant).
+  #
+  # A board with subboards of its own (folder tiles pointing OUT at other
+  # boards) also counts as in use, so the confirm carries a subboard summary
+  # and the client can opt into the cascade with delete_subboards=true.
   def destroy
     usage = Boards::UsageCheck.new(@board)
     if usage.in_use? && params[:confirm].to_s != "true"
@@ -1210,6 +1214,15 @@ class API::BoardsController < API::ApplicationController
     # group would recurse with the group's destroy_all of its members.
     if (group = usage.builder_group)
       group.destroy!
+    elsif params[:delete_subboards].to_s == "true"
+      # Opt-in cascade: also destroy the board's own subboard tree, minus any
+      # subboard something outside the tree still depends on (Boards::SubboardTree
+      # decides). All-or-nothing so a mid-tree failure can't leave a half-deleted
+      # set behind.
+      ActiveRecord::Base.transaction do
+        Board.where(id: usage.subboard_tree&.deletable_ids).find_each(&:destroy!)
+        @board.destroy!
+      end
     else
       @board.destroy!
     end

--- a/app/services/boards/subboard_tree.rb
+++ b/app/services/boards/subboard_tree.rb
@@ -1,0 +1,108 @@
+module Boards
+  # Read-only "what would 'delete the subboards too' actually delete?" check.
+  #
+  # Walks the outbound folder→child links (board_images.predictive_board_id)
+  # from a board being deleted and splits the resulting tree into boards that
+  # are safe to cascade-delete and boards that must be KEPT because something
+  # outside the tree still depends on them. Nothing here deletes — the caller
+  # (Api::BoardsController#destroy) does that with #deletable_ids.
+  #
+  # Board Builder roots don't come through here: their tree is owned by a
+  # builder BoardGroup and destroy routes through group.destroy! instead.
+  class SubboardTree
+    # Reasons a subboard is kept rather than cascaded. Surfaced in #summary so
+    # the confirm dialog can explain what survives.
+    KEPT_REASONS = %i[predefined not_owned on_communicator shared_with_team referenced_outside].freeze
+
+    NAME_SAMPLE_LIMIT = 10
+
+    def initialize(board, user: nil)
+      @board = board
+      @user = user || board.user
+    end
+
+    def any?
+      tree.any?
+    end
+
+    def deletable_ids
+      partition.fetch(:deletable).map(&:id)
+    end
+
+    def kept
+      partition.fetch(:kept)
+    end
+
+    def summary
+      return nil unless any?
+
+      {
+        total: tree.size,
+        deletable_count: deletable_ids.size,
+        kept_count: kept.size,
+        names: tree.first(NAME_SAMPLE_LIMIT).map(&:name),
+        kept_names: kept.first(NAME_SAMPLE_LIMIT).map { |k| k[:name] },
+      }
+    end
+
+    private
+
+    attr_reader :board, :user
+
+    # Every board reachable from `board` through folder tiles, minus the root
+    # itself. LinkedBoardsFinder already handles link cycles and caps the walk.
+    def tree
+      @tree ||= LinkedBoardsFinder.new(board).call.reject { |b| b.id == board.id }
+    end
+
+    def tree_ids
+      @tree_ids ||= tree.map(&:id)
+    end
+
+    # Ids that vanish in this delete: the root plus its tree. An inbound tile
+    # from one of these is not an outside reference — it's going away too.
+    def deleted_ids
+      @deleted_ids ||= tree_ids + [board.id]
+    end
+
+    def partition
+      @partition ||= begin
+        deletable = []
+        kept = []
+        tree.each do |subboard|
+          reason = kept_reason(subboard)
+          if reason
+            kept << { id: subboard.id, name: subboard.name, reason: reason }
+          else
+            deletable << subboard
+          end
+        end
+        { deletable: deletable, kept: kept }
+      end
+    end
+
+    # nil when the subboard is safe to cascade-delete; otherwise the first
+    # reason it must be kept. Order is deliberate — ownership problems are
+    # more important to report than an incidental outside link.
+    def kept_reason(subboard)
+      return :predefined if subboard.predefined? || subboard.is_template?
+      return :not_owned if user.nil? || subboard.user_id != user.id
+      return :on_communicator if subboard.child_boards.exists?
+      return :shared_with_team if subboard.team_boards.exists?
+      return :referenced_outside if referenced_outside?(subboard)
+
+      nil
+    end
+
+    # A folder tile pointing at this subboard from a board that is NOT itself
+    # being deleted. reorder(nil): BoardImage's default position ordering
+    # breaks the DISTINCT-ish exists? query.
+    def referenced_outside?(subboard)
+      BoardImage
+        .where(predictive_board_id: subboard.id)
+        .where.not(board_id: deleted_ids)
+        .reorder(nil)
+        .exists?
+    end
+  end
+end

--- a/app/services/boards/usage_check.rb
+++ b/app/services/boards/usage_check.rb
@@ -17,7 +17,8 @@ module Boards
       referencing_tiles.exists? ||
         board.child_boards.exists? ||
         board.team_boards.exists? ||
-        builder_group.present?
+        builder_group.present? ||
+        subboard_tree&.any? || false
     end
 
     def summary
@@ -26,7 +27,18 @@ module Boards
         communicators: communicators_summary,
         teams: teams_summary,
         builder_set: builder_set_summary,
+        subboards: subboard_tree&.summary,
       }
+    end
+
+    # The board's own subboards — the folder tiles ON this board pointing at
+    # other boards. Backs the optional "delete the subboards too" cascade.
+    # nil for a builder root: that tree is owned by the builder BoardGroup and
+    # destroy routes through group.destroy!, so offering the checkbox there
+    # would duplicate a cascade that already happens.
+    def subboard_tree
+      return @subboard_tree if defined?(@subboard_tree)
+      @subboard_tree = builder_group ? nil : SubboardTree.new(board)
     end
 
     # The builder BoardGroup that owns this board's built tree, when this

--- a/spec/requests/api/boards_destroy_spec.rb
+++ b/spec/requests/api/boards_destroy_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe "API::Boards destroy safety", type: :request do
   let(:user)  { create(:user) }
   let(:board) { create(:board, user: user, name: "Deletable") }
 
-  def delete_board(target, as:, confirm: nil)
-    params = confirm.nil? ? {} : { confirm: confirm }
+  def delete_board(target, as:, confirm: nil, delete_subboards: nil)
+    params = {}
+    params[:confirm] = confirm unless confirm.nil?
+    params[:delete_subboards] = delete_subboards unless delete_subboards.nil?
     delete "/api/boards/#{target.id}", params: params, headers: auth_headers(as)
   end
 
@@ -133,6 +135,53 @@ RSpec.describe "API::Boards destroy safety", type: :request do
       expect(Board.exists?(root.id)).to be false
       # legacy orphan behavior, documented: the child page survives
       expect(Board.exists?(child_page.id)).to be true
+    end
+  end
+
+  describe "a board with subboards of its own" do
+    let!(:child)      { create(:board, user: user, name: "Food") }
+    let!(:grandchild) { create(:board, user: user, name: "Snacks") }
+
+    before do
+      create(:board_image, board: board, predictive_board_id: child.id)
+      create(:board_image, board: child, predictive_board_id: grandchild.id)
+    end
+
+    it "returns 409 with a subboard summary even when nothing else references it" do
+      delete_board(board, as: user)
+      expect(response).to have_http_status(:conflict)
+      usage = JSON.parse(response.body)["usage"]
+      expect(usage["subboards"]).to include(
+        "total" => 2, "deletable_count" => 2, "kept_count" => 0,
+      )
+      expect(usage["subboards"]["names"]).to match_array(["Food", "Snacks"])
+      expect(Board.exists?(board.id)).to be true
+    end
+
+    it "confirm=true alone deletes only the parent, leaving the subboards" do
+      delete_board(board, as: user, confirm: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+      expect(Board.exists?(child.id)).to be true
+      expect(Board.exists?(grandchild.id)).to be true
+    end
+
+    it "delete_subboards=true cascades the whole tree" do
+      delete_board(board, as: user, confirm: "true", delete_subboards: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+      expect(Board.exists?(child.id)).to be false
+      expect(Board.exists?(grandchild.id)).to be false
+    end
+
+    it "keeps a subboard something outside the tree still uses" do
+      create(:child_board, board: grandchild, child_account: create(:child_account, user: user))
+
+      delete_board(board, as: user, confirm: "true", delete_subboards: "true")
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(board.id)).to be false
+      expect(Board.exists?(child.id)).to be false
+      expect(Board.exists?(grandchild.id)).to be true
     end
   end
 

--- a/spec/services/boards/subboard_tree_spec.rb
+++ b/spec/services/boards/subboard_tree_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+# Boards::SubboardTree answers "if the user checks 'delete the subboards too',
+# what actually gets deleted?" — the outbound folder-tile tree from a board,
+# split into boards safe to cascade and boards kept because something outside
+# the tree still depends on them.
+RSpec.describe Boards::SubboardTree do
+  let(:user) { create(:user) }
+  let(:root) { create(:board, user: user, name: "Home") }
+
+  # A folder tile on `from` that opens `to`.
+  def link(from, to)
+    create(:board_image, board: from, predictive_board_id: to.id)
+  end
+
+  describe "a board with no folder tiles" do
+    it "has an empty tree and a nil summary" do
+      tree = described_class.new(root)
+      expect(tree.any?).to be false
+      expect(tree.deletable_ids).to be_empty
+      expect(tree.summary).to be_nil
+    end
+
+    it "ignores a tile pointing back at the board itself" do
+      link(root, root)
+      expect(described_class.new(root).any?).to be false
+    end
+  end
+
+  describe "a nested tree the user owns outright" do
+    let!(:child)      { create(:board, user: user, name: "Food") }
+    let!(:grandchild) { create(:board, user: user, name: "Snacks") }
+
+    before do
+      link(root, child)
+      link(child, grandchild)
+    end
+
+    it "walks the whole tree, not just direct children" do
+      tree = described_class.new(root)
+      expect(tree.deletable_ids).to match_array([child.id, grandchild.id])
+      expect(tree.kept).to be_empty
+      expect(tree.summary).to include(total: 2, deletable_count: 2, kept_count: 0)
+      expect(tree.summary[:names]).to match_array(["Food", "Snacks"])
+    end
+
+    it "terminates on a link cycle" do
+      link(grandchild, root)
+      expect(described_class.new(root).deletable_ids).to match_array([child.id, grandchild.id])
+    end
+
+    it "does not treat a sibling link inside the tree as an outside reference" do
+      link(grandchild, child)
+      expect(described_class.new(root).kept).to be_empty
+    end
+  end
+
+  describe "subboards something else still depends on" do
+    let!(:child) { create(:board, user: user, name: "Food") }
+
+    before { link(root, child) }
+
+    it "keeps one referenced by a board outside the tree" do
+      outsider = create(:board, user: user, name: "School")
+      link(outsider, child)
+
+      tree = described_class.new(root)
+      expect(tree.deletable_ids).to be_empty
+      expect(tree.kept).to eq([{ id: child.id, name: "Food", reason: :referenced_outside }])
+      expect(tree.summary).to include(total: 1, deletable_count: 0, kept_count: 1)
+    end
+
+    it "keeps one on a communicator dashboard" do
+      create(:child_board, board: child, child_account: create(:child_account, user: user))
+
+      tree = described_class.new(root)
+      expect(tree.deletable_ids).to be_empty
+      expect(tree.kept.first[:reason]).to eq(:on_communicator)
+    end
+
+    it "keeps one shared with a team" do
+      TeamBoard.create!(team: create(:team, created_by: user), board: child)
+
+      expect(described_class.new(root).kept.first[:reason]).to eq(:shared_with_team)
+    end
+
+    it "keeps one owned by someone else" do
+      child.update!(user: create(:user))
+
+      expect(described_class.new(root).kept.first[:reason]).to eq(:not_owned)
+    end
+
+    it "keeps a predefined board" do
+      child.update!(predefined: true)
+
+      expect(described_class.new(root).kept.first[:reason]).to eq(:predefined)
+    end
+
+    it "keeps the kept board but still deletes its safe siblings" do
+      create(:child_board, board: child, child_account: create(:child_account, user: user))
+      sibling = create(:board, user: user, name: "Play")
+      link(root, sibling)
+
+      tree = described_class.new(root)
+      expect(tree.deletable_ids).to eq([sibling.id])
+      expect(tree.kept.map { |k| k[:id] }).to eq([child.id])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Deleting a board left its **subboards** — the boards its folder tiles open — orphaned in the user's board list. `Boards::UsageCheck` only looked *inbound* (who points at this board); nothing looked outbound. Board Builder roots were already covered, since their tree is owned by a builder `BoardGroup`; this is for hand-built board sets.

- **`Boards::SubboardTree`** (new, read-only) walks the outbound tree via the existing `Boards::LinkedBoardsFinder` — which already handles link cycles and caps the walk at `MAX_BOARDS` — and splits it into boards safe to cascade vs boards that must be **kept**. Kept when: `predefined`/`is_template`, owned by someone else, on a communicator dashboard (`ChildBoard`), shared with a team (`TeamBoard`), or reachable from a folder tile outside the deleted set. Each kept board carries its reason.
- **`Boards::UsageCheck`** — having subboards now counts as usage, so a board whose only usage is subboards gets the 409 instead of deleting in one click. `summary` gains `subboards: { total, deletable_count, kept_count, names, kept_names }`. `nil` for builder roots, whose group cascade already owns the tree.
- **`#destroy`** — accepts `delete_subboards=true` alongside `confirm=true` and destroys `deletable_ids` plus the root in one transaction. **Opt-in:** a confirmed delete without it still takes only the board itself, so nothing cascades silently. Kept boards are untouched; their folder tiles nullify through the existing `predictive_board_images dependent: :nullify`.

Frontend companion: brittanyjohns/itty-bitty-frontend#653.

## Test plan

- `spec/services/boards/subboard_tree_spec.rb` (new, 11 examples) — deep nesting, link cycles, self-links, sibling links inside the tree, and each kept-reason.
- `spec/requests/api/boards_destroy_spec.rb` (4 new) — the 409 shape with a subboard summary, `confirm=true` alone leaving subboards, `delete_subboards=true` cascading the tree, and a subboard on a communicator dashboard surviving the cascade.
- `bundle exec rspec spec/services/boards spec/requests/api/boards_destroy_spec.rb` → **606 examples, 0 failures**.

Docs: `.claude-notes/boards-and-teams.md` (deletion section) + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)