### PR TITLE
fix(communicator): merge settings on update instead of replacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Saving one part of a communicator's settings no longer wipes the rest.**
+  The communicator screen saves settings from several different places, and
+  each one sent only the handful of values it knew about — so saving from one
+  tab quietly erased what another tab had set, including the dashboard column
+  layout and which team a communicator belongs to. Saving now updates only
+  what you actually changed. Clearing a setting still works exactly as before.
+  A related crash is fixed too: updating a communicator that had never had any
+  settings saved could fail outright.
+
 - **Deleting a page in a board set no longer offers to delete the set's home
   board.** A page's "go back" tile is stored the same way as a tile that opens a
   sub-page, so deleting a page counted everything its back tile reached as one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,19 @@ an explicit decision, not a drive-by edit.
   rotates on every exchange, so it lives in `oauth_credentials` (not ENV) and
   Rails holds a **separate authorization** from the one `speakanyway-printables`
   uses — a shared grant makes the two invalidate each other.
+- **`child_accounts.settings` MERGES on update; `details` REPLACES.** The two
+  jsonb blobs have opposite semantics on purpose, and both are load-bearing.
+  Several frontend surfaces save `settings` as a fresh literal holding only
+  their own slice, so a wholesale assignment dropped every key the saving
+  screen didn't know about — dashboard layout columns, `primary_team_id`,
+  archive/reclaim/fallback state. `details` stays a replace because the AAC
+  profile clears a field by DELETING its key, so merging would make "Not set"
+  a no-op. Two corollaries: clearing a settings key means sending an explicit
+  blank/nil, never omitting it; and anything the replace used to remove as a
+  side effect must now be removed deliberately (`demo_board_limit` on
+  sandbox→active, mirroring `ChildAccount#promote_to_active!`). Note the
+  column has **no DB default**, so `settings` can be `nil` on any row — every
+  reader and writer needs `self.settings ||= {}`.
 - **Email verification is keyed on `email_verified_at`, never `confirmed_at`.**
   `User#mark_email_verified!` is the only writer. Verified status may be
   conferred ONLY by a path where the user clicked a link delivered to their

--- a/app/controllers/api/child_accounts_controller.rb
+++ b/app/controllers/api/child_accounts_controller.rb
@@ -488,9 +488,15 @@ class API::ChildAccountsController < API::ApplicationController
     end
 
     if settings
-      @child_account.settings = settings
+      # MERGE, don't replace. Each frontend tab saves its own slice of this
+      # blob as a fresh literal, so a wholesale assignment silently dropped
+      # every key that tab doesn't know about — the dashboard layout columns,
+      # primary_team_id, archive/reclaim/fallback state, demo_board_limit.
+      @child_account.settings = merged_settings(settings)
     end
 
+    # `details` is deliberately NOT merged: the frontend clears an AAC profile
+    # field by DELETING its key, so a merge would make "Not set" a no-op.
     details = params[:details]
     if details
       @child_account.details = details
@@ -498,6 +504,14 @@ class API::ChildAccountsController < API::ApplicationController
 
     if params[:layout]
       @child_account.layout = params[:layout]
+    end
+
+    # The sandbox board cap is meaningless once promoted, and the wholesale
+    # settings replace used to drop it as a side effect. Match
+    # ChildAccount#promote_to_active! and clear it deliberately.
+    if was_sandbox && requested_status != ChildAccount::SANDBOX
+      @child_account.settings ||= {}
+      @child_account.settings.delete("demo_board_limit")
     end
 
     if @child_account.save
@@ -575,6 +589,18 @@ class API::ChildAccountsController < API::ApplicationController
   end
 
   private
+
+  # Merge an incoming settings blob over what's stored, so a caller that only
+  # knows about its own slice can't wipe the rest. Shallow on purpose: a
+  # nested hash the caller does send (`voice`) is replaced whole, which is how
+  # clearing a voice to `{"name" => ""}` stays possible.
+  #
+  # Clearing a top-level key still works by sending an explicit blank/nil —
+  # what no longer works is clearing by omission, which nothing does.
+  def merged_settings(incoming)
+    incoming = incoming.to_unsafe_h if incoming.respond_to?(:to_unsafe_h)
+    (@child_account.settings || {}).merge(incoming.to_h.deep_stringify_keys)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   # `with_archived` so unarchive (and admin maintenance) can target a

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -1004,10 +1004,15 @@ class ChildAccount < ApplicationRecord
   end
 
   def go_to_words
+    self.settings ||= {}
     settings["go_to_words"] || Board.common_words
   end
 
