### PR TITLE
fix(internal-api): stop pinning Title Case from the caller's word list

### DIFF
--- a/.claude-notes/internal-api.md
+++ b/.claude-notes/internal-api.md
@@ -100,9 +100,15 @@ That is the escape hatch for callers that resolved a label themselves via
 `POST /api/internal/images/search`.
 
 **Case pinning.** The resolver may return a differently-cased image (`"Run"` →
-`run`). The controller writes the caller's authored casing to the cell's
-`display_label` so tiles aren't silently renamed; an explicit `display_label`
-always wins.
+`run`), and the controller writes the caller's casing to the cell's
+`display_label` so tiles aren't silently renamed — but `label:` is the WORD, so
+it goes through `Labels::CaseNormalizer` first, exactly like every other
+defaulted tile. `"Stop"` builds a tile reading `stop`; `"iPad"`, `"TV"` and a
+folder cell's `"Food"` keep their casing. Pinning `label` verbatim (what this
+did until #653's follow-up) made the endpoint the last remaining way to mint
+Title Cased tiles — a word list typed the natural way became a board that read
+that way. An explicit `display_label` is the deliberate override and always
+wins, untouched.
 
 **AI art for misses is on by default.** A label that resolves to an art-less
 image gets `GenerateImagesJob` enqueued in batches of 3 — otherwise the tile is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Boards built through the internal API still came out Title Cased.** The
+  endpoint treated the word you send as authored display text and pinned its
+  casing, so a word list typed the natural way — "Yes / No / Say it again" —
+  built a board that read exactly that, sitting next to lowercase tiles from
+  every other path. The word now gets the same lowercase default as everywhere
+  else. Deliberate casing ("iPad", "TV", "HELP"), folder tiles ("Food"), and an
+  explicitly supplied display label are all still kept exactly as sent.
+
 - **Board pages were being sliced off at the bottom of the listing images.**
   On the what's-included slide especially, each board page was cut short of its
   last row — a broken-looking image on the one slide whose job is to show what

--- a/app/controllers/api/internal/board_images_controller.rb
+++ b/app/controllers/api/internal/board_images_controller.rb
@@ -216,17 +216,34 @@ class API::Internal::BoardImagesController < API::Internal::ApplicationControlle
   end
 
   # The resolver matches case-insensitively, so "Run" can legitimately resolve
-  # to an Image labeled "run". Keep the caller's authored casing on the cell
-  # rather than silently renaming the tile — same rule as
-  # `ImageResolver.upgrade_board_tiles!`.
+  # to an Image labeled "run". Keep the caller's casing on the cell rather than
+  # silently renaming the tile — but a `label:` is a WORD, not display text, so
+  # it gets the same casing rule as every other defaulted tile first.
+  #
+  # This used to pin `label` verbatim, which made the endpoint the last way to
+  # mint Title Cased tiles after the creation and clone paths were fixed: a
+  # word list written "Yes / No / Say it again" — the natural way to type one —
+  # became a board that rendered exactly that. A leading capital is not evidence
+  # of intent (Labels::CaseNormalizer), so it folds; a capital past the first
+  # letter ("iPad", "TV", "HELP") still survives, as does a door's capital.
+  #
+  # A caller that genuinely wants display text different from the word sends
+  # `display_label:` — that is the explicit override, and it is left untouched.
   def pin_authored_label!(board_image, p, image)
     return unless label_path?(p)
     return if p[:display_label].present?
 
     authored = p[:label].to_s.strip
-    return if authored.blank? || authored == image.label
+    return if authored.blank?
 
-    board_image.update(display_label: authored)
+    intended = if board_image.authored_tile_text?
+        authored
+      else
+        board_image.normalized_default_label(authored)
+      end
+    return if intended == board_image.display_label
+
+    board_image.update(display_label: intended)
   end
 
   # Queue AI art for any label that resolved to an Image with no artwork.

--- a/spec/requests/api/internal/board_images_spec.rb
+++ b/spec/requests/api/internal/board_images_spec.rb
@@ -294,12 +294,38 @@ RSpec.describe "API::Internal::BoardImages", type: :request do
       expect(board.reload.board_images.last.image_id).to eq(arted.id)
     end
 
