### PR TITLE
fix(boards): make .obf import actually create the board, and show it running

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -279,14 +279,30 @@ call is **not** gated in real production.)
 `POST /api/boards/import_obf` takes three mutually exclusive inputs, and
 **all three must keep working** — dropping one silently breaks a client:
 
-- `file` with a `.obz` extension → `ObzImporter`, synchronous, creates a
-  `BoardGroup`.
+- `file` with a `.obz` extension → `ImportObzJob`, creates a `BoardGroup`.
 - `file` with a `.obf` extension → parsed to a Hash and handed to
   `ImportFromObfJob`. Anything that isn't a JSON object is a 422 at the
   controller, never a job that fails in the background where the user can't
   see it.
 - `data` (a JSON body) → same job, no `BoardGroup` unless `board_group_id`
   is supplied.
+
+**Every branch creates its target row inside the request and answers `202`
+with an id to poll** — `board_group_id` for `.obz`, `board_id` for `.obf` and
+`data`. That is not cosmetic: a response with no id gives the client nothing
+to follow, so the frontend has to guess, and a failure in the job never
+reaches the user. It also turns a row that can't be created into a visible
+422 instead of a job that dies alone. The job then only fills the row in,
+writing the same statuses every other generation job uses and
+`BoardGenerationStatusPage` polls: `processing` → `complete` / `failed`.
+
+**A board row is never saved without a slug.** `boards.slug` defaults to `""`
+and `validates :slug, uniqueness: true` does not skip blanks, so the *second*
+slug-less board in the whole table fails validation. `ImportFromObfJob` used
+to save one, log the rejection at `debug` (production runs at `info`), and
+return — every `.obf` import after the first silently created nothing, with
+no board, no error, and no log line. Call `generate_unique_slug` before
+`save` on any new board; `find_or_init_board_for_import` already does.
 
 The app's own `download_obf` produces a bare `.obf`, so the `.obf` file
 branch is what makes export→import round-trip. It was missing until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   silence. Imports now create their board up front, so the request answers with
   something to follow: both .obf and .obz land on a progress screen that shows
   the import running and says so plainly if it fails, instead of leaving you to
-  guess whether it worked.
+  guess whether it worked. Boards left stranded by the old behavior are
+  repaired by `rake obf_import:cleanup` — one that got its tiles is marked
+  finished, one that never got any is marked failed, and nothing is deleted.
 
 - **Words on newly built boards were still coming out Title Cased.** Tiles are
   supposed to default to lowercase, the AAC core-vocabulary convention, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   when Etsy zooms it. The images are full size now. Existing listings need their
   images regenerated from the admin page to pick this up.
 
+- **Importing an .obf file did nothing at all.** The file analyzed fine, but
+  clicking Import dropped you back on the boards list with no new board and no
+  error — and nothing in the logs either. The import was failing on a blank
+  slug the moment a single slug-less board existed anywhere, and the job wrote
+  that failure at a log level production doesn't record, so it failed in total
+  silence. Imports now create their board up front, so the request answers with
+  something to follow: both .obf and .obz land on a progress screen that shows
+  the import running and says so plainly if it fails, instead of leaving you to
+  guess whether it worked.
+
 - **Words on newly built boards were still coming out Title Cased.** Tiles are
   supposed to default to lowercase, the AAC core-vocabulary convention, and the
   creation paths were fixed for that — but cloning a board copied the source's

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -752,6 +752,11 @@ class API::BoardsController < API::ApplicationController
 
   def analyze_obz
     uploaded_file = params[:file]
+    if uploaded_file.blank?
+      render json: { error: "No file or data provided" }, status: :unprocessable_content
+      return
+    end
+
     report = ObzAnalyzer.analyze(uploaded_file.read)
     render json: report
   end
@@ -800,13 +805,22 @@ class API::BoardsController < API::ApplicationController
           return
         end
 
+        board = build_obf_placeholder_board(json_data)
+        unless board
+          render json: { error: "OBF import failed: could not create the board" },
+                 status: :unprocessable_content
+          return
+        end
+
         # Sidekiq serializes args to JSON — pass string-keyed hash.
-        ImportFromObfJob.perform_async(json_data, current_user.id, nil, import_options.stringify_keys)
+        ImportFromObfJob.perform_async(json_data, current_user.id, nil, import_options.stringify_keys, board.id)
         render json: {
           status: "ok",
           message: "Importing OBF file #{file_name}",
+          board_id: board.id,
+          import_status: board.status,
           include_images: import_options[:include_images],
-        }
+        }, status: :accepted
       else
         render json: { error: "Unsupported file format" }, status: :unprocessable_content
       end
