### PR TITLE
fix(printables): keep listing-slide content inside Etsy's crop

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -177,6 +177,25 @@ search thumbnail:
 is authoritative for the ones its own steps 11/13/14 originate. Same rule, and
 the same drift hazard, as `Etsy::CopyRules` above.
 
+### The horizontal safe zone — square is not what every view shows
+
+Etsy does **not** letterbox a square photo. The listing page frames it 4:5 and
+cover-crops, taking **10% off each side**, and the seller-side "Adjust
+thumbnail" dialog crops again for the search grid. So the canvas stays square —
+that is the search grid's shape and the one all six slides share — and the
+layout keeps everything that carries meaning inside `--safe-x` (160px of the
+1280px canvas, 12.5%, against the 10% Etsy takes).
+
+Only **content** moves in: the title banner, the headline, the audio badge, the
+footer bullets, the QR, the site mark, the logo corner. Backgrounds and band
+fills still bleed to the edge — a cropped colour band reads as intentional; a
+beheaded board name does not. Any new side inset written as a literal px value
+reintroduces the bug, which is why `render_listing_images_spec.rb` asserts each
+of those rules reads the token rather than a number.
+
+At the old flat 56px inset this cost every live listing the first letter of its
+board name and better than half its QR code.
+
 ### The tablet mockup
 
 `on_a_device` is a narrow port of that repo's step 14. Rails does **not** have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Etsy was cropping the edges off every printable's listing photos.** The
+  gallery slides are square, on the assumption that Etsy letterboxes anything
+  that isn't — but the listing page frames a photo 4:5 and crops 10% off each
+  side, which took the first letter of the board name and better than half the
+  QR code on every listing in the shop. All six slides now keep their text, QR
+  code and logo inside a safe margin so nothing meaningful can be cropped away.
+  Existing listings pick this up when their images are regenerated.
+
 - **Boards built through the internal API still came out Title Cased.** The
   endpoint treated the word you send as authored display text and pinned its
   casing, so a word list typed the natural way — "Yes / No / Say it again" —

--- a/app/views/layouts/listing_image.html.erb
+++ b/app/views/layouts/listing_image.html.erb
@@ -38,7 +38,15 @@
        brand hex in a rule takes it out of the rotation and every listing in the
        shop starts sharing it again. The fixed colours — navy title banner,
        white paper cards, black ribbon, navy-on-white QR — are the ones carrying
-       contrast, and they stay out of the palette on purpose. %>
+       contrast, and they stay out of the palette on purpose.
+    5. No CONTENT sits within `--safe-x` of the left or right edge. Etsy does
+       not letterbox a square photo — the listing page frames it 4:5 and
+       cover-crops, taking 10% off each side, and the seller-side "Adjust
+       thumbnail" dialog crops again for the search grid. At the old 56px inset
+       that removed the first letter of the board name and better than half the
+       QR, on every listing in the shop. Backgrounds and band fills still bleed
+       edge to edge; it is only the type, the QR and the logo that move in. A
+       new inset written as a literal px value reintroduces the bug. %>
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -60,6 +68,12 @@
 
         --shadow-soft: 0 18px 40px rgba(19, 73, 111, 0.18);
         --shadow-card: 0 24px 56px rgba(19, 73, 111, 0.28);
+
+        /* The horizontal safe zone — see rail 5 at the top of this file.
+           12.5% of the 1280px canvas, against the 10% Etsy actually takes off
+           each side. Every inset that holds CONTENT reads this token; band
+           backgrounds still bleed to the edge. */
+        --safe-x: 160px;
 
         /* Rotated per listing by Boards::Printables::Palette. These defaults
            are its first entry, so a slide rendered without a palette (a spec,
@@ -95,8 +109,9 @@
       p, li { text-wrap: pretty; hyphens: none; }
 
       /* ── The canvas ───────────────────────────────────────────────────── */
