### PR TITLE
feat(admin): publish a board printable to Etsy and paste it into TPT

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -1,0 +1,163 @@
+# Board printables → marketplaces
+
+How a `BoardPrintable` becomes a sellable product from the admin dashboard:
+Etsy over the API, Teachers Pay Teachers as paste-ready copy.
+
+Entry point: `/admin/board_printables/:id`
+(`app/views/admin/board_printables/show.html.erb` and its `_listing_form`,
+`_listing_images`, `_etsy`, `_copy_blocks` partials).
+
+## Drafts only — never activate a listing
+
+**Rails creates Etsy drafts and nothing else.** `Etsy::Client#create_listing`
+hardcodes `state: "draft"`, and the client implements no activate/update-state
+call at all. The absence is the guarantee: there is no argument, param, or flag
+anywhere in the app that can put a listing live. Going live stays a deliberate
+click in the Etsy seller UI, after a human has checked the category, the photos,
+and the return policy.
+
+This mirrors the policy already enforced in `speakanyway-printables`
+(`scripts/etsy-listing.ts` → `assertStateAllowed`). If a future change needs to
+activate a listing, that is a decision to make explicitly, not a parameter to
+add.
+
+## The token-rotation hazard (read before touching auth)
+
+Etsy's OAuth refresh token is **single-use and rotates on every exchange** — the
+token you exchange is dead afterwards, and the response carries its replacement.
+
+Two consequences:
+
+1. **The refresh token cannot live in ENV.** A value pinned in Hatchbox is dead
+   after the first exchange. It lives in `oauth_credentials` (provider `etsy`)
+   because the database is the only writable store this app has.
+2. **Rails and `speakanyway-printables` must never share a grant.** That repo
+   holds its own refresh token in its `.env` and rotates it; if Rails exchanged
+   the same token the two would invalidate each other and both would start
+   throwing intermittent 403s that look like nothing in particular.
+
+So Rails uses a **separate authorization of the same Etsy app**. To seed it:
+
+```bash
+cd ../speakanyway-printables
+npx tsx scripts/bootstrap-etsy-oauth.ts   # mint a NEW, independent grant
+```
+
+then, in this repo:
+
+```bash
+rake 'etsy:seed_refresh_token[<the-refresh-token-it-printed>]'
+rake etsy:status                          # confirms config without printing secrets
+```
+
+Do **not** paste the token currently in the printables repo's `.env`.
+
+`Etsy::Client#access_token` refreshes under a row lock (`with_lock`) so two
+Sidekiq workers can't exchange the same single-use token concurrently — the
+loser 403s *and* its rotation clobbers the winner's, killing the chain.
+
+Tokens are stored in plaintext: ActiveRecord encryption is not configured in
+this app. `OauthCredential#inspect` redacts them so they can't leak into a log
+line or a console transcript. Revisit if AR encryption is ever turned on.
+
+## Etsy API quirks worth keeping
+
+Ported from `speakanyway-printables/src/publishers/marketplaces/etsy-ops.ts`.
+Each of these was a live failure, not a theory:
+
+- `x-api-key` must be `"keystring:shared_secret"`. The bare keystring 401s
+  (Etsy's 2026-02-09 enforcement).
+- Tags go as **one** comma-separated `tags` value. Repeated params are not
+  merged — Etsy keeps only the last and silently drops the rest.
+- More than one `&` in a title is a 400. `Etsy::CopyRules.enforce_title_rules`
+  keeps the first and turns later ones into "and".
+- Price does not stick through the listing create/PATCH payload. The inventory
+  endpoint (`GET` + `PUT /listings/:id/inventory`, a full replace) is the only
+  writer. `Etsy::PublishBoardPrintable` sets it there explicitly even though
+  create also carried it.
+- **`taxonomy_id` is not validated by Etsy.** An unknown id returns 200 and the
+  listing is filed under an arbitrary category — invisible in the response and
+  fatal to discoverability. `assert_known_taxonomy!` checks it against
+  `/seller-taxonomy/nodes`. Default is `2078` (Digital Prints). Do **not** copy
+  `6816` out of the printables repo's example config or its
+  `docs/etsy-cli-for-agents.md` — both are stale, and 6816 is the id that filed
+  every listing under nail-art dotting tools.
+- A download file is capped at 20 MB. Rails refuses an oversized PDF rather
+  than failing mid-upload; splitting is still the Node pipeline's job.
+
+## Listing copy lives in two languages
+
+`Etsy::CopyRules` + `Etsy::ListingCopy` are a Ruby port of
+`speakanyway-printables/src/generator/listing-copy.ts` and the keyword pools in
+`src/plugins/aac/index.ts`. Deterministic, template-driven, no LLM — so a
+listing reads the same whichever system produced it.
+
+They **can drift**. The Ruby side is authoritative for listings originated in
+Rails; the TypeScript side for listings originated by the Node pipeline. If you
+change a rule (a cap, a tag pool, a title template), change both or accept that
+the two now differ on purpose and say so.
+
+One deliberate difference: the Ruby description is **plain text**. Etsy renders
+no markup, and TPT takes a plain-text paste cleanly, so skipping the
+markdown→text conversion means what an admin reads in the textarea is exactly
+what a buyer sees.
+
+Generated copy is only a default. It is written into
+`board_printables.listing_copy` and edited by hand before publishing;
+`BoardPrintable#listing_copy_or_default` is what previews it before anything is
+saved.
+
+## Gallery images
+
+`Boards::Printables::RenderListingImages` renders two PNGs through the **same**
+templates and CSS as the printed wrapper pages
+(`layouts/pdf_printable` with `@listing_image` set, which switches on the
+`.as-listing-image` square-canvas rules):
+
+- `cover` — literally the product's first page, built from
+  `RenderWrappers#cover_assigns` so the QR target can't drift.
+- `whats_included` — a slide naming the boards in the set. Text and labels only:
+  rasterizing PDF page thumbnails would need poppler/ImageMagick that isn't in
+  the deploy image.
+
+Etsy will create a listing with no photos but won't let it go live without one,
+so `PublishBoardPrintable` renders them if they're missing. The richer gallery
+— lifestyle mockups, scene shots, the about slide — stays in the printables
+pipeline's steps 13/14.
+
+Images are written to a **versioned** blob key. CloudFront ignores query
+strings, so re-uploading to a stable key leaves the admin looking at the
+previous render (same lesson as `Boards::GeneratePreviewAssets`).
+
+## Storage layout
+
+`BoardPrintable#files` holds both kinds of blob, separated by blob metadata
+`kind` (`pdf` / `image`) rather than a second attachment — the PNGs arrived long
+after the PDFs and re-homing the existing ones would have churned every stored
+key. **A blob with no `kind` is a PDF** (that's every blob written before this
+existed).
+
+`files_view` is PDFs only, on purpose: the admin download buttons and the
+`/api/board_printables/:id/download_url` contract both read it, and neither
+should start handing out marketing art. `listing_images_view` is the images, in
+Etsy rank order.
+
+## Publishing is never retried
+
+`PublishBoardPrintableToEtsyJob` is `retry: 0`. A retry after a partial success
+creates a **second draft in a real shop**, and nothing downstream would notice.
+A failure records itself on `board_printables.etsy_error`, shows on the page,
+and waits for a human — a half-built draft is easy to delete, a duplicate is
+easy to miss. For the same reason, a printable that already has an
+`etsy_listing_id` refuses to publish again.
+
+## Teachers Pay Teachers
+
+TPT has **no seller API**. `Printables::MarketplaceCopy#tpt_fields` lays the copy
+out field by field in the order TPT's upload form asks for it, each with a
+copy-to-clipboard button. Note TPT's title cap is 100, not Etsy's 140, and the
+`(Digital Download)` suffix is stripped — it reads as spam there.
+
+The subject / grade / resource-type values are defaults picked from TPT's fixed
+taxonomy, not rules. Standards is deliberately left blank: AAC vocabulary boards
+don't map cleanly to CCSS and a guess is worse than an omission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Board printables can be listed for sale from the admin dashboard.** A
+  finished printable's page now carries the whole last mile: a link to the board
+  it was built from (and every sub-board in the tree), editable listing copy
+  generated from the board's own name and topic, marketplace gallery images
+  rendered from the same templates as the printed pages, a **Create Etsy draft**
+  button that talks to the Etsy API directly, and copy-to-clipboard blocks for
+  Teachers Pay Teachers — which has no seller API — laid out field by field in
+  the order their upload form asks for them. Nothing here can put a listing
+  live: Etsy listings are created as drafts and published by hand, after a human
+  has looked at the category, the photos, and the return policy.
+
 ### Changed
 
 - **Admin board builder: folder tiles now open their page without speaking.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,14 @@ an explicit decision, not a drive-by edit.
   email or track real users. Transactional mail is covered by the same rule at
   the delivery layer: `StagingMailInterceptor` drops every message on staging
   unless the recipient is in `STAGING_MAIL_ALLOWLIST`.
+- **Rails creates marketplace DRAFTS and never activates one.**
+  `Etsy::Client#create_listing` hardcodes `state: "draft"` and the client
+  implements no activate call — the absence is the guarantee. Publishing a
+  board printable to Etsy means creating a draft; going live stays a deliberate
+  click in the Etsy seller UI. Relatedly, Etsy's refresh token is single-use and
+  rotates on every exchange, so it lives in `oauth_credentials` (not ENV) and
+  Rails holds a **separate authorization** from the one `speakanyway-printables`
+  uses — a shared grant makes the two invalidate each other.
 - **Email verification is keyed on `email_verified_at`, never `confirmed_at`.**
   `User#mark_email_verified!` is the only writer. Verified status may be
   conferred ONLY by a path where the user clicked a link delivered to their
@@ -329,6 +337,7 @@ an explicit decision, not a drive-by edit.
 | `.claude-notes/marketing-assets.md` | AAC Classroom Kit hosting: `MarketingAsset`, internal endpoints, marketing print style, QR scannability rule (do not re-add long UTMs to tag QRs) |
 | `.claude-notes/internal-api.md` | Internal `/api/internal/` surface: bearer auth + admin identity, public-CDN download path (`src` vs `original_url`), image + board search endpoints, `Images::CommercialLicense` licensing rule |
 | `.claude-notes/image-generation.md` | AI tile art: `Images::PromptBuilder` (the single prompt source of truth, always-wrap rule), symbol vs illustrated style resolution, part-of-speech homograph disambiguation, transparency/quality API params + model fallback, refusal retry, variations via the edit endpoint, prompt provenance on docs |
+| `.claude-notes/board-printables-etsy.md` | Publishing a board printable to a marketplace: the drafts-only rule, Etsy's rotating refresh token + why Rails holds a separate grant, the ported Etsy v3 API quirks, listing-copy rules (and their Ruby↔TypeScript drift), Grover-rendered gallery images, the TPT paste sheet |
 | `.claude-notes/writing-suggestions.md` | Contextual writing suggestions (`POST /api/suggestions`): field registry + context allow-list, the no-safety-keys privacy invariant, OpenAI generator + fixtures, free/no-credit contract, user opt-out toggle |
 
 Related tracked docs: `docs/rds-migration-runbook.md`, `docs/stripe-setup.md`,

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,11 @@ gem "font-awesome-sass", "~> 6.4.0"
 
 # HTTP requests
 gem "faraday"
+# Declared explicitly because Etsy::Client requires it directly for the listing
+# image/file uploads. It was already resolving transitively through ruby-openai,
+# which would have made a future ruby-openai change break Etsy publishing for
+# no visible reason.
+gem "faraday-multipart"
 
 # Config & ENV vars
 gem "figaro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,6 +619,7 @@ DEPENDENCIES
   down (~> 5.4)
   factory_bot_rails
   faraday
+  faraday-multipart
   ffaker
   figaro
   font-awesome-sass (~> 6.4.0)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@
   - `REVENUECAT_WEBHOOK_AUTH_HEADER` - Shared secret matched against the `Authorization` header on RevenueCat webhooks (`/api/billing/webhooks`). When blank, the webhook rejects every request with 401.
   - `REVENUECAT_REST_API_KEY` - RevenueCat v1 secret REST API key used to verify a subscriber's entitlement server-side before `/api/billing/update_subscription` flips a plan. When blank, verification fails closed (update_subscription returns 403).
   - `CDN_HOST` - CDN Host (optional)
+  - `ETSY_KEYSTRING` - Etsy app keystring, used with the shared secret as the `x-api-key` header. Required to publish a board printable to Etsy.
+  - `ETSY_SHARED_SECRET` - Etsy app shared secret.
+  - `ETSY_OAUTH_CLIENT_ID` - Etsy OAuth client id used for the refresh-token exchange.
+  - `ETSY_SHOP_ID` - Numeric Etsy shop id the drafts are created in.
+  - **Not** an ENV var: the Etsy OAuth refresh token. Etsy rotates it on every exchange, so it lives in the `oauth_credentials` table and is seeded once with `rake 'etsy:seed_refresh_token[TOKEN]'`. It must come from a **separate** Etsy authorization from the one `speakanyway-printables` holds — see `.claude-notes/board-printables-etsy.md`.
   - `DEVISE_JWT_SECRET_KEY` - Devise JWT Secret Key
   - `DOMAIN` - Domain
   - `GOOGLE_CUSTOM_SEARCH_API_KEY` - Google Custom Search API Key

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -35,6 +35,61 @@ module Admin
 
     def show
       @printable = BoardPrintable.find(params[:id])
+      @listing = @printable.listing_copy_or_default
+      @marketplace_copy = Printables::MarketplaceCopy.new(@printable, listing: @listing)
+      @tree_boards = tree_boards(@printable)
+      @etsy_configured = Etsy::Client.configured?
+    end
+
+    # Saves the editable listing copy. Deliberately separate from publishing:
+    # the copy is reviewed and edited first, and saving it must never touch
+    # Etsy.
+    def update_listing
+      printable = BoardPrintable.find(params[:id])
+
+      printable.update!(listing_copy: listing_copy_params(printable))
+      redirect_to admin_dashboard_board_printable_path(printable), notice: "Listing copy saved."
+    end
+
+    # Enqueues the DRAFT-only Etsy publish. Nothing here can activate a
+    # listing — see Etsy::PublishBoardPrintable.
+    def publish_to_etsy
+      printable = BoardPrintable.find(params[:id])
+
+      if !printable.complete?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable isn't finished generating yet."
+      elsif printable.etsy_published?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "Already on Etsy as listing #{printable.etsy_listing_id}."
+      elsif !Etsy::Client.configured?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "Etsy isn't configured. Set the ETSY_* env vars and run `rake etsy:seed_refresh_token`."
+      else
+        # Persist whatever is currently in the form's defaults so the draft and
+        # the page agree — publishing what an admin never saw would be worse
+        # than making them press Save first.
+        printable.update!(listing_copy: printable.listing_copy_or_default) if printable.listing_copy.blank?
+        printable.update_columns(etsy_error: nil, updated_at: Time.current)
+
+        PublishBoardPrintableToEtsyJob.perform_async(printable.id)
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    notice: "Creating the Etsy draft… refresh in a moment to see the result."
+      end
+    end
+
+    def regenerate_listing_images
+      printable = BoardPrintable.find(params[:id])
+
+      unless printable.complete?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable isn't finished generating yet."
+        return
+      end
+
+      RenderBoardPrintableListingImagesJob.perform_async(printable.id)
+      redirect_to admin_dashboard_board_printable_path(printable),
+                  notice: "Rendering listing images… refresh in a moment."
     end
 
     def create
@@ -72,6 +127,42 @@ module Admin
     end
 
     private
+
+    # The listing_copy jsonb is written wholesale rather than merged: the form
+    # posts every field every time, so a merge would only ever preserve stale
+    # keys from an older shape. Anything the form doesn't carry (the TPT
+    # overrides) is folded back in explicitly.
+    def listing_copy_params(printable)
+      tags = params[:tags].to_s.split(",").map(&:strip).reject(&:blank?)
+      existing = printable.listing_copy.to_h
+
+      existing.merge(
+        "title" => params[:title].to_s.strip,
+        "summary" => params[:summary].to_s.strip,
+        "description" => params[:description].to_s,
+        # Normalized here, not just at publish time, so an admin sees exactly
+        # the tags Etsy will receive rather than discovering the drops later.
+        "tags" => Etsy::Client.new.normalize_tags(tags),
+        "price_cents" => price_cents_param,
+      )
+    end
+
+    def price_cents_param
+      raw = params[:price].to_s.strip
+      return Etsy::ListingCopy::DEFAULT_PRICE_CENTS if raw.blank?
+
+      (raw.to_f * 100).round.clamp(20, 100_000)
+    end
+
+    # The boards the printable actually walked, back in tree order — a plain
+    # `where` returns them in whatever order Postgres likes.
+    def tree_boards(printable)
+      ids = printable.board_ids.to_a
+      return [] if ids.size <= 1
+
+      by_id = Board.where(id: ids).index_by(&:id)
+      ids.filter_map { |id| by_id[id] }
+    end
 
     # The boards worth offering a one-click printable for. `public_boards` is
     # the catalogue; Board Builder boards are the other half — published and

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -17,6 +17,21 @@ module Admin
       "#{base_url}/pb/#{Boards::Printables::CollectPages.qr_key_for(board)}"
     end
 
+    # Built from the numeric listing id rather than the stored
+    # `etsy_listing_url`, even though we have the URL Etsy handed back.
+    #
+    # `etsy_listing_url` is a string column, so a link_to href reading it is an
+    # XSS sink as far as any analysis can tell — the fact that only Etsy's API
+    # response ever writes it isn't visible at the call site, and wouldn't stay
+    # true if something else started writing the column. The id is a bigint, so
+    # there is nothing to inject, and Etsy resolves this canonical form to the
+    # same listing as the slug URL.
+    def etsy_listing_url_for(printable)
+      return nil if printable.etsy_listing_id.blank?
+
+      "https://www.etsy.com/listing/#{printable.etsy_listing_id.to_i}"
+    end
+
     # The list is capped at PUBLIC_BOARD_LIMIT, so which boards you see depends
     # on the sort — the summary line says which one picked them.
     def board_sort_label(sort)

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -22,6 +22,19 @@ class BoardPrintable < ApplicationRecord
   VARIANT_COLOR = "color".freeze
   VARIANT_LOW_INK = "low_ink".freeze
 
+  # `files` holds two kinds of blob: the printable PDFs a buyer downloads, and
+  # the PNG gallery images a marketplace listing needs. They are separated by
+  # blob metadata rather than a second attachment because the PNGs arrived long
+  # after the PDFs and re-homing the existing ones would have churned every
+  # stored key. Blobs written before this existed carry no "kind", and are PDFs.
+  KIND_PDF = "pdf".freeze
+  KIND_IMAGE = "image".freeze
+
+  IMAGE_COVER = "cover".freeze
+  IMAGE_WHATS_INCLUDED = "whats_included".freeze
+  # Etsy shows gallery photos in listing order; the cover earns rank 1.
+  LISTING_IMAGE_ORDER = [IMAGE_COVER, IMAGE_WHATS_INCLUDED].freeze
+
   belongs_to :board
   belongs_to :created_by, class_name: "User", optional: true
 
@@ -44,33 +57,64 @@ class BoardPrintable < ApplicationRecord
   def storage_key_for(filename) = "board_printables/#{id}/#{filename}"
 
   def attach_pdf!(filename:, bytes:, variant:)
-    key = storage_key_for(filename)
-    # Purge anything already at the deterministic key first, same reason as
-    # MarketingAsset#attach_pdf! — create_and_upload! would otherwise collide.
-    files.find { |f| f.key == key }&.purge
-
-    blob = ActiveStorage::Blob.create_and_upload!(
-      io: StringIO.new(bytes),
+    attach_blob!(
       filename: filename,
+      bytes: bytes,
       content_type: "application/pdf",
-      key: key,
-      metadata: { "variant" => variant },
+      metadata: { "variant" => variant, "kind" => KIND_PDF },
     )
-    files.attach(blob)
-    blob
   end
 
+  # Unlike the PDFs, a listing image is written to a VERSIONED key: CloudFront
+  # ignores query strings, so re-uploading to the same key leaves the admin
+  # looking at the previous render and wondering why "Regenerate" did nothing.
+  # Same lesson as Boards::GeneratePreviewAssets. Any earlier render of this
+  # variant is purged first so the versioned keys can't pile up.
+  def attach_image!(bytes:, variant:)
+    image_files.select { |f| f.metadata["variant"] == variant }.each(&:purge)
+    reload_files_association
+
+    filename = "#{variant.dasherize}-#{SecureRandom.hex(4)}.png"
+    attach_blob!(
+      filename: filename,
+      bytes: bytes,
+      content_type: "image/png",
+      metadata: { "variant" => variant, "kind" => KIND_IMAGE },
+    )
+  end
+
+  # The downloadable product. Deliberately PDFs only — the admin download
+  # buttons and the /api/board_printables/:id/download_url contract both read
+  # this, and neither should start handing out marketing images.
   def files_view
+    view_for(pdf_files)
+  end
+
+  # The marketplace gallery images, in the order Etsy should rank them.
+  def listing_images_view
+    view_for(image_files).sort_by { |f| LISTING_IMAGE_ORDER.index(f[:variant]) || LISTING_IMAGE_ORDER.size }
+  end
+
+  def pdf_files
     return [] unless files.attached?
 
-    files.map do |file|
-      {
-        variant: file.metadata["variant"].presence || VARIANT_FULL,
-        filename: file.filename.to_s,
-        url: url_for_file(file),
-        byte_size: file.byte_size,
-      }
-    end
+    files.select { |f| f.metadata["kind"].presence != KIND_IMAGE }
+  end
+
+  def image_files
+    return [] unless files.attached?
+
+    files.select { |f| f.metadata["kind"] == KIND_IMAGE }
+  end
+
+  def listing_images? = image_files.any?
+
+  def etsy_published? = etsy_listing_id.present?
+
+  # The copy an admin has saved, or the generated default when nothing has been
+  # saved yet — so the show page can preview a listing before anyone edits it.
+  def listing_copy_or_default
+    listing_copy.presence || Etsy::ListingCopy.new(self).build
   end
 
   def api_view
@@ -86,6 +130,41 @@ class BoardPrintable < ApplicationRecord
   end
 
   private
+
+  # `files` is memoized once loaded, so a purge inside a multi-step render is
+  # invisible to the next `files.find` without this.
+  def reload_files_association
+    files.reset
+    files_attachments.reset
+  end
+
+  def attach_blob!(filename:, bytes:, content_type:, metadata:)
+    key = storage_key_for(filename)
+    # Purge anything already at the deterministic key first, same reason as
+    # MarketingAsset#attach_pdf! — create_and_upload! would otherwise collide.
+    files.find { |f| f.key == key }&.purge
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(bytes),
+      filename: filename,
+      content_type: content_type,
+      key: key,
+      metadata: metadata,
+    )
+    files.attach(blob)
+    blob
+  end
+
+  def view_for(collection)
+    collection.map do |file|
+      {
+        variant: file.metadata["variant"].presence || VARIANT_FULL,
+        filename: file.filename.to_s,
+        url: url_for_file(file),
+        byte_size: file.byte_size,
+      }
+    end
+  end
 
   # Production S3 is `public: true`, so the URL is CDN_HOST + key rather than
   # a presigned one — same convention as Board#pdf_url and

--- a/app/models/oauth_credential.rb
+++ b/app/models/oauth_credential.rb
@@ -1,0 +1,51 @@
+# A long-lived OAuth grant held on behalf of the app itself (not a user), for
+# providers whose refresh token ROTATES and therefore cannot live in ENV.
+#
+# Etsy is the motivating case: every refresh exchange invalidates the token
+# that was used and returns a new one, so a token pinned in Hatchbox ENV is
+# dead after the first exchange. It has to be written back somewhere, and the
+# database is the only writable store this app has.
+#
+# The corollary is that two systems must never share one grant. The
+# speakanyway-printables repo holds its own Etsy refresh token in its .env; if
+# Rails exchanged that same token the two would invalidate each other and both
+# would start throwing intermittent 403s. Rails therefore uses a SEPARATE
+# authorization of the same Etsy app — see `rake etsy:seed_refresh_token`.
+#
+# Tokens are stored in plaintext: ActiveRecord encryption is not configured in
+# this app, and quietly introducing encryption keys here is a bigger decision
+# than this table. Access is admin-only and the value is filtered out of logs
+# below; revisit if AR encryption is ever turned on.
+class OauthCredential < ApplicationRecord
+  PROVIDER_ETSY = "etsy".freeze
+
+  validates :provider, presence: true, uniqueness: true
+
+  def self.for_provider(provider) = find_by(provider: provider)
+
+  def self.upsert_refresh_token!(provider:, refresh_token:, metadata: {})
+    record = find_or_initialize_by(provider: provider)
+    record.refresh_token = refresh_token
+    record.metadata = record.metadata.to_h.merge(metadata.stringify_keys)
+    # A newly seeded refresh token invalidates whatever access token we cached.
+    record.access_token = nil
+    record.access_token_expires_at = nil
+    record.save!
+    record
+  end
+
+  # Treat a token as expired slightly early so a request that takes a moment to
+  # reach the provider can't be issued with a token that dies in flight.
+  EXPIRY_SKEW = 60.seconds
+
+  def access_token_valid?
+    access_token.present? && access_token_expires_at.present? &&
+      access_token_expires_at > Time.current + EXPIRY_SKEW
+  end
+
+  # Never let a token reach a log line, an error report, or a console
+  # transcript by way of the default attribute-dumping inspect.
+  def inspect
+    "#<OauthCredential id: #{id.inspect} provider: #{provider.inspect} [tokens redacted]>"
+  end
+end

--- a/app/services/boards/printables/render_listing_images.rb
+++ b/app/services/boards/printables/render_listing_images.rb
@@ -1,0 +1,121 @@
+# Renders the marketplace gallery images for a printable: the cover, and a
+# "what's included" slide.
+#
+# Etsy will create a listing with no photos but will not let it go live without
+# one, so these are the minimum a draft needs to be finishable. The richer
+# gallery — lifestyle mockups, scene shots, the about slide — is still the
+# speakanyway-printables pipeline's job (its steps 13/14); reproducing that here
+# would mean compositing over photography, which is a different project.
+#
+# Both images come from the SAME templates and CSS as the printed wrapper pages,
+# rendered through layouts/pdf_printable with `@listing_image` set. A buyer
+# should not be able to tell the gallery and the product apart.
+#
+# Grover work, so it belongs on Sidekiq, never a request thread.
+module Boards
+  module Printables
+    class RenderListingImages
+      # Etsy's recommended shortest edge is 2000px. The sheet is 8.5in wide at
+      # 96 CSS px/in = 816px, so a device_scale_factor of 2.5 lands at 2040 —
+      # over the recommendation without paying for a 3x render.
+      CANVAS_PX = 816
+      SCALE = 2.5
+
+      def initialize(printable:)
+        @printable = printable
+      end
+
+      # => [BoardPrintable::IMAGE_COVER, BoardPrintable::IMAGE_WHATS_INCLUDED]
+      def call
+        printable.attach_image!(bytes: cover_png, variant: BoardPrintable::IMAGE_COVER)
+        printable.attach_image!(bytes: whats_included_png, variant: BoardPrintable::IMAGE_WHATS_INCLUDED)
+        BoardPrintable::LISTING_IMAGE_ORDER
+      end
+
+      private
+
+      attr_reader :printable
+
+      def board = printable.board
+
+      def board_count = [printable.board_ids.to_a.size, 1].max
+
+      def set? = board_count > 1
+
+      # The same assigns RenderWrappers builds for the printed cover, so the
+      # gallery's first image is literally the product's first page. Kept in
+      # sync by construction: the wrapper service owns the values, this just
+      # asks it for them.
+      def cover_png
+        wrappers = RenderWrappers.new(board: board, board_count: board_count, topic: printable.topic)
+        render_png("cover", assigns: wrappers.cover_assigns)
+      end
+
+      def whats_included_png
+        render_png("whats_included", assigns: whats_included_assigns)
+      end
+
+      def whats_included_assigns
+        {
+          heading: Boards::AssetRendering.board_title_for(board),
+          subtitle: subtitle,
+          items: included_items,
+          board_labels: board_labels,
+        }
+      end
+
+      def subtitle
+        return "Words for #{printable.topic}" if printable.topic.present?
+        return "A set of #{board_count} printable communication boards" if set?
+
+        "A printable communication board"
+      end
+
+      # Shared with the listing description so the slide and the text make the
+      # same promises in the same words.
+      #
+      # Root-scoped: this class is itself inside `Boards::Printables`, so a bare
+      # `Printables::` resolves to that and never reaches the top-level module.
+      def included_items
+        ::Printables::IncludedItems.all(board_count: board_count, page_count: printable.page_count)
+      end
+
+      # board_ids is in tree order (root first) and a `where` loses it, so the
+      # names are put back into it. Capped because the callout is one line of a
+      # fixed-height slide — a 25-board set would overflow the sheet.
+      MAX_LABELS = 12
+
+      def board_labels
+        ids = printable.board_ids.to_a
+        return [] if ids.size <= 1
+
+        names = Board.where(id: ids).pluck(:id, :name).to_h
+        labels = ids.filter_map { |id| names[id].presence }
+                    .map { |n| Etsy::CopyRules.title_case_words(n) }
+                    .uniq
+        return labels if labels.size <= MAX_LABELS
+
+        labels.first(MAX_LABELS) + ["and #{labels.size - MAX_LABELS} more"]
+      end
+
+      def render_png(template, assigns:)
+        html = ApplicationController.render(
+          template: "api/board_printables/#{template}",
+          layout: "pdf_printable",
+          assigns: assigns.merge(listing_image: true),
+          formats: [:html],
+        )
+
+        Grover.new(
+          html,
+          format: "png",
+          viewport: { width: CANVAS_PX, height: CANVAS_PX },
+          width: CANVAS_PX,
+          height: CANVAS_PX,
+          device_scale_factor: SCALE,
+          print_background: true,
+        ).to_png
+      end
+    end
+  end
+end

--- a/app/services/boards/printables/render_wrappers.rb
+++ b/app/services/boards/printables/render_wrappers.rb
@@ -53,12 +53,10 @@ module Boards
         )
       end
 
