### PR TITLE
perf(profiles): serialize public page boards as cards, not api_view

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -18,6 +18,25 @@ info** — medical details + emergency contacts + emergency notes
   frontend can show the "Emergency Info" button without shipping the data.
   `GET public` therefore carries **no** medical info or contacts — the wall is
   real, not just a UI modal.
+- **The public page serializes boards as CARDS, never `api_view`.** `#public`
+  is unauthenticated, so both board lists in the payload go through the
+  card-sized serializers: `Board#public_card_view` for `general_public_boards`
+  and `ChildBoard#public_card_view` for `public_boards`. The full `api_view`
+  on either model publishes identities — `Board#api_view` carries `in_use_by`
+  (a joined list of every communicator NAME using the board) plus
+  `communicator_account_data` (their account ids, names, avatar URLs), and
+  `ChildBoard#api_view` carries `added_by`, the EMAIL of whoever assigned the
+  board. The card keys mirror the frontend's `PublicBoardCard` type
+  (`itty-bitty-frontend/src/data/profiles.ts`), which is all the MySpeak board
+  grid renders. Adding a field to a public card is a decision about what the
+  whole internet sees.
+- **`general_public_boards` is the whole admin library, so it is cached, not
+  per-request.** `Board.public_board_cards` memoizes into `Rails.cache` (Redis
+  in prod) keyed on `Board.public_board_cards_cache_key` (count + max
+  `updated_at`). That key is also folded into `profile_public_etag`, because
+  the library rides along in the body and would otherwise be unable to
+  invalidate a 304. Serializing it inline with `api_view` is what made this
+  endpoint take 11.5s in production (of which ~10.3s was Ruby, not SQL).
 - **The gated reveal records + alerts.** `POST /api/profiles/public/:slug/safety_view`
   (`API::ProfilesController#safety_view`, unauthenticated) is the deliberate
   "open emergency info" action. It (a) returns the sensitive payload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **MySpeak pages load fast again.** Opening a communicator's public page —
+  the page a printed QR code lands on — was taking around eleven seconds. Every
+  visit was rebuilding the entire public board library from scratch, in the
+  same detail the board editor needs, when all the page draws is a grid of
+  covers. The page now sends just what the grid shows and reuses the library
+  between visitors, so it comes up quickly on a phone in a waiting room.
+
+- **Public pages no longer include information about other people.** The board
+  data on a MySpeak page carried details that were never shown but were sent to
+  every visitor anyway: the names of other communicators using the same public
+  board, and the email address of whoever assigned a board to this
+  communicator. Public pages now carry only what the page renders — the board's
+  name, cover, and colours.
+
 - **Boards no longer end up with a permanently blank cover.** An imported board
   never had a preview picture made for it at all, so it showed an empty frame
   on the import screen and in your board list until you happened to edit it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,22 @@ an explicit decision, not a drive-by edit.
   POST** — never on public page-open. It is also never sent to OpenAI: no
   `Profile::SAFETY_SENSITIVE_KEYS` entry may appear in a
   `Suggestions::Registry` context allow-list (enforced by spec).
+- **An unauthenticated endpoint never serializes a board with `api_view`.**
+  `Board#api_view` publishes `in_use_by` (every communicator NAME using the
+  board) and `communicator_account_data` (their ids, names, avatars);
+  `ChildBoard#api_view` publishes `added_by`, the assigning user's EMAIL. Both
+  models carry a `public_card_view` for public pages, matching the frontend's
+  `PublicBoardCard` type. `api_view` is also the expensive one — it runs three
+  `rows_for_screen_size` passes per board — so reaching for it on a public list
+  leaks and is slow at the same time. Details:
+  `.claude-notes/safety-profiles.md`.
+- **`print_grid_layout_for_screen_size` must build a DENSE list.** It once
+  assigned into a plain Array at `layout_to_set[bi.id]` — the global
+  `board_images` primary key — then compacted the holes away, so serializing a
+  30-tile board allocated an array sized to `MAX(board_images.id)` and the cost
+  of every `Board#api_view` grew with the whole table. Nothing reads the index
+  positions; every consumer reads each cell's own `x`/`y`. The memo it now
+  keeps is cleared wherever tile layouts are rewritten (`board_images.reset`).
 - **Never seed `profiles.bio` or `profiles.intro` with instructional copy.**
   Both are PUBLIC — `/my/:slug` prints the bio as "About me" and speaks the
   intro aloud on "Hear my intro" — so placeholder text stored there is

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -419,6 +419,10 @@ class API::ProfilesController < API::ApplicationController
       boards_scope.count,
       boards_scope.maximum(:id),
       boards_scope.maximum(:updated_at)&.utc&.to_fs(:nsec),
