### PR TITLE
feat(myspeak): optional structured care sections behind a gated, non-alerting reveal

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -86,6 +86,45 @@ info** — medical details + emergency contacts + emergency notes
   swallow a safety alert. The per-profile hourly throttle is the only timing gate.
 
 
+## Care sections — the second gated reveal
+
+`settings["care"]` holds optional, structured "how to support this person day to
+day" sections: Communication, Personal Care, Meals, Transportation, plus up to
+`MAX_CUSTOM_CARE_SECTIONS` parent-authored custom sections. They are mostly
+multiple-choice and short-answer, deliberately unlike the free-text bio.
+
+- **They are a third privacy tier, not a variant of the other two.** Not in
+  `SAFETY_PAGE_KEYS` (never open on page-load) and not in
+  `SAFETY_SENSITIVE_KEYS` (not an emergency). `POST
+  /api/profiles/public/:slug/care_view` is the only path that serves them, and
+  `safety_view`'s `has_care_info` flag is what lets the page render the button
+  without the data — the same fail-closed shape as `has_safety_info`.
+- **The care reveal logs but never alerts.** `log_care_profile_view` enqueues
+  `RecordProfileViewJob` with `kind: "care"`; the job writes a `ProfileView` with
+  `view_kind: "care"` and returns before the throttle claim, the geolocation
+  lookup, and `Notifications::SafetyViewNotifier`. This is the whole reason for a
+  separate endpoint. A substitute teacher checking a snack rule is routine; if
+  that fired the emergency-view email, parents would learn to ignore the alert
+  that actually matters. A care reveal also does **not** consume the hourly
+  notify slot, so a real emergency reveal moments later still alerts.
+- **`Profile::CARE_SECTIONS` is the whole schema.** Each field is
+  `:multi_select`, `:single_select`, or `:short_text` with its option list.
+  `sanitize_care_settings` (a `before_save`, modelled on
+  `sanitize_theme_settings`) is the only thing between a request body and an
+  unauthenticated page, because `profile_params` permits `settings: {}`
+  wholesale. It whitelists sections/fields/options, enforces the custom-key
+  format `CARE_CUSTOM_KEY_FORMAT` and every length/count cap, strips markup, and
+  **drops rather than rejects** — a stale frontend must not be able to 422 a
+  parent out of saving. If nothing survives, the key is deleted so
+  `has_care_info?` stays honest.
+- **The frontend registry must not drift.** `src/data/careSections.ts` mirrors
+  the option keys verbatim; a renamed key is silently dropped on save, not
+  reported.
+- **Care fields are never eligible for writing suggestions** — same rule as
+  `SAFETY_SENSITIVE_KEYS`. Nothing here goes to OpenAI.
+- Care info is deliberately **not** on the Safety ID card or device tag; those
+  are emergency artifacts.
+
 ## About Me (public bio) vs emergency notes (private)
 
 The MySpeak page has two distinct free-text fields that were historically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Care sections on a MySpeak page.** Beyond the intro and About Me blurb, a
+  communicator's page can now carry optional, structured sections covering how
+  they communicate, personal care, meals and snacks, and getting to and from
+  places — mostly pick-from-a-list answers rather than paragraphs, so a
+  substitute teacher or bus driver can scan them in seconds. You can also add
+  your own sections for anything the built-in four don't cover. Like emergency
+  info, none of it shows on page-load: a visitor has to open it deliberately.
+  Unlike emergency info, opening it does **not** send you an alert — these are
+  everyday support details, and an email every time someone checks a snack rule
+  would drown out the alert that matters. Every view is still recorded. (This
+  release adds the data and the page's API; the editing screen and the redesigned
+  public page follow.)
+
 - **Every board printable now includes a third, trim-ready PDF.** Alongside the
   full-colour and low-ink versions, each board is printed once more with the
   header removed so the board fills as much of the sheet as possible — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,14 @@ an explicit decision, not a drive-by edit.
   POST** — never on public page-open. It is also never sent to OpenAI: no
   `Profile::SAFETY_SENSITIVE_KEYS` entry may appear in a
   `Suggestions::Registry` context allow-list (enforced by spec).
+- **A MySpeak page has two gated reveals, and only one may notify.**
+  `safety_view` (emergency info) logs a `ProfileView` **and** alerts the parent;
+  `care_view` (`settings["care"]` — communication, personal care, meals,
+  transportation) logs with `view_kind: "care"` and returns before the throttle
+  claim, geolocation, and notifier. Care sections are day-to-day support info a
+  substitute teacher reads routinely; routing them through the emergency alert
+  would train parents to ignore it. Care fields are equally never sent to
+  OpenAI. Details: `.claude-notes/safety-profiles.md`.
 - **An unauthenticated endpoint never serializes a board with `api_view`.**
   `Board#api_view` publishes `in_use_by` (every communicator NAME using the
   board) and `communicator_account_data` (their ids, names, avatars);

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -1,5 +1,5 @@
 class API::ProfilesController < API::ApplicationController