-      private
-
-      attr_reader :board, :board_count, :topic
-
-      def set? = board_count > 1
-
+      # Public because RenderListingImages renders the SAME cover as a PNG for
+      # the marketplace gallery. Sharing the assigns rather than rebuilding them
+      # is what keeps the listing's first image identical to the product's first
+      # page — including the QR target, which is easy to get subtly wrong.
       def cover_assigns
         {
           title: Boards::AssetRendering.board_title_for(board),
@@ -68,6 +66,12 @@ module Boards
           public_url: public_url,
         }
       end
+
+      private
+
+      attr_reader :board, :board_count, :topic
+
+      def set? = board_count > 1
 
       # `low_ink` is only ever true for a set, where this page is bound into the
       # low-ink file alone and must describe that file rather than the pair.

--- a/app/services/etsy/client.rb
+++ b/app/services/etsy/client.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "faraday/multipart"
+
+# Thin REST client for Etsy's Open API v3, scoped to exactly what publishing a
+# digital printable needs: create a listing, price it, attach gallery images,
+# attach download files.
+#
+# Ported from speakanyway-printables `src/publishers/marketplaces/etsy-ops.ts`.
+# Nearly every unusual line below encodes a live Etsy failure — the comments
+# name them. Read them before changing a request shape.
+#
+# Unlike most clients in this app this one RAISES rather than returning a
+# Result struct. A failed RevenueCat lookup degrades to "unverified" and the
+# request continues; a failed Etsy call must abort the publish immediately and
+# leave nothing half-created. Etsy::PublishBoardPrintable is the boundary that
+# turns these into a Result for the UI.
+module Etsy
+  class Client
+    API_BASE = "https://openapi.etsy.com/v3/application"
+    OAUTH_TOKEN_URL = "https://api.etsy.com/v3/public/oauth/token"
+
+    # Art & Collectibles > Prints > Digital Prints.
+    #
+    # Do NOT copy 6816 out of the printables repo's example config or
+    # docs/etsy-cli-for-agents.md — both are stale. 6816 is not a node in
+    # Etsy's taxonomy at all, and because Etsy accepts unknown ids without
+    # complaint, every listing that pipeline produced silently landed under
+    # "Bath & Beauty > … > Nail Tools > Dotting Tools" until it was caught.
+    DEFAULT_TAXONOMY_ID = 2078
+
+    TAXONOMY_CACHE_KEY = "etsy/seller_taxonomy_ids".freeze
+    TAXONOMY_CACHE_TTL = 12.hours
+
+    # Etsy caps a single download file at 20 MB.
+    FILE_CAP_BYTES = 20 * 1024 * 1024
+
+    TIMEOUT = 30
+    OPEN_TIMEOUT = 10
+
+    class Error < StandardError; end
+    class ConfigurationError < Error; end
+
+    def initialize(
+      keystring: ENV["ETSY_KEYSTRING"],
+      shared_secret: ENV["ETSY_SHARED_SECRET"],
+      client_id: ENV["ETSY_OAUTH_CLIENT_ID"],
+      shop_id: ENV["ETSY_SHOP_ID"]
+    )
+      @keystring = keystring
+      @shared_secret = shared_secret
+      @client_id = client_id
+      @shop_id = shop_id
+    end
+
+    def self.configured? = new.configured?
+
+    def configured?
+      [@keystring, @shared_secret, @client_id, @shop_id].all?(&:present?) &&
+        OauthCredential.for_provider(OauthCredential::PROVIDER_ETSY)&.refresh_token.present?
+    end
+
+    attr_reader :shop_id
+
+    # Create a listing. Etsy always creates in `draft` state — going live is a
+    # separate call this client deliberately does not implement. `state` is sent
+    # explicitly anyway so the intent is visible in the request and assertable
+    # in a spec.
+    #
+    # => { listing_id:, url: }
+    def create_listing(title:, description:, price:, tags: [], taxonomy_id: DEFAULT_TAXONOMY_ID, quantity: 999)
+      body = {
+        "quantity" => quantity.to_s,
+        "title" => title.to_s,
+        "description" => description.to_s,
+        "price" => format("%.2f", price),
+        "who_made" => "i_did",
+        "when_made" => "2020_2026",
+        "taxonomy_id" => taxonomy_id.to_s,
+        "type" => "download",
+        "state" => "draft",
+      }
+
+      # Etsy expects ONE comma-separated `tags` value. Repeated `tags` params
+      # are not merged — Etsy keeps only the last, silently dropping the rest.
+      normalized = normalize_tags(tags)
+      body["tags"] = normalized.join(",") if normalized.any?
+
+      response = request(:post, "/shops/#{shop_id}/listings", body: body)
+      parsed = parse_json(response, "create-listing")
+      listing_id = parsed["listing_id"]
+      raise Error, "Etsy create-listing response missing listing_id" if listing_id.blank?
+
+      {
+        listing_id: listing_id.to_i,
+        url: parsed["url"].presence || "https://www.etsy.com/listing/#{listing_id}",
+      }
+    end
+
+    # Price cannot be set through the listing create/PATCH payload in a way that
+    # sticks — Etsy returns 200 and ignores it. The inventory endpoint is the
+    # only writer, and it is a full replace, so the current inventory has to be
+    # read and echoed back with the price swapped in.
+    def set_listing_price(listing_id, price)
+      inventory = parse_json(request(:get, "/listings/#{listing_id}/inventory"), "get-inventory")
+
+      products = Array(inventory["products"]).map do |product|
+        {
+          "sku" => product["sku"].to_s,
+          "property_values" => Array(product["property_values"]).map do |value|
+            {
+              "property_id" => value["property_id"],
+              "value_ids" => value["value_ids"],
+              "scale_id" => value["scale_id"],
+              "values" => value["values"],
+            }
+          end,
+          "offerings" => Array(product["offerings"]).map do |offering|
+            {
+              "price" => price.to_f,
+              "quantity" => offering["quantity"],
+              "is_enabled" => offering["is_enabled"],
+            }
+          end,
+        }
+      end
+
+      if products.empty?
+        raise Error, "Etsy listing #{listing_id} returned no inventory products; cannot set price."
+      end
+
+      payload = {
+        "products" => products,
+        "price_on_property" => Array(inventory["price_on_property"]),
+        "quantity_on_property" => Array(inventory["quantity_on_property"]),
+        "sku_on_property" => Array(inventory["sku_on_property"]),
+      }
+
+      request(
+        :put,
+        "/listings/#{listing_id}/inventory",
+        body: payload.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+      true
+    end
+
+    def upload_image(listing_id, bytes:, filename:, rank: 1)
+      body = {
+        "image" => multipart_part(bytes, "image/png", normalize_filename(filename)),
+        "rank" => rank.to_s,
+      }
+      request(:post, "/shops/#{shop_id}/listings/#{listing_id}/images", body: body)
+      true
+    end
+
+    def upload_file(listing_id, bytes:, filename:, rank: 1, mime_type: "application/pdf")
+      if bytes.bytesize > FILE_CAP_BYTES
+        raise Error, "#{filename} is #{bytes.bytesize} bytes; Etsy caps a download file at 20 MB."
+      end
+
+      name = normalize_filename(filename)
+      body = {
+        "file" => multipart_part(bytes, mime_type, name),
+        "name" => name,
+        "rank" => rank.to_s,
+      }
+      request(:post, "/shops/#{shop_id}/listings/#{listing_id}/files", body: body)
+      true
+    end
+
+    # Etsy does NOT validate taxonomy_id on create: it accepts an unknown id,
+    # returns 200, and files the listing under an arbitrary category — invisible
+    # in the response and fatal to discoverability. So it has to be checked here.
+    #
+    # A failure to FETCH the taxonomy is not fatal; a transient Etsy blip should
+    # not block a publish. Only a definitively-unknown id raises.
+    def assert_known_taxonomy!(taxonomy_id)
+      ids = begin
+        taxonomy_ids
+      rescue => e
+        Rails.logger.warn("[Etsy::Client] could not fetch seller taxonomy, skipping validation: #{e.message}")
+        return true
+      end
+
+      return true if ids.include?(taxonomy_id.to_i)
+
+      raise Error, "Etsy taxonomy_id #{taxonomy_id} is not a node in Etsy's seller taxonomy. " \
+                   "Etsy would accept it and file the listing under an arbitrary category."
+    end
+
+    def taxonomy_ids
+      cached = Rails.cache.read(TAXONOMY_CACHE_KEY)
+      return cached.to_set if cached.present?
+
+      parsed = parse_json(request(:get, "/seller-taxonomy/nodes"), "seller-taxonomy")
+      ids = []
+      walk = lambda do |node|
+        ids << node["id"].to_i
+        Array(node["children"]).each { |child| walk.call(child) }
+      end
+      Array(parsed["results"]).each { |root| walk.call(root) }
+
+      Rails.cache.write(TAXONOMY_CACHE_KEY, ids, expires_in: TAXONOMY_CACHE_TTL)
+      ids.to_set
+    end
+
+    # Etsy allows letters, numbers, spaces, hyphens and apostrophes in a tag,
+    # max 20 characters, max 13 tags. Anything else is silently dropped by Etsy,
+    # so it is dropped here where it can be seen.
+    def normalize_tags(tags)
+      Array(tags).filter_map { |t| CopyRules.normalize_tag(t) }.uniq.first(CopyRules::TAG_MAX)
+    end
+
+    # Etsy's download-file names must be 3–70 chars of [A-Za-z0-9._-].
+    def normalize_filename(filename)
+      base = File.basename(filename.to_s).gsub(/[^A-Za-z0-9._-]/, "-").gsub(/-{2,}/, "-")
+      base = "file-#{base}" if base.length < 3
+      base.length > 70 ? "#{base[0, 66 - File.extname(base).length]}#{File.extname(base)}" : base
+    end
+
+    private
+
+    # The DB-held grant, refreshed on demand. See OauthCredential for why the
+    # refresh token cannot live in ENV.
+    def access_token
+      credential = OauthCredential.for_provider(OauthCredential::PROVIDER_ETSY)
+      if credential.nil? || credential.refresh_token.blank?
+        raise ConfigurationError, "No Etsy OAuth credential stored. Run `rake etsy:seed_refresh_token`."
+      end
+      return credential.access_token if credential.access_token_valid?
+
+      token = nil
+      # Row lock so two Sidekiq workers can't exchange the same single-use
+      # refresh token concurrently — the loser's exchange 403s AND its rotation
+      # clobbers the winner's token, killing the whole chain.
+      credential.with_lock do
+        token = credential.access_token_valid? ? credential.access_token : exchange_refresh_token!(credential)
+      end
+      token
+    end
+
+    def exchange_refresh_token!(credential)
+      response = oauth_connection.post(OAUTH_TOKEN_URL) do |req|
+        req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req.body = {
+          "grant_type" => "refresh_token",
+          "client_id" => @client_id.to_s,
+          "refresh_token" => credential.refresh_token,
+        }
+      end
+
+      unless response.status == 200
+        raise Error, "Etsy OAuth token exchange #{response.status}: #{truncate_body(response.body)}"
+      end
+
+      parsed = JSON.parse(response.body.to_s)
+      access = parsed["access_token"]
+      rotated = parsed["refresh_token"]
+      if access.blank? || rotated.blank?
+        raise Error, "Etsy OAuth response missing tokens"
+      end
+
+      # Etsy rotates the refresh token on EVERY exchange and invalidates the old
+      # one. Persisting the new value is not an optimization — skip it and the
+      # next publish is permanently 403.
+      credential.update!(
+        access_token: access,
+        refresh_token: rotated,
+        access_token_expires_at: Time.current + parsed["expires_in"].to_i.clamp(60, 1.day.to_i),
+      )
+      access
+    end
+
+    def request(method, path, body: nil, headers: {})
+      raise ConfigurationError, "Etsy is not configured (missing ETSY_* env)." unless credentials_present?
+
+      response = connection.run_request(method, "#{API_BASE}#{path}", body, default_headers.merge(headers))
+      return response if response.success?
+
+      raise Error, "Etsy #{method.to_s.upcase} #{path} #{response.status}: #{truncate_body(response.body)}"
+    end
+
+    def credentials_present?
+      [@keystring, @shared_secret, @client_id, @shop_id].all?(&:present?)
+    end
+
+    def default_headers
+      {
+        "Authorization" => "Bearer #{access_token}",
+        # Must be "keystring:secret" since Etsy's 2026-02-09 enforcement — the
+        # bare keystring 401s.
+        "x-api-key" => "#{@keystring}:#{@shared_secret}",
+      }
+    end
+
+    def parse_json(response, label)
+      JSON.parse(response.body.to_s)
+    rescue JSON::ParserError => e
+      raise Error, "Etsy #{label} returned unparseable JSON: #{e.message}"
+    end
+
+    def multipart_part(bytes, content_type, filename)
+      Faraday::Multipart::FilePart.new(StringIO.new(bytes), content_type, filename)
+    end
+
+    def truncate_body(body) = body.to_s.truncate(300)
+
+    def connection
+      @connection ||= Faraday.new do |f|
+        f.request :multipart
+        f.request :url_encoded
+        f.options.timeout = TIMEOUT
+        f.options.open_timeout = OPEN_TIMEOUT
+      end
+    end
+
+    def oauth_connection
+      @oauth_connection ||= Faraday.new do |f|
+        f.request :url_encoded
+        f.options.timeout = TIMEOUT
+        f.options.open_timeout = OPEN_TIMEOUT
+      end
+    end
+  end
+end

--- a/app/services/etsy/copy_rules.rb
+++ b/app/services/etsy/copy_rules.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+# Pure marketplace-copy primitives: Etsy's title rules, tag normalization, and
+# tag assembly. No ENV, no network, no ActiveRecord — everything here is a
+# string in, a string out, so it can be unit-tested on its own.
+#
+# Ported from speakanyway-printables `src/generator/listing-copy.ts`. Each
+# constant and each odd-looking rule below is there because Etsy rejected (or
+# silently mangled) a real listing; the comments name the failure so nobody
+# "simplifies" one back out. Keep the two implementations in step — see
+# .claude-notes/board-printables-etsy.md for the drift note.
+module Etsy
+  module CopyRules
+    module_function
+
+    # Etsy's hard caps.
+    TITLE_MAX = 140
+    TAG_MAX = 13
+    TAG_LEN_MAX = 20
+
+    DIGITAL_DOWNLOAD_SUFFIX = "(Digital Download)".freeze
+
+    # Words that never earn a tag slot, and stay lowercase mid-title.
+    SMALL_WORDS = %w[
+      a an and as at but by for from in nor of on or the to vs with your my our
+    ].to_set.freeze
+
+    # Etsy rejects a listing title containing more than one "&":
+    #   400 {"error":"There was a problem with /title/0 : & can only be use once"}
+    # The first "&" is kept (it reads better than a third "and"); later ones
+    # become "and".
+    def enforce_title_rules(title)
+      seen = 0
+      title.to_s
+           .gsub("&") { (seen += 1) <= 1 ? "&" : "and" }
+           .gsub(/\s{2,}/, " ")
+           .strip
+    end
+
+    # Append "(Digital Download)" unless already present, trimming to fit 140.
+    def ensure_digital_download_suffix(title)
+      title = title.to_s
+      return title.rstrip if title =~ /\(digital download\)\s*\z/i
+
+      suffix = " #{DIGITAL_DOWNLOAD_SUFFIX}"
+      budget = TITLE_MAX - suffix.length
+      base = title.length > budget ? title[0, budget].rstrip : title
+      "#{base}#{suffix}"
+    end
+
+    # Title Case, leaving small words lowercase unless they lead the phrase.
+    def title_case_words(raw)
+      raw.to_s.strip.split(/\s+/).reject(&:empty?).each_with_index.map do |word, i|
+        lower = word.downcase
+        next lower if i.positive? && SMALL_WORDS.include?(lower)
+        # Preserve deliberate capitalization like "AAC" / "ID".
+        next word if word.length > 1 && word == word.upcase
+
+        lower.sub(/\A./, &:upcase)
+      end.join(" ")
+    end
+
+    # Normalize a phrase into an Etsy-legal tag, or nil if nothing usable
+    # survives. Etsy allows letters, numbers, spaces, hyphens and apostrophes,
+    # max 20 characters.
+    def normalize_tag(phrase)
+      cleaned = phrase.to_s.downcase.gsub(/[^a-z0-9 \-']/, " ").gsub(/\s+/, " ").strip
+      return nil if cleaned.empty? || cleaned.length > TAG_LEN_MAX
+      return nil if cleaned.split(" ").all? { |w| SMALL_WORDS.include?(w) }
+
+      cleaned
+    end
+
+    # Mine keyword tags out of the free-text topic — the richest keyword source
+    # a printable has.
+    #
+    # Each comma/slash-delimited segment is tried whole first. When a segment
+    # exceeds the 20-char limit we fall back to its TRAILING phrase rather than
+    # its leading one, because the head noun carries the search intent: "farm
+    # and zoo animal vocabulary" yields "animal vocabulary", not "farm and".
+    def topic_tags(topic)
+      return [] if topic.blank?
+
+      out = []
+      push = ->(candidate) { out << candidate if candidate && !out.include?(candidate) }
+
+      topic.split(%r{[/,;|]+}).each do |raw_segment|
+        segment = raw_segment.strip
+        next if segment.empty?
+
+        whole = normalize_tag(segment)
+        if whole
+          push.call(whole)
+          next
+        end
+
+        words = segment.downcase.gsub(/[^a-z0-9 \-']/, " ").split(/\s+/)
+                       .reject { |w| w.empty? || SMALL_WORDS.include?(w) }
+        [3, 2].each do |size|
+          next if words.length < size
+
+          push.call(normalize_tag(words.last(size).join(" ")))
+        end
+      end
+
+      out
+    end
+
+    # Assemble the final tag list from the pools, in priority order, deduped and
+    # normalized, capped at Etsy's 13.
+    #
+    # `top_up` is what fixes the real defect: the first four pools can only ever
+    # yield ~6 tags for a typical AAC board — under half the allowance, with the
+    # high-intent buyer language missing.
+    def assemble_tags(always_on: [], product_type: [], audience: [], topic: [], top_up: [])
+      tags = []
+      add = lambda do |candidates|
+        Array(candidates).each do |candidate|
+          break if tags.length >= TAG_MAX
+
+          tag = normalize_tag(candidate)
+          tags << tag if tag && !tags.include?(tag)
+        end
+      end
+
+      add.call(always_on)
+      add.call(product_type)
+      add.call(audience)
+      add.call(topic)
+      add.call(top_up)
+      tags
+    end
+
+    # Pick the first candidate title that fits the cap once the
+    # "(Digital Download)" suffix is accounted for, falling back through
+    # progressively shorter forms.
+    #
+    # Callers MUST order candidates widest-first and MUST make the last one a
+    # form that always fits (typically the bare board name) — a chain whose
+    # every rung overflows gets truncated mid-word by
+    # `ensure_digital_download_suffix`, which is how a shipped listing ended up
+    # titled "… Printable for Speech The (Digital Download)".
+    #
+    # Candidates containing a stringified nil — the usual result of
+    # interpolating an absent optional phrase — are skipped, not emitted.
+    def pick_fitting_title(candidates)
+      budget = TITLE_MAX - " #{DIGITAL_DOWNLOAD_SUFFIX}".length
+      shortest = nil
+
+      Array(candidates).each do |raw|
+        candidate = raw.to_s.gsub(/\s{2,}/, " ").strip
+        next if candidate.empty?
+        next if candidate =~ /(\A|[,\s])(null|undefined|nil)([,\s]|\z)/
+
+        return candidate if candidate.length <= budget
+
+        shortest = candidate if shortest.nil? || candidate.length < shortest.length
+      end
+
+      # Everything overflowed — hand back the shortest so the caller's
+      # truncation does as little damage as it can.
+      shortest.to_s
+    end
+
+    TOPIC_PHRASE_MAX = 42
+
+    # Pick the segment of the topic that adds the MOST words the title doesn't
+    # already carry, so a composed title widens keyword coverage instead of
+    # repeating itself. Returns nil when the topic adds nothing new.
+    def distinct_topic_phrase(title:, topic:, product_human:)
+      return nil if topic.blank?
+
+      known = (title.to_s.split(/\s+/) + product_human.to_s.split(/\s+/))
+              .map { |w| stem(w) }.reject(&:empty?).to_set
+
+      best = nil
+      topic.split(%r{[/,;|]+}).each do |raw_segment|
+        phrase = raw_segment.strip
+        next if phrase.empty? || phrase.length > TOPIC_PHRASE_MAX
+
+        novel = phrase.split(/\s+/).count do |w|
+          w.present? && !SMALL_WORDS.include?(w.downcase) && !known.include?(stem(w))
+        end
+        best = { phrase: phrase, novel: novel } if novel.positive? && (best.nil? || novel > best[:novel])
+      end
+
+      best ? title_case_words(best[:phrase]) : nil
+    end
+
+    # Loose stem so "animal" and "animals" count as the same word.
+    def stem(word) = word.to_s.downcase.sub(/(ies|es|s)\z/, "")
+  end
+end

--- a/app/services/etsy/listing_copy.rb
+++ b/app/services/etsy/listing_copy.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+# Builds the default marketplace listing copy for a BoardPrintable — title,
+# summary, description, tags, price — from the board it was generated from.
+#
+# Deterministic and offline on purpose. The equivalent copy in
+# speakanyway-printables is generated the same way (templates, not an LLM), so
+# a listing reads identically whether it came from the Node pipeline or from
+# here, and regenerating it never surprises anyone with new prose.
+#
+# The output is only ever a DEFAULT: it is written into
+# `board_printables.listing_copy` and then edited by hand in the admin UI
+# before publishing. Nothing here should be treated as final copy.
+module Etsy
+  class ListingCopy
+    # The product this maps to in the printables pipeline's taxonomy. Every
+    # BoardPrintable is an `existing_board` — a real SpeakAnyWay board turned
+    # into a printable — so the pools below are that type's, not a generic set.
+    PRODUCT_HUMAN = "vocabulary board".freeze
+
+    ALWAYS_ON_TAGS = ["aac", "printable", "digital download"].freeze
+    PRODUCT_TYPE_TAGS = ["vocabulary board"].freeze
+
+    # Every printable here genuinely serves all three audiences, so all three
+    # contribute tags and all three are named in the description.
+    AUDIENCE_TAGS = ["autism support", "slp", "classroom"].freeze
+    AUDIENCE_LINES = [
+      "Parents and caregivers using AAC at home.",
+      "Speech-language pathologists running structured sessions.",
+      "Classroom teachers and aides supporting AAC users.",
+    ].freeze
+
+    # Fills whatever slots the always-on / product-type / audience / topic tags
+    # leave empty, highest buyer intent first. Without these a typical board
+    # listed with 6 of a possible 13 tags. Note "voice output aac" is 16 chars —
+    # the more natural "talking communication board" is 26 and would be silently
+    # dropped by normalize_tag.
+    TOP_UP_TAGS = [
+      "aac printable",
+      "communication board",
+      "voice output aac",
+      "speech therapy",
+      "special education",
+      "nonspeaking",
+      "slp resources",
+      "visual supports",
+      "autism printable",
+      "classroom visuals",
+      "aac board",
+    ].freeze
+
+    SUMMARY_MAX = 150
+
+    # What the printables pipeline actually writes into listing.md frontmatter.
+    # Note the product-type module in that repo declares `default_price: 4.00`
+    # and config/pricing.json declares its own — neither is what ships. 500 is.
+    DEFAULT_PRICE_CENTS = 500
+
+    LEAD = "Give every voice a way to be heard with this Printable Vocabulary Board from " \
+           "SpeakAnyWay. Instant digital download. Print at home or open on any device — and " \
+           "scan the included QR code to use the same board live in the free SpeakAnyWay app " \
+           "with free voice output — tap any word and it speaks out loud. No sign-in required.".freeze
+
+    FOOTER = "Pairs with the SpeakAnyWay app at app.speakanyway.com — scan the QR code on any " \
+             "board to open the live version with free voice output — every word speaks out " \
+             "loud when tapped, no sign-in.".freeze
+
+    def initialize(printable)
+      @printable = printable
+    end
+
+    def build
+      {
+        "title" => title,
+        "summary" => summary,
+        "description" => description,
+        "tags" => tags,
+        "price_cents" => DEFAULT_PRICE_CENTS,
+      }
+    end
+
+    private
+
+    attr_reader :printable
+
+    def board = printable.board
+
+    def board_name = board&.name.presence || "Board ##{printable.board_id}"
+
+    def topic = printable.topic.presence
+
+    def board_count = [printable.board_ids.to_a.size, 1].max
+
+    def set? = board_count > 1
+
+    # Keyword-forward title. Leads with the board's own name (buyers search
+    # "core words board", not "SpeakAnyWay"), then the product type, then the
+    # bundle size, then the two highest-volume qualifiers in this niche.
+    def title
+      @title ||= begin
+        base = CopyRules.title_case_words(board_name)
+
+        # When the board's own name already names the product ("Core Words
+        # Board"), repeating "Vocabulary Board" reads badly AND eats the
+        # 140-char budget, so the type decoration shrinks to "AAC Printable".
+        type_words = PRODUCT_HUMAN.downcase.split(/\s+/).select { |w| w.length > 3 }
+        names_product = type_words.any? { |w| base.downcase.include?(w) }
+        head = names_product ? "#{base} AAC Printable" : "#{base} AAC Vocabulary Board Printable"
+
+        tail = "for Speech Therapy & Autism"
+        size_phrase = set? ? "#{board_count}-Board Set" : nil
+        topic_phrase = CopyRules.distinct_topic_phrase(
+          title: base, topic: topic, product_human: PRODUCT_HUMAN,
+        )
+
+        # Widest first, shedding a piece at a time. `base` must stay last: it
+        # is the rung guaranteed to fit, and without it a long board name
+        # overflows every rung and gets truncated mid-word.
+        composed = CopyRules.pick_fitting_title([
+          "#{head}, #{[size_phrase, topic_phrase].compact.join(' — ')} #{tail}",
+          "#{head}, #{topic_phrase} #{tail}",
+          "#{head}, #{size_phrase} #{tail}",
+          "#{head} #{tail}",
+          "#{head}, #{topic_phrase}",
+          head,
+          base,
+        ])
+
+        CopyRules.ensure_digital_download_suffix(CopyRules.enforce_title_rules(composed))
+      end
+    end
+
+    def summary
+      raw = if topic
+        "#{CopyRules.title_case_words(board_name)} — words for #{topic}."
+      elsif set?
+        "#{CopyRules.title_case_words(board_name)} — a set of #{board_count} printable communication boards."
+      else
+        "#{CopyRules.title_case_words(board_name)} — a printable communication board you can use today."
+      end
+
+      return raw if raw.length <= SUMMARY_MAX
+
+      "#{raw[0, SUMMARY_MAX - 1].rstrip}…"
+    end
+
+    def tags
+      CopyRules.assemble_tags(
+        always_on: ALWAYS_ON_TAGS,
+        product_type: PRODUCT_TYPE_TAGS,
+        audience: AUDIENCE_TAGS,
+        topic: CopyRules.topic_tags(topic),
+        top_up: TOP_UP_TAGS,
+      )
+    end
+
+    # Plain text, not markdown: Etsy renders no markup at all, and TPT's editor
+    # takes a paste of plain text cleanly. The printables pipeline emits
+    # markdown and converts it at publish time; skipping that round trip means
+    # what an admin reads in the textarea is exactly what a buyer sees.
+    def description
+      sections = [LEAD, "", summary, "", included_section]
+      sections += ["", boards_section] if boards_section
+      sections += ["", audience_section, "", how_it_works_section, "", ways_to_use_section,
+                   "", instant_download_section, "", FOOTER]
+      sections.join("\n")
+    end
+
+    def included_section
+      items = Printables::IncludedItems.all(board_count: board_count, page_count: printable.page_count)
+
+      ["WHAT'S INCLUDED", "", *items.map { |i| "- #{i}" }].join("\n")
+    end
+
+    # Name the individual boards in a bundle. A page count tells a buyer
+    # nothing; "People, Feelings, Food, Play…" is most of the reason to buy.
+    def boards_section
+      return @boards_section if defined?(@boards_section)
+
+      @boards_section = begin
+        labels = board_labels
+        if labels.size > 1
+          ["THE #{labels.size} BOARDS", "", *labels.map { |l| "- #{l}" }].join("\n")
+        end
+      end
+    end
+
+    # board_ids is in tree order (root first) and a `where` loses that, so the
+    # names are re-sorted back into it.
+    def board_labels
+      ids = printable.board_ids.to_a
+      return [] if ids.size <= 1
+
+      names = Board.where(id: ids).pluck(:id, :name).to_h
+      ids.filter_map { |id| names[id].presence }
+         .map { |n| CopyRules.title_case_words(n) }
+         .uniq
+    end
+
+    def audience_section
+      ["WHO IT'S FOR", "", *AUDIENCE_LINES.map { |l| "- #{l}" }].join("\n")
+    end
+
+    def how_it_works_section
+      boards = set? ? "boards open" : "board opens"
+      [
+        "HOW IT WORKS",
+        "",
+        "1. Download — instant PDF, nothing ships.",
+        "2. Print or tap — print at home, or open the file on any tablet, phone, or Chromebook.",
+        "3. Scan the QR code — the same #{boards} in the free SpeakAnyWay app, where every " \
+        "word is tappable and spoken out loud. Voice output is included free — no app install, " \
+        "no sign-in, no subscription.",
+      ].join("\n")
+    end
+
+    def ways_to_use_section
+      main = set? ? "main board" : "board"
+      [
+        "WAYS TO USE IT",
+        "",
+        "- Laminate the #{main} for the fridge, a binder, or the table.",
+        "- Print the low-ink version for backups, take-home copies, and whole-class sets.",
+        "- Send a copy home so vocabulary stays consistent between school and home.",
+        "- Keep the tablet version open during therapy and hand the printed copy to the family.",
+      ].join("\n")
+    end
+
+    def instant_download_section
+      [
+        "INSTANT DOWNLOAD",
+        "",
+        "This is a digital download. No physical item will be shipped, and your files are " \
+        "available immediately after purchase.",
+        "License: use with your own family, your own students, or your own caseload. Please do " \
+        "not resell, redistribute, or share the files outside your household, classroom, or " \
+        "practice.",
+      ].join("\n")
+    end
+  end
+end

--- a/app/services/etsy/publish_board_printable.rb
+++ b/app/services/etsy/publish_board_printable.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+# Creates an Etsy DRAFT listing for a finished BoardPrintable: the listing
+# itself, its price, its gallery images, and its download files.
+#
+# INVARIANT — this app creates drafts and nothing else. There is no argument,
+# flag, or param that activates a listing; going live is a deliberate click in
+# the Etsy seller UI, after a human has looked at the category, the photos, and
+# the return policy. Etsy::Client#create_listing hardcodes `state: "draft"` and
+# implements no activate call, so "publish" here means "create the draft".
+#
+# Never retried automatically (see PublishBoardPrintableToEtsyJob): a retry
+# after a partial success creates a SECOND listing in a real shop. A failure
+# leaves whatever was created in place, records the error, and waits for a
+# human — a half-built draft is easy to delete, a duplicate is easy to miss.
+module Etsy
+  class PublishBoardPrintable
+    Result = Struct.new(:ok?, :listing_id, :listing_url, :error, keyword_init: true)
+
+    def initialize(printable, client: nil)
+      @printable = printable
+      @client = client
+    end
+
+    def call
+      guard = guard_failure
+      return failure(guard) if guard
+
+      client.assert_known_taxonomy!(Client::DEFAULT_TAXONOMY_ID)
+
+      render_listing_images_if_missing
+
+      listing = client.create_listing(
+        title: copy["title"],
+        description: copy["description"],
+        price: price_dollars,
+        tags: Array(copy["tags"]),
+      )
+
+      # Etsy accepts a price on create but the inventory endpoint is the only
+      # writer that reliably sticks, so it is set again explicitly rather than
+      # trusted from the create call.
+      client.set_listing_price(listing[:listing_id], price_dollars)
+
+      upload_images(listing[:listing_id])
+      upload_files(listing[:listing_id])
+
+      printable.update!(
+        etsy_listing_id: listing[:listing_id],
+        etsy_listing_url: listing[:url],
+        etsy_published_at: Time.current,
+        etsy_error: nil,
+      )
+
+      Result.new(ok?: true, listing_id: listing[:listing_id], listing_url: listing[:url])
+    rescue => e
+      Rails.logger.error("[Etsy::PublishBoardPrintable] printable #{printable.id}: #{e.class} - #{e.message}")
+      failure(e.message)
+    end
+
+    private
+
+    attr_reader :printable
+
+    def client = @client ||= Client.new
+
+    def copy = @copy ||= printable.listing_copy_or_default.with_indifferent_access
+
+    def price_dollars = (copy["price_cents"].presence || ListingCopy::DEFAULT_PRICE_CENTS).to_i / 100.0
+
+    # Everything that would make a draft wrong rather than merely unfinished.
+    # Returned as a message for the admin, not raised — none of these are bugs.
+    def guard_failure
+      return "This printable isn't finished generating yet." unless printable.complete?
+      return "This printable has no PDF files attached." if printable.pdf_files.empty?
+
+      if printable.etsy_published?
+        return "Already on Etsy as listing #{printable.etsy_listing_id}. Delete that draft first if you want a new one."
+      end
+
+      return "Listing title and description are required." if copy["title"].blank? || copy["description"].blank?
+
+      oversized = printable.pdf_files.find { |f| f.byte_size > Client::FILE_CAP_BYTES }
+      if oversized
+        return "#{oversized.filename} is #{ActiveSupport::NumberHelper.number_to_human_size(oversized.byte_size)}; " \
+               "Etsy caps a download file at 20 MB. Split it with the speakanyway-printables pipeline first."
+      end
+
+      nil
+    end
+
+    # Etsy will create a listing with no photos but won't let it go live
+    # without one, so a draft with an empty gallery is a dead end. Rendering
+    # here rather than refusing means one button still gets you a finishable
+    # draft.
+    def render_listing_images_if_missing
+      return if printable.listing_images?
+
+      Boards::Printables::RenderListingImages.new(printable: printable).call
+      printable.reload
+    end
+
+    def upload_images(listing_id)
+      printable.image_files
+               .sort_by { |f| BoardPrintable::LISTING_IMAGE_ORDER.index(f.metadata["variant"]) || 99 }
+               .each_with_index do |file, index|
+        client.upload_image(
+          listing_id,
+          bytes: file.download,
+          filename: file.filename.to_s,
+          rank: index + 1,
+        )
+      end
+    end
+
+    def upload_files(listing_id)
+      printable.pdf_files.each_with_index do |file, index|
+        client.upload_file(
+          listing_id,
+          bytes: file.download,
+          filename: file.filename.to_s,
+          rank: index + 1,
+        )
+      end
+    end
+
+    # Persisted with update_columns so a failure can never disturb `status` or
+    # fire the record's callbacks — and so the reason survives for the show
+    # page, which is the only place anyone will look. This runs on Sidekiq, so
+    # returning the message alone would put it nowhere a human can see it.
+    def failure(message)
+      printable.update_columns(etsy_error: message.to_s.truncate(1000), updated_at: Time.current)
+      Result.new(ok?: false, error: message)
+    end
+  end
+end

--- a/app/services/printables/included_items.rb
+++ b/app/services/printables/included_items.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# The "what's included" bullet list, in one place.
+#
+# It is rendered twice — once as text in the listing description
+# (Etsy::ListingCopy) and once as the what's-included gallery image
+# (Boards::Printables::RenderListingImages) — and a buyer flipping between the
+# two should see one voice, not two. Duplicating the list is how they drift.
+module Printables
+  module IncludedItems
+    module_function
+
+    # The one line that describes the actual document, and the only line that
+    # changes with the printable. A multi-board bundle ships every board twice
+    # (color + low-ink) and arrives as TWO files, so quoting a single page count
+    # badly understates it.
+    def headline(board_count:, page_count:)
+      pages = page_count.to_i
+
+      if board_count > 1
+        return "#{board_count} boards — 2 PDFs (full color + low-ink)" unless pages.positive?
+
+        "#{board_count} boards, #{pages} pages — 2 PDFs (full color + low-ink)"
+      else
+        pages.positive? ? "#{pages}-page board PDF — color + low-ink" : "Board PDF — color + low-ink"
+      end
+    end
+
+    # "Free voice output online" leads because it is the single biggest
+    # differentiator against every other AAC printable on the marketplace, and
+    # the phrase has to name the SPEAKING — "free online version" reads as a PDF
+    # viewer.
+    def all(board_count:, page_count:)
+      [
+        headline(board_count: board_count, page_count: page_count),
+        'Print-ready Letter (8.5" x 11")',
+        "Free voice output online — tap to hear each word",
+        "Curated AAC-aligned vocabulary",
+        "Personal & classroom license",
+      ]
+    end
+  end
+end

--- a/app/services/printables/marketplace_copy.rb
+++ b/app/services/printables/marketplace_copy.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# Turns a BoardPrintable's stored listing copy into paste-ready blocks for the
+# marketplaces that have no API.
+#
+# Teachers Pay Teachers is the reason this exists: there is no seller API, so
+# the only way to list there is to type into their upload form. Rather than
+# make someone re-derive the copy by hand, this lays it out field by field in
+# the order the form asks for it.
+#
+# Every field is `{ label:, value:, hint: }` so the view can render the list
+# without knowing anything about TPT.
+module Printables
+  class MarketplaceCopy
+    Field = Struct.new(:label, :value, :hint, keyword_init: true)
+
+    # TPT's title cap is 100, not Etsy's 140 — the generated Etsy title is
+    # normally too long to paste, so it gets its own trim.
+    TPT_TITLE_MAX = 100
+
+    # TPT allows a primary subject plus two more, and up to three resource
+    # types. These are the closest matches in their fixed taxonomy for an AAC
+    # communication board; they are defaults, not rules.
+    TPT_SUBJECTS = "Special Education, Speech Therapy, Other (Specialty)".freeze
+    TPT_RESOURCE_TYPES = "Printables, Activities, Independent Work Packet".freeze
+    TPT_GRADES = "PreK - 2nd".freeze
+
+    # TPT's keyword box takes a handful of phrases, not Etsy's 13.
+    TPT_KEYWORD_COUNT = 5
+
+    def initialize(printable, listing: nil)
+      @printable = printable
+      # listing_copy defaults to an empty hash, which is blank — so falling back
+      # to it directly would leave every field empty until someone pressed Save.
+      # listing_copy_or_default is what generates the preview.
+      @listing = (listing.presence || printable.listing_copy_or_default).with_indifferent_access
+    end
+
+    def tpt_fields
+      [
+        Field.new(label: "Product title", value: tpt_title,
+                  hint: "#{tpt_title.length}/#{TPT_TITLE_MAX} characters"),
+        Field.new(label: "Description", value: description,
+                  hint: "Plain text — paste straight into TPT's editor"),
+        Field.new(label: "Price (USD)", value: price_display, hint: nil),
+        Field.new(label: "Grade levels", value: TPT_GRADES,
+                  hint: "Widen it if the board's vocabulary suits older students"),
+        Field.new(label: "Subjects", value: TPT_SUBJECTS,
+                  hint: "Primary first; TPT allows three"),
+        Field.new(label: "Resource types", value: TPT_RESOURCE_TYPES,
+                  hint: "TPT allows three"),
+        Field.new(label: "Number of pages", value: page_count_display, hint: nil),
+        Field.new(label: "Search keywords", value: tpt_keywords,
+                  hint: "Trimmed from the Etsy tag list"),
+        Field.new(label: "Files to upload", value: file_list,
+                  hint: "Download these from the Files section above"),
+        Field.new(label: "Standards", value: "(leave blank)",
+                  hint: "AAC vocabulary boards don't map cleanly to CCSS — skip rather than guess"),
+      ]
+    end
+
+    def generic_fields
+      [
+        Field.new(label: "Title", value: title, hint: "#{title.length} characters"),
+        Field.new(label: "Description", value: description, hint: nil),
+        Field.new(label: "Tags", value: tags.join(", "), hint: "#{tags.size} tags"),
+        Field.new(label: "Price (USD)", value: price_display, hint: nil),
+      ]
+    end
+
+    def title = @listing[:title].to_s
+
+    def description = @listing[:description].to_s
+
+    def tags = Array(@listing[:tags]).map(&:to_s)
+
+    def price_cents = @listing[:price_cents].presence&.to_i || Etsy::ListingCopy::DEFAULT_PRICE_CENTS
+
+    private
+
+    attr_reader :printable
+
+    # The Etsy title carries "(Digital Download)" and a long keyword tail that
+    # both overflow TPT's 100 and read as spam there. Drop the suffix first,
+    # then trim on a word boundary rather than mid-word.
+    def tpt_title
+      @tpt_title ||= begin
+        base = title.sub(/\s*#{Regexp.escape(Etsy::CopyRules::DIGITAL_DOWNLOAD_SUFFIX)}\s*\z/, "").strip
+        base.length <= TPT_TITLE_MAX ? base : base[0, TPT_TITLE_MAX].sub(/\s+\S*\z/, "").strip
+      end
+    end
+
+    def tpt_keywords = tags.first(TPT_KEYWORD_COUNT).join(", ")
+
+    def price_display = format("%.2f", price_cents / 100.0)
+
+    def page_count_display = printable.page_count.to_i.positive? ? printable.page_count.to_s : "—"
+
+    def file_list
+      files = printable.files_view
+      return "—" if files.empty?
+
+      files.map { |f| f[:filename] }.join("\n")
+    end
+  end
+end

--- a/app/sidekiq/publish_board_printable_to_etsy_job.rb
+++ b/app/sidekiq/publish_board_printable_to_etsy_job.rb
@@ -1,0 +1,23 @@
+# Creates the Etsy draft off the request thread — the work is a taxonomy fetch,
+# two Grover renders when the gallery images are missing, and up to five
+# multipart uploads.
+#
+# retry: 0 on purpose. Every other job here retries a transient blip happily,
+# but this one writes to a real Etsy shop: a retry after a partial success
+# creates a SECOND draft listing, and nothing downstream would notice. A
+# failure records itself on the printable and waits for a human to look.
+class PublishBoardPrintableToEtsyJob
+  include Sidekiq::Job
+  sidekiq_options retry: 0, queue: :default
+
+  def perform(board_printable_id)
+    printable = BoardPrintable.find_by(id: board_printable_id)
+    return unless printable
+    # Belt and braces against a double-click enqueueing twice: the service
+    # guards on this too, but checking here keeps the second job from doing any
+    # work at all.
+    return if printable.etsy_published?
+
+    Etsy::PublishBoardPrintable.new(printable).call
+  end
+end

--- a/app/sidekiq/render_board_printable_listing_images_job.rb
+++ b/app/sidekiq/render_board_printable_listing_images_job.rb
@@ -1,0 +1,13 @@
+# Re-renders the marketplace gallery images for a printable. Two Grover renders,
+# so it never runs on a request thread.
+class RenderBoardPrintableListingImagesJob
+  include Sidekiq::Job
+  sidekiq_options retry: 2, queue: :default
+
+  def perform(board_printable_id)
+    printable = BoardPrintable.find_by(id: board_printable_id)
+    return unless printable&.complete?
+
+    Boards::Printables::RenderListingImages.new(printable: printable).call
+  end
+end

--- a/app/views/admin/board_printables/_copy_blocks.html.erb
+++ b/app/views/admin/board_printables/_copy_blocks.html.erb
@@ -1,0 +1,47 @@
+<%# Paste-ready copy for the marketplaces with no seller API. Teachers Pay
+    Teachers is the whole reason this exists — the only way to list there is to
+    type into their upload form, so the fields are laid out in the order the
+    form asks for them. %>
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-1">Teachers Pay Teachers</h2>
+  <p class="text-[11px] text-t3 mb-4">
+    TPT has no seller API. Copy each field into their upload form. The subject, grade, and
+    resource-type values are sensible defaults from TPT's fixed lists — change them if the
+    board's vocabulary suits a different range.
+  </p>
+  <%= render "copy_fields", fields: @marketplace_copy.tpt_fields, prefix: "tpt" %>
+</div>
+
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-1">Generic</h2>
+  <p class="text-[11px] text-t3 mb-4">Plain title, description, and tags for anywhere else.</p>
+  <%= render "copy_fields", fields: @marketplace_copy.generic_fields, prefix: "generic" %>
+</div>
+
+<% content_for :head_extra do %>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document.querySelectorAll("[data-copy-target]").forEach(function (button) {
+        button.addEventListener("click", function () {
+          var source = document.getElementById(button.dataset.copyTarget);
+          if (!source) return;
+          // execCommand is the fallback: navigator.clipboard is undefined on
+          // plain-http origins, which is how the admin runs locally.
+          var done = function () {
+            var original = button.textContent;
+            button.textContent = "Copied";
+            setTimeout(function () { button.textContent = original; }, 1200);
+          };
+          if (navigator.clipboard && window.isSecureContext) {
+            navigator.clipboard.writeText(source.value).then(done);
+          } else {
+            source.select();
+            document.execCommand("copy");
+            window.getSelection().removeAllRanges();
+            done();
+          }
+        });
+      });
+    });
+  </script>
+<% end %>

--- a/app/views/admin/board_printables/_copy_fields.html.erb
+++ b/app/views/admin/board_printables/_copy_fields.html.erb
@@ -1,0 +1,25 @@
+<%# One marketplace field per row: label, a copy button, and a readonly textarea
+    holding exactly what should be pasted. Readonly rather than disabled — a
+    disabled field can't be selected, which breaks the execCommand fallback. %>
+<div class="space-y-4">
+  <% fields.each_with_index do |field, index| %>
+    <% field_id = "copy_#{prefix}_#{index}" %>
+    <div>
+      <div class="flex items-baseline justify-between mb-1">
+        <label class="block text-xs font-medium text-t2" for="<%= field_id %>">
+          <%= field.label %>
+          <% if field.hint.present? %>
+            <span class="text-t3 font-normal">— <%= field.hint %></span>
+          <% end %>
+        </label>
+        <button type="button" data-copy-target="<%= field_id %>"
+                class="text-[11px] font-medium px-2 py-1 rounded border admin-input cursor-pointer text-t1">
+          Copy
+        </button>
+      </div>
+      <%= text_area_tag field_id, field.value, id: field_id, readonly: true,
+            rows: field.value.to_s.lines.count > 3 ? 12 : 2,
+            class: "admin-input w-full font-mono text-[11px]" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/board_printables/_etsy.html.erb
+++ b/app/views/admin/board_printables/_etsy.html.erb
@@ -26,7 +26,9 @@
         <div class="text-t1"><%= @printable.etsy_published_at&.strftime("%b %-d, %Y %l:%M %p") || "—" %></div>
       </div>
     </div>
-    <%= link_to "Open draft on Etsy ↗", @printable.etsy_listing_url.presence || "https://www.etsy.com/your/shop",
+    <%# Href built from the numeric listing id, not the stored URL string — see
+        etsy_listing_url_for. %>
+    <%= link_to "Open draft on Etsy ↗", etsy_listing_url_for(@printable),
           target: "_blank", rel: "noopener",
           class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
     <p class="text-[11px] text-t3 mt-3">

--- a/app/views/admin/board_printables/_etsy.html.erb
+++ b/app/views/admin/board_printables/_etsy.html.erb
@@ -1,0 +1,49 @@
+<%# Etsy. This creates a DRAFT and only a draft — there is no code path in the
+    app that activates a listing. Going live stays a deliberate click in the
+    Etsy seller UI, after a human has checked the category, the photos, and the
+    return policy. %>
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <h2 class="text-sm font-medium text-t1 mb-1">Etsy</h2>
+  <p class="text-[11px] text-t3 mb-4">
+    Creates a <strong>draft</strong> listing with the copy above, the images, and the PDFs.
+    Nothing goes live until you publish it in Etsy yourself.
+  </p>
+
+  <% if @printable.etsy_error.present? %>
+    <div class="admin-flash-err border rounded-lg px-4 py-3 text-sm mb-4">
+      <%= @printable.etsy_error %>
+    </div>
+  <% end %>
+
+  <% if @printable.etsy_published? %>
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 text-xs mb-4">
+      <div>
+        <div class="text-t2 mb-0.5">Listing</div>
+        <div class="text-t1"><%= @printable.etsy_listing_id %></div>
+      </div>
+      <div>
+        <div class="text-t2 mb-0.5">Draft created</div>
+        <div class="text-t1"><%= @printable.etsy_published_at&.strftime("%b %-d, %Y %l:%M %p") || "—" %></div>
+      </div>
+    </div>
+    <%= link_to "Open draft on Etsy ↗", @printable.etsy_listing_url.presence || "https://www.etsy.com/your/shop",
+          target: "_blank", rel: "noopener",
+          class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
+    <p class="text-[11px] text-t3 mt-3">
+      To replace this draft, delete it in Etsy first — the app won't create a second listing for the
+      same printable, because a duplicate in a live shop is easy to miss and hard to undo.
+    </p>
+  <% elsif !@etsy_configured %>
+    <p class="text-xs text-t3">
+      Etsy isn't configured. Set <code>ETSY_KEYSTRING</code>, <code>ETSY_SHARED_SECRET</code>,
+      <code>ETSY_OAUTH_CLIENT_ID</code> and <code>ETSY_SHOP_ID</code>, then seed this app's own
+      refresh token with <code>rake etsy:seed_refresh_token</code>.
+    </p>
+  <% else %>
+    <%= button_to "Create Etsy draft", publish_to_etsy_admin_dashboard_board_printable_path(@printable),
+          method: :post,
+          class: "text-xs font-medium px-3 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
+          form: { data: { turbo_confirm: "Create a draft Etsy listing for \"#{@listing['title']}\"? " \
+                                         "It will NOT go live — you publish it in Etsy yourself." } } %>
+  <% end %>
+</div>

--- a/app/views/admin/board_printables/_listing_form.html.erb
+++ b/app/views/admin/board_printables/_listing_form.html.erb
@@ -1,0 +1,75 @@
+<%# Editable listing copy. Prefilled from Etsy::ListingCopy when nothing has
+    been saved yet, so the page always shows a publishable draft rather than
+    empty boxes — but nothing is written to the database until Save. %>
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <div class="flex items-baseline justify-between mb-1">
+    <h2 class="text-sm font-medium text-t1">Listing copy</h2>
+    <% if @printable.listing_copy.blank? %>
+      <span class="text-[11px] text-t3">Generated defaults — not saved yet</span>
+    <% end %>
+  </div>
+  <p class="text-[11px] text-t3 mb-4">Used for Etsy and for the copy-and-paste blocks below. Edit freely, then Save.</p>
+
+  <%= form_tag update_listing_admin_dashboard_board_printable_path(@printable), method: :patch, data: { turbo: false } do %>
+    <div class="mb-4">
+      <label class="block text-xs font-medium text-t2 mb-1" for="listing_title">
+        Title
+        <span class="text-t3 font-normal">— Etsy caps this at <%= Etsy::CopyRules::TITLE_MAX %></span>
+      </label>
+      <%= text_field_tag :title, @listing["title"], id: "listing_title",
+            class: "admin-input w-full", maxlength: Etsy::CopyRules::TITLE_MAX,
+            data: { counter_target: "listing_title_count" } %>
+      <p class="text-[11px] text-t3 mt-1">
+        <span id="listing_title_count"><%= @listing["title"].to_s.length %></span>/<%= Etsy::CopyRules::TITLE_MAX %>
+      </p>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-xs font-medium text-t2 mb-1" for="listing_summary">Summary</label>
+      <%= text_field_tag :summary, @listing["summary"], id: "listing_summary", class: "admin-input w-full" %>
+    </div>
+
+    <div class="mb-4">
+      <label class="block text-xs font-medium text-t2 mb-1" for="listing_description">
+        Description
+        <span class="text-t3 font-normal">— plain text; Etsy renders no formatting</span>
+      </label>
+      <%= text_area_tag :description, @listing["description"], id: "listing_description",
+            rows: 14, class: "admin-input w-full font-mono text-[11px]" %>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+      <div class="md:col-span-2">
+        <label class="block text-xs font-medium text-t2 mb-1" for="listing_tags">
+          Tags
+          <span class="text-t3 font-normal">— comma separated, max <%= Etsy::CopyRules::TAG_MAX %> of <%= Etsy::CopyRules::TAG_LEN_MAX %> chars</span>
+        </label>
+        <%= text_field_tag :tags, Array(@listing["tags"]).join(", "), id: "listing_tags", class: "admin-input w-full" %>
+        <p class="text-[11px] text-t3 mt-1">
+          Anything Etsy would silently drop is removed on save, so what you see here is what Etsy gets.
+        </p>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="listing_price">Price (USD)</label>
+        <%= text_field_tag :price,
+              format("%.2f", (@listing["price_cents"].presence || Etsy::ListingCopy::DEFAULT_PRICE_CENTS).to_i / 100.0),
+              id: "listing_price", class: "admin-input w-full" %>
+      </div>
+    </div>
+
+    <%= submit_tag "Save listing copy",
+          class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer" %>
+  <% end %>
+</div>
+
+<% content_for :head_extra do %>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var title = document.getElementById("listing_title");
+      var count = document.getElementById("listing_title_count");
+      if (title && count) {
+        title.addEventListener("input", function () { count.textContent = title.value.length; });
+      }
+    });
+  </script>
+<% end %>

--- a/app/views/admin/board_printables/_listing_images.html.erb
+++ b/app/views/admin/board_printables/_listing_images.html.erb
@@ -1,0 +1,37 @@
+<%# The gallery images Etsy needs. Etsy will create a listing with none, but
+    won't let it go live without one — so an empty gallery here is a draft you
+    can't finish. Publishing renders them automatically if they're missing;
+    this card exists to preview and re-render them. %>
+<div class="admin-card border rounded-xl p-5 mb-6">
+  <div class="flex items-baseline justify-between mb-1">
+    <h2 class="text-sm font-medium text-t1">Listing images</h2>
+    <%= button_to "Regenerate", regenerate_listing_images_admin_dashboard_board_printable_path(@printable),
+          method: :post,
+          class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1" %>
+  </div>
+  <p class="text-[11px] text-t3 mb-4">
+    Cover and what's-included, rendered from the same templates as the printed pages.
+    Lifestyle mockups still come from the speakanyway-printables pipeline — add those in Etsy.
+  </p>
+
+  <% images = @printable.listing_images_view %>
+  <% if images.any? %>
+    <div class="flex flex-wrap gap-4">
+      <% images.each_with_index do |image, index| %>
+        <div>
+          <%= link_to image[:url], target: "_blank", rel: "noopener" do %>
+            <%= image_tag image[:url], alt: image[:variant],
+                  class: "w-40 h-40 object-cover rounded-lg border", style: "border-color: var(--border);" %>
+          <% end %>
+          <p class="text-[11px] text-t3 mt-1">
+            Rank <%= index + 1 %> · <%= image[:variant].humanize %>
+          </p>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-xs text-t3">
+      None rendered yet. They'll be generated automatically when you create the Etsy draft.
+    </p>
+  <% end %>
+</div>

--- a/app/views/admin/board_printables/show.html.erb
+++ b/app/views/admin/board_printables/show.html.erb
@@ -3,10 +3,23 @@
   <% content_for :head_extra, tag.meta("http-equiv": "refresh", content: "5") %>
 <% end %>
 
+<%# Everything below the status card renders only when the printable is
+    complete, which is also the only time the auto-refresh above is switched
+    off — so a half-typed listing description can never be wiped by a reload. %>
+
 <div class="flex items-center justify-between mb-6">
   <div>
     <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @printable.board&.name || "Board ##{@printable.board_id}" %></h1>
-    <p class="text-sm text-t3 mt-0.5">Printable #<%= @printable.id %></p>
+    <p class="text-sm text-t3 mt-0.5">
+      Printable #<%= @printable.id %>
+      <% if @printable.board %>
+        ·
+        <%= link_to "Open board ##{@printable.board_id} ↗", board_public_page_url(@printable.board),
+              target: "_blank", rel: "noopener",
+              title: "The public page this printable's cover QR points at",
+              class: "text-accent hover:underline" %>
+      <% end %>
+    </p>
   </div>
   <%= link_to "← All printables", admin_dashboard_board_printables_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
 </div>
@@ -52,3 +65,26 @@
     </div>
   <% end %>
 </div>
+
+<% if @printable.complete? %>
+  <% if @tree_boards.any? %>
+    <div class="admin-card border rounded-xl p-5 mb-6">
+      <h2 class="text-sm font-medium text-t1 mb-1">Boards in this printable</h2>
+      <p class="text-[11px] text-t3 mb-3">In tree order — the first is the root the cover QR points at.</p>
+      <div class="flex flex-wrap gap-2">
+        <% @tree_boards.each_with_index do |board, index| %>
+          <%= link_to board_public_page_url(board), target: "_blank", rel: "noopener",
+                title: "Board ##{board.id}",
+                class: "text-xs px-2.5 py-1 rounded border admin-input text-t1 hover:text-accent transition-colors" do %>
+            <span class="text-t3"><%= index + 1 %>.</span> <%= board.name.presence || "Board ##{board.id}" %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= render "listing_form" %>
+  <%= render "listing_images" %>
+  <%= render "etsy" %>
+  <%= render "copy_blocks" %>
+<% end %>

--- a/app/views/api/board_printables/whats_included.html.erb
+++ b/app/views/api/board_printables/whats_included.html.erb
@@ -1,0 +1,43 @@
+<%# The "what's included" gallery image — the slide a buyer uses to judge how
+    much they're getting before reading a word of the description.
+
+    Deliberately built from the same .sheet / .page-head / .step primitives as
+    the printed wrapper pages so the listing gallery and the product itself
+    look like one thing. It is never bound into a PDF; it exists only as a PNG,
+    rendered through layouts/pdf_printable with .as-listing-image on <body>.
+
+    It names the boards rather than quoting a page count: for a set, "People,
+    Feelings, Food, Play…" is most of the reason to buy, and a page number tells
+    a buyer nothing. %>
+<div class="sheet whats-included">
+  <div class="sheet-body">
+    <div class="page-head">
+      <p class="eyebrow">What's included</p>
+      <h2><%= @heading %></h2>
+      <div class="rule"></div>
+      <% if @subtitle.present? %>
+        <p class="intro"><%= @subtitle %></p>
+      <% end %>
+    </div>
+
+    <div class="steps">
+      <% @items.each do |item| %>
+        <%# An SVG tick, not U+2713 — Nunito has no glyph for it and the render
+            box's fallback fonts are not guaranteed to either, so the character
+            is a tofu-box risk. Same reasoning as the heart on the About page. %>
+        <div class="step wide">
+          <span class="num">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 12.3 2.4 8.5l1.4-1.4 2.4 2.4 6-6L13.6 5z"/></svg>
+          </span>
+          <div><p class="lead"><%= item %></p></div>
+        </div>
+      <% end %>
+    </div>
+
+    <% if @board_labels.present? %>
+      <div class="callout">
+        <p><strong>Boards in this set:</strong> <%= @board_labels.to_sentence %></p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/pdf_printable.html.erb
+++ b/app/views/layouts/pdf_printable.html.erb
@@ -373,6 +373,34 @@
         color: var(--navy);
       }
 
+      /* ── What's included (gallery image only, never printed) ─────────── */
+      .whats-included .steps {
+        align-content: center;
+        gap: 0.14in;
+      }
+
+      .whats-included .step .lead {
+        margin-bottom: 0;
+        font-size: 13pt;
+      }
+
+      .whats-included .step .num svg {
+        width: 12pt;
+        height: 12pt;
+        fill: var(--navy);
+      }
+
+      .whats-included .callout {
+        flex: 0 0 auto;
+        margin-top: 0.22in;
+      }
+
+      .whats-included .callout p {
+        font-size: 11.5pt;
+        line-height: 1.45;
+        color: var(--navy);
+      }
+
       /* ── License ─────────────────────────────────────────────────────── */
       /* One centred column. Each term is a whole sentence, so a narrow
          side-by-side column squeezed them to three and four lines each with
@@ -537,10 +565,41 @@
         background: #fff;
         border: 1pt solid var(--cyan);
       }
+
+      /* ── Marketplace gallery image ───────────────────────────────────────
+         Etsy shows listing photos in a square frame and letterboxes anything
+         else, so the 8.5×11 sheet is scaled down and centred on a square
+         canvas here rather than handed over portrait and cropped by Etsy.
+
+         Gated entirely behind .as-listing-image, which only
+         Boards::Printables::RenderListingImages sets. The PDF render path
+         never sets it, so every rule above stays exactly as it prints. */
+      body.as-listing-image {
+        width: 8.5in;
+        height: 8.5in;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--cream-deep);
+        overflow: hidden;
+      }
+
+      body.as-listing-image.ink-light {
+        background: #fff;
+      }
+
+      /* 8.5/11 leaves the sheet just short of the canvas edges; the outer
+         padding is what turns the remainder into a deliberate mat. */
+      body.as-listing-image .sheet {
+        transform: scale(0.73);
+        box-shadow: 0 0.06in 0.3in rgba(19, 73, 111, 0.22);
+      }
     </style>
   </head>
 
