### PR TITLE
feat(printables): ship a trim-ready third PDF and stage the tablet in the app

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -90,8 +90,50 @@ Each of these was a live failure, not a theory:
   `6816` out of the printables repo's example config or its
   `docs/etsy-cli-for-agents.md` — both are stale, and 6816 is the id that filed
   every listing under nail-art dotting tools.
-- A download file is capped at 20 MB. Rails refuses an oversized PDF rather
-  than failing mid-upload; splitting is still the Node pipeline's job.
+- A download file is capped at 20 MB, and a listing at **five** of them
+  (`Client::MAX_DOWNLOAD_FILES`). Rails refuses an oversized or over-count
+  upload up front rather than failing mid-upload after the draft already
+  exists; splitting an oversized PDF is still the Node pipeline's job. A board
+  printable ships three files, so the count guard is there for the fourth
+  variant nobody remembers to count.
+
+## What's in the download — three PDFs, not two
+
+Every printable ships each board three times
+(`BoardPrintable::DOWNLOAD_VARIANTS`, in this order):
+
+| Variant | Ink | Header |
+|---|---|---|
+| `color` | full colour | full band — logo, board title, scan-me line, QR |
+| `low_ink` | white tile backgrounds | full band |
+| `trim_ready` | full colour | **QR alone, top-right** |
+
+A single board is ONE file holding all three pages; a subboard tree is three
+files (`<slug>.color.pdf`, `.low-ink.pdf`, `.trim-ready.pdf`), each fully
+wrapped with its own cover, how-to-use, license and credits so any one of them
+stands alone. The trim-ready file reuses the **colour** cover — it is a colour
+print, only its board pages differ — and gets its own how-to-use page, because
+that page is the only thing that tells a reader where the QR went.
+
+**`hide_header: true` is not the way to build the trim-ready page.** The QR
+lives *inside* the header block in `api/boards/print.html.erb`, so hiding the
+header takes the code with it — and the free audio companion is the single
+claim the whole listing leans on. `Boards::RenderAssetData` therefore carries a
+three-state `header_mode` (`full` / `qr_only` / `none`), never a second boolean
+that can contradict `hide_header`:
+
+- `qr_only` reserves a 20mm band (`#header_band_height_mm`) instead of 30-34mm
+  and prints a 0.6in QR in the corner. The band is **reserved, not overlaid**:
+  a width-limited board spans the full sheet, so a floating QR would land on
+  tiles.
+- `hide_header:` still works for the callers that only ever wanted
+  all-or-nothing (board previews, the print endpoints, the gallery's grid
+  thumbnails) and maps onto `full`/`none`. `header_mode:` wins when both are
+  given.
+
+`Printables::IncludedItems.headline` is the buyer-facing count and is shared by
+the listing description and the what's-included slide — changing the variant
+set means changing it in that one place, and both follow.
 
 ## Listing copy lives in two languages
 
@@ -117,7 +159,7 @@ saved.
 
 ## Gallery images
 
-`Boards::Printables::RenderListingImages` renders **five** square 2560px slides
+`Boards::Printables::RenderListingImages` renders **six** square 2560px slides
 through `layouts/listing_image.html.erb` — a marketing canvas of its own, not
 the print sheet. `LISTING_IMAGE_ORDER` is the Etsy rank order, and rank 1 is the
 search thumbnail:
@@ -125,7 +167,7 @@ search thumbnail:
 | Slide | Board-specific? | Ported from (`speakanyway-printables`) |
 |---|---|---|
 | `hero` | yes — real page thumbnails on a room background | `previews/hero-board.*` |
-| `on_a_device` | yes — the root board warped onto a photographed tablet | step 14 + `templates/compose-mockup.ts` |
+| `on_a_device` | yes — the root board, in the app's chrome, warped onto a photographed tablet | step 14 + `previews/content-mock-app.*` |
 | `whats_included` | yes — capped thumbnail grid of the colour pages | `previews/whats-included.*` |
 | `whats_included_low_ink` | yes — the same grid rendered `hide_colors` | — |
 | `how_it_works` | no | `plugins/aac/.../about-saw.*` (steps half) |
@@ -144,6 +186,24 @@ their hand-clicked screen corners are vendored into
 `Boards::Printables::TabletScene`. The other seventeen stage products this app
 doesn't make (ID cards, device tags, stickers, tattoos) or warp a printed sheet
 onto furniture — that compositing is still that repo's job.
+
+**What sits on the glass is the app, not a sheet of paper.**
+`Boards::Printables::RenderDeviceScreen` wraps the board in SpeakAnyWay's own
+chrome — board name, nav, empty speech bar, play/clear/download — and *that*
+screenshot is what gets warped. A bare printed page there reads as a photograph
+of a printout taped to a tablet, and carries nothing saying the thing on screen
+talks; the print header would put a scan-me band and a second QR on the glass.
+Ported from that repo's `renderContentAppPage`, chrome and all, so a listing
+from either source shows one app. Two constraints:
+
+- **The shell is 1100x720 (~1.528)**, the mean of the two tablet quad aspects
+  in `TabletScene::SCENES`. The homography stretches the artwork onto the quad
+  whatever shape it is, so a shell at another aspect arrives visibly squashed.
+- **The board image is the header-less thumbnail** the what's-included grid
+  already rendered, so the slide costs one extra Grover render, not two. A
+  board too tall for the shell is top-anchored and clipped — that's what a real
+  screen with more board below the fold looks like — and a short wide one is
+  centred.
 
 Three things hold the warp together:
 
@@ -193,11 +253,12 @@ Rules that hold across the slides:
   `CollectPages` prints from. The old note here said page thumbnails would need
   poppler/ImageMagick, which the deploy image lacks — they don't, and that is
   what unlocked showing real boards in the gallery.
-- **The hero keeps the page header; the grids don't.** The printed QR lives
-  inside that header (`api/boards/print.html.erb`), and the hero's claim is that
-  the sheet itself carries the code. On a grid tile at a sixth the size the
-  header is just the slide's own title band again, so `hide_header: true` gives
-  the board the whole tile.
+- **The hero keeps the page header; the grids and the tablet don't.** The
+  printed QR lives inside that header (`api/boards/print.html.erb`), and the
+  hero's claim is that the sheet itself carries the code. On a grid tile at a
+  sixth the size the header is just the slide's own title band again, so
+  `hide_header: true` gives the board the whole tile; on the tablet it is the
+  tell that the screen is really a photographed printout.
 - **Thumbnails are trimmed by measurement, not calculation.** How much of a
   Letter sheet a board fills depends on its shape; a 12x3 grid leaves over half
   the page blank and reads as a broken image. The header renders ~24mm against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Every board printable now includes a third, trim-ready PDF.** Alongside the
+  full-colour and low-ink versions, each board is printed once more with the
+  header removed so the board fills as much of the sheet as possible — the
+  version to print when you're cutting and laminating. The QR code moves to the
+  top corner rather than disappearing with the header, so the free audio
+  companion is still one scan away after the page has been trimmed. A single
+  board arrives as one file holding all three; a board set arrives as three
+  files, each with its own cover and instructions.
+
 - **Regenerate and delete board printables from the admin dashboard.**
   *Regenerate* rebuilds a printable's PDFs from the board as it is now — the
   sub-board tree is re-walked, so pages added since the first run are picked up
@@ -28,6 +37,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   has looked at the category, the photos, and the return policy.
 
 ### Changed
+
+- **The listing gallery's tablet slide now shows the SpeakAnyWay app, not a
+  printout.** The board sits inside the app's own header — board name, speech
+  bar, play/clear/download — instead of being a printed page with its scan-me
+  band warped onto the glass, so the slide reads as "this also opens on the
+  tablet you already own" rather than as a photo of paper taped to a screen.
 
 - **Board printables now get a real listing gallery.** The marketplace images
   used to be the printed cover and a text slide, shrunk onto a square mat —

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -2,8 +2,9 @@
 # board plus its whole subboard tree). Admin-only; this is the in-app port of
 # the speakanyway-printables pipeline's PDF-producing core.
 #
-# One attachment for a single board (the 6-page document), two for a subboard
-# bundle (a colour variant and a low-ink variant, each fully wrapped).
+# One attachment for a single board (one document holding every variant of the
+# page), three for a subboard bundle (colour, low-ink and trim-ready, each
+# fully wrapped).
 #
 # Deliberately NOT `board.pdf_file` — that's the existing single-page cached
 # board export and it's exposed through Board#api_view.
@@ -16,11 +17,20 @@ class BoardPrintable < ApplicationRecord
   # worker for hours by typo.
   MAX_BOARDS_CEILING = 100
 
-  # The single-board document carries both the colour and the low-ink page,
-  # so it is neither variant — it's the whole printable.
+  # The single-board document carries the colour, low-ink and trim-ready pages
+  # together, so it is none of those variants — it's the whole printable.
   VARIANT_FULL = "full".freeze
   VARIANT_COLOR = "color".freeze
   VARIANT_LOW_INK = "low_ink".freeze
+  # Full colour with the print header replaced by a corner QR: the board fills
+  # the sheet, and the code survives a buyer trimming the page down before
+  # laminating it. Ships alongside the other two, never instead of them.
+  VARIANT_TRIM_READY = "trim_ready".freeze
+
+  # Order is the order the files are attached, listed in the admin, and
+  # uploaded to a marketplace — colour first, because it's the one a buyer
+  # prints if they only print one.
+  DOWNLOAD_VARIANTS = [VARIANT_COLOR, VARIANT_LOW_INK, VARIANT_TRIM_READY].freeze
 
   # `files` holds two kinds of blob: the printable PDFs a buyer downloads, and
   # the PNG gallery images a marketplace listing needs. They are separated by

--- a/app/services/boards/printables/collect_pages.rb
+++ b/app/services/boards/printables/collect_pages.rb
@@ -1,5 +1,6 @@
 # Port of the printables pipeline's step 05 (build-content). Walks the board
