### PR TITLE
fix(builder): link the Food page's More folder on OBF import

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -303,6 +303,27 @@ only signal a caller may treat as "this file is good."** A zeroed-out report
 without that flag is indistinguishable from a valid empty package, which is
 exactly how a garbage upload once rendered as "Looks good" in the UI.
 
+## OBF/OBZ import — one authored button is one tile, never one Image
+
+Two authored buttons can legitimately resolve to the **same `Image`**: Core
+60/84 author both a `more` word button and a `More` folder button, and `Image`
+lookup is case-insensitive by design. Every per-button structure in the import
+path must therefore be keyed on the **button or the tile**, never on
+`image.id`:
+
+- `Board.find_board_image_for_button`'s `image_id` fallback is **claim-once**
+  (the entry is deleted as it's consumed), so a second button can't collapse
+  onto the first's tile.
+- `Board.from_obf`'s returned `dynamic_data` — the rows
+  `ObzImporter#link_dynamic_boards!` turns into `predictive_board_id` links —
+  is keyed on `board_image.id`. Keying it on `image.id` let whichever button
+  came second overwrite the first's row, so on the one page that authors the
+  FOLDER before the WORD (`food.obf` in both sets) the word's row (no
+  `load_board`) won and the `More` folder imported unlinked — a dead tile that
+  opened nothing. It also cost the page its `more` word tile, because
+  `Boards::TileDeduper` groups on `(label, folder?)` and an unlinked folder
+  looks like a duplicate word.
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Core 60/84 Food pages: the "More" folder opened nothing, and the "more"
+  word tile was missing.** The authored Food page is the one page in each set
+  that lists the `More` folder before the `more` word, and the two share one
+  symbol — so the importer's link step credited the word's (unlinked) button and
+  left the folder tile dead, then the duplicate-tile cleanup mistook the dead
+  folder for a copy of the word and deleted the word. Both tiles now import
+  correctly on every page of both sets, and every built board set is checked for
+  dead folder tiles on all of its pages, not just the home board.
+
 - **Admin board builder: pages were being built with nothing to open them.** A
   page only became reachable if the main board's word list carried a hand-typed
   `>page_key` tile, and only "Draft the whole set with AI" ever wrote one — so

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2823,7 +2823,15 @@ class Board < ApplicationRecord
       board_image = upsert_board_image(board, image, item, coords, temp_display_image,
                                        apply_button_attributes: apply_button_attributes,
                                        board_image_cache: board_image_cache)