-  <body class="<%= "ink-light" if @ink_light %>">
+  <%# Joined rather than interpolated side by side: a stray space here changes
+      the rendered attribute for every PDF page, and the wrapper specs pin it. %>
+  <body class="<%= [("ink-light" if @ink_light), ("as-listing-image" if @listing_image)].compact.join(" ") %>">
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,13 @@ Rails.application.routes.draw do
     end
     get "feedback", to: "feedback#index", as: :dashboard_feedback
     get "word_events", to: "word_events#index", as: :dashboard_word_events
-    resources :board_printables, only: [:index, :show, :create], as: :dashboard_board_printables
+    resources :board_printables, only: [:index, :show, :create], as: :dashboard_board_printables do
+      member do
+        patch :update_listing
+        post :publish_to_etsy
+        post :regenerate_listing_images
+      end
+    end
   end
 
   get "main/index", as: :home

--- a/db/migrate/20260810140000_add_listing_fields_to_board_printables.rb
+++ b/db/migrate/20260810140000_add_listing_fields_to_board_printables.rb
@@ -1,0 +1,11 @@
+class AddListingFieldsToBoardPrintables < ActiveRecord::Migration[8.0]
+  def change
+    add_column :board_printables, :listing_copy, :jsonb, default: {}, null: false
+    add_column :board_printables, :etsy_listing_id, :bigint
+    add_column :board_printables, :etsy_listing_url, :string
+    add_column :board_printables, :etsy_published_at, :datetime
+    add_column :board_printables, :etsy_error, :text
+
+    add_index :board_printables, :etsy_listing_id
+  end
+end