@@ -822,16 +836,49 @@ class API::BoardsController < API::ApplicationController
       end
       board_name = json_data["name"] || "Imported Board"
 
+      board = build_obf_placeholder_board(json_data)
+      unless board
+        render json: { error: "OBF import failed: could not create the board" },
+               status: :unprocessable_content
+        return
+      end
+
       # Sidekiq serializes args to JSON — pass string-keyed hash.
-      ImportFromObfJob.perform_async(json_data, current_user.id, board_group&.id, import_options.stringify_keys)
+      ImportFromObfJob.perform_async(json_data, current_user.id, board_group&.id, import_options.stringify_keys, board.id)
       render json: {
         status: "ok",
         message: "Importing OBF data for board #{board_name}",
+        board_id: board.id,
+        import_status: board.status,
         include_images: import_options[:include_images],
-      }
+      }, status: :accepted
     else
       render json: { error: "No file or data provided" }, status: :unprocessable_content
     end
+  end
+
+  # The .obz branch creates its BoardGroup inside the request, so a failure is
+  # a visible 422 and the response carries an id the client can poll while the
+  # job runs. The .obf branch does the same with the Board itself — without an
+  # id there is nothing for the frontend to follow, and a failure in the job is
+  # invisible to the user.
+  #
+  # `generate_unique_slug` is load-bearing: `boards.slug` defaults to "" and
+  # `validates :slug, uniqueness: true` does not skip blanks, so a board saved
+  # without one collides with the first slug-less row in the table.
+  def build_obf_placeholder_board(json_data)
+    board = Board.new(
+      name: json_data["name"].presence || "Imported Board",
+      user: current_user,
+      status: "queued",
+    )
+    board.assign_parent
+    board.generate_unique_slug
+    board.save!
+    board
+  rescue => e
+    Rails.logger.error "[import_obf] could not create the board to import into: #{e.message}"
+    nil
   end
 
   # A bare .obf upload is a single JSON board document (an .obz is a zip of

--- a/app/sidekiq/import_from_obf_job.rb
+++ b/app/sidekiq/import_from_obf_job.rb
@@ -1,38 +1,65 @@
 class ImportFromObfJob
   include Sidekiq::Job
 
-  def perform(board_data, user_id, board_group_id = nil, import_options = {})
+  # `board_id` is the placeholder row API::BoardsController#import_obf creates
+  # inside the request, so the client gets an id to poll. The create-it-here
+  # branch is kept for jobs enqueued by an older deploy.
+  #
+  # Status vocabulary is the one BoardGenerationStatusPage polls and every
+  # other generation job writes: processing -> complete / failed.
+  def perform(board_data, user_id, board_group_id = nil, import_options = {}, board_id = nil)
     current_user = User.find_by(id: user_id)
     return unless current_user
     unless board_data.is_a?(Hash)
-      Rails.logger.error "Invalid board data provided for import: #{board_data.class.name}"
+      Rails.logger.error "[ImportFromObfJob] invalid board data for import: #{board_data.class.name}"
       return
     end
-    Rails.logger.debug "Importing from OBF file"
+
     board_group = BoardGroup.find_by(id: board_group_id, user_id: current_user.id) if board_group_id
-    board_name = board_data["name"] || "Imported Board"
-    @board = Board.new(name: board_name, user: current_user, status: "importing")
-    @board.assign_parent
-    unless @board.save
-      Rails.logger.debug "Failed to create board: #{@board.errors.full_messages.join(", ")}"
-      return
-    end
-    Rails.logger.debug "Created new board with ID #{@board.id} for import"
-    @board, _data = Board.from_obf(board_data, current_user, board_group, @board.id, import_options: import_options || {})
-    if @board
-      @board.update(status: "active")
-      Rails.logger.debug "Board import completed successfully for board ID #{@board.id}"
+    @board = resolve_board(board_id, board_data, current_user)
+    return unless @board
+
+    @board.update_column(:status, "processing")
+    imported, _data = Board.from_obf(board_data, current_user, board_group, @board.id, import_options: import_options || {})
+    if imported
+      @board = imported
+      @board.update_column(:status, "complete")
     else
