### PR TITLE
fix(admin): restore access control on the legacy /users admin pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **One account could edit another account's profile.** The legacy HTML pages
+  under `/users` — the old admin area, kept alongside the `/admin` dashboard —
+  had lost their permission checks: any signed-in person could rename or change
+  the voice settings of any other account by visiting its URL, and could delete
+  another account's uploaded document. Those pages are now restricted to the
+  account's owner and to admins, matching the `/admin` dashboard. The `/admin`
+  dashboard itself was already gated and exposed nothing.
+
 - **"Reset to Default Voice" was unreachable.** The API never told the app a
   tile was on custom audio, so the button that undoes a recording never
   appeared — and choosing a synthesized voice from the list didn't clear the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,17 @@ an explicit decision, not a drive-by edit.
 - **External-service failures fail soft.** Redis blips, PostHog, Mailchimp,
   and geolocation errors are rescued and logged — they can never 500 a
   request or a webhook.
+- **Every admin page is gated by inheritance, never by an inline check.** HTML
+  admin controllers inherit `Admin::ApplicationController`
+  (`authenticate_user!` + `require_admin!`); JSON ones inherit
+  `API::Admin::ApplicationController` (admin-role token). A controller routed
+  under `/admin` that does not descend from the base fails
+  `spec/requests/admin/access_control_spec.rb`, which sweeps the whole
+  namespace. Gate in a `before_action`, not inline in the action body — a bare
+  `redirect_to … unless current_user.admin?` mid-action still runs every query
+  below it, and the next person to add an early `render` turns it into a leak.
+  The legacy HTML admin under `/users` (`/users`, `/users/admin`, `/users/:id`)
+  is outside the `Admin::` namespace and carries its own copy of the gate.
 - **Safety-profile emergency info is only served by the gated `safety_view`
   POST** — never on public page-open. It is also never sent to OpenAI: no
   `Profile::SAFETY_SENSITIVE_KEYS` entry may appear in a

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,19 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
+  # The legacy HTML admin pages (/users, /users/admin) list every account in the
+  # system — admin-only, same as the /admin namespace. Gating happens in a
+  # before_action, not inline in the action, so the body never runs for a caller
+  # who shouldn't reach it. (#word_events has no route left, but is gated with
+  # them so re-adding one can't quietly reopen it.)
+  before_action :require_admin!, only: %i[index admin word_events]
+  before_action :set_user, only: %i[show edit update]
+  before_action :require_self_or_admin!, only: %i[show edit update]
 
   def index
-    redirect_back_or_to root_url unless current_user.admin?
     @users = User.all.order(created_at: :desc).page params[:page]
   end
 
   def admin
-    unless current_user.admin?
-      redirect_back_or_to root_url
-    end
     @users = User.all.order(created_at: :desc).page params[:page]
     @beta_requests = BetaRequest.all.order(created_at: :desc).page params[:page]
     @messages = Message.all.order(created_at: :desc).page params[:page]
@@ -20,9 +24,6 @@ class UsersController < ApplicationController
   end
 
   def word_events
-    unless current_user.admin?
-      redirect_back_or_to root_url
-    end
     @total_clicks = WordEvent.count
     @clicks_per_user = WordEvent.group(:user_id).count
     @most_clicked_words = WordEvent.group(:word).order("count_id DESC").count(:id)
@@ -31,32 +32,53 @@ class UsersController < ApplicationController
   end
 
   def show
-    # redirect_back_or_to root_url unless current_user.admin? || current_user.id == params[:id].to_i
-    @user = User.find(params[:id])
   end
 
   def remove_user_doc
     @user_doc = UserDoc.find(params[:id])
+    return deny! unless current_user&.admin? || @user_doc.user_id == current_user&.id
+
     @user_doc.destroy
     redirect_back_or_to root_url
   end
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
     if @user.update(user_params)
       redirect_to user_path(@user), notice: "Successfully updated."
     else