-# tree, then renders every board twice — once in colour, once low-ink.
+# tree, then renders every board once per BoardPrintable::DOWNLOAD_VARIANTS —
+# colour, low-ink, and trim-ready (colour, header replaced by a corner QR).
 #
 # The renderer itself already exists: this goes straight to
 # Boards::RenderAssetData rather than HTTP-calling our own
@@ -77,7 +78,7 @@ module Boards
       # => { boards: [Board], pages: [Page] }
       #
       # Page order matches the pipeline: every colour page in BFS order, then
-      # every low-ink page in the same board order.
+      # every low-ink page in the same board order, then every trim-ready one.
       def call
         boards = self.class.walk_board_tree(
           board: board,
@@ -85,10 +86,11 @@ module Boards
           max_boards: max_boards,
         )
 
-        color_pages = boards.map { |b| render_page(b, variant: BoardPrintable::VARIANT_COLOR) }
-        low_ink_pages = boards.map { |b| render_page(b, variant: BoardPrintable::VARIANT_LOW_INK) }
+        pages = BoardPrintable::DOWNLOAD_VARIANTS.flat_map do |variant|
+          boards.map { |b| render_page(b, variant: variant) }
+        end
 
-        { boards: boards, pages: color_pages + low_ink_pages }
+        { boards: boards, pages: pages }
       end
 
       private
@@ -98,14 +100,15 @@ module Boards
       def render_page(target, variant:)
         hide_colors = variant == BoardPrintable::VARIANT_LOW_INK
 
-        # hide_header stays false on every board page: the QR lives inside the
-        # header in print.html.erb, so hiding the header would also kill the
-        # per-page QR. There is no header-less-with-QR combination.
+        # Every board page carries a QR, in one form or another. The trim-ready
+        # variant drops the title band but keeps a corner code (header_mode
+        # qr_only) — a bare `hide_header: true` would take the QR with it and
+        # hand a buyer a sheet with no way back to the talking version.
         render_data = Boards::RenderAssetData.new(
           board: target,
           screen_size: "lg",
           hide_colors: hide_colors,
-          hide_header: false,
+          header_mode: header_mode_for(variant),
           routes: Rails.application.routes.url_helpers,
           include_qr: true,
           qr_target_url: qr_target_url_for(target),
@@ -124,6 +127,14 @@ module Boards
           board_name: target.name,
           variant: variant,
         )
+      end
+
+      def header_mode_for(variant)
+        if variant == BoardPrintable::VARIANT_TRIM_READY
+          Boards::RenderAssetData::HEADER_QR_ONLY
+        else
+          Boards::RenderAssetData::HEADER_FULL
+        end
       end
 
       # Every board page's QR targets ITS OWN board, so a buyer scanning page 5

--- a/app/services/boards/printables/merge_pdf.rb
+++ b/app/services/boards/printables/merge_pdf.rb
@@ -17,18 +17,26 @@ module Boards
         @slug = slug.presence || "board"
       end
 
-      # Single board  => one file:  cover, how-to-use, colour, low-ink, license, credits
-      # Subboard tree => two files: each is cover, how-to-use, that variant's N
-      #                  board pages, license, credits. No combined master —
-      #                  the cover and its root QR are duplicated into both, by
-      #                  design, so either file stands alone.
+      # Which file a bundle's variant lands in. Dasherized because a filename
+      # reads better that way and "low_ink.pdf" looks like a bug.
+      BUNDLE_FILENAMES = {
+        BoardPrintable::VARIANT_COLOR => "color",
+        BoardPrintable::VARIANT_LOW_INK => "low-ink",
+        BoardPrintable::VARIANT_TRIM_READY => "trim-ready",
+      }.freeze
+
+      # Single board  => one file:  cover, how-to-use, colour, low-ink,
+      #                  trim-ready, license, credits
+      # Subboard tree => three files: each is cover, how-to-use, that variant's
+      #                  N board pages, license, credits. No combined master —
+      #                  the cover and its root QR are duplicated into each, by
+      #                  design, so every file stands alone.
       def call
         return [single_file] if boards.length <= 1
 
-        [
-          bundle_file(BoardPrintable::VARIANT_COLOR, "#{slug}.color.pdf"),
-          bundle_file(BoardPrintable::VARIANT_LOW_INK, "#{slug}.low-ink.pdf"),
-        ]
+        BoardPrintable::DOWNLOAD_VARIANTS.map do |variant|
+          bundle_file(variant, "#{slug}.#{BUNDLE_FILENAMES.fetch(variant)}.pdf")
+        end
       end
 
       private
@@ -68,17 +76,17 @@ module Boards
       end
 
       # The cover and the how-to-use page both make claims about the file they
-      # sit in, so the low-ink FILE gets its own render of each: an ink-light
-      # cover, and instructions that describe a low-ink print rather than the
-      # colour one it doesn't contain.
+      # sit in, so each variant FILE gets its own render of them: an ink-light
+      # cover for the low-ink file, and instructions that describe the print in
+      # hand rather than a sibling file it doesn't contain.
       #
       # RenderWrappers only produces those for a set, so fall back rather than
       # assuming the key is there — the single-board file is one document
-      # holding both halves and has no low-ink identity to honour.
+      # holding every variant and has no per-variant identity to honour.
       def wrapper_for(key, variant)
-        return wrappers[key] unless variant == BoardPrintable::VARIANT_LOW_INK
+        return wrappers[key] if variant == BoardPrintable::VARIANT_COLOR
 
-        wrappers[:"#{key}_low_ink"] || wrappers[key]
+        wrappers[:"#{key}_#{variant}"] || wrappers[key]
       end
     end
   end

--- a/app/services/boards/printables/render_device_screen.rb
+++ b/app/services/boards/printables/render_device_screen.rb
@@ -1,0 +1,96 @@
+# Screenshots a board inside SpeakAnyWay's app chrome, for the tablet in the
+# "on a device" listing slide.
+#
+# The slide used to warp a bare printed page onto the glass. It read as a
+# photograph of a sheet of paper taped to a tablet: Letter-shaped, letterboxed
+# by the screen's own proportions, and carrying no sign that the thing on screen
+# talks. This wraps the same board in the app's own header — board name, nav,
+# speech bar, play/clear/download — so the slide shows the product a buyer
+# reaches by scanning the QR.
+#
+# Ported from speakanyway-printables' renderContentAppPage
+# (src/generator/steps/11-render-previews.ts). Same chrome, same shell geometry,
+# same fits-vs-clips rule, so a listing from either source shows one app.
+#
+# Grover work: Sidekiq only, never a request thread.
+module Boards
+  module Printables
+    class RenderDeviceScreen
+      # 1100x720 ≈ 1.528, the mean of the two tablet quad aspects in
+      # TabletScene::SCENES (1.50 and 1.55). A homography stretches the artwork
+      # onto the quad whatever shape it is, so this ratio is what keeps the
+      # board from arriving on the glass squashed. Changing it means re-checking
+      # every scene.
+      SHELL_WIDTH = 1100
+      SHELL_HEIGHT = 720
+
+      # 2x, matching the slide it is composited into — the tablet fills most of
+      # a 1280px square, so a 1x screen render is visibly soft.
+      SCALE = 2
+
+      # Chrome block: 20px top padding + title (27px at 1.1) + 15px margin +
+      # the 66px control row + 16px bottom padding + 1px border. Duplicated from
+      # layouts/device_screen.html.erb because the centre-vs-clip decision has
+      # to be made before the page is rendered, and only ever used for that — a
+      # few px of drift here is cosmetic.
+      CHROME_HEIGHT = 148
+      BODY_PADDING = 14
+
+      # `thumbnail` is a RenderPageThumbnails::Thumbnail of a HEADER-LESS page
+      # (Boards::RenderAssetData::HEADER_NONE). A page carrying the print header
+      # would put the scan-me band and its QR on the screen, which is the exact
+      # tell this slide exists to remove.
+      def initialize(title:, thumbnail:)
+        @title = title
+        @thumbnail = thumbnail
+      end
+
+      # => a PNG data URI, or nil when there is no board render to stage. nil
+      # rather than raising: the slide falls back to an empty tablet, which is
+      # a plainer image, not a broken gallery.
+      def call
+        return nil unless thumbnail&.data_uri.present?
+
+        html = ApplicationController.render(
+          template: "api/board_printables/device_screen",
+          layout: "device_screen",
+          assigns: {
+            title: title,
+            board_data_uri: thumbnail.data_uri,
+            fits: fits?,
+          },
+          formats: [:html],
+        )
+
+        png = Grover.new(
+          html,
+          viewport: { width: SHELL_WIDTH, height: SHELL_HEIGHT, device_scale_factor: SCALE },
+          full_page: false,
+          print_background: true,
+        ).to_png
+
+        "data:image/png;base64,#{Base64.strict_encode64(png)}"
+      rescue StandardError => e
+        Rails.logger.warn("[RenderDeviceScreen] skipped: #{e.class}: #{e.message}")
+        nil
+      end
+
+      private
+
+      attr_reader :title, :thumbnail
+
+      # Does the board, drawn at full width, still fit under the chrome? A wide,
+      # short board does and gets centred; anything taller runs past the bottom
+      # and is clipped there, which is what a real screen with more board below
+      # the fold looks like.
+      def fits?
+        return true unless thumbnail.width.to_i.positive? && thumbnail.height.to_i.positive?
+
+        body_width = SHELL_WIDTH - (BODY_PADDING * 2)
+        body_height = SHELL_HEIGHT - CHROME_HEIGHT - BODY_PADDING
+
+        (thumbnail.width.to_f / thumbnail.height) >= (body_width.to_f / body_height)
+      end
+    end
+  end
+end