--- a/db/migrate/20260810140100_create_oauth_credentials.rb
+++ b/db/migrate/20260810140100_create_oauth_credentials.rb
@@ -1,0 +1,15 @@
+class CreateOauthCredentials < ActiveRecord::Migration[8.0]
+  def change
+    create_table :oauth_credentials do |t|
+      t.string :provider, null: false
+      t.text :refresh_token
+      t.text :access_token
+      t.datetime :access_token_expires_at
+      t.jsonb :metadata, default: {}, null: false
+
+      t.timestamps
+    end
+
+    add_index :oauth_credentials, :provider, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_10_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_10_140100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -236,9 +236,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_120000) do
     t.text "error_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "listing_copy", default: {}, null: false
+    t.bigint "etsy_listing_id"
+    t.string "etsy_listing_url"
+    t.datetime "etsy_published_at"
+    t.text "etsy_error"
     t.index ["board_id", "status"], name: "index_board_printables_on_board_id_and_status"
     t.index ["board_id"], name: "index_board_printables_on_board_id"
     t.index ["created_by_id"], name: "index_board_printables_on_created_by_id"
+    t.index ["etsy_listing_id"], name: "index_board_printables_on_etsy_listing_id"
   end
 
   create_table "board_screenshot_cells", force: :cascade do |t|
