### PR TITLE
fix(board-sets): give a new board set and its boards a thumbnail

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -859,6 +859,28 @@ collections of boards. CRUD is open to any signed-in user;
   counts own non-predefined sets; `User#at_board_group_limit?` is the gate
   (admins exempt). `create` returns **HTTP 422** `{ error, limit, count }` at
   the cap. **Not 402** — 402 is reserved for credit exhaustion.
+- **A new set always gets a thumbnail.** Board previews are rendered
+  asynchronously, so at creation time a member board typically has neither a
+  `preview_image` nor a `display_image_url` — it renders as a broken image on
+  the set page. `BoardGroup#seed_display_images!` (called from
+  `Boards::BoardGroupCreator` on both create and re-sync, and from
+  `API::BoardGroupsController#create` after members are attached) runs
+  `Boards::SubBoardThumbnails` over the members — the same folder-tile
+  thumbnail an imported or built set gets, one query for the whole set rather
+  than a Grover render per page — with `purge_previews: false`, since these are
+  ordinary boards whose real preview must keep winning. Anything that leaves
+  blank (a board hand-picked into a set with no folder tile pointing at it, or
+  the root) falls back to the board's own tiles via
+  `Board#seed_display_image_from_tiles!`. It then pins the set's cover. Two
+  rails: the seed goes in the
+  `display_image_url` **column**, which `Board#display_image_url` treats as the
+  lowest-priority fallback — a real preview or a custom cover still wins, so the
+  seed can never pin a stale image. And the **set's** cover is pinned *by
+  reference* (`settings["cover_board_id"]`), never by copying a board's URL,
+  since a copied preview URL carries a `?v=` that goes stale on the next
+  preview regen. Nothing already set — a pinned `cover_board_id`, a chosen
+  column value — is overwritten. Backfill for pre-existing sets:
+  `rake board_groups:backfill_display_images` (`DRY_RUN=1`, `USER_ID=N`).
 - **`add_board` route.** `POST /api/board_groups/:id/add_board/:board_id`
   (`BoardGroup#add_board` does the join + layout init). Beyond the owner-or-admin
   set check, the *board* must belong to the caller or be predefined/public.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   lands. Printable PDFs are unaffected — they still wait for the real artwork.
   The pages inside an imported set now show a picture too: each one uses the
   folder tile you tap to open it, the same way a built board set already did.
+
+- **A board set made from your own linked boards showed broken thumbnails.**
+  Making a set from a board and the pages it links to left every page with an
+  empty picture box. Those pages now get the same treatment as an imported or
+  built set — each shows the folder tile you tap to open it, falling back to
+  one of its own tiles — and the set itself picks up a cover from its first
+  board, so it looks right the moment it's created. Existing sets are fixed by
+  a one-off backfill.
 - **Etsy was cropping the edges off every printable's listing photos.** The
   gallery slides are square, on the assumption that Etsy letterboxes anything
   that isn't — but the listing page frames a photo 4:5 and crops 10% off each

--- a/app/controllers/api/board_groups_controller.rb
+++ b/app/controllers/api/board_groups_controller.rb
@@ -110,13 +110,17 @@ class API::BoardGroupsController < API::ApplicationController
     screen_size = board_group_params[:screen_size] || "lg"
     boards = board_group_params[:board_ids].map { |id| Board.find_by(id: id) if id.present? }.compact if board_group_params[:board_ids].present?
     Rails.logger.debug "Creating Board Group with parameters: #{board_group_params.inspect}"
-    if board_group.save
-      mark_default(board_group)
-      # board_group.calculate_grid_layout_for_screen_size(screen_size)
-      render json: board_group.api_view_with_boards(current_user), status: :created
-    else
+    unless board_group.save
       render json: { errors: board_group.errors.full_messages }, status: :unprocessable_content
+      return
     end
+
+    mark_default(board_group)
+    # board_group.calculate_grid_layout_for_screen_size(screen_size)
+
+    # Members are attached BEFORE rendering: the response has to carry the
+    # boards (and the cover seeded from them), and #seed_display_images! can
+    # only pick a cover once the group actually has members.
     if boards.blank?
       Rails.logger.debug "No boards provided, saving empty board group"
     else
@@ -124,7 +128,11 @@ class API::BoardGroupsController < API::ApplicationController
         board_group_board = board_group.add_board(board)
         board_group_board.save!
       end
+      board_group.reload
     end
+    board_group.seed_display_images!
+
+    render json: board_group.api_view_with_boards(current_user), status: :created
   end
 
   def rearrange_boards

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -675,6 +675,29 @@ class Board < ApplicationRecord
     end
   end
 