--- a/app/services/boards/printables/render_listing_images.rb
+++ b/app/services/boards/printables/render_listing_images.rb
@@ -1,5 +1,6 @@
-# Renders the five marketplace gallery slides for a printable: the hero, what's
-# included in colour, the same in low-ink, how it works, and about.
+# Renders the six marketplace gallery slides for a printable: the hero, the
+# board on a tablet, what's included in colour, the same in low-ink, how it
+# works, and about.
 #
 # Etsy will create a listing with no photos but won't let it go live without
 # one, so these are the minimum a draft needs to be finishable — but they're
@@ -85,8 +86,9 @@ module Boards
       #           header is just the slide's own title band again, and hiding it
       #           gives the board the whole tile.
       #
-      # Budget: min(boards, 3) + min(boards, 8) * 2 renders, plus five slides.
-      # That is why this runs on Sidekiq and never on a request thread.
+      # Budget: min(boards, 3) + min(boards, 8) * 2 renders, plus six slides and
+      # the one device screen. That is why this runs on Sidekiq and never on a
+      # request thread.
       def hero_thumbnails
         @hero_thumbnails ||= RenderPageThumbnails.new(
           boards: plan.boards.first(HERO_TILES),
@@ -148,17 +150,24 @@ module Boards
         )
       end
 
-      # Reuses the root board's header-hidden grid thumbnail — it is already
-      # rendered, and a page with no print header is what actually reads as a
-      # screen. This slide costs one Grover render, not two.
+      # The tablet shows the board inside the APP's chrome, not a bare printed
+      # page: a Letter sheet warped onto the glass reads as a photograph of
+      # paper taped to a screen, and carries nothing that says the thing on it
+      # talks. RenderDeviceScreen wraps the root board's already-rendered
+      # header-less thumbnail in that chrome — one extra Grover render for the
+      # slide whose whole job is "this also opens on the tablet you own".
       def on_a_device_assigns
         scene = TabletScene.for(board)
+        title = Boards::AssetRendering.board_title_for(board)
 
         shared_assigns.merge(
-          title: Boards::AssetRendering.board_title_for(board),
+          title: title,
           scene: scene,
           scene_data_uri: scene.data_uri,
-          board_data_uri: grid_thumbnails(low_ink: false).dig(board.id)&.data_uri,
+          board_data_uri: RenderDeviceScreen.new(
+            title: title,
+            thumbnail: grid_thumbnails(low_ink: false)[board.id],
+          ).call,
         )
       end
 

--- a/app/services/boards/printables/render_wrappers.rb
+++ b/app/services/boards/printables/render_wrappers.rb
@@ -17,17 +17,23 @@ module Boards
       end
 
       # => { cover:, how_to_use:, license:, credits: } of PDF bytes, plus
-      #    cover_low_ink: and how_to_use_low_ink: for a set.
+      #    cover_low_ink:, how_to_use_low_ink: and how_to_use_trim_ready: for
+      #    a set. The keys are `<page>_<variant>` because that is how MergePdf
+      #    looks them up.
       #
-      # A set is emitted as two separate FILES (MergePdf), so the two pages that
-      # make claims about the document they sit in get rendered twice — once per
-      # variant — and MergePdf binds the matching one into each file. Without
-      # that, the low-ink file opens on a full-bleed gradient cover and then
-      # explains a colour print it doesn't contain.
+      # A set is emitted as three separate FILES (MergePdf), so the two pages
+      # that make claims about the document they sit in get rendered per variant
+      # and MergePdf binds the matching one into each file. Without that, the
+      # low-ink file opens on a full-bleed gradient cover and then explains a
+      # colour print it doesn't contain.
       #
-      # A single board is ONE file holding both a colour and a low-ink half, so
-      # it has no per-variant identity: one cover, one how-to-use, and the copy
-      # describes the pair of halves.
+      # No cover_trim_ready: that file is full colour, so the colour cover is
+      # already the right one — only its board pages differ. MergePdf falls back
+      # to the unsuffixed key rather than needing one rendered.
+      #
+      # A single board is ONE file holding every variant of the page, so it has
+      # no per-variant identity: one cover, one how-to-use, and the copy
+      # describes the set of halves.
       def call
         wrappers = {
           cover: render("cover", assigns: cover_assigns),
@@ -40,7 +46,8 @@ module Boards
 
         wrappers.merge(
           cover_low_ink: render("cover", assigns: cover_assigns.merge(ink_light: true)),
-          how_to_use_low_ink: render("how_to_use", assigns: how_to_use_assigns(low_ink: true)),
+          how_to_use_low_ink: render("how_to_use", assigns: how_to_use_assigns(variant: BoardPrintable::VARIANT_LOW_INK)),
+          how_to_use_trim_ready: render("how_to_use", assigns: how_to_use_assigns(variant: BoardPrintable::VARIANT_TRIM_READY)),
         )
       end
 
@@ -64,12 +71,13 @@ module Boards
 
       def set? = board_count > 1
 
-      # `low_ink` is only ever true for a set, where this page is bound into the
-      # low-ink file alone and must describe that file rather than the pair.
-      def how_to_use_assigns(low_ink: false)
+      # `variant` is only ever set for a board SET, where this page is bound
+      # into one variant's file alone and must describe that file rather than
+      # the collection of halves a single-board document holds.
+      def how_to_use_assigns(variant: nil)
         {
           is_set: set?,
-          low_ink: low_ink,
+          variant: variant,
           topic: topic,
           noun: set? ? "set of #{board_count} communication boards" : "communication board",
         }

--- a/app/services/boards/render_asset_data.rb
+++ b/app/services/boards/render_asset_data.rb
@@ -1,11 +1,29 @@
 # app/services/boards/render_asset_data.rb
 module Boards
   class RenderAssetData
-    def initialize(board:, screen_size: "lg", hide_colors: false, hide_header: false, routes:, qr_target_url: :default, include_qr: true)
+    # How much of the print header a page carries. Three states rather than two
+    # booleans, because "hide the header" and "keep the QR" can contradict each
+    # other and the combination that matters most — no title band, code intact —
+    # is exactly the one two booleans make ambiguous.
+    #
+    #   full    — logo, board title, scan-me line and the QR beside them.
+    #   qr_only — a small QR alone in the top-right. The board gets nearly the
+    #             whole sheet, and the code survives the buyer trimming the band.
+    #   none    — nothing. Used for screen mockups and grid thumbnails, where a
+    #             printed QR reads as an ad pasted on the glass.
+    HEADER_FULL = "full".freeze
+    HEADER_QR_ONLY = "qr_only".freeze
+    HEADER_NONE = "none".freeze
+    HEADER_MODES = [HEADER_FULL, HEADER_QR_ONLY, HEADER_NONE].freeze
+
+    # `hide_header:` is kept for the callers that only ever wanted all-or-
+    # nothing (board previews, the print endpoints, grid thumbnails). Pass
+    # `header_mode:` to reach the third state; it wins when both are given.
+    def initialize(board:, screen_size: "lg", hide_colors: false, hide_header: false, header_mode: nil, routes:, qr_target_url: :default, include_qr: true)
       @board = board
       @screen_size = screen_size
       @hide_colors = hide_colors
-      @hide_header = hide_header
+      @header_mode = resolve_header_mode(header_mode, hide_header)
       @routes = routes
       @qr_target_url_override = qr_target_url
       @include_qr = include_qr
@@ -28,7 +46,8 @@ module Boards
         qr_data_url: qr_data_url,
         screen_size: screen_size,
         hide_colors: hide_colors,
-        hide_header: hide_header,
+        header_mode: header_mode,
+        hide_header: header_mode == HEADER_NONE,
         columns: columns,
         rows: rows,
         tiles: tiles,
@@ -44,7 +63,14 @@ module Boards
 
     private
 
-    attr_reader :board, :screen_size, :hide_colors, :hide_header, :routes
+    attr_reader :board, :screen_size, :hide_colors, :header_mode, :routes
+
+    def resolve_header_mode(mode, hide_header)
+      return hide_header ? HEADER_NONE : HEADER_FULL if mode.blank?
+
+      mode = mode.to_s
+      HEADER_MODES.include?(mode) ? mode : HEADER_FULL
+    end
 
     def resolved_qr_target_url
       return nil unless @include_qr
@@ -77,12 +103,25 @@ module Boards
       rows > columns
     end
 
+    # The qr_only band reserves room for the code and nothing else — the QR
+    # prints at 0.6in there, so 20mm clears it with a little air. Reserving the
+    # space rather than floating the QR over the sheet is deliberate: a
+    # width-limited board spans the full page, and an overlaid code would land
+    # on top of tiles.
+    def header_band_height_mm(landscape)
+      case header_mode
+      when HEADER_NONE then 0
+      when HEADER_QR_ONLY then 20.0
+      else landscape ? 30.0 : 34.0
+      end
+    end
+
     def fitted_board_dimensions_mm(columns:, rows:, landscape:)
       page_width_mm = landscape ? 279.4 : 215.9
       page_height_mm = landscape ? 215.9 : 279.4
 
       outer_padding_mm = 6.0
-      header_height_mm = hide_header ? 0 : (landscape ? 30.0 : 34.0)
+      header_height_mm = header_band_height_mm(landscape)
       footer_buffer_mm = 2.0
 
       available_width_mm = page_width_mm - outer_padding_mm

--- a/app/services/etsy/client.rb
+++ b/app/services/etsy/client.rb
@@ -33,8 +33,12 @@ module Etsy
     TAXONOMY_CACHE_KEY = "etsy/seller_taxonomy_ids".freeze
     TAXONOMY_CACHE_TTL = 12.hours
 
-    # Etsy caps a single download file at 20 MB.
+    # Etsy caps a single download file at 20 MB, and a listing at five of them.
+    # A board printable ships three (colour, low-ink, trim-ready), so the
+    # ceiling only matters if a fourth variant is ever added — which is exactly
+    # when a silent drop would be hardest to notice.
     FILE_CAP_BYTES = 20 * 1024 * 1024
+    MAX_DOWNLOAD_FILES = 5
 
     TIMEOUT = 30
     OPEN_TIMEOUT = 10

--- a/app/services/etsy/listing_copy.rb
+++ b/app/services/etsy/listing_copy.rb
@@ -226,6 +226,8 @@ module Etsy
         "",
         "- Laminate the #{main} for the fridge, a binder, or the table.",
         "- Print the low-ink version for backups, take-home copies, and whole-class sets.",
+        "- Print the trim-ready version when you're cutting and laminating — no header to " \
+        "trim off, and the QR code still opens the talking version.",
         "- Send a copy home so vocabulary stays consistent between school and home.",
         "- Keep the tablet version open during therapy and hand the printed copy to the family.",
       ].join("\n")

