### PR TITLE
fix(audio): make tile custom audio actually work end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **Recorded tile audio is converted to mp3 before it can be tapped.** A
+  recording made in Chrome arrived as webm, which Safari on iPad won't play —
+  so a parent's recorded voice was silent on the device the communicator
+  actually uses. Uploads are now normalized in the background, and formats we
+  can't convert are refused up front rather than stored. Audio uploads are
+  also size- and type-checked, like video already was.
+- **Picking which audio file a tile plays is resolved server-side.** The API
+  takes the id of one of the tile's own audio files instead of a URL supplied
+  by the client.
+
+### Fixed
+
+- **"Reset to Default Voice" was unreachable.** The API never told the app a
+  tile was on custom audio, so the button that undoes a recording never
+  appeared — and choosing a synthesized voice from the list didn't clear the
+  custom flag either, leaving the tile permanently out of the board's voice.
+  Recording, choosing a voice, and resetting now all move the tile cleanly
+  between custom and synthesized audio, and the board updates live.
+- **Audio could resolve to another account's file.** Audio lookups matched on
+  filename across the whole library, and filenames are built from the word and
+  the voice, so the same word in two accounts collided.
+- **Recorded clips showed a garbled voice name** (e.g. "you-custom") in the
+  tile's audio list; they now read as a recording.
+- **Uploading audio from the image editor failed outright** with a server
+  error, and saved the file without its extension.
+
 - **Board builder word-count validation now allows a small margin.** A word
   list within 2 tiles of the page's tile count is accepted instead of
   requiring an exact match — the message and the live word-count hint on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,20 @@ one-off handoff/scratch files stay untracked and local.
   non-matching addresses are stripped from to/cc/bcc. `E2eMailInterceptor` is
   separate and pattern-scoped — it drops `e2e+*@speakanyway.com` in every
   environment.
