### PR TITLE
fix(profiles): card-serialize user_boards and repair the favorites preload

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -19,17 +19,31 @@ info** — medical details + emergency contacts + emergency notes
   `GET public` therefore carries **no** medical info or contacts — the wall is
   real, not just a UI modal.
 - **The public page serializes boards as CARDS, never `api_view`.** `#public`
-  is unauthenticated, so both board lists in the payload go through the
-  card-sized serializers: `Board#public_card_view` for `general_public_boards`
-  and `ChildBoard#public_card_view` for `public_boards`. The full `api_view`
-  on either model publishes identities — `Board#api_view` carries `in_use_by`
-  (a joined list of every communicator NAME using the board) plus
-  `communicator_account_data` (their account ids, names, avatar URLs), and
-  `ChildBoard#api_view` carries `added_by`, the EMAIL of whoever assigned the
-  board. The card keys mirror the frontend's `PublicBoardCard` type
-  (`itty-bitty-frontend/src/data/profiles.ts`), which is all the MySpeak board
-  grid renders. Adding a field to a public card is a decision about what the
-  whole internet sees.
+  is unauthenticated, so **all three** board lists in the payload go through
+  card-sized serializers, with no exceptions left:
+  | payload key | serializer | page |
+  |---|---|---|
+  | `general_public_boards` | `Board#public_card_view` | both |
+  | `public_boards` | `ChildBoard#public_card_view` | MySpeak (`/my/:slug`) |
+  | `user_boards` | `Board#public_page_card_view` | User page (`/u/:slug`) |
+
+  The full `api_view` on either model publishes identities — `Board#api_view`
+  carries `in_use_by` (a joined list of every communicator NAME using the
+  board) plus `communicator_account_data` (their account ids, names, avatar
+  URLs), and `ChildBoard#api_view` carries `added_by`, the EMAIL of whoever
+  assigned the board. On a User's own public page `in_use_by` is that user's
+  OWN communicators' names, which is exactly the thing a public page must not
+  hand out. The frontend gates all of it behind `!isPublicGrid && can_edit`,
+  so none of it was ever rendered publicly — it was only ever transmitted,
+  which is the whole failure mode: a field nobody sees is a field nobody
+  notices leaving. `public_page_card_view` is the wider of the two Board
+  cards (it adds `predefined` / `published` / `user_id` and pins `can_edit`,
+  `locked`, `in_a_public_group` to false) because the User page's grids
+  (`BoardGrid` / `BoardGridItem` / `PublicFeaturedBoards`) read more than the
+  MySpeak grid does. `Profile#api_view` — the AUTHENTICATED view behind
+  `GET /api/profiles/:id`, which the edit form uses — keeps `api_view` for
+  `user_boards`; only the public payloads are carded. Adding a field to a
+  public card is a decision about what the whole internet sees.
 - **`general_public_boards` is the whole admin library, so it is cached, not
   per-request.** `Board.public_board_cards` memoizes into `Rails.cache` (Redis
   in prod) keyed on `Board.public_board_cards_cache_key` (count + max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,12 +89,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   covers. The page now sends just what the grid shows and reuses the library
   between visitors, so it comes up quickly on a phone in a waiting room.
 
+- **Public profile pages load again for users who have favorited a board.**
+  A page could fail outright rather than render — the error depended only on
+  whether the owner had ever starred one of their own boards.
+
 - **Public pages no longer include information about other people.** The board
   data on a MySpeak page carried details that were never shown but were sent to
   every visitor anyway: the names of other communicators using the same public
   board, and the email address of whoever assigned a board to this
-  communicator. Public pages now carry only what the page renders — the board's
-  name, cover, and colours.
+  communicator. The same was true of your own public profile page, where the
+  board list carried the names of *your* communicators to anyone who opened it.
+  Public pages now carry only what the page renders — the board's name, cover,
+  and colours. Nothing about how these pages look has changed.
 
 - **Boards no longer end up with a permanently blank cover.** An imported board
   never had a preview picture made for it at all, so it showed an empty frame

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,9 +302,15 @@ an explicit decision, not a drive-by edit.
   board) and `communicator_account_data` (their ids, names, avatars);
   `ChildBoard#api_view` publishes `added_by`, the assigning user's EMAIL. Both
   models carry a `public_card_view` for public pages, matching the frontend's
