### PR TITLE
feat(printables): regenerate and delete board printables from the admin

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -178,6 +178,33 @@ instead of 2040 until it was caught. `width:`/`height:` are PDF-only keys, and
 `to_png`/`to_jpeg` set the screenshot type themselves. Specs pin the nested
 option because the failure is invisible: the render still succeeds, just small.
 
+## Regenerating and deleting a printable
+
+`POST /admin/board_printables/:id/regenerate` re-runs `GenerateBoardPrintableJob`
+on the **same record** so it picks up board edits — `Boards::Printables::Generate`
+re-walks the tree and rewrites `board_ids`, so a sub-board added since the first
+run is included. It resets `status` to `pending` and clears `error_message`, and
+is refused while the record is already `pending`/`generating`.
+
+What it deliberately does NOT touch: `listing_copy`, `etsy_listing_id`, and the
+gallery images. Clearing reviewed copy, or the pointer to a live Etsy draft,
+would be a worse surprise than stale marketing images — which the existing
+**Regenerate** button on the listing-images card re-renders. The redirect notice
+says so.
+
+A re-run can produce different filenames (the name carries the board slug) or a
+different variant set (one `full` file becomes a `color`/`low_ink` pair once the
+tree grows past one board), so `Generate` calls
+`BoardPrintable#purge_stale_pdfs!` with the keys it just wrote. That runs
+**after** the new files are attached — same rule as the listing images — so a
+failed re-render leaves the previous downloads in place rather than emptying the
+record.
+
+`DELETE /admin/board_printables/:id` destroys the record; Active Storage purges
+its PDFs and images with it. It cannot touch Etsy — this app implements no
+listing update or delete call — so the confirm dialog names the surviving draft
+id when one exists (`Admin::BoardPrintablesHelper#board_printable_delete_confirm`).
+
 ## Storage layout
 
 `BoardPrintable#files` holds both kinds of blob, separated by blob metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Regenerate and delete board printables from the admin dashboard.**
+  *Regenerate* rebuilds a printable's PDFs from the board as it is now — the
+  sub-board tree is re-walked, so pages added since the first run are picked up
+  — while keeping the listing copy you already reviewed and any Etsy draft it's
+  linked to; the old downloads are replaced only once the new ones are safely
+  built. *Delete* removes a printable and its files. An Etsy draft is never
+  touched by either action, so deleting says plainly that the draft is still
+  sitting in the Etsy seller UI waiting for you to remove it there.
+
 - **Board printables can be listed for sale from the admin dashboard.** A
   finished printable's page now carries the whole last mile: a link to the board
   it was built from (and every sub-board in the tree), editable listing copy

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -78,6 +78,44 @@ module Admin
       end
     end
 
+    # Re-runs the whole PDF pipeline on the SAME record so the printable picks
+    # up board edits. The tree is re-walked (Generate rewrites board_ids), so a
+    # subboard added since the first run is included.
+    #
+    # Listing copy, the Etsy listing id and the gallery images are deliberately
+    # left alone: regenerating is about the document, and silently clearing an
+    # admin's reviewed copy — or the pointer to a live Etsy draft — would be a
+    # far worse surprise than stale marketing images they can re-render with the
+    # button that already exists.
+    def regenerate
+      printable = BoardPrintable.find(params[:id])
+
+      if %w[pending generating].include?(printable.status)
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable is already generating."
+        return
+      end
+
+      printable.update!(status: "pending", error_message: nil)
+      GenerateBoardPrintableJob.perform_async(printable.id)
+
+      redirect_to admin_dashboard_board_printable_path(printable),
+                  notice: "Regenerating from the current board… the listing images are now out of date, so re-render those when it finishes."
+    end
+
+    # Destroys the record and (via Active Storage) its PDFs and gallery images.
+    # Nothing is sent to Etsy: an existing draft stays where it is, because this
+    # app never mutates a listing's state — see Etsy::Client.
+    def destroy
+      printable = BoardPrintable.find(params[:id])
+      name = printable.board&.name || "Board ##{printable.board_id}"
+
+      printable.destroy!
+
+      redirect_to admin_dashboard_board_printables_path,
+                  notice: "Deleted the printable for “#{name}”."
+    end
+
     def regenerate_listing_images
       printable = BoardPrintable.find(params[:id])
 

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -32,6 +32,17 @@ module Admin
       "https://www.etsy.com/listing/#{printable.etsy_listing_id.to_i}"
     end
 
