### PR TITLE
fix(labels): stop board clones from re-pinning the seed's Title Case

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -116,6 +116,15 @@ curated folder name is pinned explicitly: `SeededSetCloner#copy_tiles!` restores
 the authored label/display_label post-save, and `BuildBoardSetJob#add_folder_tile!`
 sets the tile text to the category name.
 
+**Word tiles are NOT pinned — they inherit the seed's casing and are re-folded.**
+A built set is a clone of an admin-owned seed board, so whatever casing that seed
+stores is what the build would render. Both clone paths (`SeededSetCloner#copy_tiles!`
+and `Board#clone_with_images`) therefore run the copied text back through
+`BoardImage#cloned_display_label_from`, which folds everything except doors. The
+practical consequence: a seed board with stale Title Case no longer poisons the
+builds, but fixing the seed itself (`bin/rails labels:fold_casing`) is still worth
+doing so the source and the clones read the same.
+
 #### Fringe boards get the upgrade too (`upgrade_board_tiles!`)
 
 Originally only the **root** board ran the blank→art upgrade (via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Words on newly built boards were still coming out Title Cased.** Tiles are
+  supposed to default to lowercase, the AAC core-vocabulary convention, and the
+  creation paths were fixed for that — but cloning a board copied the source's
+  tile text over the top of the fold, one step after it happened. Since the
+  Board Builder builds every set by cloning a seed board, and those seeds were
+  authored before the rule existed, every built board inherited their casing:
+  "Higher" next to "swing" on the same page. Cloned word tiles are now folded
+  like any other defaulted tile. Folder tiles — the ones you tap to open a page
+  — keep their capital, and deliberate casing ("iPad", "TV", "HELP", "I") is
+  left alone as always.
+
 - **MySpeak pages published setup instructions as the communicator's own
   words.** Every profile was created with placeholder copy already saved into
   its bio and intro, so any page that had never been personalized greeted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,11 +249,13 @@ an explicit decision, not a drive-by edit.
   identify a folder (predictive/dynamic word tiles carry it too), so never use
   it to infer that a tile's casing was intentional. `BoardImage#door_tile?` is
   the test: the `mute_name`/nav flags, or a pointer at a board that isn't
-  `board_type: "predictive"`.
+  `board_type: "predictive"`. `#authored_tile_text?` widens that to every tile
+  whose text isn't a word — doors plus keyboard keys ("A", "Space"), which
+  carry a `data["tile_type"]`.
 - **A CLONED tile's text is defaulted, not authored.** It carries whatever the
   source board happened to store, so it gets the same casing rule as any other
   defaulted tile — `BoardImage#cloned_display_label_from` folds it, and only
-  doors keep their capital. Copying `display_label` verbatim (which both clone
+  `authored_tile_text?` tiles keep their casing. Copying `display_label` verbatim (which both clone
   paths used to do, one line after `set_labels` had folded it) makes every seed
   board's casing permanent in every board built from it: that is what kept the
   Board Builder emitting Title Case after the creation paths were fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,16 @@ an explicit decision, not a drive-by edit.
   label and `Boards::BoardTreeBuilder` pins the blueprint's folder label; both
   bypass the lowercase default by design. `predictive_board_id` alone does NOT
   identify a folder (predictive/dynamic word tiles carry it too), so never use
-  it to infer that a tile's casing was intentional.
+  it to infer that a tile's casing was intentional. `BoardImage#door_tile?` is
+  the test: the `mute_name`/nav flags, or a pointer at a board that isn't
+  `board_type: "predictive"`.
+- **A CLONED tile's text is defaulted, not authored.** It carries whatever the
+  source board happened to store, so it gets the same casing rule as any other
+  defaulted tile — `BoardImage#cloned_display_label_from` folds it, and only
+  doors keep their capital. Copying `display_label` verbatim (which both clone
+  paths used to do, one line after `set_labels` had folded it) makes every seed
+  board's casing permanent in every board built from it: that is what kept the
+  Board Builder emitting Title Case after the creation paths were fixed.
 - **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
   and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
   silently reverts a slug change on a published board (reverts, never raises —

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1251,7 +1251,10 @@ class Board < ApplicationRecord
       new_board_image.image_id = image.id
       new_board_image.set_labels
       if new_board_image
-        new_board_image.display_label = board_image.display_label
+        # Fold, don't copy: the source board's casing is defaulted text, not
+        # authored. Doors ("Food") keep their capital — see
+        # BoardImage#cloned_display_label_from.
+        new_board_image.display_label = new_board_image.cloned_display_label_from(board_image)
 
         new_board_image.voice = board_image.voice
         new_board_image.predictive_board_id = board_image.predictive_board_id

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -194,6 +194,39 @@ class BoardImage < ApplicationRecord
     Labels::CaseNormalizer.normalize(text, language: lang, part_of_speech: effective_part_of_speech)
   end
 
+  # The display text a clone of `source` should carry.
+  #
+  # A cloned tile's text is DEFAULTED, not authored: it came from whatever the
+  # source board happened to store, so it gets the same casing rule as any other
+  # defaulted tile. Copying it verbatim is what let a Title Cased seed board
+  # propagate "Higher" into every board built from it — set_labels folded it and
+  # the next line put it straight back.
+  #
+  # Doors are the exception: a tile that opens a page keeps its authored capital
+  # ("Food", "Play"), per the category-tile rule.
+  def cloned_display_label_from(source)
+    text = source.display_label
+    return text if source.door_tile?
+
+    normalized_default_label(text)
+  end
+
+  # A tile whose job is to navigate, not to speak — its capital is authored.
+  #
+  # `predictive_board_id` on its own does NOT make a tile a door: a predictive
+  # WORD tile carries one too, pointing at a generated board of next words. The
+  # distinguishing signal is what it points AT — a curated folder opens a real
+  # page, a predictive word tile opens a `board_type: "predictive"` board.
+  #
+  # Builder and nav tiles are flagged outright and don't need the lookup.
+  def door_tile?
+    d = data || {}
+    return true if d["mute_name"] == true || d[Boards::NavRowSync::NAV_TILE_KEY] == true
+    return false if predictive_board_id.blank? || predictive_board_id == board_id
+
+    predictive_board&.board_type != "predictive"
+  end
+
   # Delegates to the underlying Image's language_settings. Stored `label` /
   # `display_label` columns reflect the board's authored language; this resolves
   # the viewer's preferred language at read time.

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -202,13 +202,29 @@ class BoardImage < ApplicationRecord
   # propagate "Higher" into every board built from it — set_labels folded it and
   # the next line put it straight back.
   #
-  # Doors are the exception: a tile that opens a page keeps its authored capital
-  # ("Food", "Play"), per the category-tile rule.
+  # Tiles that don't carry a WORD are the exception — see authored_tile_text?.
   def cloned_display_label_from(source)
     text = source.display_label
-    return text if source.door_tile?
+    return text if source.authored_tile_text?
 
     normalized_default_label(text)
+  end
+
+  # True when this tile's text isn't a word the communicator speaks, so word
+  # casing rules don't apply to it and it must survive a clone verbatim:
+  #
+  #   - a door: a folder tile you tap to open a page ("Food", "Play"), whose
+  #     capital is what separates it from a word on the same board
+  #   - a keyboard key ("A", "Space", "Delete") — a key legend, not vocabulary.
+  #     Folding these would spell in lowercase and rename Space to "space".
+  def authored_tile_text?
+    door_tile? || keyboard_key?
+  end
+
+  # Every tile on a keyboard board is stamped with a tile_type ("letter" or
+  # "action") by db/seeds/keyboard_boards.rb.
+  def keyboard_key?
+    (data || {})["tile_type"].present?
   end
 
   # A tile whose job is to navigate, not to speak — its capital is authored.

--- a/app/services/boards/seeded_set_cloner.rb
+++ b/app/services/boards/seeded_set_cloner.rb
@@ -185,7 +185,11 @@ module Boards
         new_board_image.board_id = target.id
         new_board_image.image_id = image.id
         new_board_image.set_labels
-        new_board_image.display_label = board_image.display_label
+        # Fold, don't copy — a seed board's casing is defaulted text, and copying
+        # it verbatim is what propagated the seeds' Title Case into every built
+        # set. Doors ("Food") keep their capital.
+        intended_display_label = new_board_image.cloned_display_label_from(board_image)
+        new_board_image.display_label = intended_display_label
         new_board_image.voice = board_image.voice
         new_board_image.predictive_board_id = board_image.predictive_board_id
         new_board_image.audio_url = board_image.audio_url
@@ -193,9 +197,10 @@ module Boards
 
         # BoardImage#set_defaults (before_create) derives label from the image,
         # so an upgraded art image stored under different casing ("people") would
-        # rename the tile. Restore the AUTHORED tile text ("People") post-save.
-        if new_board_image.label != board_image.label || new_board_image.display_label != board_image.display_label
-          new_board_image.update_columns(label: board_image.label, display_label: board_image.display_label)
+        # rename the tile. Restore the intended tile text post-save — the folded
+        # display text, not the source's, or this would undo the fold above.
+        if new_board_image.label != board_image.label || new_board_image.display_label != intended_display_label
+          new_board_image.update_columns(label: board_image.label, display_label: intended_display_label)
         end
       end
     end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -141,8 +141,11 @@ RSpec.describe Board, type: :model do
         tile = FactoryBot.create(:board_image, board: board, image: source_image)
         tile.update_columns({ label: text.downcase, display_label: text }.merge(source_attrs))
 
-        cloned = board.clone_with_images(user.id)
-        cloned.reload.board_images.find_by(image_id: source_image.id)
+        # Match on the lowercase key, not image_id: the clone re-resolves each
+        # tile to the best image for the label and may land on a different row.
+        # reload so a second call in one example sees the tile it just added.
+        cloned = board.reload.clone_with_images(user.id)
+        cloned.reload.board_images.find_by(label: text.downcase)
       end
 
       it "folds a stuck leading capital on a word tile" do
@@ -156,6 +159,16 @@ RSpec.describe Board, type: :model do
 
       it "keeps deliberate casing" do
         expect(clone_tile_reading("iPad").display_label).to eq("iPad")
+      end
+
+      # A key legend is not vocabulary: folding these would spell in lowercase
+      # and rename the Space key to "space".
+      it "keeps a keyboard key's legend" do
+        space = clone_tile_reading("Space", data: { "tile_type" => "action", "tile_action" => "space" })
+        letter = clone_tile_reading("A", data: { "tile_type" => "letter" })
+
+        expect(space.display_label).to eq("Space")
+        expect(letter.display_label).to eq("A")
       end
     end
   end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -130,6 +130,34 @@ RSpec.describe Board, type: :model do
         expect(cloned_tile.display_image_url).to eq("https://cdn.example.com/source.webp")
       end
     end
+
+    # A clone used to copy the source tile's display_label verbatim, one line
+    # after set_labels had folded it — so a Title Cased seed board propagated
+    # "Higher" into every board built from it.
+    context "tile casing on clone" do
+      def clone_tile_reading(text, source_attrs = {})
+        source_image = FactoryBot.create(:image, user: user)
+        source_image.update_columns(label: text.downcase, display_label: text)
+        tile = FactoryBot.create(:board_image, board: board, image: source_image)
+        tile.update_columns({ label: text.downcase, display_label: text }.merge(source_attrs))
+
+        cloned = board.clone_with_images(user.id)
+        cloned.reload.board_images.find_by(image_id: source_image.id)
+      end
+
+      it "folds a stuck leading capital on a word tile" do
+        expect(clone_tile_reading("Higher").display_label).to eq("higher")
+      end
+
+      it "keeps the capital on a door tile" do
+        tile = clone_tile_reading("Food", data: { "mute_name" => true })
+        expect(tile.display_label).to eq("Food")
+      end
+
+      it "keeps deliberate casing" do
+        expect(clone_tile_reading("iPad").display_label).to eq("iPad")
+      end
+    end
   end
 
   describe "#check_in_use (before_save)" do

--- a/spec/services/boards/seeded_set_cloner_spec.rb
+++ b/spec/services/boards/seeded_set_cloner_spec.rb
@@ -290,6 +290,43 @@ RSpec.describe Boards::SeededSetCloner do
     end
   end
 
+  # The cloner used to copy the source tile's display_label verbatim, undoing
+  # the fold set_labels had just done — so a seed board carrying pre-#636 Title
+  # Case propagated it into every set built from it.
+  describe "tile casing on clone" do
+    # The clone re-resolves art and re-packs positions, so assert on the set of
+    # tile text rather than trying to pair a cloned tile back to its source.
+    def cloned_root_labels(source_text)
+      # Rolled back with the example's savepoint; the shared source set survives.
+      @source[:root].board_images.find_by(label: "want")
+                    .update_columns(label: source_text.downcase, display_label: source_text)
+      # before_all left the association cached on the shared source board.
+      @source[:root].reload
+
+      described_class.new(@source[:root], communicator: communicator).call
+                     .board_images.pluck(:display_label)
+    end
+
+    it "folds a stuck leading capital on a word tile" do
+      labels = cloned_root_labels("Higher")
+
+      expect(labels).to include("higher")
+      expect(labels).not_to include("Higher")
+    end
+
+    it "keeps deliberate casing" do
+      expect(cloned_root_labels("iPad")).to include("iPad")
+    end
+
+    it "keeps the capital on a curated folder tile" do
+      labels = described_class.new(@source[:root], communicator: communicator)
+                              .call.board_images.pluck(:display_label)
+
+      expect(labels).to include("Food", "Feelings")
+      expect(labels).not_to include("food", "feelings")
+    end
+  end
+
   # Regression for #278: seed BOTH real sets, then clone each.
   # A set cloned for a user with no communicator — assignable to one later.
   describe "#call without a communicator" do


### PR DESCRIPTION
New words were still coming out Title Cased after #636, most visibly in the Board Builder.

## What was wrong

#636 was fine — the *creation* paths (`Image#set_label`, `BoardImage#set_labels`, `Board#add_image`, the `word_list` flow, `ImageResolver`, the AI word-list drafter) all fold correctly. The problem is that **both clone paths put the Title Case back, one line after the fold**:

```ruby
new_board_image.set_labels                                 # folds → "higher"
new_board_image.display_label = board_image.display_label  # ...and restores "Higher"
```

The Board Builder builds every set by cloning an admin seed board, and those seeds were authored before the lowercase rule existed — so every built board inherited their casing. "Higher" next to "swing" on the same page, which reads as a defect in print, where these boards become physical signs.

## What changed

- **`BoardImage#cloned_display_label_from(source)`** — a cloned tile's text is *defaulted*, not authored: it carries whatever the source happened to store, so it gets the same casing rule as any other defaulted tile. Reuses `normalized_default_label`, so the clone path and the live path can't drift.
- **`BoardImage#door_tile?`** — doors keep their capital ("Food", "Play"). `predictive_board_id` alone can't identify one (per the CLAUDE.md invariant, predictive *word* tiles carry it too), so the test is the `mute_name`/nav flags **or** a pointer at a board that isn't `board_type: "predictive"`: a curated folder opens a real page, a predictive word tile opens a generated one. The lookup only runs for the minority of tiles that are linked at all.
- **`Board#clone_with_images`** and **`Boards::SeededSetCloner#copy_tiles!`** use it. The cloner's post-save `update_columns` repair (which exists so an art upgrade to a differently-cased image can't rename the tile) now compares against the *folded* value — otherwise it would undo the fix on its own.

Deliberate casing (`iPad`, `TV`, `HELP`, standalone `I`) is untouched — `Labels::CaseNormalizer` already handles it, so no new exception list. This is a re-casing and can never change what a tile says.

## Reviewer notes

- **This only governs boards built from here on.** The existing seeds and the library's `images.display_label` are still Title Cased and need the existing backfill — `bin/rails labels:fold_casing APPLY=1 ONLY=down` (dry run: `labels:fold_casing_report`). Worth running scoped to the admin user first so future clones start from clean seeds.
- Several surfaces read the *Image's* `display_label` rather than the tile's (image search/gallery `images_controller.rb:709,725`, predictive board list `account/boards_controller.rb:86`). Those are only fixed by the backfill, not by this PR.
- Not touched here: the paths that pin authored casing on purpose (OBF import, `BoardTreeBuilder`, `NavRowSync`, `FolderPlacer`, the internal API's `pin_authored_label!`, `board_from_screenshot`'s raw OCR text). The last two are arguably wrong — an LLM or an OCR pass isn't an "author" — but that's a separate call.

## Test plan

New specs on both clone paths: a word tile folds ("Higher" → "higher"), a curated folder tile keeps its capital ("Food", "Feelings"), deliberate casing survives ("iPad").

```
bundle exec rspec spec/services/boards/seeded_set_cloner_spec.rb spec/models/board_spec.rb \
  spec/models/board_image_spec.rb spec/sidekiq/build_board_set_job_spec.rb
→ 205 examples, 0 failures
```

Also green (regression sweep over everything clone- or label-adjacent):

```
spec/services/boards/{assignment_cloner,board_tree_builder,nav_row_sync,image_resolver,phrases_page_builder,folder_placer}_spec.rb
spec/services/boards/admin_builder
→ 309 examples, 0 failures

spec/models/{image,board_format_with_ai,board_from_obf_idempotency}_spec.rb
spec/requests/api/{images_label_casing,board_images_label_case}_spec.rb
spec/lib/tasks/tile_label_casing_rake_spec.rb spec/services/vocab_sets_spec.rb
spec/tasks/board_builder_sync_nav_rows_spec.rb
→ 170 examples, 0 failures
```

Docs: `CLAUDE.md` (new invariant — a cloned tile's text is defaulted), `.claude-notes/board-builder.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)