### PR TITLE
feat(admin): pick the page names when drafting a whole board set

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -355,6 +355,34 @@ a field, so `reindexPages()` has to rewrite that `value` alongside the field
 `name`s — renumbering names alone leaves a moved block drafting into whichever
 page took its old position.
 
+#### Page names are authored input — `Boards::AdminBuilder::PageNamesSuggester`
+
+**A page key or name on the form is never overwritten by a drafter.** It decides
+what `SetDrafter` writes and, once built, it is the sub-board's name — so
+`draft_set` passes the named pages through as `pages:` and the model only names
+the blanks. Two consequences to keep:
+
+- The pinned keys go **into the prompt**, not merged in afterwards: the root's
+  folder tiles carry `links_to` per page, so a key invented by the model and
+  renamed later would leave the root linking at nothing. `apply_pinned` is the
+  backstop for a paraphrased answer — it matches on key, falls back to position,
+  and forces the admin's key/name back on.
+- Naming more pages than `page_count` **raises the count** (capped at
+  `MAX_PAGES`) rather than dropping the extra names; the drafter echoes the
+  count it actually used back as `page_count:` so the notice and the select
+  follow it.
+
+`PageNamesSuggester` is the names-only half: topic/name/audience + a count →
+`[{ key:, name: }]`, no words, `ContextSuggester`'s shape throughout. Pages the
+admin already named are repeated back in place and never duplicated, and the
+call is skipped entirely when they already fill the count. `suggest_pages` drops
+the suggestions onto blank blocks **where they sit** — assigning by position in
+the suggestion would land a name on a block that already holds another page's
+word list.
+
+`Keys.normalize` is the one slugifier for all of this; a second copy is how a
+`>key` link silently resolves to nothing.
+
 ### Phase 3 — linked child pages
 
 - Plan gains `children: [{ key, name, tiles }]` and tiles gain `links_to`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **You pick the page names when the admin board builder drafts a whole set.**
+  "Draft the whole set with AI" now keeps every page key and name already typed
+  on the form and only names the pages left blank — previously it replaced the
+  pages wholesale, so a chosen title survived only by being retyped afterwards.
+  Naming more pages than the page count asks for raises the count instead of
+  dropping them. A new "Suggest page names" button fills in the page titles on
+  their own — no words — so the shape of the set can be read and edited before
+  any word list is drafted under it.
+
 - **The admin board builder can draft one page at a time from its title.** Each
   page block gets a "Draft this page with AI" button that fills only that page's
   word list, worked out from the page's own name with the board's topic as

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -111,6 +111,10 @@ module Admin
     # Optional step zero, the multi-page form of `draft`. Drafts the whole set
     # — root word list with its folder tiles already linked, plus each page —
     # into the form and stops there. Nothing is previewed or built from it.
+    #
+    # Page keys and names already on the form are authored input: they are
+    # passed through and used verbatim, and the AI only names the pages that are
+    # still blank. Word lists are the part this replaces.
     def draft_set
       @form = submitted_form
       @form = @form.merge(suggested_context(@form)) if @form[:topic].blank? || @form[:name].blank?
@@ -123,6 +127,7 @@ module Admin
         tile_count: @form[:tile_count].to_i,
         page_count: @form[:page_count].to_i,
         audience: @form[:audience],
+        pages: named_pages(@form),
       ).call
 
       # The prompt asks for a folder tile per page, but a draft that came back
@@ -131,6 +136,9 @@ module Admin
         words: tiles_to_words(set[:root_tiles]),
         tiles: set[:root_tiles],
         children: children_form_from(set[:children]),
+        # Naming more pages than the count asked for raises the count rather
+        # than dropping the names, so the select has to follow.
+        page_count: (set[:page_count] || @form[:page_count]).to_s,
       ))
       flash.now[:notice] = draft_set_notice(set, @form)
       render :new
