### PR TITLE
fix(admin): link every builder page from the main board

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1092,6 +1092,25 @@ Its own invariants:
   root and its pages into one list so validation, preview and build never
   special-case the root; the root's key is `Plan::ROOT_KEY` (`__root__`), which
   is also what a "back to home" tile links to.
+- **A page nothing opens is never authored on purpose, so the door is written
+  for you.** `Boards::AdminBuilder::FolderTiles.link` runs on EVERY form
+  round-trip (`submitted_form`, and again after each drafting action rewrites
+  part of the form) and gives any keyed page with no inbound link a folder tile
+  on the root. It has to run on every round-trip because every drafter replaces
+  something after the fact: `WordListDrafter` rewrites the whole root list —
+  wiping the `>key` tokens a set draft had put there — and `PageDrafter` knows
+  about one page and can't name a sibling, so only `SetDrafter` ever emitted a
+  link at all. A tile already saying the page's word is *promoted* rather than
+  duplicated, including one whose `links_to` names a page that doesn't exist (a
+  mistyped `>fod` next to a page called Food is a door meant for that page).
+  Root drafting asks for `tile_count - reserved_count` words so the folder tiles
+  land inside the grid; when the root is already full, trailing plain words are
+  displaced to make room and named in the banner — a word is regenerable, a door
+  is not, and an overflowing board can't be built at all. Folder tiles carry a
+  `display_label` because a category tile's label is authored ("Food" opens a
+  page, "food" says the word) and `Image#set_label` would otherwise fold the
+  capital. `PlanValidator#orphan_problems` is the backstop, not the mechanism —
+  it only fires for a page whose key never got far enough to link.
 - **Linking is a three-pass write, NOT a topological build order.** Every page's
   Board row is created first, then tiles, then the links. `build_board.py` needs
   `build_order()` with cycle-breaking because its HTTP API creates a board

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Admin board builder: pages were being built with nothing to open them.** A
+  page only became reachable if the main board's word list carried a hand-typed
+  `>page_key` tile, and only "Draft the whole set with AI" ever wrote one — so
+  adding a page by hand, drafting a page on its own, or re-drafting the main
+  board after a set draft produced pages that built, published, and went live
+  with no tile a communicator could tap to reach them. The folder tile is now
+  written onto the main board automatically for any page nothing opens, room is
+  made for it if the board is already full, and the builder says what it added
+  and what it displaced. A mistyped page key on a tile that plainly names the
+  page is repaired rather than rejected. As a backstop, a plan with an
+  unreachable page no longer passes validation.
+
 ### Added
 
 - **The admin board builder can draft one page at a time from its title.** Each

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -52,14 +52,19 @@ module Admin
       @problems = draft_problems(@form)
       return render(:new, status: :unprocessable_entity) if @problems.any?
 
+      # Drafting replaces the root outright, so every page is about to need a
+      # folder tile written back in. Asking for that many fewer words lands on
+      # the tile count exactly, instead of drafting a full board and then having
+      # its tail displaced to make room.
+      reserved = Boards::AdminBuilder::FolderTiles.reserved_count(children: @form[:children])
       tiles = Boards::AdminBuilder::WordListDrafter.new(
         topic: @form[:topic],
-        tile_count: @form[:tile_count].to_i,
+        tile_count: [@form[:tile_count].to_i - reserved, 1].max,
         audience: @form[:audience],
       ).call
 
-      @form = @form.merge(words: tiles_to_words(tiles), tiles: tiles)
-      flash.now[:notice] = draft_notice(tiles, @form)
+      @form = with_folder_tiles(@form.merge(words: tiles_to_words(tiles), tiles: tiles))
+      flash.now[:notice] = draft_notice(@form[:tiles], @form)
       render :new
     rescue Boards::AdminBuilder::WordListDrafter::GenerationError => e
       @problems = ["Couldn't draft a word list: #{e.message}"]
@@ -92,7 +97,7 @@ module Admin
       ).call
 
       all_tiles = existing + new_tiles
-      @form = @form.merge(words: tiles_to_words(all_tiles), tiles: all_tiles)
+      @form = with_folder_tiles(@form.merge(words: tiles_to_words(all_tiles), tiles: all_tiles))
       flash.now[:notice] = add_words_notice(new_tiles, missing, @form)
       render :new
     rescue Boards::AdminBuilder::WordListDrafter::GenerationError => e