-      render "edit", alert: "There was an error updating the user.\nErrors: #{user.errors.full_messages.join(", ")}"
+      render "edit", alert: "There was an error updating the user.\nErrors: #{@user.errors.full_messages.join(", ")}"
     end
   end
 
   private
 
+  def set_user
+    @user = User.find(params[:id])
+  end
+
   def user_params
     params.require(:user).permit(:name, :base_words, settings: [:voice, :speed, :pitch, :rate, :volume, :language])
+  end
+
+  def require_admin!
+    deny! unless current_user&.admin?
+  end
+
+  # A user's own profile is self-service ("Edit Profile" on /users/:id); every
+  # other account is admin-only. `user_params` deliberately permits no role or
+  # plan field, so this is the whole gate for the HTML profile pages.
+  def require_self_or_admin!
+    return if current_user&.admin? || current_user&.id == @user&.id
+
+    deny!
+  end
+
+  # Always root, never `redirect_back_or_to` — bouncing a denied caller to its
+  # referrer can ping-pong between two pages that both deny.
+  def deny!
+    redirect_to root_url, alert: "You are not authorized to perform this action."
   end
 end

--- a/spec/requests/admin/access_control_spec.rb
+++ b/spec/requests/admin/access_control_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+# A per-controller sweep of the whole /admin namespace. The individual admin
+# request specs each check one action; this checks that *every* route in the
+# namespace is behind the gate, including ones added later. A new
+# Admin::FooController that forgets to inherit Admin::ApplicationController
+# fails here rather than shipping an open page.
+RSpec.describe "Admin dashboard access control", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  # Every distinct controller reachable under /admin.
+  def self.admin_routes
+    Rails.application.routes.routes.filter_map do |route|
+      path = route.path.spec.to_s.sub(/\(\.:format\)\z/, "")
+      next unless path == "/admin" || path.start_with?("/admin/")
+
+      controller = route.defaults[:controller]
+      next unless controller
+
+      { path: path, controller: controller, verb: route.verb }
+    end
+  end
+
+  ADMIN_ROUTES = admin_routes.freeze
+
+  it "has routes to sweep" do
+    expect(ADMIN_ROUTES).not_to be_empty
+  end
+
+  describe "controller inheritance" do
+    ADMIN_ROUTES.map { |r| r[:controller] }.uniq.each do |controller|
+      it "#{controller} inherits the admin gate" do
+        klass = "#{controller}_controller".camelize.constantize
+
+        expect(klass.ancestors).to include(Admin::ApplicationController),
+          "#{klass} is routed under /admin but does not inherit " \
+          "Admin::ApplicationController, so authenticate_user!/require_admin! never run."
+      end
+    end
+  end
+
+  # GET pages with no dynamic segments can be hit directly, so assert the real
+  # HTTP behavior too — inheritance alone wouldn't catch a stray
+  # skip_before_action.
+  describe "GET pages" do
+    let(:gettable) do
+      ADMIN_ROUTES.select { |r| r[:verb] == "GET" && !r[:path].include?(":") }
+    end
+
+    it "actually has pages to sweep" do
+      # Without this the three examples below pass on an empty list.
+      expect(gettable.size).to be >= 10
+    end
+
+    before do
+      allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+        .to receive(:stylesheet_link_tag).and_return("")
+      allow_any_instance_of(ActionView::Helpers::AssetTagHelper)
+        .to receive(:javascript_include_tag).and_return("")
+    end
+
+    it "redirects anonymous visitors to sign in" do
+      gettable.each do |route|
+        get route[:path]
+
+        expect(response).to have_http_status(:redirect), "#{route[:path]} did not redirect"
+        expect(response.location).to include("/users/sign_in"),
+          "#{route[:path]} let an anonymous visitor through (went to #{response.location})"
+      end
+    end
+
+    it "bounces a signed-in non-admin off every page" do
+      sign_in create(:user, email: "not-an-admin@example.com")
+
+      gettable.each do |route|
+        get route[:path]
+
+        expect(response).to have_http_status(:redirect), "#{route[:path]} did not redirect a non-admin"
+        expect(response.location).not_to include("/admin"),
+          "#{route[:path]} let a non-admin through (went to #{response.location})"
+      end
+    end
+
+    it "lets an admin through" do
+      sign_in create(:admin_user)
+
+      gettable.each do |route|
+        get route[:path]
+
+        expect(response).not_to have_http_status(:unauthorized), "#{route[:path]} rejected an admin"
+        expect(response.location.to_s).not_to include("/users/sign_in"),
+          "#{route[:path]} sent an admin to sign in"
+      end
+    end
+  end
+end

