### PR TITLE
fix(admin): step tile count by the column count, publish builder boards

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -38,8 +38,15 @@ and the models directly. Do **not** have Rails HTTP-call `/api/internal/*`.
    and shows coverage, fuzzy matches, and license flags. **Nothing is written
    until a second, explicit Build click.** This is the single most valuable
    behaviour being ported — a wrong symbol is expensive to fix after the fact.
-3. **Boards are created unpublished.** Publishing is a separate confirmed action,
-   never chained onto a build.
+3. **Boards are created published but NOT `predefined`.** Published so the set is
+   live at `/pb/<slug>` and shows up on the printables page the moment it builds;
+   not `predefined` so it stays out of `Board.public_boards` — the catalogue is a
+   curated surface, and dropping every build into it would bury the library.
+   `Admin::BoardPrintablesController` reaches builder boards through
+   `AdminBoardBuild.builder_boards` instead. Unpublish is the way back, and it is
+   still a set-wide operation. (Originally the reverse — created unpublished,
+   published by a separate confirmed action — changed once the printables page
+   became the main consumer.)
 4. **Boards are owned by `User::DEFAULT_ADMIN_ID`**, not `current_user` — same as
    `Admin::VideoBoardsController#seed_admin`.
 5. **Phase 1 is a single board. Phase 3 adds linked child pages.** Build them in
@@ -244,7 +251,7 @@ Inside one transaction:
    correct that misses create blank Images; those are what generation targets.
 2. Create the board: `board_type: "static"`, `voice`, `large_screen_columns`,
    `settings: { "admin_builder" => true, "disable_scroll" => true }`,
-   `user: seed_admin`, `published: false`.
+   `user: seed_admin`, `published: true`, `predefined: false`.
 3. Add tiles in authored order via `Board#add_image(image_id)` (guarding the nil
    return), then `update!(part_of_speech:)` per the Colors section above, plus
    `display_label` when given.
@@ -374,7 +381,7 @@ Behaviour to prove:
 - tile count ≠ `columns × rows` → re-renders `:new`, 422, nothing written, and
   the submitted values are still in the form
 - duplicate labels rejected; unknown `part_of_speech` rejected
-- happy path → `published == false`, `user_id == DEFAULT_ADMIN_ID`,
+- happy path → `published == true`, `predefined == false`, `user_id == DEFAULT_ADMIN_ID`,
   `settings["admin_builder"] == true`, `large_screen_columns` as chosen, and
   md/sm derived by `ScreenColumns` rather than set equal to lg
 - tiles land in authored reading order after `apply_layout!`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   takes the id of one of the tile's own audio files instead of a URL supplied
   by the client.
 
+- **Admin-built boards land published and print-ready.** A board built from the
+  admin Board Builder is now live at its `/pb/<slug>` page the moment it
+  finishes, and appears in the board list on the admin printables page without
+  a search. They stay out of the public catalogue on purpose — publishing makes
+  a board shareable and printable, not featured. Unpublish (still set-wide)
+  reverses it, and a published board still has to be unpublished before it can
+  be deleted.
+
+- **Board builder word-count validation now allows a small margin.** A word
+  list within 2 tiles of the page's tile count is accepted instead of
+  requiring an exact match — the message and the live word-count hint on the
+  form now say "within 2" rather than "exactly." A gap larger than that still
+  blocks preview/build with the same "Add N" / "Remove N" guidance.
+
 ### Fixed
 
 - **"Reset to Default Voice" was unreachable.** The API never told the app a
@@ -43,13 +57,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - **Uploading audio from the image editor failed outright** with a server
   error, and saved the file without its extension.
 
-- **Board builder word-count validation now allows a small margin.** A word
-  list within 2 tiles of the page's tile count is accepted instead of
-  requiring an exact match — the message and the live word-count hint on the
-  form now say "within 2" rather than "exactly." A gap larger than that still
-  blocks preview/build with the same "Add N" / "Remove N" guidance.
-
-### Fixed
+- **The admin Board Builder's Tiles spinner now skips to the next whole row.**
+  Clicking up on a 6-column board went 24 → 25 — a count the form then rejects
+  for leaving dead cells — and the correction only landed if the field happened
+  to fire a change event. Tiles now steps by the column count (24 → 30 → 36),
+  follows a page's own column override, and re-snaps whenever the columns change
+  or a build is loaded back in. Ticking "allow a partial row" returns it to
+  stepping by one.
 
 - **Tiles stopped coming out Title Cased.** The lowercase tile default was a
   no-op on the exact input it existed to fix: any capital at all counted as

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -10,10 +10,11 @@ module Admin
   #      the whole reason the build is two steps.
   #   2. Nothing is written until the plan validates. A bad word list re-renders
   #      the form with exactly what the admin typed.