+      # The admin board library rides along in the body as
+      # `general_public_boards`, so a change to it has to be able to bust a
+      # cached page — without this a client can be served a stale 304.
+      Board.public_board_cards_cache_key,
     ]
   end
 
@@ -430,8 +434,11 @@ class API::ProfilesController < API::ApplicationController
 
   def public_page_board_ids(profile)
     if profile.profileable_type == "ChildAccount"
-      board_ids = profile.communication_boards.pluck(:id)
-      return board_ids
+      # communication_boards is favorite_boards, which returns ChildBoard join
+      # rows — pluck the Board they point at, not the join row's own id. These
+      # ids are handed to Board.where(id:) by the freshness helpers below, so
+      # plucking :id keyed the ETag off arbitrary unrelated boards.
+      return profile.communication_boards.pluck(:board_id).compact.uniq
     end
     public_page = profile_public_page_settings(profile)
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1352,15 +1352,19 @@ class Board < ApplicationRecord
 
   SCREEN_SIZES = %w[sm md lg].freeze
 
+  # Cells are collected in `position` order. This used to assign into a plain
+  # Array at `layout_to_set[bi.id]` — indexing by the GLOBAL board_images
+  # primary key — and then `.compact` the holes away. That allocated an array
+  # sized to MAX(board_images.id) for every call, so the cost of serializing a
+  # 30-tile board grew with the size of the whole board_images table.
+  # `api_view` calls this three times per board (lg/md/sm), so on any endpoint
+  # that serializes a list of boards it dominated the request. Nothing
+  # consumes the index positions — every caller reads each cell's own x/y —
+  # so build the dense list directly.
   def print_grid_layout_for_screen_size(screen_size)
-    layout_to_set = []
-    board_images.order(:position).each_with_index do |bi, i|
-      if bi.layout[screen_size]
-        layout_to_set[bi.id] = bi.layout[screen_size]
-      end
-    end
-    layout_to_set = layout_to_set.compact # Remove nil values
-    layout_to_set
+    @grid_layouts ||= {}
+    @grid_layouts[screen_size] ||=
+      board_images.order(:position).filter_map { |bi| bi.layout[screen_size] }
   end
 
   def print_grid_layout
@@ -1401,6 +1405,7 @@ class Board < ApplicationRecord
 
     self.layout[screen_size] = layout_to_set
     self.board_images.reset
+    @grid_layouts = nil # tile layouts just changed; drop the read-side memo
     self.save!
   end
 
@@ -1473,6 +1478,7 @@ class Board < ApplicationRecord
     end
     self.save
     self.board_images.reset
+    @grid_layouts = nil # tile layouts just changed; drop the read-side memo
   end
 
   # Open cells in the authored grid before a new tile would spill onto a fresh
@@ -1529,6 +1535,7 @@ class Board < ApplicationRecord
     end
     self.layout[screen_size] = layout_to_set
     self.board_images.reset
+    @grid_layouts = nil # tile layouts just changed; drop the read-side memo
     self.save!
   end
 
@@ -2329,6 +2336,50 @@ class Board < ApplicationRecord
     else
       large_screen_columns > 0 ? large_screen_columns : 12
     end
+  end
+
+  # Board card for UNAUTHENTICATED public pages (the MySpeak page's board grid).
+  # Deliberately NOT api_view: that emits `in_use_by` and
+  # `communicator_account_data` — the names, account ids, and avatar URLs of
+  # every communicator using the board — which must never be served on a page
+  # with no authentication. It also runs three rows_for_screen_size passes per
+  # board that a card doesn't render. Keys mirror the frontend's
+  # `PublicBoardCard` type (itty-bitty-frontend/src/data/profiles.ts).
+  def public_card_view
+    {
+      id: id,
+      board_id: id,
+      slug: slug,
+      name: name,
+      display_image_url: display_image_url,
+      preview_image_url: preview_image_url,
+      preset_display_image_url: preset_display_image_url,
+    }
+  end
+
+  # The curated admin board library, rendered as public cards. Identical for
+  # every visitor, so it is computed once rather than per request — this used
+  # to be `Board.public_boards.map(&:api_view)` inlined into every public
+  # profile payload, which serialized the whole library on each page load.
+  # Rails.cache is Redis in production and :null_store in test, so this must
+  # stay correct when the block runs every time.
+  def self.public_board_cards
+    Rails.cache.fetch(public_board_cards_cache_key, expires_in: 15.minutes) do
+      public_boards
+        .includes(preview_image_attachment: :blob, preset_display_image_attachment: :blob)
+        .map(&:public_card_view)
+    end
+  end
+
+  # Also folded into the public profile ETag so a library change can invalidate
+  # a cached page (the library rides along in that payload).
+  def self.public_board_cards_cache_key
+    scope = public_boards
+    [
+      "public_board_cards/v1",
+      scope.count,
+      scope.maximum(:updated_at)&.utc&.to_fs(:nsec),
+    ].join("/")
   end
 
   def list_api_view(viewing_user = nil)