+    # Deleting the record can't touch Etsy — Rails only ever creates drafts and
+    # implements no update/delete call — so a printable already on Etsy has to
+    # say so loudly, or an admin deletes the record and assumes the draft went
+    # with it.
+    def board_printable_delete_confirm(printable)
+      base = "Delete this printable and its PDFs? This can't be undone."
+      return base unless printable.etsy_published?
+
+      "#{base} Etsy draft #{printable.etsy_listing_id} stays on Etsy — remove it there yourself."
+    end
+
     # The list is capped at PUBLIC_BOARD_LIMIT, so which boards you see depends
     # on the sort — the summary line says which one picked them.
     def board_sort_label(sort)

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -139,6 +139,20 @@ class BoardPrintable < ApplicationRecord
     LISTING_IMAGE_ORDER.all? { |variant| variants.include?(variant) }
   end
 
+  # PDFs left over from an earlier generation of this same record. A re-run
+  # overwrites the deterministic key when the filename matches, but the filename
+  # carries the board slug and the variant set depends on how many boards the
+  # walk found — so a renamed board, or a subboard added since the first run,
+  # leaves a stale download sitting next to the fresh one. Purged AFTER the new
+  # files are attached, so a failed re-render never empties the record.
+  def purge_stale_pdfs!(keep_keys)
+    stale = pdf_files.reject { |f| keep_keys.include?(f.key) }
+    return if stale.empty?
+
+    stale.each(&:purge)
+    reload_files_association
+  end
+
   # Blobs from a retired gallery design. Purged after a re-render rather than
   # before it, so a render that fails leaves the old images in place instead of
   # emptying the gallery.

--- a/app/services/boards/printables/generate.rb
+++ b/app/services/boards/printables/generate.rb
@@ -33,9 +33,14 @@ module Boards
           slug: printable.board.slug.presence || "board-#{printable.board.id}",
         ).call
 
-        files.each do |file|
+        blobs = files.map do |file|
           printable.attach_pdf!(filename: file.filename, bytes: file.bytes, variant: file.variant)
         end