-  #   3. Boards are created unpublished and owned by User::DEFAULT_ADMIN_ID.
-  #      Publishing is a separate, confirmed POST, and every member action is
-  #      scoped through AdminBoardBuild.builder_boards so it can never reach a
-  #      board this page didn't create.
+  #   3. Boards are owned by User::DEFAULT_ADMIN_ID and created published but
+  #      NOT predefined — public at /pb/<slug> and listed on the printables
+  #      page, without being dropped into the public catalogue. Every member
+  #      action is scoped through AdminBoardBuild.builder_boards so it can never
+  #      reach a board this page didn't create; unpublish is the way back.
   class BoardBuildsController < Admin::ApplicationController
     MAX_COLUMNS = 12
     # 12x12, the old grid ceiling expressed as tiles.
@@ -227,7 +228,8 @@ module Admin
       BuildAdminBoardJob.perform_async(build.id)
 
       redirect_to admin_dashboard_board_build_path(build),
-                  notice: "Building “#{build.name}” — it lands unpublished for review."
+                  notice: "Building “#{build.name}” — it lands published, ready to print. " \
+                          "Check the art and unpublish it if anything's wrong."
     end
 
     def show

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -27,9 +27,8 @@ module Admin
         []
       end
 
-      public_boards = Board.public_boards
-      @public_boards_count = public_boards.count
-      @public_boards = sorted_boards(public_boards).limit(PUBLIC_BOARD_LIMIT)
+      @public_boards_count = printable_boards.count
+      @public_boards = sorted_boards(printable_boards).limit(PUBLIC_BOARD_LIMIT)
 
       @subboard_counts = direct_subboard_counts(@public_boards + @boards)
     end
@@ -73,6 +72,23 @@ module Admin
     end
 
     private
+
+    # The boards worth offering a one-click printable for. `public_boards` is
+    # the catalogue; Board Builder boards are the other half — published and
+    # authored for print, but deliberately not `predefined`, so the catalogue
+    # scope can't see them (see Boards::AdminBuilder::Build#new_board).
+    #
+    # Builder CHILD pages are excluded: a printable walks the tree from its
+    # root, so listing every folder page as its own row would bury the board
+    # they belong to. They're still reachable through the search box below.
+    def printable_boards
+      @printable_boards ||= Board.where(id: Board.public_boards.select(:id))
+                                 .or(Board.where(id: builder_root_boards.select(:id)))
+    end
+
+    def builder_root_boards
+      AdminBoardBuild.builder_boards.published.not_builder_child
+    end
 
     # @board_sort / @board_dir are whitelisted above, so they are safe to
     # interpolate. Every sort falls back to name so the order is total —

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -93,13 +93,18 @@ module Boards
           name: page[:name],
           user: admin,
           parent: admin,
-          # Only the root belongs in the public catalogue: `Board.public_boards`
-          # keys on `predefined`, and a set whose every folder page showed up
-          # there as a standalone board would bury the board it belongs to.
-          # Child pages stay reachable because `Board#viewable_by?` gates on
-          # `published` alone.
-          predefined: root,
-          published: false,
+          # Deliberately NOT `predefined`. `Board.public_boards` keys on it, and
+          # a builder board is authored for printables and direct /pb/ sharing,
+          # not for the public catalogue — dropping a whole set (root plus every
+          # folder page) into the library each time an admin tried a build is
+          # what that flag would do. Admin::BoardPrintablesController reaches
+          # these through AdminBoardBuild.builder_boards instead.
+          predefined: false,
+          # Published on creation, root and pages alike. `Board#viewable_by?`
+          # gates each board on its OWN flag, so a half-published set 404s every
+          # folder tile — the set is only ever published as a unit (the same
+          # rule Admin::BoardBuildsController#publish enforces).
+          published: true,
           board_type: "static",
           # Set at create time: assigning `voice` later cascades to every tile
           # and re-queues all their audio.