-      Rails.logger.debug "Board import failed"
-      @board.update(status: "error")
+      Rails.logger.error "[ImportFromObfJob] import produced no board (board_id=#{@board.id})"
+      @board.update_column(:status, "failed")
     end
   rescue => e
-    Rails.logger.error "Error during board import: #{e.message}"
+    Rails.logger.error "[ImportFromObfJob] error during board import: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
     if @board
       @board.reset_layouts
-      @board.update(status: "error")
-      Rails.logger.error "Board status set to error for board ID #{@board.id}"
+      @board.update_column(:status, "failed")
+      Rails.logger.error "[ImportFromObfJob] board #{@board.id} marked failed"
     end
+  end
+
+  private
+
+  def resolve_board(board_id, board_data, current_user)
+    if board_id
+      board = current_user.boards.find_by(id: board_id)
+      Rails.logger.error "[ImportFromObfJob] board #{board_id} not found for user #{current_user.id}" unless board
+      return board
+    end
+
+    board = Board.new(
+      name: board_data["name"].presence || "Imported Board",
+      user: current_user,
+      status: "processing",
+    )
+    board.assign_parent
+    # Not optional: `boards.slug` defaults to "" and `validates :slug,
+    # uniqueness: true` does not skip blanks, so a board saved without a
+    # generated slug collides with the first slug-less row in the table.
+    board.generate_unique_slug
+    return board if board.save
+
+    Rails.logger.error "[ImportFromObfJob] failed to create board: #{board.errors.full_messages.join(", ")}"
+    nil
   end
 end

--- a/lib/tasks/obf_import_cleanup.rake
+++ b/lib/tasks/obf_import_cleanup.rake
@@ -1,0 +1,73 @@
+namespace :obf_import do
+  # Fallout from the silent .obf import failure (#656).
+  #
+  # Two leftovers, both harmless on their own and both worth clearing:
+  #
+  # 1. Boards parked in the retired `importing` status. ImportFromObfJob used
+  #    to write `importing` -> `active`/`error`; it now writes the vocabulary
+  #    the progress page polls (`processing` -> `complete`/`failed`). A board
+  #    still saying `importing` never reached either end. One with tiles got
+  #    its content and lost only the final status write, so it is `complete`;
+  #    one with no tiles is an empty husk from a run that died, so it is
+  #    `failed`. Nothing is deleted — an empty board is still the user's, and
+  #    they can see it and remove it themselves.
+  #
+  # 2. Boards saved with a blank slug. `boards.slug` defaults to "" and
+  #    `validates :slug, uniqueness: true` does not skip blanks, so the FIRST
+  #    such row silently blocks every later board that tries to save without
+  #    one. That is the actual bug this cleans up after; backfilling the slugs
+  #    removes the landmine for any code path that forgets to generate one.
+  #
+  #   bin/rails obf_import:cleanup                    # preview (default)
+  #   DRY_RUN=false bin/rails obf_import:cleanup      # apply
+  desc "Repair boards left stuck by the silent .obf import failure (DRY_RUN=false to apply)"
+  task cleanup: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    prefix = dry_run ? "[DRY RUN] " : ""
+
+    stuck = Board.where(status: "importing").order(:id)
+    puts "Boards stuck in the retired 'importing' status: #{stuck.count}"
+
+    repaired = Hash.new(0)
+    stuck.find_each do |board|
+      tile_count = board.board_images.count
+      target = tile_count.positive? ? "complete" : "failed"
+      repaired[target] += 1
+
+      puts "#{prefix}board ##{board.id} #{board.name.inspect} " \
+           "(user #{board.user_id}, #{tile_count} tiles) importing -> #{target}"
+
+      # update_column: this is a status correction, not a content edit. A full
+      # save would fire the board's before_save chain (layout, parent, voice)
+      # on a row nobody asked us to touch.
+      board.update_column(:status, target) unless dry_run
+    end
+
+    blank_slugs = Board.where(slug: [nil, ""]).order(:id)
+    puts
+    puts "Boards saved without a slug: #{blank_slugs.count}"
+
+    backfilled = 0
+    blank_slugs.find_each do |board|
+      begin
+        board.generate_unique_slug
+      rescue => e
+        puts "  board ##{board.id}: could not build a slug (#{e.message}) — skipped"
+        next
+      end
+      next if board.slug.blank?
+
+      backfilled += 1
+      puts "#{prefix}board ##{board.id} #{board.name.inspect} slug -> #{board.slug.inspect}"
+      # A dry run writes nothing, so generate_unique_slug can't see the slugs
+      # it just handed out — two same-named boards will preview the same slug
+      # and get distinct ones on the real run.
+      board.update_column(:slug, board.slug) unless dry_run
+    end
+
+    puts
+    puts "#{prefix}marked complete: #{repaired['complete']}, " \
+         "marked failed: #{repaired['failed']}, slugs backfilled: #{backfilled}"
+    puts "Re-run with DRY_RUN=false to apply." if dry_run
+  end
+end

