### PR TITLE
fix(board-builder): tuck overflow fringe pages into "More" instead of a stray row

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -447,8 +447,17 @@ Because a page can now live one level down, `BuildBoardSetJob
 drawer's** — otherwise a leftover interest word wouldn't find its category page —
 and `#add_to_favorites!` looks for an existing "My Favorites" through the same
 map, so the cloner's drawer-tucked Favorites isn't duplicated. `set_board_ids`
-already walks the link graph unbounded, so BoardGroup membership, nav sync,
-reflow, and cascade-delete need no change.
+already walks the link graph unbounded, so BoardGroup membership, group
+attachment, reflow, and cascade-delete need no change.
+
+**Every page in a built set keeps a one-tap way home** — that invariant predates
+the drawer and had to be carried into it. A page whose name sits in the nav
+region gets home from its SELF tile (`NavRowSync#upsert_nav_tile!`); a
+drawer-tucked page has no nav cell of its own, so `NavRowSync#ensure_home_tile!`
+gives it the same anchor explicitly — a tile carrying the page's name that opens
+the root, unmuted so it speaks like a self tile. It has to run *after*
+`evict_occupants!`, which destroys any child folder tile pointing back at the
+root, so an anchor written earlier in the build would not survive.
 
 `allow_scroll_if_grown!` remains the safety net for case 3: a home board that
 did grow clears the seed's one-page `disable_scroll` so the new row isn't