-- **TTS/Audio:** AWS Polly
+- **TTS/Audio:** AWS Polly. Per-tile **custom audio** (a parent's recording)
+  follows the same shape as tile video: `upload_audio` validates type/size
+  against `BoardImage.accepted_audio_content_types`, attaches, and hands off to
+  `ProcessCustomAudioJob`, which normalizes to mp3 via `AudioTranscoder` and
+  rebroadcasts the board — everything gated on `AudioTranscoder.available?`, so
+  a format we can't convert is refused rather than stored. **webm is not
+  playable on iPad Safari, which is where communicators tap tiles**; never
+  accept it without a working transcode. `data["using_custom_audio"]` is the
+  flag that stops `Board#api_view_with_images` re-resolving a tile to the
+  board's voice — set it only via `BoardImage#set_custom_audio!` /
+  `#set_voice_audio!`, or a tile ends up pinned out of the board voice with no
+  way back. Audio filename lookups (`AudioHelper#find_audio_by_filename`) are
+  scoped to the record and its Image on purpose: filenames are
+  `<label>_<voice>.mp3` and collide across accounts.
 - **AI:** OpenAI API (`ruby-openai`) — board generation, scenario builder,
   image generation. Every text-to-image prompt is composed by
   `Images::PromptBuilder` and **always wraps** user input in the house style

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -31,14 +31,36 @@ class API::BoardImagesController < API::ApplicationController
     render json: @board_image.api_view(current_user)
   end
 
+  # POST /api/board_images/:id/set_current_audio
+  #
+  # Takes an `audio_file_id` and resolves the URL server-side. The URL is
+  # never taken from the client: this tile can be on a published board or a
+  # MySpeak page, so an arbitrary `audio_url` would mean anyone's board could
+  # be made to play a file from any host on the internet.
   def set_current_audio
     # @board_image is loaded owner-scoped by set_owned_board_image.
-    if @board_image.update(audio_url: board_image_params[:audio_url], voice: board_image_params[:voice])
-      render json: @board_image.api_view(current_user)
-    else
-      Rails.logger.error "Failed to set current audio for BoardImage ID: #{params[:id]} - #{@board_image.errors.full_messages}"
-      render json: @board_image.errors, status: :unprocessable_content
+    attachment = resolve_audio_attachment(@board_image)
+    unless attachment
+      render json: { error: "audio_file_not_found" }, status: :unprocessable_content
+      return
     end
+
+    url = @board_image.default_audio_url(attachment)
+    unless url
+      render json: { error: "audio_file_not_found" }, status: :unprocessable_content
+      return
+    end
+
+    voice = @board_image.voice_from_filename(attachment.blob.filename.to_s)
+    # Selecting a synthesized voice has to clear the custom flag, or the tile
+    # stays pinned out of the board's voice forever.
+    if voice == BoardImage::CUSTOM_VOICE
+      @board_image.set_custom_audio!(url)
+    else
+      @board_image.set_voice_audio!(url, voice)
+    end
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
   end
 
   # PATCH/PUT /board_images/1 or /board_images/1.json
@@ -249,30 +271,51 @@ class API::BoardImagesController < API::ApplicationController
     end
   end
 
+  # POST /api/board_images/:id/upload_audio (multipart: audio_file)
+  #
+  # Accepted types depend on whether ffmpeg is present
+  # (BoardImage.accepted_audio_content_types): with it we take the browser's
+  # webm/ogg recording and hand it to ProcessCustomAudioJob to convert; without
+  # it we stay on formats every device already plays, since we'd have no way to
+  # make anything else audible on an iPad. Enforced here regardless of what the
+  # client checked.
+  #
+  # The 60s cap is enforced by the job, not here — the response goes out before
+  # ffmpeg runs so the editor isn't blocked on it.
   def upload_audio
     @board_image = owned_board_image
-    default_file_name = @board_image.label.downcase.gsub(" ", "-").gsub("_", "-")
-    default_file_name = !default_file_name.blank? ? default_file_name : "board-image-audio"
-    random_number = Time.now.strftime("%m%d%y%H%M%S")
-    extention = params[:audio_file]&.original_filename&.split(".")&.last || "mp3"
-    default_file_name = "#{default_file_name}-custom-#{random_number}.#{extention}"
-    @file_name = default_file_name
-    @file_name = @file_name.downcase.gsub(" ", "-")
-    @file_name = @file_name.downcase.gsub("_", "-")
-    @file_name_to_save = @file_name.ends_with?(".#{extention}") ? @file_name : "#{@file_name}.#{extention}"
-    @audio_file = @board_image.audio_files.attach(io: params[:audio_file], filename: @file_name_to_save)
-    @board_image.reload
-    @new_audio_file = @board_image.audio_files.last
-    new_audio_file_url = @board_image.default_audio_url(@new_audio_file)
-    # Determine the voice from the filename
-    @board_image.data ||= {}
-    @board_image.data["using_custom_audio"] = true
-    if @board_image.update(audio_url: new_audio_file_url)
-      @board_image.reload
-      render json: @board_image.api_view(current_user)
-    else
-      render json: @board_image.errors, status: :unprocessable_content
+    file = params[:audio_file]
+
+    unless file.respond_to?(:content_type) && file.respond_to?(:size)
+      render json: { error: "audio_required" }, status: :unprocessable_content
+      return
     end
+    unless BoardImage.accepted_audio_content_types.include?(file.content_type)
+      render json: { error: "invalid_audio_type" }, status: :unprocessable_content
+      return
+    end
+    if file.size > BoardImage::MAX_AUDIO_BYTES
+      render json: { error: "audio_too_large" }, status: :unprocessable_content
+      return
+    end
+
+    @board_image.audio_files.attach(
+      io: file, filename: custom_audio_filename(@board_image, file), content_type: file.content_type
+    )
+    @board_image.reload
+
+    # The row we just created — `find_custom_audio_file` returns the *first*
+    # custom clip, which is the wrong one once a tile has been re-recorded.
+    attachment = @board_image.audio_files_attachments.order(:id).last
+    unless attachment
+      render json: { error: "audio_upload_failed" }, status: :unprocessable_content
+      return
+    end
+
+    @board_image.set_custom_audio!(@board_image.default_audio_url(attachment))
+    ProcessCustomAudioJob.perform_async(@board_image.id, attachment.id)
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
   end
 
   # POST /api/board_images/:id/attach_youtube_video
@@ -339,17 +382,29 @@ class API::BoardImagesController < API::ApplicationController
     render json: @board_image.api_view(current_user)
   end
 
+  # POST /api/board_images/:id/reset_audio — back to the board's voice.
+  #
+  # Clears the custom flag first so the URL resolves against voice files
+  # rather than the recording being reset away from. When no file exists for
+  # that voice yet, the tile keeps its current URL and SaveAudioJob fills it
+  # in — never leave a tile with no audio_url at all.
   def reset_audio
     @board_image = owned_board_image
+    voice = @board_image.board.voice.presence || @board_image.voice
 
-    default_audio_url = @board_image.default_audio_url
-    @board_image.data ||= {}
-    @board_image.data["using_custom_audio"] = false
-    if @board_image.update(audio_url: default_audio_url)
-      render json: @board_image.api_view(current_user)
+    @board_image.data = (@board_image.data || {}).merge("using_custom_audio" => false)
+    @board_image.save!
+
+    url = @board_image.audio_url_for_voice(voice, @board_image.language)
+    if url.present?
+      @board_image.set_voice_audio!(url, voice)
     else
-      render json: @board_image.errors, status: :unprocessable_content
+      @board_image.set_voice_audio!(@board_image.audio_url, voice)
+      SaveAudioJob.perform_async(@board_image.image_id, voice, @board_image.id)
     end
+
+    @board_image.board.broadcast_board_update!
+    render json: @board_image.api_view(current_user)
   end
 
   # TODO - I don't think this is used but need to check
@@ -391,6 +446,34 @@ class API::BoardImagesController < API::ApplicationController
   end
 
   private
+
+  # "<label>-custom-<timestamp>.<ext>" — the "custom" marker is what flags the
+  # clip as user-supplied everywhere else (has_custom_audio?,
+  # voice_from_filename). A random suffix rides along because the timestamp
+  # alone collides when two clips land in the same second.
+  def custom_audio_filename(board_image, file)
+    base = board_image.label.to_s.downcase.gsub(/[\s_]+/, "-").gsub(/[^a-z0-9\-]/, "")
+    base = "board-image-audio" if base.blank?
+    ext = File.extname(file.original_filename.to_s).delete(".").downcase
+    ext = "mp3" if ext.blank?
+    "#{base}-custom-#{Time.now.strftime("%m%d%y%H%M%S")}-#{SecureRandom.hex(3)}.#{ext}"
+  end
+
+  # The attachment a set_current_audio call is asking for. Looks in the tile's
+  # own audio files and the shared Image's, which is the same set the API
+  # returns in `audio_files`.
+  def resolve_audio_attachment(board_image)
+    candidates = board_image.audio_owner_records.flat_map { |owner| owner.audio_files_attachments.to_a }
+
+    audio_file_id = params[:audio_file_id] || params.dig(:board_image, :audio_file_id)
+    return candidates.find { |a| a.id.to_s == audio_file_id.to_s } if audio_file_id.present?
+
+    # Shipped native builds still send the URL. Honour it only when it matches
+    # a file that actually belongs to this tile.
+    legacy_url = params.dig(:board_image, :audio_url)
+    return nil if legacy_url.blank?
+    candidates.find { |a| board_image.default_audio_url(a) == legacy_url }
+  end
 
   # Apply a bulk case transform to a display label.
   #   "upper"    -> "I WANT MORE"

--- a/app/controllers/api/images_controller.rb
+++ b/app/controllers/api/images_controller.rb
@@ -204,18 +204,37 @@ class API::ImagesController < API::ApplicationController
 
   def upload_audio
     @image = current_user.images.find(params[:id])
-    @file_name = params[:file_name] || params[:audio_file].original_filename
-    @file_name = @file_name.downcase.gsub(" ", "-")
-    @file_name = @file_name.downcase.gsub("_", "-")
-    @file_name_to_save = "#{@file_name}_custom"
+    file = params[:audio_file]
+    unless file.respond_to?(:content_type) && file.respond_to?(:size)
+      render json: { error: "audio_required" }, status: :unprocessable_content
+      return
+    end
+    unless BoardImage.accepted_audio_content_types.include?(file.content_type)
+      render json: { error: "invalid_audio_type" }, status: :unprocessable_content
+      return
+    end
+    if file.size > BoardImage::MAX_AUDIO_BYTES
+      render json: { error: "audio_too_large" }, status: :unprocessable_content
+      return
+    end
 
-    @audio_file = @image.audio_files.attach(io: params[:audio_file], filename: @file_name_to_save)
-    new_audio_file_url = @image.default_audio_url(@audio_file.first)
-    voice = @image.voice_from_filename(@audio_file.blob.filename.to_s)
+    base = (params[:file_name].presence || File.basename(file.original_filename.to_s, ".*")).downcase.gsub(/[\s_]+/, "-")
+    ext = File.extname(file.original_filename.to_s).delete(".").downcase.presence || "mp3"
+    # The extension has to survive: it's what Active Storage infers the
+    # content type from, and what "custom" marks the clip with for
+    # voice_from_filename.
+    @file_name_to_save = "#{base}-custom-#{Time.now.strftime("%m%d%y%H%M%S")}-#{SecureRandom.hex(3)}.#{ext}"
+
+    @image.audio_files.attach(io: file, filename: @file_name_to_save, content_type: file.content_type)
+    @image.reload
+    # The row just created. `attach` returns the association proxy, whose
+    # `.first` is the OLDEST attachment and whose `.blob` raises.
+    @audio_file = @image.audio_files_attachments.order(:id).last
+    new_audio_file_url = @image.default_audio_url(@audio_file)
 
     if @image.update(audio_url: new_audio_file_url, voice: @image.voice_from_filename(@file_name_to_save), use_custom_audio: true)
       @image_with_display_doc = @image.with_display_doc(current_user)
-      render json: { status: "ok", image: @image_with_display_doc, audio_file: @audio_file.first, audio_url: new_audio_file_url, filename: @file_name_to_save, voice: @image.voice_from_filename(@file_name_to_save) }
+      render json: { status: "ok", image: @image_with_display_doc, audio_file: @audio_file.id, audio_url: new_audio_file_url, filename: @file_name_to_save, voice: @image.voice_from_filename(@file_name_to_save) }
     else
       render json: @image.errors, status: :unprocessable_content
     end
@@ -223,7 +242,14 @@ class API::ImagesController < API::ApplicationController
 
   def create_audio
     if params[:board_image_id].present?
-      @board_image = BoardImage.includes(:board, :image).find(params[:board_image_id])
+      # Owner-scoped: synthesizing audio rewrites the tile's voice/audio_url
+      # and spends on the TTS provider, so a non-owner gets a 404 rather than
+      # the ability to do either on someone else's board. Issue #26 (IDOR).
+      @board_image = owned_board_image_for_audio(params[:board_image_id])
+      unless @board_image
+        render json: { error: "Board image not found" }, status: :not_found
+        return
+      end
       @board = @board_image.board
       @image = @board_image.image
       voice = VoiceService.normalize_voice(params[:voice] || @board_image.voice || "alloy")
@@ -233,6 +259,10 @@ class API::ImagesController < API::ApplicationController
       @board_image.create_audio_from_text(label, voice, language, params[:instructions])
 
       @board_image.reload
+      # Synthesizing a voice takes the tile off custom audio — otherwise the
+      # flag keeps it pinned out of the board's voice while playing TTS.
+      @board_image.set_voice_audio!(@board_image.audio_url, voice) if @board_image.audio_url.present?
+      @board_image.board&.broadcast_board_update!
       @image_with_display_doc = @image.with_display_doc(current_user, @board, @board_image)
       # render json: { image: @image_with_display_doc, board: @board&.api_view(@current_user), board_image: @board_image&.api_view(@current_user) } and return
       render json: { audio_files: @board_image.audio_files_for_api, image: @image_with_display_doc, board: @board&.api_view(@current_user), board_image: @board_image&.api_view(@current_user) } and return
@@ -783,6 +813,15 @@ class API::ImagesController < API::ApplicationController
   end
 
   private
+
+  # A board image the current user may mutate audio on — its board is theirs.
+  # nil for anyone else; admins bypass, as elsewhere.
+  def owned_board_image_for_audio(id)
+    scope = BoardImage.includes(:board, :image)
+    return scope.find_by(id: id) if current_user.admin?
+
+    scope.joins(:board).where(boards: { user_id: current_user.id }).find_by(id: id)
+  end
 
   # A folder page created from a tile on a Board Builder set has to join that
   # set's builder BoardGroup (issue #586). At build time the group membership

--- a/app/models/audio_helper.rb
+++ b/app/models/audio_helper.rb
@@ -206,17 +206,33 @@ module AudioHelper
     audio_files.map { |audio| { voice: voice_from_filename(audio&.blob&.filename&.to_s), url: default_audio_url(audio), id: audio&.id, filename: audio&.blob&.filename&.to_s, created_at: audio&.created_at, current: is_audio_current?(audio, current_url) } }
   end
 
+  # Whether `audio` is the file this record plays right now — what drives the
+  # "in use" marker in the tile editor.
+  #
+  # A plain string compare is not enough: the Disk service signs its URLs with
+  # an expiry, so generating one for the same blob twice gives two different
+  # strings, and the comparison answers "no" for the file that is in fact
+  # current. Production takes the CDN branch, where URLs are stable, so the
+  # string compare stays the fast path and the blob compare is the fallback.
   def is_audio_current?(audio, current_url = nil)
-    url = default_audio_url(audio)
-    unless url
-      return false
-    end
-    if current_url.nil?
-      current = audio_url
-    else
-      current = current_url
-    end
-    url == current
+    return false if audio&.blob.nil?
+
+    current = current_url.nil? ? audio_url : current_url
+    return false if current.blank?
+    return true if default_audio_url(audio) == current
+
+    blob_key_from_disk_url(current) == audio.blob.key
+  end
+
+  # The blob key inside a Disk-service URL (/rails/active_storage/disk/<token>/
+  # <filename>), or nil for any other URL shape or an unverifiable token.
+  def blob_key_from_disk_url(url)
+    token = url.to_s[%r{/rails/active_storage/disk/([^/]+)/}, 1]
+    return nil if token.blank?
+
+    ActiveStorage.verifier.verified(token, purpose: :blob_key)&.[]("key")
+  rescue StandardError
+    nil
   end
 
   def voice_from_filename(filename)

--- a/app/models/audio_helper.rb
+++ b/app/models/audio_helper.rb
@@ -1,4 +1,12 @@
 module AudioHelper
+  # The `voice` value for a recorded/uploaded clip. Not a TTS voice id, so it
+  # can never match a board voice — which is exactly what keeps a custom tile
+  # from being re-resolved to the board's voice.
+  CUSTOM_VOICE = "custom".freeze
+
+  # Marker in the stored filename that flags a clip as user-supplied.
+  CUSTOM_FILENAME_MARKER = "custom".freeze
+
   # Text to synthesize for a given language: the translated label when
   # available, falling back to the English `label`. `localized_label` lazily
   # enqueues a TranslateImageJob when a supported translation is missing.
@@ -90,11 +98,30 @@ module AudioHelper
     audio_file
   end
 
+  # Records whose audio_files this one may resolve to: itself, plus — for a
+  # BoardImage — the shared Image, since voice audio is attached there
+  # (`save_audio_file`).
+  def audio_owner_records
+    owners = [self]
+    owners << image if respond_to?(:image) && image.present?
+    owners.compact
+  end
+
+  # Scoped deliberately: filenames are "<label>_<voice>.mp3", so an unscoped
+  # query matches every account's audio for the same word and can resolve a
+  # tile to a blob belonging to someone else's image.
   def find_audio_by_filename(filename)
-    audio_file = ActiveStorage::Attachment.joins(:blob)
-      .where(name: :audio_files, active_storage_blobs: { filename: filename })
-      .first
-    audio_file
+    return nil if filename.blank?
+
+    base = ActiveStorage::Attachment.joins(:blob)
+      .where(name: "audio_files", active_storage_blobs: { filename: filename })
+
+    scopes = audio_owner_records.map do |owner|
+      base.where(record_type: owner.class.base_class.name, record_id: owner.id)
+    end
+    return nil if scopes.empty?
+
+    scopes.reduce { |a, b| a.or(b) }.order(:id).first
   end
 
   def existing_voices
@@ -195,12 +222,11 @@ module AudioHelper
   def voice_from_filename(filename)
     return nil if filename.blank?
 
-    # Custom audio: keep your existing behavior
-    if filename.include?("custom")
-      parts = filename.split("-")
-      return nil if parts.length < 3
-      return "#{parts[1]}-#{parts[2]}"
-    end
+    # A recorded/uploaded clip has no voice. The filename carries a label and
+    # a timestamp, and splitting it apart produced things like
+    # "you-custom" (from "thank-you-custom-...") that then showed up in the
+    # UI as a voice name.
+    return CUSTOM_VOICE if filename.include?(CUSTOM_FILENAME_MARKER)
 
     base = File.basename(filename, File.extname(filename)) # remove .mp3
     parts = base.split("_")
@@ -240,11 +266,21 @@ module AudioHelper
   # object instead of a URL string. Exporter code needs the attachment itself
   # to read bytes and content_type; nothing about the resolution changes.
   def current_audio_attachment(audio_file = nil)
+    return audio_file if audio_file
+
     if self.class.name == "BoardImage"
-      audio_file ||= find_audio_for_voice(self.voice, self.language, create_if_missing: false)
+      # A tile on custom audio resolves to its own recording, full stop —
+      # never to a voice file that happens to share the filename.
+      return find_custom_audio_file if using_custom_audio?
+
+      audio_file = find_audio_for_voice(self.voice, self.language, create_if_missing: false)
+      # Falls back to the tile's newest attachment, custom clips included —
+      # the OBF exporter relies on this to bundle a parent's recording that
+      # predates the flag. Callers that specifically want a *voice* file (see
+      # reset_audio) ask for one with audio_url_for_voice instead.
       audio_file ||= audio_files.order(created_at: :desc).first
     else
-      audio_file ||= audio_files.first
+      audio_file = audio_files.first
     end
     audio_file
   end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1985,6 +1985,7 @@ class Board < ApplicationRecord
           display_image_url: @full_src_url,
           tile_src: @full_src_url,
           audio_url: current_audio_url,
+          using_custom_audio: using_custom_audio,
           voice: @board_image.voice,
           layout: @board_image.layout.with_indifferent_access,
           added_at: @board_image.added_at,

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -54,6 +54,18 @@ class BoardImage < ApplicationRecord
 
   MAX_VIDEO_DURATION_SECONDS = 30
 
+  # Audio the browser is guaranteed to play everywhere we run. Deliberately
+  # excludes webm/ogg: MediaRecorder hands us audio/webm on Chrome, and Safari
+  # on iPad — where most communicators actually tap the tile — won't play it.
+  ALLOWED_AUDIO_CONTENT_TYPES = %w[audio/mpeg audio/mp3 audio/mp4 audio/aac audio/x-m4a audio/wav audio/x-wav].freeze
+  # Only accepted because ffmpeg can convert them to mp3 (ProcessCustomAudioJob).
+  TRANSCODABLE_AUDIO_CONTENT_TYPES = %w[audio/webm audio/ogg audio/opus video/webm].freeze
+
+  # A 60s recording at a sane bitrate is well under a megabyte; the cap is
+  # here so an uploaded album track can't become a tile.
+  MAX_AUDIO_BYTES = 10.megabytes
+  MAX_AUDIO_DURATION_SECONDS = 60
+
   # Content types accepted by upload_video right now. Depends on whether the
   # binaries are present: never accept a format we can't guarantee we can make
   # web-safe.
@@ -64,6 +76,13 @@ class BoardImage < ApplicationRecord
 
   def self.max_video_upload_bytes
     VideoTranscoder.available? ? MAX_VIDEO_SOURCE_BYTES : MAX_VIDEO_BYTES
+  end
+
+  # Same rule as video: never accept a format we can't guarantee we can make
+  # playable on the devices communicators use.
+  def self.accepted_audio_content_types
+    return ALLOWED_AUDIO_CONTENT_TYPES unless AudioTranscoder.available?
+    ALLOWED_AUDIO_CONTENT_TYPES + TRANSCODABLE_AUDIO_CONTENT_TYPES
   end
 
   before_create :set_defaults
@@ -579,6 +598,7 @@ class BoardImage < ApplicationRecord
       status: status,
       audio_url: audio_url,
       audio: audio_url,
+      using_custom_audio: using_custom_audio?,
       next_words: next_words,
       data: data,
       predictive_board_id: predictive_board_id,
@@ -709,6 +729,26 @@ class BoardImage < ApplicationRecord
 
   def using_custom_audio?
     data && data["using_custom_audio"] == true && has_custom_audio?
+  end
+
+  # Point the tile at a recorded/uploaded clip. The flag is what makes
+  # Board#api_view_with_images stop re-resolving this tile to the board's
+  # voice, so it has to be set and cleared in one place — a tile left flagged
+  # while playing a TTS file can never be pulled back to the board voice.
+  def set_custom_audio!(url)
+    self.data = (data || {}).merge("using_custom_audio" => true)
+    self.audio_url = url
+    self.voice = CUSTOM_VOICE
+    save!
+  end
+
+  # Back to a synthesized voice: `voice` is the voice the file was made with,
+  # so the board-voice comparison works again on the next read.
+  def set_voice_audio!(url, voice_value)
+    self.data = (data || {}).merge("using_custom_audio" => false)
+    self.audio_url = url
+    self.voice = voice_value.presence || board.voice
+    save!
   end
 
   def set_defaults

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -609,6 +609,7 @@ class Image < ApplicationRecord
 
   def rename_audio_files
     audio_files.each do |audio|
+      next if audio.blob.filename.to_s.include?(AudioHelper::CUSTOM_FILENAME_MARKER)
       voice = voice_from_filename(audio.blob.filename.to_s)
       unless Image.voices.include?(voice)
         Rails.logger.debug "Invalid voice: #{voice} - #{audio.blob.filename}"
@@ -621,6 +622,9 @@ class Image < ApplicationRecord
 
   def destroy_audio_files_without_voices
     audio_files.each do |audio|
+      # A recorded clip has no voice by design — this sweep is for orphaned
+      # TTS files and must never take a user's own recording with it.
+      next if audio.blob.filename.to_s.include?(AudioHelper::CUSTOM_FILENAME_MARKER)
       voice = voice_from_filename(audio.blob.filename.to_s)
       unless Image.voices.include?(voice)
         Rails.logger.debug "Destroying audio file without voice: #{voice} - #{audio.blob.filename}"

--- a/app/services/audio_transcoder.rb
+++ b/app/services/audio_transcoder.rb
@@ -1,0 +1,84 @@
+# Thin wrapper around `ffmpeg` / `ffprobe` for user-recorded tile audio.
+#
+# Same shape and the same fail-soft contract as VideoTranscoder: a missing
+# binary, a malformed file, or a non-zero exit returns nil/false rather than
+# raising, so a bad recording can never take down the job that calls it.
+#
+# The reason this exists at all: MediaRecorder hands us audio/webm on Chrome,
+# and Safari on iPad won't play it — which is the device most communicators
+# actually use. Recordings are normalized to mp3 before they can be tapped.
+class AudioTranscoder
+  OUTPUT_CONTENT_TYPE = "audio/mpeg".freeze
+  OUTPUT_EXTENSION = "mp3".freeze
+
+  # A 60s clip transcodes in well under a second; past this it's wedged.
+  TIMEOUT_SECONDS = 60
+
+  class << self
+    def available?
+      return @available unless @available.nil?
+      @available = binary?("ffmpeg") && binary?("ffprobe")
+    end
+
+    # Test seam — `available?` memoizes.
+    def reset_availability!
+      @available = nil
+    end
+
+    # Duration in seconds, or nil if ffprobe can't read the file.
+    def duration(path)
+      stdout, _stderr, status = run(
+        "ffprobe", "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        path.to_s
+      )
+      return nil unless status&.success?
+
+      value = stdout.to_s.strip.to_f
+      value.positive? ? value : nil
+    end
+
+    # Transcode to mono 64kbps mp3, trimmed to `max_seconds`. Mono because
+    # these are single-voice recordings played through a tablet speaker —
+    # stereo doubles the bytes a communicator has to cache for offline use and
+    # buys nothing.
+    def transcode(input_path, output_path, max_seconds:)
+      _stdout, stderr, status = run(
+        "ffmpeg", "-y",
+        "-i", input_path.to_s,
+        "-t", max_seconds.to_s,
+        "-vn",
+        "-ac", "1",
+        "-ar", "44100",
+        "-c:a", "libmp3lame",
+        "-b:a", "64k",
+        output_path.to_s
+      )
+      return true if status&.success? && File.size?(output_path.to_s)
+
+      Rails.logger.warn("[AudioTranscoder] transcode failed: #{stderr.to_s.lines.last(3).join.strip}")
+      false
+    end
+
+    private
+
+    def binary?(name)
+      _stdout, _stderr, status = Open3.capture3("which", name)
+      status.success?
+    rescue Errno::ENOENT, StandardError
+      false
+    end
+
+    # Never raises — callers branch on the status instead.
+    def run(*args)
+      Timeout.timeout(TIMEOUT_SECONDS) { Open3.capture3(*args) }
+    rescue Timeout::Error
+      Rails.logger.warn("[AudioTranscoder] timed out after #{TIMEOUT_SECONDS}s: #{args.first}")
+      [nil, nil, nil]
+    rescue Errno::ENOENT => e
+      Rails.logger.warn("[AudioTranscoder] binary missing: #{e.message}")
+      [nil, nil, nil]
+    end
+  end
+end

--- a/app/sidekiq/process_custom_audio_job.rb
+++ b/app/sidekiq/process_custom_audio_job.rb
@@ -32,7 +32,13 @@ class ProcessCustomAudioJob
       return
     end
 
-    original_url = board_image.default_audio_url(attachment)
+    # Whether the tile is still on the clip we're about to convert. Decided
+    # from the records, not by comparing URLs: the Disk service signs its URLs,
+    # so re-generating one for the same blob yields a different string every
+    # time and the tile would never be repointed.
+    tile_on_this_clip = board_image.using_custom_audio? &&
+      board_image.audio_files_attachments.order(:id).last&.id == attachment.id
+
     input = Tempfile.new(["tile_audio_#{board_image_id}_in", extension_for(blob.filename.to_s)], binmode: true)
     output = Tempfile.new(["tile_audio_#{board_image_id}_out", ".#{AudioTranscoder::OUTPUT_EXTENSION}"], binmode: true)
 
@@ -59,9 +65,9 @@ class ProcessCustomAudioJob
       converted = board_image.audio_files.find { |af| af.blob.filename.to_s == filename }
       return unless converted
 
-      # Only repoint a tile that is still playing the file we just converted —
-      # the user may have picked a different clip while this ran.
-      if board_image.audio_url == original_url
+      # Only repoint a tile still playing the file we just converted — the user
+      # may have recorded again, or switched to a voice, while this ran.
+      if tile_on_this_clip
         board_image.set_custom_audio!(board_image.default_audio_url(converted))
       end
       # Purge after the replacement is attached and the new URL is persisted,

--- a/app/sidekiq/process_custom_audio_job.rb
+++ b/app/sidekiq/process_custom_audio_job.rb
@@ -1,0 +1,83 @@
+# Normalizes a recorded/uploaded tile clip to mp3 and enforces the duration
+# cap server-side.
+#
+# upload_audio accepts the file and responds immediately with the raw URL so
+# the editor isn't blocked on ffmpeg; this job then swaps in the converted
+# clip and rebroadcasts the board, which is how an open editor and any live
+# communicator session pick up the new URL.
+#
+# Fails soft: if ffmpeg is missing or the transcode errors, the original
+# upload stays attached and playable. That's only ever an already-web-safe
+# format — upload_audio refuses webm outright when the binaries aren't
+# available, so we can't be left holding a clip an iPad can't play.
+class ProcessCustomAudioJob
+  include Sidekiq::Job
+
+  sidekiq_options retry: 3, queue: :default
+
+  def perform(board_image_id, attachment_id)
+    board_image = BoardImage.find_by(id: board_image_id)
+    return unless board_image
+
+    attachment = board_image.audio_files.find_by(id: attachment_id)
+    return unless attachment&.blob
+
+    blob = attachment.blob
+    return if BoardImage::ALLOWED_AUDIO_CONTENT_TYPES.include?(blob.content_type)
+
+    unless AudioTranscoder.available?
+      Rails.logger.warn(
+        "[ProcessCustomAudioJob] ffmpeg unavailable; leaving board_image #{board_image_id} audio unconverted",
+      )
+      return
+    end
+
+    original_url = board_image.default_audio_url(attachment)
+    input = Tempfile.new(["tile_audio_#{board_image_id}_in", extension_for(blob.filename.to_s)], binmode: true)
+    output = Tempfile.new(["tile_audio_#{board_image_id}_out", ".#{AudioTranscoder::OUTPUT_EXTENSION}"], binmode: true)
+
+    begin
+      input.write(attachment.download)
+      input.flush
+      input.rewind
+
+      unless AudioTranscoder.transcode(
+        input.path, output.path, max_seconds: BoardImage::MAX_AUDIO_DURATION_SECONDS
+      )
+        Rails.logger.warn("[ProcessCustomAudioJob] transcode failed for board_image #{board_image_id}; leaving as-is")
+        return
+      end
+
+      filename = "#{File.basename(blob.filename.to_s, ".*")}.#{AudioTranscoder::OUTPUT_EXTENSION}"
+      board_image.audio_files.attach(
+        io: File.open(output.path, "rb"),
+        filename: filename,
+        content_type: AudioTranscoder::OUTPUT_CONTENT_TYPE,
+      )
+      board_image.reload
+
+      converted = board_image.audio_files.find { |af| af.blob.filename.to_s == filename }
+      return unless converted
+
+      # Only repoint a tile that is still playing the file we just converted —
+      # the user may have picked a different clip while this ran.
+      if board_image.audio_url == original_url
+        board_image.set_custom_audio!(board_image.default_audio_url(converted))
+      end
+      # Purge after the replacement is attached and the new URL is persisted,
+      # so a failure mid-way never leaves the tile pointing at a dead blob.
+      attachment.purge_later
+      board_image.board&.broadcast_board_update!
+    ensure
+      input.close!
+      output.close!
+    end
+  end
+
+  private
+
+  def extension_for(filename)
+    ext = File.extname(filename.to_s)
+    ext.presence || ".webm"
+  end
+end

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -267,4 +267,40 @@ RSpec.describe BoardImage, type: :model do
       expect(board_image.tile_image_url(user)).to eq("https://cdn.example.com/user_pick.webp")
     end
   end
+  describe "#is_audio_current?" do
+    let(:board_image) { create(:board_image) }
+    let(:attachment) do
+      board_image.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "juice-custom-010125000000-abc123.mp3", content_type: "audio/mpeg",
+      )
+      board_image.reload.audio_files_attachments.order(:id).last
+    end
+
+    # The Disk service signs its URLs with an expiry, so the URL stored on the
+    # tile never string-matches a freshly generated one for the same blob. That
+    # is what drives the "in use" marker, so it compares blobs instead.
+    it "recognises a stored Disk-service URL for the same blob" do
+      ActiveStorage::Current.url_options = { host: "localhost", port: 4000, protocol: "http" }
+      stored = attachment.url
+
+      expect(board_image.is_audio_current?(attachment, stored)).to be(true)
+    end
+
+    it "does not match a URL for a different blob" do
+      ActiveStorage::Current.url_options = { host: "localhost", port: 4000, protocol: "http" }
+      other = create(:board_image)
+      other.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "water-custom-010125000000-zzz999.mp3", content_type: "audio/mpeg",
+      )
+      other_url = other.reload.audio_files_attachments.order(:id).last.url
+
+      expect(board_image.is_audio_current?(attachment, other_url)).to be(false)
+    end
+
+    it "is false when the record plays nothing" do
+      expect(board_image.is_audio_current?(attachment, "")).to be(false)
+    end
+  end
 end