@@ -175,6 +183,38 @@ module Admin
       render :new
     rescue Boards::AdminBuilder::PageDrafter::GenerationError => e
       @problems = ["Couldn't draft that page: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    end
+
+    # Names the pages and nothing else — no words, no grids. The set drafter
+    # then honours those names, so this is the "decide the shape first" half of
+    # `draft_set`: titles are the cheapest thing to read and re-read, and a set
+    # drafted under the wrong page names is thrown away wholesale.
+    def suggest_pages
+      @form = submitted_form
+      @form = @form.merge(suggested_context(@form)) if @form[:topic].blank?
+      @problems = suggest_pages_problems(@form)
+      return render(:new, status: :unprocessable_entity) if @problems.any?
+
+      pages = Boards::AdminBuilder::PageNamesSuggester.new(
+        topic: @form[:topic],
+        name: @form[:name],
+        audience: @form[:audience],
+        count: suggested_page_count(@form),
+        existing: named_pages(@form),
+      ).call
+
+      children = children_named_from(@form[:children], pages)
+      # Naming a page is what makes it a page, so the folder tile that opens it
+      # is written now rather than a round trip later.
+      @form = with_folder_tiles(@form.merge(children: children, page_count: page_count_for(children, @form)))
+      flash.now[:notice] = suggest_pages_notice(pages)
+      render :new
+    rescue Boards::AdminBuilder::PageNamesSuggester::GenerationError => e
+      @problems = ["Couldn't suggest page names: #{e.message}"]
+      render :new, status: :unprocessable_entity
+    rescue Boards::AdminBuilder::ContextSuggester::GenerationError => e
+      @problems = ["Couldn't work out the topic: #{e.message}"]
       render :new, status: :unprocessable_entity
     end
 
@@ -511,6 +551,63 @@ module Admin
         "add #{wanted - tiles.size} more before previewing."
     end
 
+    # The pages the admin has already named, in form order. A block with only a
+    # key or only a name still counts — the suggester and the set drafter both
+    # fill the missing half rather than treating it as unnamed.
+    def named_pages(form)
+      form[:children].filter_map do |child|
+        next if child[:key].blank? && child[:name].blank?
+
+        { key: child[:key], name: child[:name] }
+      end
+    end
+
+    # Never fewer pages than are already on the form: a suggestion that dropped
+    # a block the admin added would take its word list with it.
+    def suggested_page_count(form)
+      [form[:page_count].to_i, form[:children].size, 1].max
+        .clamp(1, Boards::AdminBuilder::SetDrafter::MAX_PAGES)
+    end
+
+    def suggest_pages_problems(form)
+      return ["Give the board a name or a topic to suggest pages from."] if form[:topic].blank?
+
+      []
+    end
+
+    # Suggested names fill the unnamed blocks where they sit — never by
+    # position in the suggestion, which would move a name onto a block that
+    # already holds someone else's word list. Whatever is left over becomes new
+    # blank blocks at the end.
+    def children_named_from(children, pages)
+      taken = named_pages({ children: children })
+              .map { |page| Boards::AdminBuilder::Keys.normalize(page[:key].presence || page[:name]) }
+              .to_set
+      extras = pages.reject { |page| taken.include?(page[:key]) }
+
+      filled = children.map do |child|
+        next child if child[:key].present? || child[:name].present?
+
+        page = extras.shift
+        page ? child.merge(key: page[:key], name: page[:name]) : child
+      end
+
+      filled + extras.map { |page| blank_child.merge(key: page[:key], name: page[:name]) }
+    end
+
+    # The select only offers 0..MAX_PAGES, so a form carrying more blocks than
+    # that keeps whatever it had rather than being shown a count it can't hold.
+    def page_count_for(children, form)
+      return form[:page_count] if children.size > Boards::AdminBuilder::SetDrafter::MAX_PAGES
+
+      children.size.to_s
+    end
+
+    def suggest_pages_notice(pages)
+      "Suggested #{pages.size} #{"page".pluralize(pages.size)} — " \
+        "edit the names, then draft the set to fill them with words."
+    end
+
     def tiles_to_words(tiles)
       Boards::AdminBuilder::WordList.render(tiles)
     end
@@ -532,7 +629,9 @@ module Admin
 
     def draft_set_notice(set, form)
       wanted_tiles = form[:tile_count].to_i
-      wanted_pages = form[:page_count].to_i
+      # What was attempted, not what the select said: pages the admin named
+      # above the count raise it rather than being dropped.
+      wanted_pages = (set[:page_count] || form[:page_count]).to_i
       pages = set[:children].size
       short_boards = ([set[:root_tiles]] + set[:children].map { |child| child[:tiles] })
                      .count { |tiles| tiles.size != wanted_tiles }

--- a/app/services/boards/admin_builder/keys.rb
+++ b/app/services/boards/admin_builder/keys.rb
@@ -1,0 +1,20 @@
+module Boards
+  module AdminBuilder
+    # Page keys are the link targets a tile points at with `>key`, so every
+    # producer of one — the AI drafters and the admin's own typing — has to
+    # slugify it the same way or a link silently resolves to nothing.
+    module Keys
+      module_function
+
+      # Strips leading/trailing underscores from a slugified key — except when
+      # the value already equals the root sentinel, which is nothing but
+      # underscores and would otherwise be stripped to blank.
+      def normalize(value)
+        cleaned = value.to_s.strip.downcase.gsub(/[^a-z0-9_]+/, "_")
+        return cleaned if cleaned == Plan::ROOT_KEY
+
+        cleaned.gsub(/\A_+|_+\z/, "")
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/page_names_suggester.rb
+++ b/app/services/boards/admin_builder/page_names_suggester.rb
@@ -1,0 +1,140 @@
+module Boards
+  module AdminBuilder
+    # Proposes the pages of a set — key and name only, no words — so the admin
+    # can read and edit the titles before a whole set is drafted under them.
+    # One OpenAI call returning `{ pages: [{ key:, name: }] }`.
+    #
+    # The counterpart to ContextSuggester: same shape, same rule that anything
+    # already typed is repeated back unchanged rather than improved. Names that
+    # come out of here are fed straight back into SetDrafter as pinned pages.
+    #
+    # ONLY EVER POPULATES THE FORM — nothing is previewed or built from it.
+    #
+    # No credit charge: the boards it drafts for are admin-owned.
+    class PageNamesSuggester
+      class GenerationError < StandardError; end
+
+      # A page name is user-facing and becomes the sub-board's name.
+      MAX_NAME_LENGTH = 60
+
+      def initialize(topic:, count:, name: nil, audience: nil, existing: [])
+        @topic = topic.to_s.strip
+        @name = name.to_s.strip
+        @audience = audience.to_s.strip
+        @existing = clean_existing(existing)
+        @count = count.to_i.clamp(0, SetDrafter::MAX_PAGES)
+      end
+
+      def call
+        raise GenerationError, "give the board a topic to suggest pages for" if topic.blank? && name.blank?
+        return existing.first(count) if count <= existing.size
+
+        parse_response(generate_via_openai)
+      end
+
+      private
+
+      attr_reader :topic, :name, :audience, :existing, :count
+
+      # Pages the admin already named. Kept in order and repeated back to the
+      # model so what comes out slots into the form without renaming anything.
+      def clean_existing(pages)
+        seen = Set.new
+
+        Array(pages).filter_map do |page|
+          page_name = page[:name].to_s.strip
+          key = Keys.normalize(page[:key].presence || page_name)
+          next if key.blank?
+          next unless seen.add?(key)
+
+          { key: key, name: page_name.presence || key.titleize }
+        end
+      end
+
+      def generate_via_openai
+        client = OpenAiClient.new(
+          prompt: topic.presence || name,
+          messages: [{ role: "user", content: build_prompt }],
+        )
+        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
+        result = client.create_chat(true)
+
+        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
+
+        result[:content]
+      end
+
+      def build_prompt
+        <<~PROMPT
+          You are planning a set of AAC (Augmentative and Alternative Communication) boards
+          for a nonspeaking communicator: a main board plus #{count} pages, each opened by a
+          folder tile on the main board.
+
+          #{name.present? ? "The board is called: #{name}" : ""}
+          #{topic.present? ? "The set is about: #{topic}" : ""}
+          #{audience.present? ? "It is for: #{audience}" : ""}
+
+          Name the #{count} #{"page".pluralize(count)}. Do not write any words or tiles — titles only.
+          #{existing_instruction}
+          Rules:
+          - "name" is what a teacher or parent would recognize in a list: short title case,
+            1-3 words, no punctuation. "Snack Time", "Feelings", "Getting Dressed".
+          - "key" is the same page as an identifier: lowercase letters, numbers and
+            underscores only.
+          - Each page is a distinct subject of the topic — no two pages that would hold the
+            same words, and nothing so broad it repeats the main board's core words.
+
+          Respond in JSON format:
+          { "pages": [{ "key": "snack_time", "name": "Snack Time" }] }
+
+          Return ONLY the JSON, no other text.
+        PROMPT
+      end
+
+      def existing_instruction
+        return "" if existing.empty?
+
+        listed = existing.map { |page| %("#{page[:name]}") }.join(", ")
+        "The first #{existing.size} #{"page".pluralize(existing.size)} are already chosen: " \
+          "#{listed}. Repeat #{existing.size == 1 ? "it" : "them"} back first, unchanged, then " \
+          "name the rest so they don't overlap.\n"
+      end
+
+      def parse_response(raw)
+        data = JSON.parse(raw)
+        pages = merge_existing(clean_pages(Array(data["pages"])))
+
+        raise GenerationError, "AI returned no usable page names" if pages.empty?
+
+        pages
+      rescue JSON::ParserError => e
+        raise GenerationError, "Failed to parse AI response: #{e.message}"
+      end
+
+      def clean_pages(raw_pages)
+        seen = Set.new
+
+        raw_pages.filter_map do |page|
+          next unless page.is_a?(Hash)
+
+          page_name = page["name"].to_s.strip.truncate(MAX_NAME_LENGTH)
+          key = Keys.normalize(page["key"].presence || page_name)
+          next if key.blank?
+          next unless seen.add?(key)
+
+          { key: key, name: page_name.presence || key.titleize }
+        end
+      end
+
+      # What the admin typed is authoritative even when the model rewrote it, so
+      # the chosen pages are put back at the front and only unseen suggestions
+      # fill the rest.
+      def merge_existing(suggested)
+        taken = existing.map { |page| page[:key] }.to_set
+        extras = suggested.reject { |page| taken.include?(page[:key]) }
+
+        (existing + extras).first(count)
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/set_drafter.rb
+++ b/app/services/boards/admin_builder/set_drafter.rb
@@ -24,12 +24,18 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES_PER_PAGE = 144
 
-      def initialize(topic:, columns:, tile_count:, page_count:, audience: nil)
+      # `pages` are the pages the admin already named on the form, as
+      # `{ key:, name: }` hashes. They are used verbatim and the model only
+      # invents the rest — so a page count below the number of names would
+      # throw away typed input, and the larger of the two wins.
+      def initialize(topic:, columns:, tile_count:, page_count:, audience: nil, pages: [])
         @topic = topic.to_s.strip
         @tile_count = tile_count.to_i.clamp(1, MAX_TILES_PER_PAGE)
-        @page_count = page_count.to_i.clamp(0, MAX_PAGES)
         @audience = audience.to_s.strip
         @columns = columns.to_i
+        @pinned = clean_pinned(pages)
+        @page_count = [page_count.to_i, @pinned.size].max.clamp(0, MAX_PAGES)
+        @pinned = @pinned.first(@page_count)
       end
 
       def call
@@ -41,7 +47,23 @@ module Boards
 
       private
 
-      attr_reader :topic, :tile_count, :page_count, :audience, :columns
+      attr_reader :topic, :tile_count, :page_count, :audience, :columns, :pinned
+
+      # A page is pinned by whichever half the admin typed: a name alone gives
+      # the key, a key alone gives the name. Blank blocks and duplicate keys are
+      # dropped rather than sent to the prompt as noise.
+      def clean_pinned(pages)
+        seen = Set.new
+
+        Array(pages).filter_map do |page|
+          name = page[:name].to_s.strip
+          key = Keys.normalize(page[:key].presence || name)
+          next if key.blank?
+          next unless seen.add?(key)
+
+          { key: key, name: name.presence || key.titleize }
+        end
+      end
 
       # A set with no pages is exactly what WordListDrafter already answers.
       def single_page_set
@@ -49,7 +71,7 @@ module Boards
           topic: topic, tile_count: tile_count, audience: audience.presence,
         ).call
 