-  `PublicBoardCard` type. `api_view` is also the expensive one — it runs three
-  `rows_for_screen_size` passes per board — so reaching for it on a public list
-  leaks and is slow at the same time. Details:
+  `PublicBoardCard` type; `Board#public_page_card_view` is the slightly wider
+  card the User public page's grids need. **All three** board lists in the
+  public profile payload are carded — `general_public_boards`, `public_boards`,
+  and `user_boards` (a User's own page, where `in_use_by` is that user's own
+  communicators' names). The frontend gates every one of these fields behind
+  `!isPublicGrid && can_edit`, so they were never rendered — only transmitted,
+  which is why the leak survived so long. `api_view` is also the expensive one
+  — it runs three `rows_for_screen_size` passes per board — so reaching for it
+  on a public list leaks and is slow at the same time. Details:
   `.claude-notes/safety-profiles.md`.
 - **`print_grid_layout_for_screen_size` must build a DENSE list.** It once
   assigned into a plain Array at `layout_to_set[bi.id]` — the global

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2380,6 +2380,27 @@ class Board < ApplicationRecord
     }
   end
 
+  # The public-page variant of the card, for a User profile's own board grid
+  # (`Profile#public_page_view` -> user_boards). Same no-identities rule as
+  # public_card_view — it just carries the few extra presentational flags the
+  # richer public grids read (BoardGrid / BoardGridItem / PublicFeaturedBoards).
+  #
+  # can_edit / locked / in_a_public_group are pinned false rather than derived:
+  # public_page_view has no viewer, so `api_view` was already being called with
+  # viewing_user = nil, and all three were false for every visitor. Pinning
+  # them keeps the payload identical for those keys while making it obvious
+  # that a public page never grants edit affordances.
+  def public_page_card_view
+    public_card_view.merge(
+      user_id: user_id,
+      predefined: predefined,
+      published: published,
+      can_edit: false,
+      locked: false,
+      in_a_public_group: false,
+    )
+  end
+
   # The curated admin board library, rendered as public cards. Identical for
   # every visitor, so it is computed once rather than per request — this used
   # to be `Board.public_boards.map(&:api_view)` inlined into every public

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -247,12 +247,21 @@ class Profile < ApplicationRecord
     []
   end
 
+  # `favorite_boards` is polymorphic in RETURN TYPE, not just in receiver:
+  # ChildAccount#favorite_boards returns ChildBoard join rows, User#favorite_boards
+  # returns Boards. The preload has to follow that — `includes(board: ...)` on a
+  # Board relation raises AssociationNotFoundError and 500s the public page.
+  # Both branches still answer `public_card_view`, which is what the callers need.
   def communication_boards
-    if profileable&.respond_to?(:favorite_boards) && profileable.favorite_boards.present?
-      profileable.favorite_boards.includes(board: BOARD_CARD_PRELOADS)
+    return [] unless profileable&.respond_to?(:favorite_boards)
+
+    favorites = profileable.favorite_boards
+    return [] if favorites.blank?
+
+    if favorites.klass == Board
+      favorites.includes(*BOARD_CARD_PRELOADS)
     else
-      # Board.public_boards
-      []
+      favorites.includes(board: BOARD_CARD_PRELOADS)
     end
   end
 
@@ -408,7 +417,7 @@ class Profile < ApplicationRecord
 
       # If you want this on creator pages, keep it public-only
       public_boards: public_boards.map(&:public_card_view),
-      user_boards: user_boards.map(&:api_view),
+      user_boards: user_boards.map(&:public_page_card_view),
       general_public_boards: Board.public_board_cards,
       # NOTE: email intentionally omitted — use settings["show_email"]
       # on the frontend if the user opted in to displaying contact info.

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1252,4 +1252,56 @@ RSpec.describe Board, type: :model do
       expect(described_class.public_board_cards_cache_key).not_to eq(before_key)
     end
   end
