### PR TITLE
feat(admin): build folder tiles muted in the board builder

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -403,7 +403,9 @@ word list.
   NavRowSync there is **no self-tile exception**: nothing in an admin-built set
   is a you-are-here anchor, so a child's "back to home" tile is muted too.
   Speaking the folder's label puts a word into the utterance the communicator
-  didn't choose to say.
+  didn't choose to say. Sets built before this fix are repaired by
+  `rake admin_board_builder:mute_folder_tiles` (dry run by default,
+  `DRY_RUN=false` to write, `BUILD_ID=N` to scope to one build).
 
 ### Phase 4 — verify + publish
 

--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -395,6 +395,15 @@ word list.
   (build_board.py:176–215) rather than re-deriving it.
 - Set the link with `board_image.update!(predictive_board_id: child.id)` —
   `Boards::BoardTreeBuilder` already does exactly this.
+- **A folder tile is a door, not a word: it navigates muted.** `Build#link_pages!`
+  writes `data["mute_name"] = true` on the same `update!` that sets
+  `predictive_board_id`, so a built set is right on first render rather than
+  fixed up afterwards — the communicator builder's equivalents are
+  `BuildBoardSetJob#mute_dynamic_tile_names!` and `Boards::NavRowSync`. Unlike
+  NavRowSync there is **no self-tile exception**: nothing in an admin-built set
+  is a you-are-here anchor, so a child's "back to home" tile is muted too.
+  Speaking the folder's label puts a word into the utterance the communicator
+  didn't choose to say.
 
 ### Phase 4 — verify + publish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   hadn't chosen to say. Every tile the builder links to a page (a child's "back
   to home" tile included) is now built muted, matching how the communicator
   board builder has always treated its folder tiles. The art preview labels
-  these tiles "silent" so it's clear before the board is built.
+  these tiles "silent" so it's clear before the board is built. Boards already
+  built are repaired by `rake admin_board_builder:mute_folder_tiles`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Admin board builder: folder tiles now open their page without speaking.**
+  A tile that opens another page is a door, not a word — tapping "Food" to get
+  to the food page was putting a word into the utterance the communicator
+  hadn't chosen to say. Every tile the builder links to a page (a child's "back
+  to home" tile included) is now built muted, matching how the communicator
+  board builder has always treated its folder tiles. The art preview labels
+  these tiles "silent" so it's clear before the board is built.
+
 ### Fixed
 
 - **Admin board builder: pages were being built with nothing to open them.** A

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -182,6 +182,15 @@ module Boards
 
       # A tile becomes a folder when its predictive_board_id points at another
       # board — the same one-line link Boards::BoardTreeBuilder makes.
+      #
+      # Folder tiles navigate silently. A tile that opens a page is a door, not
+      # a word: speaking "Food" out loud on the way to the food page puts a word
+      # into the utterance the communicator didn't choose to say. `mute_name` is
+      # the same display-only flag BuildBoardSetJob defaults on the communicator
+      # builder's dynamic tiles and NavRowSync sets on its nav tiles — set it
+      # here rather than after the fact so a built set is right on first render.
+      # No self-tile exception: nothing in an admin-built set is a you-are-here
+      # anchor, so the "back to home" tile is a door like any other.
       def link_pages!(boards, tiles_by_key)
         pages.each do |page|
           page[:tiles].each_with_index do |tile, index|
@@ -191,7 +200,11 @@ module Boards
             child = boards[target]
             raise BuildError, "tile #{tile[:label].inspect} links to unknown page #{target.inspect}" if child.nil?
 
-            tiles_by_key[page[:key]][index].update!(predictive_board_id: child.id)
+            board_image = tiles_by_key[page[:key]][index]
+            board_image.update!(
+              predictive_board_id: child.id,
+              data: (board_image.data || {}).merge("mute_name" => true),
+            )
           end
         end
       end

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -161,7 +161,8 @@
         <p class="text-[11px] text-t3 mt-0.5">
           A folder tile on the main board opens a page. Give each page a key and the folder tile is
           written for you — point a tile at it with <span class="font-mono">&gt;key</span> yourself only if you