+  # `settings` has no DB default, so it can be nil on any row — every writer in
+  # this model guards for that, and these readers must too or an ordinary
+  # update 500s before it reaches the controller's save.
   def voice_settings
+    self.settings ||= {}
     settings["voice"] = { name: "polly:kevin", speed: 1, pitch: 1, volume: 1, rate: 1, language: "en-US" } unless settings["voice"]
     settings["voice"]
   end
@@ -1021,6 +1026,7 @@ class ChildAccount < ApplicationRecord
   end
 
   def voice=(voice_name)
+    self.settings ||= {}
     settings["voice"] ||= {}
     settings["voice"]["name"] = voice_name
     save!

--- a/spec/requests/api/child_accounts_settings_merge_spec.rb
+++ b/spec/requests/api/child_accounts_settings_merge_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+# The communicator screen saves `settings` from several places — the Settings
+# tab, the Boards-tab layout editor, the vendor form — and each builds a fresh
+# literal holding only its own keys. Update therefore MERGES the incoming blob
+# over what's stored; a wholesale assignment silently dropped everything the
+# saving tab didn't know about.
+RSpec.describe "API::ChildAccounts settings merge", type: :request do
+  let(:user) { create(:user) }
+  let(:communicator) { create(:child_account, user: user) }
+  let(:headers) { auth_headers(user).merge("Content-Type" => "application/json") }
+
+  def update_settings(settings, extra = {})
+    patch "/api/child_accounts/#{communicator.id}",
+          params: { settings: settings }.merge(extra).to_json,
+          headers: headers
+  end
+
+  describe "PATCH /api/child_accounts/:id" do
+    it "preserves keys the caller didn't send" do
+      communicator.update!(settings: {
+        "large_layout_cols" => 4,
+        "primary_team_id" => 99,
+        "enable_image_display" => true,
+      })
+
+      update_settings({ enable_image_display: false })
+
+      expect(response).to have_http_status(:ok)
+      settings = communicator.reload.settings
+      expect(settings["enable_image_display"]).to be(false)
+      expect(settings["large_layout_cols"]).to eq(4)
+      expect(settings["primary_team_id"]).to eq(99)
+    end
+
+    it "still overwrites the keys the caller does send" do
+      communicator.update!(settings: { "large_layout_cols" => 12 })
+
+      update_settings({ large_layout_cols: 6 })
+
+      expect(communicator.reload.settings["large_layout_cols"]).to eq(6)
+    end
+
+    # Clearing by omission is gone; clearing by explicit blank must still work,
+    # because that is what every frontend form actually sends.
+    it "clears a key sent as an explicit blank" do
+      communicator.update!(settings: { "phrase_board_id" => "42" })
+
+      update_settings({ phrase_board_id: "" })
+
+      expect(communicator.reload.settings["phrase_board_id"]).to eq("")
+    end
+
+    it "clears a key sent as an explicit nil" do
+      communicator.update!(settings: { "phrase_board_id" => "42" })
+
+      update_settings({ phrase_board_id: nil })
+
+      expect(communicator.reload.settings["phrase_board_id"]).to be_nil
+    end
+
+    it "replaces a nested hash wholesale rather than merging into it" do
+      communicator.update!(settings: {
+        "voice" => { "name" => "polly:kevin", "language" => "en-US" },
+      })
+
+      update_settings({ voice: { name: "", language: "en-US" } })
+
+      expect(communicator.reload.settings["voice"]).to eq(
+        "name" => "", "language" => "en-US",
+      )
+    end
+
+    it "survives an account whose settings column is nil" do
+      communicator.update_column(:settings, nil)
+
+      update_settings({ enable_image_display: true })
+
+      expect(response).to have_http_status(:ok)
+      expect(communicator.reload.settings["enable_image_display"]).to be(true)
+    end
+
+    it "leaves settings alone when the param is absent" do
+      communicator.update!(settings: { "large_layout_cols" => 5 })
+
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { name: "Renamed" }.to_json,
+            headers: headers
+
+      expect(communicator.reload.settings["large_layout_cols"]).to eq(5)
+    end
+
+    # The sandbox board cap used to be removed as a side effect of the
+    # wholesale replace. Under a merge it has to be cleared deliberately.
+    it "drops demo_board_limit when a sandbox is promoted" do
+      user.update!(plan_type: "pro", plan_status: "active")
+      communicator.update!(
+        status: ChildAccount::SANDBOX,
+        settings: { "demo_board_limit" => 1, "enable_image_display" => true },
+      )
+
+      update_settings({ enable_image_display: true }, status: ChildAccount::ACTIVE)
+
+      expect(response).to have_http_status(:ok)
+      settings = communicator.reload.settings
+      expect(settings).not_to have_key("demo_board_limit")
+      expect(settings["enable_image_display"]).to be(true)
+    end
+
+    it "keeps demo_board_limit while the account stays a sandbox" do
+      communicator.update!(
+        status: ChildAccount::SANDBOX,
+        settings: { "demo_board_limit" => 1 },
+      )
+
+      update_settings({ enable_image_display: true }, is_demo: true)
+
+      expect(communicator.reload.settings["demo_board_limit"]).to eq(1)
+    end
+  end
+
+  # details is deliberately NOT merged — the frontend clears an AAC profile
+  # field by deleting its key, so merging would make "Not set" a no-op.
+  describe "details stays a wholesale replace" do
+    it "drops a details key the caller omitted" do
+      communicator.update!(details: { "aac_level" => "emerging", "age" => 7 })
+
+      patch "/api/child_accounts/#{communicator.id}",
+            params: { details: { age: 7 } }.to_json,
+            headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(communicator.reload.details).not_to have_key("aac_level")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Companion to [itty-bitty-frontend#675](https://github.com/brittanyjohns/itty-bitty-frontend/pull/675), which had to work *around* this: `API::ChildAccountsController#update` assigned `params[:settings]` wholesale.

Several frontend surfaces save a communicator's settings as a **fresh literal holding only their own slice** — `ChildAccountForm` (Settings tab), `VendorAccountForm`, and the Boards-tab layout editor. A wholesale assignment therefore dropped every key the saving screen didn't know about. Real data loss, not theoretical: `large/medium/small_layout_cols`, `primary_team_id`, `archive_reason`/`archived_status`, `reclaim_reason`, `fallback_mode`/`fallback_since`/`fallback_reason`, `assignment_root_id`, `dynamic_board_id`, `can_edit_boards`, `go_to_words`. `VendorAccountForm` sends the smallest blob of all — six keys, no `voice` — so a vendor save wiped the most.

`settings` now merges over what's stored.

### `details` deliberately stays a replace

Opposite semantics, on purpose. The AAC profile clears a field by **deleting its key** (`ChildAccountForm.tsx:185-208` — `if (value) next[field] = value; else delete next[field]`), so merging `details` would make "Not set" a silent no-op for `aac_level`, `vocab_type`, `age_band`, and `glp_stage`. Worth flagging: the existing `child_accounts_aac_profile_spec.rb` clear-cases send an explicit `""`/`nil`, so they'd have stayed **green** while the actual frontend behavior broke. This PR pins the distinction in both directions.

### Two things the merge required handling

- **`demo_board_limit` on sandbox→active.** The wholesale replace removed it as a side effect. Under a merge it would survive onto a promoted account, so `update` now clears it deliberately, mirroring `ChildAccount#promote_to_active!`. (It's only read behind `sandbox?` guards, so this was inert — but leaving stale state around because it happens not to be read is how it stops being inert.)
- **`params[:settings]` is unpermitted `ActionController::Parameters`**, not a Hash — `to_h` on it returns empty. The helper goes through `to_unsafe_h` and `deep_stringify_keys` so symbol keys can't shadow the existing string keys in jsonb.

### Pre-existing crash fixed in passing

`settings` has **no DB default**, so it can be `nil` on any row. `voice_settings` read `settings["voice"]` with no guard and `update` calls it on line 483 — so updating a communicator that never had settings saved raised `NoMethodError: undefined method '[]' for nil` **before reaching any of my code**. My "nil settings column" spec surfaced it; guarded `voice_settings`, `go_to_words`, and `voice=` to match the ~7 other writers in the model that already do `self.settings ||= {}`.

## Test plan

- New `spec/requests/api/child_accounts_settings_merge_spec.rb` — 10 examples: unsent keys preserved; sent keys still overwritten; clearing via explicit `""` and via explicit `nil`; a nested hash (`voice`) replaced whole rather than deep-merged; nil settings column survives; absent `settings` param is a no-op; `demo_board_limit` dropped on promotion but kept while still a sandbox; and `details` still dropping an omitted key.
- **1019 examples, 0 failures** across every `child_account`-touching spec in `spec/requests`, `spec/models`, and `spec/services` (includes AAC profile, demo limit, assign boards, owner protection, archive/claim/status/handoff/team).

## Docs

`CHANGELOG.md` entry added. `CLAUDE.md` gains the invariant — settings merges, details replaces, why each, plus the "no DB default so it can be nil" note and the "clear by explicit blank, never by omission" rule.

## Note on rollout

The frontend PR is safe with or without this one (it always sends a complete blob). This PR makes the *other* callers — `VendorAccountForm` especially — stop losing data. No ordering requirement between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)