--- a/app/models/child_board.rb
+++ b/app/models/child_board.rb
@@ -114,6 +114,24 @@ class ChildBoard < ApplicationRecord
     user.can_add_boards_to_account?([child_account_id])
   end
 
+  # Board card for UNAUTHENTICATED public pages (the MySpeak page's board
+  # grid). Deliberately NOT api_view: that emits `added_by` — the email of
+  # whoever assigned the board — plus the assigning user's id and the board
+  # owner's name, none of which belongs on a page with no authentication and
+  # none of which a card renders. Keys mirror the frontend's `PublicBoardCard`
+  # type (itty-bitty-frontend/src/data/profiles.ts).
+  def public_card_view
+    {
+      id: id,
+      board_id: board_id,
+      name: board.name,
+      display_image_url: display_image_url || preview_image_url,
+      preview_image_url: preview_image_url,
+      bg_color: board.bg_color,
+      text_color: board.text_color,
+    }
+  end
+
   def api_view
     {
       id: id,

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -236,15 +236,20 @@ class Profile < ApplicationRecord
   end
 
   # --- Boards ---
+  # Preloads matter here: both of these are serialized straight into the public
+  # profile payload, and every board card reads display_image_url /
+  # preview_image_url, which are ActiveStorage lookups.
+  BOARD_CARD_PRELOADS = [{ preview_image_attachment: :blob }, { preset_display_image_attachment: :blob }].freeze
+
   def user_boards
     return [] if profileable.nil?
-    return profileable.boards.main_boards.alphabetical if profileable_type == "User"
+    return profileable.boards.main_boards.alphabetical.includes(:user, *BOARD_CARD_PRELOADS) if profileable_type == "User"
     []
   end
 
   def communication_boards
     if profileable&.respond_to?(:favorite_boards) && profileable.favorite_boards.present?
-      profileable.favorite_boards
+      profileable.favorite_boards.includes(board: BOARD_CARD_PRELOADS)
     else
       # Board.public_boards
       []
@@ -363,8 +368,8 @@ class Profile < ApplicationRecord
       has_safety_info: has_safety_info?,
 
       # Boards shown publicly should be safe/public
-      public_boards: public_boards.map(&:api_view),
-      general_public_boards: Board.public_boards.map(&:api_view),
+      public_boards: public_boards.map(&:public_card_view),
+      general_public_boards: Board.public_board_cards,
 
       # If you need this for the UI, keep it minimal
       profileable_type: profileable_type,
@@ -402,9 +407,9 @@ class Profile < ApplicationRecord
       settings: public_settings(kind: :public_page),
 
       # If you want this on creator pages, keep it public-only
-      public_boards: public_boards.map(&:api_view),
+      public_boards: public_boards.map(&:public_card_view),
       user_boards: user_boards.map(&:api_view),
-      general_public_boards: Board.public_boards.map(&:api_view),
+      general_public_boards: Board.public_board_cards,
       # NOTE: email intentionally omitted — use settings["show_email"]
       # on the frontend if the user opted in to displaying contact info.
       public_about_html: safe_html(public_about&.body&.to_s),
@@ -449,7 +454,7 @@ class Profile < ApplicationRecord
       claim_token: claim_token,
       claim_url: claim_url,
       sku: sku,
-      general_public_boards: Board.public_boards.map(&:api_view),
+      general_public_boards: Board.public_board_cards,
     }
   end
 

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1153,4 +1153,103 @@ RSpec.describe Board, type: :model do
   # deleted in favor of Boards::ObfExporter (see
   # spec/services/boards/obf_exporter_spec.rb), which covers the same ground:
   # spec-shaped output, load_board linking, and sound omission.