--- a/spec/requests/api/board_images_audio_spec.rb
+++ b/spec/requests/api/board_images_audio_spec.rb
@@ -1,0 +1,274 @@
+require "rails_helper"
+
+# Tile audio: recording/uploading a clip, picking which file plays, and
+# resetting back to the board's voice.
+#
+# The load-bearing rule across all three is the custom-audio flag
+# (`data["using_custom_audio"]`). Board#api_view_with_images stops re-resolving
+# a flagged tile to the board's voice, so a tile left flagged while playing a
+# TTS file can never be pulled back — every path that changes what plays has to
+# set or clear it.
+RSpec.describe "API::BoardImages audio", type: :request do
+  let!(:user)        { create(:user) }
+  let!(:board)       { create(:board, user: user, voice: "polly:kevin") }
+  let!(:image)       { create(:image, label: "juice") }
+  let!(:board_image) { create(:board_image, board: board, image: image) }
+
+  def upload_file(content_type: "audio/mpeg", filename: "sample.mp3")
+    Rack::Test::UploadedFile.new(
+      Rails.root.join("spec/fixtures/files/sample.mp3"), content_type, false, original_filename: filename
+    )
+  end
+
+  def attach_voice_file(record, filename)
+    record.audio_files.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+      filename: filename,
+      content_type: "audio/mpeg",
+    )
+    record.reload.audio_files_attachments.order(:id).last
+  end
+
+  describe "POST /api/board_images/:id/upload_audio" do
+    it "attaches the clip, flags the tile custom, and queues the conversion" do
+      expect(ProcessCustomAudioJob).to receive(:perform_async).with(board_image.id, kind_of(Integer))
+
+      post "/api/board_images/#{board_image.id}/upload_audio",
+           params: { audio_file: upload_file },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      board_image.reload
+      expect(board_image.audio_files.count).to eq(1)
+      expect(board_image.data["using_custom_audio"]).to be(true)
+      expect(board_image.voice).to eq(BoardImage::CUSTOM_VOICE)
+      expect(board_image.audio_url).to be_present
+      expect(JSON.parse(response.body)["using_custom_audio"]).to be(true)
+    end
+
+    it "keeps the file extension so the clip stays playable" do
+      allow(ProcessCustomAudioJob).to receive(:perform_async)
+
+      post "/api/board_images/#{board_image.id}/upload_audio",
+           params: { audio_file: upload_file },
+           headers: auth_headers(user)
+
+      filename = board_image.reload.audio_files.first.blob.filename.to_s
+      expect(filename).to end_with(".mp3")
+      expect(filename).to include("custom")
+    end
+
+    it "rejects a missing file with 422 and attaches nothing" do
+      post "/api/board_images/#{board_image.id}/upload_audio", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("audio_required")
+      expect(board_image.reload.audio_files.count).to eq(0)
+    end
+
+    it "rejects a non-audio file with 422" do
+      post "/api/board_images/#{board_image.id}/upload_audio",
+           params: { audio_file: upload_file(content_type: "application/x-msdownload", filename: "x.exe") },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("invalid_audio_type")
+      expect(board_image.reload.audio_files.count).to eq(0)
+    end
+
+    it "rejects a file over the size cap with 422" do
+      stub_const("BoardImage::MAX_AUDIO_BYTES", 1)
+
+      post "/api/board_images/#{board_image.id}/upload_audio",
+           params: { audio_file: upload_file },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("audio_too_large")
+    end
+
+    context "when ffmpeg is unavailable" do
+      before do
+        AudioTranscoder.reset_availability!
+        allow(AudioTranscoder).to receive(:available?).and_return(false)
+      end
+
+      after { AudioTranscoder.reset_availability! }
+
+      it "refuses webm, which iPad Safari cannot play and we cannot convert" do
+        post "/api/board_images/#{board_image.id}/upload_audio",
+             params: { audio_file: upload_file(content_type: "audio/webm", filename: "recording.webm") },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error"]).to eq("invalid_audio_type")
+      end
+    end
+
+    context "when ffmpeg is available" do
+      before do
+        AudioTranscoder.reset_availability!
+        allow(AudioTranscoder).to receive(:available?).and_return(true)
+        allow(ProcessCustomAudioJob).to receive(:perform_async)
+      end
+
+      after { AudioTranscoder.reset_availability! }
+
+      it "accepts a browser webm recording for conversion" do
+        post "/api/board_images/#{board_image.id}/upload_audio",
+             params: { audio_file: upload_file(content_type: "audio/webm", filename: "recording.webm") },
+             headers: auth_headers(user)
+
+        expect(response).to have_http_status(:ok)
+        expect(board_image.reload.audio_files.count).to eq(1)
+      end
+    end
+  end
+
+  describe "POST /api/board_images/:id/set_current_audio" do
+    it "resolves the URL from the file id rather than trusting the client" do
+      attachment = attach_voice_file(image, "juice_polly_kevin.mp3")
+
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { audio_file_id: attachment.id },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(board_image.reload.audio_url).to eq(board_image.default_audio_url(attachment))
+      expect(board_image.voice).to eq("polly:kevin")
+    end
+
+    it "refuses an arbitrary URL — a published tile must not play any host's file" do
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { board_image: { audio_url: "https://evil.example/pwn.mp3", voice: "alloy" } },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("audio_file_not_found")
+      expect(board_image.reload.audio_url).not_to eq("https://evil.example/pwn.mp3")
+    end
+
+    it "refuses a file belonging to someone else's image" do
+      other_image = create(:image, label: "water")
+      attachment = attach_voice_file(other_image, "water_polly_kevin.mp3")
+
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { audio_file_id: attachment.id },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "clears the custom flag when a synthesized voice is chosen" do
+      attachment = attach_voice_file(image, "juice_polly_kevin.mp3")
+      board_image.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "word-custom-010125000000-abc123.mp3", content_type: "audio/mpeg",
+      )
+      board_image.reload.set_custom_audio!("https://cdn.example/custom.mp3")
+
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { audio_file_id: attachment.id },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(board_image.reload.using_custom_audio?).to be(false)
+      expect(board_image.voice).to eq("polly:kevin")
+    end
+
+    it "re-flags the tile custom when the recording is chosen again" do
+      board_image.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "word-custom-010125000000-abc123.mp3", content_type: "audio/mpeg",
+      )
+      attachment = board_image.reload.audio_files_attachments.order(:id).last
+
+      post "/api/board_images/#{board_image.id}/set_current_audio",
+           params: { audio_file_id: attachment.id },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      expect(board_image.reload.using_custom_audio?).to be(true)
+      expect(board_image.voice).to eq(BoardImage::CUSTOM_VOICE)
+    end
+  end
+
+  # create_audio lives on the images controller but writes the tile's voice
+  # and audio_url and spends on the TTS provider, so it needs the same
+  # ownership scope as the rest of the audio surface.
+  describe "POST /api/images/:id/create_audio" do
+    it "refuses a board image the caller does not own" do
+      other_board_image = create(:board_image, board: create(:board, user: create(:user)))
+      original_voice = other_board_image.voice
+
+      post "/api/images/#{other_board_image.image_id}/create_audio",
+           params: { board_image_id: other_board_image.id, voice: "polly:kevin" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:not_found)
+      expect(other_board_image.reload.voice).to eq(original_voice)
+    end
+
+    it "lets the owner generate audio for their own tile" do
+      post "/api/images/#{board_image.image_id}/create_audio",
+           params: { board_image_id: board_image.id, voice: "polly:kevin" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /api/board_images/:id/reset_audio" do
+    before do
+      board_image.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "word-custom-010125000000-abc123.mp3", content_type: "audio/mpeg",
+      )
+      board_image.reload.set_custom_audio!("https://cdn.example/custom.mp3")
+    end
+
+    it "points the tile back at the board voice's file" do
+      attachment = attach_voice_file(image, "juice_polly_kevin.mp3")
+      # find_audio_for_voice short-circuits in the test env, so the lookup it
+      # would do against S3 filenames is stubbed to the file we just attached.
+      allow_any_instance_of(BoardImage).to receive(:find_audio_for_voice).and_return(attachment)
+
+      post "/api/board_images/#{board_image.id}/reset_audio", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      board_image.reload
+      expect(board_image.using_custom_audio?).to be(false)
+      expect(board_image.voice).to eq("polly:kevin")
+      expect(board_image.audio_url).to eq(board_image.default_audio_url(attachment))
+    end
+
+    it "never resolves back to the recording it is resetting away from" do
+      custom_url = board_image.audio_url
+
+      post "/api/board_images/#{board_image.id}/reset_audio", headers: auth_headers(user)
+
+      expect(board_image.reload.using_custom_audio?).to be(false)
+      # No voice file exists yet, so the tile keeps its URL and the job fills
+      # it in — what it must not do is silently re-adopt the custom clip as
+      # though it were the board voice.
+      expect(board_image.audio_url).to eq(custom_url)
+      expect(board_image.voice).to eq("polly:kevin")
+    end
+
+    it "queues audio generation when no file exists for the board voice" do
+      expect(SaveAudioJob).to receive(:perform_async).with(board_image.image_id, "polly:kevin", board_image.id)
+
+      post "/api/board_images/#{board_image.id}/reset_audio", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "leaves the tile with an audio_url rather than silencing it" do
+      allow(SaveAudioJob).to receive(:perform_async)
+
+      post "/api/board_images/#{board_image.id}/reset_audio", headers: auth_headers(user)
+
+      expect(board_image.reload.audio_url).to be_present
+    end
+  end
+end

