### PR TITLE
fix(myspeak): stop seeding bio/intro and clear the rows already carrying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **MySpeak pages published setup instructions as the communicator's own
+  words.** Every profile was created with placeholder copy already saved into
+  its bio and intro, so any page that had never been personalized greeted
+  visitors with "Write a short bio about yourself. This will help others
+  understand who you are and what you do." — printed as About Me and read
+  aloud in the communicator's voice. Nothing writes that copy any more, and a
+  migration clears it from existing profiles (81 of 284 profiles in the
+  development database were carrying it). Bios and intros people actually
+  wrote are untouched, including ones that happen to quote the phrase.
+
 - **Core 60/84 Food pages: the "More" folder opened nothing, and the "more"
   word tile was missing.** The authored Food page is the one page in each set
   that lists the `More` folder before the `more` word, and the two share one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,18 @@ an explicit decision, not a drive-by edit.
   POST** — never on public page-open. It is also never sent to OpenAI: no
   `Profile::SAFETY_SENSITIVE_KEYS` entry may appear in a
   `Suggestions::Registry` context allow-list (enforced by spec).
+- **Never seed `profiles.bio` or `profiles.intro` with instructional copy.**
+  Both are PUBLIC — `/my/:slug` prints the bio as "About me" and speaks the
+  intro aloud on "Hear my intro" — so placeholder text stored there is
+  published to visitors *in the communicator's own voice*, and `bio.present?`
+  stops meaning "the owner wrote something". Every creation path used to do it
+  (`set_defaults`, `.create_for_user`, `.generate_with_username`,
+  `.create_placeholders`); blank is the honest state, and the frontend supplies
+  its own copy when there is nothing to show. `Profile::SEEDED_TEXT` /
+  `.seeded_text?` exist only to recognize the historical strings — match whole
+  strings, never a substring, since a real bio may quote the phrase. Note
+  `claim!` keeps whatever is stored, so anything seeded onto a placeholder
+  follows it onto a real, claimed page.
 - **Third-party sends are env-gated to production** (Mailchimp journeys,
   PostHog captures; staging excluded via `AppEnv.staging?`) so non-prod can't
   email or track real users. Transactional mail is covered by the same rule at

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -57,6 +57,32 @@ class Profile < ApplicationRecord
     public privacy terms support
   ].freeze
 
+  # Instructional copy this app used to write into `bio` / `intro` on create.
+  # It was never something a user typed, but it is stored exactly like text
+  # that was — so `bio.present?` is not an "did the owner write this?" check,
+  # and every MySpeak page that had not been personalized published
+  # "Write a short bio about yourself…" to visitors as if the communicator had
+  # said it. Nothing writes these strings any more; the constant exists so the
+  # historical rows stay identifiable (see `seeded_text?` and the
+  # `profiles:copy_onboarding_bio_to_emergency_notes` rake task).
+  #
+  # Compare whole strings, never a substring: a real bio that quotes the phrase
+  # belongs to its author.
+  SEEDED_TEXT = [
+    "Write a short bio about yourself. This will help others understand who you are and what you do.",
+    "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself.",
+    "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself here.",
+    "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+    # Variants from lib/tasks/accounts.rake's placeholder task, which had its
+    # own near-copy of Profile.create_placeholders.
+    "This is a placeholder profile. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+    "Welcome to MySpeak! Let's get started.",
+  ].freeze
+
+  def self.seeded_text?(value)
+    SEEDED_TEXT.include?(value.to_s.strip)
+  end
+
   validates :username, presence: true, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   # Format/reserved/numeric checks run only on new records or when the slug
@@ -665,11 +691,12 @@ class Profile < ApplicationRecord
       placeholder_name = "MySpeak #{SecureRandom.hex(4)}"
       slug = placeholder_name.parameterize
 