@@ -621,6 +627,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_120000) do
     t.index ["sender_deleted_at"], name: "index_messages_on_sender_deleted_at"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
     t.index ["sent_at"], name: "index_messages_on_sent_at"
+  end
+
+  create_table "oauth_credentials", force: :cascade do |t|
+    t.string "provider", null: false
+    t.text "refresh_token"
+    t.text "access_token"
+    t.datetime "access_token_expires_at"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider"], name: "index_oauth_credentials_on_provider", unique: true
   end
 
   create_table "open_symbols", force: :cascade do |t|

--- a/lib/tasks/etsy.rake
+++ b/lib/tasks/etsy.rake
@@ -1,0 +1,48 @@
+namespace :etsy do
+  desc "Store this app's Etsy OAuth refresh token (rake 'etsy:seed_refresh_token[TOKEN]')"
+  task :seed_refresh_token, [:token] => :environment do |_t, args|
+    token = args[:token].presence || ENV["ETSY_OAUTH_REFRESH_TOKEN"].presence
+
+    if token.blank?
+      abort <<~MSG
+        Usage: rake 'etsy:seed_refresh_token[<refresh-token>]'
+
+        The token must come from a SEPARATE Etsy authorization, minted just for
+        this app. Do NOT paste the one in speakanyway-printables/.env.
+
+        Etsy rotates the refresh token on every exchange and invalidates the old
+        one, so two systems sharing a single grant knock each other offline.
+        Mint an independent one by running the printables repo's bootstrap again:
+
+          cd ../speakanyway-printables
+          npx tsx scripts/bootstrap-etsy-oauth.ts
+
+        then pass the refresh token it prints to this task.
+      MSG
+    end
+
+    credential = OauthCredential.upsert_refresh_token!(
+      provider: OauthCredential::PROVIDER_ETSY,
+      refresh_token: token,
+      metadata: { "seeded_at" => Time.current.iso8601, "shop_id" => ENV["ETSY_SHOP_ID"] },
+    )
+
+    puts "Stored Etsy refresh token (credential ##{credential.id})."
+    puts "Missing env: #{missing_etsy_env.join(', ')}" if missing_etsy_env.any?
+  end
+
+  desc "Show whether Etsy publishing is configured, without printing any secrets"
+  task status: :environment do
+    credential = OauthCredential.for_provider(OauthCredential::PROVIDER_ETSY)
+
+    puts "ETSY_SHOP_ID:       #{ENV['ETSY_SHOP_ID'].presence || '(unset)'}"
+    puts "Missing env:        #{missing_etsy_env.presence&.join(', ') || 'none'}"
+    puts "Refresh token:      #{credential&.refresh_token.present? ? 'stored' : 'MISSING'}"
+    puts "Access token:       #{credential&.access_token_valid? ? "cached until #{credential.access_token_expires_at}" : 'will refresh on next call'}"
+    puts "Configured:         #{Etsy::Client.configured?}"
+  end
+
+  def missing_etsy_env
+    %w[ETSY_KEYSTRING ETSY_SHARED_SECRET ETSY_OAUTH_CLIENT_ID ETSY_SHOP_ID].reject { |k| ENV[k].present? }
+  end
+end