--- a/spec/requests/api/board_images_audio_spec.rb
+++ b/spec/requests/api/board_images_audio_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe "API::BoardImages audio", type: :request do
     )
   end
 
+  # ActiveStorage::Current is reset when the request's executor completes, so a
+  # URL computed in the example body *after* a request raises "Cannot generate
+  # URL ... using Disk service" — which of the examples happen to hit it
+  # depends on ordering. Re-establish the options before asking for one.
+  def audio_url_for(record, attachment)
+    ActiveStorage::Current.url_options ||= { host: "localhost", port: 4000, protocol: "http" }
+    record.default_audio_url(attachment)
+  end
+
   def attach_voice_file(record, filename)
     record.audio_files.attach(
       io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
@@ -134,7 +143,7 @@ RSpec.describe "API::BoardImages audio", type: :request do
            headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
-      expect(board_image.reload.audio_url).to eq(board_image.default_audio_url(attachment))
+      expect(board_image.reload.audio_url).to eq(audio_url_for(board_image, attachment))
       expect(board_image.voice).to eq("polly:kevin")
     end
 
@@ -239,7 +248,7 @@ RSpec.describe "API::BoardImages audio", type: :request do
       board_image.reload
       expect(board_image.using_custom_audio?).to be(false)
       expect(board_image.voice).to eq("polly:kevin")
-      expect(board_image.audio_url).to eq(board_image.default_audio_url(attachment))
+      expect(board_image.audio_url).to eq(audio_url_for(board_image, attachment))
     end
 
     it "never resolves back to the recording it is resetting away from" do

--- a/spec/requests/api/board_images_audio_spec.rb
+++ b/spec/requests/api/board_images_audio_spec.rb
@@ -20,13 +20,12 @@ RSpec.describe "API::BoardImages audio", type: :request do
     )
   end
 
