### PR TITLE
feat(admin): draft one board-builder page at a time from its title

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -325,6 +325,36 @@ describing words, 25–35% topic nouns; no near-duplicates; and **exactly**
 
 No credit charge — admin-owned. Populate the form; never build from it directly.
 
+#### Per-page drafting — `Boards::AdminBuilder::PageDrafter`
+
+Page title + tile count (+ board topic/audience as optional context) →
+`[{ label:, part_of_speech:, links_to: }]` for **one** child page. Backs the
+`Draft this page with AI` button in each page block; `draft_page` merges the
+result into `children[page_index]` only, so the root and every sibling survive.
+
+Not `WordListDrafter` with a different topic, and not a slice of `SetDrafter`:
+
+- The page title is the subject, and it's the one input that can't be inferred —
+  `draft_page` rejects a nameless page rather than guessing. The `key` stands in
+  only when there's no title, underscores folded back to spaces.
+- **No `CORE_SPINE`.** The root carries the core words the whole set leans on; a
+  page that repeats "I / want / more / help" spends its cells twice.
+- **Exactly one `back` tile linking to `Plan::ROOT_KEY`**, counted toward the
+  page's tile count. `link_for` drops every other target: this drafter is given
+  one page and knows no other page's key, and `PlanValidator` rejects a link to
+  a key that isn't in the set.
+- Tile count is the page's own override when set, else the root's — what the
+  page will actually be built at.
+
+**No `MAX_PAGES` ceiling here**, unlike `SetDrafter`. One page per call is the
+accurate way to draft a set larger than `SetDrafter::MAX_PAGES`, where a single
+long response starts dropping per-page tile counts.
+
+The button posts its index as the submit's `name="page_index"` value rather than
+a field, so `reindexPages()` has to rewrite that `value` alongside the field
+`name`s — renumbering names alone leaves a moved block drafting into whichever
+page took its old position.
+
 ### Phase 3 — linked child pages
 
 - Plan gains `children: [{ key, name, tiles }]` and tiles gain `links_to`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **The admin board builder can draft one page at a time from its title.** Each
+  page block gets a "Draft this page with AI" button that fills only that page's
+  word list, worked out from the page's own name with the board's topic as
+  context — the main board and every other page stay exactly as typed. Previously
+  the only way to get AI words onto a page was "Draft the whole set", which
+  replaced everything. Drafted pages come back with a "back" tile already
+  pointing home, and there's no four-page limit the way the whole-set draft has.
+
 - **Deleting a board can now take its subboards with it.** A board whose
   buttons open other boards asks before deleting, and offers an optional
   "Also delete its N subboards" that removes the whole linked set in one go.

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -135,6 +135,41 @@ module Admin
       render :new, status: :unprocessable_entity
     end
 