--- a/spec/models/board_printable_spec.rb
+++ b/spec/models/board_printable_spec.rb
@@ -8,4 +8,69 @@ RSpec.describe BoardPrintable do
     expect { board.destroy! }.not_to raise_error
     expect(described_class.exists?(printable.id)).to be false
   end
+
+  describe "PDFs vs listing images" do
+    let(:board) { FactoryBot.create(:board, name: "Core Words") }
+    let(:printable) do
+      described_class.create!(board: board, status: "complete", board_ids: [board.id])
+    end
+
+    before do
+      printable.attach_pdf!(filename: "core.pdf", bytes: "pdf", variant: described_class::VARIANT_FULL)
+      printable.attach_image!(bytes: "png", variant: described_class::IMAGE_COVER)
+      printable.reload
+    end
+
+    it "keeps files_view to PDFs only, so the download buttons never offer marketing art" do
+      expect(printable.files_view.map { |f| f[:filename] }).to eq(["core.pdf"])
+    end
+
+    it "exposes the images separately, in listing rank order" do
+      printable.attach_image!(bytes: "png", variant: described_class::IMAGE_WHATS_INCLUDED)
+
+      expect(printable.reload.listing_images_view.map { |i| i[:variant] })
+        .to eq([described_class::IMAGE_COVER, described_class::IMAGE_WHATS_INCLUDED])
+    end
+
+    it "treats a blob written before the kind metadata existed as a PDF" do
+      legacy = printable.pdf_files.first
+      legacy.blob.update!(metadata: legacy.metadata.except("kind"))
+
+      expect(printable.reload.files_view.length).to eq(1)
+      expect(printable.image_files.length).to eq(1)
+    end
+
+    it "replaces an image variant instead of accumulating renders" do
+      printable.attach_image!(bytes: "png-2", variant: described_class::IMAGE_COVER)
+
+      expect(printable.reload.image_files.length).to eq(1)
+    end
+  end
+
+  describe "#listing_copy_or_default" do
+    let(:board) { FactoryBot.create(:board, name: "Core Words") }
+    let(:printable) { described_class.create!(board: board, board_ids: [board.id]) }
+
+    it "generates a preview when nothing has been saved" do
+      expect(printable.listing_copy).to eq({})
+      expect(printable.listing_copy_or_default["title"]).to include("Core Words")
+    end
+
+    it "returns the saved copy untouched once it exists" do
+      printable.update!(listing_copy: { "title" => "Edited by hand" })
+
+      expect(printable.listing_copy_or_default).to eq({ "title" => "Edited by hand" })
+    end
+  end
+
+  describe "#etsy_published?" do
+    let(:board) { FactoryBot.create(:board) }
+    let(:printable) { described_class.create!(board: board, board_ids: [board.id]) }
+
+    it "is false until a listing id is recorded" do
+      expect(printable.etsy_published?).to be false
+      printable.update!(etsy_listing_id: 123)
+      expect(printable.etsy_published?).to be true
+    end
+  end
 end

--- a/spec/models/oauth_credential_spec.rb
+++ b/spec/models/oauth_credential_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe OauthCredential do
+  describe ".upsert_refresh_token!" do
+    it "creates the row and merges metadata on a re-seed" do
+      described_class.upsert_refresh_token!(
+        provider: "etsy", refresh_token: "one", metadata: { "shop_id" => "42" },
+      )
+      record = described_class.upsert_refresh_token!(
+        provider: "etsy", refresh_token: "two", metadata: { "seeded_at" => "now" },
+      )
+
+      expect(described_class.count).to eq(1)
+      expect(record.refresh_token).to eq("two")
+      expect(record.metadata).to include("shop_id" => "42", "seeded_at" => "now")
+    end
+
+    it "drops the cached access token — a new grant invalidates the old one" do
+      described_class.create!(
+        provider: "etsy", refresh_token: "one",
+        access_token: "cached", access_token_expires_at: 1.hour.from_now,
+      )
+
+      record = described_class.upsert_refresh_token!(provider: "etsy", refresh_token: "two")
+
+      expect(record.access_token).to be_nil
+      expect(record.access_token_expires_at).to be_nil
+    end
+  end
+
+  describe "#access_token_valid?" do
+    it "treats a token expiring within the skew window as already expired" do
+      record = described_class.new(access_token: "t", access_token_expires_at: 10.seconds.from_now)
+      expect(record.access_token_valid?).to be false
+    end
+
+    it "is true for a token comfortably in the future" do
+      record = described_class.new(access_token: "t", access_token_expires_at: 1.hour.from_now)
+      expect(record.access_token_valid?).to be true
+    end
+  end
+
+  it "keeps tokens out of inspect output" do
+    record = described_class.new(provider: "etsy", refresh_token: "super-secret", access_token: "also-secret")
+
+    expect(record.inspect).not_to include("super-secret", "also-secret")
+    expect(record.inspect).to include("etsy")
+  end
+
+  it "allows only one credential per provider" do
+    described_class.create!(provider: "etsy", refresh_token: "a")
+
+    expect { described_class.create!(provider: "etsy", refresh_token: "b") }
+      .to raise_error(ActiveRecord::RecordInvalid)
+  end
+end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -359,4 +359,158 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       end
     end
   end
+
+  describe "listing and publishing" do
+    let!(:printable) do
+      BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+    end
+
+    before do
+      printable.attach_pdf!(filename: "core.pdf", bytes: "pdf", variant: BoardPrintable::VARIANT_FULL)
+    end
+
+    describe "authorization" do
+      it "refuses every member action to a non-admin" do
+        sign_in create(:user)
+
+        patch update_listing_admin_dashboard_board_printable_path(printable), params: { title: "x" }
+        expect(response).to redirect_to(root_path)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+        expect(response).to redirect_to(root_path)
+
+        post regenerate_listing_images_admin_dashboard_board_printable_path(printable)
+        expect(response).to redirect_to(root_path)
+
+        expect(printable.reload.listing_copy).to eq({})
+      end
+    end
+
+    describe "GET show" do
+      it "renders the generated listing copy and the paste blocks" do
+        sign_in admin
+        allow(Etsy::Client).to receive(:configured?).and_return(true)
+
+        get admin_dashboard_board_printable_path(printable)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Listing copy", "Teachers Pay Teachers", "Create Etsy draft")
+        # The link back to the board the printable was built from.
+        expect(response.body).to include("Open board ##{board.id}")
+      end
+
+      it "says Etsy is unconfigured instead of offering a button that would fail" do
+        sign_in admin
+        allow(Etsy::Client).to receive(:configured?).and_return(false)
+
+        get admin_dashboard_board_printable_path(printable)
+
+        expect(response.body).to include("Etsy isn't configured")
+        expect(response.body).not_to include("Create Etsy draft")
+      end
+    end
+
+    describe "PATCH update_listing" do
+      it "saves the copy and normalizes the tags to what Etsy will accept" do
+        sign_in admin
+
+        patch update_listing_admin_dashboard_board_printable_path(printable), params: {
+          title: "Core Words", summary: "S", description: "D",
+          tags: "AAC, talking communication board, printable", price: "4.50",
+        }
+
+        expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+        expect(printable.reload.listing_copy).to include(
+          "title" => "Core Words",
+          # The 27-char tag is dropped here rather than silently by Etsy later.
+          "tags" => ["aac", "printable"],
+          "price_cents" => 450,
+        )
+      end
+
+      it "does not touch Etsy" do
+        sign_in admin
+        expect(PublishBoardPrintableToEtsyJob).not_to receive(:perform_async)
+
+        patch update_listing_admin_dashboard_board_printable_path(printable),
+              params: { title: "T", description: "D" }
+      end
+    end
+
+    describe "POST publish_to_etsy" do
+      before { allow(Etsy::Client).to receive(:configured?).and_return(true) }
+
+      it "enqueues the publish job and clears a stale error" do
+        sign_in admin
+        printable.update_columns(etsy_error: "an old failure")
+
+        expect(PublishBoardPrintableToEtsyJob).to receive(:perform_async).with(printable.id)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+        expect(printable.reload.etsy_error).to be_nil
+      end
+
+      it "saves the generated copy first, so the draft matches what the page showed" do
+        sign_in admin
+        allow(PublishBoardPrintableToEtsyJob).to receive(:perform_async)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.listing_copy["title"]).to be_present
+      end
+
+      it "refuses a printable that is still generating" do
+        sign_in admin
+        printable.update_columns(status: "generating")
+
+        expect(PublishBoardPrintableToEtsyJob).not_to receive(:perform_async)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to match(/isn't finished generating/)
+      end
+
+      it "refuses to create a second listing for the same printable" do
+        sign_in admin
+        printable.update!(etsy_listing_id: 555)
+
+        expect(PublishBoardPrintableToEtsyJob).not_to receive(:perform_async)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to match(/Already on Etsy as listing 555/)
+      end
+
+      it "refuses when Etsy isn't configured" do
+        sign_in admin
+        allow(Etsy::Client).to receive(:configured?).and_return(false)
+
+        expect(PublishBoardPrintableToEtsyJob).not_to receive(:perform_async)
+
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to match(/isn't configured/)
+      end
+    end
+
+    describe "POST regenerate_listing_images" do
+      it "enqueues the render job" do
+        sign_in admin
+
+        expect(RenderBoardPrintableListingImagesJob).to receive(:perform_async).with(printable.id)
+
+        post regenerate_listing_images_admin_dashboard_board_printable_path(printable)
+        expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+      end
+
+      it "refuses a printable that is still generating" do
+        sign_in admin
+        printable.update_columns(status: "generating")
+
+        expect(RenderBoardPrintableListingImagesJob).not_to receive(:perform_async)
+
+        post regenerate_listing_images_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
 end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -399,6 +399,19 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
         expect(response.body).to include("Open board ##{board.id}")
       end
 
+      it "links a published draft by its numeric listing id, never by the stored URL string" do
+        sign_in admin
+        # The stored URL is whatever Etsy's API handed back; the href is built
+        # from the bigint id so a string column can never reach an href.
+        printable.update!(etsy_listing_id: 987, etsy_listing_url: "https://www.etsy.com/listing/987/core-words")
+
+        get admin_dashboard_board_printable_path(printable)
+
+        expect(response.body).to include("https://www.etsy.com/listing/987\"")
+        expect(response.body).not_to include("core-words\"")
+        expect(response.body).not_to include("Create Etsy draft")
+      end
+
       it "says Etsy is unconfigured instead of offering a button that would fail" do
         sign_in admin
         allow(Etsy::Client).to receive(:configured?).and_return(false)

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Boards::Printables::RenderListingImages do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "Core Words") }
+  let(:other) { create(:board, user: owner, name: "Feelings") }
+
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+  end
+
+  # Grover shells out to headless Chrome; the specs care about what gets
+  # rendered and attached, not about the pixels.
+  let(:rendered_html) { [] }
+
+  before do
+    grover = instance_double(Grover, to_png: "png-bytes")
+    allow(Grover).to receive(:new) do |html, **_opts|
+      rendered_html << html
+      grover
+    end
+  end
+
+  it "attaches a cover and a what's-included image, tagged as images not PDFs" do
+    described_class.new(printable: printable).call
+
+    printable.reload
+    expect(printable.listing_images_view.map { |i| i[:variant] })
+      .to eq([BoardPrintable::IMAGE_COVER, BoardPrintable::IMAGE_WHATS_INCLUDED])
+    # The download buttons and the API read files_view; marketing images must
+    # never leak into it.
+    expect(printable.files_view).to be_empty
+  end
+
+  it "renders through the print layout with the square-canvas flag set" do
+    described_class.new(printable: printable).call
+
+    expect(rendered_html.length).to eq(2)
+    expect(rendered_html).to all(include("as-listing-image"))
+  end
+
+  it "writes a fresh key on every render so a regenerate isn't hidden by the CDN" do
+    described_class.new(printable: printable).call
+    first = printable.reload.image_files.map(&:key)
+
+    described_class.new(printable: printable.reload).call
+    second = printable.reload.image_files.map(&:key)
+
+    expect(second & first).to be_empty
+    expect(printable.image_files.size).to eq(2)
+  end
+
+  it "names the boards in a set on the what's-included slide" do
+    printable.update!(board_ids: [board.id, other.id], include_subboards: true)
+
+    described_class.new(printable: printable).call
+
+    expect(rendered_html.last).to include("Core Words", "Feelings")
+  end
+
+  it "caps the named boards so a large tree can't overflow the slide" do
+    ids = [board.id]
+    (described_class::MAX_LABELS + 3).times do |i|
+      ids << create(:board, user: owner, name: "Page #{i}").id
+    end
+    printable.update!(board_ids: ids, include_subboards: true)
+
+    described_class.new(printable: printable).call
+
+    expect(rendered_html.last).to include("and 4 more")
+  end
+end