@@ -120,11 +125,13 @@ module Admin
         audience: @form[:audience],
       ).call
 
-      @form = @form.merge(
+      # The prompt asks for a folder tile per page, but a draft that came back
+      # without one would otherwise build an unreachable page.
+      @form = with_folder_tiles(@form.merge(
         words: tiles_to_words(set[:root_tiles]),
         tiles: set[:root_tiles],
         children: children_form_from(set[:children]),
-      )
+      ))
       flash.now[:notice] = draft_set_notice(set, @form)
       render :new
     rescue Boards::AdminBuilder::SetDrafter::GenerationError => e
@@ -163,6 +170,7 @@ module Admin
       ).call
 
       @form[:children][index] = child.merge(words: tiles_to_words(tiles), tiles: tiles)
+      @form = with_folder_tiles(@form)
       flash.now[:notice] = draft_page_notice(tiles, child, tile_count)
       render :new
     rescue Boards::AdminBuilder::PageDrafter::GenerationError => e
@@ -279,7 +287,9 @@ module Admin
     # re-type. The name is copied verbatim; `preview` warns about the
     # collision rather than forcing an edit up front.
     def duplicate
-      @form = form_from_build(@build)
+      # Runs the folder-tile pass too, so re-opening a set built before this
+      # existed repairs its missing doors instead of reproducing them.
+      @form = with_folder_tiles(form_from_build(@build))
       flash.now[:notice] = "Loaded “#{@build.name}” into the form. Nothing is written until you build."
       render :new
     end
@@ -641,7 +651,30 @@ module Admin
         commercial_safe_only: checked?(params[:commercial_safe_only]),
         allow_partial_row: checked?(params[:allow_partial_row]),
         allow_mixed_grids: checked?(params[:allow_mixed_grids]),
-      }
+      }.then { |form| with_folder_tiles(form) }
+    end
+
+    # Writes a folder tile onto the main board for any page nothing opens, and
+    # re-renders the root textarea so the admin sees the line that was added.
+    #
+    # Called on every round-trip — not once at submit — because every drafting
+    # action replaces part of the form after `submitted_form` has run:
+    # `draft` and `add_words` rewrite the root list (dropping the `>key` tokens
+    # a set draft had put there), `draft_page` rewrites a page. Re-applying
+    # after each of those is what makes a page reachable no matter which order
+    # the buttons were pressed.
+    #
+    # `@auto_linked` is what the form and the preview report from; the last
+    # call in a request wins, which is the state actually being rendered.
+    def with_folder_tiles(form)
+      @auto_linked = Boards::AdminBuilder::FolderTiles.link(
+        root_tiles: form[:tiles],
+        children: form[:children],
+        tile_count: form[:tile_count].to_i,
+      )
+      return form unless @auto_linked.changed?
+
+      form.merge(tiles: @auto_linked.tiles, words: tiles_to_words(@auto_linked.tiles))
     end
 
     # Child pages arrive as an indexed hash, the same shape