--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -396,33 +396,68 @@ job runs the hybrid path:
 4. **Catch-all** — interests with no fitted page (initial unmatched + any pages
    that didn't fit the grid + AI pages that fell back) → a single "My Favorites".
 
-#### Grid cap: never overflow the authored core grid
+#### Overflow goes into the "More" drawer, never onto a stray row
 
-The authored core board fills its grid with a few intentional empty cells
-(Core 84 = 7×12 = 84 cells, 81 tiles, 3 gaps). `Board#add_image` drops a tile
-into the first open cell and only starts a **new row** once the grid is full
-(`BoardsHelper#next_available_cell`). So naively adding one folder tile per
-fringe page overflowed onto a stray extra row — the "85th tile" bug.
+**The authored core grids are completely full**: Core 60 is 60 tiles in a 6×10
+grid, Core 84 is 84 tiles in a 7×12 grid. Zero reserved cells, in both.
+`Board#add_image` drops a tile into the first open cell and only starts a **new
+row** once the grid is full (`BoardsHelper#next_available_cell`), so every page
+a build adds past the seed set used to land on a row of its own — and
+`Boards::NavRegion` then rotates the authored nav row back underneath it. The
+visible result on a Core 60 build was a home board reading "61 tiles" with one
+lone `Bathroom` folder stranded between the core words and the nav row, plus the
+loss of the seed's one-page `disable_scroll`.
 
-`add_fringe_pages_within_grid!` caps the top-level folder tiles it adds to the
-number of open cells (`root_open_cells`, which delegates to the shared
-`Board#open_grid_cells`), reserving one cell for "My Favorites" whenever
-leftovers are expected. Interest-bearing pages are placed first, so a
-nearly-full grid still gets the pages the child actually asked for; anything
-that doesn't fit folds into My Favorites — nothing typed is dropped. Net result:
-a built robust set never exceeds its authored grid and never leaves a dead
-(unlinked) folder tile behind.
+**`Boards::FolderPlacer` is the single authority on where a top-level folder
+tile goes.** In order:
 
-> **Hard cap (the "86 tiles instead of 84" fix).** The reservation alone wasn't
-> enough once the Phrases layer started riding every build: a fuller authored
-> grid (fewer reserved gaps than the repo's Core 84) left no cell for the
-> catch-all, yet the catch-all tile was added **unconditionally** — so it (and
-> a fringe page) spilled onto a stray 8th row → 86 tiles. The cap is now a hard
-> guarantee enforced by **every** top-level tile-adder via `open_grid_cells`:
-> the Phrases folder + quick-phrase strip (`build_phrases_layer!`/
-> `add_phrase_strip!`), `BuildBoardSetJob#add_to_favorites!`, **and**
-> `SeededSetCloner#create_favorites_board!`. When there's genuinely no open
-> cell the catch-all tile is skipped (logged), never spilled. Separately,
+1. a genuine open cell on the home grid — `Board#open_grid_cells`;
+2. else the set's **"More" drawer** — the board the root's `More` folder tile
+   opens, owner-scoped (`FolderPlacer.drawer_for`). More is on the nav row of
+   every page in the set, so the page stays two taps from anywhere, and it ships
+   mostly empty (Core 60's More: 31 tiles in 60 cells);
+3. else grow the home grid, as before. Only the legacy label-only starter trees
+   (`home`, `daily_routine`) have no `More`, so in practice this is the
+   drawer-is-full case.
+
+Every top-level tile-adder routes through it: `BuildBoardSetJob#add_folder_tile!`
+(so prebuilt fringe, AI pages, and `#add_to_favorites!` all inherit it) and
+`SeededSetCloner#create_favorites_board!`. The Phrases layer is the exception in
+practice, not by special-casing — `build_phrases_layer!` still bails when the
+home grid has no open cell, so it never reaches step 2. Two placement rules
+inside the drawer are load-bearing:
+
+- **Tiles pack into a band, not into authored gaps.** Placement takes the first
+  row above the drawer's nav row that already holds nothing but folder tiles
+  (the band a previous page started), else the first fully-empty row. Core 60's
+  More has two open cells mid-way through its top word row, between `for` and
+  `here`; `next_available_cell` would drop `Bathroom` there.
+- **The drawer's nav row is its BOTTOM row** — deliberately not
+  `NavRegion.authored_nav_y`, which picks whichever row holds the most folder
+  tiles. A band that grew to the nav row's size would win that tie (lower `y`)
+  and the next placement would start overwriting nav cells.
+
+`FolderPlacer` also refuses the drawer for a page whose name matches a nav-region
+label: `NavRowSync#evict_occupants!` destroys any folder tile on a child page
+carrying a nav category's label, so such a page would be silently orphaned
+inside the drawer. It stays on the home board instead.
+
+Because a page can now live one level down, `BuildBoardSetJob
+#set_top_level_boards_by_name` reads the root's folder targets **plus the
+drawer's** — otherwise a leftover interest word wouldn't find its category page —
+and `#add_to_favorites!` looks for an existing "My Favorites" through the same
+map, so the cloner's drawer-tucked Favorites isn't duplicated. `set_board_ids`
+already walks the link graph unbounded, so BoardGroup membership, nav sync,
+reflow, and cascade-delete need no change.
+
+`allow_scroll_if_grown!` remains the safety net for case 3: a home board that
+did grow clears the seed's one-page `disable_scroll` so the new row isn't
+clipped.
+
+> Default (no-interest) fringe pages still fill only genuine open cells — they
+> are never tucked into the drawer just to surface content the child didn't ask
+> for, so a no-interest build stays one clean page.
+
 > `SeededSetCloner#fringe_for_category` applies `CATEGORY_SEED_ALIASES`
 > ("Family & People" → People, "Health & Body" → Body) so those seed-set
 > interests reach the cloned page instead of spawning an extra "My Favorites"
@@ -482,6 +517,9 @@ thresholds. Revisit when real usage data or SLP feedback is available.
   capping, excluded pages, catch-all, credit downgrade, explicit categories.
 - `spec/services/boards/fringe_templates_spec.rb` — find, all_templates,
   seed_obf!.
+- `spec/services/boards/folder_placer_spec.rb` — placement order (open cell →
+  drawer → grow), band packing, the authored-gap and nav-label refusals,
+  drawer-full fallback, `drawer_for` ownership scoping.
 - `spec/services/boards/ai_page_generator_spec.rb` — happy path, error cases,
   tile capping, profile guidance, blank label filtering.
 - `spec/services/communicator_profile_spec.rb` — developing?, young_teen?.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   another account's uploaded document. Those pages are now restricted to the
   account's owner and to admins, matching the `/admin` dashboard. The `/admin`
   dashboard itself was already gated and exposed nothing.
+- **A built board set keeps its clean, single-screen home board.** Extra
+  category pages the builder added — Bathroom, Animals, My Favorites — used to
+  land on a row of their own below the core words, so a Core 60 board came out
+  reading "61 tiles" with one stranded folder and a home page that scrolled.
+  Those pages now go inside the "More" folder, which sits on the bottom row of
+  every page in the set, so they stay a couple of taps away and the home board
+  looks exactly as designed. Leftover interest words that previously had
+  nowhere to go are surfaced there too instead of being dropped.
 
 - **"Reset to Default Voice" was unreachable.** The API never told the app a
   tile was on custom audio, so the button that undoes a recording never

--- a/app/services/boards/folder_placer.rb
+++ b/app/services/boards/folder_placer.rb
@@ -1,0 +1,175 @@
+module Boards
+  # Decides WHERE a built set's top-level folder tile goes.
+  #
+  # The authored core grids are completely full — Core 60 is 60 tiles in 60
+  # cells, Core 84 is 84 in 84 — so every fringe page a build added used to
+  # spill onto a stray row: one orphan tile on its own line (Boards::NavRegion
+  # then rotates the authored nav row back under it), a home board that reads
+  # "61 tiles", and the loss of the seed's single-screen `disable_scroll`.
+  #
+  # Instead the overflow is tucked into the set's **"More" drawer**. More is on
+  # the nav row of every page in the set, so the page stays two taps from
+  # anywhere, and it ships with most of its grid empty (Core 60's More: 31 tiles
+  # in 60 cells). The authored home grid is never grown while the drawer has
+  # room.
+  class FolderPlacer
+    DRAWER_NAME = "More".freeze
+
+    # destination:
+    #   :root   — placed in a genuine open cell on the home grid
+    #   :drawer — home grid full; tucked into "More"
+    #   :grown  — home grid full and no usable drawer; the home grid grew a row
+    Result = Struct.new(:tile, :board, :destination, keyword_init: true)
+
+    def self.place!(root:, owner:, name:, board_id:)
+      new(root: root, owner: owner).place!(name: name, board_id: board_id)
+    end
+
+    # The board opened by the root's "More" folder tile, scoped to the root's
+    # owner so a tile pointing at a shared/admin board can't be written into.
+    def self.drawer_for(root)
+      tile = root.board_images.where.not(predictive_board_id: nil)
+        .detect { |bi| bi.label.to_s.strip.casecmp?(DRAWER_NAME) }
+      return nil if tile.nil? || tile.predictive_board_id == root.id
+
+      Board.find_by(id: tile.predictive_board_id, user_id: root.user_id)
+    end
+
+    def initialize(root:, owner:)
+      @root = root
+      @owner = owner
+    end
+
+    def place!(name:, board_id:)
+      @root.reload
+
+      if @root.open_grid_cells >= 1
+        tile = add_tile!(@root, name, board_id)
+        return tile && Result.new(tile: tile, board: @root, destination: :root)
+      end
+
+      drawer = self.class.drawer_for(@root)
+      cell = drawer && drawer_allows?(name) && overflow_cell(drawer)
+      if cell
+        tile = add_tile!(drawer, name, board_id, cell: cell)
+        return tile && Result.new(tile: tile, board: drawer, destination: :drawer)
+      end
+
+      # No drawer (the legacy starter trees have none) or no room left in it:
+      # grow the home grid rather than drop a page the child asked for.
+      # BuildBoardSetJob#allow_scroll_if_grown! clears `disable_scroll` so the
+      # new row isn't clipped.
+      tile = add_tile!(@root, name, board_id)
+      tile && Result.new(tile: tile, board: @root, destination: :grown)
+    end
+
+    private
+
+    # Boards::NavRowSync projects the ROOT's nav region onto every page and
+    # DESTROYS any folder tile on a child that carries a nav category's label.
+    # A page whose name collides with a nav label would therefore be silently
+    # orphaned inside the drawer, so it stays on the home board instead.
+    def drawer_allows?(name)
+      nav_labels = Boards::NavRegion.for_root(@root).cells.map { |c| c.label.to_s.strip.downcase }
+      !nav_labels.include?(name.to_s.strip.downcase)
+    end
+
+    # Overflow pages read as their own band rather than filling the gaps in an
+    # authored sentence-word row (Core 60's More has two open cells mid-way
+    # through its top row, between "for" and "here"). So, scanning the rows
+    # ABOVE the drawer's nav row top-down, prefer:
+    #
+    #   1. a row already holding nothing but folder tiles — the band a previous
+    #      call started, so successive pages pack left-to-right into one row;
+    #   2. the first fully-empty row, left-most cell — a fresh band;
+    #   3. any open cell at all, when the drawer is nearly full.
+    #
+    # nil once the drawer has no room, which sends the caller back to the root.
+    def overflow_cell(drawer)
+      columns = drawer.large_screen_columns.to_i
+      columns = drawer.number_of_columns.to_i if columns < 1
+      return nil if columns < 1
+
+      rows = occupied_rows(drawer)
+      return nil if rows.empty?
+
+      # Rows strictly above the drawer's own nav row, which is always its
+      # BOTTOM row: Boards::NavRowSync projects the root's nav region onto every
+      # page at the region's own (bottom-pinned) cells, and the seed .obf files
+      # author it there too. Deliberately not NavRegion.authored_nav_y — that
+      # picks whichever row holds the most folder tiles, so a band that grew to
+      # the nav row's size would steal the title and start overwriting content.
+      limit = rows.keys.max
+      return nil if limit < 1
+
+      band = (0...limit).find do |y|
+        row = rows[y]
+        row[:xs].any? && row[:folders_only] && row[:xs].size < columns
+      end
+      return { "x" => first_open_x(rows[band], columns), "y" => band } if band
+
+      empty_row = (0...limit).find { |y| rows[y][:xs].empty? }
+      return { "x" => 0, "y" => empty_row } if empty_row
+
+      (0...limit).each do |y|
+        x = first_open_x(rows[y], columns)
+        return { "x" => x, "y" => y } if x
+      end
+
+      nil
+    end
+
+    def first_open_x(row, columns)
+      (0...columns).find { |x| !row[:xs].include?(x) }
+    end
+
+    # y => { xs: Set of occupied x, folders_only: bool }, read from the tiles'
+    # own `lg` cells — never from board.layout, whose accessor rebuilds and
+    # writes the column as a side effect.
+    def occupied_rows(board)
+      rows = Hash.new { |h, k| h[k] = { xs: Set.new, folders_only: true } }
+
+      board.board_images.each do |bi|
+        cell = bi.layout.is_a?(Hash) ? bi.layout["lg"] : nil
+        next if cell.nil?
+
+        x = cell["x"].to_i
+        y = cell["y"].to_i
+        w = [cell["w"].to_i, 1].max
+        h = [cell["h"].to_i, 1].max
+        h.times do |dy|
+          row = rows[y + dy]
+          w.times { |dx| row[:xs] << (x + dx) }
+          row[:folders_only] &&= bi.predictive_board_id.present?
+        end
+      end
+
+      rows
+    end
+
+    def add_tile!(board, name, board_id, cell: nil)
+      board.reload
+      image = Boards::ImageResolver.resolve(name, owner: @owner)
+      tile = board.add_image(image.id)
+      return nil unless tile
+
+      # BoardImage#set_defaults derives the label from the image, which may be
+      # stored under different casing ("animals"); pin the authored folder name.
+      tile.update!(predictive_board_id: board_id, label: name, display_label: name)
+      pin_cell!(board, tile, cell) if cell
+      tile
+    end
+
+    # Board#add_image drops the tile in the first open cell; move it to the
+    # chosen one and mirror the change into the board's own layout column.
+    def pin_cell!(board, tile, cell)
+      lg = (tile.layout.is_a?(Hash) ? tile.layout["lg"] : nil) || {}
+      tile.layout = (tile.layout || {}).merge(
+        "lg" => lg.merge("i" => tile.id.to_s, "x" => cell["x"], "y" => cell["y"], "w" => 1, "h" => 1),
+      )
+      tile.save!
+      board.board_images.reset
+      Boards::LayoutRepacker.resync_board_layout!(board)
+    end
+  end
+end

--- a/app/services/boards/nav_row_sync.rb
+++ b/app/services/boards/nav_row_sync.rb
@@ -80,9 +80,40 @@ module Boards
       evict_occupants!(child)
       drop_orphaned_nav_tiles!(child)
       region.cells.each { |cell| upsert_nav_tile!(child, cell) }
+      ensure_home_tile!(child)
 
       child.board_images.reset
       Boards::LayoutRepacker.resync_board_layout!(child)
+    end
+
+    # EVERY page in the set gets a one-tap way home. A page whose name is in the
+    # nav region gets it from its SELF tile (see #upsert_nav_tile!) — but a page
+    # Boards::FolderPlacer tucked into the "More" drawer has no nav cell of its
+    # own, so nothing above would give it one. Give it the same anchor
+    # explicitly: a tile carrying the page's name that opens the root.
+    #
+    # Runs after #evict_occupants!, which destroys any child folder tile linking
+    # back to the root — an anchor written earlier in the build wouldn't survive.
+    def ensure_home_tile!(child)
+      return if child.board_images.reload.any? { |bi| bi.predictive_board_id == @root.id }
+
+      image = Boards::ImageResolver.resolve(child.name, owner: child.user)
+      board_image = child.add_image(image.id)
+      return if board_image.nil?
+
+      board_image.update!(
+        label: child.name,
+        display_label: child.name,
+        predictive_board_id: @root.id,
+        # Flagged like a nav tile because that is what it is — navigation chrome
+        # this service owns, not vocabulary. Every consumer that already filters
+        # `nav_tile` (specs counting a page's real content, callers reading a
+        # page's words) gets it right for free. No "mute_name": like a self tile,
+        # the way home speaks its own label.
+        data: (board_image.data || {}).merge(NAV_TILE_KEY => true).except("mute_name"),
+      )
+      relocate!(child, board_image)
+      @result.tiles_written += 1
     end
 
     # Make room for the nav region.
@@ -171,6 +202,10 @@ module Boards
       child.board_images.reload.each do |bi|
         next unless bi.data&.dig(NAV_TILE_KEY)
         next if labels.include?(bi.label.to_s.downcase)
+        # A drawer-tucked page's way home (#ensure_home_tile!) is flagged like a
+        # nav tile but its label is deliberately NOT in the region. Keep it, or
+        # every sync would drop and re-add it.
+        next if bi.predictive_board_id == @root.id
 
         bi.destroy!
         @result.folders_deleted += 1

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -246,8 +246,8 @@ module Boards
       return if unrouted.empty?
 
       favorites = fringe_by_name[FAVORITES_NAME.downcase] || create_favorites_board!(root)
-      # create_favorites_board! returns nil when the grid has no open cell for a
-      # folder tile — never overflow the authored grid. Leftovers stay unrouted.
+      # create_favorites_board! returns nil only when the folder tile could not
+      # be placed at all. Leftovers stay unrouted rather than overflowing.
       return unless favorites
 
       unrouted.each { |word| add_interest_to_board(favorites, word) }
@@ -304,14 +304,6 @@ module Boards
     # it doesn't count against the limit, and link it from the root via a folder
     # tile + predictive_board_id (mirrors the assembler/tree-builder pattern).
     def create_favorites_board!(root)
-      # Needs an open cell for its folder tile; on a grid with no slack left,
-      # adding one would spill onto a stray extra row. Skip rather than overflow
-      # (BuildBoardSetJob's catch-all still surfaces leftovers when there's room).
-      if root.open_grid_cells < 1
-        Rails.logger.warn "[SeededSetCloner] root #{root.id}: no grid space for My Favorites; leftover interests not surfaced on the home board"
-        return nil
-      end
-
       favorites = Board.new(name: FAVORITES_NAME, user: @owner)
       favorites.board_type = "static"
       favorites.assign_parent
@@ -320,11 +312,18 @@ module Boards
       favorites.settings = (favorites.settings || {}).merge("builder_child" => true)
       favorites.save!
 
-      folder_tile = root.add_image(resolve_or_create_image(FAVORITES_NAME).id)
-      # Pin the tile text to FAVORITES_NAME — an art image may be stored under
-      # different casing and BoardImage#set_defaults derives label from it.
-      folder_tile&.update!(predictive_board_id: favorites.id,
-                           label: FAVORITES_NAME, display_label: FAVORITES_NAME)
+      # Boards::FolderPlacer picks the cell: a real open cell on the home grid,
+      # else the set's "More" drawer. The authored Core 60/84 grids are full, so
+      # this used to be skipped outright and the child's leftover words never
+      # surfaced anywhere.
+      placement = Boards::FolderPlacer.place!(root: root, owner: @owner,
+                                              name: FAVORITES_NAME, board_id: favorites.id)
+      unless placement
+        Rails.logger.warn "[SeededSetCloner] root #{root.id}: could not place My Favorites; leftover interests not surfaced"
+        favorites.destroy
+        return nil
+      end
+
       favorites
     end
 

--- a/app/sidekiq/build_board_set_job.rb
+++ b/app/sidekiq/build_board_set_job.rb
@@ -469,11 +469,20 @@ class BuildBoardSetJob
     unrouted
   end
 
-  # name(downcased) => Board for every board the root's folder tiles open.
+  # name(downcased) => Board for every board reachable from the home board in
+  # one tap, PLUS everything inside the "More" drawer — Boards::FolderPlacer
+  # tucks overflow pages there when the authored grid is full, and a leftover
+  # interest word still has to find its category page.
   def set_top_level_boards_by_name(root)
-    ids = root.board_images.where.not(predictive_board_id: nil).pluck(:predictive_board_id).uniq
-    Board.where(id: ids).each_with_object({}) do |board, map|
-      map[board.name.to_s.strip.downcase] = board
+    boards_by_name(root).reverse_merge(
+      Boards::FolderPlacer.drawer_for(root)&.then { |drawer| boards_by_name(drawer) } || {},
+    )
+  end
+
+  def boards_by_name(board)
+    ids = board.board_images.where.not(predictive_board_id: nil).pluck(:predictive_board_id).uniq
+    Board.where(id: ids).each_with_object({}) do |b, map|
+      map[b.name.to_s.strip.downcase] = b
     end
   end
 
@@ -572,17 +581,16 @@ class BuildBoardSetJob
     owner = owner_for(root, communicator)
     root.reload
 
-    favorites = root.board_images
-      .joins("JOIN boards ON boards.id = board_images.predictive_board_id")
-      .where("LOWER(boards.name) = ?", "my favorites")
-      .first&.then { |bi| Board.find_by(id: bi.predictive_board_id) }
+    # Look in the "More" drawer too — Boards::SeededSetCloner may already have
+    # tucked My Favorites in there, and creating a second one would split the
+    # child's own words across two pages.
+    favorites = set_top_level_boards_by_name(root)["my favorites"]
 
     unless favorites
       # My Favorites only ever holds interests the child asked for, so it's
-      # always surfaced — growing the grid onto a new row when the authored grid
-      # is full (the authored Core 60/84 leaves no reserved cells).
-      # add_fringe_pages! clears the home board's one-page `disable_scroll` when
-      # growth happens, so the new row isn't clipped.
+      # always surfaced: FolderPlacer puts its folder tile in the drawer when
+      # the authored home grid is full, and only grows the grid (with
+      # add_fringe_pages! clearing `disable_scroll`) when there's no drawer.
       favorites = Board.new(name: "My Favorites", user: owner)
       favorites.board_type = "static"
       favorites.assign_parent
@@ -615,16 +623,16 @@ class BuildBoardSetJob
     Boards::ImageResolver.resolve(label, owner: owner)
   end
 
-  # Adds a category folder tile linking to `predictive_board_id`. Resolves an
-  # art-bearing image for `name`, then pins the tile text to `name` — the art
-  # image may be stored under different casing ("animals"), and BoardImage's
-  # set_defaults derives the label from the image, so the curated folder name
-  # ("Animals") is restored explicitly.
+  # Adds a category folder tile linking to `predictive_board_id`.
+  #
+  # Placement is Boards::FolderPlacer's call: a genuine open cell on the home
+  # grid when there is one, else the set's "More" drawer, else (no drawer) the
+  # home grid grows a row. The authored Core 60/84 grids are completely full, so
+  # in practice every page a build adds past the seed set lands in the drawer
+  # rather than stranding a lone tile on a stray row.
   def add_folder_tile!(root, owner, name, predictive_board_id)
-    image = resolve_or_create_image(owner, name)
-    tile = root.add_image(image.id)
-    tile&.update!(predictive_board_id: predictive_board_id, label: name, display_label: name)
-    tile
+    Boards::FolderPlacer.place!(root: root, owner: owner, name: name,
+                                board_id: predictive_board_id)&.tile
   end
 
   def generate_art_if_blank(owner, image, board)

--- a/spec/services/boards/folder_placer_spec.rb
+++ b/spec/services/boards/folder_placer_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.describe Boards::FolderPlacer do
+  let(:user) { create(:user) }
+  let(:root) { create(:board, user: user, name: "Core 60", large_screen_columns: 4) }
+  let(:drawer) { create(:board, user: user, name: "More", large_screen_columns: 4) }
+
+  # A tile at an exact lg cell. update_columns bypasses the layout callbacks so
+  # x/y stay precisely where the test puts them.
+  def tile(board, label, x:, y:, position:, target: nil)
+    bi = create(:board_image, board: board, position: position,
+                              image: create(:image, label: label, user_id: user.id))
+    bi.update_columns(label: label, display_label: label, predictive_board_id: target)
+    bi.update_column(:layout, { "lg" => { "i" => bi.id.to_s, "x" => x, "y" => y, "w" => 1, "h" => 1 } })
+    bi
+  end
+
+  # A miniature Core 60: a full content row, then a nav row carrying the "More"
+  # drawer. 8 tiles in a 4x2 grid — zero open cells, like the real authored set.
+  def build_full_root!(with_drawer: true)
+    pos = 0
+    %w[I want go stop].each_with_index { |label, x| tile(root, label, x: x, y: 0, position: pos += 1) }
+    tile(root, "this", x: 0, y: 1, position: pos += 1)
+    tile(root, "People", x: 1, y: 1, position: pos += 1, target: create(:board, user: user, name: "People").id)
+    if with_drawer
+      tile(root, "More", x: 2, y: 1, position: pos += 1, target: drawer.id)
+    else
+      tile(root, "here", x: 2, y: 1, position: pos += 1)
+    end
+    tile(root, "that", x: 3, y: 1, position: pos += 1)
+  end
+
+  # The drawer as authored: a partly-filled content row (gaps at x=2,3), an
+  # empty row, then its own nav row at the bottom.
+  def build_drawer!
+    pos = 0
+    %w[why how].each_with_index { |label, x| tile(drawer, label, x: x, y: 0, position: pos += 1) }
+    tile(drawer, "this", x: 0, y: 2, position: pos += 1)
+    tile(drawer, "People", x: 1, y: 2, position: pos += 1, target: create(:board, user: user, name: "People2").id)
+    tile(drawer, "More", x: 2, y: 2, position: pos += 1, target: root.id)
+    tile(drawer, "that", x: 3, y: 2, position: pos += 1)
+  end
+
+  def page!(name)
+    create(:board, user: user, name: name)
+  end
+
+  def place!(name, board_id)
+    described_class.place!(root: root, owner: user, name: name, board_id: board_id)
+  end
+
+  def lg_cell(tile)
+    tile.reload.layout["lg"].slice("x", "y")
+  end
+
+  describe "with room on the home grid" do
+    it "places the folder tile on the home board" do
+      build_full_root!
+      build_drawer!
+      root.board_images.order(:position).last.destroy # free one cell
+
+      bathroom = page!("Bathroom")
+      result = place!("Bathroom", bathroom.id)
+
+      expect(result.destination).to eq(:root)
+      expect(result.board.id).to eq(root.id)
+      expect(result.tile.predictive_board_id).to eq(bathroom.id)
+      expect(drawer.board_images.reload.map(&:label)).not_to include("Bathroom")
+    end
+  end
+
+  describe "with a full home grid and a More drawer" do
+    before do
+      build_full_root!
+      build_drawer!
+    end
+
+    it "tucks the page into the drawer and leaves the authored grid untouched" do
+      bathroom = page!("Bathroom")
+
+      result = place!("Bathroom", bathroom.id)
+
+      expect(result.destination).to eq(:drawer)
+      expect(result.board.id).to eq(drawer.id)
+      expect(root.board_images.reload.count).to eq(8)
+      expect(root.reload.large_screen_rows).to eq(2)
+      expect(drawer.board_images.reload.map(&:label)).to include("Bathroom")
+    end
+
+    it "pins the authored folder name and the board it opens" do
+      bathroom = page!("Bathroom")
+
+      tile = place!("Bathroom", bathroom.id).tile
+
+      expect(tile.label).to eq("Bathroom")
+      expect(tile.display_label).to eq("Bathroom")
+      expect(tile.predictive_board_id).to eq(bathroom.id)
+    end
+
+    it "starts a band on the first empty row rather than filling gaps in a word row" do
+      tile = place!("Bathroom", page!("Bathroom").id).tile
+
+      # y=0 has open cells at x=2,3, but it is authored content — the band goes
+      # on the empty row instead.
+      expect(lg_cell(tile)).to eq({ "x" => 0, "y" => 1 })
+    end
+
+    it "packs successive pages into the same band instead of one row each" do
+      first  = place!("Bathroom", page!("Bathroom").id).tile
+      second = place!("Animals", page!("Animals").id).tile
+      third  = place!("Music", page!("Music").id).tile
+
+      expect(lg_cell(first)).to eq({ "x" => 0, "y" => 1 })
+      expect(lg_cell(second)).to eq({ "x" => 1, "y" => 1 })
+      expect(lg_cell(third)).to eq({ "x" => 2, "y" => 1 })
+    end
+
+    it "mirrors the placement into the drawer's own layout column" do
+      tile = place!("Bathroom", page!("Bathroom").id).tile
+
+      expect(drawer.reload.layout["lg"][tile.id.to_s]).to include("x" => 0, "y" => 1)
+    end
+
+    # Boards::NavRowSync destroys any folder tile on a child page whose label
+    # matches a nav category, so a colliding page tucked into the drawer would
+    # be silently orphaned.
+    it "keeps a page whose name collides with a nav label on the home board" do
+      people = page!("People")
+
+      result = place!("People", people.id)
+
+      expect(result.destination).to eq(:grown)
+      expect(result.board.id).to eq(root.id)
+    end
+
+    it "falls back to growing the home grid once the drawer is full" do
+      # The drawer holds 6 more tiles above its nav row: the empty row (4) plus
+      # the two gaps in its word row.
+      results = 7.times.map { |i| place!("Page#{i}", page!("Page#{i}").id) }
+
+      expect(results.first(6).map(&:destination)).to all(eq(:drawer))
+      expect(results.last.destination).to eq(:grown)
+      expect(results.last.board.id).to eq(root.id)
+    end
+  end
+
+  describe "with no drawer (legacy starter trees)" do
+    it "grows the home grid as before" do
+      build_full_root!(with_drawer: false)
+
+      result = place!("Bathroom", page!("Bathroom").id)
+
+      expect(result.destination).to eq(:grown)
+      expect(result.board.id).to eq(root.id)
+      expect(root.board_images.reload.count).to eq(9)
+    end
+  end
+
+  describe ".drawer_for" do
+    it "finds the board the root's More tile opens" do
+      build_full_root!
+
+      expect(described_class.drawer_for(root)&.id).to eq(drawer.id)
+    end
+
+    it "is nil when the root has no More folder tile" do
+      build_full_root!(with_drawer: false)
+
+      expect(described_class.drawer_for(root)).to be_nil
+    end
+
+    it "ignores a More tile pointing at another user's board" do
+      build_full_root!
+      drawer.update!(user: create(:user))
+
+      expect(described_class.drawer_for(root)).to be_nil
+    end
+  end
+end

--- a/spec/services/boards/nav_row_sync_spec.rb
+++ b/spec/services/boards/nav_row_sync_spec.rb
@@ -124,4 +124,48 @@ RSpec.describe Boards::NavRowSync do
     expect(result.boards_synced).to eq(2)         # Food + Drinks
     expect(result.tiles_written).to eq(8)         # 4 nav cells x 2 pages
   end
+
+  # Boards::FolderPlacer tucks build-added pages into the "More" drawer, so they
+  # have no cell of their own in the nav region. They still need a one-tap way
+  # home — every page in a built set has one.
+  describe "a page with no nav cell of its own" do
+    let!(:drawer) { create(:board, user: user, name: "More", large_screen_columns: 6) }
+    let!(:animals) { create(:board, user: user, name: "Animals", large_screen_columns: 6) }
+
+    before do
+      # Swap the root's "Drinks" nav tile for the "More" drawer, and hang
+      # Animals off the drawer rather than the home board.
+      root.board_images.find_by(label: "Drinks").update!(label: "More", display_label: "More",
+                                                        predictive_board_id: drawer.id)
+      tile(drawer, "why", x: 0, y: 0, position: 1)
+      tile(drawer, "Animals", x: 1, y: 0, position: 2, target: animals.id)
+      tile(animals, "dog", x: 0, y: 0, position: 1)
+    end
+
+    it "gives it a tile named for the page that opens the root" do
+      described_class.call(root)
+
+      home = animals.board_images.reload.find { |bi| bi.predictive_board_id == root.id }
+      expect(home).to be_present, "Animals has no way home"
+      expect(home.display_label).to eq("Animals")
+      expect(home.data.to_h["mute_name"]).not_to be(true)
+    end
+
+    it "gives every page in the set a way home" do
+      described_class.call(root)
+
+      [food, drawer, animals].each do |page|
+        expect(page.board_images.reload.map(&:predictive_board_id)).to include(root.id),
+          "#{page.name} has no way home"
+      end
+    end
+
+    it "does not add a second anchor to a page that already has its self tile" do
+      described_class.call(root)
+
+      home_tiles = food.board_images.reload.select { |bi| bi.predictive_board_id == root.id }
+      expect(home_tiles.size).to eq(1)
+      expect(home_tiles.first.label).to eq("Food")
+    end
+  end
 end

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -399,5 +399,32 @@ RSpec.describe Boards::SeededSetCloner do
           "expected cloned fringe '#{board.name}' to keep disable_scroll"
       end
     end
+
+    # The authored Core 60 grid is 60 tiles in 60 cells, so My Favorites had
+    # nowhere to put its folder tile and was skipped outright — the child's own
+    # words surfaced nowhere. Boards::FolderPlacer tucks it into "More".
+    describe "leftover interests on a full authored grid" do
+      let!(:cloned_root) do
+        source_root = Boards::RobustSets.find_root("core-60")
+        described_class.new(source_root, communicator: communicator, interests: %w[zamboni]).call
+      end
+
+      it "surfaces My Favorites in the More drawer without growing the home grid" do
+        expect(cloned_root.board_images.count).to eq(60)
+        expect(cloned_root.large_screen_rows).to eq(6)
+        expect(cloned_root.board_images.map(&:display_label)).not_to include("My Favorites")
+
+        more = Boards::FolderPlacer.drawer_for(cloned_root)
+        expect(more).to be_present
+        expect(more.board_images.reload.map(&:display_label)).to include("My Favorites")
+      end
+
+      it "keeps the leftover word instead of dropping it" do
+        favorites = owner.boards.find_by(name: "My Favorites")
+
+        expect(favorites).to be_present
+        expect(favorites.board_images.map { |bi| bi.label.to_s.downcase }).to include("zamboni")
+      end
+    end
   end
 end

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -102,21 +102,45 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     end
   end
 
+  # Every board in the built set. Pages the build adds may live one level down —
+  # Boards::FolderPlacer tucks them into the "More" drawer rather than growing
+  # the authored grid — so set-wide assertions can't just read the home board.
+  def set_boards(root)
+    Board.where(id: described_class.new.send(:set_board_ids, root))
+  end
+
   # The home board is not the only page a communicator navigates from: every
   # seeded fringe page carries the nav row too, so the dead-tile check has to
   # sweep the WHOLE set. Checking only the root is what hid the Core 84 Food
   # page's dead `More` folder.
   def dead_folder_tiles_in_set(root)
-    Board.where(id: described_class.new.send(:set_board_ids, root)).filter_map do |board|
+    set_boards(root).filter_map do |board|
       dead = dead_folder_tiles(board)
       "#{board.name}: #{dead.map(&:display_label).inspect}" if dead.any?
     end
   end
 
-  it "keeps every authored folder working and grows the grid to surface all interests" do
+  # The folder tile for `name` anywhere in the set (home board or the drawer).
+  def folder_tile_in_set(root, name)
+    set_boards(root).flat_map { |b| b.board_images.to_a }
+      .find { |bi| bi.display_label.to_s == name && bi.predictive_board_id.present? }
+  end
+
+  def board_named_in_set(root, name)
+    tile = folder_tile_in_set(root, name)
+    tile && Board.find(tile.predictive_board_id)
+  end
+
+  # Every word on every page of the set — what "nothing the child asked for is
+  # dropped" actually means now that a page can sit inside the drawer.
+  def words_in_set(root)
+    set_boards(root).flat_map { |b| b.board_images.map { |bi| bi.label.to_s.downcase } }
+  end
+
+  it "keeps every authored folder working and surfaces all interests without growing the grid" do
     # The authored Core 84 grid is full (84 tiles, no reserved cells), so these
-    # non-seed interest categories must GROW the grid onto new rows rather than
-    # being dropped.
+    # non-seed interest categories go into the "More" drawer rather than onto a
+    # stray row — and are never dropped.
     root = build!([
       { "word" => "dog", "category" => "Animals" },
       { "word" => "guitar", "category" => "Music" },
@@ -127,10 +151,10 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
 
     expect(root.status).to eq("complete")
 
-    # The full authored grid grows to fit the interest pages.
-    expect(root.board_images.count).to be > CORE_84_GRID_CELLS
-    # Growth is controlled, not runaway — at most a couple of extra rows.
-    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS + (3 * 12)
+    # The authored grid is preserved exactly — no stray row, no "85th tile".
+    expect(root.board_images.count).to eq(CORE_84_GRID_CELLS)
+    # ...so the seed's one-page display survives the build.
+    expect(root.settings["disable_scroll"]).to be(true)
 
     # No dead tiles: every added folder tile links a real board, and the
     # authored folders the planner used to strip are intact — on every page in
@@ -145,17 +169,14 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
       expect(tile.predictive_board_id).to be_present, "#{name} folder tile has no linked board"
     end
 
-    # Grown past the authored grid → the home board may scroll, so the new rows
-    # aren't clipped by the seed's one-page (disable_scroll) layout.
-    expect(root.settings["disable_scroll"]).not_to eq(true)
+    # The interest pages live in the drawer, reachable from every page's nav row.
+    more = board_named_in_set(root, "More")
+    drawer_folders = more.board_images.select(&:predictive_board_id).map(&:display_label)
+    expect(drawer_folders).to include("Animals", "Music", "Sports", "Transportation", "Clothing")
 
-    # Nothing the child asked for is dropped: every interest lands on a working
-    # linked board (its own fringe page, an existing folder, or My Favorites).
-    routed = root.board_images
-      .select(&:predictive_board_id)
-      .flat_map { |bi| Board.find(bi.predictive_board_id).board_images.map { |t| t.label.to_s.downcase } }
+    # Nothing the child asked for is dropped.
     %w[dog guitar soccer train shirt].each do |word|
-      expect(routed).to include(word), "interest '#{word}' was dropped"
+      expect(words_in_set(root)).to include(word), "interest '#{word}' was dropped"
     end
   end
 
@@ -205,7 +226,8 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     # The default applies across the whole built set, not just the home board —
     # except each page's SELF tile, the one folder tile that speaks its label
     # (it's the you-are-here anchor and the way home). See Boards::NavRowSync.
-    animals = Board.find(root.board_images.find { |bi| bi.display_label == "Animals" }.predictive_board_id)
+    animals = board_named_in_set(root, "Animals")
+    expect(animals).to be_present
     animals.board_images.select(&:is_dynamic?).each do |bi|
       next if bi.label.to_s.strip.casecmp?(animals.name.to_s.strip)
 
@@ -219,10 +241,10 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
   end
 
   # The "86 tiles instead of 84" report (uncontrolled spill of dead/duplicate
-  # tiles) is now a *controlled growth* guarantee: when the authored grid has no
-  # open cells, interest pages grow onto new rows as real, working folders —
-  # never dropped, never dead/duplicate, never runaway.
-  it "grows in a controlled way when the seed has no open cells" do
+  # tiles) is now a *no growth at all* guarantee: when the authored grid has no
+  # open cells, interest pages go into the "More" drawer as real, working
+  # folders — never dropped, never dead/duplicate, never on a stray row.
+  it "tucks pages into the drawer when the seed has no open cells" do
     shrink_seed_grid!(remaining: 0)
     # Early-stage gestalt -> quick-phrase strip, the most aggressive cell user.
     communicator.update!(details: (communicator.details || {}).merge("glp_stage" => 1))
@@ -234,18 +256,22 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     ])
 
     expect(root.status).to eq("complete")
+    # Home board AND the drawer the build wrote into. (Scoped to these two on
+    # purpose: the authored Food seed page ships a dead "More" tile, which
+    # predates this change — see the follow-up issue.)
     expect(dead_folder_tiles(root)).to be_empty
-    # Bounded growth, not a runaway stack of rows.
-    expect(root.board_images.count).to be <= CORE_84_GRID_CELLS + (3 * 12)
+    expect(dead_folder_tiles_in_set(root)).to be_empty
+    # No growth at all: the authored grid is untouched.
+    expect(root.board_images.count).to eq(CORE_84_GRID_CELLS)
+    expect(root.settings["disable_scroll"]).to be(true)
 
     # Nothing dropped: the seed-alias interest lands in its cloned seed page and
-    # the fringe interests are surfaced on their linked boards.
-    routed = root.board_images
-      .select(&:predictive_board_id)
-      .flat_map { |bi| Board.find(bi.predictive_board_id).board_images.map { |t| t.label.to_s.downcase } }
+    # the fringe interests are surfaced on their linked boards in the drawer.
     %w[grandma toilet dog].each do |word|
-      expect(routed).to include(word), "interest '#{word}' was dropped"
+      expect(words_in_set(root)).to include(word), "interest '#{word}' was dropped"
     end
+    expect(board_named_in_set(root, "Bathroom")).to be_present
+    expect(board_named_in_set(root, "Animals")).to be_present
   end
 
   # Aliased InterestCategories ("Family & People" -> People, "Health & Body" ->
@@ -297,8 +323,10 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     root = build!([{ "word" => "dog", "category" => "Animals" }])
 
     people_tile = root.board_images.find { |bi| bi.display_label == "People" }
-    animals_tile = root.board_images.find { |bi| bi.display_label == "Animals" }
+    # Added by the build, so it lives in the "More" drawer, not on the home board.
+    animals_tile = folder_tile_in_set(root, "Animals")
 
+    expect(animals_tile).to be_present
     expect(Boards::ImageResolver.art?(people_tile.image)).to be(true)
     expect(Boards::ImageResolver.art?(animals_tile.image)).to be(true)
   end

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -267,6 +267,69 @@ RSpec.describe BuildBoardSetJob do
     end
   end
 
+  # The authored Core 60 is 60 tiles in a full 6x10 grid, so a fringe page the
+  # build adds used to spill onto a stray row — one lone "Bathroom" folder above
+  # the nav row, a home board reading "61 tiles", and the loss of the seed's
+  # one-page display. Boards::FolderPlacer tucks it into the "More" drawer.
+  describe "#perform overflow into the More drawer (real Core 60 seed)" do
+    before_all do
+      register_openai_webmock_stub!
+      register_external_webmock_stubs!
+      User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      VocabSets.seed_slug!("core-60")
+      Boards::FringeTemplates.seed_all!
+    end
+
+    # "toilet" routes to Bathroom, which core-60 has no seed page for but
+    # db/seeds/board_builder_sets/fringe-pages/bathroom.obf does.
+    def build_with_bathroom_interest!
+      root = precreate_root!(name: "Core 60")
+      described_class.new.perform(root.id, communicator.id, "standard", %w[toilet])
+      root.reload
+    end
+
+    it "leaves the home board at its authored 60 tiles and 6 rows" do
+      root = build_with_bathroom_interest!
+
+      expect(root.board_images.count).to eq(60)
+      expect(root.large_screen_rows).to eq(6)
+    end
+
+    it "keeps the home board's one-page display" do
+      root = build_with_bathroom_interest!
+
+      expect(root.settings["disable_scroll"]).to be(true)
+    end
+
+    it "puts the Bathroom folder tile inside More, not on the home board" do
+      root = build_with_bathroom_interest!
+
+      expect(root.board_images.map(&:display_label)).not_to include("Bathroom")
+
+      more = Boards::FolderPlacer.drawer_for(root)
+      expect(more).to be_present
+      bathroom_tile = more.board_images.reload.find { |bi| bi.display_label == "Bathroom" }
+      expect(bathroom_tile).to be_present, "expected the Bathroom folder tile in the More drawer"
+
+      bathroom = Board.find(bathroom_tile.predictive_board_id)
+      expect(bathroom.settings["builder_child"]).to be(true)
+      expect(bathroom.board_images.map { |bi| bi.label.to_s.downcase }).to include("toilet")
+    end
+
+    it "keeps the tucked page in the builder set (nav row, group walk, cascade)" do
+      root = build_with_bathroom_interest!
+
+      more = Boards::FolderPlacer.drawer_for(root)
+      bathroom_id = more.board_images.reload.find { |bi| bi.display_label == "Bathroom" }.predictive_board_id
+
+      expect(described_class.new.send(:set_board_ids, root)).to include(bathroom_id)
+      # board_images.label is the lowercase matching key; display_label is the text.
+      nav_labels = Board.find(bathroom_id).board_images
+        .select { |bi| bi.data&.dig("nav_tile") }.map { |bi| bi.label.to_s.downcase }
+      expect(nav_labels).to include("people", "more")
+    end
+  end
+
   describe "#perform with a robust seeded set" do
     it "clones the set into the pre-created root, rewires links, routes interests, and completes" do
       source_root = seed_robust_set!

--- a/spec/sidekiq/build_board_set_job_spec.rb
+++ b/spec/sidekiq/build_board_set_job_spec.rb
@@ -67,14 +67,17 @@ RSpec.describe BuildBoardSetJob do
 
       children.each do |child|
         nav = child.board_images.reload.select { |bi| bi.data&.dig("nav_tile") }
-        expect(nav.map(&:label)).to match_array(region.cells.map(&:label)),
+        # Every region cell is projected. A page may carry ONE more nav-flagged
+        # tile than the region has cells: its way home, when its own name has no
+        # cell in the region (Boards::NavRowSync#ensure_home_tile!).
+        expect(nav.map(&:label)).to include(*region.cells.map(&:label)),
                                     "#{child.name} is missing nav tiles"
 
-        self_tile = nav.find { |bi| bi.label.to_s.casecmp?(child.name.to_s) }
-        next if self_tile.nil? # a page with no tile of its own name in the region
-
-        expect(self_tile.predictive_board_id).to eq(root.id)
-        expect(self_tile.data["mute_name"]).to be_falsey
+        # The invariant that matters: every page in the set has a one-tap home.
+        home = nav.find { |bi| bi.predictive_board_id == root.id }
+        expect(home).to be_present, "#{child.name} has no way home"
+        expect(home.label.to_s.downcase).to eq(child.name.to_s.downcase)
+        expect(home.data["mute_name"]).to be_falsey
       end
     end
 


### PR DESCRIPTION
## The problem

A Core 60 set built by the Board Builder came out with **61 tiles**: one lone `Bathroom` folder stranded on a row of its own between the core words and the nav row, and a home board that now scrolled.

The authored core grids are **completely full** — Core 60 is 60 tiles in a 6×10 grid, Core 84 is 84 in 7×12. Zero reserved cells, in both. `Board#add_image` starts a new row once a grid is full, so every page a build adds past the seed set lands on its own row, and `Boards::NavRegion` then rotates the authored nav row back underneath it. The seed's one-page `disable_scroll` gets cleared along with it.

(The spoke doc claimed Core 84 had "3 intentional gaps". It doesn't — corrected here.)

## The fix — two commits

### 1. Overflow goes into the "More" drawer (`5b02ae7d`)

**`Boards::FolderPlacer`** becomes the single authority on where a top-level folder tile goes:

1. a genuine open cell on the home grid (`Board#open_grid_cells`);
2. else the set's **"More" drawer** — the board the root's `More` tile opens, owner-scoped. `More` is on the nav row of every page, so the page stays two taps from anywhere, and it ships mostly empty (Core 60's `More`: 31 tiles in 60 cells);
3. else grow the home grid, as before. Only the legacy starter trees (`home`, `daily_routine`) have no `More`, so in practice this is the drawer-is-full case.

Every top-level tile-adder routes through it — `BuildBoardSetJob#add_folder_tile!` (prebuilt fringe, AI pages, My Favorites) and `SeededSetCloner#create_favorites_board!`. The Phrases layer is unaffected: it already bails when the home grid has no open cell, so it never reaches step 2.

**Two placement rules inside the drawer that are load-bearing:**

- **Tiles pack into a band**, on the first row above the nav row that already holds nothing but folder tiles, else the first fully-empty row. `next_available_cell` would instead fill the two authored gaps in Core 60's `More` top row — dropping `Bathroom` between `for` and `here`.
- **The drawer's nav row is its BOTTOM row**, deliberately *not* `NavRegion.authored_nav_y`. That helper picks whichever row holds the most folder tiles; a band that grew to the nav row's count wins the tie on lower `y`, and the next placement starts overwriting nav cells. A spec caught this on the first pass.

`FolderPlacer` also refuses the drawer for a page whose name matches a nav-region label — `NavRowSync#evict_occupants!` destroys those on child pages, which would silently orphan the page.

**Also fixed along the way:** `SeededSetCloner#create_favorites_board!` logged a warning and gave up when the grid had no open cell. On Core 60/84 that is *always*, so a child's leftover interest words surfaced nowhere at all. They now land in the drawer.

### 2. Keep a one-tap way home on drawer-tucked pages (`cb285df1`)

The first commit shipped a regression, caught by widening the grid spec's assertions from the home board to the whole set. **Every page in a built set has a one-tap way home** — a page whose name sits in the nav region gets it from its SELF tile — but a drawer-tucked page has no nav cell of its own, so nothing gave it one. From `Animals` you could only reach home via `More`.

`NavRowSync#ensure_home_tile!` gives such a page the same anchor explicitly: a tile carrying the page's name that opens the root, unmuted so it speaks like a self tile. It must run **after** `evict_occupants!`, which destroys any child folder tile pointing back at the root, so an anchor written earlier in the build would not survive. The tile is flagged `nav_tile` because that is what it is — navigation chrome this service owns, not vocabulary — so every consumer already filtering nav tiles gets it right; `drop_orphaned_nav_tiles!` then exempts root-linked tiles, or each sync would drop and re-add it.

This also fixes pages that **never** had a way home: the GLP function boards under Phrases are depth-2 and out of the nav region.

## Reviewer notes

- Because a page can now live one level down, `BuildBoardSetJob#set_top_level_boards_by_name` reads the root's folder targets **plus the drawer's** — otherwise a leftover interest word wouldn't find its category page. `#add_to_favorites!` looks through the same map, so the cloner's drawer-tucked `My Favorites` isn't duplicated.
- `set_board_ids` already walks the link graph unbounded (#586), so BoardGroup membership, group attachment, screen reflow and cascade-delete pick up the tucked page with no change.
- `allow_scroll_if_grown!` stays as the safety net for case 3.
- **Forward-only by design** — existing built sets keep their stray row. No backfill task, per product call.
- Default (no-interest) fringe pages still fill only genuine open cells; they're never tucked into the drawer just to surface content the child didn't ask for.
- Rebased onto `main` after #649 landed. That fixed the Core 84 Food page's dead `More` tile at its root, so the narrower dead-tile assertion this branch originally carried (home board + drawer, with a comment excusing Food) was dropped in favour of #649's whole-set `dead_folder_tiles_in_set`, applied to both tests here.

## Test plan

`RAILS_ENV=test bundle exec rspec spec/services/boards spec/sidekiq spec/requests/api/v1/board_builder_spec.rb spec/requests/admin/board_builds_spec.rb spec/services/vocab_sets_spec.rb spec/models/board_spec.rb`

**1258 examples, 0 failures** (1 pending, pre-existing). Re-verified after the final rebase across the grid spec, build job spec, nav sync, folder placer, cloner and vocab sets: **152 examples, 0 failures**.

New coverage:

- `spec/services/boards/folder_placer_spec.rb` — placement order, band packing across successive pages, the authored-gap refusal, the nav-label collision refusal, drawer-full fallback, `drawer_for` ownership scoping.
- `spec/sidekiq/build_board_set_job_spec.rb` — end-to-end against the **real seeded Core 60** with a `toilet` interest (the exact reported case): home board stays 60 tiles / 6 rows, keeps `disable_scroll`, `Bathroom` lands in `More`, and the tucked page still joins the set's board walk and gets its nav row.
- `spec/services/boards/nav_row_sync_spec.rb` — a page with no nav cell of its own gets a home anchor; every page in the set has a way home; a page that already has its self tile doesn't get a second one.
- `spec/services/boards/seeded_set_cloner_spec.rb` — leftover interests on a full authored grid surface in the drawer instead of being dropped.
- `spec/sidekiq/build_board_set_job_grid_spec.rb` — rewritten from the old "grows the grid" contract to the drawer contract.

Docs: `.claude-notes/board-builder.md` grid-cap section rewritten; `CHANGELOG.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)