@@ -116,10 +121,9 @@ module Boards
           small_screen_columns: Boards::ScreenColumns.derive(columns, "sm"),
           number_of_columns: columns,
           settings: settings_for(page),
-          # Catalogue metadata belongs to the root alone: child pages are
-          # created with `predefined: false` and never appear in
-          # `Board.public_boards`, so tagging them would fill the public tag
-          # filter with folder-page noise.
+          # Catalogue metadata belongs to the root alone — it describes the set,
+          # and a folder page carrying the same description and tags is noise in
+          # every list that shows them.
           description: root ? build.description : nil,
           tags: root ? Array(build.tags) : [],
         )

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -129,7 +129,8 @@
         You need about <span id="cell-count" class="text-t1 font-medium">—</span> words
         (within <%= Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE %>) —
         <span id="word-count" class="text-t1 font-medium">0</span> so far.
-        A tile count that isn’t a whole number of rows leaves dead cells at the end of the last row.
+        A tile count that isn’t a whole number of rows leaves dead cells at the end of the last row,
+        so Tiles steps a whole row at a time unless you allow a partial row.
       </p>
     </div>
 
@@ -284,6 +285,10 @@
       wordCount.style.color = cells && Math.abs(used - cells) > TILE_COUNT_TOLERANCE ? "#f87171" : "";
     }
 
+    function partialRowAllowed() {
+      return !!(allowPartialRow && allowPartialRow.checked);
+    }
+
     // Rounds up to the next full row for the given column count; if that
     // overshoots the field's max, rounds down to the last full row instead
     // so a full-grid ceiling (144) is never exceeded by rounding.
@@ -293,24 +298,66 @@
       return roundedUp > max ? Math.floor(max / cols) * cols : roundedUp;
     }
 
+    // The spinner is what actually has to land on a valid value. With the
+    // default step of 1 it walks 24 -> 25 — a count the validator then
+    // rejects — and the change-handler snap below can't help, because a
+    // stepper click doesn't reliably fire `change` until the field blurs.
+    // Setting step to the column count makes the browser itself skip to the
+    // next whole row (24 -> 30). `min` has to move with it: a number input
+    // steps in min + n*step, so leaving min at 1 with step 6 would offer
+    // 1, 7, 13 instead of 6, 12, 18.
+    function applyTileStep(field, cols) {
+      var step = partialRowAllowed() || !cols ? 1 : cols;
+      field.step = step;
+      field.min = step;
+    }
+
     // "Rows have to be complete" is only relaxed by the partial-row checkbox
     // — everywhere else, a tile count that isn't cols x rows leaves dead
     // cells at the end of the grid, so snap it the moment either field
     // settles (not on every keystroke, which would fight the admin's typing).