-  skip_before_action :authenticate_token!, only: %i[public safety_view check_placeholder generate claim_placeholder next_placeholder check_slug]
+  skip_before_action :authenticate_token!, only: %i[public safety_view care_view check_placeholder generate claim_placeholder next_placeholder check_slug]
 
   def index
     @profile = current_user&.profile
@@ -101,6 +101,37 @@ class API::ProfilesController < API::ApplicationController
     log_safety_profile_view(profile)
 
     render json: profile.safety_details_view
+  end
+
+  # Gated care-details endpoint. Same shape as #safety_view — the open page
+  # withholds settings["care"] and this is the deliberate reveal — but a
+  # DIFFERENT notification contract: the access is logged for the abuse-pattern
+  # history and the parent is NOT alerted. Care sections are day-to-day support
+  # info (how someone communicates, eats, gets home), so a substitute teacher
+  # reading them is routine; routing them through the emergency alert would
+  # train parents to ignore it.
+  def care_view
+    profile = Profile.find_by(slug: params[:slug]) ||
+              Profile.find_by(legacy_slug: params[:slug])
+
+    if profile.nil?
+      render json: { error: "Profile not found" }, status: :not_found
+      return
+    end
+
+    unless profile.safety?
+      render json: { error: "Not a safety profile" }, status: :not_found
+      return
+    end
+
+    if profile.placeholder? && profile.claimed_at.nil?
+      render json: { id: profile.id, settings: {} }
+      return
+    end
+
+    log_care_profile_view(profile)
+
+    render json: profile.care_details_view
   end
 
   def create
@@ -367,6 +398,16 @@ class API::ProfilesController < API::ApplicationController
     RecordProfileViewJob.perform_async(profile.id, request.remote_ip, request.user_agent)
   rescue => e
     Rails.logger.warn("[Profiles#public] failed to enqueue view log: #{e.class}: #{e.message}")
+  end
+
+  # Same hand-off as log_safety_profile_view, but tagged "care" so the job logs
+  # the view and stops short of the parent alert.
+  def log_care_profile_view(profile)
+    return unless profile.safety?
+
+    RecordProfileViewJob.perform_async(profile.id, request.remote_ip, request.user_agent, "care")
+  rescue => e
+    Rails.logger.warn("[Profiles#care_view] failed to enqueue view log: #{e.class}: #{e.message}")
   end
 
   def set_placeholders

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -99,6 +99,7 @@ class Profile < ApplicationRecord
   before_save :set_kind
   before_save :touch_slug_changed_at
   before_save :sanitize_theme_settings
+  before_save :sanitize_care_settings
 
   has_rich_text :public_about
   has_rich_text :public_intro
@@ -367,6 +368,10 @@ class Profile < ApplicationRecord
       settings: public_settings(kind: :safety),
       has_safety_info: has_safety_info?,
 
+      # Same contract for the care sections: the flag ships on page-open, the
+      # data only via the gated care_view endpoint.
+      has_care_info: has_care_info?,
+
       # Boards shown publicly should be safe/public
       public_boards: public_boards.map(&:public_card_view),
       general_public_boards: Board.public_board_cards,
@@ -513,6 +518,100 @@ class Profile < ApplicationRecord
   THEME_HEX_FORMAT = /\A#[0-9a-fA-F]{6}\z/.freeze
   THEME_SLUG_FORMAT = /\A[a-z0-9_-]{1,40}\z/.freeze
 