+  # Last-resort thumbnail: a board with no rendered preview and no seed URL
+  # renders as a broken image everywhere it's listed. Seed the column from one
+  # of the board's OWN tiles.
+  #
+  # For a page inside a set, `Boards::SubBoardThumbnails` is the better and
+  # preferred source — it uses the folder tile that opens the page, which is
+  # the picture the user already associates with it. This covers what that
+  # can't reach: a board with no folder tile pointing at it (hand-picked into
+  # a set, or a set root).
+  #
+  # Safe to leave in place: #display_image_url still prefers the live preview
+  # (and a custom cover) over the column, so the seed can never pin a stale
+  # image once a real preview exists.
+  def seed_display_image_from_tiles!
+    return false if display_image_url.present?
+
+    url = board_images.includes(:image).detect { |bi| bi.image && bi.tile_image_url.present? }&.tile_image_url
+    return false if url.blank?
+
+    update_column(:display_image_url, url)
+    true
+  end
+
   def rearrange_images(layout = nil, screen_size = "lg")
     ActiveRecord::Base.logger.silence do
       layout ||= calculate_grid_layout_for_screen_size(screen_size)

--- a/app/models/board_group.rb
+++ b/app/models/board_group.rb
@@ -135,6 +135,47 @@ class BoardGroup < ApplicationRecord
     read_attribute(:display_image_url)
   end
 
+  # Give a brand-new set something to show. A member board's preview is
+  # rendered asynchronously, so at creation time most members have neither a
+  # preview_image nor a display_image_url and render as broken thumbnails.
+  #
+  # Sub-boards get the same thumbnail an imported or built set gets:
+  # `Boards::SubBoardThumbnails` resolves the folder tile that OPENS each page
+  # (one query for the whole set, no Grover render per page). `purge_previews:
+  # false` — these are ordinary boards, so a real preview must keep winning
+  # over the seeded column. Anything it can't reach (a board hand-picked into
+  # the set with no folder tile pointing at it) falls back to one of the
+  # board's own tiles.
+  #
+  # The set's own cover is then pinned BY REFERENCE (`settings["cover_board_id"]`),
+  # never by copying a board's URL into the column — a copied preview URL
+  # carries a `?v=` that goes stale the moment that preview is regenerated.
+  # Nothing already chosen is overwritten, by reference or by column.
+  def seed_display_images!
+    member_ids = board_group_boards.pluck(:board_id).uniq
+    if member_ids.any?
+      Boards::SubBoardThumbnails.apply!(
+        owner: user,
+        board_ids: member_ids,
+        root_id: root_board_id,
+        purge_previews: false,
+      )
+    end
+    # A fresh relation, not the (possibly cached) association — it has to see
+    # the columns SubBoardThumbnails just wrote.
+    boards.includes(board_images: :image).load.each(&:seed_display_image_from_tiles!)
+
+    return false if cover_board_id.present? || read_attribute(:display_image_url).present?
+
+    candidates = [root_board, *board_group_boards.order(:position).map(&:board)].compact.uniq
+    cover = candidates.detect { |board| board.display_image_url.present? }
+    return false unless cover
+
+    self.settings = (settings || {}).merge("cover_board_id" => cover.id)
+    save!
+    true
+  end
+
   # Delegates to the root board's rendered preview once import/build has
   # produced one. Used by the frontend's generic generation-status poller
   # (BoardGenerationStatusPage) while status is still "queued"/"processing" —

--- a/app/services/boards/board_group_creator.rb
+++ b/app/services/boards/board_group_creator.rb
@@ -74,6 +74,10 @@ module Boards
       # attached; reload so the caller sees every board just added rather
       # than that stale, empty cache.
       group.reload
+      # Outside the transaction: a thumbnail is cosmetic, so it seeds after the
+      # group is safely committed rather than being able to roll it back.
+      group.seed_display_images!
+      group
     end
 
     # The map's membership must not silently freeze the moment a group is
@@ -91,6 +95,7 @@ module Boards
 
       newly_reachable.each { |member| add_board!(group, member) }
       group.reload
+      group.seed_display_images!
     end
 
     def add_board!(group, member)

--- a/lib/tasks/board_groups.rake
+++ b/lib/tasks/board_groups.rake
@@ -116,6 +116,44 @@ namespace :board_groups do
 
     puts "\nDry run only — re-run without DRY_RUN to apply." if dry_run
   end