+    # Per-page form of `draft`: fills ONE child page's word list from that
+    # page's title, leaving the root and every other page exactly as typed.
+    # `draft_set` is the only other way to get words onto a page and it replaces
+    # the whole set, so editing one page of a set previously meant re-drafting
+    # (and re-editing) all of it.
+    #
+    # Also the way past SetDrafter::MAX_PAGES: one page per call keeps the
+    # per-page tile count accurate where a single long response drifts.
+    def draft_page
+      @form = submitted_form
+      index = params[:page_index].to_i
+      child = @form[:children][index]
+
+      @problems = draft_page_problems(@form, child)
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      tile_count = child[:tile_count].presence&.to_i || @form[:tile_count].to_i
+      tiles = Boards::AdminBuilder::PageDrafter.new(
+        page_name: child[:name],
+        page_key: child[:key],
+        tile_count: tile_count,
+        # The page title is the subject; a blank board topic is context this
+        # page can do without, so no ContextSuggester round trip here.
+        topic: @form[:topic],
+        audience: @form[:audience],
+      ).call
+
+      @form[:children][index] = child.merge(words: tiles_to_words(tiles), tiles: tiles)
+      flash.now[:notice] = draft_page_notice(tiles, child, tile_count)
+      render :new
+    rescue Boards::AdminBuilder::PageDrafter::GenerationError => e
+      @problems = ["Couldn't draft that page: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    end
+
     # Fills in topic and audience on their own, so they can be read and edited
     # before a whole word list is drafted from them.
     def suggest
@@ -435,6 +470,35 @@ module Admin
       problems << "Columns must be between 1 and #{MAX_COLUMNS}." unless columns.between?(1, MAX_COLUMNS)
       problems << "Tiles must be between 1 and #{MAX_TILES}." unless tiles.between?(1, MAX_TILES)
       problems
+    end
+
+    # A page title is the whole input, so it's the one thing that can't be
+    # inferred. The tile count is the page's own override when it has one and
+    # the root's otherwise, matching what the page will actually be built at.
+    def draft_page_problems(form, child)
+      return ["That page is no longer on the form — add it again before drafting."] if child.nil?
+
+      problems = []
+      if child[:name].blank? && child[:key].blank?
+        problems << "Give the page a name to draft from."
+      end
+
+      tiles = child[:tile_count].presence&.to_i || form[:tile_count].to_i
+      problems << "Tiles must be between 1 and #{MAX_TILES}." unless tiles.between?(1, MAX_TILES)
+      problems
+    end
+
+    # Same shortfall handling as draft_notice — the drafter can come back short
+    # when near-duplicates get dropped, and the admin should hear that here
+    # rather than discover it at preview.
+    def draft_page_notice(tiles, child, wanted)
+      page = child[:name].presence || child[:key]
+      if tiles.size == wanted
+        return "Drafted #{tiles.size} words for “#{page}”. Edit them, then preview the art."
+      end
+
+      "Drafted #{tiles.size} of #{wanted} words for “#{page}” — " \
+        "add #{wanted - tiles.size} more before previewing."
     end
 
     def tiles_to_words(tiles)

--- a/app/services/boards/admin_builder/page_drafter.rb
+++ b/app/services/boards/admin_builder/page_drafter.rb
@@ -1,0 +1,170 @@
+module Boards
+  module AdminBuilder
+    # Drafts the word list for ONE child page, from that page's title.
+    #
+    # The output ONLY EVER POPULATES THE FORM, like every other drafter here. A
+    # human edits it, previews the art, then builds.
+    #
+    # Deliberately not WordListDrafter with a different topic. That one opens
+    # with CORE_SPINE and never emits a link, and both are wrong for a page: the
+    # root carries the core words the whole set leans on, a page carries its own
+    # subject's, and a page with no way home is a dead end for a communicator.
+    # The prompt is SetDrafter's per-page half, scoped to a single page.
+    #
+    # Unlike SetDrafter there is no page ceiling here — one page per call is how
+    # a set larger than SetDrafter::MAX_PAGES gets drafted without the per-page
+    # tile counts slipping.
+    #
+    # No credit charge: the boards it drafts are admin-owned.
+    class PageDrafter
+      class GenerationError < StandardError; end
+
+      # 12x12, matching the controller's grid ceiling.
+      MAX_TILES = 144
+
+      # `topic` is the whole board's subject and is optional context — the page
+      # title is the actual input, and a page can be drafted before the board
+      # has a topic at all.
+      def initialize(page_name:, tile_count:, page_key: nil, topic: nil, audience: nil)
+        @page_name = page_name.to_s.strip
+        @page_key = page_key.to_s.strip
+        @tile_count = tile_count.to_i.clamp(1, MAX_TILES)
+        @topic = topic.to_s.strip
+        @audience = audience.to_s.strip
+      end
+
+      def call
+        raise GenerationError, "give the page a name to draft from" if subject.blank?
+
+        parse_response(generate_via_openai)
+      end
+
+      private
+
+      attr_reader :page_name, :page_key, :tile_count, :topic, :audience
+
+      # The key is a fallback rather than an equal: it's an identifier
+      # ("my_turn"), so it only stands in when there is no title to read.
+      def subject
+        page_name.presence || page_key.tr("_", " ").strip
+      end
+
+      def generate_via_openai
+        client = OpenAiClient.new(
+          prompt: subject,
+          messages: [{ role: "user", content: build_prompt }],
+        )
+        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
+        result = client.create_chat(true)
+
+        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
+
+        result[:content]
+      end
+
+      def build_prompt
+        <<~PROMPT
+          You are filling in ONE page of a set of AAC (Augmentative and Alternative
+          Communication) boards for a nonspeaking communicator.
+
+          The page is about: #{subject}
+          #{topic.present? ? "It is a page on a board about: #{topic}" : ""}
+          #{audience.present? ? "It is for: #{audience}" : ""}
+
+          Generate EXACTLY #{tile_count} tiles for this page — it is a fixed grid and a
+          count that doesn't fill whole rows leaves visible dead cells.
+
+          Structure rules:
+          - Exactly ONE tile goes back to the main board: label it "back", with
+            "links_to" set to "#{Plan::ROOT_KEY}". It counts towards the #{tile_count} tiles.
+          - No other tile has "links_to" — this page opens nothing further.
+
+          Word rules:
+          - A board for talking, not a vocabulary list. Favour words that finish a
+            sentence over words that name a thing.
+          - This is a page, not the main board: the main board already carries the core
+            words the whole set leans on, so spend these cells on #{subject} rather than
+            repeating "I", "want", "more" and "help".
+          - No near-duplicates ("happy" and "glad", "big" and "large"). Each tile costs a
+            cell.
+          - Keep each label short — 1-2 words.
+          - Concrete and age-appropriate.
+          - A label is display text, not an identifier: separate words with a plain
+            space, never an underscore.
+          - Give every tile a part_of_speech from exactly this list:
+            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
+          - Classify by communicative function, not strict grammar: "more", "yes" and
+            "please" are social; "no", "not" and "stop" are important_function.
+
+          Respond in JSON format:
+          {
+            "tiles": [
+              { "label": "apple", "part_of_speech": "noun" },
+              { "label": "hungry", "part_of_speech": "adjective" },
+              { "label": "back", "part_of_speech": "social", "links_to": "#{Plan::ROOT_KEY}" }
+            ]
+          }
+
+          Return ONLY the JSON, no other text.
+        PROMPT
+      end
+
+      def parse_response(raw)
+        data = JSON.parse(raw)
+        tiles = dedupe(Array(data["tiles"])).first(tile_count)
+
+        # Only a response with nothing usable in it is an error — this fills a
+        # textarea, so a short draft is survivable and the form's counter shows
+        # the gap.
+        raise GenerationError, "AI returned no usable words" if tiles.empty?
+
+        tiles
+      rescue JSON::ParserError => e
+        raise GenerationError, "Failed to parse AI response: #{e.message}"
+      end
+
+      # Exact and casing-only repeats are dropped here rather than left for
+      # PlanValidator: `images.label` is a lowercase matching key, so "Go" and
+      # "go" are one symbol, and a draft that fails validation on arrival is
+      # worse than a short one. Near-duplicates are the prompt's job.
+      def dedupe(raw_tiles)
+        seen = Set.new
+
+        raw_tiles.filter_map do |tile|
+          next unless tile.is_a?(Hash)
+
+          label = sanitize_label(tile["label"] || tile["word"])
+          next if label.blank?
+          next unless seen.add?(label.downcase)
+
+          { label: label, part_of_speech: part_of_speech_for(tile), links_to: link_for(tile) }.compact
+        end
+      end
+
+      # The model occasionally answers a multi-word label snake_cased, like an
+      # identifier rather than the tile text it's meant to be — underscores have
+      # no legitimate place in display text, so they're folded to spaces rather
+      # than left for the admin to notice and retype.
+      def sanitize_label(raw)
+        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
+      end
+
+      # An unrecognized value would be rejected by PlanValidator on preview, so
+      # fall back to "default" (grey) and let the admin re-colour it rather than
+      # handing back a list that can't be submitted.
+      def part_of_speech_for(tile)
+        value = tile["part_of_speech"].to_s.strip.downcase
+        ColorHelper::PARTS_OF_SPEECH.include?(value) ? value : "default"
+      end
+
+      # Only the back edge survives. This drafter is given one page and knows no
+      # other page's key, so a link anywhere else would name a page it can't
+      # vouch for — and PlanValidator rejects a link to a key that isn't in the
+      # set, which is worse than a tile that simply doesn't open anything.
+      def link_for(tile)
+        target = tile["links_to"].to_s.strip.downcase
+        target == Plan::ROOT_KEY ? target : nil
+      end
+    end
+  end
+end

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -211,6 +211,16 @@
               <button type="button" class="remove-page text-t3 hover:text-t1 text-sm leading-none px-1 pb-2 cursor-pointer" title="Remove page">&times;</button>
             </div>
           </div>
+          <div class="flex justify-end mb-2">
+            <%# formaction, not a second form: the drafter has to see this page's
+                name, tile count and the board's topic. name/value on the submit
+                is what tells the server which page block was clicked. %>
+            <button type="submit" name="page_index" value="<%= index %>"
+                    formaction="<%= draft_page_admin_dashboard_board_builds_path %>" formnovalidate
+                    class="draft-page text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+              Draft this page with AI
+            </button>
+          </div>
           <textarea name="children[<%= index %>][words]" rows="6" spellcheck="false"
                     placeholder="apple | noun&#10;hungry | adjective&#10;back | social | &gt;<%= Boards::AdminBuilder::Plan::ROOT_KEY %>"
                     class="admin-input border rounded px-3 py-2 text-sm w-full font-mono focus:border-indigo-500 focus:outline-none"><%= child[:words] %></textarea>
@@ -251,6 +261,13 @@
           </div>
           <button type="button" class="remove-page text-t3 hover:text-t1 text-sm leading-none px-1 pb-2 cursor-pointer" title="Remove page">&times;</button>
         </div>
+      </div>
+      <div class="flex justify-end mb-2">
+        <button type="submit" name="page_index" value=""
+                formaction="<%= draft_page_admin_dashboard_board_builds_path %>" formnovalidate
+                class="draft-page text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+          Draft this page with AI
+        </button>
       </div>
       <textarea name="children[IDX][words]" rows="6" spellcheck="false"
                 class="admin-input border rounded px-3 py-2 text-sm w-full font-mono focus:border-indigo-500 focus:outline-none"></textarea>
@@ -370,6 +387,11 @@
         block.querySelectorAll("input, textarea").forEach(function (field) {
           field.name = field.name.replace(/children\[\w*\]/, "children[" + i + "]");
         });
+        // The per-page draft button posts its index as a submit value rather
+        // than a field name, so renumbering the names alone would leave a moved
+        // block drafting into whichever page now sits at its old position.
+        var draft = block.querySelector(".draft-page");
+        if (draft) draft.value = i;
       });
     }
 