+  # --- MySpeak care sections ---
+  # Optional, structured "how to support this person day to day" sections stored
+  # on settings["care"]. Deliberately NOT in SAFETY_PAGE_KEYS (they are not open
+  # on page-load) and NOT in SAFETY_SENSITIVE_KEYS (they are not an emergency).
+  # They are served only by the gated care-details endpoint
+  # (POST public/:slug/care_view), which logs the access but does NOT fire the
+  # parent's emergency-view alert — a bus driver checking a snack rule must not
+  # read as someone opening the medical record.
+  #
+  # Shape:
+  #   settings["care"] = {
+  #     "order"    => ["communication", "c_7f3a91"],
+  #     "sections" => {
+  #       "communication" => { "enabled" => true, "values" => { ... } },
+  #       "c_7f3a91"      => { "enabled" => true, "custom" => true,
+  #                            "title" => "Sensory",
+  #                            "items" => [{ "label" => ..., "value" => ... }] },
+  #     },
+  #   }
+  #
+  # Built-in sections validate every value against the registry below; custom
+  # sections are free label/value pairs a parent adds themselves. Whitelist, not
+  # blocklist — an unknown section, field, or option is dropped on save.
+  #
+  # NOTE: no care field may ever appear in a Suggestions::Registry context
+  # allow-list. These are private care details, not copy to hand to OpenAI.
+  CARE_SECTIONS = {
+    "communication" => {
+      fields: [
+        { key: "methods", type: :multi_select,
+          options: %w[aac_device aac_book sign gestures some_speech echolalia
+                      writing eye_gaze partner_assisted facial_expressions] },
+        { key: "help_level", type: :single_select,
+          options: %w[independent needs_setup needs_prompts hand_over_hand
+                      partner_required] },
+        { key: "response_time", type: :single_select,
+          options: %w[right_away needs_time needs_lots_of_time] },
+        { key: "notes", type: :short_text },
+      ],
+    },
+    "personal_care" => {
+      fields: [
+        { key: "toileting", type: :single_select,
+          options: %w[independent needs_reminders needs_help toilet_training
+                      pull_ups diapers] },
+        { key: "schedule", type: :single_select,
+          options: %w[on_request scheduled_times both] },
+        { key: "help_level", type: :single_select,
+          options: %w[independent some_help full_help] },
+        { key: "dressing", type: :single_select,
+          options: %w[independent some_help full_help] },
+        { key: "notes", type: :short_text },
+      ],
+    },
+    "meals" => {
+      fields: [
+        { key: "eating", type: :single_select,
+          options: %w[independent some_help full_help tube_fed] },
+        { key: "textures", type: :multi_select,
+          options: %w[regular soft chopped pureed thickened_liquids] },
+        { key: "equipment", type: :multi_select,
+          options: %w[fork_and_spoon fingers specific_cup straw_only no_straw
+                      adapted_utensils] },
+        { key: "preferences", type: :short_text },
+        { key: "notes", type: :short_text },
+      ],
+    },
+    "transportation" => {
+      fields: [
+        { key: "mode", type: :multi_select,
+          options: %w[bus car_rider walker wheelchair_van parent_pickup] },
+        { key: "seating", type: :multi_select,
+          options: %w[harness car_seat booster wheelchair_securement
+                      specific_seat front_seat_only] },
+        { key: "bus_info", type: :short_text },
+        { key: "notes", type: :short_text },
+      ],
+    },
+  }.freeze
+
+  CARE_KEYS = %w[care].freeze
+
+  # A parent-added section. The key is generated client-side; the format is what
+  # keeps an arbitrary attacker-chosen key out of the settings hash.
+  CARE_CUSTOM_KEY_FORMAT = /\Ac_[0-9a-f]{6}\z/.freeze
+
+  MAX_CUSTOM_CARE_SECTIONS = 4
+  MAX_CARE_CUSTOM_ITEMS = 8
+  MAX_CARE_MULTI_SELECT = 10
+  CARE_TITLE_MAX = 60
+  CARE_ITEM_LABEL_MAX = 60
+  CARE_ITEM_VALUE_MAX = 200
+  CARE_SHORT_TEXT_MAX = 300
+
   PUBLIC_PAGE_KEYS = %w[
     public_page
     socials
@@ -574,6 +673,33 @@ class Profile < ApplicationRecord
     {
       id: id,
       settings: safety_sensitive_settings,
+    }
+  end
+
+  # The sanitized care blob, always a Hash. Only ever reaches a visitor through
+  # #care_details_view.
+  def care_settings
+    raw = settings.is_a?(Hash) ? settings : {}
+    care = raw["care"]
+    care.is_a?(Hash) ? care : {}
+  end
+
+  # True when at least one care section is filled in and enabled. Drives the
+  # frontend's "Care & routines" button without exposing the data itself —
+  # the same contract as has_safety_info?.
+  def has_care_info?
+    sections = care_settings["sections"]
+    return false unless sections.is_a?(Hash)
+
+    sections.any? { |_key, section| section.is_a?(Hash) && section["enabled"] != false }
+  end
+
+  # Payload for the gated care-details endpoint. Carries only the care blob the
+  # open page omits; the frontend merges it into the profile it already loaded.
+  def care_details_view
+    {
+      id: id,
+      settings: { "care" => care_settings },
     }
   end
 
@@ -906,6 +1032,133 @@ class Profile < ApplicationRecord
     else
       settings["theme"] = clean
     end
+  end
+
+  # Whitelist + validate settings["care"] on every save. The controller permits
+  # `settings: {}` wholesale, so this is the only thing standing between a
+  # request body and an unauthenticated public page — same role
+  # sanitize_theme_settings plays for the theme. Unknown sections, unknown
+  # fields, and out-of-registry option values are dropped rather than rejected:
+  # a stale frontend must not be able to 422 a parent out of saving.
+  def sanitize_care_settings
+    return unless settings.is_a?(Hash)
+    return unless settings.key?("care")
+
+    raw = settings["care"]
+    unless raw.is_a?(Hash)
+      settings.delete("care")
+      return
+    end
+
+    raw_sections = raw["sections"]
+    raw_sections = {} unless raw_sections.is_a?(Hash)
+
+    requested_order = raw["order"].is_a?(Array) ? raw["order"].map(&:to_s) : []
+    present_keys = raw_sections.keys.map(&:to_s)
+    # The parent's ordering decides which custom sections survive the cap, so
+    # walk the ordered keys first and only then whatever else is in the hash.
+    candidate_keys = (requested_order & present_keys) | present_keys
+
+    clean_sections = {}
+    custom_count = 0
+
+    candidate_keys.each do |key|
+      section = raw_sections[key]
+      next unless section.is_a?(Hash)
+
+      cleaned =
+        if CARE_SECTIONS.key?(key)
+          clean_builtin_care_section(key, section)
+        elsif key.match?(CARE_CUSTOM_KEY_FORMAT) && custom_count < MAX_CUSTOM_CARE_SECTIONS
+          clean_custom_care_section(section)
+        end
+      next if cleaned.nil?
+
+      custom_count += 1 unless CARE_SECTIONS.key?(key)
+      clean_sections[key] = cleaned
+    end
+
+    if clean_sections.empty?
+      settings.delete("care")
+      return
+    end
+
+    order = requested_order.uniq.select { |k| clean_sections.key?(k) }
+    order += (clean_sections.keys - order)
+
+    settings["care"] = { "order" => order, "sections" => clean_sections }
+  end
+
+  def clean_builtin_care_section(key, section)
+    raw_values = section["values"]
+    raw_values = {} unless raw_values.is_a?(Hash)
+
+    clean_values = {}
+    CARE_SECTIONS.fetch(key)[:fields].each do |field|
+      raw_value = raw_values[field[:key]]
+
+      cleaned =
+        case field[:type]
+        when :multi_select
+          next unless raw_value.is_a?(Array)
+          raw_value.map(&:to_s).uniq
+                   .select { |v| field[:options].include?(v) }
+                   .first(MAX_CARE_MULTI_SELECT)
+        when :single_select
+          value = raw_value.to_s
+          value if field[:options].include?(value)
+        when :short_text
+          care_text(raw_value, CARE_SHORT_TEXT_MAX)
+        end
+
+      clean_values[field[:key]] = cleaned if cleaned.present?
+    end
+
+    return nil if clean_values.empty?
+
+    { "enabled" => care_enabled?(section["enabled"]), "values" => clean_values }
+  end
+
+  def clean_custom_care_section(section)
+    title = care_text(section["title"], CARE_TITLE_MAX)
+    return nil if title.blank?
+
+    raw_items = section["items"]
+    raw_items = [] unless raw_items.is_a?(Array)
+
+    items = raw_items.filter_map do |item|
+      next unless item.is_a?(Hash)
+
+      label = care_text(item["label"], CARE_ITEM_LABEL_MAX)
+      value = care_text(item["value"], CARE_ITEM_VALUE_MAX)
+      next if label.blank? && value.blank?
+
+      { "label" => label.to_s, "value" => value.to_s }
+    end.first(MAX_CARE_CUSTOM_ITEMS)
+
+    return nil if items.empty?
+
+    {
+      "enabled" => care_enabled?(section["enabled"]),
+      "custom" => true,
+      "title" => title,
+      "items" => items,
+    }
+  end
+
+  # Care values render as text on an unauthenticated page, so markup is stripped
+  # rather than escaped — there is no field here where a tag is meaningful.
+  def care_text(value, limit)
+    text = ActionController::Base.helpers.strip_tags(value.to_s).squish
+    return nil if text.blank?
+
+    text[0, limit]
+  end
+
+  # Enabled unless the owner explicitly turned the section off. A section that
+  # arrives without the flag is one a parent just filled in.
+  def care_enabled?(value)
+    ![false, "false", "0", 0].include?(value)
   end
 
   public

--- a/app/models/profile_view.rb
+++ b/app/models/profile_view.rb
@@ -13,17 +13,28 @@
 #  viewed_at       :datetime         not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  view_kind       :string           default("safety"), not null
 #
-# An audit record of a single public view of a safety (communicator) profile
-# page. Written by RecordProfileViewJob after a request to
-# API::ProfilesController#public. Two purposes:
+# An audit record of a single gated reveal on a safety (communicator) MySpeak
+# page. Written by RecordProfileViewJob. Two purposes:
 #
 #   1. Drives the parent "someone viewed your child's safety page" alert.
 #   2. Builds a history so unexpected access patterns become visible (the abuse-
 #      detection value in issue #384).
 #
+# `view_kind` distinguishes the two reveals the page offers, and only one of
+# them can notify:
+#
+#   "safety" — the emergency-info reveal (medical details + ICE contacts).
+#              Logged AND alerts the parent.
+#   "care"   — the care-sections reveal (communication, personal care, meals,
+#              transportation). Logged, never alerts: this is day-to-day support
+#              info, and alerting on it would train parents to ignore the alert
+#              that matters.
+#
 # `notified: true` marks the views that actually triggered a parent email (at
-# most one per profile per hour — see RecordProfileViewJob throttling).
+# most one per profile per hour — see RecordProfileViewJob throttling). It is
+# therefore always false on a "care" row.
 class ProfileView < ApplicationRecord
   belongs_to :profile
 
@@ -34,6 +45,8 @@ class ProfileView < ApplicationRecord
   scope :recent, -> { order(viewed_at: :desc) }
   scope :notified, -> { where(notified: true) }
   scope :since, ->(time) { where("viewed_at >= ?", time) }
+  scope :safety_kind, -> { where(view_kind: "safety") }
+  scope :care_kind, -> { where(view_kind: "care") }
 
   private
 

--- a/app/sidekiq/record_profile_view_job.rb
+++ b/app/sidekiq/record_profile_view_job.rb
@@ -6,6 +6,11 @@
 # happens here, off the request, so the public emergency page always loads fast
 # and is never broken by this feature.
 #
+#
+# `kind` is a trailing optional arg so jobs already enqueued during a deploy
+# keep working. "care" (the care-sections reveal) logs and returns at step 3;
+# only "safety" continues into the alert.
+#
 # Flow:
 #   1. Bail unless this is a safety profile with an owner to notify.
 #   2. Coarse IP→location lookup (best-effort; nil on any failure).
@@ -21,10 +26,11 @@ class RecordProfileViewJob
 
   NOTIFY_THROTTLE_WINDOW = (ENV["SAFETY_VIEW_THROTTLE_SECONDS"] || 1.hour.to_i).to_i
 
-  def perform(profile_id, ip_address = nil, user_agent = nil)
+  def perform(profile_id, ip_address = nil, user_agent = nil, kind = "safety")
     profile = Profile.find_by(id: profile_id)
     return if profile.nil? || !profile.safety?
 
+    kind = "safety" unless kind == "care"
     owner = profile.alert_recipient
 
     # Always log the raw view (IP + timestamp) for the abuse-pattern history.
@@ -33,7 +39,13 @@ class RecordProfileViewJob
       user_agent: user_agent,
       viewed_at: Time.current,
       notified: false,
+      view_kind: kind,
     )