-        { root_tiles: tiles, children: [] }
+        { root_tiles: tiles, children: [], page_count: page_count }
       rescue WordListDrafter::GenerationError => e
         raise GenerationError, e.message
       end
@@ -80,6 +102,7 @@ module Boards
           tiles for each page — every board in the set is #{columns} columns wide with the
           same tile count, and a count that doesn't fill whole rows leaves visible dead cells.
 
+          #{pinned_pages_instruction}
           Structure rules:
           - Give every page a "key": lowercase letters, numbers and underscores only.
           - Every page must have exactly one tile on the main board that opens it. Give that
@@ -126,6 +149,30 @@ module Boards
         PROMPT
       end
 
+      # The pinned pages are named in the prompt rather than merged in after the
+      # fact because the root's folder tiles have to carry `links_to` for each
+      # one — a key invented here and reconciled later would leave the root
+      # linking to a page that no longer exists.
+      def pinned_pages_instruction
+        return "" if pinned.empty?
+
+        listed = pinned.map { |page| %(- key "#{page[:key]}", name "#{page[:name]}") }.join("\n")
+        remaining = page_count - pinned.size
+
+        <<~TEXT
+          These pages are already decided. Use these exact keys and names, in this order,
+          and do not rename or merge them:
+          #{listed}
+          #{if remaining.positive?
+              "Then add #{remaining} more #{"page".pluralize(remaining)} of your own that fit the " \
+              "topic, with keys and names that don't repeat the ones above."
+            else
+              "Do not add any other pages."
+            end}
+
+        TEXT
+      end
+
       def parse_response(raw)
         data = JSON.parse(raw)
         children = clean_children(Array(data["pages"]))