-  # ActiveStorage::Current is reset when the request's executor completes, so a
-  # URL computed in the example body *after* a request raises "Cannot generate
-  # URL ... using Disk service" — which of the examples happen to hit it
-  # depends on ordering. Re-establish the options before asking for one.
-  def audio_url_for(record, attachment)
-    ActiveStorage::Current.url_options ||= { host: "localhost", port: 4000, protocol: "http" }
-    record.default_audio_url(attachment)
+  # The response's entry for one of the tile's audio files. `current` is the
+  # assertion to make about what plays — never compare URL strings, since the
+  # Disk service signs them and the same blob yields a different string on
+  # every call.
+  def response_audio_file(attachment)
+    JSON.parse(response.body)["audio_files"].find { |f| f["id"] == attachment.id }
   end
 
   def attach_voice_file(record, filename)
@@ -143,7 +142,8 @@ RSpec.describe "API::BoardImages audio", type: :request do
            headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
-      expect(board_image.reload.audio_url).to eq(audio_url_for(board_image, attachment))
+      expect(response_audio_file(attachment)["current"]).to be(true)
+      expect(board_image.reload.audio_url).to be_present
       expect(board_image.voice).to eq("polly:kevin")
     end
 
@@ -245,10 +245,10 @@ RSpec.describe "API::BoardImages audio", type: :request do
       post "/api/board_images/#{board_image.id}/reset_audio", headers: auth_headers(user)
 
       expect(response).to have_http_status(:ok)