--- a/spec/services/etsy/client_spec.rb
+++ b/spec/services/etsy/client_spec.rb
@@ -1,0 +1,204 @@
+require "rails_helper"
+
+RSpec.describe Etsy::Client do
+  subject(:client) do
+    described_class.new(
+      keystring: "KEY", shared_secret: "SECRET", client_id: "CLIENT", shop_id: "42",
+    )
+  end
+
+  let!(:credential) do
+    OauthCredential.create!(provider: OauthCredential::PROVIDER_ETSY, refresh_token: "old-refresh")
+  end
+
+  let(:token_url) { described_class::OAUTH_TOKEN_URL }
+  let(:api) { described_class::API_BASE }
+
+  def stub_token_exchange(access: "access-1", refresh: "rotated-1", expires_in: 3600)
+    stub_request(:post, token_url).to_return(
+      status: 200,
+      body: { access_token: access, refresh_token: refresh, expires_in: expires_in }.to_json,
+      headers: { "Content-Type" => "application/json" },
+    )
+  end
+
+  describe "OAuth" do
+    it "persists the ROTATED refresh token, not just the access token" do
+      # Etsy invalidates the token used in the exchange. Failing to write the
+      # new one back means every later publish is permanently 403.
+      stub_token_exchange
+      stub_request(:get, "#{api}/seller-taxonomy/nodes").to_return(status: 200, body: { results: [] }.to_json)
+
+      client.taxonomy_ids
+
+      credential.reload
+      expect(credential.refresh_token).to eq("rotated-1")
+      expect(credential.access_token).to eq("access-1")
+      expect(credential.access_token_expires_at).to be_present
+    end
+
+    it "reuses a cached access token instead of burning another refresh" do
+      credential.update!(access_token: "cached", access_token_expires_at: 1.hour.from_now)
+      stub_request(:get, "#{api}/seller-taxonomy/nodes").to_return(status: 200, body: { results: [] }.to_json)
+
+      client.taxonomy_ids
+
+      expect(a_request(:post, token_url)).not_to have_been_made
+    end
+
+    it "raises a configuration error when no credential is stored" do
+      credential.destroy!
+      expect { client.taxonomy_ids }.to raise_error(described_class::ConfigurationError, /seed_refresh_token/)
+    end
+  end
+
+  describe "#create_listing" do
+    before do
+      stub_token_exchange
+      stub_request(:post, "#{api}/shops/42/listings")
+        .to_return(status: 201, body: { listing_id: 987, url: "https://etsy.test/987" }.to_json)
+    end
+
+    def create!(tags: ["aac", "printable"])
+      client.create_listing(title: "T", description: "D", price: 5.0, tags: tags)
+    end
+
+    it "creates a DRAFT download listing and never an active one" do
+      expect(create!()).to eq(listing_id: 987, url: "https://etsy.test/987")
+
+      expect(a_request(:post, "#{api}/shops/42/listings").with { |req|
+        params = Rack::Utils.parse_nested_query(req.body)
+        params["state"] == "draft" && params["type"] == "download"
+      }).to have_been_made
+    end
+
+    it "sends tags as ONE comma-separated value" do
+      # Repeated `tags` params are not merged by Etsy — it keeps only the last
+      # and silently drops the rest.
+      create!(tags: ["aac", "printable", "slp"])
+
+      expect(a_request(:post, "#{api}/shops/42/listings").with { |req|
+        req.body.scan(/(?:^|&)tags=/).length == 1 &&
+          Rack::Utils.parse_nested_query(req.body)["tags"] == "aac,printable,slp"
+      }).to have_been_made
+    end
+
+    it "drops tags Etsy would silently reject" do
+      create!(tags: ["aac", "talking communication board", "for the"])
+
+      expect(a_request(:post, "#{api}/shops/42/listings").with { |req|
+        Rack::Utils.parse_nested_query(req.body)["tags"] == "aac"
+      }).to have_been_made
+    end
+
+    it "sends the api key in the keystring:secret form Etsy enforces" do
+      create!()
+      expect(a_request(:post, "#{api}/shops/42/listings")
+        .with(headers: { "x-api-key" => "KEY:SECRET" })).to have_been_made
+    end
+
+    it "raises with the response body when Etsy rejects the listing" do
+      stub_request(:post, "#{api}/shops/42/listings")
+        .to_return(status: 400, body: "& can only be use once")
+
+      expect { create!() }.to raise_error(described_class::Error, /400.*can only be use once/)
+    end
+  end
+
+  describe "#set_listing_price" do
+    before { stub_token_exchange }
+
+    it "writes through the inventory endpoint, which is the only writer that sticks" do
+      stub_request(:get, "#{api}/listings/987/inventory").to_return(
+        status: 200,
+        body: {
+          products: [{ sku: "s", property_values: [], offerings: [{ price: { amount: 100 }, quantity: 999, is_enabled: true }] }],
+          price_on_property: [],
+        }.to_json,
+      )
+      stub_request(:put, "#{api}/listings/987/inventory").to_return(status: 200, body: "{}")
+
+      client.set_listing_price(987, 4.5)
+
+      expect(a_request(:put, "#{api}/listings/987/inventory").with { |req|
+        JSON.parse(req.body).dig("products", 0, "offerings", 0, "price") == 4.5
+      }).to have_been_made
+    end
+
+    it "raises rather than silently leaving the price unset when there is no inventory" do
+      stub_request(:get, "#{api}/listings/987/inventory")
+        .to_return(status: 200, body: { products: [] }.to_json)
+
+      expect { client.set_listing_price(987, 4.5) }
+        .to raise_error(described_class::Error, /no inventory products/)
+    end
+  end
+
+  describe "#assert_known_taxonomy!" do
+    before { stub_token_exchange }
+
+    it "raises on an id that isn't in Etsy's taxonomy" do
+      # Etsy accepts an unknown id, returns 200, and files the listing under an
+      # arbitrary category — so it has to fail here or not at all.
+      stub_request(:get, "#{api}/seller-taxonomy/nodes")
+        .to_return(status: 200, body: { results: [{ id: 2078, children: [] }] }.to_json)
+
+      expect { client.assert_known_taxonomy!(6816) }
+        .to raise_error(described_class::Error, /not a node in Etsy's seller taxonomy/)
+      expect(client.assert_known_taxonomy!(2078)).to be true
+    end
+
+    it "does not block a publish when the taxonomy fetch itself fails" do
+      stub_request(:get, "#{api}/seller-taxonomy/nodes").to_return(status: 503, body: "nope")
+
+      expect(client.assert_known_taxonomy!(2078)).to be true
+    end
+  end
+
+  describe "#upload_file" do
+    before { stub_token_exchange }
+
+    it "refuses a file over Etsy's 20 MB cap instead of failing mid-upload" do
+      expect {
+        client.upload_file(987, bytes: "x" * (described_class::FILE_CAP_BYTES + 1), filename: "big.pdf")
+      }.to raise_error(described_class::Error, /caps a download file at 20 MB/)
+    end
+
+    it "posts multipart with the normalized name" do
+      stub_request(:post, "#{api}/shops/42/listings/987/files").to_return(status: 201, body: "{}")
+
+      client.upload_file(987, bytes: "pdf-bytes", filename: "core words (set).pdf")
+
+      expect(a_request(:post, "#{api}/shops/42/listings/987/files").with { |req|
+        req.headers["Content-Type"].to_s.start_with?("multipart/form-data") &&
+          req.body.include?("core-words-set-.pdf")
+      }).to have_been_made
+    end
+  end
+
+  describe "#normalize_filename" do
+    it "keeps only the characters Etsy allows" do
+      expect(client.normalize_filename("Core Words! v2.pdf")).to eq("Core-Words-v2.pdf")
+    end
+
+    it "pads a name shorter than Etsy's 3-character minimum" do
+      expect(client.normalize_filename("a")).to eq("file-a")
+    end
+  end
+
+  describe ".configured?" do
+    it "is false without a stored refresh token" do
+      credential.update!(refresh_token: nil)
+      expect(client.configured?).to be false
+    end
+
+    it "is false when the env is incomplete" do
+      expect(described_class.new(keystring: nil, shared_secret: "S", client_id: "C", shop_id: "1").configured?)
+        .to be false
+    end
+
+    it "is true with env plus a stored token" do
+      expect(client.configured?).to be true
+    end
+  end
+end

--- a/spec/services/etsy/copy_rules_spec.rb
+++ b/spec/services/etsy/copy_rules_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe Etsy::CopyRules do
+  describe ".enforce_title_rules" do
+    it "keeps the first ampersand and turns later ones into 'and'" do
+      # Etsy 400s a title with more than one "&".
+      expect(described_class.enforce_title_rules("Farm & Zoo for Speech & Autism"))
+        .to eq("Farm & Zoo for Speech and Autism")
+    end
+
+    it "collapses runs of whitespace" do
+      expect(described_class.enforce_title_rules("Core   Words  Board ")).to eq("Core Words Board")
+    end
+  end
+
+  describe ".ensure_digital_download_suffix" do
+    it "appends the suffix" do
+      expect(described_class.ensure_digital_download_suffix("Core Words"))
+        .to eq("Core Words (Digital Download)")
+    end
+
+    it "leaves an existing suffix alone" do
+      expect(described_class.ensure_digital_download_suffix("Core Words (Digital Download)"))
+        .to eq("Core Words (Digital Download)")
+    end
+
+    it "keeps the whole title within Etsy's cap" do
+      result = described_class.ensure_digital_download_suffix("a" * 200)
+      expect(result.length).to be <= described_class::TITLE_MAX
+      expect(result).to end_with("(Digital Download)")
+    end
+  end
+
+  describe ".normalize_tag" do
+    it "downcases and strips characters Etsy rejects" do
+      expect(described_class.normalize_tag("AAC Board!")).to eq("aac board")
+    end
+
+    it "rejects a tag over 20 characters rather than truncating it" do
+      expect(described_class.normalize_tag("talking communication board")).to be_nil
+    end
+
+    it "rejects a phrase made only of small words" do
+      expect(described_class.normalize_tag("for the")).to be_nil
+    end
+  end
+
+  describe ".assemble_tags" do
+    it "caps at 13, dedupes, and fills the tail from top_up" do
+      tags = described_class.assemble_tags(
+        always_on: ["aac", "printable"],
+        product_type: ["aac"],
+        audience: ["slp"],
+        topic: ["farm animals"],
+        top_up: (1..20).map { |i| "keyword #{i}" },
+      )
+
+      expect(tags.length).to eq(described_class::TAG_MAX)
+      expect(tags.uniq).to eq(tags)
+      expect(tags.first(4)).to eq(["aac", "printable", "slp", "farm animals"])
+    end
+  end
+
+  describe ".topic_tags" do
+    it "falls back to a segment's TRAILING phrase when the whole is too long" do
+      # The head noun carries the search intent: "animal vocabulary", not
+      # "farm and".
+      expect(described_class.topic_tags("farm and zoo animal vocabulary"))
+        .to include("animal vocabulary")
+    end
+
+    it "splits on commas and slashes" do
+      expect(described_class.topic_tags("core words / feelings")).to eq(["core words", "feelings"])
+    end
+  end
+
+  describe ".pick_fitting_title" do
+    it "returns the first candidate that fits once the suffix is accounted for" do
+      long = "x" * 130
+      expect(described_class.pick_fitting_title([long, "Core Words"])).to eq("Core Words")
+    end
+
+    it "returns the shortest when everything overflows, rather than an early truncation" do
+      expect(described_class.pick_fitting_title(["y" * 200, "z" * 150])).to eq("z" * 150)
+    end
+
+    it "skips candidates carrying a stringified nil from an absent phrase" do
+      expect(described_class.pick_fitting_title(["Core Words, , Set"])).to eq("Core Words, , Set")
+      expect(described_class.pick_fitting_title(["Core Words, nil Set", "Core Words"]))
+        .to eq("Core Words")
+    end
+  end
+
+  describe ".distinct_topic_phrase" do
+    it "picks the segment adding the most words the title doesn't have" do
+      phrase = described_class.distinct_topic_phrase(
+        title: "Core 60", topic: "core vocabulary / core words for snack time",
+        product_human: "vocabulary board",
+      )
+      expect(phrase).to eq("Core Words for Snack Time")
+    end
+
+    it "returns nil when the topic adds nothing new" do
+      expect(described_class.distinct_topic_phrase(
+               title: "Core Words", topic: "core words", product_human: "vocabulary board",
+             )).to be_nil
+    end
+  end
+end

--- a/spec/services/etsy/listing_copy_spec.rb
+++ b/spec/services/etsy/listing_copy_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe Etsy::ListingCopy do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "core words") }
+
+  def printable(**attrs)
+    BoardPrintable.create!(
+      { board: board, status: "complete", board_ids: [board.id], page_count: 6 }.merge(attrs),
+    )
+  end
+
+  def build(**attrs) = described_class.new(printable(**attrs)).build
+
+  describe "title" do
+    it "stays within Etsy's cap and carries the digital-download suffix" do
+      title = build["title"]
+      expect(title.length).to be <= Etsy::CopyRules::TITLE_MAX
+      expect(title).to end_with("(Digital Download)")
+    end
+
+    it "never carries more than one ampersand" do
+      long_board = create(:board, user: owner, name: "Farm & Zoo")
+      title = described_class.new(
+        BoardPrintable.create!(board: long_board, status: "complete", board_ids: [long_board.id]),
+      ).build["title"]
+
+      expect(title.count("&")).to be <= 1
+    end
+
+    it "shrinks the product decoration when the board already names it" do
+      named = create(:board, user: owner, name: "Feelings Vocabulary Board")
+      title = described_class.new(
+        BoardPrintable.create!(board: named, status: "complete", board_ids: [named.id]),
+      ).build["title"]
+
+      expect(title).to include("AAC Printable")
+      expect(title).not_to include("AAC Vocabulary Board Printable")
+    end
+
+    it "falls back to a form that fits rather than truncating a long board name mid-word" do
+      wordy = create(:board, user: owner, name: ("Snack Time " * 14).strip)
+      title = described_class.new(
+        BoardPrintable.create!(board: wordy, status: "complete", board_ids: [wordy.id]),
+      ).build["title"]
+
+      expect(title.length).to be <= Etsy::CopyRules::TITLE_MAX
+      expect(title).not_to include("for Speech The")
+    end
+  end
+
+  describe "tags" do
+    it "fills all 13 slots with legal tags" do
+      tags = build(topic: "farm animals")["tags"]
+
+      expect(tags.length).to eq(Etsy::CopyRules::TAG_MAX)
+      expect(tags.map(&:length).max).to be <= Etsy::CopyRules::TAG_LEN_MAX
+      expect(tags.uniq).to eq(tags)
+      expect(tags).to include("aac", "printable", "farm animals")
+    end
+  end
+
+  describe "description" do
+    it "opens with the brand lead and closes with the app footer" do
+      description = build["description"]
+
+      expect(description).to start_with(described_class::LEAD)
+      expect(description).to end_with(described_class::FOOTER)
+      expect(description).to include("WHAT'S INCLUDED")
+    end
+
+    it "names each board in a set rather than quoting a page count" do
+      other = create(:board, user: owner, name: "feelings")
+      description = build(board_ids: [board.id, other.id], include_subboards: true)["description"]
+
+      expect(description).to include("THE 2 BOARDS")
+      expect(description).to include("Core Words", "Feelings")
+      expect(description).to include("2 boards, 6 pages — 2 PDFs (full color + low-ink)")
+    end
+
+    it "describes a single board as an n-page PDF" do
+      expect(build["description"]).to include("6-page board PDF — color + low-ink")
+    end
+
+    it "omits the boards section for a single-board printable" do
+      expect(build["description"]).not_to include("THE 1 BOARDS")
+    end
+  end
+
+  describe "summary" do
+    it "stays under the summary cap" do
+      wordy = create(:board, user: owner, name: "x" * 300)
+      summary = described_class.new(
+        BoardPrintable.create!(board: wordy, status: "complete", board_ids: [wordy.id]),
+      ).build["summary"]
+
+      expect(summary.length).to be <= described_class::SUMMARY_MAX
+    end
+  end
+
+  it "defaults the price to what the printables pipeline actually ships" do
+    expect(build["price_cents"]).to eq(500)
+  end
+end