@@ -136,7 +183,10 @@ module Boards
         # fills the form and the counter shows the gap.
         raise GenerationError, "AI returned no usable words" if root_tiles.empty?
 
-        { root_tiles: root_tiles, children: children }
+        # The count is echoed back because pinned pages can raise it above what
+        # the form asked for, and the notice compares against what was actually
+        # attempted.
+        { root_tiles: root_tiles, children: children, page_count: page_count }
       rescue JSON::ParserError => e
         raise GenerationError, "Failed to parse AI response: #{e.message}"
       end
@@ -154,7 +204,9 @@ module Boards
           next unless seen.add?(key)
 
           { key: key, name: page["name"].to_s.strip.presence || key.titleize, tiles: Array(page["tiles"]) }
-        end.first(page_count)
+        end
+
+        pages = apply_pinned(pages).first(page_count)
 
         keys = pages.map { |page| page[:key] }
         pages.map do |page|
@@ -162,14 +214,28 @@ module Boards
         end
       end
 
-      # Strips leading/trailing underscores from a slugified key — except when
-      # the value already equals the root sentinel, which is nothing but
-      # underscores and would otherwise be stripped to blank.
-      def normalize_key(value)
-        cleaned = value.to_s.strip.downcase.gsub(/[^a-z0-9_]+/, "_")
-        return cleaned if cleaned == Plan::ROOT_KEY
+      # The admin's key and name win even when the model paraphrased them: a
+      # pinned page takes the response page with the same key, and otherwise the
+      # next unclaimed one in order (the prompt asks for the pinned pages first).
+      # A pinned page the model skipped entirely still appears, empty — the form
+      # shows the gap and the page can be drafted on its own.
+      def apply_pinned(pages)
+        return pages if pinned.empty?
 
-        cleaned.gsub(/\A_+|_+\z/, "")
+        remaining = pages.dup
+
+        claimed = pinned.map do |page|
+          match = remaining.find { |candidate| candidate[:key] == page[:key] } || remaining.first
+          remaining.delete(match) if match
+
+          { key: page[:key], name: page[:name], tiles: Array(match && match[:tiles]) }
+        end
+
+        claimed + remaining
+      end
+
+      def normalize_key(value)
+        Keys.normalize(value)
       end
 
       def clean_tiles(raw_tiles, known_keys:)

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -162,12 +162,19 @@
           A folder tile on the main board opens a page. Give each page a key and the folder tile is
           written for you — point a tile at it with <span class="font-mono">&gt;key</span> yourself only if you
           want a different word on it. Pages inherit the main board's grid unless you say otherwise.