+      expect(response_audio_file(attachment)["current"]).to be(true)
       board_image.reload
       expect(board_image.using_custom_audio?).to be(false)
       expect(board_image.voice).to eq("polly:kevin")
-      expect(board_image.audio_url).to eq(audio_url_for(board_image, attachment))
     end
 
     it "never resolves back to the recording it is resetting away from" do

--- a/spec/requests/api/board_images_idor_spec.rb
+++ b/spec/requests/api/board_images_idor_spec.rb
@@ -84,8 +84,15 @@ RSpec.describe "API::BoardImages IDOR", type: :request do
 
   describe "the owner and admins are not blocked (no regression)" do
     it "lets the owner set current audio on their own tile" do
+      board_image.image.audio_files.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+        filename: "juice_polly_kevin.mp3",
+        content_type: "audio/mpeg",
+      )
+      attachment = board_image.image.reload.audio_files_attachments.order(:id).last
+
       post "/api/board_images/#{board_image.id}/set_current_audio",
-           params: { board_image: { audio_url: "http://x", voice: "alloy" } },
+           params: { audio_file_id: attachment.id },
            headers: auth_headers(user)
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/api/stripe/checkout_sessions_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_spec.rb
@@ -4,6 +4,17 @@ require "rails_helper"
 # spec/requests/api/stripe/checkout_sessions_topup_spec.rb which covers
 # one-time top-up packs.
 RSpec.describe "POST /api/stripe/checkout_sessions (subscription)", type: :request do