-    function snapTileCount() {
-      if (allowPartialRow && allowPartialRow.checked) return;
-      var cols = parseInt(columns.value, 10) || 0;
-      var tiles = parseInt(tileCount.value, 10) || 0;
+    // The step above handles the spinner; this catches a typed value.
+    //
+    // Snapping is not optional once a step is set: a number input fails its
+    // own constraint check on a value that isn't min + n*step, which would
+    // block the submit behind a browser tooltip instead of the form's own
+    // problem list. Every path that changes a step re-snaps the field.
+    function snapTileCount(field, cols) {
+      if (partialRowAllowed()) return;
+      var tiles = parseInt(field.value, 10) || 0;
       if (!cols || !tiles) return;
-      var max = parseInt(tileCount.max, 10) || tiles;
+      var max = parseInt(field.max, 10) || tiles;
       var snapped = snappedTileCount(tiles, cols, max);
-      if (snapped !== tiles) tileCount.value = snapped;
+      if (snapped !== tiles) field.value = snapped;
+    }
+
+    function syncTileField(field, cols) {
+      if (!field) return;
+      applyTileStep(field, cols);
+      snapTileCount(field, cols);
+    }
+
+    // Pages inherit the main board's columns unless they override them, so a
+    // page's own step follows whichever applies — which means a change to the
+    // main board's columns has to re-sync every inheriting page too.
+    function syncTileFields() {
+      var rootCols = parseInt(columns.value, 10) || 0;
+      syncTileField(tileCount, rootCols);
+
+      pages.querySelectorAll(".page-block").forEach(function (block) {
+        syncTileField(block.querySelector('input[name$="[tile_count]"]'), pageColumnsFor(block, rootCols));
+      });
       update();
     }
 
+    function pageColumnsFor(block, rootCols) {
+      var pageCols = block.querySelector('input[name$="[columns]"]');
+      return parseInt(pageCols && pageCols.value, 10) || rootCols;
+    }
+
     [words, columns, tileCount].forEach(function (el) { el.addEventListener("input", update); });
-    [columns, tileCount].forEach(function (el) { el.addEventListener("change", snapTileCount); });
-    if (allowPartialRow) allowPartialRow.addEventListener("change", snapTileCount);
+    [columns, tileCount].forEach(function (el) { el.addEventListener("change", syncTileFields); });
+    if (allowPartialRow) allowPartialRow.addEventListener("change", syncTileFields);
     update();
 
     // Page blocks are indexed, so every add/remove has to renumber the whole
@@ -329,6 +376,7 @@
     document.getElementById("add-page").addEventListener("click", function () {
       pages.appendChild(pageTemplate.content.cloneNode(true));
       reindexPages();
+      syncTileFields();
     });
 
     pages.addEventListener("click", function (event) {
@@ -337,7 +385,24 @@
       reindexPages();
     });
 
+    // Delegated, because page blocks come and go — a listener bound per field
+    // would miss every block added after load.
+    pages.addEventListener("change", function (event) {
+      var block = event.target.closest(".page-block");
+      if (!block) return;
+      if (!/\[(columns|tile_count)\]$/.test(event.target.name || "")) return;
+
+      var rootCols = parseInt(columns.value, 10) || 0;
+      syncTileField(block.querySelector('input[name$="[tile_count]"]'), pageColumnsFor(block, rootCols));
+    });
+
     reindexPages();
+
+    // On load as well as on edit: a duplicated build or a re-rendered failed
+    // submit can arrive holding a count that's off the grid, and leaving it
+    // there would fail the browser's own step check with nothing but a tooltip
+    // to explain it.
+    syncTileFields();
 
     // Drafting replaces the textarea wholesale, so only confirm when there is
     // something to lose.

--- a/app/views/admin/board_builds/index.html.erb
+++ b/app/views/admin/board_builds/index.html.erb
@@ -3,7 +3,7 @@
 <div class="flex items-center justify-between mb-6">
   <div>
     <h1 class="text-2xl font-semibold text-t1 tracking-tight">Board Builds</h1>
-    <p class="text-sm text-t3 mt-0.5">Dense AAC boards built from a word list. Art is reviewed before anything is written; boards land unpublished.</p>
+    <p class="text-sm text-t3 mt-0.5">Dense AAC boards built from a word list. Art is reviewed before anything is written; boards land published and ready to print.</p>
   </div>
   <%= link_to "New board build", new_admin_dashboard_board_build_path,
         class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -109,8 +109,9 @@
 <div class="admin-card border rounded-xl p-5 mb-8">
   <h2 class="text-sm font-medium text-t1 mb-1">Happy with it?</h2>
   <p class="text-xs text-t2 mb-4">
-    Building creates the board unpublished, owned by the default admin, and queues AI art for anything the library
-    didn't cover. Publishing is a separate step.
+    Building creates the board published and owned by the default admin, and queues AI art for anything the library
+    didn't cover. It goes live at <span class="font-mono">/pb/&lt;slug&gt;</span> and onto the printables page — not into
+    the public catalogue. Unpublish it from the build page if the art comes back wrong.
   </p>
 
   <%# Hidden-field resubmit of exactly what was previewed. `create` re-parses

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -77,7 +77,13 @@
                 form: { data: { turbo_confirm: "Publish “#{@board.name}”? This makes it public to everyone. Have you looked at every tile?" } } %>
         <% end %>
       <% end %>
-      <% unless @board&.published? %>
+      <%# Builds land published, so this is now the usual state rather than a
+          rare one — say why the button isn't there instead of just hiding it. %>
+      <% if @board&.published? %>
+        <span class="text-[11px] text-t3 whitespace-nowrap" title="A published slug is frozen and may already be in a QR code">
+          Unpublish to delete
+        </span>
+      <% else %>
         <%= button_to "Delete", admin_dashboard_board_build_path(@build), method: :delete,
               class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1",
               form: { data: { turbo_confirm: "Delete this build and its board? This can't be undone." } } %>

--- a/app/views/admin/board_printables/index.html.erb
+++ b/app/views/admin/board_printables/index.html.erb
@@ -11,9 +11,9 @@
   <%# Sorting reloads the page, so a sort click has to leave the picker open. %>
   <details <%= "open" if params[:sort].present? %>>
     <summary class="flex items-baseline justify-between gap-3 cursor-pointer list-none">
-      <h2 class="text-sm font-medium text-t1">Public boards <span class="text-t3 font-normal">(click to expand)</span></h2>
+      <h2 class="text-sm font-medium text-t1">Published boards <span class="text-t3 font-normal">(click to expand)</span></h2>
       <span class="text-xs text-t3">
-        <%= pluralize(@public_boards_count, "published public board") %><%= " · showing first #{@public_boards.size} by #{board_sort_label(@board_sort)}" if @public_boards_count > @public_boards.size %>
+        <%= pluralize(@public_boards_count, "published board") %> — catalogue + Board Builder<%= " · showing first #{@public_boards.size} by #{board_sort_label(@board_sort)}" if @public_boards_count > @public_boards.size %>
       </span>
     </summary>
 
@@ -22,7 +22,7 @@
         <%= render "board_table", boards: @public_boards, subboard_counts: @subboard_counts %>
       </div>
     <% else %>
-      <p class="text-xs text-t3 mt-3">No published public boards yet — use the search below to find any board.</p>
+      <p class="text-xs text-t3 mt-3">No published boards yet — use the search below to find any board.</p>
     <% end %>
   </details>
 </div>

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -61,6 +61,36 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       expect(response.body).not_to include("Core Words")
     end
 
+    # Board Builder boards are created published but NOT predefined, so
+    # Board.public_boards can't see them — and they are exactly what this page
+    # exists to print.
+    it "lists published Board Builder boards alongside the catalogue" do
+      sign_in admin
+      builder_board = create(:board, user: default_admin, predefined: false, published: true,
+                                     name: "Builder Playground",
+                                     settings: { AdminBoardBuild::BUILDER_SETTING => true })
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).to include("Builder Playground")
+      expect(response.body).to include("value=\"#{builder_board.id}\"")
+    end
+
+    # A printable walks the tree from its root, so a folder page listed as its
+    # own row would bury the board it belongs to.
+    it "leaves builder child pages and unpublished builder boards out of the list" do
+      sign_in admin
+      create(:board, user: default_admin, predefined: false, published: true, name: "Builder Food Page",
+                     settings: { AdminBoardBuild::BUILDER_SETTING => true, "builder_child" => true })
+      create(:board, user: default_admin, predefined: false, published: false, name: "Builder Draft",
+                     settings: { AdminBoardBuild::BUILDER_SETTING => true })
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).not_to include("Builder Food Page")
+      expect(response.body).not_to include("Builder Draft")
+    end
+
     it "leaves unpublished and menu boards out of the public list" do
       sign_in admin
       create(:board, user: default_admin, predefined: true, published: false, name: "Draft Public Board")

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -44,12 +44,16 @@ RSpec.describe Boards::AdminBuilder::Build do
   describe "the board it writes" do
     let(:build) { build_record(tiles: four_tiles) }
 