-      dynamic_data[image.id] = {
+      # Keyed on the TILE, not the Image. Two authored buttons can legitimately
+      # resolve to one Image (Core 60/84 author both a "more" word button and a
+      # "More" folder button; Image lookup is case-insensitive by design), and
+      # keying on image.id let whichever button came second overwrite the
+      # first's row. On any page authoring the folder BEFORE the word — Core
+      # 84's `food.obf` — the word's row (no `load_board`) won, so
+      # ObzImporter#link_dynamic_boards! never linked the folder and the page
+      # shipped a dead `More` tile that opened nothing.
+      dynamic_data[board_image.id] = {
         "board_id" => board.id,
         "board" => board,
         "original_obf_id" => obf_id,

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -982,6 +982,37 @@ RSpec.describe Board, type: :model do
       expect(happy_bi.layout["lg"]).to include("x" => 0, "y" => 0)
     end
 
+    # Regression: dynamic_data is keyed per TILE, not per Image. Core 60/84
+    # author both a "more" word button and a "More" folder button, which resolve
+    # to one case-insensitively-matched Image. Keying on the Image let whichever
+    # button came second overwrite the first's row — so on a page authoring the
+    # FOLDER first (food.obf) the word's `load_board`-less row won, and
+    # ObzImporter#link_dynamic_boards! left the folder tile dead.
+    it "returns one dynamic_data row per tile when two buttons share an Image" do
+      shared_image_obf = {
+        "format" => "open-board-0.1",
+        "id" => "shared",
+        "name" => "Shared",
+        "grid" => { "rows" => 1, "columns" => 2, "order" => [[1, 2]] },
+        "buttons" => [
+          { "id" => 1, "label" => "More", "load_board" => { "path" => "boards/more.obf" } },
+          { "id" => 2, "label" => "more" },
+        ],
+        "images" => [],
+        "sounds" => [],
+      }
+
+      board, dynamic_data = described_class.from_obf(shared_image_obf, user)
+
+      expect(board.board_images.count).to eq(2)
+      expect(dynamic_data.size).to eq(2)
+      expect(dynamic_data.keys).to match_array(board.board_images.map(&:id))
+      folder_row = dynamic_data.values.find { |row| row["dynamic_board"].present? }
+      expect(folder_row).to be_present
+      expect(folder_row["label"]).to eq("More")
+      expect(BoardImage.find(folder_row["board_image_id"]).display_label).to eq("More")
+    end
+
     it "re-raises instead of silently returning nil on malformed input" do
       expect {
         described_class.from_obf("not json", user)

--- a/spec/services/vocab_sets_spec.rb
+++ b/spec/services/vocab_sets_spec.rb
@@ -439,6 +439,50 @@ RSpec.describe VocabSets do
     end
   end
 
+  # A seeded page's own authored nav row is as load-bearing as the home board's:
+  # a folder button with a `load_board` that imported UNLINKED opens nothing when
+  # tapped. Sweeps every page in the set, not just the root — the Food page's
+  # `More` folder was dead in both sets because food.obf is the one page that
+  # authors the `More` FOLDER before the `more` WORD, and the importer keyed its
+  # link rows on the shared Image so the word's row (no `load_board`) won.
+  describe "authored folder links across the whole set" do
+    { "core-60" => :@c60_root, "core-84" => :@c84_root }.each do |slug, ivar|
+      it "links every authored load_board button on every #{slug} page" do
+        root = instance_variable_get(ivar)
+        source_dir = VocabSets::SETS_DIR.join(slug, "boards")
+
+        Board.where(id: collect_set_board_ids(root)).each do |board|
+          obf_path = source_dir.join("#{board.obf_id.to_s.split(':').last}.obf")
+          next unless File.exist?(obf_path)
+
+          authored_folder_ids = JSON.parse(File.read(obf_path))["buttons"]
+            .select { |btn| btn["load_board"].is_a?(Hash) }
+            .map { |btn| btn["id"].to_s }
+
+          dead = board.board_images.select do |bi|
+            authored_folder_ids.include?(bi.data.to_h["obf_button_id"].to_s) &&
+              bi.predictive_board_id.nil?
+          end
+
+          expect(dead).to be_empty,
+            "#{board.name}: dead folder tiles #{dead.map(&:display_label).inspect}"
+        end
+      end
+    end
+
+    # The same collision silently ate a WORD tile: with the folder left unlinked,
+    # TileDeduper saw two non-folder "more" tiles and destroyed one.
+    it "keeps both the More folder and the more word tile on the Food page" do
+      food = Board.find(@c84_root.board_images.find_by(display_label: "Food").predictive_board_id)
+      tiles = food.board_images.select { |bi| bi.label.to_s.downcase == "more" }
+
+      expect(tiles.map(&:display_label)).to contain_exactly("More", "more")
+      folder = tiles.find { |bi| bi.display_label == "More" }
+      expect(Board.find(folder.predictive_board_id).name).to eq("More")
+      expect(tiles.find { |bi| bi.display_label == "more" }.predictive_board_id).to be_nil
+    end
+  end
+
   # [{label:, predictive_board_id:}] for the tiles in one grid row of a seeded
   # board, indexed by lg column — nil for an empty cell.
   def nav_row_spec(board, y)

--- a/spec/sidekiq/build_board_set_job_grid_spec.rb
+++ b/spec/sidekiq/build_board_set_job_grid_spec.rb
@@ -102,6 +102,17 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     end
   end
 
+  # The home board is not the only page a communicator navigates from: every
+  # seeded fringe page carries the nav row too, so the dead-tile check has to
+  # sweep the WHOLE set. Checking only the root is what hid the Core 84 Food
+  # page's dead `More` folder.
+  def dead_folder_tiles_in_set(root)
+    Board.where(id: described_class.new.send(:set_board_ids, root)).filter_map do |board|
+      dead = dead_folder_tiles(board)
+      "#{board.name}: #{dead.map(&:display_label).inspect}" if dead.any?
+    end
+  end
+
   it "keeps every authored folder working and grows the grid to surface all interests" do
     # The authored Core 84 grid is full (84 tiles, no reserved cells), so these
     # non-seed interest categories must GROW the grid onto new rows rather than
@@ -122,8 +133,10 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(root.board_images.count).to be <= CORE_84_GRID_CELLS + (3 * 12)
 
     # No dead tiles: every added folder tile links a real board, and the
-    # authored folders the planner used to strip are intact.
+    # authored folders the planner used to strip are intact — on every page in
+    # the set, not just the home board.
     expect(dead_folder_tiles(root)).to be_empty
+    expect(dead_folder_tiles_in_set(root)).to be_empty
 
     labels = root.board_images.map(&:display_label)
     expect(labels).to include("More", "School", "Time", "Describe")
@@ -152,6 +165,7 @@ RSpec.describe BuildBoardSetJob, "Core 84 grid integrity", type: :model do
     expect(root.status).to eq("complete")
     expect(root.board_images.count).to be <= CORE_84_GRID_CELLS
     expect(dead_folder_tiles(root)).to be_empty
+    expect(dead_folder_tiles_in_set(root)).to be_empty
   end
 
   # Regression: Core 84, GLP unchecked (include_phrases: false) + no interests


### PR DESCRIPTION
## What

The authored Core 60/84 **Food** page shipped a dead `More` folder tile — it opened nothing when tapped — and was silently missing its `more` word tile (25 tiles instead of the authored 26). Fixed at the importer.

## Why

The `.obf` source is correct: `food.obf` authors `More` → `boards/more.obf` properly. The bug was in `Board.from_obf`, which keyed its `dynamic_data` link rows on **`image.id`**. Two authored buttons can legitimately resolve to one `Image` — Core 60/84 author both a `more` word button and a `More` folder button, and `Image` lookup is case-insensitive by design — so whichever button was processed second overwrote the other's row.

`food.obf` is the only page in either set that lists the **folder before the word**, so the word's row (no `load_board`) won, `ObzImporter#link_dynamic_boards!` saw `dynamic_board => nil`, and the folder tile was never linked. The root board authors them in the opposite order, which is exactly why this was page-specific.

Knock-on damage: with the folder left unlinked, `Boards::TileDeduper` groups on `(label, folder?)`, saw two non-folder `more` tiles, and destroyed the word one.

Pre-existing on `main`; unrelated to the FolderPlacer `More` drawer change in #642. It was invisible because the grid spec only checked dead tiles on the **home board**, never on the seeded fringe pages.

## Changes

- `app/models/board.rb` — key `dynamic_data` on `board_image.id`, not `image.id`.
- `spec/sidekiq/build_board_set_job_grid_spec.rb` — `dead_folder_tiles_in_set` walks the whole built set via `set_board_ids`; wired into two existing builds so this already-slow file doesn't gain another build.
- `spec/services/vocab_sets_spec.rb` — sweeps every page of both real sets, cross-checking each authored `load_board` button id against its imported tile; plus the Food-page `More`/`more` assertion.
- `spec/models/board_spec.rb` — `from_obf` returns one row per tile when two buttons share an Image, folder-first ordering.
- `.claude-notes/boards-and-teams.md` — invariant: per-button import structures key on the button or the tile, never the Image.
- `CHANGELOG.md` — user-facing entry.

## Reviewer notes

This repairs the **seed** on the next \`rake vocab_sets:seed\`. Board sets users already built are deep clones and still carry the stale dead tile — \`NavRowSync\` relocates it as content rather than evicting it, since a nil target is indistinguishable from a word tile after the fact. A repair pass for existing built sets is not in this PR.

## Test plan

Reproduced first (seeded the real set, built an Extended set, swept every board): before — \`DEAD Food: "More"\`; after — no dead folder tiles anywhere in the set, \`More\` links the More board, and the \`more\` word tile is back.

All green locally:

- \`spec/sidekiq/build_board_set_job_grid_spec.rb\` + \`spec/services/boards/nav_row_sync_spec.rb\` → **18 examples, 0 failures**
- \`spec/models/board_spec.rb\` + \`spec/services/vocab_sets_spec.rb\` + \`nav_row_sync_spec.rb\` + \`spec/models/board_from_obf_idempotency_spec.rb\` → **150 examples, 0 failures**
- \`spec/models/obz_importer_spec.rb\` + \`spec/services/boards/fringe_templates_spec.rb\` + \`spec/services/boards/tile_deduper_spec.rb\` → **21 examples, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)