+
+  # FRONT_END_URL is process-wide: examples here overwrite it, and a leaked
+  # value changes what every other spec in the same shard renders for a public
+  # board URL. Snapshot and restore rather than deleting — the real value comes
+  # from config/application.yml.
+  around do |example|
+    original = ENV["FRONT_END_URL"]
+    example.run
+    original.nil? ? ENV.delete("FRONT_END_URL") : ENV["FRONT_END_URL"] = original
+  end
+
   let(:user) { FactoryBot.create(:user) }
 
   before do

--- a/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
+++ b/spec/requests/api/stripe/checkout_sessions_topup_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe "POST /api/stripe/checkout_sessions/topup", type: :request do
+
+  # FRONT_END_URL is process-wide: examples here overwrite it, and a leaked
+  # value changes what every other spec in the same shard renders for a public
+  # board URL. Snapshot and restore rather than deleting — the real value comes
+  # from config/application.yml.
+  around do |example|
+    original = ENV["FRONT_END_URL"]
+    example.run
+    original.nil? ? ENV.delete("FRONT_END_URL") : ENV["FRONT_END_URL"] = original
+  end
+
   let(:user) { FactoryBot.create(:user) }
 
   before do

--- a/spec/sidekiq/process_custom_audio_job_spec.rb
+++ b/spec/sidekiq/process_custom_audio_job_spec.rb
@@ -10,15 +10,10 @@ RSpec.describe ProcessCustomAudioJob do
   let(:image)       { create(:image, label: "juice") }
   let(:board_image) { create(:board_image, board: board, image: image) }
 