@@ -383,6 +405,20 @@
       if (!event.target.classList.contains("remove-page")) return;
       event.target.closest(".page-block").remove();
       reindexPages();
+    });
+
+    // Drafting a page replaces that page's textarea wholesale, so only confirm
+    // when there is something to lose. Delegated for the same reason the
+    // grid-sync listener is: blocks added after load would miss a bound one.
+    pages.addEventListener("click", function (event) {
+      var button = event.target.closest(".draft-page");
+      if (!button) return;
+
+      var textarea = button.closest(".page-block").querySelector('textarea[name$="[words]"]');
+      if (!textarea || textarea.value.trim() === "") return;
+      if (!window.confirm("Replace this page's word list with an AI draft?")) {
+        event.preventDefault();
+      }
     });
 
     // Delegated, because page blocks come and go — a listener bound per field

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
         post :draft
         post :add_words
         post :draft_set
+        post :draft_page
         post :describe, to: "board_builds#describe_board"
         post :preview
       end

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1020,6 +1020,126 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  describe "POST draft_page" do
+    before { sign_in admin }
+
+    def stub_page_drafter(tiles)
+      allow(Boards::AdminBuilder::PageDrafter).to receive(:new).and_return(
+        instance_double(Boards::AdminBuilder::PageDrafter, call: tiles),
+      )
+    end
+
+    let(:drafted) do
+      [
+        { label: "apple", part_of_speech: "noun" },
+        { label: "back", part_of_speech: "social", links_to: "__root__" },
+      ]
+    end
+
+    # Two pages, the second one empty and the one being drafted.
+    def two_page_params(overrides = {})
+      form_params(
+        columns: "1",
+        tile_count: "2",
+        children: {
+          "0" => { key: "drinks", name: "Drinks", columns: "", tile_count: "",
+                   words: "juice | noun\nback | social | >__root__" },
+          "1" => { key: "food", name: "Food", columns: "", tile_count: "", words: "" },
+        },
+      ).merge(overrides)
+    end
+
+    it "fills only the targeted page and leaves the root and siblings alone" do
+      stub_page_drafter(drafted)
+
+      post draft_page_admin_dashboard_board_builds_path, params: two_page_params(page_index: "1")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("apple | noun")
+      expect(response.body).to include("back | social | &gt;__root__")
+      # Sibling page untouched.
+      expect(response.body).to include("juice | noun")
+      # Root word list untouched.
+      expect(response.body).to include("swing | noun")
+    end
+
+    it "drafts from the page title, with the board topic as context" do
+      stub_page_drafter(drafted)
+
+      post draft_page_admin_dashboard_board_builds_path, params: two_page_params(page_index: "1")
+
+      expect(Boards::AdminBuilder::PageDrafter).to have_received(:new).with(
+        page_name: "Food", page_key: "food", tile_count: 2,
+        topic: "the playground", audience: "",
+      )
+    end
+
+    # A page's own Tiles override is what it will actually be built at.
+    it "uses the page's tile override over the root's count" do
+      stub_page_drafter(drafted)
+
+      params = two_page_params(page_index: "1")
+      params[:children]["1"][:tile_count] = "6"
+      post draft_page_admin_dashboard_board_builds_path, params: params
+
+      expect(Boards::AdminBuilder::PageDrafter).to have_received(:new)
+        .with(hash_including(tile_count: 6))
+    end
+
+    it "writes nothing" do
+      stub_page_drafter(drafted)
+
+      expect {
+        post draft_page_admin_dashboard_board_builds_path, params: two_page_params(page_index: "1")
+      }.to not_change(Board, :count).and not_change(Image, :count).and not_change(AdminBoardBuild, :count)
+    end
+
+    # The page title is the whole input, so it's the one thing that can't be
+    # inferred from anything else on the form.
+    it "refuses a page with no name or key" do
+      params = two_page_params(page_index: "1")
+      params[:children]["1"] = { key: "", name: "", columns: "", tile_count: "", words: "x | noun" }
+
+      post draft_page_admin_dashboard_board_builds_path, params: params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Give the page a name to draft from")
+      expect(response.body).to include("swing | noun")
+    end
+
+    it "reports a page index that is no longer on the form" do
+      stub_page_drafter(drafted)
+
+      post draft_page_admin_dashboard_board_builds_path, params: two_page_params(page_index: "7")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("no longer on the form")
+    end
+
+    it "reports a generation failure without losing what was typed" do
+      allow(Boards::AdminBuilder::PageDrafter).to receive(:new).and_raise(
+        Boards::AdminBuilder::PageDrafter::GenerationError, "OpenAI returned no content",
+      )
+
+      post draft_page_admin_dashboard_board_builds_path, params: two_page_params(page_index: "1")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Couldn&#39;t draft that page")
+      expect(response.body).to include("juice | noun")
+    end
+
+    it "warns rather than claiming success when the AI comes back short" do
+      stub_page_drafter([{ label: "apple", part_of_speech: "noun" }])
+
+      params = two_page_params(page_index: "1")
+      params[:children]["1"][:tile_count] = "6"
+      post draft_page_admin_dashboard_board_builds_path, params: params
+
+      expect(response).to have_http_status(:ok)
+      expect(flash[:notice]).to include("1 of 6")
+    end
+  end
+
   describe "POST describe" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/page_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/page_drafter_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::PageDrafter do