-          want a different word on it. Pages inherit the main board's grid unless you say otherwise.
+          want a different word on it. Folder tiles open their page without speaking their label.
+          Pages inherit the main board's grid unless you say otherwise.
           Page names you type are kept — drafting the whole set only names the pages you left blank.
         </p>
       </div>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -92,7 +92,9 @@
         <div class="p-2">
           <p class="text-xs font-medium text-t1 truncate" title="<%= row.label %>"><%= row.label %></p>
           <% if row.folder? %>
-            <p class="text-[10px] text-accent truncate">opens “<%= row.links_to %>”</p>
+            <%# Folder tiles are built muted — say so here, where the admin is
+                deciding whether the set is right, not after they tap one. %>
+            <p class="text-[10px] text-accent truncate">opens “<%= row.links_to %>” · silent</p>
           <% end %>
           <% if row.found? && !row.exact %>
             <p class="text-[10px] text-amber-500 truncate" title="<%= row.matched_label %>">matched “<%= row.matched_label %>”</p>

--- a/lib/tasks/admin_board_builder.rake
+++ b/lib/tasks/admin_board_builder.rake
@@ -1,0 +1,71 @@
+namespace :admin_board_builder do
+  # Backfill for the folder-tile muting fix in Boards::AdminBuilder::Build:
+  # a tile that opens another page is a door, not a word, so it navigates
+  # without speaking its label. Sets built before that fix speak "food" on the
+  # way to the food page — a word the communicator never chose to say — because
+  # tile data is written once at build time.
+  #
+  # This sets data["mute_name"] = true on every linked tile across every board
+  # the admin Board Builder created, which is what a new build now does inline.
+  # No self-tile exception: nothing in an admin-built set is a you-are-here
+  # anchor, so a child's "back to home" tile is muted too. (The COMMUNICATOR
+  # builder's equivalent is BuildBoardSetJob#mute_dynamic_tile_names!, which
+  # does keep that exception — don't point this task at those sets.)
+  #
+  # Scoped through AdminBoardBuild.builder_boards, the same rail every admin
+  # action on these boards runs on, so it can never reach a board this page
+  # didn't create.
+  #
+  # Read-only by default. Apply with DRY_RUN=false; scope with BUILD_ID=N:
+  #   rake admin_board_builder:mute_folder_tiles                    # preview all
+  #   DRY_RUN=false rake admin_board_builder:mute_folder_tiles      # apply all
+  #   DRY_RUN=false BUILD_ID=12 rake admin_board_builder:mute_folder_tiles
+  desc "Mute the names of linked tiles on admin-built boards (DRY_RUN=false to apply; BUILD_ID=N to scope)"
+  task mute_folder_tiles: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    boards = AdminBoardBuild.builder_boards
+    if ENV["BUILD_ID"].present?
+      build = AdminBoardBuild.find(ENV["BUILD_ID"])
+      boards = boards.where(id: build.set_boards.map(&:id))
+    end
+
+    names_by_board_id = boards.pluck(:id, :name).to_h
+
+    # reorder(nil): board_images carries a default position order and find_each
+    # overrides it, which logs "Scoped order is ignored" on every batch. Each
+    # tile is muted independently, so order is irrelevant.
+    tiles = BoardImage
+      .reorder(nil)
+      .where(board_id: names_by_board_id.keys)
+      .where.not(predictive_board_id: nil)
+      .where("predictive_board_id <> board_id")
+
+    boards_touched = Set.new
+    muted = 0
+
+    tiles.find_each do |board_image|
+      data = board_image.data || {}
+      next if data["mute_name"] == true
+
+      muted += 1
+      boards_touched << board_image.board_id
+      puts "#{dry_run ? '[DRY RUN] ' : ''}board ##{board_image.board_id} " \
+           "#{names_by_board_id[board_image.board_id].inspect}: mute #{board_image.label.inspect} " \
+           "(opens board ##{board_image.predictive_board_id})"
+
+      next if dry_run
+
+      # update_column: mute_name is display-only, and a full save would fire the
+      # audio hooks and re-render every tile's speech for nothing.
+      board_image.update_column(:data, data.merge("mute_name" => true))
+    end
+
+    if dry_run
+      puts "\nDry run only — #{muted} linked tile(s) across #{boards_touched.size} board(s) " \
+           "would be muted. Re-run with DRY_RUN=false to apply."
+    else
+      puts "\nMuted #{muted} linked tile(s) across #{boards_touched.size} board(s)."
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -198,6 +198,26 @@ RSpec.describe Boards::AdminBuilder::Build do
       expect(child.board_images.order(:position).map(&:label)).to eq(%w[apple banana hungry eat])
     end
 