+
+    # A care-sections reveal is logged and stops here — no throttle claim, no
+    # geolocation lookup, no email. See ProfileView for why only the emergency
+    # reveal is allowed to notify.
+    return if kind == "care"
 
     return if owner.nil?
     return unless profile.view_alerts_enabled?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -441,6 +441,7 @@ Rails.application.routes.draw do
         get "next_placeholder"
         get "public/:slug", to: "profiles#public"
         post "public/:slug/safety_view", to: "profiles#safety_view"
+        post "public/:slug/care_view", to: "profiles#care_view"
         get "check_slug", to: "profiles#check_slug"
         post "generate"
       end

--- a/db/migrate/20260812120000_add_view_kind_to_profile_views.rb
+++ b/db/migrate/20260812120000_add_view_kind_to_profile_views.rb
@@ -1,0 +1,9 @@
+# A ProfileView now records two different reveals on a MySpeak page: the gated
+# emergency-info reveal (which also alerts the parent) and the gated care-
+# sections reveal (which does not). Existing rows are all emergency reveals, so
+# the "safety" default backfills them correctly.
+class AddViewKindToProfileViews < ActiveRecord::Migration[8.0]
+  def change
+    add_column :profile_views, :view_kind, :string, default: "safety", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_10_140100) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_12_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -888,6 +888,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_10_140100) do
     t.datetime "viewed_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "view_kind", default: "safety", null: false
     t.index ["profile_id", "viewed_at"], name: "index_profile_views_on_profile_id_and_viewed_at"
     t.index ["profile_id"], name: "index_profile_views_on_profile_id"
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -302,6 +302,191 @@ RSpec.describe Profile, type: :model do
     end
   end
 