--- a/spec/services/etsy/publish_board_printable_spec.rb
+++ b/spec/services/etsy/publish_board_printable_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+RSpec.describe Etsy::PublishBoardPrintable do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "Core Words") }
+
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+  end
+
+  let(:client) { instance_double(Etsy::Client) }
+
+  before do
+    printable.attach_pdf!(filename: "core-words.pdf", bytes: "pdf-bytes", variant: BoardPrintable::VARIANT_FULL)
+    printable.update!(listing_copy: { "title" => "T", "description" => "D", "tags" => ["aac"], "price_cents" => 450 })
+
+    allow(client).to receive(:assert_known_taxonomy!).and_return(true)
+    allow(client).to receive(:create_listing)
+      .and_return({ listing_id: 987, url: "https://etsy.test/987" })
+    allow(client).to receive(:set_listing_price).and_return(true)
+    allow(client).to receive(:upload_image).and_return(true)
+    allow(client).to receive(:upload_file).and_return(true)
+
+    # Grover renders two PNGs; the bytes themselves are irrelevant here.
+    allow_any_instance_of(Boards::Printables::RenderListingImages).to receive(:call) do
+      printable.attach_image!(bytes: "png", variant: BoardPrintable::IMAGE_COVER)
+      printable.attach_image!(bytes: "png", variant: BoardPrintable::IMAGE_WHATS_INCLUDED)
+    end
+  end
+
+  def publish = described_class.new(printable.reload, client: client).call
+
+  describe "the drafts-only invariant" do
+    it "creates the listing as a draft and never asks the client to activate it" do
+      expect(client).to receive(:create_listing).with(
+        hash_including(title: "T", description: "D", price: 4.5, tags: ["aac"]),
+      ).and_return({ listing_id: 987, url: "https://etsy.test/987" })
+
+      publish
+
+      # There is no activate/update path on the client at all — the absence is
+      # the guarantee, so assert it rather than trusting the call list.
+      expect(Etsy::Client.instance_methods).not_to include(:activate_listing, :update_listing)
+    end
+  end
+
+  describe "a successful publish" do
+    it "records the listing and clears any previous error" do
+      printable.update_columns(etsy_error: "an earlier failure")
+
+      result = publish
+
+      expect(result.ok?).to be true
+      expect(result.listing_id).to eq(987)
+      expect(printable.reload).to have_attributes(
+        etsy_listing_id: 987,
+        etsy_listing_url: "https://etsy.test/987",
+        etsy_error: nil,
+      )
+      expect(printable.etsy_published_at).to be_present
+    end
+
+    it "sets the price through the inventory endpoint even though create carried it" do
+      expect(client).to receive(:set_listing_price).with(987, 4.5)
+      publish
+    end
+
+    it "uploads the cover first and the what's-included second" do
+      ranks = []
+      allow(client).to receive(:upload_image) { |_id, opts| ranks << [opts[:rank], opts[:filename]] }
+
+      publish
+
+      expect(ranks.map(&:first)).to eq([1, 2])
+      expect(ranks.first.last).to start_with("cover-")
+    end
+
+    it "uploads every PDF variant as a download file" do
+      printable.attach_pdf!(filename: "core-words.low-ink.pdf", bytes: "b", variant: BoardPrintable::VARIANT_LOW_INK)
+
+      expect(client).to receive(:upload_file).twice
+      publish
+    end
+
+    it "renders the gallery images when they are missing, so the draft can go live" do
+      expect(printable.listing_images?).to be false
+      publish
+      expect(printable.reload.listing_images?).to be true
+    end
+  end
+
+  describe "guards" do
+    it "refuses a printable that hasn't finished generating" do
+      printable.update_columns(status: "generating")
+
+      result = publish
+
+      expect(result.ok?).to be false
+      expect(result.error).to match(/isn't finished generating/)
+      expect(client).not_to have_received(:create_listing)
+    end
+
+    it "refuses to create a second listing for the same printable" do
+      printable.update!(etsy_listing_id: 111)
+
+      result = publish
+
+      expect(result.error).to match(/Already on Etsy as listing 111/)
+      expect(client).not_to have_received(:create_listing)
+    end
+
+    it "refuses a PDF over Etsy's 20 MB cap rather than failing mid-upload" do
+      printable.files.each(&:purge)
+      printable.reload.attach_pdf!(
+        filename: "huge.pdf", bytes: "x" * (Etsy::Client::FILE_CAP_BYTES + 1),
+        variant: BoardPrintable::VARIANT_FULL,
+      )
+
+      result = publish
+
+      expect(result.error).to match(/caps a download file at 20 MB/)
+      expect(client).not_to have_received(:create_listing)
+    end
+
+    it "refuses when the listing copy has no title" do
+      printable.update!(listing_copy: { "title" => "", "description" => "D" })
+
+      expect(publish.error).to match(/title and description are required/)
+    end
+  end
+
+  describe "failure handling" do
+    it "records the error on the printable so it shows up in the admin" do
+      allow(client).to receive(:create_listing).and_raise(Etsy::Client::Error, "Etsy POST 400: bad tags")
+
+      result = publish
+
+      expect(result.ok?).to be false
+      expect(printable.reload.etsy_error).to eq("Etsy POST 400: bad tags")
+      expect(printable.etsy_listing_id).to be_nil
+    end
+
+    it "leaves the printable's generation status untouched" do
+      allow(client).to receive(:create_listing).and_raise("boom")
+
+      publish
+
+      expect(printable.reload.status).to eq("complete")
+    end
+  end
+end

--- a/spec/services/printables/included_items_spec.rb
+++ b/spec/services/printables/included_items_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Printables::IncludedItems do
+  describe ".headline" do
+    it "describes a single board by its page count" do
+      expect(described_class.headline(board_count: 1, page_count: 6))
+        .to eq("6-page board PDF — color + low-ink")
+    end
+
+    it "describes a set by board count AND page count, and says it's two files" do
+      # A bundle ships every board twice and arrives as two PDFs; quoting one
+      # page count understates a 9-board set badly.
+      expect(described_class.headline(board_count: 9, page_count: 22))
+        .to eq("9 boards, 22 pages — 2 PDFs (full color + low-ink)")
+    end
+
+    it "omits the page count rather than claiming zero pages" do
+      expect(described_class.headline(board_count: 1, page_count: nil))
+        .to eq("Board PDF — color + low-ink")
+      expect(described_class.headline(board_count: 3, page_count: 0))
+        .to eq("3 boards — 2 PDFs (full color + low-ink)")
+    end
+  end
+
+  describe ".all" do
+    it "leads with the document line and names the voice output" do
+      items = described_class.all(board_count: 1, page_count: 6)
+
+      expect(items.first).to eq("6-page board PDF — color + low-ink")
+      expect(items).to include("Free voice output online — tap to hear each word")
+    end
+  end
+end

--- a/spec/services/printables/marketplace_copy_spec.rb
+++ b/spec/services/printables/marketplace_copy_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe Printables::MarketplaceCopy do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "Core Words") }
+
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+  end
+
+  subject(:copy) { described_class.new(printable) }
+
+  def field(fields, label) = fields.find { |f| f.label == label }
+
+  describe "TPT" do
+    it "trims the title to TPT's 100-char cap on a word boundary, without the Etsy suffix" do
+      long = "Snack Time " * 12
+      printable.update!(listing_copy: {
+        "title" => "#{long}(Digital Download)", "description" => "D", "tags" => [], "price_cents" => 500,
+      })
+
+      value = field(copy.tpt_fields, "Product title").value
+
+      expect(value.length).to be <= described_class::TPT_TITLE_MAX
+      expect(value).not_to include("Digital Download")
+      expect(value).not_to end_with("Sna")
+    end
+
+    it "lays out every field TPT's upload form asks for" do
+      labels = copy.tpt_fields.map(&:label)
+
+      expect(labels).to include(
+        "Product title", "Description", "Price (USD)", "Grade levels",
+        "Subjects", "Resource types", "Number of pages", "Search keywords",
+        "Files to upload", "Standards",
+      )
+    end
+
+    it "trims the keyword list — TPT takes a handful, not Etsy's thirteen" do
+      value = field(copy.tpt_fields, "Search keywords").value
+      expect(value.split(",").length).to eq(described_class::TPT_KEYWORD_COUNT)
+    end
+
+    it "lists the PDFs by name so there's no guessing which files to upload" do
+      printable.attach_pdf!(filename: "core-words.pdf", bytes: "b", variant: BoardPrintable::VARIANT_FULL)
+
+      expect(field(described_class.new(printable.reload).tpt_fields, "Files to upload").value)
+        .to eq("core-words.pdf")
+    end
+  end
+
+  describe "generic" do
+    it "hands back the title, description, tags and price unchanged" do
+      printable.update!(listing_copy: {
+        "title" => "T", "description" => "D", "tags" => %w[aac printable], "price_cents" => 450,
+      })
+
+      fields = described_class.new(printable.reload).generic_fields
+
+      expect(field(fields, "Title").value).to eq("T")
+      expect(field(fields, "Tags").value).to eq("aac, printable")
+      expect(field(fields, "Price (USD)").value).to eq("4.50")
+    end
+  end
+
+  it "falls back to the generated defaults when nothing has been saved yet" do
+    expect(copy.title).to be_present
+    expect(copy.tags).to be_present
+  end
+end

--- a/spec/sidekiq/publish_board_printable_to_etsy_job_spec.rb
+++ b/spec/sidekiq/publish_board_printable_to_etsy_job_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe PublishBoardPrintableToEtsyJob do
+  let(:board) { create(:board) }
+  let(:printable) { BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id]) }
+
+  it "never retries — a retry after a partial success creates a duplicate listing in a live shop" do
+    expect(described_class.sidekiq_options["retry"]).to eq(0)
+  end
+
+  it "publishes the printable" do
+    service = instance_double(Etsy::PublishBoardPrintable, call: true)
+    expect(Etsy::PublishBoardPrintable).to receive(:new).with(printable).and_return(service)
+
+    described_class.new.perform(printable.id)
+  end
+
+  it "does nothing when the printable already has a listing" do
+    printable.update!(etsy_listing_id: 99)
+
+    expect(Etsy::PublishBoardPrintable).not_to receive(:new)
+    described_class.new.perform(printable.id)
+  end
+
+  it "does nothing when the printable has been deleted" do
+    expect { described_class.new.perform(-1) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Summary

`/admin/board_printables/:id` was read-only — a status badge and download links — so a printable generated in the admin had no path to a marketplace without leaving the app for the `speakanyway-printables` pipeline. This adds the last mile.

**On the show page, once a printable is complete:**

- **Board links** — the header links to the source board's `/pb/` page (the same URL the printed cover QR points at), and a card lists every sub-board in tree order.
- **Listing copy** — editable title / summary / description / tags / price, prefilled from defaults generated off the board's own name and topic. Tags are normalized on save, so what you see is what Etsy gets.
- **Listing images** — a cover and a what's-included slide, rendered by Grover through the *same* templates and CSS as the printed wrapper pages.
- **Create Etsy draft** — real Etsy v3 API: draft listing → price via the inventory endpoint → images by rank → PDFs as download files.
- **Copy blocks** — Teachers Pay Teachers laid out field by field in their upload-form order (TPT has no seller API), plus a generic title/description/tags block.

## Two things worth reading before reviewing

**Rails creates DRAFTS and nothing else.** `Etsy::Client#create_listing` hardcodes `state: "draft"` and the client implements no activate call — the absence is the guarantee. Going live stays a deliberate click in the Etsy seller UI. `PublishBoardPrintableToEtsyJob` is `retry: 0` for the same reason: a retry after a partial success creates a second draft in a real shop and nothing downstream would notice.

**Rails needs its own Etsy authorization.** Etsy's refresh token is single-use and rotates on every exchange, so it can't live in ENV — it's in the new `oauth_credentials` table, refreshed under a row lock so two Sidekiq workers can't burn the same token. Critically, it must be a *separate* grant from the one `speakanyway-printables` holds; a shared grant makes the two invalidate each other and both start throwing intermittent 403s.

## Before this works in production

```bash
cd ../speakanyway-printables && npx tsx scripts/bootstrap-etsy-oauth.ts
```

Mints a new, independent grant — **do not** reuse the token in that repo's `.env`. Then here:

```bash
rake 'etsy:seed_refresh_token[<the-token-it-printed>]'
```

Plus `ETSY_KEYSTRING`, `ETSY_SHARED_SECRET`, `ETSY_OAUTH_CLIENT_ID`, `ETSY_SHOP_ID` in Hatchbox. `rake etsy:status` confirms configuration without printing secrets. Until then the Etsy card says "not configured" instead of offering a button that would fail.

## Notable implementation details

- `Etsy::CopyRules` is a Ruby port of `speakanyway-printables/src/generator/listing-copy.ts`. Every odd-looking rule (one `&` per title, one comma-joined `tags` param, the 20-char tag cap, the widest-first title chain) encodes a live Etsy failure — the comments name them. **These rules now exist in two languages and can drift**; documented in the spoke.
- `taxonomy_id` defaults to `2078` (Digital Prints) and is asserted against `/seller-taxonomy/nodes`. Etsy accepts an unknown id, returns 200, and files the listing under an arbitrary category — that's how the printables pipeline filed everything under nail-art dotting tools for months.
- `BoardPrintable#files` now holds PDFs and PNGs, separated by blob metadata `kind`. `files_view` stays **PDF-only** so the download buttons and the `/api/board_printables/:id/download_url` contract are unchanged; a blob with no `kind` is treated as a PDF.
- Listing images use versioned blob keys — CloudFront ignores query strings, so a stable key would leave the admin looking at the previous render after "Regenerate".
- The `.as-listing-image` square-canvas CSS is gated so the PDF render path is byte-identical; the wrapper specs pin the rendered `<body class="">`.
- `faraday-multipart` is now declared explicitly. It was resolving transitively through `ruby-openai`, which would have made a future `ruby-openai` change break Etsy publishing for no visible reason. Lockfile change is one line in `DEPENDENCIES`, no versions moved.

## Test plan

`bundle exec rspec` over the changed areas — **218 examples, 0 failures**:

- `spec/services/etsy/` — copy rules, client (WebMock: rotated refresh token persisted, `x-api-key` colon form, tags as one param, price via inventory `PUT`, unknown taxonomy raises, 20 MB cap), and publish (asserts `state: "draft"`, guards, error persistence)
- `spec/services/printables/` — TPT/generic paste blocks, shared included-items list
- `spec/services/boards/printables/` — listing images plus the existing wrapper/merge/generate specs, to confirm the layout change didn't move the PDFs
- `spec/models/board_printable_spec.rb`, `spec/models/oauth_credential_spec.rb`
- `spec/sidekiq/publish_board_printable_to_etsy_job_spec.rb`
- `spec/requests/admin/board_printables_spec.rb`, `spec/requests/api/admin/board_printables_spec.rb`, `spec/requests/admin/access_control_spec.rb`

Also verified by hand: `bin/rails zeitwerk:check` clean, `rake etsy:status` reports correctly with nothing configured, and both gallery PNGs rendered for real against a live board (Grover is stubbed in the specs).

**Not verified:** the admin page in a browser. The dev server in this worktree can't serve `application.css` (sprockets reports it missing despite the file existing; `yarn install` timed out) — a pre-existing worktree setup issue, unrelated to this change. The request spec asserts the page renders with every new section, but nobody has looked at it. Worth a click-through on staging.

## Out of scope

- Lifestyle mockups / hero / scene / about-slide images — those stay in the printables pipeline's steps 13/14. This ships cover + what's-included, which is enough for a draft to be *able* to go live.
- Gumroad publishing from Rails.
- Splitting >20 MB PDFs — Rails refuses with a message pointing at the Node pipeline rather than half-shipping.
- Activating a listing. Always manual, in Etsy.
- A note in `speakanyway-printables/.claude-notes/backlog.md` that Rails now holds a second Etsy authorization — separate repo, needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