+    # A door isn't a word: opening the food page shouldn't speak "food".
+    it "mutes the folder tile's name and leaves word tiles speaking" do
+      root = described_class.new(admin_board_build: build).call
+      tiles = root.board_images.index_by(&:label)
+
+      expect(tiles["food"].data["mute_name"]).to be(true)
+      expect(tiles["want"].data["mute_name"]).to be_nil
+    end
+
+    it "mutes a page's back-link to the root" do
+      back = food_page(tiles: [
+        { "label" => "apple", "part_of_speech" => "noun" },
+        { "label" => "back", "part_of_speech" => "social", "links_to" => Boards::AdminBuilder::Plan::ROOT_KEY },
+      ])
+      root = described_class.new(admin_board_build: build_record(tiles: root_with_folder, children: [back])).call
+      child = Board.find(root.board_images.find { |bi| bi.predictive_board_id }.predictive_board_id)
+
+      expect(child.board_images.find { |bi| bi.label == "back" }.data["mute_name"]).to be(true)
+    end
+
     it "records every page on the build so publish and show can reach them" do
       root = described_class.new(admin_board_build: build).call
       boards = build.reload.art_report["boards"]

--- a/spec/tasks/admin_board_builder_mute_folder_tiles_spec.rb
+++ b/spec/tasks/admin_board_builder_mute_folder_tiles_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "admin_board_builder:mute_folder_tiles" do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("admin_board_builder:mute_folder_tiles")
+  end
+
+  let(:task) { Rake::Task["admin_board_builder:mute_folder_tiles"] }
+  let(:user) { create(:user) }
+  let(:builder_settings) { { AdminBoardBuild::BUILDER_SETTING => true } }
+  let!(:root) do
+    create(:board, user: user, name: "Snack Time", settings: builder_settings.merge("builder_root" => true))
+  end
+  let!(:food) do
+    create(:board, user: user, name: "Food", settings: builder_settings.merge("builder_child" => true))
+  end
+
+  def tile(board, label, target: nil)
+    board_image = create(:board_image, board: board, image: create(:image, label: label, user_id: user.id))
+    board_image.update_columns(label: label, predictive_board_id: target)
+    board_image
+  end
+
+  let!(:folder) { tile(root, "food", target: food.id) }
+  let!(:word) { tile(root, "want") }
+  let!(:back) { tile(food, "back", target: root.id) }
+
+  before { task.reenable }
+
+  after { ENV.delete("DRY_RUN") }
+
+  it "writes nothing by default" do
+    expect { task.invoke }.to output(/Dry run only — 2 linked tile/).to_stdout
+
+    expect(folder.reload.data["mute_name"]).to be_nil
+    expect(back.reload.data["mute_name"]).to be_nil
+  end
+
+  # A door isn't a word: opening the food page shouldn't speak "food", and the
+  # way back out isn't a word either.
+  it "mutes every linked tile with DRY_RUN=false and leaves word tiles alone" do
+    ENV["DRY_RUN"] = "false"
+
+    expect { task.invoke }.to output(/Muted 2 linked tile\(s\) across 2 board\(s\)/).to_stdout
+
+    expect(folder.reload.data["mute_name"]).to be(true)
+    expect(back.reload.data["mute_name"]).to be(true)
+    expect(word.reload.data["mute_name"]).to be_nil
+  end
+
+  # builder_boards is the rail every admin action on these boards runs on; a
+  # board this page didn't create is out of reach even when it has folder tiles.
+  it "leaves boards the admin builder didn't create alone" do
+    other_root = create(:board, user: user, name: "Someone else's board")
+    other_folder = tile(other_root, "food", target: food.id)
+    ENV["DRY_RUN"] = "false"
+
+    expect { task.invoke }.to output(/Muted 2 linked tile/).to_stdout
+
+    expect(other_folder.reload.data["mute_name"]).to be_nil
+  end
+
+  it "scopes to one build with BUILD_ID" do
+    build = AdminBoardBuild.create!(
+      created_by: user, name: "Snack Time", voice: "polly:kevin",
+      columns_count: 2, tile_count: 4, board: root,
+      art_report: { "boards" => { "root" => root.id } },
+    )
+    ENV["DRY_RUN"] = "false"
+    ENV["BUILD_ID"] = build.id.to_s
+
+    expect { task.invoke }.to output(/Muted 1 linked tile\(s\) across 1 board\(s\)/).to_stdout
+
+    expect(folder.reload.data["mute_name"]).to be(true)
+    expect(back.reload.data["mute_name"]).to be_nil
+  ensure
+    ENV.delete("BUILD_ID")
+  end
+
+  it "is a no-op on a tile that is already muted" do
+    folder.update_column(:data, { "mute_name" => true })
+    ENV["DRY_RUN"] = "false"
+
+    expect { task.invoke }.to output(/Muted 1 linked tile\(s\) across 1 board\(s\)/).to_stdout
+  end
+end