+  describe "care sections" do
+    let(:profile) { build_profile(slug: "care-page").tap(&:save!) }
+
+    # `order` is positional, not a keyword: a bare `"key" => value` at the call
+    # site binds to keyword params in Ruby 3, which would swallow the sections.
+    def care(sections, order = nil)
+      blob = { "sections" => sections }
+      blob["order"] = order if order
+      profile.update!(settings: { "care" => blob })
+      profile.reload.settings["care"]
+    end
+
+    describe "sanitize_care_settings callback" do
+      it "keeps registry-valid values on a built-in section" do
+        result = care(
+          "communication" => {
+            "enabled" => true,
+            "values" => {
+              "methods" => %w[aac_device gestures],
+              "help_level" => "needs_prompts",
+              "notes" => "Give me ten seconds to answer.",
+            },
+          },
+        )
+
+        expect(result["sections"]["communication"]).to eq(
+          "enabled" => true,
+          "values" => {
+            "methods" => %w[aac_device gestures],
+            "help_level" => "needs_prompts",
+            "notes" => "Give me ten seconds to answer.",
+          },
+        )
+      end
+
+      it "drops unknown sections, unknown fields, and out-of-registry options" do
+        result = care(
+          "communication" => {
+            "values" => {
+              "methods" => %w[aac_device not_a_method],
+              "help_level" => "wildly_invented",
+              "sneaky_field" => "nope",
+            },
+          },
+          "not_a_section" => { "values" => { "methods" => %w[aac_device] } },
+        )
+
+        expect(result["sections"].keys).to eq(%w[communication])
+        expect(result["sections"]["communication"]["values"]).to eq("methods" => %w[aac_device])
+      end
+
+      it "drops a built-in section whose every value was invalid" do
+        profile.update!(settings: { "care" => { "sections" => {
+          "meals" => { "values" => { "eating" => "invented" } },
+        } } })
+
+        expect(profile.reload.settings).not_to have_key("care")
+      end
+
+      it "strips markup from free text" do
+        result = care(
+          "communication" => { "values" => { "notes" => "<script>alert(1)</script>Use <b>signs</b>" } },
+        )
+
+        expect(result["sections"]["communication"]["values"]["notes"]).to eq("alert(1)Use signs")
+      end
+
+      it "truncates over-long free text and caps multi-select length" do
+        result = care(
+          "communication" => {
+            "values" => {
+              "notes" => "a" * 500,
+              "methods" => Profile::CARE_SECTIONS["communication"][:fields]
+                             .find { |f| f[:key] == "methods" }[:options],
+            },
+          },
+        )
+
+        values = result["sections"]["communication"]["values"]
+        expect(values["notes"].length).to eq(Profile::CARE_SHORT_TEXT_MAX)
+        expect(values["methods"].length).to be <= Profile::MAX_CARE_MULTI_SELECT
+      end
+
+      it "accepts a well-formed custom section" do
+        result = care(
+          "c_7f3a91" => {
+            "custom" => true,
+            "title" => "Sensory",
+            "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+          },
+        )
+
+        expect(result["sections"]["c_7f3a91"]).to eq(
+          "enabled" => true,
+          "custom" => true,
+          "title" => "Sensory",
+          "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+        )
+      end
+
+      it "rejects a custom section key that doesn't match the generated format" do
+        profile.update!(settings: { "care" => { "sections" => {
+          "c_NOTHEX" => { "title" => "Nope", "items" => [{ "label" => "a", "value" => "b" }] },
+          "../../etc" => { "title" => "Nope", "items" => [{ "label" => "a", "value" => "b" }] },
+        } } })
+
+        expect(profile.reload.settings).not_to have_key("care")
+      end
+
+      it "caps the number of custom sections, keeping the parent's ordering" do
+        keys = (1..Profile::MAX_CUSTOM_CARE_SECTIONS + 2).map { |i| format("c_%06x", i) }
+        sections = keys.index_with do |key|
+          { "title" => key, "items" => [{ "label" => "l", "value" => "v" }] }
+        end
+
+        result = care(sections, keys)
+
+        expect(result["sections"].keys).to eq(keys.first(Profile::MAX_CUSTOM_CARE_SECTIONS))
+      end
+
+      it "caps the number of items in a custom section" do
+        items = (1..Profile::MAX_CARE_CUSTOM_ITEMS + 3).map { |i| { "label" => "l#{i}", "value" => "v" } }
+        result = care("c_7f3a91" => { "title" => "Sensory", "items" => items })
+
+        expect(result["sections"]["c_7f3a91"]["items"].length).to eq(Profile::MAX_CARE_CUSTOM_ITEMS)
+      end
+
+      it "drops a custom section with no title or no usable items" do
+        profile.update!(settings: { "care" => { "sections" => {
+          "c_000001" => { "title" => "", "items" => [{ "label" => "l", "value" => "v" }] },
+          "c_000002" => { "title" => "Empty", "items" => [{ "label" => "", "value" => "" }] },
+        } } })
+
+        expect(profile.reload.settings).not_to have_key("care")
+      end
+
+      it "prunes order to surviving sections and appends any that were missing" do
+        result = care(
+          {
+            "communication" => { "values" => { "help_level" => "independent" } },
+            "meals" => { "values" => { "eating" => "some_help" } },
+          },
+          %w[meals gone_section],
+        )
+
+        expect(result["order"]).to eq(%w[meals communication])
+      end
+
+      it "clears the key entirely when care is not a hash" do
+        profile.update!(settings: { "care" => "nope" })
+        expect(profile.reload.settings).not_to have_key("care")
+      end
+    end
+
+    describe "#has_care_info?" do
+      it "is false with no care data" do
+        expect(profile.has_care_info?).to eq(false)
+      end
+
+      it "is true once a section is filled in" do
+        care("communication" => { "values" => { "help_level" => "independent" } })
+        expect(profile.has_care_info?).to eq(true)
+      end
+
+      it "is false when every section is disabled" do
+        care("communication" => { "enabled" => false, "values" => { "help_level" => "independent" } })
+        expect(profile.has_care_info?).to eq(false)
+      end
+    end
+
+    describe "#safety_view / #care_details_view" do
+      before { care("communication" => { "values" => { "help_level" => "independent" } }) }
+
+      it "advertises care on the open page without shipping the data" do
+        view = profile.safety_view
+        expect(view[:has_care_info]).to eq(true)
+        expect(view[:settings]).not_to have_key("care")
+      end
+
+      it "returns the care blob only from the gated view" do
+        expect(profile.care_details_view[:settings]["care"]["sections"]).to have_key("communication")
+      end
+    end
+  end
+
   describe "sanitize_theme_settings callback" do
     let(:profile) { build_profile(slug: "theme-page").tap(&:save!) }
 

--- a/spec/requests/api/profiles_care_view_spec.rb
+++ b/spec/requests/api/profiles_care_view_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The care-sections reveal (POST public/:slug/care_view) mirrors the emergency
+# reveal's shape — withheld on page-open, returned only by the deliberate action
+# — but carries a DIFFERENT notification contract: the access is logged and the
+# parent is not alerted. These specs pin both halves of that, since the whole
+# point of a separate endpoint is the alert it doesn't send.
+RSpec.describe "MySpeak care sections", type: :request do
+  let(:owner) { FactoryBot.create(:user, email: "parent-care@example.com") }
+  let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Sky") }
+
+  let(:care_settings) do
+    {
+      "pronouns" => "she/her",
+      "allergies" => "peanuts",
+      "care" => {
+        "order" => %w[communication c_7f3a91],
+        "sections" => {
+          "communication" => {
+            "enabled" => true,
+            "values" => { "methods" => %w[aac_device gestures], "help_level" => "needs_prompts" },
+          },
+          "c_7f3a91" => {
+            "custom" => true,
+            "title" => "Sensory",
+            "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+          },
+        },
+      },
+    }
+  end
+
+  def safety_profile(settings: care_settings, slug: "sky-care")
+    Profile.create!(profileable: child, username: slug, slug: slug, settings: settings)
+  end
+
+  before { RecordProfileViewJob.jobs.clear }
+
+  describe "GET /api/profiles/public/:slug (page-open)" do
+    it "advertises care without shipping any of it" do
+      profile = safety_profile
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      body = JSON.parse(response.body)
+      expect(body["has_care_info"]).to be(true)
+      expect(body["settings"]).not_to have_key("care")
+      # The values themselves appear nowhere in the open response.
+      expect(response.body).not_to include("Headphones help")
+      expect(response.body).not_to include("needs_prompts")
+    end
+
+    it "reports has_care_info=false when no care section is filled in" do
+      profile = safety_profile(settings: { "pronouns" => "they/them" })
+
+      get "/api/profiles/public/#{profile.slug}"
+
+      expect(JSON.parse(response.body)["has_care_info"]).to be(false)
+    end
+
+    it "does not enqueue a view-log job" do
+      profile = safety_profile
+
+      expect {
+        get "/api/profiles/public/#{profile.slug}"
+      }.not_to change { RecordProfileViewJob.jobs.size }
+    end
+  end
+
+  describe "POST /api/profiles/public/:slug/care_view" do
+    it "returns the care blob and logs the access as a care view" do
+      profile = safety_profile
+
+      expect {
+        post "/api/profiles/public/#{profile.slug}/care_view"
+      }.to change { RecordProfileViewJob.jobs.size }.by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(RecordProfileViewJob.jobs.last["args"]).to eq([profile.id, "127.0.0.1", nil, "care"])
+
+      sections = JSON.parse(response.body).dig("settings", "care", "sections")
+      expect(sections["communication"]["values"]).to include("help_level" => "needs_prompts")
+      expect(sections["c_7f3a91"]["title"]).to eq("Sensory")
+    end
+
+    it "never leaks emergency info through the care endpoint" do
+      profile = safety_profile
+
+      post "/api/profiles/public/#{profile.slug}/care_view"
+
+      expect(JSON.parse(response.body)["settings"].keys).to eq(%w[care])
+      expect(response.body).not_to include("peanuts")
+    end
+
+    it "still reveals the sections when enqueue raises" do
+      profile = safety_profile
+      allow(RecordProfileViewJob).to receive(:perform_async).and_raise(StandardError, "redis down")
+
+      post "/api/profiles/public/#{profile.slug}/care_view"
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).dig("settings", "care", "sections")).to have_key("communication")
+    end
+
+    it "404s for an unknown slug" do
+      post "/api/profiles/public/does-not-exist/care_view"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "does not enqueue or reveal for a pro public_page profile" do
+      profile = Profile.new(profileable: child, username: "sky-pro", slug: "sky-pro", settings: care_settings)
+      profile.profile_kind = "public_page"
+      profile.save!
+
+      expect {
+        post "/api/profiles/public/#{profile.slug}/care_view"
+      }.not_to change { RecordProfileViewJob.jobs.size }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/sidekiq/record_profile_view_job_spec.rb
+++ b/spec/sidekiq/record_profile_view_job_spec.rb
@@ -104,5 +104,49 @@ RSpec.describe RecordProfileViewJob, type: :sidekiq do
       # Both views are logged; only the first is marked notified.
       expect(ProfileView.where(profile: profile, notified: true).count).to eq(1)
     end
+
+    it "defaults to a safety-kind view when no kind is given" do
+      job.perform(profile.id, "8.8.8.8", "UA")
+
+      expect(ProfileView.last.view_kind).to eq("safety")
+    end
+  end
+
+  # The care-sections reveal shares this job but must never alert the parent —
+  # it is day-to-day support info, not an emergency.
+  describe "#perform with kind: care" do
+    it "logs a care-kind view and sends no email" do
+      expect {
+        job.perform(profile.id, "8.8.8.8", "Mozilla/5.0", "care")
+      }.to change { ProfileView.count }.by(1).and change { deliveries }.by(0)
+
+      view = ProfileView.last
+      expect(view.view_kind).to eq("care")
+      expect(view.ip_address).to eq("8.8.8.8")
+      expect(view.notified).to eq(false)
+    end
+
+    it "skips geolocation entirely" do
+      job.perform(profile.id, "8.8.8.8", "UA", "care")
+
+      expect(IpGeolocation).not_to have_received(:coarse)
+      expect(ProfileView.last.approx_location).to be_nil
+      expect(ProfileView.last.geo).to eq({})
+    end
+
+    it "does not consume the hourly notify slot, so a later emergency reveal still alerts" do
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA", "care")
+        described_class.new.perform(profile.id, "8.8.8.8", "UA")
+      }.to change { ProfileView.count }.by(2).and change { deliveries }.by(1)
+    end
+
+    it "treats an unrecognized kind as safety rather than silently skipping the alert" do
+      expect {
+        job.perform(profile.id, "8.8.8.8", "UA", "nonsense")
+      }.to change { deliveries }.by(1)
+
+      expect(ProfileView.last.view_kind).to eq("safety")
+    end
   end
 end