--- a/app/services/boards/admin_builder/folder_tiles.rb
+++ b/app/services/boards/admin_builder/folder_tiles.rb
@@ -1,0 +1,160 @@
+module Boards
+  module AdminBuilder
+    # Guarantees every child page is reachable: a page with nothing pointing at
+    # it gets a folder tile on the main board, written into the root word list.
+    #
+    # **A page nobody can open is never what was meant.** `links_to` is a
+    # hand-typed `>key` token in the textarea, and only SetDrafter ever emits
+    # one — PageDrafter knows about a single page and can't name a sibling, and
+    # WordListDrafter has no concept of links and *replaces* the root list, so
+    # re-drafting the main board after drafting a set silently deleted every
+    # folder tile it had. The build then published the pages anyway
+    # (`Board#viewable_by?` gates each board on its own flag, so they are live
+    # but unreachable) because PlanValidator only ever checked the forward
+    # direction — a link naming a page that doesn't exist — never that a page
+    # is named by anything.
+    #
+    # Reachability is not an authoring preference, so this runs on every form
+    # round-trip rather than behind a button. What it did is reported back, not
+    # applied silently: `Result#changed?` drives the banner on the form and the
+    # preview.
+    #
+    # Only the ROOT gains tiles, but a page counts as reachable when ANY page
+    # links to it — a page opened from a sibling is already reachable, and
+    # adding a second door to it from the main board isn't this module's call.
+    module FolderTiles
+      # A folder tile is a category tile, and a category tile's label is
+      # authored: "Food" opens a page, "food" says the word. `Image#set_label`
+      # folds a plain leading capital, so the authored casing is pinned as the
+      # tile's own display_label rather than left to the shared Image.
+      FOLDER_PART_OF_SPEECH = "noun".freeze
+
+      Result = Struct.new(:tiles, :added, :displaced, keyword_init: true) do
+        def changed? = added.any?
+      end
+
+      module_function
+
+      # `root_tiles` and each child's `tiles` are Plan tile hashes; `tile_count`
+      # is the root's authored size (0 when unset — then nothing is displaced).
+      def link(root_tiles:, children:, tile_count: 0)
+        tiles = Array(root_tiles).map(&:dup)
+        pending = unlinked_pages(tiles, children)
+        return Result.new(tiles: tiles, added: [], displaced: []) if pending.empty?
+
+        known = known_keys(children)
+        added = []
+        appended = []
+
+        pending.each do |page|
+          key = page[:key].to_s.strip.downcase
+
+          # A tile already carrying the page's word is promoted rather than
+          # duplicated — appending a second "Food" would trip the duplicate-word
+          # check and cost a cell for nothing.
+          if (existing = promotable_tile(tiles, page, appended, known))
+            existing[:links_to] = key
+            existing[:part_of_speech] = FOLDER_PART_OF_SPEECH if existing[:part_of_speech].to_s == "default"
+            existing[:display_label] ||= page_label(page)
+            added << { key: key, label: existing[:label].to_s }
+          else
+            appended << folder_tile(page)
+            added << { key: key, label: page_label(page) }
+          end
+        end
+
+        tiles, displaced = fit(tiles, appended, tile_count)
+        Result.new(tiles: tiles, added: added, displaced: displaced)
+      end
+
+      # How many cells the root has to leave for folder tiles when its word
+      # list is about to be drafted from scratch. Drafting replaces the root
+      # outright, so every keyed page will need a door — asking the drafter for
+      # that many fewer words lands on the tile count exactly, instead of
+      # drafting a full board and then displacing the tail of it.
+      def reserved_count(children:)
+        Array(children).count { |child| linkable_key?(child[:key]) }
+      end
+
+      # Pages that nothing — root or sibling — currently opens.
+      def unlinked_pages(root_tiles, children)
+        linked = link_targets(root_tiles, children)
+
+        Array(children).select do |child|
+          linkable_key?(child[:key]) && linked.exclude?(child[:key].to_s.strip.downcase)
+        end
+      end
+
+      def link_targets(root_tiles, children)
+        pages = [Array(root_tiles)] + Array(children).map { |child| Array(child[:tiles]) }
+        pages.flatten.filter_map { |tile| tile[:links_to].presence }.to_set
+      end
+
+      # A key that fails this is a key PlanValidator is about to reject on its
+      # own terms, and emitting a link to it would stack a second, more
+      # confusing error on top of the real one.
+      def linkable_key?(key)
+        key = key.to_s.strip.downcase
+        key.present? && key != Plan::ROOT_KEY && key.match?(/\A[a-z0-9_]+\z/)
+      end
+
+      def page_label(page)
+        page[:name].to_s.strip.presence || page[:key].to_s.tr("_", " ").strip
+      end
+
+      def folder_tile(page)
+        label = page_label(page)
+        {
+          label: label,
+          part_of_speech: FOLDER_PART_OF_SPEECH,
+          display_label: label,
+          links_to: page[:key].to_s.strip.downcase,
+        }
+      end
+
+      def known_keys(children)
+        Array(children).filter_map { |child| child[:key].to_s.strip.downcase.presence }.to_set << Plan::ROOT_KEY
+      end
+
+      # Matches on the page's name or its key read as words, and takes over a
+      # tile that links nowhere OR whose target doesn't exist — a mistyped
+      # `>fod` is a door meant for this page, and retargeting it is better than
+      # leaving a dangling link next to a freshly appended duplicate of the same
+      # word.
+      def promotable_tile(tiles, page, appended, known)
+        wanted = [page_label(page), page[:key].to_s.tr("_", " ")].map { |value| value.strip.downcase }
+        taken = appended.map { |tile| tile[:label].to_s.downcase }
+
+        tiles.find do |tile|
+          target = tile[:links_to].presence
+          next false if target && known.include?(target)
+          next false unless wanted.include?(tile[:label].to_s.strip.downcase)
+
+          taken.exclude?(tile[:label].to_s.downcase)
+        end
+      end
+
+      # Folder tiles are appended, and the root is normally authored to exactly
+      # its tile count — so making room is part of adding one. Trailing plain
+      # words go first and are named in the report: a word is regenerable and a
+      # door is not, and a board that overflows its grid can't be built at all.
+      # Never drops another folder tile, and never trims below the appended
+      # tiles themselves.
+      def fit(tiles, appended, tile_count)
+        overflow = tile_count.to_i.positive? ? (tiles.size + appended.size) - tile_count.to_i : 0
+        return [tiles + appended, []] unless overflow.positive?
+
+        displaced = []
+        kept = tiles.reverse.reject do |tile|
+          next false unless displaced.size < overflow
+          next false if tile[:links_to].present?
+
+          displaced << tile[:label].to_s
+          true
+        end.reverse
+
+        [kept + appended, displaced.reverse]
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -38,7 +38,8 @@ module Boards
         # A page whose key is broken can't have its links checked coherently.
         return problems if problems.any?
 