+  let(:root) { Boards::AdminBuilder::Plan::ROOT_KEY }
+
+  def ai_tiles(*tiles)
+    { "tiles" => tiles }.to_json
+  end
+
+  def tile(label, pos, links_to: nil)
+    { "label" => label, "part_of_speech" => pos }.tap do |raw|
+      raw["links_to"] = links_to if links_to
+    end
+  end
+
+  def stub_ai(content)
+    allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+      .and_return({ role: "assistant", content: content })
+  end
+
+  def captured_prompt
+    prompt = nil
+    allow(OpenAiClient).to receive(:new).and_wrap_original do |original, **kwargs|
+      prompt = kwargs[:messages].first[:content]
+      original.call(**kwargs)
+    end
+    yield
+    prompt
+  end
+
+  let(:four_tiles) do
+    ai_tiles(
+      tile("apple", "noun"),
+      tile("hungry", "adjective"),
+      tile("eat", "verb"),
+      tile("back", "social", links_to: root),
+    )
+  end
+
+  # Never let a spec reach the real API.
+  before { stub_ai(four_tiles) }
+
+  describe "#call" do
+    it "returns labels with parts of speech and the back link" do
+      result = described_class.new(page_name: "Food", tile_count: 4).call
+
+      expect(result).to eq([
+        { label: "apple", part_of_speech: "noun" },
+        { label: "hungry", part_of_speech: "adjective" },
+        { label: "eat", part_of_speech: "verb" },
+        { label: "back", part_of_speech: "social", links_to: root },
+      ])
+    end
+
+    it "refuses to draft without a page title" do
+      expect { described_class.new(page_name: "  ", tile_count: 4).call }
+        .to raise_error(described_class::GenerationError, /page a name/)
+    end
+
+    # The key is an identifier, so it stands in only when there's no title.
+    it "falls back to the page key when the name is blank" do
+      expect { described_class.new(page_name: "", page_key: "my_turn", tile_count: 4).call }
+        .not_to raise_error
+    end
+
+    it "trims a response longer than the grid" do
+      stub_ai(ai_tiles(
+                tile("apple", "noun"), tile("hungry", "adjective"),
+                tile("eat", "verb"), tile("back", "social", links_to: root), tile("pear", "noun")
+              ))
+
+      expect(described_class.new(page_name: "Food", tile_count: 4).call.size).to eq(4)
+    end
+
+    # This only fills a textarea, so a short draft is survivable.
+    it "returns a short draft rather than raising" do
+      stub_ai(ai_tiles(tile("apple", "noun")))
+
+      expect(described_class.new(page_name: "Food", tile_count: 9).call.size).to eq(1)
+    end
+
+    it "raises when nothing in the response is usable" do
+      stub_ai({ "tiles" => [] }.to_json)
+
+      expect { described_class.new(page_name: "Food", tile_count: 4).call }
+        .to raise_error(described_class::GenerationError, /no usable words/)
+    end
+
+    it "raises on an unparseable response" do
+      stub_ai("not json")
+
+      expect { described_class.new(page_name: "Food", tile_count: 4).call }
+        .to raise_error(described_class::GenerationError, /parse/)
+    end
+  end
+
+  describe "the prompt" do
+    it "is built around the page title, with the board topic as context" do
+      prompt = captured_prompt do
+        described_class.new(page_name: "Food", tile_count: 4, topic: "the playground", audience: "a preschooler").call
+      end
+
+      expect(prompt).to include("The page is about: Food")
+      expect(prompt).to include("a board about: the playground")
+      expect(prompt).to include("It is for: a preschooler")
+      expect(prompt).to include("EXACTLY 4 tiles")
+      expect(prompt).to include(root)
+    end
+
+    it "omits the board context when there is none" do
+      prompt = captured_prompt { described_class.new(page_name: "Food", tile_count: 4).call }
+
+      expect(prompt).not_to include("a board about:")
+      expect(prompt).not_to include("It is for:")
+    end
+  end
+
+  describe "cleanup of what the model returns" do
+    # `images.label` is a lowercase matching key, so "Apple" and "apple" are one
+    # symbol — a draft that fails validation on arrival is worse than a short one.
+    it "drops casing-only repeats" do
+      stub_ai(ai_tiles(tile("apple", "noun"), tile("Apple", "noun"), tile("eat", "verb")))
+
+      expect(described_class.new(page_name: "Food", tile_count: 4).call.map { |t| t[:label] })
+        .to eq(%w[apple eat])
+    end
+
+    it "folds a snake_cased label back to display text" do
+      stub_ai(ai_tiles(tile("all_done", "social")))
+
+      expect(described_class.new(page_name: "Food", tile_count: 4).call.first[:label]).to eq("all done")
+    end
+
+    it "falls back to 'default' for a part of speech off the list" do
+      stub_ai(ai_tiles(tile("apple", "fruit")))
+
+      expect(described_class.new(page_name: "Food", tile_count: 4).call.first[:part_of_speech]).to eq("default")
+    end
+
+    it "tolerates 'word' as an alias for 'label'" do
+      stub_ai({ "tiles" => [{ "word" => "apple", "part_of_speech" => "noun" }] }.to_json)
+
+      expect(described_class.new(page_name: "Food", tile_count: 1).call)
+        .to eq([{ label: "apple", part_of_speech: "noun" }])
+    end
+
+    # This drafter is given one page and knows no other page's key, so a link
+    # anywhere but back would name a page it can't vouch for — and PlanValidator
+    # rejects a link to a key that isn't in the set.
+    it "keeps only the back link and drops any other link target" do
+      stub_ai(ai_tiles(tile("drinks", "noun", links_to: "drinks"), tile("back", "social", links_to: root)))
+
+      result = described_class.new(page_name: "Food", tile_count: 4).call
+      expect(result.first).not_to have_key(:links_to)
+      expect(result.last[:links_to]).to eq(root)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a **"Draft this page with AI"** button to each child page block in the admin board builder (`/admin/board_builds`). It fills only that page's word list, worked out from the page's own **title**, with the board's topic and audience as context.