--- a/spec/lib/tasks/obf_import_cleanup_rake_spec.rb
+++ b/spec/lib/tasks/obf_import_cleanup_rake_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "obf_import rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:user) { create(:user) }
+
+  def run(**env)
+    env.each { |k, v| ENV[k.to_s] = v.to_s }
+    task = Rake::Task["obf_import:cleanup"]
+    task.reenable
+    task.invoke
+  ensure
+    env.each_key { |k| ENV.delete(k.to_s) }
+  end
+
+  def silence_stream
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original
+  end
+
+  # These stand in for rows the OLD job left behind: it wrote the retired
+  # `importing` status and could save a board with no slug at all.
+  def stuck_board(name:, tiles: 0, slug: "stuck-#{SecureRandom.hex(4)}")
+    board = create(:board, user: user, name: name, slug: slug)
+    board.update_column(:status, "importing")
+    tiles.times do
+      board.board_images.create!(image: create(:image, user_id: user.id),
+                                 voice: "polly:kevin", skip_create_voice_audio: true)
+    end
+    board
+  end
+
+  describe "the default dry run" do
+    it "previews the repair without making it" do
+      board = stuck_board(name: "half imported", tiles: 1)
+
+      expect { run }.to output(
+        /\[DRY RUN\] board ##{board.id} .* importing -> complete/,
+      ).to_stdout
+
+      expect(board.reload.status).to eq("importing")
+    end
+  end
+
+  describe "with DRY_RUN=false" do
+    # It got its content and lost only the final status write.
+    it "marks a stuck board that has tiles complete" do
+      board = stuck_board(name: "half imported", tiles: 2)
+
+      silence_stream { run(DRY_RUN: false) }
+
+      expect(board.reload.status).to eq("complete")
+    end
+
+    # An empty husk from a run that died. Kept, not deleted — it is still the
+    # user's board and theirs to remove.
+    it "marks an empty stuck board failed without deleting it" do
+      board = stuck_board(name: "never got going")
+
+      silence_stream { run(DRY_RUN: false) }
+
+      expect(board.reload.status).to eq("failed")
+      expect(Board.exists?(board.id)).to be true
+    end
+
+    it "leaves boards in any other status alone" do
+      board = create(:board, user: user)
+      board.update_column(:status, "complete")
+
+      silence_stream { run(DRY_RUN: false) }
+
+      expect(board.reload.status).to eq("complete")
+    end
+
+    # The landmine: `boards.slug` defaults to "" and uniqueness does not skip
+    # blanks, so the first blank-slug row blocks every later slug-less save.
+    it "backfills a blank slug so it can't block the next board's save" do
+      board = create(:board, user: user, name: "Zoo Animals", slug: "zoo-animals")
+      board.update_column(:slug, "")
+
+      silence_stream { run(DRY_RUN: false) }
+
+      expect(board.reload.slug).to be_present
+    end
+
+    it "gives two blank-slug boards with the same name distinct slugs" do
+      first = create(:board, user: user, name: "Snack Time")
+      second = create(:board, user: user, name: "Snack Time")
+      [first, second].each { |b| b.update_column(:slug, "") }
+
+      silence_stream { run(DRY_RUN: false) }
+
+      expect(first.reload.slug).to be_present
+      expect(second.reload.slug).to be_present
+      expect(first.slug).not_to eq(second.slug)
+    end
+  end
+end

--- a/spec/requests/api/boards/import_export_spec.rb
+++ b/spec/requests/api/boards/import_export_spec.rb
@@ -60,26 +60,57 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
       # example would otherwise drain into this one's assertions.
       before { ImportFromObfJob.jobs.clear }
 
-      it "accepts the file and queues the import" do
+      # The board row is created inside the request so the response can hand
+      # back an id — without one the client has nothing to poll and a failure
+      # in the job never reaches the user.
+      it "accepts the file, creates the board to poll, and queues the import" do
         expect {
           post "/api/boards/import_obf",
                params: { file: obf_upload },
                headers: auth_headers(user)
         }.to change { ImportFromObfJob.jobs.size }.by(1)
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:accepted)
         body = JSON.parse(response.body)
         expect(body["status"]).to eq("ok")