--- a/app/services/etsy/publish_board_printable.rb
+++ b/app/services/etsy/publish_board_printable.rb
@@ -80,6 +80,11 @@ module Etsy
 
       return "Listing title and description are required." if copy["title"].blank? || copy["description"].blank?
 
+      if printable.pdf_files.size > Client::MAX_DOWNLOAD_FILES
+        return "This printable has #{printable.pdf_files.size} PDFs; Etsy caps a listing at " \
+               "#{Client::MAX_DOWNLOAD_FILES} download files."
+      end
+
       oversized = printable.pdf_files.find { |f| f.byte_size > Client::FILE_CAP_BYTES }
       if oversized
         return "#{oversized.filename} is #{ActiveSupport::NumberHelper.number_to_human_size(oversized.byte_size)}; " \

--- a/app/services/printables/included_items.rb
+++ b/app/services/printables/included_items.rb
@@ -11,18 +11,22 @@ module Printables
     module_function
 
     # The one line that describes the actual document, and the only line that
-    # changes with the printable. A multi-board bundle ships every board twice
-    # (color + low-ink) and arrives as TWO files, so quoting a single page count
-    # badly understates it.
+    # changes with the printable. A multi-board bundle ships every board three
+    # times (color, low-ink, trim-ready) and arrives as THREE files, so quoting
+    # a single page count badly understates it.
+    #
+    # "Trim-ready" rather than "header-less": the buyer-facing name has to say
+    # what it's FOR. The band is what gets cut off before laminating, and this
+    # is the copy that survives the cut.
     def headline(board_count:, page_count:)
       pages = page_count.to_i
 
       if board_count > 1
-        return "#{board_count} boards — 2 PDFs (full color + low-ink)" unless pages.positive?
+        return "#{board_count} boards — 3 PDFs (full color + low-ink + trim-ready)" unless pages.positive?
 
-        "#{board_count} boards, #{pages} pages — 2 PDFs (full color + low-ink)"
+        "#{board_count} boards, #{pages} pages — 3 PDFs (full color + low-ink + trim-ready)"
       else
-        pages.positive? ? "#{pages}-page board PDF — color + low-ink" : "Board PDF — color + low-ink"
+        pages.positive? ? "#{pages}-page board PDF — color, low-ink + trim-ready" : "Board PDF — color, low-ink + trim-ready"
       end
     end
 

--- a/app/services/printables/slide_copy.rb
+++ b/app/services/printables/slide_copy.rb
@@ -82,7 +82,7 @@ module Printables
     def how_it_works_steps
       [
         {title: "Download", body: "Instant PDF. No waiting, no shipping."},
-        {title: "Print", body: "Full colour or low-ink, on plain Letter paper."},
+        {title: "Print", body: "Full colour, low-ink or trim-ready. Plain Letter paper."},
         {title: "Cut & laminate", body: "Optional — laminate to make it last a school year."},
         {title: "Scan to hear it", body: "The QR opens the same board online — tap a word, it talks."},
       ]

--- a/app/views/api/board_printables/device_screen.html.erb
+++ b/app/views/api/board_printables/device_screen.html.erb
@@ -1,0 +1,54 @@
+<%# SpeakAnyWay's app chrome around a header-less render of the board: the
+    screenshot that gets warped onto the tablet in the "on a device" slide.
+
+    The sentence bar is empty and the nav says "Sign in" because that is what a
+    buyer scanning the QR actually lands on — the public board, signed out,
+    nothing tapped yet. See layouts/device_screen.html.erb for the geometry. %>
+<div class="app-shell">
+  <div class="app-chrome">
+    <div class="app-title"><%= @title %></div>
+
+    <div class="app-controls">
+      <div class="app-nav">
+        <span class="icon-btn" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#3c4654" stroke-width="2.2" stroke-linecap="round">
+            <path d="M3 6h18M3 12h18M3 18h18" />
+          </svg>
+        </span>
+        <span class="icon-btn" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#3c4654" stroke-width="2.2">
+            <rect x="3" y="3" width="7.5" height="7.5" rx="1.6" />
+            <rect x="13.5" y="3" width="7.5" height="7.5" rx="1.6" />
+            <rect x="3" y="13.5" width="7.5" height="7.5" rx="1.6" />
+            <rect x="13.5" y="13.5" width="7.5" height="7.5" rx="1.6" />
+          </svg>
+        </span>
+        <span class="signin">Sign in</span>
+      </div>
+
+      <div class="sentence-bar"></div>
+
+      <div class="app-actions">
+        <span class="action play" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="#ffffff"><path d="M8 5.5v13l11-6.5z" /></svg>
+        </span>
+        <span class="action delete" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round">
+            <path d="M4 7h16M9.5 7V5h5v2M6.5 7l1 12.5h9L17.5 7" />
+          </svg>
+        </span>
+        <span class="action download" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 4v10m0 0l-4-4m4 4l4-4M5 19h14" />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="app-body <%= "fits" if @fits %>">
+    <% if @board_data_uri.present? %>
+      <img class="app-page" src="<%= @board_data_uri %>" alt="<%= @title %>" />
+    <% end %>
+  </div>
+</div>

--- a/app/views/api/board_printables/how_to_use.html.erb
+++ b/app/views/api/board_printables/how_to_use.html.erb
@@ -5,11 +5,13 @@
     Exception — step 1, which is the one claim this page makes about the
     document it sits in, so it can only ever describe THAT document:
 
-      single board  → one file holding a colour half and a low-ink half
-      set, colour   → this file is all colour
-      set, low-ink  → this file is all low-ink
+      single board     → one file holding a colour, a low-ink and a
+                         trim-ready copy of the board
+      set, colour      → this file is all colour
+      set, low-ink     → this file is all low-ink
+      set, trim-ready  → this file is all header-less, QR in the corner
 
-    Neither set variant mentions the other file. A reader holding the low-ink
+    No set variant mentions the other files. A reader holding the low-ink
     print doesn't need to be told a colour one exists somewhere; being told so
     just raises a question the page can't answer.
 
@@ -37,17 +39,25 @@
         <span class="num">1</span>
         <div>
           <% if !@is_set %>
-            <p class="lead">Printed twice</p>
+            <p class="lead">Printed three ways</p>
             <p>
-              This file includes the board twice: once in full color, then again
-              with white tile backgrounds for a cleaner, lower-ink print. Use
-              whichever fits your printer.
+              This file includes the board three times: in full color, again
+              with white tile backgrounds for a lower-ink print, and once more
+              with no header so the board fills the whole page. Use whichever
+              fits your printer.
             </p>
-          <% elsif @low_ink %>
+          <% elsif @variant == BoardPrintable::VARIANT_LOW_INK %>
             <p class="lead">Printed low-ink</p>
             <p>
               Every board in this file uses white tile backgrounds, so it prints
               cleanly and goes easy on your ink.
+            </p>
+          <% elsif @variant == BoardPrintable::VARIANT_TRIM_READY %>
+            <p class="lead">Printed to the edges</p>
+            <p>
+              Every board in this file drops the page header so the board prints
+              as large as the sheet allows. The QR code moves to the top corner,
+              so it still opens online after you trim and laminate.
             </p>
           <% else %>
             <p class="lead">Printed in full color</p>

--- a/app/views/api/boards/print.html.erb
+++ b/app/views/api/boards/print.html.erb
@@ -1,4 +1,23 @@
-<% unless @hide_header %>
+<%# Three header states, from @header_mode (Boards::RenderAssetData) — never a
+    pair of booleans. The QR lives INSIDE this block, so "hide the header" and
+    "keep the code" are the same decision and have to be made in one place.
+
+    qr_only is what the trim-ready PDF prints: buyers cut the title band off to
+    laminate the board, and the code has to survive that cut.
+
+    Falls back to @hide_header so a caller that renders this template with its
+    own assigns — rather than through RenderAssetData — still gets the old
+    all-or-nothing behaviour instead of an unstyled full header. %>
+<% header_mode = @header_mode.presence || (@hide_header ? Boards::RenderAssetData::HEADER_NONE : Boards::RenderAssetData::HEADER_FULL) %>
+<% if header_mode == Boards::RenderAssetData::HEADER_QR_ONLY %>
+  <div class="header header-qr-only">
+    <% if @qr_data_url.present? %>
+      <div class="qr-small">
+        <img src="<%= @qr_data_url %>" alt="QR code">
+      </div>
+    <% end %>
+  </div>
+<% elsif header_mode != Boards::RenderAssetData::HEADER_NONE %>
   <div class="header">
     <div class="header-inner">
       <div class="logo">