+
+  # Sets created before BoardGroup#seed_display_images! existed have member
+  # boards whose display_image_url is blank and whose preview hasn't been
+  # rendered — they show as broken thumbnails on the set page. Seed each from
+  # its own tiles and pin the set's cover by reference. Idempotent: anything
+  # that already resolves an image is left alone.
+  #
+  #   DRY_RUN=1 rake board_groups:backfill_display_images   # preview
+  #   rake board_groups:backfill_display_images             # apply
+  #   USER_ID=740 rake board_groups:backfill_display_images # scope to one owner
+  desc "Seed missing display images on board sets and their member boards (DRY_RUN=1 to preview; USER_ID=N to scope)"
+  task backfill_display_images: :environment do
+    dry_run = %w[1 true yes].include?(ENV["DRY_RUN"].to_s.downcase.strip)
+
+    groups = BoardGroup.all
+    groups = groups.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    seeded_boards = 0
+    seeded_groups = 0
+
+    groups.find_each do |group|
+      missing = group.boards.reject { |board| board.display_image_url.present? }
+      needs_cover = group.cover_board_id.blank? && group.read_attribute(:display_image_url).blank?
+      next if missing.empty? && !needs_cover
+
+      if dry_run
+        puts "set ##{group.id} #{group.name.inspect}: #{missing.size} board(s) without an image" \
+             "#{needs_cover ? ', no cover' : ''}"
+        next
+      end
+
+      seeded_boards += missing.count(&:seed_display_image_from_tiles!)
+      seeded_groups += 1 if group.seed_display_images!
+    end
+
+    puts "Seeded #{seeded_boards} board image(s) and #{seeded_groups} set cover(s)."
+    puts "Dry run only — re-run without DRY_RUN to apply." if dry_run
+  end
 end
 
 # Every board in a builder set: BFS the predictive_board_id links from the root,