+          Page names you type are kept — drafting the whole set only names the pages you left blank.
         </p>
       </div>
       <div class="flex items-center gap-2">
         <%= select_tag :page_count,
               options_for_select((0..Boards::AdminBuilder::SetDrafter::MAX_PAGES).map { |n| [n.zero? ? "no pages" : "#{n} #{"page".pluralize(n)}", n.to_s] }, @form[:page_count]),
               class: "admin-input border rounded px-2 py-1.5 text-xs focus:border-indigo-500 focus:outline-none" %>
+        <%# Names only, no words: the titles decide what the set drafter writes,
+            so they're the cheapest thing to read and change first. %>
+        <button type="submit" id="suggest-pages-button" formaction="<%= suggest_pages_admin_dashboard_board_builds_path %>" formnovalidate
+                class="text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+          Suggest page names
+        </button>
         <%# formaction, not a second form: the drafter has to see the topic,
             audience and grid typed above. formnovalidate for the same reason
             the word-list drafter has it — a missing name is inferred. %>
@@ -453,16 +460,20 @@
       });
     }
 
-    // Drafting the set replaces the root list AND every page.
+    // Drafting the set replaces the root list AND every page's words. Page
+    // names survive it, so the warning says so rather than overstating it.
     var draftSetButton = document.getElementById("draft-set-button");
     if (draftSetButton) {
       draftSetButton.addEventListener("click", function (event) {
         var hasPages = pages.querySelectorAll(".page-block").length > 0;
         if (words.value.trim() === "" && !hasPages) return;
-        if (!window.confirm("Replace the word list and every page with an AI draft?")) {
+        if (!window.confirm("Replace the word list and every page's words with an AI draft? Page names you've typed are kept.")) {
           event.preventDefault();
         }
       });
     }
+
+    // No confirm on "Suggest page names" on purpose: it only fills key/name
+    // fields that are blank, so there is nothing to lose.
   })();
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
     resources :board_builds, only: [:index, :new, :create, :show, :update, :destroy], as: :dashboard_board_builds do
       collection do
         post :suggest
+        post :suggest_pages
         post :draft
         post :add_words
         post :draft_set

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1057,7 +1057,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
 
     it "warns rather than claiming success when the AI comes back short on pages" do
-      stub_set_drafter(root_tiles: drafted[:root_tiles], children: [])
+      stub_set_drafter(root_tiles: drafted[:root_tiles], children: [], page_count: 2)
 
       post draft_set_admin_dashboard_board_builds_path,
            params: form_params(words: "", page_count: "2", columns: "1", tile_count: "2")
@@ -1065,6 +1065,106 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(response).to have_http_status(:ok)
       expect(flash[:notice]).to match(/short|didn.t come back|asked for 2/i)
       expect(flash[:notice]).not_to eq("Drafted the main board and 0 pages. Edit them, then preview the art.")
+    end
+
+    # Page names are authored input: the drafter is told about them and only
+    # names the pages left blank.
+    it "hands the page names already on the form to the drafter" do
+      expect(Boards::AdminBuilder::SetDrafter).to receive(:new)
+        .with(hash_including(pages: [{ key: "food", name: "Food" }]))
+        .and_return(instance_double(Boards::AdminBuilder::SetDrafter, call: drafted))
+
+      post draft_set_admin_dashboard_board_builds_path,
+           params: form_params(
+             words: "", page_count: "1", columns: "1", tile_count: "2",
+             children: { "0" => { key: "food", name: "Food", columns: "", tile_count: "", words: "" } },
+           )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("value=\"Food\"")
+    end
+
+    it "follows the page count up when more pages were named than asked for" do
+      stub_set_drafter(drafted.merge(page_count: 2))
+
+      post draft_set_admin_dashboard_board_builds_path,
+           params: form_params(words: "", page_count: "1", columns: "1", tile_count: "2")
+
+      expect(response.body).to include("<option selected=\"selected\" value=\"2\">")
+    end
+  end
+
+  describe "POST suggest_pages" do
+    before { sign_in admin }
+
+    def stub_suggester(pages)
+      allow(Boards::AdminBuilder::PageNamesSuggester).to receive(:new).and_return(
+        instance_double(Boards::AdminBuilder::PageNamesSuggester, call: pages),
+      )
+    end
+
+    let(:suggested) { [{ key: "food", name: "Food" }, { key: "drinks", name: "Drinks" }] }
+
+    it "fills the page names and nothing else" do
+      stub_suggester(suggested)
+
+      post suggest_pages_admin_dashboard_board_builds_path,
+           params: form_params(words: "swing | noun", page_count: "2", columns: "1", tile_count: "2")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("value=\"Food\"")
+      expect(response.body).to include("value=\"drinks\"")
+      # The root word list is untouched — this names pages, it doesn't draft.
+      expect(response.body).to include("swing | noun")
+      expect(flash[:notice]).to include("Suggested 2 pages")
+    end
+
+    it "keeps a page the admin already named, and its words" do
+      expect(Boards::AdminBuilder::PageNamesSuggester).to receive(:new)
+        .with(hash_including(existing: [{ key: "drinks", name: "Drinks" }], count: 2))
+        .and_return(instance_double(Boards::AdminBuilder::PageNamesSuggester,
+                                    call: [{ key: "drinks", name: "Drinks" }, { key: "food", name: "Food" }]))
+
+      post suggest_pages_admin_dashboard_board_builds_path,
+           params: form_params(
+             page_count: "2", columns: "1", tile_count: "2",
+             children: { "0" => { key: "drinks", name: "Drinks", columns: "", tile_count: "",
+                                  words: "juice | noun" } },
+           )
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("juice | noun")
+      expect(response.body).to include("value=\"Food\"")
+    end
+
+    it "writes nothing" do
+      stub_suggester(suggested)
+
+      expect {
+        post suggest_pages_admin_dashboard_board_builds_path,
+             params: form_params(page_count: "2", columns: "1", tile_count: "2")
+      }.to not_change(Board, :count).and not_change(Image, :count).and not_change(AdminBoardBuild, :count)
+    end
+
+    it "refuses with nothing to work from" do
+      post suggest_pages_admin_dashboard_board_builds_path,
+           params: form_params(name: "", topic: "", words: "", page_count: "2")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("suggest pages from")
+    end
+
+    it "reports a generation failure without losing what was typed" do
+      allow(Boards::AdminBuilder::PageNamesSuggester).to receive(:new).and_raise(
+        Boards::AdminBuilder::PageNamesSuggester::GenerationError, "OpenAI returned no content",
+      )
+
+      post suggest_pages_admin_dashboard_board_builds_path,
+           params: form_params(name: "Playground", page_count: "2")
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Couldn&#39;t suggest page names")
+      expect(response.body).to include("Playground")
     end
   end
 