-        problems + pages.flat_map { |page| page_problems(page) } + grid_problems + link_problems
+        problems + pages.flat_map { |page| page_problems(page) } + grid_problems + link_problems +
+          orphan_problems
       end
 
       private
@@ -187,6 +188,25 @@ module Boards
 
             prefixed(page, "tile “#{tile[:label]}” opens page “#{target}”, which doesn't exist.")
           end
+        end
+      end
+
+      # The other direction, and the one that actually shipped broken sets: a
+      # page nothing opens still builds and still publishes, so it goes live at
+      # its own /pb/ slug with no way for a communicator to reach it.
+      # Boards::AdminBuilder::FolderTiles writes the missing door on every form
+      # round-trip, so in practice this fires only for a page whose key never
+      # made it that far — it is the backstop, not the mechanism.
+      def orphan_problems
+        return [] unless multi_page?
+
+        linked = pages.flat_map { |page| page[:tiles] }.filter_map { |tile| tile[:links_to].presence }.to_set
+
+        pages.drop(1).filter_map do |page|
+          next if linked.include?(page[:key])
+
+          "#{label_for(page)}: nothing opens this page. Add a tile to the main board with " \
+            "“#{Boards::AdminBuilder::WordList::LINK_TOKEN}#{page[:key]}”, or remove the page."
         end
       end
     end

--- a/app/views/admin/board_builds/_auto_links.html.erb
+++ b/app/views/admin/board_builds/_auto_links.html.erb
@@ -1,0 +1,29 @@
+<%# What Boards::AdminBuilder::FolderTiles did on this round trip. Rendered on
+    both the form and the preview: the tiles are already in the root word list
+    by the time either is drawn, so this is a report, not a prompt. %>
+<% if @auto_linked&.changed? %>
+  <div class="admin-card border border-indigo-500/40 rounded-xl p-4 mb-6">
+    <p class="text-xs text-indigo-400 font-medium">
+      <%= "Added #{@auto_linked.added.size} folder #{"tile".pluralize(@auto_linked.added.size)} to the main board" %>
+      — a page with nothing opening it builds unreachable.
+    </p>
+    <ul class="text-[11px] text-t2 mt-2 flex flex-col gap-1">
+      <% @auto_linked.added.each do |link| %>
+        <li>
+          <span class="font-mono"><%= link[:label] %></span> opens
+          <span class="font-mono">&gt;<%= link[:key] %></span>
+        </li>
+      <% end %>
+    </ul>
+    <% if @auto_linked.displaced.any? %>
+      <p class="text-[11px] text-t3 mt-2">
+        The main board was already full, so
+        <%= @auto_linked.displaced.map { |label| "“#{label}”" }.to_sentence %>
+        <%= @auto_linked.displaced.one? ? "was" : "were" %> dropped to make room. Edit the word list
+        if you'd rather lose a different word.
+      </p>
+    <% else %>
+      <p class="text-[11px] text-t3 mt-2">Edit the word list above to rename or re-colour them.</p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -159,8 +159,9 @@
       <div>
         <h2 class="text-sm font-medium text-t1">Pages <span class="text-t3 font-normal">(optional)</span></h2>
         <p class="text-[11px] text-t3 mt-0.5">