+        expect(body["board_id"]).to be_present
+        expect(body["import_status"]).to eq("queued")
         expect(body["include_images"]).to eq(false)
+
+        board = user.boards.find(body["board_id"])
+        expect(board.slug).to be_present
       end
 
-      it "creates the board once the queued job runs" do
+      it "fills in that board once the queued job runs" do
         post "/api/boards/import_obf",
              params: { file: obf_upload },
              headers: auth_headers(user)
+        board_id = JSON.parse(response.body)["board_id"]
 
-        expect { ImportFromObfJob.drain }.to change { user.boards.count }.by(1)
-        expect(user.boards.last.status).to eq("active")
+        expect { ImportFromObfJob.drain }.not_to change { user.boards.count }
+
+        board = user.boards.find(board_id)
+        expect(board.status).to eq("complete")
+        expect(board.board_images.count).to be > 0
+      end
+
+      # `boards.slug` defaults to "" and `validates :slug, uniqueness: true`
+      # does not skip blanks, so ONE existing slug-less board was enough to
+      # fail every later import's `board.save` — silently, because the job
+      # logged that at :debug and production runs at :info. Every board we
+      # create must generate a slug before saving.
+      it "still creates the board when a slug-less board already exists" do
+        create(:board, user: create(:user), slug: "")
+
+        expect {
+          post "/api/boards/import_obf",
+               params: { file: obf_upload },
+               headers: auth_headers(user)
+        }.to change { user.boards.count }.by(1)
+
+        expect(response).to have_http_status(:accepted)
+        ImportFromObfJob.drain
+        expect(user.boards.last.status).to eq("complete")
       end
 
       it "passes the image opt-in through to the job" do
@@ -91,9 +122,9 @@ RSpec.describe "API::Boards OBF/OBZ import + export", type: :request do
              },
              headers: auth_headers(user)
 
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:accepted)
         expect(JSON.parse(response.body)["include_images"]).to eq(true)
-        options = ImportFromObfJob.jobs.last["args"].last
+        options = ImportFromObfJob.jobs.last["args"][3]
         expect(options).to include("include_images" => true, "license_acknowledged" => true)
       end
 

--- a/spec/sidekiq/import_from_obf_job_spec.rb
+++ b/spec/sidekiq/import_from_obf_job_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe ImportFromObfJob do
+  let(:user) { create(:user) }
+  let(:board_data) { JSON.parse(File.read(Rails.root.join("spec/data/test_internal.obf"))) }
+
+  # Mirrors what API::BoardsController#import_obf persists in-request before
+  # enqueueing this job: a Board in "queued", already carrying a slug.
+  def precreate_board!(owner: user)
+    board = Board.new(name: board_data["name"], user: owner, status: "queued")
+    board.assign_parent
+    board.generate_unique_slug
+    board.save!
+    board
+  end
+
+  context "with a pre-created board" do
+    it "fills that board in rather than creating another" do
+      board = precreate_board!
+
+      expect {
+        described_class.new.perform(board_data, user.id, nil, {}, board.id)
+      }.not_to change { user.boards.count }
+
+      board.reload
+      expect(board.status).to eq("complete")
+      expect(board.board_images.count).to be > 0
+    end
+
+    it "marks the board failed and logs at error when the import blows up" do
+      board = precreate_board!
+      allow(Board).to receive(:from_obf).and_raise(StandardError, "boom")
+      expect(Rails.logger).to receive(:error).at_least(:once)
+
+      described_class.new.perform(board_data, user.id, nil, {}, board.id)
+
+      expect(board.reload.status).to eq("failed")
+    end
+
+    it "does nothing when the board belongs to someone else" do
+      board = precreate_board!(owner: create(:user))
+
+      described_class.new.perform(board_data, user.id, nil, {}, board.id)
+
+      expect(board.reload.status).to eq("queued")
+    end
+  end
+
+  # Jobs enqueued by an older deploy carry no board_id.
+  context "without a board_id" do
+    it "creates the board itself" do
+      expect {
+        described_class.new.perform(board_data, user.id)
+      }.to change { user.boards.count }.by(1)
+
+      expect(user.boards.last.status).to eq("complete")
+    end
+
+    # `boards.slug` defaults to "" and `validates :slug, uniqueness: true`
+    # does not skip blanks — a board saved without a generated slug collides
+    # with the first slug-less row in the table and the import vanishes.
+    it "generates a slug so an existing slug-less board can't block the save" do
+      create(:board, user: create(:user), slug: "")
+
+      expect {
+        described_class.new.perform(board_data, user.id)
+      }.to change { user.boards.count }.by(1)
+
+      expect(user.boards.last.slug).to be_present
+    end
+  end
+
+  it "ignores board data that isn't a board document" do
+    expect {
+      described_class.new.perform([1, 2, 3], user.id)
+    }.not_to change { Board.count }
+  end
+end