--- a/spec/requests/users_access_control_spec.rb
+++ b/spec/requests/users_access_control_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+# The legacy HTML admin lives under /users, outside the /admin namespace:
+# /users and /users/admin list every account, and /users/:id renders one
+# account's email, token balance, boards, menus and images.
+#
+# Those *pages* are already dead — their templates reference routes that no
+# longer exist (boards_path, products_path, set_next_words_images_path), so
+# they raise on render for admins too. The write actions are not dead: #update
+# and #remove_user_doc redirect instead of rendering, and before this gate any
+# signed-in user could point them at any other account.
+#
+# So the assertions below are about the gate, not the templates: a denied
+# caller must be redirected to root and must not mutate anything. The
+# allowed-caller cases assert only that the gate let them past, since what
+# happens next is a pre-existing template failure.
+RSpec.describe "UsersController access control", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+  let(:owner) { create(:user, email: "owner@example.com") }
+  let(:intruder) { create(:user, email: "intruder@example.com") }
+
+  describe "the account-listing pages" do
+    %w[/users /users/admin].each do |path|
+      it "redirects an anonymous visitor from #{path} to sign in" do
+        get path
+
+        expect(response).to redirect_to(%r{/users/sign_in})
+      end
+
+      it "bounces a signed-in non-admin off #{path}" do
+        sign_in intruder
+
+        get path
+
+        expect(response).to redirect_to(root_url)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    it "does not leak another account's email through the listing" do
+      owner
+      sign_in intruder
+
+      get "/users/admin"
+
+      expect(response.body).not_to include(owner.email)
+    end
+  end
+
+  describe "GET /users/:id" do
+    it "does not leak another user's profile" do
+      sign_in intruder
+
+      get user_path(owner)
+
+      expect(response).to redirect_to(root_url)
+      expect(response.body).not_to include(owner.email)
+    end
+
+    # No allow-path example here: #show renders the dead template and raises
+    # before it can assert anything. #show, #edit and #update share one
+    # before_action, so the self/admin allow paths are covered by the PATCH
+    # examples below.
+  end
+
+  describe "PATCH /users/:id" do
+    it "refuses to let one user edit another" do
+      sign_in intruder
+      original = owner.name
+
+      get edit_user_path(owner)
+      expect(response).to redirect_to(root_url)
+
+      patch user_path(owner), params: { user: { name: "Renamed By Intruder" } }
+
+      expect(response).to redirect_to(root_url)
+      expect(owner.reload.name).to eq(original)
+    end
+
+    it "lets a user edit their own profile" do
+      sign_in owner
+
+      patch user_path(owner), params: { user: { name: "Renamed By Self" } }
+
+      expect(owner.reload.name).to eq("Renamed By Self")
+    end
+
+    it "lets an admin edit another user" do
+      sign_in admin
+
+      patch user_path(owner), params: { user: { name: "Renamed By Admin" } }
+
+      expect(owner.reload.name).to eq("Renamed By Admin")
+    end
+  end
+
+  describe "DELETE /users/:id/remove_user_doc" do
+    # No :user_doc factory — build the join row directly.
+    let(:user_doc) { UserDoc.create!(user: owner, doc: create(:doc, user: owner)) }
+
+    it "refuses to let another user destroy it" do
+      sign_in intruder
+
+      delete remove_user_doc_user_path(user_doc)
+
+      expect(response).to redirect_to(root_url)
+      expect(UserDoc.exists?(user_doc.id)).to be(true)
+    end
+
+    it "lets the owner destroy their own" do
+      sign_in owner
+
+      delete remove_user_doc_user_path(user_doc)
+
+      expect(UserDoc.exists?(user_doc.id)).to be(false)
+    end
+
+    it "lets an admin destroy it" do
+      sign_in admin
+
+      delete remove_user_doc_user_path(user_doc)
+
+      expect(UserDoc.exists?(user_doc.id)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Asked to make sure only admins can reach the admin dashboard pages. The `/admin` namespace turned out to be **already correctly gated** — every controller inherits `Admin::ApplicationController` (`authenticate_user!` + `require_admin!`), and the JSON side inherits `API::Admin::ApplicationController`. No hole there.

The hole was the **legacy HTML admin under `/users`**, which sits outside the `Admin::` namespace and had lost its checks.

| Action | Before |
|---|---|
| `show` | admin check **commented out** — any signed-in user could open any account |
| `edit` / `update` | **no check** — any signed-in user could rename any account and change its voice settings |
| `remove_user_doc` | **no check** — any signed-in user could delete any account's document |
| `index` / `admin` | checked inline without a `return`, so every listing query still ran for a denied caller |

`update` and `remove_user_doc` were the genuinely exploitable ones. The read paths happen to raise on render (their templates call route helpers that no longer exist), so they weren't leaking in practice — but only by accident, which is exactly the kind of thing that stops being true after an unrelated view fix.

## What changed

- **`app/controllers/users_controller.rb`** — gates moved into `before_action`s: `require_admin!` for the listing pages, `require_self_or_admin!` for the profile pages, and an owner-or-admin check on `remove_user_doc`. A user's own profile stays self-service — that's what the "Edit Profile" link on `/users/:id` targets — and `user_params` permits no role or plan field, so this is the whole gate.
  - Denials redirect to root rather than `redirect_back_or_to`, which could ping-pong between two pages that both deny.
  - `#word_events` has no route left, but is gated alongside the others so re-adding one can't quietly reopen it.
- **`spec/requests/admin/access_control_spec.rb`** (new) — a sweep over the whole `/admin` namespace. Asserts every routed controller descends from the gate, and hits every parameterless GET page as anonymous / non-admin / admin. A future `Admin::FooController` that forgets to inherit the base fails here instead of shipping open. Includes a guard so the sweep can't go vacuously green on an empty route list.
- **`spec/requests/users_access_control_spec.rb`** (new) — 12 examples over the fixed actions.
- **`CLAUDE.md`** — new invariant: gate admin pages by inheritance, never with an inline check. An inline `redirect_to … unless current_user.admin?` mid-action still runs every query below it, and the next early `render` added under it turns that into a leak.
- **`CHANGELOG.md`** — user-facing entry.

## Reviewer notes

**The legacy `/users` pages are already broken for everyone**, admins included. `GET /users`, `/users/admin` and `/users/:id` all 500 because their templates call route helpers that no longer exist (`boards_path`, `set_next_words_images_path`, `products_path`), and `UsersController#word_events` has no route at all.

I deliberately did **not** fix that here — it's separate from access control, and the `/admin` namespace already replaces those pages. It's filed as a follow-up. The consequence for this PR: the allow-path assertions verify the gate lets a caller *through*, not that the page renders. That's called out in a comment in the spec so it doesn't read as an oversight.

## Test plan

```
bundle exec rspec spec/requests/admin/ spec/requests/users_access_control_spec.rb
```

**274 examples, 0 failures** — the 13 new sweep examples, the 12 new `/users` examples, and all pre-existing `spec/requests/admin/` specs with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