-          A folder tile on the main board opens a page. Give each page a key, then point a tile at it
-          with <span class="font-mono">&gt;key</span>. Pages inherit the main board's grid unless you say otherwise.
+          A folder tile on the main board opens a page. Give each page a key and the folder tile is
+          written for you — point a tile at it with <span class="font-mono">&gt;key</span> yourself only if you
+          want a different word on it. Pages inherit the main board's grid unless you say otherwise.
         </p>
       </div>
       <div class="flex items-center gap-2">

--- a/app/views/admin/board_builds/new.html.erb
+++ b/app/views/admin/board_builds/new.html.erb
@@ -18,4 +18,6 @@
   </div>
 <% end %>
 
+<%= render "auto_links" %>
+
 <%= render "form" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -29,6 +29,8 @@
   </div>
 <% end %>
 
+<%= render "auto_links" %>
+
 <div class="admin-card border rounded-xl p-5 mb-6">
   <div class="flex flex-wrap items-center gap-6">
     <div>

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -175,12 +175,21 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(AdminBoardBuild.last.children.size).to eq(1)
     end
 
+    # The tile's own word names no page in the set, so there is nothing to
+    # infer from it — unlike the mistyped-key case below.
     it "rejects a tile pointing at a page that doesn't exist" do
-      params = set_params(words: "i | pronoun\nwant | verb\nmore | social\nFood | noun | >nope")
+      params = set_params(words: "i | pronoun\nwant | verb\nFood | noun | >food\nsnack | noun | >nope")
 
       expect { post admin_dashboard_board_builds_path, params: params }.not_to change(AdminBoardBuild, :count)
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("which doesn&#39;t exist")
+    end
+
+    it "repairs a mistyped key on a tile that plainly names the page" do
+      params = set_params(words: "i | pronoun\nwant | verb\nmore | social\nFood | noun | >fod")
+
+      expect { post admin_dashboard_board_builds_path, params: params }.to change(AdminBoardBuild, :count).by(1)
+      expect(AdminBoardBuild.last.tiles.last).to include("label" => "Food", "links_to" => "food")
     end
 
     it "rejects a page whose grid differs from the main board's" do
@@ -215,6 +224,45 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       post admin_dashboard_board_builds_path, params: params
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to include("Food: columns must be between 1 and 12")
+    end
+
+    # The bug this exists for: a page added without a `>key` tile on the main
+    # board still built and still published, live at its own slug with nothing
+    # a communicator could tap to reach it.
+    describe "pages nothing opens" do
+      def unlinked_params(overrides = {})
+        set_params(
+          words: "i | pronoun\nwant | verb\nmore | social\nhelp | social",
+        ).merge(overrides)
+      end
+
+      it "writes the folder tile onto the main board before building" do
+        expect { post admin_dashboard_board_builds_path, params: unlinked_params }
+          .to change(AdminBoardBuild, :count).by(1)
+
+        expect(AdminBoardBuild.last.tiles.last)
+          .to include("label" => "Food", "links_to" => "food", "display_label" => "Food")
+      end
+
+      it "makes room on a main board that is already full and says what it dropped" do
+        post preview_admin_dashboard_board_builds_path, params: unlinked_params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Added 1 folder tile")
+        expect(response.body).to include("“help”")
+      end
+
+      it "shows the added tile in the word list it hands back" do
+        post preview_admin_dashboard_board_builds_path, params: unlinked_params
+
+        expect(response.body).to include("Food | noun | Food | &gt;food")
+      end
+
+      it "leaves a set alone when the folder tile is already there" do
+        post preview_admin_dashboard_board_builds_path, params: set_params
+
+        expect(response.body).not_to include("builds unreachable")
+      end
     end
 
     it "preserves the submitted pages when something else fails validation" do