-    it "creates an unpublished board owned by the default admin and marked as ours" do
+    it "creates a published, non-predefined board owned by the default admin and marked as ours" do
       board = described_class.new(admin_board_build: build).call
 
-      expect(board.published).to be(false)
+      expect(board.published).to be(true)
       expect(board.user_id).to eq(admin.id)
-      expect(board.predefined).to be(true)
+      # Published but out of the public catalogue: `Board.public_boards` keys on
+      # `predefined`, and a builder board is authored for /pb/ sharing and
+      # printables, not for the library.
+      expect(board.predefined).to be(false)
+      expect(Board.public_boards).not_to include(board)
       expect(board.board_type).to eq("static")
       expect(board.settings["admin_builder"]).to be(true)
       expect(board.settings["disable_scroll"]).to be(true)
@@ -203,14 +207,15 @@ RSpec.describe Boards::AdminBuilder::Build do
       expect(build.set_boards.map(&:id)).to eq([root.id, boards["food"]])
     end
 
-    # Only the root belongs in the public catalogue — Board.public_boards keys
-    # on `predefined`, and a set whose folder pages showed up there as
-    # standalone boards would bury the board they belong to.
-    it "marks the root predefined and the pages not" do
+    # Board#viewable_by? gates each board on its OWN published flag, so a set
+    # published only at the root 404s every folder tile for a public visitor.
+    it "publishes every page of the set and leaves none predefined" do
       root = described_class.new(admin_board_build: build).call
       child = build.reload.set_boards.last
 