+
+  describe "#public_page_card_view" do
+    let(:owner) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: owner, predefined: false, published: true) }
+
+    it "carries the presentational flags the public grids read" do
+      view = board.public_page_card_view
+
+      expect(view.keys).to contain_exactly(
+        :id, :board_id, :slug, :name,
+        :display_image_url, :preview_image_url, :preset_display_image_url,
+        :user_id, :predefined, :published,
+        :can_edit, :locked, :in_a_public_group
+      )
+      expect(view[:name]).to eq(board.name)
+      expect(view[:published]).to be(true)
+      expect(view[:predefined]).to be(false)
+    end
+
+    # A User's own public page listed their boards with the full api_view, so
+    # every visitor received in_use_by — a joined list of that user's own
+    # communicators' names — plus communicator_account_data (ids, names,
+    # avatars). The frontend gates both behind `!isPublicGrid && can_edit`, so
+    # neither was ever rendered publicly; they were only ever transmitted.
+    it "omits the communicator identities api_view exposes" do
+      view = board.public_page_card_view
+
+      expect(view).not_to have_key(:in_use_by)
+      expect(view).not_to have_key(:communicator_account_data)
+      expect(view).not_to have_key(:in_use)
+      expect(view).not_to have_key(:user_name)
+    end
+
+    it "omits the bulk fields a card never renders" do
+      view = board.public_page_card_view
+
+      %i[data settings layout word_list word_sample margin_settings
+         large_screen_rows medium_screen_rows small_screen_rows].each do |key|
+        expect(view).not_to have_key(key)
+      end
+    end
+
+    # public_page_view has no viewer, so api_view was already being called with
+    # viewing_user = nil and these were false for everyone. Pinned, not derived.
+    it "never grants edit affordances" do
+      view = board.public_page_card_view
+
+      expect(view[:can_edit]).to be(false)
+      expect(view[:locked]).to be(false)
+      expect(view[:in_a_public_group]).to be(false)
+    end
+  end
 end

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -422,4 +422,81 @@ RSpec.describe "API::Profiles", type: :request do
         .to be_within(2.seconds).of(board_touched_at)
     end
   end