+
+        # A re-run of the same record can produce different filenames (renamed
+        # board) or a different variant set (a subboard added since last time),
+        # so anything not written by THIS run is a stale download.
+        printable.purge_stale_pdfs!(blobs.map(&:key))
 
         printable.update!(
           status: "complete",

--- a/app/views/admin/board_printables/index.html.erb
+++ b/app/views/admin/board_printables/index.html.erb
@@ -56,7 +56,7 @@
   <table class="w-full text-sm">
     <thead>
       <tr style="border-bottom: 1px solid var(--border);">
-        <% ["Board", "Status", "Pages", "Subboards", "Requested", "Created"].each do |label| %>
+        <% ["Board", "Status", "Pages", "Subboards", "Requested", "Created", ""].each do |label| %>
           <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
         <% end %>
       </tr>
@@ -74,6 +74,20 @@
           <td class="px-5 py-3 text-xs text-t2"><%= printable.include_subboards? ? "Yes (#{printable.board_ids.size})" : "No" %></td>
           <td class="px-5 py-3 text-xs text-t2"><%= printable.created_by&.email || "—" %></td>
           <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= printable.created_at.strftime("%b %-d, %Y %H:%M") %></td>
+          <td class="px-5 py-3 whitespace-nowrap">
+            <div class="flex items-center gap-2 justify-end">
+              <% unless %w[pending generating].include?(printable.status) %>
+                <%= button_to "Regenerate", regenerate_admin_dashboard_board_printable_path(printable),
+                      method: :post,
+                      class: "text-xs font-medium px-2.5 py-1 rounded border admin-input cursor-pointer text-t1",
+                      form: { data: { turbo_confirm: "Rebuild this printable from “#{printable.board&.name || "board ##{printable.board_id}"}” as it is now? The PDFs are replaced; listing copy is kept." } } %>
+                <%= button_to "Delete", admin_dashboard_board_printable_path(printable),
+                      method: :delete,
+                      class: "text-xs font-medium px-2.5 py-1 rounded bg-red-600 hover:bg-red-500 text-white cursor-pointer",
+                      form: { data: { turbo_confirm: board_printable_delete_confirm(printable) } } %>
+              <% end %>
+            </div>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/board_printables/show.html.erb
+++ b/app/views/admin/board_printables/show.html.erb
@@ -29,6 +29,17 @@
     <span class="<%= board_printable_status_badge(@printable.status) %> inline-block text-xs rounded px-2.5 py-1"><%= @printable.status %></span>
     <% if %w[pending generating].include?(@printable.status) %>
       <span class="text-xs text-t3">This page refreshes automatically every 5 seconds.</span>
+    <% else %>
+      <%# Regenerating re-walks the board tree, so this is how a printable picks
+          up board edits. It keeps the listing copy and any Etsy draft. %>
+      <%= button_to "Regenerate", regenerate_admin_dashboard_board_printable_path(@printable),
+            method: :post,
+            class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1",
+            form: { data: { turbo_confirm: "Rebuild this printable from the board as it is now? The PDFs are replaced; your listing copy is kept, and the listing images will need re-rendering." } } %>
+      <%= button_to "Delete printable", admin_dashboard_board_printable_path(@printable),
+            method: :delete,
+            class: "text-xs font-medium px-3 py-1.5 rounded bg-red-600 hover:bg-red-500 text-white cursor-pointer",
+            form: { data: { turbo_confirm: board_printable_delete_confirm(@printable) } } %>
     <% end %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,11 +103,12 @@ Rails.application.routes.draw do
     end
     get "feedback", to: "feedback#index", as: :dashboard_feedback
     get "word_events", to: "word_events#index", as: :dashboard_word_events
-    resources :board_printables, only: [:index, :show, :create], as: :dashboard_board_printables do
+    resources :board_printables, only: [:index, :show, :create, :destroy], as: :dashboard_board_printables do
       member do
         patch :update_listing
         post :publish_to_etsy
         post :regenerate_listing_images
+        post :regenerate
       end
     end
   end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -525,5 +525,90 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
         expect(flash[:alert]).to be_present
       end
     end
+
+    describe "POST regenerate" do
+      it "re-runs the PDF pipeline on the same record" do
+        sign_in admin
+
+        expect(GenerateBoardPrintableJob).to receive(:perform_async).with(printable.id)
+
+        post regenerate_admin_dashboard_board_printable_path(printable)
+
+        expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+        expect(printable.reload.status).to eq("pending")
+      end
+
+      it "keeps the listing copy and the Etsy draft — regenerating is about the document" do
+        sign_in admin
+        allow(GenerateBoardPrintableJob).to receive(:perform_async)
+        printable.update!(listing_copy: { "title" => "Reviewed title" }, etsy_listing_id: 987)
+
+        post regenerate_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.listing_copy["title"]).to eq("Reviewed title")
+        expect(printable.etsy_listing_id).to eq(987)
+      end
+
+      it "clears a previous failure so the status card isn't stale while it re-runs" do
+        sign_in admin
+        allow(GenerateBoardPrintableJob).to receive(:perform_async)
+        printable.update_columns(status: "failed", error_message: "Chrome died")
+
+        post regenerate_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.status).to eq("pending")
+        expect(printable.error_message).to be_nil
+      end
+
+      it "refuses a printable that is already generating" do
+        sign_in admin
+        printable.update_columns(status: "generating")
+
+        expect(GenerateBoardPrintableJob).not_to receive(:perform_async)
+
+        post regenerate_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to be_present
+      end
+
+      it "refuses a non-admin" do
+        sign_in create(:user)
+
+        expect(GenerateBoardPrintableJob).not_to receive(:perform_async)
+
+        post regenerate_admin_dashboard_board_printable_path(printable)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "deletes the printable and its files" do
+        sign_in admin
+
+        expect {
+          delete admin_dashboard_board_printable_path(printable)
+        }.to change(BoardPrintable, :count).by(-1)
+
+        expect(response).to redirect_to(admin_dashboard_board_printables_path)
+        expect(flash[:notice]).to include("Core Words")
+      end
+
+      it "leaves the board itself alone" do
+        sign_in admin
+
+        delete admin_dashboard_board_printable_path(printable)
+
+        expect(Board.find_by(id: board.id)).to be_present
+      end
+
+      it "refuses a non-admin" do
+        sign_in create(:user)
+
+        expect {
+          delete admin_dashboard_board_printable_path(printable)
+        }.not_to change(BoardPrintable, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 end

--- a/spec/services/boards/printables/generate_spec.rb
+++ b/spec/services/boards/printables/generate_spec.rb
@@ -151,4 +151,42 @@ RSpec.describe Boards::Printables::Generate do
 
     expect(printable.reload.files.count).to eq(1)
   end
+
+  # The admin "Regenerate" action re-runs this on a record that already has
+  # files. The filename carries the board slug, so a rename would otherwise
+  # leave the previous PDF attached and downloadable next to the fresh one.
+  it "purges a previous run's PDF when the board slug has changed" do
+    printable = printable_for
+    described_class.new(printable: printable).call
+
+    root.update_column(:slug, "core-words-v2")
+    described_class.new(printable: printable).call
+    printable.reload
+
+    expect(printable.files_view.map { |f| f[:filename] }).to eq(["core-words-v2.pdf"])
+  end
+
+  # A subboard added since the first run flips the document from one full file
+  # to a colour/low-ink pair; the orphaned "full" file is not a real download.
+  it "purges the single-board file when the tree has grown into a bundle" do
+    printable = printable_for(include_subboards: true)
+    described_class.new(printable: printable).call
+
+    link(root, create(:board, user: user, name: "Food"))
+    described_class.new(printable: printable).call
+    printable.reload
+
+    expect(printable.files_view.map { |f| f[:variant] })
+      .to match_array([BoardPrintable::VARIANT_COLOR, BoardPrintable::VARIANT_LOW_INK])
+  end
+
+  it "leaves the listing images alone when the PDFs are regenerated" do
+    printable = printable_for
+    described_class.new(printable: printable).call
+    printable.attach_image!(bytes: "png", variant: BoardPrintable::IMAGE_HERO)
+
+    described_class.new(printable: printable).call
+
+    expect(printable.reload.image_files.map { |f| f.metadata["variant"] }).to eq([BoardPrintable::IMAGE_HERO])
+  end
 end


### PR DESCRIPTION
## Summary

A board printable was a one-shot. Once the board it was built from changed, there was no way to rebuild the PDFs, and no way to remove a printable that was no longer wanted.

**Regenerate** (`POST /admin/board_printables/:id/regenerate`) re-runs `GenerateBoardPrintableJob` on the same record. `Boards::Printables::Generate` re-walks the tree and rewrites `board_ids`, so board edits — including a sub-board added since the first run — are picked up. It resets `status` to `pending`, clears `error_message`, and is refused while the record is already pending/generating.

It deliberately leaves `listing_copy`, `etsy_listing_id`, and the gallery images alone: clearing reviewed copy or the pointer to a live Etsy draft would be a worse surprise than stale marketing images, which the existing button on the listing-images card re-renders. The redirect notice says so.

**Delete** (`DELETE /admin/board_printables/:id`) destroys the record; Active Storage purges its PDFs and images with it.

Both buttons live on the show page's status card and in each row of the recent-printables table, hidden while a printable is generating.

## Worth a reviewer's attention

- **Stale PDFs.** A re-run can produce different filenames (the name carries the board slug) or a different variant set — one `full` file becomes a `color`/`low_ink` pair once the tree grows past one board — leaving an orphaned, downloadable PDF next to the fresh one. `BoardPrintable#purge_stale_pdfs!` drops anything not written by the current run. It's called **after** the new files attach, same rule as the listing images, so a failed re-render leaves the previous downloads in place rather than emptying the record.
- **Deleting can't touch Etsy.** Rails implements no listing update or delete call (that absence is the drafts-only guarantee), so a deleted printable leaves its Etsy draft behind. `board_printable_delete_confirm` names the surviving listing id in the confirm dialog so an admin doesn't assume the draft went with it.
- Both new actions are gated by inheritance from `Admin::ApplicationController`; the namespace-wide `spec/requests/admin/access_control_spec.rb` sweep still passes.

## Test plan

```
bundle exec rspec spec/services/boards/printables/generate_spec.rb spec/requests/admin/board_printables_spec.rb
```
63 examples, 0 failures.

- Request specs: regenerate enqueues the job + resets status, preserves listing copy and the Etsy id, clears a previous failure, refuses mid-generation, refuses a non-admin; destroy deletes the record, leaves the board itself alone, refuses a non-admin.
- Service specs: stale PDF purged on a slug change and on single→bundle growth; listing images untouched by a PDF regeneration.

```
bundle exec rspec spec/requests/admin/access_control_spec.rb
```
14 examples, 0 failures.

## Docs

- `.claude-notes/board-printables-etsy.md` — new "Regenerating and deleting a printable" section.
- `CHANGELOG.md` — user-facing entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)