--- a/spec/services/boards/admin_builder/page_names_suggester_spec.rb
+++ b/spec/services/boards/admin_builder/page_names_suggester_spec.rb
@@ -1,0 +1,171 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::PageNamesSuggester do
+  def ai_pages(pages)
+    { "pages" => pages }.to_json
+  end
+
+  def stub_ai(content)
+    allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+      .and_return({ role: "assistant", content: content })
+  end
+
+  let(:suggested) do
+    ai_pages([
+      { "key" => "snack_time", "name" => "Snack Time" },
+      { "key" => "drinks", "name" => "Drinks" },
+    ])
+  end
+
+  before { stub_ai(suggested) }
+
+  def suggest(**overrides)
+    described_class.new(**{ topic: "snack time at school", count: 2 }.merge(overrides)).call
+  end
+
+  describe "#call" do
+    it "returns a key and a name per page" do
+      expect(suggest).to eq([
+        { key: "snack_time", name: "Snack Time" },
+        { key: "drinks", name: "Drinks" },
+      ])
+    end
+
+    it "refuses to suggest without a name or a topic" do
+      expect { suggest(topic: "  ") }.to raise_error(described_class::GenerationError, /topic/)
+    end
+
+    it "works from the board name alone" do
+      expect(suggest(topic: "", name: "Snack Time")).not_to be_empty
+    end
+
+    it "trims to the requested count" do
+      expect(suggest(count: 1).map { |page| page[:key] }).to eq(["snack_time"])
+    end
+
+    it "caps the count at what the set drafter will accept" do
+      expect(described_class.new(topic: "a", count: 99).send(:count))
+        .to eq(Boards::AdminBuilder::SetDrafter::MAX_PAGES)
+    end
+  end
+
+  # What the admin typed is authoritative — it comes back first, unchanged,
+  # and a suggestion that repeats it doesn't get a second block.
+  describe "pages the admin already named" do
+    it "keeps them first and unchanged" do
+      pages = suggest(count: 2, existing: [{ key: "treats", name: "Treats" }])
+
+      expect(pages).to eq([
+        { key: "treats", name: "Treats" },
+        { key: "snack_time", name: "Snack Time" },
+      ])
+    end
+
+    it "doesn't repeat one the model named again" do
+      stub_ai(ai_pages([{ "key" => "treats", "name" => "Treats and Snacks" },
+                        { "key" => "drinks", "name" => "Drinks" }]))
+
+      pages = suggest(count: 2, existing: [{ key: "treats", name: "Treats" }])
+
+      expect(pages).to eq([
+        { key: "treats", name: "Treats" },
+        { key: "drinks", name: "Drinks" },
+      ])
+    end
+
+    it "derives the key from a page named without one" do
+      expect(suggest(count: 1, existing: [{ key: "", name: "Quiet Time" }]))
+        .to eq([{ key: "quiet_time", name: "Quiet Time" }])
+    end
+
+    # Nothing left to ask about, so nothing is asked.
+    it "skips the AI call when they already fill the count" do
+      expect(OpenAiClient).not_to receive(:new)
+
+      expect(suggest(count: 1, existing: [{ key: "treats", name: "Treats" }]))
+        .to eq([{ key: "treats", name: "Treats" }])
+    end
+  end
+
+  describe "cleanup of what the model returns" do
+    it "normalizes a key to lowercase letters, numbers and underscores" do
+      stub_ai(ai_pages([{ "key" => "Snack Time!", "name" => "Snack Time" }]))
+
+      expect(suggest(count: 1).first[:key]).to eq("snack_time")
+    end
+
+    it "derives a key from the name when the model omitted one" do
+      stub_ai(ai_pages([{ "name" => "Snack Time" }]))
+
+      expect(suggest(count: 1).first[:key]).to eq("snack_time")
+    end
+
+    it "falls back to the key when the model omitted the name" do
+      stub_ai(ai_pages([{ "key" => "snack_time" }]))
+
+      expect(suggest(count: 1).first[:name]).to eq("Snack Time")
+    end
+
+    it "drops a page with nothing usable in it" do
+      stub_ai(ai_pages([{ "key" => "  ", "name" => "  " }, { "key" => "drinks", "name" => "Drinks" }]))
+
+      expect(suggest(count: 2).map { |page| page[:key] }).to eq(["drinks"])
+    end
+
+    it "drops a key that repeats an earlier one" do
+      stub_ai(ai_pages([{ "key" => "drinks", "name" => "Drinks" },
+                        { "key" => "drinks", "name" => "More Drinks" }]))
+
+      expect(suggest(count: 2).map { |page| page[:name] }).to eq(["Drinks"])
+    end
+  end
+
+  describe "failures" do
+    it "raises when OpenAI returns nothing" do
+      stub_ai("")
+      expect { suggest }.to raise_error(described_class::GenerationError, /no content/)
+    end
+
+    it "raises on unparseable JSON" do
+      stub_ai("not json")
+      expect { suggest }.to raise_error(described_class::GenerationError, /Failed to parse/)
+    end
+
+    it "raises when nothing usable came back" do
+      stub_ai(ai_pages([]))
+      expect { suggest }.to raise_error(described_class::GenerationError, /no usable page names/)
+    end
+  end
+
+  describe "the prompt" do
+    def prompt_for(**args)
+      captured = nil
+      allow(OpenAiClient).to receive(:new) do |opts|
+        captured = opts[:messages].first[:content]
+        instance_double(OpenAiClient, create_chat: { role: "assistant", content: suggested })
+          .tap { |double| allow(double).to receive(:instance_variable_set) }
+      end
+      described_class.new(**{ topic: "snack time at school", count: 2 }.merge(args)).call
+      captured
+    end
+
+    it "asks for titles only" do
+      expect(prompt_for).to include("Do not write any words or tiles")
+    end
+
+    it "asks for the requested number of pages" do
+      expect(prompt_for).to include("Name the 2 pages")
+    end
+
+    it "includes the audience only when one is given" do
+      expect(prompt_for(audience: "a preschooler")).to include("It is for: a preschooler")
+      expect(prompt_for).not_to include("It is for:")
+    end
+
+    it "repeats back the pages the admin already chose" do
+      prompt = prompt_for(count: 2, existing: [{ key: "treats", name: "Treats" }])
+
+      expect(prompt).to include("already chosen: \"Treats\"")
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/set_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/set_drafter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
                                     call: [{ label: "swing", part_of_speech: "noun" }]))
 
       expect(draft(page_count: 0)).to eq(
-        { root_tiles: [{ label: "swing", part_of_speech: "noun" }], children: [] },
+        { root_tiles: [{ label: "swing", part_of_speech: "noun" }], children: [], page_count: 0 },
       )
     end
 