--- a/spec/services/boards/admin_builder/folder_tiles_spec.rb
+++ b/spec/services/boards/admin_builder/folder_tiles_spec.rb
@@ -1,0 +1,202 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::FolderTiles do
+  def tile(label, links_to: nil, part_of_speech: "noun")
+    { label: label, part_of_speech: part_of_speech, links_to: links_to }.compact
+  end
+
+  def page(key, name: nil, tiles: [])
+    { key: key, name: name, tiles: tiles }
+  end
+
+  def link(root_tiles:, children:, tile_count: 0)
+    described_class.link(root_tiles: root_tiles, children: children, tile_count: tile_count)
+  end
+
+  describe ".link" do
+    it "leaves a set alone when every page already has a door" do
+      result = link(
+        root_tiles: [tile("i"), tile("Food", links_to: "food")],
+        children: [page("food", name: "Food", tiles: [tile("apple")])],
+      )
+
+      expect(result).not_to be_changed
+      expect(result.tiles.map { |t| t[:links_to] }).to eq([nil, "food"])
+    end
+
+    it "appends a folder tile for a page nothing opens" do
+      result = link(
+        root_tiles: [tile("i"), tile("want")],
+        children: [page("in_the_classroom", name: "In the classroom")],
+      )
+
+      expect(result).to be_changed
+      expect(result.added).to eq([{ key: "in_the_classroom", label: "In the classroom" }])
+      expect(result.tiles.last).to eq(
+        label: "In the classroom",
+        part_of_speech: "noun",
+        # Pinned so Image#set_label's lowercase default can't fold a category
+        # tile's authored capital.
+        display_label: "In the classroom",
+        links_to: "in_the_classroom",
+      )
+    end
+
+    it "falls back to the key read as words when the page has no name" do
+      result = link(root_tiles: [tile("i")], children: [page("snack_time")])
+
+      expect(result.tiles.last[:label]).to eq("snack time")
+    end
+
+    it "adds one door per unlinked page" do
+      result = link(
+        root_tiles: [tile("i")],
+        children: [page("food", name: "Food"), page("play", name: "Play")],
+      )
+
+      expect(result.tiles.map { |t| t[:links_to] }).to eq([nil, "food", "play"])
+    end
+
+    it "counts a link from a sibling page as a door" do
+      result = link(
+        root_tiles: [tile("i")],
+        children: [
+          page("food", name: "Food", tiles: [tile("Play", links_to: "play")]),
+          page("play", name: "Play"),
+        ],
+      )
+
+      expect(result.added.map { |a| a[:key] }).to eq(["food"])
+    end
+
+    it "promotes a plain tile that already says the page's word" do
+      result = link(
+        root_tiles: [tile("i"), tile("Food", part_of_speech: "default")],
+        children: [page("food", name: "Food")],
+      )
+
+      expect(result.tiles.size).to eq(2)
+      expect(result.tiles.last).to include(links_to: "food", part_of_speech: "noun", display_label: "Food")
+    end
+
+    it "matches a plain tile against the key read as words" do
+      result = link(root_tiles: [tile("snack time")], children: [page("snack_time")])
+
+      expect(result.tiles.size).to eq(1)
+      expect(result.tiles.first[:links_to]).to eq("snack_time")
+    end
+
+    it "retargets a tile whose link names a page that doesn't exist" do
+      result = link(
+        root_tiles: [tile("i"), tile("Food", links_to: "fod")],
+        children: [page("food", name: "Food")],
+      )
+
+      expect(result.tiles.size).to eq(2)
+      expect(result.tiles.last[:links_to]).to eq("food")
+    end
+
+    it "never takes over a tile that already opens a real page" do
+      result = link(
+        root_tiles: [tile("Food", links_to: "play")],
+        children: [page("food", name: "Food"), page("play", name: "Play")],
+      )
+
+      expect(result.tiles.map { |t| t[:links_to] }).to eq(["play", "food"])
+    end
+
+    it "normalizes the key it writes" do
+      result = link(root_tiles: [tile("i")], children: [page("  FOOD  ", name: "Food")])
+
+      expect(result.tiles.last[:links_to]).to eq("food")
+      expect(result.added.first[:key]).to eq("food")
+    end
+  end
+
+  describe "keys it refuses to link" do
+    it "skips a page with no key — PlanValidator says so in its own words" do
+      result = link(root_tiles: [tile("i")], children: [page("", name: "Food")])
+
+      expect(result).not_to be_changed
+    end
+
+    it "skips a key that isn't lowercase letters, numbers and underscores" do
+      result = link(root_tiles: [tile("i")], children: [page("food page!", name: "Food")])
+
+      expect(result).not_to be_changed
+    end
+
+    it "skips a page claiming the root's own key" do
+      result = link(root_tiles: [tile("i")], children: [page(Boards::AdminBuilder::Plan::ROOT_KEY)])
+
+      expect(result).not_to be_changed
+    end
+  end
+
+  describe "making room on a full main board" do
+    it "drops trailing plain words when the board is already at its tile count" do
+      result = link(
+        root_tiles: [tile("i"), tile("want"), tile("more"), tile("help")],
+        children: [page("food", name: "Food")],
+        tile_count: 4,
+      )
+
+      expect(result.tiles.map { |t| t[:label] }).to eq(["i", "want", "more", "Food"])
+      expect(result.displaced).to eq(["help"])
+    end
+
+    it "drops as many as it needs, from the end, in reading order" do
+      result = link(
+        root_tiles: [tile("i"), tile("want"), tile("more"), tile("help")],
+        children: [page("food", name: "Food"), page("play", name: "Play")],
+        tile_count: 4,
+      )
+
+      expect(result.tiles.map { |t| t[:label] }).to eq(["i", "want", "Food", "Play"])
+      expect(result.displaced).to eq(["more", "help"])
+    end
+
+    it "never drops another page's door to make room" do
+      result = link(
+        root_tiles: [tile("i"), tile("want"), tile("more"), tile("Play", links_to: "play")],
+        children: [page("play", name: "Play"), page("food", name: "Food")],
+        tile_count: 4,
+      )
+
+      expect(result.tiles.map { |t| t[:label] }).to eq(["i", "want", "Play", "Food"])
+      expect(result.displaced).to eq(["more"])
+    end
+
+    it "displaces nothing when promoting an existing tile" do
+      result = link(
+        root_tiles: [tile("i"), tile("want"), tile("more"), tile("Food")],
+        children: [page("food", name: "Food")],
+        tile_count: 4,
+      )
+
+      expect(result.tiles.size).to eq(4)
+      expect(result.displaced).to be_empty
+    end
+
+    it "displaces nothing when there is room" do
+      result = link(root_tiles: [tile("i")], children: [page("food", name: "Food")], tile_count: 4)
+
+      expect(result.tiles.size).to eq(2)
+      expect(result.displaced).to be_empty
+    end
+
+    it "displaces nothing when no tile count is set" do
+      result = link(root_tiles: [tile("i")], children: [page("food", name: "Food")])
+
+      expect(result.displaced).to be_empty
+    end
+  end
+
+  describe ".reserved_count" do
+    it "counts the pages a from-scratch root draft will have to leave room for" do
+      children = [page("food"), page("play"), page(""), page("Nope!")]
+
+      expect(described_class.reserved_count(children: children)).to eq(2)
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/plan_validator_spec.rb
+++ b/spec/services/boards/admin_builder/plan_validator_spec.rb
@@ -160,6 +160,30 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
       ))).to eq([])
     end
 