### PR DESCRIPTION
## Summary

MySpeak pages carry only freeform prose — `intro` (spoken aloud) and `bio` ("About me") — plus the gated emergency reveal. The practical day-to-day things a substitute teacher, bus driver, or respite worker needs are neither medical emergencies nor suited to a prose bio, so today they either get crammed into the public bio or live nowhere.

This adds `settings["care"]`: optional, **structured** sections — mostly multiple-choice and short-answer — that a parent fills in once and a caregiver can scan in ten seconds.

- Four registry-defined sections: **Communication, Personal Care, Meals, Transportation**
- Plus up to 4 **parent-authored custom sections** (free label/value pairs), so the feature isn't capped at what we imagined

Backend only. The editor UI and the redesigned public page follow in the frontend repo.

## Privacy: a third tier, not a variant of the existing two

Care data is in **neither** `SAFETY_PAGE_KEYS` (never open on page-load) nor `SAFETY_SENSITIVE_KEYS` (not an emergency).

- `POST /api/profiles/public/:slug/care_view` is the only path that serves it.
- `safety_view` gains `has_care_info`, so the page renders the button without the data — same fail-closed shape as `has_safety_info`.
- **The care reveal logs but never alerts.** `RecordProfileViewJob` takes a trailing optional `kind`; `"care"` writes a `ProfileView` with `view_kind: "care"` and returns before the throttle claim, geolocation, and `SafetyViewNotifier`. This is the whole reason for a separate endpoint — a caregiver checking a snack rule must not fire the emergency-view email, or parents learn to ignore the alert that matters. A care reveal also doesn't consume the hourly notify slot, so a real emergency reveal moments later still alerts.
- No care field is eligible for writing suggestions; nothing here reaches OpenAI.
- Care info is deliberately **not** on the Safety ID card or device tag — those are emergency artifacts.