@@ -169,6 +169,88 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
     end
   end
 
+  # Pages the admin named on the form are authored input: the model fills the
+  # rest of the set around them and never renames them.
+  describe "pinned pages" do
+    it "keeps the admin's key and name even when the model paraphrases them" do
+      stub_ai(ai_set(
+        root: [tile("Snacks", "noun", "snack_time")],
+        pages: [{ "key" => "snack_time", "name" => "Snacks and Treats",
+                  "tiles" => [tile("apple", "noun")] }],
+      ))
+
+      child = draft(columns: 1, tile_count: 1, pages: [{ key: "snack_time", name: "Snack Time" }])[:children].first
+      expect(child[:key]).to eq("snack_time")
+      expect(child[:name]).to eq("Snack Time")
+      expect(child[:tiles]).to eq([{ label: "apple", part_of_speech: "noun" }])
+    end
+
+    it "takes the next unclaimed page when the model answered a different key" do
+      stub_ai(ai_set(
+        root: [tile("I", "pronoun")],
+        pages: [{ "key" => "treats", "name" => "Treats", "tiles" => [tile("apple", "noun")] }],
+      ))
+
+      child = draft(columns: 1, tile_count: 1, pages: [{ key: "snack_time", name: "Snack Time" }])[:children].first
+      expect(child[:key]).to eq("snack_time")
+      expect(child[:tiles].first[:label]).to eq("apple")
+    end
+
+    it "fills the pages the admin left blank around the ones they named" do
+      stub_ai(ai_set(
+        root: [tile("I", "pronoun")],
+        pages: [
+          { "key" => "snack_time", "name" => "Snack Time", "tiles" => [tile("apple", "noun")] },
+          { "key" => "drinks", "name" => "Drinks", "tiles" => [tile("water", "noun")] },
+        ],
+      ))
+
+      children = draft(columns: 1, tile_count: 1, page_count: 2,
+                       pages: [{ key: "snack_time", name: "Snack Time" }])[:children]
+      expect(children.map { |child| child[:name] }).to eq(["Snack Time", "Drinks"])
+    end
+
+    # Dropping a page the admin typed would throw away authored input to honour
+    # a count they can raise with one click.
+    it "raises the page count rather than dropping a named page" do
+      stub_ai(ai_set(
+        root: [tile("I", "pronoun")],
+        pages: [
+          { "key" => "snacks", "name" => "Snacks", "tiles" => [tile("apple", "noun")] },
+          { "key" => "drinks", "name" => "Drinks", "tiles" => [tile("water", "noun")] },
+        ],
+      ))
+
+      result = draft(columns: 1, tile_count: 1, page_count: 1,
+                     pages: [{ key: "snacks", name: "Snacks" }, { key: "drinks", name: "Drinks" }])
+      expect(result[:page_count]).to eq(2)
+      expect(result[:children].map { |child| child[:key] }).to eq(%w[snacks drinks])
+    end
+
+    it "derives the missing half of a page named with only a key or only a name" do
+      stub_ai(ai_set(root: [tile("I", "pronoun")], pages: []))
+
+      children = draft(columns: 1, tile_count: 1, page_count: 2,
+                       pages: [{ key: "snack_time", name: "" }, { key: "", name: "Quiet Time" }])[:children]
+      expect(children.map { |child| [child[:key], child[:name]] })
+        .to eq([["snack_time", "Snack Time"], ["quiet_time", "Quiet Time"]])
+    end
+
+    it "keeps a page the model skipped entirely, with no words" do
+      stub_ai(ai_set(root: [tile("I", "pronoun")], pages: []))
+
+      children = draft(columns: 1, tile_count: 1, pages: [{ key: "snacks", name: "Snacks" }])[:children]
+      expect(children.map { |child| child[:key] }).to eq(["snacks"])
+      expect(children.first[:tiles]).to be_empty
+    end
+
+    it "ignores a wholly blank page block" do
+      children = draft(columns: 1, tile_count: 1, pages: [{ key: "", name: "  " }])[:children]
+
+      expect(children.map { |child| child[:key] }).to eq(["food"])
+    end
+  end
+
   describe "failures" do
     it "raises when OpenAI returns nothing" do
       stub_ai("")