+    # The backstop behind Boards::AdminBuilder::FolderTiles: a page nothing
+    # opens builds and publishes anyway, live at its own slug with no way in.
+    it "rejects a page nothing opens" do
+      root = tiles("i", "want", "more", "help")
+      problems = validate(pages: pages(root_tiles: root, children: [child]))
+
+      expect(problems).to include(a_string_including("Food: nothing opens this page"))
+      expect(problems).to include(a_string_including(">food"))
+    end
+
+    it "accepts a page opened only by a sibling" do
+      root = tiles("i", "want", "more") + [{ label: "Food", part_of_speech: "noun", links_to: "food" }]
+      food = tiles("apple", "banana", "hungry") + [{ label: "Play", part_of_speech: "noun", links_to: "play" }]
+
+      expect(validate(pages: pages(
+        root_tiles: root,
+        children: [child(tiles_list: food), child(key: "play", name: "Play")],
+      ))).to eq([])
+    end
+
+    it "says nothing about reachability on a single board" do
+      expect(validate(pages: pages(root_tiles: tiles("i", "want", "more", "help")))).to eq([])
+    end
+
     it "rejects a duplicate page key" do
       problems = validate(pages: pages(root_tiles: root_with_folder, children: [child, child]))
       expect(problems).to include(a_string_including("Duplicate page keys: food"))