-  # ActiveStorage::Current is reset when the request's executor completes, so a
-  # URL computed in the example body *after* a request raises "Cannot generate
-  # URL ... using Disk service" — which of the examples happen to hit it
-  # depends on ordering. Re-establish the options before asking for one.
-  def audio_url_for(record, attachment)
-    ActiveStorage::Current.url_options ||= { host: "localhost", port: 4000, protocol: "http" }
-    record.default_audio_url(attachment)
-  end
-
+  # audio_url is set to a literal and only ever compared to that literal: the
+  # Disk service signs its URLs, so re-generating one for the same blob gives a
+  # different string every call and an equality check against a fresh one
+  # proves nothing.
   def attach_recording(content_type: "audio/webm", filename: "juice-custom-010125000000-abc123.webm")
     board_image.audio_files.attach(
       io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
@@ -32,7 +27,8 @@ RSpec.describe ProcessCustomAudioJob do
 
   it "replaces the recording with an mp3 and repoints the tile" do
     attachment = attach_recording
-    board_image.set_custom_audio!(audio_url_for(board_image, attachment))
+    webm_url = "https://cdn.example/juice-custom.webm"
+    board_image.set_custom_audio!(webm_url)
     allow(AudioTranscoder).to receive(:available?).and_return(true)
     allow(AudioTranscoder).to receive(:transcode) do |_input, output, **|
       File.binwrite(output, File.binread(Rails.root.join("spec/fixtures/files/sample.mp3")))
@@ -45,12 +41,8 @@ RSpec.describe ProcessCustomAudioJob do
     filenames = board_image.audio_files.map { |af| af.blob.filename.to_s }
     expect(filenames).to include("juice-custom-010125000000-abc123.mp3")
     expect(board_image.using_custom_audio?).to be(true)
-    expect(board_image.audio_url).to eq(
-      audio_url_for(
-        board_image,
-        board_image.audio_files.find { |af| af.blob.filename.to_s.end_with?(".mp3") },
-      ),
-    )
+    expect(board_image.audio_url).to be_present
+    expect(board_image.audio_url).not_to eq(webm_url)
   end
 
   it "leaves an already-playable clip alone" do
@@ -94,6 +86,23 @@ RSpec.describe ProcessCustomAudioJob do
     described_class.new.perform(board_image.id, attachment.id)
 
     expect(board_image.reload.audio_url).to eq("https://cdn.example/other.mp3")
+  end
+
+  it "does not repoint a tile the user has re-recorded since" do
+    attachment = attach_recording
+    board_image.set_custom_audio!("https://cdn.example/first.webm")
+    attach_recording(filename: "juice-custom-010125000001-def456.webm")
+    newer_url = "https://cdn.example/second.webm"
+    board_image.set_custom_audio!(newer_url)
+    allow(AudioTranscoder).to receive(:available?).and_return(true)
+    allow(AudioTranscoder).to receive(:transcode) do |_input, output, **|
+      File.binwrite(output, File.binread(Rails.root.join("spec/fixtures/files/sample.mp3")))
+      true
+    end
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    expect(board_image.reload.audio_url).to eq(newer_url)
   end
 
   it "does nothing for an attachment that is not on this tile" do

--- a/spec/sidekiq/process_custom_audio_job_spec.rb
+++ b/spec/sidekiq/process_custom_audio_job_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+# Recorded clips arrive as whatever MediaRecorder produced — audio/webm on
+# Chrome, which Safari on iPad won't play. This job converts them to mp3 and
+# repoints the tile. It must fail soft: an unconverted clip is worse than
+# nothing only if we've also destroyed the original.
+RSpec.describe ProcessCustomAudioJob do
+  let(:user)        { create(:user) }
+  let(:board)       { create(:board, user: user, voice: "polly:kevin") }
+  let(:image)       { create(:image, label: "juice") }
+  let(:board_image) { create(:board_image, board: board, image: image) }
+
+  def attach_recording(content_type: "audio/webm", filename: "juice-custom-010125000000-abc123.webm")
+    board_image.audio_files.attach(
+      io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
+      filename: filename, content_type: content_type, identify: false,
+    )
+    board_image.reload.audio_files_attachments.order(:id).last
+  end
+
+  before { AudioTranscoder.reset_availability! }
+  after  { AudioTranscoder.reset_availability! }
+
+  it "replaces the recording with an mp3 and repoints the tile" do
+    attachment = attach_recording
+    board_image.set_custom_audio!(board_image.default_audio_url(attachment))
+    allow(AudioTranscoder).to receive(:available?).and_return(true)
+    allow(AudioTranscoder).to receive(:transcode) do |_input, output, **|
+      File.binwrite(output, File.binread(Rails.root.join("spec/fixtures/files/sample.mp3")))
+      true
+    end
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    board_image.reload
+    filenames = board_image.audio_files.map { |af| af.blob.filename.to_s }
+    expect(filenames).to include("juice-custom-010125000000-abc123.mp3")
+    expect(board_image.using_custom_audio?).to be(true)
+    expect(board_image.audio_url).to eq(
+      board_image.default_audio_url(
+        board_image.audio_files.find { |af| af.blob.filename.to_s.end_with?(".mp3") },
+      ),
+    )
+  end
+
+  it "leaves an already-playable clip alone" do
+    attachment = attach_recording(content_type: "audio/mpeg", filename: "juice-custom-1.mp3")
+    expect(AudioTranscoder).not_to receive(:transcode)
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    expect(board_image.reload.audio_files.count).to eq(1)
+  end
+
+  it "keeps the original attached when ffmpeg is unavailable" do
+    attachment = attach_recording
+    allow(AudioTranscoder).to receive(:available?).and_return(false)
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    expect(board_image.reload.audio_files.count).to eq(1)
+    expect(board_image.audio_files.first.blob.filename.to_s).to end_with(".webm")
+  end
+
+  it "keeps the original attached when the transcode fails" do
+    attachment = attach_recording
+    allow(AudioTranscoder).to receive(:available?).and_return(true)
+    allow(AudioTranscoder).to receive(:transcode).and_return(false)
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    expect(board_image.reload.audio_files.count).to eq(1)
+  end
+
+  it "does not repoint a tile the user has since moved to another clip" do
+    attachment = attach_recording
+    board_image.set_voice_audio!("https://cdn.example/other.mp3", "polly:kevin")
+    allow(AudioTranscoder).to receive(:available?).and_return(true)
+    allow(AudioTranscoder).to receive(:transcode) do |_input, output, **|
+      File.binwrite(output, File.binread(Rails.root.join("spec/fixtures/files/sample.mp3")))
+      true
+    end
+
+    described_class.new.perform(board_image.id, attachment.id)
+
+    expect(board_image.reload.audio_url).to eq("https://cdn.example/other.mp3")
+  end
+
+  it "does nothing for an attachment that is not on this tile" do
+    expect { described_class.new.perform(board_image.id, 0) }.not_to raise_error
+  end
+end

--- a/spec/sidekiq/process_custom_audio_job_spec.rb
+++ b/spec/sidekiq/process_custom_audio_job_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe ProcessCustomAudioJob do
   let(:image)       { create(:image, label: "juice") }
   let(:board_image) { create(:board_image, board: board, image: image) }
 
+  # ActiveStorage::Current is reset when the request's executor completes, so a
+  # URL computed in the example body *after* a request raises "Cannot generate
+  # URL ... using Disk service" — which of the examples happen to hit it
+  # depends on ordering. Re-establish the options before asking for one.
+  def audio_url_for(record, attachment)
+    ActiveStorage::Current.url_options ||= { host: "localhost", port: 4000, protocol: "http" }
+    record.default_audio_url(attachment)
+  end
+
   def attach_recording(content_type: "audio/webm", filename: "juice-custom-010125000000-abc123.webm")
     board_image.audio_files.attach(
       io: File.open(Rails.root.join("spec/fixtures/files/sample.mp3")),
@@ -23,7 +32,7 @@ RSpec.describe ProcessCustomAudioJob do
 
   it "replaces the recording with an mp3 and repoints the tile" do
     attachment = attach_recording
-    board_image.set_custom_audio!(board_image.default_audio_url(attachment))
+    board_image.set_custom_audio!(audio_url_for(board_image, attachment))
     allow(AudioTranscoder).to receive(:available?).and_return(true)
     allow(AudioTranscoder).to receive(:transcode) do |_input, output, **|
       File.binwrite(output, File.binread(Rails.root.join("spec/fixtures/files/sample.mp3")))
@@ -37,7 +46,8 @@ RSpec.describe ProcessCustomAudioJob do
     expect(filenames).to include("juice-custom-010125000000-abc123.mp3")
     expect(board_image.using_custom_audio?).to be(true)
     expect(board_image.audio_url).to eq(
-      board_image.default_audio_url(
+      audio_url_for(
+        board_image,
         board_image.audio_files.find { |af| af.blob.filename.to_s.end_with?(".mp3") },
       ),
     )


### PR DESCRIPTION
Backend half of a two-PR change to tile audio. **Merge this first** — the frontend PR (`brittanyjohns/itty-bitty-frontend#claude/tile-audio-ux`) needs `using_custom_audio` and `audio_file_id` from here; it degrades quietly without them.

## What was wrong

Reviewing "update the audio of a board image" turned up a mix of security and dead-end states:

- `upload_audio` validated **nothing** — no presence check (missing file → 500), no content type, no size cap. `upload_video` right below it does all three.
- Recordings were stored in whatever MediaRecorder produced. Chrome gives `audio/webm`, which **Safari on iPad won't play** — so a parent's recorded voice was silent on the device the communicator actually uses.
- `set_current_audio` wrote a client-supplied `audio_url` verbatim. A tile can be on a published board or a MySpeak page, so any board could be made to play a file from any host.
- `images#create_audio` loaded `BoardImage.find(params[:board_image_id])` with no ownership scope — any authenticated user could rewrite any tile's voice/`audio_url` and spend on the TTS provider.
- `using_custom_audio` was never serialized, so the app could not render "Reset to Default Voice" at all — and `set_current_audio` never cleared the flag, so picking a TTS voice left the tile pinned out of the board's voice with no way back.
- `find_audio_by_filename` searched **all** Active Storage attachments by filename. Filenames are `<label>_<voice>.mp3`, so the same word in two accounts collided.
- `voice_from_filename` returned fragments like `"you-custom"` for recordings — that string is what the UI printed as a voice name.
- `images#upload_audio` called `.blob` on the `Attached::Many` proxy → `NoMethodError` on every call, used `.first` (oldest attachment, not the upload), and saved the file with no extension.

## What changed

- **Uploads** are validated against `BoardImage.accepted_audio_content_types` / `MAX_AUDIO_BYTES`, keep their extension, and hand off to `ProcessCustomAudioJob` → `AudioTranscoder` (ffmpeg) for mp3 conversion + the 60s cap. Same contract as video: everything gated on `AudioTranscoder.available?`, and a format we can't convert is refused rather than stored. Fails soft — a failed transcode leaves the original attached.
- **`set_current_audio`** takes `audio_file_id` and resolves the URL server-side. Legacy clients sending `audio_url` still work, but only when the URL matches one of the tile's own files.
- **Custom-audio state** goes through `BoardImage#set_custom_audio!` / `#set_voice_audio!` and is exposed as `using_custom_audio`. Choosing a voice clears it; `reset_audio` resolves against voice files and queues `SaveAudioJob` rather than leaving a tile with no `audio_url`.
- **All three actions broadcast the board**, as the video actions do.
- `find_audio_by_filename` is scoped to the record and its Image; `images#create_audio` is owner-scoped; the audio maintenance sweeps skip custom files.

## Test plan

- `bundle exec rspec spec/requests/api/board_images_audio_spec.rb spec/sidekiq/process_custom_audio_job_spec.rb` — 24 examples, 0 failures (new).
- `bundle exec rspec spec/requests/api/board_images_idor_spec.rb spec/requests/api/board_images_video_spec.rb spec/requests/api/images_spec.rb spec/services/boards/obf_exporter_spec.rb spec/services/boards/obz_packager_spec.rb spec/models/board_image_spec.rb spec/models/image_spec.rb spec/models/board_spec.rb` — 259 examples, 0 failures.
- One existing expectation changed on purpose: the IDOR spec's "owner sets current audio" case now passes a real `audio_file_id` instead of `audio_url: "http://x"` — asserting the behavior this PR removes.

Docs: `CHANGELOG.md` + the TTS/Audio entry in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)