-    it "keeps the caller's authored casing as the cell's display_label" do
+    # A `label:` is the WORD, not display text. Pinning it verbatim made this
+    # endpoint the last way to mint Title Cased tiles: a word list typed the
+    # natural way ("Yes / No / Say it again") built a board that read that way.
+    it "folds a plain leading capital out of the caller's label" do
       with_art(create(:image, label: "stop", user_id: admin_user.id))
 
       bulk_post([{ label: "Stop" }])
 
-      expect(board.reload.board_images.last.display_label).to eq("Stop")
+      expect(board.reload.board_images.last.display_label).to eq("stop")
+    end
+
+    it "folds a multi-word label the same way" do
+      bulk_post([{ label: "Say it again" }])
+
+      expect(board.reload.board_images.last.display_label).to eq("say it again")
+    end
+
+    it "keeps casing the caller could only have typed on purpose" do
+      with_art(create(:image, label: "ipad", user_id: admin_user.id))
+
+      bulk_post([{ label: "iPad" }])
+
+      expect(board.reload.board_images.last.display_label).to eq("iPad")
+    end
+
+    it "keeps a folder tile's capital" do
+      page = create(:board, user: admin_user, name: "Food")
+      with_art(create(:image, label: "food", user_id: admin_user.id))
+
+      bulk_post([{ label: "Food", predictive_board_id: page.id }])
+
+      expect(board.reload.board_images.last.display_label).to eq("Food")
     end
 
     it "does not override an explicit display_label with the authored casing" do


### PR DESCRIPTION
Follow-up to #653. Boards were *still* being created Title Cased — board 5889 on production had 161 such tiles ("Yes", "No", "Say it again", "Don't shout", "My wheelchair"). This is the path that made them.

## What was wrong

`API::Internal::BoardImagesController#pin_authored_label!` wrote the caller's `label:` onto the tile's `display_label` verbatim. The intent was right — the resolver matches case-insensitively, so `"Run"` can land on an Image labeled `run`, and the tile shouldn't be silently renamed — but it treated the **word** as authored **display text**.

With the creation paths (#636) and the clone paths (#653) fixed, this was the last way left to mint Title Cased tiles, and it's the path the board-build tooling posts to. A word list typed the natural way — "Yes / No / Say it again" — built a board that read exactly that, sitting next to lowercase tiles from every other path.

Per the project's own rule (`Labels::CaseNormalizer`), a plain leading capital is *not* evidence of intent — it's what typing a word list produces.

## What changed

`label:` now goes through `Labels::CaseNormalizer` before it's pinned, like every other defaulted tile. Kept exactly as sent:

- casing the caller could only have typed on purpose — `iPad`, `TV`, `HELP`
- a folder cell's capital — `"Food"` with a `predictive_board_id`, via `BoardImage#authored_tile_text?` (added in #653)
- an explicit `display_label:` — the deliberate override, untouched

The skill that drives this endpoint sends `label` + `links_to`, so word tiles fold and folder tiles keep their capital, which is the intended result.

## Reviewer notes

- **One existing spec asserted the old behavior** ("keeps the caller's authored casing as the cell's display_label" → `"Stop"`). It now expects `"stop"`. That's the intended contract change, not a broken test.
- Boards already built this way still need the backfill: `bin/rails labels:fold_casing APPLY=1 USER_ID=1 ONLY=down`. Note the report task (`labels:fold_casing_report`) ignores `APPLY=1` — it's hardcoded dry-run, which is easy to trip over.
- Not touched: `board_from_screenshot` still stores raw OCR casing, and the OBF importer still pins authored button labels (documented as deliberate in `CLAUDE.md`). Both are arguably the same mistake — an OCR pass isn't an author either — but they're separate calls.

## Test plan

Updated + new specs in `spec/requests/api/internal/board_images_spec.rb`: a plain capital folds (`"Stop"` → `stop`), a multi-word label folds (`"Say it again"` → `say it again`), deliberate casing survives (`"iPad"`), a folder cell keeps its capital (`"Food"` + `predictive_board_id`), and an explicit `display_label` still wins.

```
bundle exec rspec spec/requests/api/internal/ spec/models/board_image_spec.rb \
  spec/services/labels/case_normalizer_spec.rb
→ 218 examples, 0 failures
```

Docs: `.claude-notes/internal-api.md` (case-pinning section rewritten), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)