### PR DESCRIPTION
## The bug

Builder pages were being created, published, and left unreachable — no tile on the main board opened them. The set root looked complete; the pages were live at their own `/pb/` slugs with nothing a communicator could tap to get there.

A page became reachable only if the root's word list carried a hand-typed `>page_key` token, and **only `SetDrafter` ever wrote one**:

| Path | Emitted a root `links_to`? |
|---|---|
| `draft_set` → `SetDrafter` | yes — its prompt requires one folder tile per page |
| `draft_page` → `PageDrafter` | no — scoped to a single page, so it can't name a sibling; `link_for` drops everything except `__root__` |
| `draft` / `add_words` → `WordListDrafter` | no — no concept of links, and it *replaces* the root list, wiping any `>key` tokens already there |

So adding a page by hand, drafting a page on its own (shipped in #643), or re-drafting the main board after a set draft all produced orphan pages. `PlanValidator` only checked the forward direction — a link naming a page that doesn't exist — never that a page is named by anything, so nothing caught it before the build.

## The fix

New `Boards::AdminBuilder::FolderTiles`, run on every form round-trip (`submitted_form`) **and again after each drafting action rewrites part of the form**. Running it once at submit isn't enough: every drafter replaces something after the fact.

- Any keyed page nothing opens gets a folder tile on the root, written into the word list so it's visible and editable.
- A tile already saying the page's word is **promoted**, not duplicated — including one whose `links_to` names a page that doesn't exist. A mistyped `>fod` beside a page called Food is a door meant for that page, so it's retargeted rather than rejected.
- A link from a sibling page counts as a door; no redundant second one is added.
- Root drafting asks for `tile_count - reserved_count` words, so folder tiles land inside the grid instead of overflowing it.
- If the root is already full, trailing plain words are displaced to make room — **never another page's door** — and the banner names exactly what went. A word is regenerable, a door isn't, and an overflowing board can't be built at all.
- Folder tiles carry a `display_label`, so `Image#set_label`'s lowercase default can't fold a category tile's authored capital. (Existing `SetDrafter` folder tiles didn't set this, so they were building as "food" rather than "Food".)
- `duplicate` runs the same pass, so loading an already-broken build into the form repairs it.

`PlanValidator#orphan_problems` is the backstop, not the mechanism — it can only fire for a page whose key never got far enough to be linked.

## Reviewer notes

- **One existing spec changed meaning.** "rejects a tile pointing at a page that doesn't exist" used `Food | noun | >nope` next to a page named Food — that case is now *repaired* rather than rejected. The spec was rewritten to use a tile whose word names no page in the set (nothing to infer from), and a new spec covers the repair.
- **Nothing here fixes already-built sets.** This is authoring-side only. The repair path for a live broken set is Duplicate → rebuild; the form now comes back with the folder tiles filled in.
- The `.claude-notes/board-builder.md` spoke is gitignored and force-added, per this repo's convention.

## Test plan

```
bundle exec rspec spec/services/boards/admin_builder spec/requests/admin/board_builds_spec.rb spec/models/admin_board_build_spec.rb spec/requests/admin/access_control_spec.rb
```

**348 examples, 0 failures.** Includes 20 new `FolderTiles` unit specs (append, promote, retarget, sibling links, key rejection, displacement rules), 3 new `PlanValidator` orphan specs, and 4 new request specs covering the end-to-end build, the banner, and the round-tripped word list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)