### PR DESCRIPTION
## Summary

Importing a bare `.obf` file analyzed fine and then did nothing — the user landed back on `/boards` with no board, no error, and nothing in the logs. Reproduced on production today:

```
14:12:29  GET  /api/boards/5825/download_obf   200   9463ms   (exported a board)
14:17:25  POST /api/boards/analyze_obz          200     13ms
14:17:34  POST /api/boards/import_obf           200     17ms   db=2.30ms
14:17:35  GET  /api/boards                      200            (nothing new)
```

**Root cause.** `boards.slug` defaults to `""` and `validates :slug, uniqueness: true` does not skip blanks, so the *second* slug-less board in the whole table fails validation. `ImportFromObfJob` was the one board-creation path in the app that saved without calling `generate_unique_slug`, and it logged the rejection at `debug` — which production, running at `info`, does not record. Once any slug-less row existed, every `.obf` import after it failed in total silence. Confirmed by a regression spec that fails on `main`.

**The shape of the fix.** The `.obz` branch already creates its `BoardGroup` inside the request, so a failure is a visible 422 and the response carries an id the client can poll. The `.obf` and `data` branches now do the same with the Board itself: created up front with a slug, `202` with `board_id`, job fills it in. Without an id there is nothing for the frontend to follow, which is the other half of why this looked like a no-op.

The job also adopts the status vocabulary every other generation job writes and `BoardGenerationStatusPage` polls (`processing` → `complete` / `failed`, was `importing`/`active`/`error`), and logs its outcomes at `error`. A production import can no longer fail with zero log output.

Also guards `analyze_obz` against a missing `file` param, which was a 500.

Frontend counterpart: brittanyjohns/itty-bitty-frontend#666 — lands the user on the progress page instead of `/boards`.

### API change

`POST /api/boards/import_obf`, `.obf` file and `data` branches: `200 {status, message, include_images}` → `202 {status, message, board_id, import_status, include_images}`. The `.obz` branch is unchanged.

## Cleaning up what the bug left behind

`rake obf_import:cleanup` — dry run by default, `DRY_RUN=false` to apply — repairs two leftovers:

- **Boards parked in the retired `importing` status.** One with tiles got its content and lost only the final status write, so it becomes `complete`; one with no tiles is an empty husk from a run that died, so it becomes `failed`. Nothing is deleted — an empty board is still the user's and theirs to remove.
- **Boards saved with a blank slug** — the landmine itself. Backfilling their slugs removes the trap for any path that forgets to generate one.

Run the preview on production after deploy, then re-run with `DRY_RUN=false`.

## Test plan

- New regression spec: a `.obf` import still creates its board when a slug-less board already exists (fails on `main`).
- New `spec/sidekiq/import_from_obf_job_spec.rb`: fills a pre-created board, marks it `failed` and logs at `error` when the import raises, ignores a board owned by someone else, and generates a slug on the legacy no-`board_id` path.
- New `spec/lib/tasks/obf_import_cleanup_rake_spec.rb`: the dry run previews without writing, a stuck board with tiles goes `complete`, an empty one goes `failed` and survives, other statuses are untouched, and two same-named blank-slug boards get distinct slugs.
- Updated `import_export_spec.rb` for the 202 + `board_id` contract.

```
bundle exec rspec spec/lib/tasks/obf_import_cleanup_rake_spec.rb spec/requests/api/boards/import_export_spec.rb spec/sidekiq/import_from_obf_job_spec.rb spec/sidekiq/import_obz_job_spec.rb spec/models/obz_importer_spec.rb spec/services/boards/obz_round_trip_spec.rb spec/models/board_from_obf_idempotency_spec.rb
58 examples, 0 failures
```

Docs: `.claude-notes/boards-and-teams.md` records the new response shapes and the never-save-a-board-without-a-slug invariant. CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