+      # No seeded bio/intro: `claim!` keeps whatever is stored, so placeholder
+      # copy written here would follow the profile onto a real, claimed MySpeak
+      # page. The claim screen's own copy explains an unclaimed page.
       profile = Profile.create!(
         username: placeholder_name,
         slug: slug,
-        bio: "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
-        intro: "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself here.",
         placeholder: true,
         claimed_at: nil,
         claim_token: SecureRandom.hex(10),
@@ -694,8 +721,6 @@ class Profile < ApplicationRecord
       profileable_type: "User",
       profileable_id: user.id,
       slug: slug,
-      bio: "Write a short bio about yourself. This will help others understand who you are and what you do.",
-      intro: "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself.",
       placeholder: false,
       claimed_at: Time.zone.now,
       claim_token: nil,
@@ -734,8 +759,6 @@ class Profile < ApplicationRecord
     profile = Profile.create!(
       username: username,
       slug: slug,
-      bio: "Write a short bio about yourself. This will help others understand who you are and what you do.",
-      intro: "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself.",
       claimed_at: nil,
       claim_token: SecureRandom.hex(10),
       placeholder: true,
@@ -758,8 +781,11 @@ class Profile < ApplicationRecord
   def set_defaults
     self.settings ||= {}
 
-    self.intro = "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself." if intro.blank?
-    self.bio = "Write a short bio about yourself. This will help others understand who you are and what you do." if bio.blank?
+    # `bio` and `intro` are deliberately left nil when blank. They are PUBLIC —
+    # the MySpeak page prints the bio as About Me and speaks the intro aloud —
+    # so seeding them here published instructions to visitors in the owner's
+    # voice. Blank is the honest state; the frontend supplies its own copy when
+    # there is nothing to show. See SEEDED_TEXT.
 
     # If you want to infer kind automatically:
     self.settings["profile_kind"] ||= default_profile_kind

--- a/db/migrate/20260810120000_null_out_seeded_profile_bio_and_intro.rb
+++ b/db/migrate/20260810120000_null_out_seeded_profile_bio_and_intro.rb
@@ -1,0 +1,68 @@
+# Clears the instructional copy this app used to write into `profiles.bio` and
+# `profiles.intro` at creation.
+#
+# Both columns are PUBLIC — the MySpeak page (`/my/:slug`) prints the bio as
+# "About me" and speaks the intro aloud on "Hear my intro" — so every profile
+# that had never been personalized published "Write a short bio about
+# yourself…" to visitors in the communicator's own voice. The seeding is gone
+# (Profile#set_defaults, .create_for_user, .generate_with_username,
+# .create_placeholders); this clears the rows already carrying it.
+#
+# The strings are inlined rather than read from Profile::SEEDED_TEXT on
+# purpose. A migration has to keep running years from now, after the constant
+# has drifted or been deleted — it records what the data looked like at this
+# point in history, and must not change meaning when the model does.
+#
+# Matched with `=` on the BTRIM'd value, never LIKE or a substring test: a real
+# bio that happens to quote the phrase belongs to whoever wrote it and must
+# survive untouched.
+#
+# Raw SQL rather than find_each: this is a data correction across every profile
+# row, and Profile's validation + before_save chain (slug format, kind
+# inference, slug_changed_at) has no business firing for it. Blanking these
+# columns cannot invalidate a row — neither has a presence validation.
+class NullOutSeededProfileBioAndIntro < ActiveRecord::Migration[8.0]
+  SEEDED_BIOS = [
+    "Write a short bio about yourself. This will help others understand who you are and what you do.",
+    "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+    "This is a placeholder profile. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+  ].freeze
+
+  SEEDED_INTROS = [
+    "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself.",
+    "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself here.",
+    "Welcome to MySpeak! Let's get started.",
+  ].freeze
+
+  def up
+    say_with_time "Clearing seeded profiles.bio" do
+      execute(<<~SQL.squish)
+        UPDATE profiles
+           SET bio = NULL
+         WHERE BTRIM(bio) IN (#{quoted_list(SEEDED_BIOS)})
+      SQL
+    end
+
+    say_with_time "Clearing seeded profiles.intro" do
+      execute(<<~SQL.squish)
+        UPDATE profiles
+           SET intro = NULL
+         WHERE BTRIM(intro) IN (#{quoted_list(SEEDED_INTROS)})
+      SQL
+    end
+  end
+
+  # Irreversible on purpose. Re-seeding the copy would republish the exact text
+  # this migration exists to take off public pages, and there is no record of
+  # which rows held it — a blank bio after this runs is indistinguishable from
+  # one that was always blank. Rolling back means leaving the columns nil.
+  def down
+    say "No-op: seeded bio/intro copy is not restored."
+  end
+
+  private
+
+  def quoted_list(values)
+    values.map { |value| connection.quote(value) }.join(", ")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_08_140036) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"

--- a/lib/tasks/accounts.rake
+++ b/lib/tasks/accounts.rake
@@ -13,11 +13,12 @@ namespace :accounts do
       puts "Account name: #{placeholder_name}"
       slug = placeholder_name.parameterize
 
+      # No seeded bio/intro — `claim!` keeps whatever is stored, so this copy
+      # followed the profile onto a real MySpeak page and was published there
+      # as the communicator's own About Me. See Profile::SEEDED_TEXT.
       profile = Profile.create!(
         username: placeholder_name,
         slug: slug,
-        bio: "This is a placeholder profile. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
-        intro: "Welcome to MySpeak! Let's get started.",
         placeholder: true,
         claimed_at: nil,
         claim_token: SecureRandom.hex(10),

--- a/lib/tasks/profiles.rake
+++ b/lib/tasks/profiles.rake
@@ -79,13 +79,6 @@ namespace :profiles do
     dry_run = ENV["DRY_RUN"] != "false"
     user_id = ENV["USER_ID"].presence
 
-    # Generated placeholder bios (Profile#set_defaults and the placeholder
-    # factories) are not real About Me text — never migrate them.
-    default_bios = [
-      "Write a short bio about yourself. This will help others understand who you are and what you do.",
-      "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
-    ].freeze
-
     scope = Profile.where(profile_kind: "safety", profileable_type: "ChildAccount")
     if user_id
       child_ids = ChildAccount.where(user_id: user_id).pluck(:id)
@@ -99,8 +92,10 @@ namespace :profiles do
       bio = profile.bio.to_s.strip
       raw = profile.settings.is_a?(Hash) ? profile.settings : {}
 
-      # Skip: no real bio, a generated default, or emergency notes already set.
-      if bio.blank? || default_bios.include?(bio) || raw["emergency_notes"].present?
+      # Skip: no real bio, generated boilerplate, or emergency notes already
+      # set. Nothing seeds Profile::SEEDED_TEXT any more and a migration has
+      # cleared it, but rows restored from an older backup can still carry it.
+      if bio.blank? || Profile.seeded_text?(bio) || raw["emergency_notes"].present?
         skipped += 1
         next
       end

--- a/spec/migrations/null_out_seeded_profile_bio_and_intro_spec.rb
+++ b/spec/migrations/null_out_seeded_profile_bio_and_intro_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+require Rails.root.join("db/migrate/20260810120000_null_out_seeded_profile_bio_and_intro.rb")
+
+# The rows this migration exists for were written when Profile seeded bio and
+# intro on create. Nothing writes that copy any more, so the specs put it back
+# with update_column to reproduce the historical state.
+RSpec.describe NullOutSeededProfileBioAndIntro do
+  let(:migration) { described_class.new }
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child_account, user: user, owner: user) }
+
+  let(:seeded_bio) do
+    "Write a short bio about yourself. This will help others understand who you are and what you do."
+  end
+  let(:seeded_intro) do
+    "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself."
+  end
+
+  def profile_with(slug:, bio: nil, intro: nil)
+    profile = Profile.create!(profileable: child, username: slug, slug: slug)
+    profile.update_columns(bio: bio, intro: intro)
+    profile
+  end
+
+  before { migration.verbose = false }
+
+  it "clears a seeded bio and intro" do
+    seeded = profile_with(slug: "quiet-fox", bio: seeded_bio, intro: seeded_intro)
+
+    migration.up
+
+    expect(seeded.reload.bio).to be_nil
+    expect(seeded.reload.intro).to be_nil
+  end
+
+  it "clears the placeholder variants too" do
+    placeholder = profile_with(
+      slug: "loud-fox",
+      bio: "This is a placeholder profile waiting to be claimed. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+      intro: "Welcome to MySpeak! Personalize your page by adding a short introduction about yourself here.",
+    )
+
+    migration.up
+
+    expect(placeholder.reload.bio).to be_nil
+    expect(placeholder.reload.intro).to be_nil
+  end
+
+  # lib/tasks/accounts.rake carried its own near-copy of the placeholder
+  # wording, so these rows exist too and claim! would have carried them onto a
+  # real page.
+  it "clears the accounts.rake placeholder wording" do
+    placeholder = profile_with(
+      slug: "pale-fox",
+      bio: "This is a placeholder profile. Once claimed, you can customize it and make it your own. You can add your own bio, avatar, and other details.",
+      intro: "Welcome to MySpeak! Let's get started.",
+    )
+
+    migration.up
+
+    expect(placeholder.reload.bio).to be_nil
+    expect(placeholder.reload.intro).to be_nil
+  end
+
+  it "matches despite surrounding whitespace" do
+    padded = profile_with(slug: "sly-fox", bio: "  #{seeded_bio}  ", intro: " #{seeded_intro}")
+
+    migration.up
+
+    expect(padded.reload.bio).to be_nil
+    expect(padded.reload.intro).to be_nil
+  end
+
+  # The whole point of matching exactly rather than with LIKE — these belong to
+  # the people who wrote them.
+  it "leaves a real bio and intro untouched" do
+    real = profile_with(slug: "red-fox", bio: "I love trains.", intro: "Hi, I'm Sky.")
+
+    migration.up
+
+    expect(real.reload.bio).to eq("I love trains.")
+    expect(real.reload.intro).to eq("Hi, I'm Sky.")
+  end
+
+  it "leaves a real bio that quotes the seeded copy untouched" do
+    quoting = profile_with(
+      slug: "grey-fox",
+      bio: "The app said \"#{seeded_bio}\" so here goes: I love trains.",
+      intro: nil,
+    )
+
+    migration.up
+
+    expect(quoting.reload.bio).to include("I love trains.")
+  end
+
+  it "is idempotent" do
+    seeded = profile_with(slug: "swift-fox", bio: seeded_bio, intro: seeded_intro)
+
+    migration.up
+    expect { migration.up }.not_to raise_error
+
+    expect(seeded.reload.bio).to be_nil
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -36,6 +36,78 @@ RSpec.describe Profile, type: :model do
     )
   end
 
+  # bio and intro are PUBLIC — /my/:slug prints the bio as About Me and speaks
+  # the intro aloud — so seeding them published app instructions to visitors in
+  # the communicator's own voice.
+  describe "bio and intro defaults" do
+    it "leaves both blank on create rather than seeding instructional copy" do
+      profile = Profile.create!(profileable: child, username: "quiet-fox", slug: "quiet-fox")
+
+      expect(profile.bio).to be_blank
+      expect(profile.intro).to be_blank
+    end
+
+    it "keeps what the owner actually wrote" do
+      profile = Profile.create!(
+        profileable: child,
+        username: "loud-fox",
+        slug: "loud-fox",
+        bio: "I love trains.",
+        intro: "Hi, I'm Sky.",
+      )
+
+      expect(profile.bio).to eq("I love trains.")
+      expect(profile.intro).to eq("Hi, I'm Sky.")
+    end
+
+    it "does not seed a profile built for a user" do
+      profile = Profile.create_for_user(user, "pat-smith")
+
+      expect(profile.bio).to be_blank
+      expect(profile.intro).to be_blank
+    end
+
+    it "does not seed a generated placeholder" do
+      Profile.create_placeholders(1)
+      placeholder = Profile.where(placeholder: true).order(:created_at).last
+
+      # claim! keeps whatever is stored, so anything seeded here would follow
+      # the profile onto a real, claimed MySpeak page.
+      expect(placeholder.bio).to be_blank
+      expect(placeholder.intro).to be_blank
+    end
+
+    it "does not seed a profile generated from a username" do
+      profile = Profile.generate_with_username("sky-jones")
+
+      expect(profile.bio).to be_blank
+      expect(profile.intro).to be_blank
+    end
+  end
+
+  describe ".seeded_text?" do
+    it "recognizes copy this app used to write into bio and intro" do
+      expect(Profile.seeded_text?(Profile::SEEDED_TEXT.first)).to be(true)
+    end
+
+    it "ignores surrounding whitespace" do
+      expect(Profile.seeded_text?("  #{Profile::SEEDED_TEXT.first}\n")).to be(true)
+    end
+
+    it "is false for blank input" do
+      expect(Profile.seeded_text?(nil)).to be(false)
+      expect(Profile.seeded_text?("")).to be(false)
+    end
+
+    # Whole-string match, never a substring: a real bio that quotes the phrase
+    # belongs to whoever wrote it.
+    it "does not match a real bio that merely quotes the copy" do
+      quoting = "The app told me to \"#{Profile::SEEDED_TEXT.first}\" so here goes: I love trains."
+
+      expect(Profile.seeded_text?(quoting)).to be(false)
+    end
+  end
+
   describe "slug format validation (on change)" do
     it "accepts a kebab-case 3-40 char slug" do
       profile = build_profile(slug: "river-stone-42")

--- a/spec/requests/api/v1/onboarding/myspeak_spec.rb
+++ b/spec/requests/api/v1/onboarding/myspeak_spec.rb
@@ -114,15 +114,17 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
         expect(profile.safety_sensitive_settings["emergency_notes"]).to include("Has seizures")
       end
 
-      it "keeps the default placeholder bio when only emergency_notes is provided" do
+      it "leaves the public bio blank when only emergency_notes is provided" do
         payload = base_payload.except(:about_me)
         post "/api/v1/onboarding/myspeak", params: payload.to_json, headers: headers
 
         expect(response).to have_http_status(:created)
         profile = user.communicator_accounts.last.profile
-        # No About Me typed → bio falls back to the generated placeholder, so no
-        # safety text leaks onto the public page.
-        expect(profile.bio).to include("Write a short bio")
+        # No About Me typed → the public bio stays empty. The safety text must
+        # not leak into it, and it is no longer seeded with instructional copy
+        # either — the MySpeak page used to publish that as the owner's own
+        # About Me.
+        expect(profile.bio).to be_blank
         expect(profile.settings["emergency_notes"]).to include("Has seizures")
       end
 
@@ -146,7 +148,7 @@ RSpec.describe "API::V1::Onboarding::Myspeak", type: :request do
           profile = user.communicator_accounts.last.profile
           # Old framing was safety info — privacy wins: it must NOT be public bio.
           expect(profile.bio).not_to include("peanuts")
-          expect(profile.bio).to include("Write a short bio")
+          expect(profile.bio).to be_blank
           expect(profile.settings["emergency_notes"]).to include("peanuts")
         end
       end


### PR DESCRIPTION
Backend counterpart to itty-bitty-frontend#662 (merged). That PR shipped a client-side shim; this removes the cause.

## The problem

`profiles.bio` and `profiles.intro` are **public** — `/my/:slug` prints the bio as "About me" and speaks the intro aloud on "Hear my intro". Every creation path wrote instructional copy into them, so any page that had never been personalized greeted visitors with:

> Write a short bio about yourself. This will help others understand who you are and what you do.

…presented as the communicator's own words. **81 of 284 profiles in the development database were carrying it.**

It also broke the meaning of the column: `bio.present?` stopped answering *"did the owner write something"*, so nothing downstream could distinguish authored text from boilerplate.

## The fix

Seeding removed from `Profile#set_defaults`, `.create_for_user`, `.generate_with_username`, and `.create_placeholders`. Blank is the honest state — the frontend already supplies its own copy when there's nothing to show. Neither column has a presence validation and no caller assumes non-nil (`profiles.rake` uses `.to_s.strip`, `users.rake` uses `.blank?`), so nothing else has to change.

**`lib/tasks/accounts.rake` turned out to hold its own near-copy of `create_placeholders`** with slightly different wording. It's fixed too, and both variants are listed. This matters more than it looks: `claim!` keeps whatever is stored, so copy seeded onto a placeholder followed the profile onto a real, claimed MySpeak page. Catching that variant cleared 5 further rows in dev.

## The migration

`20260810120000_null_out_seeded_profile_bio_and_intro` clears the historical rows.

- **Matches whole strings** with `=` on the `BTRIM`'d value, **never `LIKE`** — a real bio that quotes the phrase belongs to whoever wrote it, and survives untouched (covered by spec).
- **String list inlined**, not read from `Profile::SEEDED_TEXT`. A migration has to keep meaning the same thing years from now, after the constant has drifted or been deleted.
- **Raw SQL**, not `find_each` — this is a data correction and Profile's validation/`before_save` chain has no business firing for it.
- **Irreversible on purpose.** Re-seeding would republish the exact text this exists to remove, and after it runs a blank bio is indistinguishable from one that was always blank.

`Profile::SEEDED_TEXT` / `.seeded_text?` remain so the historical strings stay recognizable — rows restored from an older backup can still carry them. `profiles.rake`'s bio→emergency_notes task now uses them instead of its own private copy.

## Test plan

- **383 examples, 0 failures** across every profile-touching spec (`$(grep -rl "Profile" spec)`), re-run after rebasing onto `origin/main`
- New `spec/migrations/null_out_seeded_profile_bio_and_intro_spec.rb` (7 examples): clears seeded bio + intro, clears both placeholder wordings, matches through surrounding whitespace, **leaves a real bio untouched**, **leaves a real bio that quotes the seeded copy untouched**, idempotent
- New `Profile` model coverage: no seeding on plain create / `.create_for_user` / `.create_placeholders` / `.generate_with_username`, authored text preserved, plus `.seeded_text?` behavior including the quoting case
- Migration run against the development database: 81 seeded bios and 6 seeded intros cleared, then 5 more from the `accounts.rake` variant; **0 seeded rows left, 141 real bios preserved**

### Two specs changed rather than deleted

`spec/requests/api/v1/onboarding/myspeak_spec.rb` asserted `profile.bio` *includes* "Write a short bio". Read in context, those cases are really asserting a **privacy property** — that safety/care text never lands in the public bio — and used the placeholder as the stand-in for "not the safety text". They now assert the bio is blank, which keeps the guarantee without depending on the seeding. The neighbouring `expect(profile.bio).not_to include("peanuts")` is untouched.

## Deploy note

Ordering is safe either way — the frontend shim (`src/data/profileText.ts`) suppresses this copy client-side whether or not the migration has run. **Once this deploys and the migration completes, that shim can be deleted**; it's commented as temporary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)