--- a/spec/models/board_group_display_images_spec.rb
+++ b/spec/models/board_group_display_images_spec.rb
@@ -1,0 +1,131 @@
+require "rails_helper"
+
+RSpec.describe "board set display images" do
+  let(:user) { create(:user) }
+
+  def add_tile(board, label:, src: nil, links_to: nil)
+    image = create(:image, label: label)
+    bi = create(:board_image, board: board, image: image, predictive_board_id: links_to&.id)
+    bi.update_column(:display_image_url, src) if src
+    bi
+  end
+
+  describe "Board#seed_display_image_from_tiles!" do
+    it "seeds the column from the first tile that resolves an image" do
+      board = create(:board, user: user)
+      add_tile(board, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      expect(board.seed_display_image_from_tiles!).to be(true)
+      expect(board.reload.display_image_url).to eq("https://cdn.example.com/apple.png")
+    end
+
+    it "leaves a board that already has an image alone" do
+      board = create(:board, user: user, display_image_url: "https://cdn.example.com/chosen.png")
+      add_tile(board, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      expect(board.seed_display_image_from_tiles!).to be(false)
+      expect(board.reload.display_image_url).to eq("https://cdn.example.com/chosen.png")
+    end
+
+    it "is a no-op for a board with no tiles" do
+      board = create(:board, user: user)
+
+      expect(board.seed_display_image_from_tiles!).to be(false)
+      expect(board.reload.display_image_url).to be_blank
+    end
+  end
+
+  describe "BoardGroup#seed_display_images!" do
+    it "gives a sub-board the folder tile that opens it, not its own first tile" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "Food", src: "https://cdn.example.com/folder.png", links_to: food)
+      add_tile(food, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      group = BoardGroup.create!(user: user, name: "Set")
+      group.add_board(home)
+      group.add_board(food)
+      group.update!(root_board_id: home.id)
+
+      group.reload.seed_display_images!
+
+      expect(food.reload.display_image_url).to eq("https://cdn.example.com/folder.png")
+    end
+
+    it "seeds every member board and pins the set cover by reference" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "food", src: "https://cdn.example.com/food.png")
+      add_tile(food, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      group = BoardGroup.create!(user: user, name: "Set")
+      group.add_board(home)
+      group.add_board(food)
+      group.update!(root_board_id: home.id)
+
+      expect(group.reload.seed_display_images!).to be(true)
+
+      expect(home.reload.display_image_url).to eq("https://cdn.example.com/food.png")
+      expect(food.reload.display_image_url).to eq("https://cdn.example.com/apple.png")
+      # Pinned by reference, never by copying the board's URL into the column.
+      expect(group.reload.cover_board_id).to eq(home.id)
+      expect(group.read_attribute(:display_image_url)).to be_blank
+      expect(group.display_image_url).to eq("https://cdn.example.com/food.png")
+    end
+
+    it "does not overwrite a cover that is already pinned" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "food", src: "https://cdn.example.com/food.png")
+      add_tile(food, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      group = BoardGroup.create!(user: user, name: "Set", settings: { "cover_board_id" => food.id })
+      group.add_board(home)
+      group.add_board(food)
+
+      expect(group.reload.seed_display_images!).to be(false)
+      expect(group.reload.cover_board_id).to eq(food.id)
+      # Member boards are still seeded even when the cover is left alone.
+      expect(home.reload.display_image_url).to eq("https://cdn.example.com/food.png")
+    end
+
+    it "does not overwrite an explicitly chosen display_image_url column" do
+      home = create(:board, user: user, name: "Home")
+      add_tile(home, label: "food", src: "https://cdn.example.com/food.png")
+
+      group = BoardGroup.create!(user: user, name: "Set", display_image_url: "https://cdn.example.com/cover.png")
+      group.add_board(home)
+
+      expect(group.reload.seed_display_images!).to be(false)
+      expect(group.reload.display_image_url).to eq("https://cdn.example.com/cover.png")
+    end
+
+    it "is a no-op when no member board can resolve an image" do
+      home = create(:board, user: user, name: "Home")
+      add_tile(home, label: "food")
+
+      group = BoardGroup.create!(user: user, name: "Set")
+      group.add_board(home)
+
+      expect(group.reload.seed_display_images!).to be(false)
+      expect(group.reload.cover_board_id).to be_blank
+    end
+  end
+
+  describe "Boards::BoardGroupCreator" do
+    it "seeds display images for the new group and its member boards" do
+      home = create(:board, user: user, name: "Home")
+      food = create(:board, user: user, name: "Food")
+      add_tile(home, label: "Food", src: "https://cdn.example.com/food.png", links_to: food)
+      add_tile(food, label: "apple", src: "https://cdn.example.com/apple.png")
+
+      group = Boards::BoardGroupCreator.new(board: home, user: user).call
+
+      expect(group.cover_board_id).to eq(home.id)
+      # Root falls back to its own first tile; the linked page takes the folder
+      # tile that opens it.
+      expect(group.display_image_url).to eq("https://cdn.example.com/food.png")
+      expect(food.reload.display_image_url).to eq("https://cdn.example.com/food.png")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Creating a Board Set from a board and its linked pages left every page rendering as a broken image on the set page.

Board previews render asynchronously, so at the moment a set is created most members have neither a `preview_image` nor a `display_image_url` — `Board#display_image_url` returns nil and the frontend has nothing to show.

#663 fixed this for **imported** and **built** sets. The path it didn't cover is the one a user hits from the app: creating a set on demand from a hand-linked board (`Boards::BoardGroupCreator`), and the hand-picked `API::BoardGroupsController#create`.

## What changed

- **`BoardGroup#seed_display_images!`** closes the gap by *reusing* the resolver #663 added rather than inventing a second one:
  - `Boards::SubBoardThumbnails` gives each page the folder tile that **opens** it — one query for the whole set, no Grover render per page. Called with `purge_previews: false`: these are ordinary boards, so a real preview must keep winning over the seeded column.
  - Anything that can't reach — a board hand-picked into a set with no folder tile pointing at it, or the set root — falls back to the board's own tiles via the new `Board#seed_display_image_from_tiles!`.
  - The set's own cover is then pinned **by reference** (`settings["cover_board_id"]`), never by copying a board's URL into the column — a copied preview URL carries a `?v=` that goes stale on the next preview regen.
  - Nothing already chosen is overwritten: a pinned `cover_board_id`, a chosen column value, or a board that already resolves an image is left alone.
- Wired into `Boards::BoardGroupCreator` on both create and membership re-sync, outside the transaction — a missing thumbnail is cosmetic and must never roll back the group.
- **`API::BoardGroupsController#create` was rendering before attaching its boards**, so the response never carried them at all. Members are now attached, then seeded, then rendered.
- `rake board_groups:backfill_display_images` for pre-existing sets (`DRY_RUN=1`, `USER_ID=N`).

## Reviewer notes

- The seed lands in the `display_image_url` **column**, which `Board#display_image_url` treats as the lowest-priority fallback (behind a custom cover and a live preview). That's the documented "pre-preview seed" role, so the seed can't pin a stale image once a real preview exists.
- Rebased onto #663 — the two overlap in subject, and this one deliberately builds on `Boards::SubBoardThumbnails` instead of duplicating its logic.

## Test plan

New `spec/models/board_group_display_images_spec.rb` (9 examples) covers: folder tile wins over a page's own tile; own-tile fallback when nothing links to the board; no-op with no tiles; cover pinned by reference and not by URL; an already-pinned cover and an explicitly chosen column value both left alone; and the `BoardGroupCreator` wiring end to end.

Ran the new spec plus every existing board-group and thumbnail spec:

```
bundle exec rspec spec/models/board_group_display_images_spec.rb \
  spec/services/boards/board_group_creator_spec.rb \
  spec/services/boards/sub_board_thumbnails_spec.rb \
  spec/requests/api/board_groups_spec.rb \
  spec/requests/api/board_groups_graph_spec.rb \
  spec/requests/api/boards_create_board_group_spec.rb \
  spec/models/board_group_spec.rb \
  spec/models/board_eligible_board_group_spec.rb \
  spec/sidekiq/import_obz_job_spec.rb
```

**95 examples, 0 failures.**

Docs: `.claude-notes/boards-and-teams.md` (Board Sets section) + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