-      /* Etsy shows listing photos in a square frame and letterboxes anything
-         else, so the slide IS square rather than being cropped to one. */
+      /* Square, because that is the shape Etsy's search grid uses and the one
+         all six slides share. It is NOT the shape every view uses — see rail 5
+         above; the safe zone is what makes a square source survive the crops. */
       .slide {
         position: relative;
         width: 1280px;
@@ -155,7 +170,7 @@
         flex-direction: column;
         align-items: flex-start;
         gap: 20px;
-        padding: 52px 56px 56px;
+        padding: 52px var(--safe-x) 56px;
       }
 
       /* The footer strip is anchored to the bottom edge, so the column has to
@@ -177,7 +192,7 @@
         position: absolute;
         z-index: 5;
         top: 34px;
-        right: 34px;
+        right: var(--safe-x);
         width: 108px;
         height: 108px;
       }
@@ -197,7 +212,6 @@
         font-weight: 800;
         font-size: 64px;
         line-height: 1.05;
-        max-width: 940px;
         box-shadow: var(--shadow-soft);
       }
 
@@ -255,7 +269,7 @@
         top: 0;
         left: 0;
         right: 0;
-        padding: 16px 56px;
+        padding: 16px var(--safe-x);
         background: var(--ink);
         color: var(--white);
         font-weight: 800;
@@ -329,7 +343,7 @@
         right: 0;
         bottom: 0;
         min-height: 226px;
-        padding: 24px 56px 46px;
+        padding: 24px var(--safe-x) 46px;
         background: var(--band);
         display: flex;
         align-items: center;
@@ -342,7 +356,7 @@
          beside it is what a buyer is meant to act on. */
       .footer-strip .site-mark {
         position: absolute;
-        left: 56px;
+        left: var(--safe-x);
         bottom: 16px;
         font-size: 19px;
         font-weight: 800;
@@ -434,11 +448,12 @@
 
       .hero-stage .paper { flex: 1 1 0; }
 
-      /* A single page gets the whole stage. */
-      .hero-stage.single .paper { max-width: 940px; }
+      /* A single page gets the whole stage — which the safe zone has already
+         narrowed to 960px, so this needs no cap of its own. */
+      .hero-stage.single .paper { max-width: 100%; }
 
       /* A set fans into an overlapping pile rather than a tidy row. Three
-         side-by-side cards on a 1168px stage are ~370px wide, and a board page
+         side-by-side cards on the 960px stage are ~300px wide, and a board page
          at that size is a coloured smudge — the buyer can count the pages but
          can't see a single word. Overlapping buys each card ~50% more width
          and reads as "more than one board" just as fast. */

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -221,6 +221,48 @@ RSpec.describe Boards::Printables::RenderListingImages do
     expect(slide_html.join("\n")).not_to include('src="http')
   end
 
+  # Etsy does not letterbox a square photo. The listing page frames it 4:5 and
+  # cover-crops, taking 10% off each side; at the old flat 56px inset that
+  # sliced the first letter off the board name and better than half the QR on
+  # every listing in the shop. The margin is the whole fix, so it is asserted
+  # rather than left to a comment.
+  describe "the horizontal safe zone" do
+    # Every rule that positions CONTENT against a side edge. Band fills still
+    # bleed; it is the type, the QR and the logo that have to move in.
+    SAFE_ZONE_RULES = [
+      ".slide-stack",       # title banner, headline, audio badge, page stage
+      ".instant-ribbon",
+      ".footer-strip",
+      ".footer-strip .site-mark",
+      ".logo-corner",
+    ].freeze
+
+    let(:css) { slide_html.first }
+
+    def declarations_for(selector)
+      css[/^\s*#{Regexp.escape(selector)}\s*\{(.*?)\}/m, 1]
+    end
+
+    it "reserves more than the 10% of each side that Etsy's 4:5 crop takes" do
+      described_class.new(printable: printable).call
+
+      safe_x = css[/--safe-x:\s*(\d+)px/, 1]&.to_i
+      expect(safe_x).to be_present
+      expect(safe_x).to be >= described_class::CANVAS_PX * 0.10
+    end
+
+    it "insets every content-bearing edge from the token, never a literal" do
+      described_class.new(printable: printable).call
+
+      SAFE_ZONE_RULES.each do |selector|
+        block = declarations_for(selector)
+        expect(block).to be_present, "#{selector} is gone — move its inset, don't drop it"
+        expect(block).to include("var(--safe-x)"),
+                         "#{selector} sets a side inset Etsy will crop through:\n#{block}"
+      end
+    end
+  end
+
   def thumbnail_for(target)
     Boards::Printables::RenderPageThumbnails::Thumbnail.new(
       board_id: target.id,


### PR DESCRIPTION
## Summary

The gallery slides are rendered on a square canvas on the assumption — written into the layout — that *"Etsy shows listing photos in a square frame and letterboxes anything else."* That isn't true. The listing page frames a photo **4:5 and cover-crops it**, taking **10% off each side**, and the seller-side "Adjust thumbnail" dialog crops again for the search grid.

Against the layout's flat `56px` inset that meant, on **every listing in the shop**:

- the first letter of the board name gone ("At the Hair Salon" → "t the Hair Salon")
- better than half the QR code gone — the free audio companion is the single claim the whole listing leans on
- the logo corner and the `speakanyway.com` site mark clipped

Rendered from the real templates, cropped 4:5 the way Etsy does it:

| Before | After |
|---|---|
| title, QR, logo and site mark all sliced | everything intact |

## What changed

A `--safe-x` token (160px of the 1280px canvas, 12.5% — headroom over the 10% Etsy actually takes). Every inset that positions **content** reads it: `.slide-stack`, `.instant-ribbon`, `.footer-strip`, `.footer-strip .site-mark`, `.logo-corner`. Backgrounds and band fills still bleed edge to edge — a cropped colour band reads as intentional; a beheaded board name does not.

Canvas stays square: that's the search grid's shape and the one all six slides share.

Two now-redundant `max-width: 940px` caps drop out, since the safe zone narrows the stage to 960px on its own.

Only the horizontal crop is addressed here. Etsy's *landscape* crop cuts top and bottom instead, which would eat the ribbon and the footer band — protecting that means redesigning the hero around a 960×960 safe area and shrinking the board art 25% linear. Deliberately left for a separate call.

## Test plan

- `bundle exec rspec spec/services/boards/printables/ spec/models/board_printable_spec.rb` — **158 examples, 0 failures**
- `bundle exec rspec spec/sidekiq/publish_board_printable_to_etsy_job_spec.rb spec/requests/admin/board_printables_spec.rb` — **56 examples, 0 failures**
- New: `render_listing_images_spec.rb` asserts `--safe-x` is at least 10% of `CANVAS_PX`, and that each of the five content-bearing rules insets from the token rather than a literal. Verified it fails when `.logo-corner` is reverted to `right: 34px`.
- Visually verified all six slides rendered through Grover from the real templates, both uncropped and at Etsy's 4:5 crop.

## Follow-up

Existing listings keep their old images until regenerated — `POST regenerate_listing_images` from `/admin/board_printables/:id`, or `rake printables:refresh_listing_images`.

Docs: `.claude-notes/board-printables-etsy.md` gains a "horizontal safe zone" section; the stale letterbox claim in the layout header is replaced with rail 5. CHANGELOG entry under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)