+
+  # A User profile's public page (`/u/:slug`, profile_kind "public_page") lists
+  # the user's OWN boards. That list was still going through Board#api_view,
+  # so every visitor received `in_use_by` — the names of that user's own
+  # communicators — plus communicator_account_data.
+  describe "GET /api/profiles/public/:slug user_boards payload" do
+    let(:owner) { FactoryBot.create(:user) }
+    let!(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Rowan Doe") }
+    let!(:profile) do
+      Profile.new(profileable: owner, username: "pat-pages", slug: "pat-pages").tap(&:save!)
+    end
+    # board_type must be set: Board.main_boards filters through non_menus,
+    # whose `where.not(board_type: "menu")` drops rows with a NULL board_type.
+    let!(:board) do
+      FactoryBot.create(:board, user: owner, name: "Morning Routine",
+                        published: true, board_type: "board", sub_board: false)
+    end
+
+    before do
+      allow_any_instance_of(Profile).to receive(:generate_attachments!).and_return(true)
+      board.update!(in_use: true)
+      FactoryBot.create(:child_board, board: board, child_account: child, created_by: owner)
+    end
+
+    it "serves the page as the public_page kind" do
+      expect(profile.reload).to be_public_page
+    end
+
+    it "lists the user's boards with the fields the public grids render" do
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(response).to have_http_status(:ok)
+      card = JSON.parse(response.body)["user_boards"].find { |b| b["id"] == board.id }
+      expect(card).to be_present
+      expect(card["name"]).to eq("Morning Routine")
+      expect(card["slug"]).to eq(board.slug)
+      expect(card["published"]).to be(true)
+      expect(card["predefined"]).to be(false)
+      expect(card["can_edit"]).to be(false)
+    end
+
+    it "does not publish the owner's communicator names" do
+      get "/api/profiles/public/#{profile.slug}"
+
+      cards = JSON.parse(response.body)["user_boards"]
+      cards.each do |card|
+        expect(card).not_to have_key("in_use_by")
+        expect(card).not_to have_key("communicator_account_data")
+      end
+      expect(response.body).not_to include("Rowan Doe")
+    end
+
+    # `favorite_boards` differs in RETURN TYPE by profileable:
+    # ChildAccount#favorite_boards -> ChildBoard join rows,
+    # User#favorite_boards -> Boards. Preloading `board:` against the Board
+    # relation raises AssociationNotFoundError and 500s the whole public page.
+    context "when the user has favorited a board" do
+      before { board.update!(favorite: true) }
+
+      it "serves the page instead of raising on the preload" do
+        get "/api/profiles/public/#{profile.slug}"
+
+        expect(response).to have_http_status(:ok)
+        cards = JSON.parse(response.body)["public_boards"]
+        expect(cards.map { |c| c["id"] }).to include(board.id)
+      end
+
+      it "still serializes those boards as cards" do
+        get "/api/profiles/public/#{profile.slug}"
+
+        card = JSON.parse(response.body)["public_boards"].find { |c| c["id"] == board.id }
+        expect(card["name"]).to eq("Morning Routine")
+        expect(card).not_to have_key("in_use_by")
+        expect(card).not_to have_key("communicator_account_data")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #667, which flagged `user_boards` as the one board list still going through `Board#api_view` on a public page.

While verifying the fix against real local data I hit a **live 500 that #667 introduced and is already on `main`** — that's fixed here too, and it's the more urgent half of this PR.

## 1. `/api/profiles/public/:slug` 500s for users who have favorited a board

`favorite_boards` is polymorphic in **return type**, not just receiver:

```ruby
ChildAccount#favorite_boards  # -> ChildBoard join rows  (child_account.rb:656)
User#favorite_boards          # -> Boards               (user.rb:1791)
```

`Profile#communication_boards` is polymorphic over both, and #667 added `.includes(board: BOARD_CARD_PRELOADS)` unconditionally. Against the Board relation that raises `ActiveRecord::AssociationNotFoundError: Association named 'board' was not found on Board`, taking down the whole page.

The trigger is narrow enough to have slipped through review and specs — a **User** profile (`/u/:slug`) whose owner has starred at least one of their own boards. MySpeak (`/my/:slug`) pages are ChildAccount-backed and unaffected, which is why #667's specs stayed green.

Fixed by branching the preload on `favorites.klass`. Both branches already answer `public_card_view`, so nothing downstream changes.

## 2. `user_boards` still used `api_view`

The last uncarded board list in the public payload. `Board#api_view` publishes `in_use_by` — on a User's own page, the names of **that user's own communicators** — plus `communicator_account_data` (ids, names, avatar URLs).

The frontend gates all of it behind `!isPublicGrid && can_edit`, and `PublicVendorProfile` passes `isPublicGrid={true}`, so none of it was ever rendered. It was only ever transmitted — which is the failure mode worth naming: a field nobody sees is a field nobody notices leaving.

New `Board#public_page_card_view` = `public_card_view` + `predefined`, `published`, `user_id`, with `can_edit` / `locked` / `in_a_public_group` pinned false. Pinned rather than derived because `public_page_view` passes no viewer, so `api_view` was already computing all three as false for every visitor — the payload is identical for those keys.

Field inventory checked against every consumer of `user_boards` on a public page: `PublicFeaturedBoards` (id, display_image_url, name, predefined, slug), `BoardGrid` (id, predefined, published, most_used), `BoardGridItem` (board_id, slug, name, the three image URLs, can_edit, locked, in_a_public_group, user_id). `most_used`, `added_by`, `board_owner_name`, `can_delete` are read by those components but were never emitted by `Board#api_view`, so they were already undefined.

`Profile#api_view` — the **authenticated** view behind `GET /api/profiles/:id`, which `EditUserPublicProfilePage` → `UserPublicProfileForm` uses via `getProfile(id)` — keeps `api_view` for `user_boards`. Only the public payloads are carded.

Measured on a real local profile with 348 boards:

| | before | after |
|---|---|---|
| `user_boards` serialization | 1081 ms | 40 ms |
| `user_boards` JSON | 915,621 B | 135,137 B |

## Test plan

New:
- `spec/requests/api/profiles_spec.rb` — `user_boards` carries the fields the public grids render; carries no `in_use_by` / `communicator_account_data` and no communicator name; **and a `favorite: true` context asserting the page returns 200 instead of raising.** Verified red-then-green: reverting only the preload fix makes both favorites examples fail with `AssociationNotFoundError`.
- `spec/models/board_spec.rb` — `public_page_card_view` key set, omits the identity fields, omits the bulk fields (`data`, `settings`, `layout`, `word_list`, the three `*_screen_rows`), and never grants edit affordances.

Run, all passing:
- `spec/requests/api/profiles_spec.rb` `spec/models/board_spec.rb` `spec/models/profile_spec.rb` `spec/models/child_board_spec.rb` — 220 examples, 0 failures
- Plus `spec/requests/api/boards_spec.rb` `spec/requests/api/profiles_owner_protection_spec.rb` `spec/requests/api/profiles_view_alerts_spec.rb` `spec/models/profile_view_spec.rb` — 296 examples, 0 failures over the combined set

Also verified against real local data that the previously-500ing profile now serializes, with the expected keys and no leaked keys.

Docs: `.claude-notes/safety-profiles.md` (now a table of all three lists and their serializers, plus the return-type trap), `CLAUDE.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)