+
+  describe "#print_grid_layout_for_screen_size" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+
+    def add_tile(position:, layout:)
+      bi = FactoryBot.create(:board_image, board: board, image: FactoryBot.create(:image, user: user))
+      bi.update_columns(position: position, layout: layout)
+      bi
+    end
+
+    it "returns each tile's cell for the screen size, in position order" do
+      add_tile(position: 1, layout: { "lg" => { "i" => "b", "x" => 1, "y" => 0, "w" => 1, "h" => 1 } })
+      add_tile(position: 0, layout: { "lg" => { "i" => "a", "x" => 0, "y" => 0, "w" => 1, "h" => 1 } })
+
+      cells = board.reload.print_grid_layout_for_screen_size("lg")
+
+      expect(cells.map { |c| c["i"] }).to eq(%w[a b])
+    end
+
+    it "skips tiles with no cell for that screen size" do
+      add_tile(position: 0, layout: { "lg" => { "i" => "a", "x" => 0, "y" => 0, "w" => 1, "h" => 1 } })
+      add_tile(position: 1, layout: { "sm" => { "i" => "b", "x" => 0, "y" => 0, "w" => 1, "h" => 1 } })
+
+      expect(board.reload.print_grid_layout_for_screen_size("lg").size).to eq(1)
+    end
+
+    # Regression: this used to build a plain Array indexed by the GLOBAL
+    # board_images primary key and then compact the holes away, so the work and
+    # memory for a two-tile board scaled with MAX(board_images.id) across the
+    # whole table. api_view calls it three times per board, which is what made
+    # serializing a list of boards take seconds in production.
+    it "does not scale with the size of the board_images id space" do
+      a = add_tile(position: 0, layout: { "lg" => { "i" => "a", "x" => 0, "y" => 0, "w" => 1, "h" => 2 } })
+      b = add_tile(position: 1, layout: { "lg" => { "i" => "b", "x" => 1, "y" => 0, "w" => 1, "h" => 1 } })
+      a.update_columns(id: 5_000_001)
+      b.update_columns(id: 5_000_002)
+
+      cells = board.reload.print_grid_layout_for_screen_size("lg")
+
+      expect(cells.size).to eq(2)
+      expect(board.rows_for_screen_size("lg")).to eq(2)
+    end
+
+    it "drops the memo when the layout is recalculated" do
+      add_tile(position: 0, layout: {})
+      expect(board.reload.print_grid_layout_for_screen_size("lg")).to eq([])
+
+      board.calculate_grid_layout_for_screen_size("lg", true)
+
+      expect(board.print_grid_layout_for_screen_size("lg").size).to eq(1)
+    end
+  end
+
+  describe "#public_card_view / .public_board_cards" do
+    let(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+    let!(:public_board) do
+      FactoryBot.create(:board, user: admin_user, predefined: true, published: true, parent_type: "User")
+    end
+
+    it "carries the keys the public board card renders" do
+      view = public_board.public_card_view
+
+      expect(view.keys).to contain_exactly(
+        :id, :board_id, :slug, :name,
+        :display_image_url, :preview_image_url, :preset_display_image_url
+      )
+      expect(view[:id]).to eq(public_board.id)
+      expect(view[:board_id]).to eq(public_board.id)
+      expect(view[:name]).to eq(public_board.name)
+    end
+
+    # The MySpeak page is unauthenticated. api_view emits in_use_by (a joined
+    # list of communicator NAMES) and communicator_account_data (their account
+    # ids, names, and avatar URLs); none of that may ride along on a public page.
+    it "omits the communicator identities api_view exposes" do
+      view = public_board.public_card_view
+
+      expect(view).not_to have_key(:in_use_by)
+      expect(view).not_to have_key(:communicator_account_data)
+      expect(view).not_to have_key(:user_name)
+      expect(view).not_to have_key(:data)
+      expect(view).not_to have_key(:settings)
+    end
+
+    it "returns one card per public board" do
+      cards = described_class.public_board_cards
+
+      expect(cards.map { |c| c[:id] }).to include(public_board.id)
+      expect(cards.size).to eq(described_class.public_boards.count)
+    end
+
+    it "changes its cache key when a public board is touched" do
+      before_key = described_class.public_board_cards_cache_key
+      public_board.touch
+
+      expect(described_class.public_board_cards_cache_key).not_to eq(before_key)
+    end
+  end
 end

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -345,4 +345,81 @@ RSpec.describe "API::Profiles", type: :request do
       expect(profile.reload.settings["theme"]).to be_nil
     end
   end
+
+  # The MySpeak page is unauthenticated and is the page a printed QR code
+  # lands on. Its board lists used to be serialized with the full editor
+  # api_view, which both cost seconds per request and published identities
+  # (Board#api_view -> in_use_by / communicator_account_data;
+  # ChildBoard#api_view -> added_by, the assigning user's EMAIL).
+  describe "GET /api/profiles/public/:slug board payload" do
+    let(:owner) { FactoryBot.create(:user, email: "assigning-parent@example.com") }
+    let(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+    let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky Doe") }
+    let!(:profile) do
+      Profile.new(profileable: child, username: "sky-boards", slug: "sky-boards").tap(&:save!)
+    end
+    let!(:library_board) do
+      FactoryBot.create(:board, user: admin_user, predefined: true, published: true, parent_type: "User")
+    end
+    let!(:favorite) do
+      board = FactoryBot.create(:board, user: owner, name: "Snack Time")
+      FactoryBot.create(:child_board, board: board, child_account: child, favorite: true, created_by: owner)
+    end
+
+    before do
+      allow_any_instance_of(Profile).to receive(:generate_attachments!).and_return(true)
+    end
+
+    it "serves the communicator's boards as cards without the assigner's email" do
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(response).to have_http_status(:ok)
+      card = JSON.parse(response.body)["public_boards"].first
+      expect(card["name"]).to eq("Snack Time")
+      expect(card["board_id"]).to eq(favorite.board_id)
+      expect(card).not_to have_key("added_by")
+      expect(card).not_to have_key("added_by_id")
+      expect(card).not_to have_key("board_owner_name")
+      expect(response.body).not_to include("assigning-parent@example.com")
+    end
+
+    it "serves the admin library as cards without communicator identities" do
+      get "/api/profiles/public/#{profile.slug}"
+
+      cards = JSON.parse(response.body)["general_public_boards"]
+      expect(cards.map { |c| c["id"] }).to include(library_board.id)
+      cards.each do |card|
+        expect(card).not_to have_key("in_use_by")
+        expect(card).not_to have_key("communicator_account_data")
+      end
+      # The page legitimately shows this communicator's own name; what must not
+      # appear is any communicator name reachable through a library board card.
+      expect(cards.to_json).not_to include("Sky Doe")
+    end
+
+    it "invalidates the ETag when a library board changes" do
+      get "/api/profiles/public/#{profile.slug}"
+      first_etag = response.headers["ETag"]
+      expect(first_etag).to be_present
+
+      library_board.touch
+
+      get "/api/profiles/public/#{profile.slug}"
+      expect(response.headers["ETag"]).not_to eq(first_etag)
+    end
+
+    # public_page_board_ids used to pluck the ChildBoard join row's own id and
+    # hand it to Board.where(id:), so the favorited Board could never be found
+    # and Last-Modified always collapsed to the profile's own timestamp.
+    it "tracks the favorited board's updated_at in Last-Modified" do
+      board_touched_at = 1.hour.from_now.change(usec: 0)
+      profile.update_columns(updated_at: 3.days.ago)
+      favorite.board.update_columns(updated_at: board_touched_at)
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(Time.parse(response.headers["Last-Modified"]))
+        .to be_within(2.seconds).of(board_touched_at)
+    end
+  end
 end


### PR DESCRIPTION
## Why

A production request to `GET /api/profiles/public/s-j5nz86` took **11.5s** — `db_runtime` 1074ms, `view_runtime` 51ms, so **~10.3s was Ruby/GC**, not SQL.

The cost was one field:

```ruby
general_public_boards: Board.public_boards.map(&:api_view),
```

`Board.public_boards` is the entire admin preset library — no `includes`, no limit, no pagination — and `Board#api_view` is the full editor serializer. It ran for every board in that library on every load of the MySpeak page, the page a printed QR code lands on. Nothing about the profile filtered it.

**It was also leaking.** On an endpoint with `skip_before_action :authenticate_token!`:
- `Board#api_view` emits `in_use_by` (a comma-joined list of every communicator **name** using the board) and `communicator_account_data` (their account ids, names, avatar URLs).
- `ChildBoard#api_view` emits `added_by` — the **email** of whoever assigned the board.

The frontend wanted none of it. `PublicProfile.tsx` is the only consumer of `general_public_boards`, and it renders each entry through `renderBoardCard` against the 7-field `PublicBoardCard` type.

## What changed

1. **`Board#public_card_view` / `ChildBoard#public_card_view`** — card-sized serializers matching `PublicBoardCard`, used for `public_boards` and `general_public_boards` on all three public payloads (`safety_view`, `public_page_view`, `placeholder_view`). `user_boards` is unchanged.
2. **`Board.public_board_cards`** — the library is identical for every visitor, so it is cached in `Rails.cache` (Redis in prod) keyed on count + max `updated_at`, with the attachments preloaded. That key is folded into `profile_public_etag`, since the library rides along in the body and previously couldn't invalidate a 304.
3. **`print_grid_layout_for_screen_size`** — it assigned into a plain Array at `layout_to_set[bi.id]`, the *global* `board_images` primary key, then compacted the holes away. A 30-tile board allocated an array sized to `MAX(board_images.id)`; `api_view` calls it three times per board. Now builds a dense list via `filter_map`, memoized per screen size and cleared wherever tile layouts are rewritten. This helps `/api/boards` too.
4. **`public_page_board_ids`** — plucked the ChildBoard join row's own `:id` and handed it to `Board.where(id:)`, so a ChildAccount page's ETag/Last-Modified were computed over unrelated boards. Now plucks `:board_id`.
5. Preloads on `user_boards` / `communication_boards`.

Measured locally (19 public boards, `MAX(board_images.id)` = 106k):

| | before | after |
|---|---|---|
| library serialization | 81.7 ms | 2.5 ms |
| library JSON | 79,778 B | 5,392 B |
| full `safety_view` | — | 4.5 ms |

The production gap should be larger: the sparse-array cost scales with the size of the whole `board_images` table (simulating a 3M id space: 4.9 ms per call, ×3 per board), and `in_use_by` fans out over every `ChildBoard` row for boards that are cloned to many communicators.

## Test plan

New:
- `spec/models/board_spec.rb` — `print_grid_layout_for_screen_size` returns cells in position order, skips tiles with no cell, **does not scale with the board_images id space** (regression, tiles pushed to id 5,000,001+), and drops its memo on recalculation. `public_card_view` carries exactly the card keys and omits `in_use_by` / `communicator_account_data` / `data` / `settings`; `public_board_cards` returns one card per public board and its cache key moves when a board is touched.
- `spec/requests/api/profiles_spec.rb` — the public payload's `public_boards` carry no `added_by` and the response body does not contain the assigning user's email; `general_public_boards` carry no communicator identities; the ETag changes when a library board changes; `Last-Modified` tracks the *favorited board's* `updated_at`.

Run, all passing:
- `spec/models/board_spec.rb` `spec/requests/api/boards_spec.rb` `spec/models/profile_spec.rb` `spec/models/child_board_spec.rb` `spec/requests/api/profiles_spec.rb` — 166 + 8 examples, 0 failures
- OBF/grid consumers of the changed layout method: `spec/models/board_image_obf_format_spec.rb` `spec/requests/api/board_exports_spec.rb` `spec/requests/api/boards/import_export_spec.rb` `spec/models/board_group_spec.rb` `spec/sidekiq/build_board_set_job_grid_spec.rb` — 73 examples, 0 failures
- `spec/models/profile_view_spec.rb` `spec/requests/api/profiles_owner_protection_spec.rb` `spec/requests/api/profiles_view_alerts_spec.rb` — 0 failures

Also verified against real local data that both card paths produce the expected keys and no leaked keys.

Docs: `.claude-notes/safety-profiles.md` (the public-page serializer rule + library caching), `CLAUDE.md` (two invariants), `CHANGELOG.md`.

## Follow-ups, not in this PR

- `user_boards` still uses `Board#api_view` on `public_page_view`, so a user's own public page still publishes `in_use_by` — their own communicators' names — to visitors. `PublicUserProfilePage`/`PublicVendorProfile` read more Board fields, so slimming it needs its own check. Worth a decision.
- The endpoint still sends `Cache-Control: no-cache, private, must-revalidate`, so nothing edge-caches. A short public `s-maxage` would be a bigger win but changes the sharing model for a page with a gated safety section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)