@@ -229,6 +311,26 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
 
     it "caps the page count it will ask for" do
       expect(prompt_for(page_count: 99)).to include("exactly #{described_class::MAX_PAGES} pages")
+    end
+
+    # The pinned keys have to be in the prompt, not merged in afterwards: the
+    # root's folder tiles carry links_to for each one.
+    it "names the pages the admin already chose, and asks for the rest" do
+      prompt = prompt_for(page_count: 3, pages: [{ key: "snack_time", name: "Snack Time" }])
+
+      expect(prompt).to include(%(key "snack_time", name "Snack Time"))
+      expect(prompt).to include("add 2 more pages of your own")
+    end
+
+    it "asks for no other pages when every page is already named" do
+      prompt = prompt_for(page_count: 2, pages: [{ key: "snacks", name: "Snacks" },
+                                                 { key: "drinks", name: "Drinks" }])
+
+      expect(prompt).to include("Do not add any other pages.")
+    end
+
+    it "says nothing about chosen pages when there are none" do
+      expect(prompt_for).not_to include("already decided")
     end
   end
 end


### PR DESCRIPTION
## Summary

On `/admin/board_builds/new`, **"Draft the whole set with AI"** replaced `children` wholesale — any page key or name typed on the form was thrown away and the AI's titles won. The only way to control a page title was to draft the set, retype the names, then re-draft each page one at a time.

Page keys and names are now **authored input**:

- `draft_set` passes the named pages to `SetDrafter` as pinned pages. They go **into the prompt** (the root's folder tiles carry `links_to` per page, so a key invented by the model and reconciled afterwards would leave the root linking at nothing), and `apply_pinned` forces the admin's key/name back on if the model paraphrases. A page the model skips entirely still comes back, empty, rather than vanishing.
- Naming more pages than the page count asks for **raises the count** (capped at `SetDrafter::MAX_PAGES`) rather than dropping typed input; the drafter echoes back the count it used so the notice and the select follow.
- New **"Suggest page names"** button → `Boards::AdminBuilder::PageNamesSuggester`: titles only, no words, shaped like `ContextSuggester`. Names already typed are repeated back in place and never duplicated, and the AI call is skipped when they already fill the count. Suggestions land on blank blocks **where they sit** — assigning by position would move a name onto a block holding another page's word list.
- `Keys.normalize` extracted so all three producers of a page key slugify identically.

Nothing about preview/build changes: this only ever populates the form.

## Test plan

- `bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/requests/admin/access_control_spec.rb spec/services/boards/admin_builder` → **355 examples, 0 failures**
- New coverage: pinned keys/names in the prompt, paraphrase reconciliation, count raised over dropping a named page, half-named pages, `PageNamesSuggester` (21 examples), and request specs for `draft_set` honoring form names + the new `POST suggest_pages` (fills names only, leaves word lists alone, writes nothing, 422 paths).
- Docs: `.claude-notes/admin-board-builder-handoff.md` (the new invariant) and a `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)