## Why

The builder already had `draft` / `add_words` for the main board and `draft_set` for the whole set. There was nothing in between: the only way to get AI words onto a child page was "Draft the whole set", which replaces the root **and** every other page. Revising one page of a set meant re-drafting and re-editing all of it.

## How

**`Boards::AdminBuilder::PageDrafter`** (new) — `page_name` + `tile_count` (+ optional `topic` / `audience`) → `[{ label:, part_of_speech:, links_to: }]`.

Deliberately **not** `WordListDrafter` with a swapped topic. That one opens with `CORE_SPINE` and never emits a link, and both are wrong for a page — the root carries the core words the whole set leans on, so a page repeating "I / want / more / help" spends its cells twice. The prompt is `SetDrafter`'s per-page half, scoped to one page.

**`draft_page`** action merges the result into `children[page_index]` only. The root and every sibling survive untouched.

### Points a reviewer should know

- **The back tile comes with the draft** — one `back → Plan::ROOT_KEY` tile, counted toward the page's budget. A drafted page with no way home is a dead end for a communicator. Every *other* link target is dropped: this drafter is given one page and knows no sibling's key, and `PlanValidator` rejects a link to a key that isn't in the set.
- **No `MAX_PAGES` ceiling**, unlike `SetDrafter` (capped at 4 because per-page tile counts slip in a long response). One page per call is now the accurate route for bigger sets.
- **The button posts its index as the submit's `name`/`value`**, not a field — so `reindexPages()` had to be extended to rewrite that `value` alongside the field `name`s. Renumbering names alone would leave a moved block drafting into whichever page took its old slot.
- **The page title is the one input that can't be inferred**, so a nameless page is rejected rather than guessed at (no `ContextSuggester` round trip). The `key` stands in only when there's no title, underscores folded back to spaces.
- **Tile count** follows the page's own `Tiles` override when set, else the root's — what the page will actually be built at.
- Writes nothing, like every other drafter here: it populates the form, a human edits, then previews the art, then builds.

## Test plan

All run locally, zero failures:

- `bundle exec rspec spec/services/boards/admin_builder/` — **187 examples, 0 failures** (14 new for `PageDrafter`: prompt content, back-link handling, dedupe of casing-only repeats, snake_case label folding, short and unparseable responses, blank-title refusal, key fallback)
- `bundle exec rspec spec/requests/admin/board_builds_spec.rb -e "POST draft_page"` — **8 examples, 0 failures** (targeted page filled; root + siblings untouched; page tile override honored over the root's; `Board` / `Image` / `AdminBoardBuild` counts unchanged; nameless page → 422 with typed values preserved; stale page index and generation failure both reported; short draft warns instead of claiming success)
- `bundle exec rspec spec/requests/admin/access_control_spec.rb` — **14 examples, 0 failures** (namespace sweep covers the new route via `Admin::ApplicationController` inheritance)

OpenAI is stubbed in every spec; nothing reaches the real API.

## Docs

- `.claude-notes/admin-board-builder-handoff.md` — new "Per-page drafting" section covering the invariants above
- `CHANGELOG.md` — user-facing entry under Unreleased / Added

🤖 Generated with [Claude Code](https://claude.com/claude-code)