### PR DESCRIPTION
## Summary

A tile that opens another page is a door, not a word. In the admin Board Builder, tapping "Food" to reach the food page spoke *"food"* — a word the communicator never chose to say. Folder tiles now navigate silently, matching what the communicator board builder has always done (`BuildBoardSetJob#mute_dynamic_tile_names!`, `Boards::NavRowSync`).

- **`Build#link_pages!`** writes `data["mute_name"] = true` on the same `update!` that sets `predictive_board_id`, so a built set is right on first render rather than fixed up afterwards.
- **No self-tile exception**, unlike `NavRowSync`: nothing in an admin-built set is a you-are-here anchor, so a child's "back to home" tile is muted too.
- **The art preview says so** — a folder tile now reads `opens "food" · silent`, before the board is built rather than after someone taps one.
- **Backfill for existing sets**, since tile data is written once at build time:

  ```
  bin/rails admin_board_builder:mute_folder_tiles              # dry run
  DRY_RUN=false bin/rails admin_board_builder:mute_folder_tiles
  DRY_RUN=false BUILD_ID=12 bin/rails admin_board_builder:mute_folder_tiles
  ```

  Scoped through `AdminBoardBuild.builder_boards` — the rail every admin action on these boards runs on — so it can't reach a board this page didn't create, including the communicator builder's sets (which keep the self-tile-speaks rule and would be wrong to sweep). Uses `update_column`: `mute_name` is display-only, and a full save would re-render every tile's audio for nothing.

## Test plan

`bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder spec/tasks/admin_board_builder_mute_folder_tiles_spec.rb` — **376 examples, 0 failures.**

New coverage:
- `build_spec.rb` — the root's folder tile is muted and word tiles are not; a child's back-link to the root is muted.
- `admin_board_builder_mute_folder_tiles_spec.rb` — dry run writes nothing; apply mutes folder + back-link but not word tiles; boards the admin builder didn't create are untouched; `BUILD_ID` scoping; already-muted tile is a no-op.

Also ran `bin/rails zeitwerk:check` (clean), ERB syntax check on both changed views, and the backfill task's dry run against the local dev DB (0 tiles — no admin-built boards locally).

Docs: `.claude-notes/admin-board-builder-handoff.md` (Phase 3) and a `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)