-      expect(root.predefined).to be(true)
+      expect(root.published).to be(true)
+      expect(child.published).to be(true)
+      expect(root.predefined).to be(false)
       expect(child.predefined).to be(false)
       expect(child.settings["admin_builder"]).to be(true)
       expect(child.settings["builder_child"]).to be(true)
@@ -324,7 +329,7 @@ RSpec.describe Boards::AdminBuilder::Build do
 
       expect(root.settings).not_to have_key("builder_root")
       expect(root.settings).not_to have_key("builder_child")
-      expect(root.predefined).to be(true)
+      expect(root.predefined).to be(false)
     end
   end
 


### PR DESCRIPTION
Two fixes to the admin Board Builder.

## The Tiles spinner didn't skip to the next valid value

Clicking up on a 6-column board went 24 → 25 — a count the plan validator then rejects, because it leaves dead cells at the end of the last row. The existing snap ran on `change`, which a stepper click doesn't reliably fire until the field blurs, so nothing corrected it.

Tiles now carries a `step` equal to the column count, so the browser itself skips a whole row: 24 → 30 → 36. `min` moves with it — a number input only steps in `min + n*step`, so leaving min at 1 with step 6 would have offered 1, 7, 13. The step follows a page's own column override, falls back to the main board's columns when a page inherits, re-syncs when the columns change or a page is added, and drops back to stepping by one when "allow a partial row" is ticked.

Values are re-snapped on load as well as on edit: a duplicated build holding an off-grid count would otherwise fail the browser's own step check and block the submit behind a tooltip instead of the form's problem list.

## Built boards are now published and NOT predefined

Root and pages alike — `Board#viewable_by?` gates each board on its own flag, so a set published only at the root 404s every folder tile for a public visitor.

- **Published** so the set is live at `/pb/<slug>` and printable the moment it builds.
- **Not `predefined`** so it stays out of `Board.public_boards`. That scope is the curated public catalogue, and dropping every build into it would bury the library.

`Admin::BoardPrintablesController` reaches builder boards through `AdminBoardBuild.builder_boards` instead, excluding `builder_child` pages so a folder page can't bury the root it belongs to. The section on that page is relabeled "Published boards — catalogue + Board Builder."

## Reviewer notes

- **Delete now needs an unpublish first.** `destroy` still refuses a published board (a published slug is frozen and may already be in a QR code). That guard used to be rare; it now fires on every build, so the build page says "Unpublish to delete" where the button was rather than just hiding it. Easy to relax if that's the wrong call.
- **Builder boards no longer appear in the in-app public library** and no longer contribute to the public tag filter. That's the deliberate tradeoff of dropping `predefined` — they're shareable and printable, not featured.
- Copy updated on the builds index, preview, and show pages; handoff doc rail #3 rewritten; CHANGELOG entries added.

## Test plan

- `bundle exec rspec spec/requests/admin spec/services/boards/admin_builder` → **423 examples, 0 failures** (re-run after rebasing onto `origin/main`).
- Updated `build_spec` to assert `published == true`, `predefined == false`, every page of a set published, and that the root is not in `Board.public_boards`.
- Added two `board_printables_spec` cases: published builder boards are listed alongside the catalogue; builder child pages and unpublished builder boards are not.
- **The stepper has no Ruby test** — this repo has no Capybara/system-spec setup, so there's no harness for client-side JS. I verified the real script in a browser against a replica of the form markup: stepUp 24→30→36, stepDown→30, columns 6→5 re-steps and re-snaps both root and pages, a typed 23 snaps to 25, a page override of 4 steps 16→20, clearing the override falls back to 6, `checkValidity()` true throughout, and ticking allow-partial-row returns step/min to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)