## The sanitizer is the security boundary

`profile_params` permits `settings: {}` wholesale, so `sanitize_care_settings` (a `before_save`, modelled on `sanitize_theme_settings`) is the only thing between a request body and an unauthenticated public page. It whitelists sections / fields / option values, enforces `CARE_CUSTOM_KEY_FORMAT` and every length and count cap, strips markup, prunes `order`, and deletes the key when nothing survives so `has_care_info?` stays honest.

It **drops rather than rejects** — a stale frontend must not be able to 422 a parent out of saving.

## Test plan

`bundle exec rspec` over the profile model, profile view, the job, all five profiles request specs, and the suggestions-registry sweep (to confirm no care field slipped into an OpenAI allow-list):

**195 examples, 0 failures.**

New coverage:
- `spec/models/profile_spec.rb` — registry-valid values kept; unknown sections/fields/options dropped; markup stripped; text truncation and multi-select caps; custom-key format rejection (including `../../etc`); custom-section and item caps; `order` pruned and backfilled; empty care deleted; `has_care_info?` all three ways
- `spec/requests/api/profiles_care_view_spec.rb` (new) — page-open advertises but never ships care; the gated endpoint returns it; emergency info never leaks through the care endpoint; the reveal survives an enqueue failure; 404s; public_page profiles are a no-op
- `spec/sidekiq/record_profile_view_job_spec.rb` — care logs without emailing, skips geolocation, leaves the notify slot free, and an unrecognized `kind` falls back to `"safety"` rather than silently skipping the alert

Migration `add_view_kind_to_profile_views` run locally; existing rows correctly default to `"safety"`.

## Docs

`.claude-notes/safety-profiles.md` (new "Care sections" section), a CLAUDE.md invariant for the two-reveals-one-notifier rule, and a CHANGELOG entry.

## Note for review

The four sections' **field and option lists are a first draft** — e.g. Personal Care's toileting options are `independent / needs_reminders / needs_help / toilet_training / pull_ups / diapers`. Wording and coverage are worth a pass; they're one constant in one file. Meals deliberately has no allergies field: that stays in Emergency info, and the editor will cross-link rather than duplicate a life-threatening field into a calmer reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)