--- a/app/views/layouts/device_screen.html.erb
+++ b/app/views/layouts/device_screen.html.erb
@@ -1,0 +1,175 @@
+<%# Layout for the tablet screen that gets warped onto the glass in the
+    "on a device" listing slide. Not a page, not a slide: a screenshot of what
+    the SpeakAnyWay app looks like with this board open.
+
+    Ported from speakanyway-printables' src/templates/previews/content-mock-app
+    .{html,css} — the same chrome that repo composites into its tablet scenes,
+    so a listing from either source shows the same app.
+
+    Two things are load-bearing:
+
+    1. The shell's aspect ratio. Boards::Printables::RenderDeviceScreen renders
+       it at 1100x720 (1.528), the mean of the two tablet quads in
+       TabletScene::SCENES (1.50 and 1.55). A homography stretches the artwork
+       onto the quad whatever shape it is, so a shell at some other aspect
+       arrives on the glass visibly squashed or stretched.
+    2. The board image is a HEADER-LESS page render. The printed header — board
+       name, scan-me line, QR — is the point on paper and a tell on a screen:
+       it reads as a photographed marketing sheet rather than the live app. The
+       chrome below replaces it, and carries the board's own name.
+
+    Nothing is fetched over the network by the chrome. Same rule as
+    layouts/listing_image.html.erb; the symbol art inside the board image is the
+    one documented exception, and it is already baked into that PNG. %>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Device screen</title>
+
+    <style>
+      <%= Boards::Printables::Fonts.face_css %>
+
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: #ffffff;
+      }
+
+      .app-shell {
+        width: 1100px;
+        height: 720px;
+        background: #ffffff;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        font-family: "Nunito", system-ui, -apple-system, sans-serif;
+        overflow: hidden;
+      }
+
+      /* ── Chrome ───────────────────────────────────────────────────────── */
+
+      .app-chrome {
+        padding: 20px 24px 16px;
+        border-bottom: 1px solid #e6e9ef;
+        background: #ffffff;
+        flex: none;
+      }
+
+      /* The board's own name, which is the whole reason this chrome beats a
+         generic app screenshot: the tablet is showing THIS product. */
+      .app-title {
+        font-size: 27px;
+        font-weight: 800;
+        color: #1b2430;
+        line-height: 1.1;
+        margin-bottom: 15px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .app-controls {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+      }
+
+      .app-nav {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex: none;
+      }
+
+      .icon-btn {
+        width: 30px;
+        height: 30px;
+        display: block;
+      }
+
+      .icon-btn svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .signin {
+        font-size: 19px;
+        font-weight: 600;
+        color: #3c4654;
+        white-space: nowrap;
+      }
+
+      /* The speech bar, empty on purpose: nothing has been tapped yet, and a
+         mocked-up sentence would be a claim about words this board may not
+         have. */
+      .sentence-bar {
+        flex: 1;
+        height: 84px;
+        background: #e8eaf6;
+        border-radius: 14px;
+        min-width: 0;
+      }
+
+      .app-actions {
+        display: flex;
+        align-items: center;
+        gap: 13px;
+        flex: none;
+      }
+
+      .action {
+        width: 78px;
+        height: 66px;
+        border-radius: 14px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .action svg {
+        width: 34px;
+        height: 34px;
+        display: block;
+      }
+
+      .action.play { background: #22c55e; }
+      .action.delete { background: #e5352b; }
+      .action.download { background: #14181f; }
+
+      /* ── Board ────────────────────────────────────────────────────────── */
+
+      .app-body {
+        flex: 1;
+        padding: 0 14px 14px;
+        box-sizing: border-box;
+        min-height: 0;
+        /* Clip, never scale. An over-tall board cut off mid-row is what a real
+           screen with more board below the fold looks like; shrinking it to fit
+           makes the tiles unreadable, which is the one thing a board
+           screenshot can't afford. */
+        overflow: hidden;
+      }
+
+      /* A board wider than the body still fits at full width and leaves room
+         underneath, and a band of white pinned to the bottom edge reads as a
+         rendering bug — so that case centres instead. */
+      .app-body.fits {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .app-page {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+    </style>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/layouts/listing_image.html.erb
+++ b/app/views/layouts/listing_image.html.erb
@@ -708,16 +708,22 @@
 
       /* These room photos are dim and warm; the scrim is what keeps the navy
          title and the footer readable over them. Top and bottom only, so the
-         tablet in the middle stays untouched. */
+         tablet in the middle stays untouched.
+
+         The top half is deliberately light and fades out early: the title
+         banner and the audio badge carry their own solid fills, so they don't
+         need the scrim to be legible — and the tablet's own screen starts at
+         ~23% of the slide, where a heavier gradient washes out the app chrome
+         and makes the screenshot read as dim rather than lit. */
       .mockup-scrim {
         position: absolute;
         inset: 0;
         z-index: 1;
         background: linear-gradient(
           180deg,
-          rgba(251, 247, 241, 0.94) 0%,
-          rgba(251, 247, 241, 0.55) 22%,
-          rgba(251, 247, 241, 0) 40%,
+          rgba(251, 247, 241, 0.90) 0%,
+          rgba(251, 247, 241, 0.35) 15%,
+          rgba(251, 247, 241, 0) 27%,
           rgba(251, 247, 241, 0) 68%,
           rgba(251, 247, 241, 0.70) 88%,
           rgba(251, 247, 241, 0.90) 100%

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -109,6 +109,24 @@
         margin-left: 4mm;
       }
 
+      /* The trim-ready page: no logo, title or scan-me line, just the code in
+         the top-right corner. The band is reserved rather than overlaid — a
+         width-limited board fills the sheet edge to edge, and a floating QR
+         would sit on top of tiles. Keep it in step with
+         RenderAssetData#header_band_height_mm. */
+      .header-qr-only {
+        display: flex;
+        justify-content: flex-end;
+        align-items: flex-start;
+        height: 18mm;
+      }
+
+      .header-qr-only .qr-small img {
+        width: 0.6in;
+        height: 0.6in;
+        margin: 0 2mm 0 0;
+      }
+
       .board-wrap {
         min-width: 0;
         min-height: 0;

--- a/spec/services/boards/printables/collect_pages_variants_spec.rb
+++ b/spec/services/boards/printables/collect_pages_variants_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+# Which page each download variant actually renders. The walk lives in
+# collect_pages_spec.rb; this covers the render side, where the trap is that
+# "header-less" and "no QR" are the same flag in the print template.
+RSpec.describe Boards::Printables::CollectPages, "#call" do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user, name: "Core Words", slug: "core-words") }
+
+  let(:render_args) { [] }
+
+  before do
+    allow(Grover).to receive(:new).and_return(instance_double(Grover, to_pdf: "%PDF-fake"))
+    allow(ApplicationController).to receive(:render).and_return("<html></html>")
+
+    allow(Boards::RenderAssetData).to receive(:new).and_wrap_original do |original, **kwargs|
+      render_args << kwargs
+      original.call(**kwargs)
+    end
+  end
+
+  subject(:result) { described_class.new(board: board).call }
+
+  it "renders one page per download variant, colour first" do
+    expect(result[:pages].map(&:variant)).to eq(BoardPrintable::DOWNLOAD_VARIANTS)
+  end
+
+  it "drops the tile colours on the low-ink page only" do
+    result
+
+    by_variant = BoardPrintable::DOWNLOAD_VARIANTS.zip(render_args).to_h
+
+    expect(by_variant[BoardPrintable::VARIANT_LOW_INK][:hide_colors]).to be(true)
+    expect(by_variant[BoardPrintable::VARIANT_COLOR][:hide_colors]).to be(false)
+    expect(by_variant[BoardPrintable::VARIANT_TRIM_READY][:hide_colors]).to be(false)
+  end
+
+  # The whole point of the trim-ready variant: the title band goes, the code
+  # stays. `hide_header: true` would take the QR with it and hand a buyer a
+  # sheet with no route to the free audio companion the listing promises.
+  it "gives the trim-ready page a corner QR instead of the full header" do
+    result
+
+    modes = render_args.map { |kwargs| kwargs[:header_mode] }
+
+    expect(modes).to eq([
+      Boards::RenderAssetData::HEADER_FULL,
+      Boards::RenderAssetData::HEADER_FULL,
+      Boards::RenderAssetData::HEADER_QR_ONLY,
+    ])
+    expect(render_args.map { |kwargs| kwargs[:include_qr] }).to all(be(true))
+  end
+
+  it "points every variant's QR at the board's own public page" do
+    result
+
+    expect(render_args.map { |kwargs| kwargs[:qr_target_url] }.uniq)
+      .to eq(["https://app.speakanyway.com/pb/core-words"])
+  end
+end

--- a/spec/services/boards/printables/generate_spec.rb
+++ b/spec/services/boards/printables/generate_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Boards::Printables::Generate do
   end
 
   describe "a single board" do
-    it "attaches one fully-wrapped 6-page file" do
+    it "attaches one fully-wrapped 7-page file" do
       printable = printable_for
 
       described_class.new(printable: printable).call
@@ -46,8 +46,8 @@ RSpec.describe Boards::Printables::Generate do
 
       expect(printable.status).to eq("complete")
       expect(printable.files.count).to eq(1)
-      # cover, how-to-use, colour, low-ink, license, credits
-      expect(printable.page_count).to eq(6)
+      # cover, how-to-use, colour, low-ink, trim-ready, license, credits
+      expect(printable.page_count).to eq(7)
       expect(printable.board_ids).to eq([root.id])
       expect(printable.error_message).to be_nil
     end
@@ -81,21 +81,20 @@ RSpec.describe Boards::Printables::Generate do
       link(root, child_b, position: 1)
     end
 
-    it "attaches exactly two files, colour and low-ink, each fully wrapped" do
+    it "attaches one file per download variant, each fully wrapped" do
       printable = printable_for(include_subboards: true)
 
       described_class.new(printable: printable).call
       printable.reload
 
       expect(printable.status).to eq("complete")
-      files = printable.files_view.sort_by { |f| f[:variant] }
-      expect(files.map { |f| f[:variant] })
-        .to eq([BoardPrintable::VARIANT_COLOR, BoardPrintable::VARIANT_LOW_INK])
+      files = printable.files_view
+      expect(files.map { |f| f[:variant] }).to eq(BoardPrintable::DOWNLOAD_VARIANTS)
       expect(files.map { |f| f[:filename] })
-        .to eq(["core-words.color.pdf", "core-words.low-ink.pdf"])
+        .to eq(["core-words.color.pdf", "core-words.low-ink.pdf", "core-words.trim-ready.pdf"])
 
-      # 2N + 8: each file is cover + how-to-use + 3 board pages + license + credits.
-      expect(printable.page_count).to eq(14)
+      # 3 x (cover + how-to-use + 3 board pages + license + credits).
+      expect(printable.page_count).to eq(21)
       expect(printable.board_ids).to eq([root.id, child_a.id, child_b.id])
     end
 
@@ -104,13 +103,15 @@ RSpec.describe Boards::Printables::Generate do
 
       described_class.new(printable: printable).call
 
-      # Two renders per board (colour + low-ink), each targeting that board by
-      # its slug — CollectPages.qr_key_for, matching Board#public_url.
+      # One render per board per download variant, each targeting that board by
+      # its slug — CollectPages.qr_key_for, matching Board#public_url. The
+      # trim-ready page is included: it drops the header band but keeps a QR.
+      variants = BoardPrintable::DOWNLOAD_VARIANTS.length
       [root, child_a, child_b].each do |board|
         key = board.slug.presence || board.id
-        expect(qr_targets.count("https://app.speakanyway.com/pb/#{key}")).to eq(2)
+        expect(qr_targets.count("https://app.speakanyway.com/pb/#{key}")).to eq(variants)
       end
-      expect(qr_targets.length).to eq(6)
+      expect(qr_targets.length).to eq(3 * variants)
     end
 
     # Each board in a tree gets its own key, so a slugless board in the middle
@@ -122,7 +123,8 @@ RSpec.describe Boards::Printables::Generate do
       described_class.new(printable: printable).call
 
       expect(qr_targets.uniq.length).to eq(3)
-      expect(qr_targets.count("https://app.speakanyway.com/pb/#{child_a.id}")).to eq(2)
+      expect(qr_targets.count("https://app.speakanyway.com/pb/#{child_a.id}"))
+        .to eq(BoardPrintable::DOWNLOAD_VARIANTS.length)
     end
   end
 
@@ -167,7 +169,7 @@ RSpec.describe Boards::Printables::Generate do
   end
 
   # A subboard added since the first run flips the document from one full file
-  # to a colour/low-ink pair; the orphaned "full" file is not a real download.
+  # to a file per variant; the orphaned "full" file is not a real download.
   it "purges the single-board file when the tree has grown into a bundle" do
     printable = printable_for(include_subboards: true)
     described_class.new(printable: printable).call
@@ -177,7 +179,7 @@ RSpec.describe Boards::Printables::Generate do
     printable.reload
 
     expect(printable.files_view.map { |f| f[:variant] })
-      .to match_array([BoardPrintable::VARIANT_COLOR, BoardPrintable::VARIANT_LOW_INK])
+      .to match_array(BoardPrintable::DOWNLOAD_VARIANTS)
   end
 
   it "leaves the listing images alone when the PDFs are regenerated" do

--- a/spec/services/boards/printables/merge_pdf_spec.rb
+++ b/spec/services/boards/printables/merge_pdf_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Boards::Printables::MergePdf do
   let(:credits) { 604 }
   let(:cover_low_ink) { 605 }
   let(:how_to_low_ink) { 606 }
+  let(:how_to_trim_ready) { 607 }
 
   let(:wrappers) do
     {
@@ -26,6 +27,7 @@ RSpec.describe Boards::Printables::MergePdf do
       credits: page_pdf(credits),
       cover_low_ink: page_pdf(cover_low_ink),
       how_to_use_low_ink: page_pdf(how_to_low_ink),
+      how_to_use_trim_ready: page_pdf(how_to_trim_ready),
     }
   end
 
@@ -51,6 +53,8 @@ RSpec.describe Boards::Printables::MergePdf do
         board_page(BoardPrintable::VARIANT_COLOR, 102),
         board_page(BoardPrintable::VARIANT_LOW_INK, 201),
         board_page(BoardPrintable::VARIANT_LOW_INK, 202),
+        board_page(BoardPrintable::VARIANT_TRIM_READY, 301),
+        board_page(BoardPrintable::VARIANT_TRIM_READY, 302),
       ]
     end
 
@@ -70,31 +74,49 @@ RSpec.describe Boards::Printables::MergePdf do
       expect(widths(colour)).to eq([cover, how_to, 101, 102, license, credits])
     end
 
-    # The two files have to stay interchangeable — same length, same structure,
-    # only the ink differs.
-    it "gives both files the same page count" do
+    # The trim-ready file is full colour, so it keeps the colour cover — only
+    # its board pages and its instructions differ.
+    it "gives the trim-ready file the colour cover and its own instructions" do
+      trim_ready = files.find { |f| f.variant == BoardPrintable::VARIANT_TRIM_READY }
+
+      expect(trim_ready.filename).to eq("core-words.trim-ready.pdf")
+      expect(widths(trim_ready)).to eq([cover, how_to_trim_ready, 301, 302, license, credits])
+    end
+
+    # The three files have to stay interchangeable — same length, same
+    # structure, only the pages differ.
+    it "gives every file the same page count" do
       expect(files.map(&:page_count).uniq).to eq([6])
+    end
+
+    it "emits one file per download variant, colour first" do
+      expect(files.map(&:variant)).to eq(BoardPrintable::DOWNLOAD_VARIANTS)
     end
 
     # RenderWrappers only produces an ink-light cover for a set, but MergePdf
     # must not assume the key is present — a missing one falls back rather than
     # merging nil and blowing up mid-job.
-    it "falls back to the colour pages when no low-ink variants were rendered" do
+    it "falls back to the colour pages when no per-variant wrappers were rendered" do
       wrappers.delete(:cover_low_ink)
       wrappers.delete(:how_to_use_low_ink)
-      low_ink = files.find { |f| f.variant == BoardPrintable::VARIANT_LOW_INK }
+      wrappers.delete(:how_to_use_trim_ready)
 
-      expect(widths(low_ink).take(2)).to eq([cover, how_to])
+      %w[low_ink trim_ready].each do |variant|
+        file = files.find { |f| f.variant == variant }
+
+        expect(widths(file).take(2)).to eq([cover, how_to])
+      end
     end
   end
 
-  # One document holding both halves: there is no low-ink FILE to give its own
-  # identity to, so it keeps the one colour cover.
+  # One document holding every variant: there is no low-ink or trim-ready FILE
+  # to give its own identity to, so it keeps the one colour cover.
   describe "a single board" do
-    it "wraps both halves in one file behind the colour cover and instructions" do
+    it "wraps every variant in one file behind the colour cover and instructions" do
       pages = [
         board_page(BoardPrintable::VARIANT_COLOR, 101),
         board_page(BoardPrintable::VARIANT_LOW_INK, 201),
+        board_page(BoardPrintable::VARIANT_TRIM_READY, 301),
       ]
 
       files = described_class.new(
@@ -104,7 +126,7 @@ RSpec.describe Boards::Printables::MergePdf do
       expect(files.length).to eq(1)
       expect(files.first.variant).to eq(BoardPrintable::VARIANT_FULL)
       expect(files.first.filename).to eq("core-words.pdf")
-      expect(widths(files.first)).to eq([cover, how_to, 101, 201, license, credits])
+      expect(widths(files.first)).to eq([cover, how_to, 101, 201, 301, license, credits])
     end
   end
 end

--- a/spec/services/boards/printables/render_device_screen_spec.rb
+++ b/spec/services/boards/printables/render_device_screen_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+# What the tablet in the "on a device" slide is actually showing. Grover is
+# stubbed but the ERB is not: the point is that the chrome compiles and carries
+# the board's own name, since that is the only thing tying the mockup to the
+# product being sold.
+RSpec.describe Boards::Printables::RenderDeviceScreen do
+  let(:rendered_html) { [] }
+  let(:rendered_opts) { [] }
+
+  before do
+    allow(Grover).to receive(:new) do |html, **opts|
+      rendered_html << html
+      rendered_opts << opts
+      instance_double(Grover, to_png: "png-bytes")
+    end
+  end
+
+  def thumbnail(width: 1200, height: 900)
+    Boards::Printables::RenderPageThumbnails::Thumbnail.new(
+      board_id: 1,
+      data_uri: "data:image/png;base64,QQ==",
+      landscape: true,
+      width: width,
+      height: height,
+    )
+  end
+
+  def render(title: "Core Words", thumb: thumbnail)
+    described_class.new(title: title, thumbnail: thumb).call
+  end
+
+  it "returns a PNG data URI of the shell" do
+    expect(render).to eq("data:image/png;base64,#{Base64.strict_encode64("png-bytes")}")
+  end
+
+  it "renders at the shell aspect the tablet quads were calibrated for" do
+    render
+
+    expect(rendered_opts.first[:viewport]).to include(
+      width: described_class::SHELL_WIDTH,
+      height: described_class::SHELL_HEIGHT,
+    )
+  end
+
+  # The app header is what makes the slide read as the live app rather than a
+  # photographed sheet, and it carries the BOARD's name — a generic app title
+  # would stage some other product.
+  it "puts the board's own name in the app header, over the app controls" do
+    render(title: "Snack Time")
+
+    html = rendered_html.first
+    expect(html).to include("Snack Time")
+    expect(html).to include("app-chrome", "sentence-bar", "Sign in")
+    expect(html).to include("action play", "action delete", "action download")
+  end
+
+  # It is a screenshot of a screen: a printed QR on the glass reads as an ad
+  # someone taped to the tablet. The slide carries its own QR in the footer.
+  it "never fetches over the network and prints no scan-me band" do
+    render
+
+    html = rendered_html.first
+    expect(html).not_to include("Created with SpeakAnyWay AAC")
+    expect(html).not_to match(%r{src="https?://})
+  end
+
+  describe "how the board sits under the chrome" do
+    it "centres a board short enough to fit" do
+      render(thumb: thumbnail(width: 2400, height: 700))
+
+      expect(rendered_html.first).to include('class="app-body fits"')
+    end
+
+    it "top-anchors a taller board so it clips like a real screen" do
+      render(thumb: thumbnail(width: 1200, height: 1600))
+
+      expect(rendered_html.first).to include('class="app-body "')
+    end
+  end
+
+  # A gallery that renders a plainer tablet beats a job that dies on it: the
+  # PDFs a buyer receives are untouched by anything here.
+  it "returns nil rather than raising when there is no board render" do
+    expect(described_class.new(title: "Core Words", thumbnail: nil).call).to be_nil
+  end
+
+  it "returns nil when the screenshot fails" do
+    allow(Grover).to receive(:new).and_raise(StandardError, "Chrome crashed")
+
+    expect(render).to be_nil
+  end
+end

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -165,14 +165,28 @@ RSpec.describe Boards::Printables::RenderListingImages do
     expect(slide_html[2]).to include("Core Words", "Feelings")
   end
 
-  # The one claim a buyer is least likely to believe from text alone. It reuses
-  # the root board's header-hidden thumbnail rather than paying Grover again.
-  it "warps the root board onto a tablet without rendering it a second time" do
+  # The one claim a buyer is least likely to believe from text alone.
+  it "warps the root board onto a tablet" do
     described_class.new(printable: printable).call
 
     device = slide_html[1]
     expect(device).to include("matrix3d(", "mockup-screen")
     expect(device).to include("data:image/jpeg;base64,")
+  end
+
+  # What sits on the glass is the app, not a sheet of paper: the same board
+  # inside SpeakAnyWay's own chrome, titled with the board's name. A bare
+  # printed page there reads as a photograph of a printout taped to a tablet,
+  # which is the opposite of what this slide is for.
+  it "shows the board inside the app's chrome, titled with the board name" do
+    described_class.new(printable: printable).call
+
+    screen = rendered_html.find { |html| html.include?("app-chrome") }
+    expect(screen).to be_present
+    expect(screen).to include("Core Words", "sentence-bar", "Sign in")
+    # The board on the screen is the header-less render, so the printed
+    # scan-me band never ends up on the glass.
+    expect(screen).not_to include("Created with SpeakAnyWay AAC")
   end
 
   it "writes a fresh key on every render so a regenerate isn't hidden by the CDN" do

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Boards::Printables::RenderWrappers do
   let(:rendered) { {} }
 
   before do
-    order = %i[cover how_to_use license credits cover_low_ink how_to_use_low_ink]
+    order = %i[cover how_to_use license credits cover_low_ink how_to_use_low_ink how_to_use_trim_ready]
     index = 0
     allow(Grover).to receive(:new) do |html, **_opts|
       rendered[order[index]] = html
@@ -102,15 +102,15 @@ RSpec.describe Boards::Printables::RenderWrappers do
   end
 
   describe "the how-to-use page" do
-    it "explains the two prints of one board for a single board" do
+    it "explains the three prints of one board for a single board" do
       render
 
       expect(rendered[:how_to_use]).to include("This communication board")
-      expect(rendered[:how_to_use]).to include("includes the board twice")
+      expect(rendered[:how_to_use]).to include("includes the board three times")
       expect(rendered[:how_to_use]).to include("The same board")
     end
 
-    # A set ships as two separate FILES (MergePdf#call), and this page is bound
+    # A set ships as three separate FILES (MergePdf#call), and this page is bound
     # into each one, so it describes the file it's in and nothing else. Naming
     # the other file would raise a question this page can't answer — the reader
     # is holding one print, not a pair.
@@ -130,18 +130,44 @@ RSpec.describe Boards::Printables::RenderWrappers do
         expect(rendered[:how_to_use_low_ink]).to include("white tile backgrounds")
       end
 
-      it "never mentions the other file from either one" do
+      # The trim-ready file is the one whose QR moved, so it is the one page
+      # that has to say where the code went — a buyer who can't find it assumes
+      # the header-less print is the one without the audio companion.
+      it "tells the trim-ready file the header is gone and the QR moved" do
         render(board_count: 4)
 
-        [rendered[:how_to_use], rendered[:how_to_use_low_ink]].each do |html|
-          expect(html).not_to include("two files")
-          expect(html).not_to include("twice")
+        expect(rendered[:how_to_use_trim_ready]).to include("Printed to the edges")
+        expect(rendered[:how_to_use_trim_ready]).to include("drops the page header")
+        expect(rendered[:how_to_use_trim_ready]).to include("QR code moves to the top corner")
+      end
+
+      it "never mentions the other files from any one of them" do
+        render(board_count: 4)
+
+        [
+          rendered[:how_to_use],
+          rendered[:how_to_use_low_ink],
+          rendered[:how_to_use_trim_ready],
+        ].each do |html|
+          expect(html).not_to include("three files")
+          expect(html).not_to include("three times")
         end
       end
 
-      it "renders a low-ink how-to only for a set" do
-        expect(render(board_count: 4)).to have_key(:how_to_use_low_ink)
-        expect(render).not_to have_key(:how_to_use_low_ink)
+      it "renders the per-variant how-tos only for a set" do
+        set = render(board_count: 4)
+        expect(set).to have_key(:how_to_use_low_ink)
+        expect(set).to have_key(:how_to_use_trim_ready)
+
+        single = render
+        expect(single).not_to have_key(:how_to_use_low_ink)
+        expect(single).not_to have_key(:how_to_use_trim_ready)
+      end
+
+      # The trim-ready file is full colour: rendering it a second cover would
+      # be the same pixels and one more Grover run per printable.
+      it "reuses the colour cover for the trim-ready file" do
+        expect(render(board_count: 4)).not_to have_key(:cover_trim_ready)
       end
     end
 

--- a/spec/services/boards/render_asset_data_header_mode_spec.rb
+++ b/spec/services/boards/render_asset_data_header_mode_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+# The three header states and the sheet space each one leaves for the board.
+RSpec.describe Boards::RenderAssetData, "header modes" do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user, name: "Core Words") }
+
+  def render(**kwargs)
+    described_class.new(
+      board: board,
+      routes: Rails.application.routes.url_helpers,
+      **kwargs,
+    ).call
+  end
+
+  it "defaults to the full header" do
+    expect(render[:header_mode]).to eq(described_class::HEADER_FULL)
+  end
+
+  it "maps the legacy hide_header flag onto the none mode" do
+    data = render(hide_header: true)
+
+    expect(data[:header_mode]).to eq(described_class::HEADER_NONE)
+    expect(data[:hide_header]).to be(true)
+  end
+
+  it "lets an explicit mode win over hide_header" do
+    data = render(hide_header: true, header_mode: described_class::HEADER_QR_ONLY)
+
+    expect(data[:header_mode]).to eq(described_class::HEADER_QR_ONLY)
+    # hide_header stays false so the template can't take the QR away — the two
+    # can't be allowed to contradict each other.
+    expect(data[:hide_header]).to be(false)
+  end
+
+  it "falls back to the full header rather than trusting an unknown mode" do
+    expect(render(header_mode: "banner")[:header_mode]).to eq(described_class::HEADER_FULL)
+  end
+
+  # The reason the mode exists: qr_only reserves a slim band instead of the
+  # full one, so the board prints bigger, and none reserves nothing at all.
+  #
+  # Measured on a TALL board on purpose. A wide, short one is limited by the
+  # page width rather than by what the header leaves behind, so it would print
+  # the same size in all three modes and prove nothing.
+  it "grows the board as the header shrinks" do
+    tiles = 12.times.map do |i|
+      { "x" => 0, "y" => i, "w" => 1, "h" => 1, "label" => "word #{i}" }
+    end
+    allow(Boards::BoardPdfLayoutNormalizer).to receive(:call).and_return(tiles)
+    allow(board).to receive(:columns_for_screen_size).and_return(2)
+
+    heights = [
+      described_class::HEADER_FULL,
+      described_class::HEADER_QR_ONLY,
+      described_class::HEADER_NONE,
+    ].map { |mode| render(header_mode: mode)[:board_render_height_mm] }
+
+    expect(heights).to eq(heights.sort)
+    expect(heights.uniq.length).to eq(3)
+  end
+
+  it "still builds a QR for the qr_only page" do
+    data = render(header_mode: described_class::HEADER_QR_ONLY)
+
+    expect(data[:qr_data_url]).to start_with("data:image/")
+  end
+end

--- a/spec/services/etsy/listing_copy_spec.rb
+++ b/spec/services/etsy/listing_copy_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe Etsy::ListingCopy do
 
       expect(description).to include("THE 2 BOARDS")
       expect(description).to include("Core Words", "Feelings")
-      expect(description).to include("2 boards, 6 pages — 2 PDFs (full color + low-ink)")
+      expect(description).to include("2 boards, 6 pages — 3 PDFs (full color + low-ink + trim-ready)")
     end
 
     it "describes a single board as an n-page PDF" do
-      expect(build["description"]).to include("6-page board PDF — color + low-ink")
+      expect(build["description"]).to include("6-page board PDF — color, low-ink + trim-ready")
     end
 
     it "omits the boards section for a single-board printable" do

--- a/spec/services/etsy/publish_board_printable_spec.rb
+++ b/spec/services/etsy/publish_board_printable_spec.rb
@@ -81,8 +81,9 @@ RSpec.describe Etsy::PublishBoardPrintable do
 
     it "uploads every PDF variant as a download file" do
       printable.attach_pdf!(filename: "core-words.low-ink.pdf", bytes: "b", variant: BoardPrintable::VARIANT_LOW_INK)
+      printable.attach_pdf!(filename: "core-words.trim-ready.pdf", bytes: "c", variant: BoardPrintable::VARIANT_TRIM_READY)
 
-      expect(client).to receive(:upload_file).twice
+      expect(client).to receive(:upload_file).exactly(3).times
       publish
     end
 
@@ -136,6 +137,20 @@ RSpec.describe Etsy::PublishBoardPrintable do
       result = publish
 
       expect(result.error).to match(/caps a download file at 20 MB/)
+      expect(client).not_to have_received(:create_listing)
+    end
+
+    # A board printable ships three files, comfortably inside Etsy's five. The
+    # guard is here for the fourth variant nobody remembers to count — Etsy
+    # rejects the extra upload after the draft already exists.
+    it "refuses more download files than a listing can carry" do
+      (Etsy::Client::MAX_DOWNLOAD_FILES + 1).times do |i|
+        printable.attach_pdf!(filename: "extra-#{i}.pdf", bytes: "x", variant: BoardPrintable::VARIANT_COLOR)
+      end
+
+      result = publish
+
+      expect(result.error).to match(/caps a listing at 5 download files/)
       expect(client).not_to have_received(:create_listing)
     end
 

--- a/spec/services/printables/included_items_spec.rb
+++ b/spec/services/printables/included_items_spec.rb
@@ -4,21 +4,32 @@ RSpec.describe Printables::IncludedItems do
   describe ".headline" do
     it "describes a single board by its page count" do
       expect(described_class.headline(board_count: 1, page_count: 6))
-        .to eq("6-page board PDF — color + low-ink")
+        .to eq("6-page board PDF — color, low-ink + trim-ready")
     end
 
-    it "describes a set by board count AND page count, and says it's two files" do
-      # A bundle ships every board twice and arrives as two PDFs; quoting one
-      # page count understates a 9-board set badly.
-      expect(described_class.headline(board_count: 9, page_count: 22))
-        .to eq("9 boards, 22 pages — 2 PDFs (full color + low-ink)")
+    it "describes a set by board count AND page count, and says it's three files" do
+      # A bundle ships every board three times and arrives as three PDFs;
+      # quoting one page count understates a 9-board set badly.
+      expect(described_class.headline(board_count: 9, page_count: 33))
+        .to eq("9 boards, 33 pages — 3 PDFs (full color + low-ink + trim-ready)")
     end
 
     it "omits the page count rather than claiming zero pages" do
       expect(described_class.headline(board_count: 1, page_count: nil))
-        .to eq("Board PDF — color + low-ink")
+        .to eq("Board PDF — color, low-ink + trim-ready")
       expect(described_class.headline(board_count: 3, page_count: 0))
-        .to eq("3 boards — 2 PDFs (full color + low-ink)")
+        .to eq("3 boards — 3 PDFs (full color + low-ink + trim-ready)")
+    end
+
+    # Every headline lands in a fixed-height band on a 1280px slide, where copy
+    # that outgrows its slot overlaps the next one rather than wrapping.
+    it "stays inside the slide's bullet budget" do
+      [
+        described_class.headline(board_count: 25, page_count: 130),
+        described_class.headline(board_count: 1, page_count: 7),
+      ].each do |line|
+        expect(line.length).to be <= Printables::SlideCopy::MAX_BULLET_LENGTH
+      end
     end
   end
 
@@ -29,7 +40,7 @@ RSpec.describe Printables::IncludedItems do
     it "leads with the document line and names the audio companion" do
       items = described_class.all(board_count: 1, page_count: 6)
 
-      expect(items.first).to eq("6-page board PDF — color + low-ink")
+      expect(items.first).to eq("6-page board PDF — color, low-ink + trim-ready")
       expect(items).to include("Free audio companion — tap any word and it talks")
     end
   end

--- a/spec/views/api/boards/print_template_spec.rb
+++ b/spec/views/api/boards/print_template_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "api/boards/print.html.erb", type: :view do
     }
   end
 
-  def render_print(tiles)
+  def render_print(tiles, **overrides)
     ApplicationController.render(
       template: "api/boards/print",
       layout: "pdf",
@@ -38,8 +38,12 @@ RSpec.describe "api/boards/print.html.erb", type: :view do
         board_render_height_mm: 100,
         landscape: false,
         bw: false,
-      },
+      }.merge(overrides),
     )
+  end
+
+  def header_nodes(html)
+    Nokogiri::HTML(html).css(".header")
   end
 
   def tile_nodes(html)
@@ -67,6 +71,55 @@ RSpec.describe "api/boards/print.html.erb", type: :view do
     # ...and the separate caption <div class="label"> is suppressed so the
     # label doesn't appear twice.
     expect(node.at_css(".label")).to be_nil
+  end
+
+  # The QR lives inside the header block, so the header state and the presence
+  # of the printed code are one decision. A "header-less" page that also lost
+  # its QR is a sheet with no way back to the talking version of the board —
+  # which is the promise the whole listing leans on.
+  describe "header modes" do
+    let(:tiles) { [tile(label: "happy", image_url: "https://cdn.example/happy.png")] }
+    let(:qr) { "data:image/png;base64,QQ==" }
+
+    def render_with(mode)
+      render_print(
+        tiles,
+        header_mode: mode,
+        hide_header: false,
+        qr_data_url: qr,
+        qr_target_url: "https://app.speakanyway.com/pb/core-words",
+        board_title: "Core Words",
+      )
+    end
+
+    it "prints the full band — title, scan line and QR — in full mode" do
+      html = render_with(Boards::RenderAssetData::HEADER_FULL)
+
+      expect(html).to include("Core Words")
+      expect(html).to include("for the full interactive version")
+      expect(Nokogiri::HTML(html).at_css(".qr-small img")["src"]).to eq(qr)
+    end
+
+    it "keeps the QR and drops everything else in qr_only mode" do
+      html = render_with(Boards::RenderAssetData::HEADER_QR_ONLY)
+      doc = Nokogiri::HTML(html)
+
+      expect(doc.at_css(".header-qr-only .qr-small img")["src"]).to eq(qr)
+      expect(doc.at_css(".board-title")).to be_nil
+      expect(doc.at_css(".board-link")).to be_nil
+      expect(doc.at_css(".logo")).to be_nil
+    end
+
+    it "prints no header at all in none mode" do
+      expect(header_nodes(render_with(Boards::RenderAssetData::HEADER_NONE))).to be_empty
+    end
+
+    # Callers that render this template with their own assigns still get the
+    # old all-or-nothing behaviour instead of an unstyled full header.
+    it "falls back to hide_header when no mode was passed" do
+      expect(header_nodes(render_print(tiles, hide_header: true))).to be_empty
+      expect(header_nodes(render_print(tiles, hide_header: false))).not_to be_empty
+    end
   end
 
   it "still suppresses the caption on an image tile when hide_label is set" do


### PR DESCRIPTION
Closes #660.

## The third PDF

Every board printable now ships each board three times — `color`, `low_ink`, and a new `trim_ready` — instead of twice. A single board is one file holding all three pages; a board set is three files (`.color.pdf`, `.low-ink.pdf`, `.trim-ready.pdf`), each fully wrapped so any one of them stands alone.

Trim-ready is what buyers were making themselves: header cut off, board as large as the sheet allows.

## The catch the issue flagged

`hide_header: true` would have shipped a page with **no QR at all** — it lives inside the header block in `api/boards/print.html.erb`, and the free audio companion is the claim the listing leans on hardest. So `Boards::RenderAssetData` gained a three-state `header_mode` rather than a second boolean that could contradict `hide_header`:

| mode | what prints |
|---|---|
| `full` | logo, board title, scan-me line, QR |
| `qr_only` | a 0.6in QR alone, top-right |
| `none` | nothing (screen mockups, grid thumbnails) |

`qr_only` reserves a 20mm band instead of 30–34mm. Reserved, not overlaid: a width-limited board spans the full sheet, so a floating QR would land on tiles. `hide_header:` still works for every existing caller and maps onto `full`/`none`; `header_mode:` wins when both are given.

The trim-ready **file** in a set reuses the colour cover (it is a colour print) and gets its own how-to-use page, which is the only thing that tells a reader where the QR went.

## Copy and Etsy

- `Printables::IncludedItems.headline` → "3 PDFs (full color + low-ink + trim-ready)". Shared with the listing description and the what's-included slide, so both follow.
- `Etsy::ListingCopy` gains a ways-to-use line for it; the how-it-works step says "full colour, low-ink or trim-ready".
- Etsy's per-file 20 MB cap already had a guard. Added `Client::MAX_DOWNLOAD_FILES = 5` and a matching guard — three files is comfortably inside it, but a fourth variant would be rejected *after* the draft exists.

## The tablet slide

Second half of the ask. `on_a_device` warped a printed page onto the glass, which read as a photograph of paper taped to a tablet. It now shows the board inside SpeakAnyWay's own chrome — board name, nav, empty speech bar, play/clear/download — via `Boards::Printables::RenderDeviceScreen`, a port of the printables pipeline's `renderContentAppPage`.

- Shell is 1100x720 (~1.528), the mean of the two tablet quad aspects in `TabletScene::SCENES`, so the homography doesn't stretch it.
- Reuses the header-less thumbnail the what's-included grid already renders: one extra Grover render, not two.
- Softened the top half of `.mockup-scrim` — the title banner and audio badge carry their own fills, and the old gradient washed out the app chrome.

Existing printables go stale on their gallery as usual; publishing re-renders, and `rake printables:refresh_listing_images` does them in bulk.

## Test plan

- `bundle exec rspec spec/services/boards/printables spec/services/printables spec/services/etsy spec/models/board_printable_spec.rb spec/views spec/services/boards/render_asset_data_header_mode_spec.rb spec/requests/api/admin/board_printables_spec.rb spec/sidekiq` — **585 examples, 0 failures**, 1 pending.
- New specs: `render_asset_data_header_mode_spec.rb` (three states, the hide_header fallback, and that the board actually grows as the band shrinks), `collect_pages_variants_spec.rb` (trim-ready renders `qr_only` and keeps its QR), `render_device_screen_spec.rb`, plus header-mode cases in the print template spec.
- Rendered real proofs against a live board (Grover + local Chrome) and looked at the PNGs: the qr_only sheet has the code in the corner and no title band, and the tablet slide shows the app chrome with the board's own name.
- Nothing was published to Etsy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)