### PR TITLE
feat(boards): put a page's back tile where its folder tile sits

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -468,6 +468,20 @@ the root, unmuted so it speaks like a self tile. It has to run *after*
 `evict_occupants!`, which destroys any child folder tile pointing back at the
 root, so an anchor written earlier in the build would not survive.
 
+**The way home goes WHERE THE WAY IN WAS.** A subboard's back tile occupies the
+same `lg` cell as the folder tile that opens it — muscle memory only works if
+the way back is where the way in was, and re-scanning the grid on every page is
+exactly what an AAC layout exists to prevent. A nav-region page gets this for
+free (`upsert_nav_tile!` writes the self tile at the root's own cell); a
+drawer-tucked page gets it from `NavRowSync#place_home_tile!`, which mirrors the
+cell of the tile that links to it — usually on the **drawer**, not the root.
+Two rails there: the move is a **swap**, so the occupant takes the cell the
+anchor would otherwise have been given and no hole opens; and a mirrored `y`
+inside the nav region is **refused, never clamped into it** (a drawer's content
+area can be taller than the page it opens, and clamping would put the anchor in
+a cell `upsert_nav_tile!` owns). The link target stays the root either way — the
+anchor mirrors the drawer tile's *position*, not its destination.
+
 `allow_scroll_if_grown!` remains the safety net for case 3: a home board that
 did grow clears the seed's one-page `disable_scroll` so the new row isn't
 clipped.
@@ -1115,6 +1129,27 @@ Its own invariants:
   second has an escape hatch ("allow a partial row") — a tile count that isn't a
   multiple of the columns leaves dead cells at the right end of the last row.
   Shrinking the board is the fix for a short word list, not ticking the box.
+- **A page's back tile is placed by mirroring, not by authored order.** Tiles
+  otherwise land in pure reading order (`Build#apply_reading_order!`:
+  `x = i % columns`, `y = i / columns`), and both drafters ask the model for
+  "one tile that goes back" — which it reliably writes **last**, parking every
+  page's way home in the bottom-right corner.
+  `Boards::AdminBuilder::BackTileAlignment` swaps it into the cell its parent's
+  folder tile occupies, at every depth. It is a **pure function over the plan**
+  with no database reads: reading-order positions are derivable from a tile's
+  index, so the parent's cell is known from the plan alone. That is what lets
+  `ArtPreview` render the same permutation — otherwise the admin approves a grid
+  the build won't produce. Parentage is BFS from `ROOT_KEY`, so the *shallowest*
+  parent wins when two pages open the same child; x and y are clamped into the
+  child's own grid (pages may carry their own `columns`) and the final clamp
+  handles a ragged last row. A **swap, not an insert** — both tiles are 1×1, so
+  the grid stays packed and the displaced word takes the corner.
+  `Board#apply_layout!` sorts by `[y, x]` and renumbers `position`, so reading
+  order downstream follows the aligned layout for free.
+  **Gap:** nothing guarantees a page *has* a back tile — `FolderTiles` and
+  `PlanValidator#orphan_problems` only enforce the forward direction (a door
+  *into* every child), and there is no admin-side `ensure_home_tile!`. Alignment
+  moves a back tile that exists; it does not create a missing one.
 - **Boards are marked `settings["admin_builder"] = true`** and every member
   action is scoped through `AdminBoardBuild.builder_boards`, the same rail
   `Admin::VideoBoardsController` runs on. Boards are created unpublished;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **A page's "back" button now sits where the button that opened it sat.** When
+  a built board set puts a folder tile in a given spot on the main board, the
+  page it opens puts its way home in that same spot — at every level, on every
+  page. Previously the back button landed wherever the word list happened to
+  leave it, usually the bottom-right corner, so finding the way home meant
+  re-scanning the grid on each page instead of reaching for the same cell. The
+  word that was in that spot swaps into the corner, so no tile is lost and the
+  grid stays full. Applies to admin-authored board sets and to sets from the
+  Board Builder; imported OBF/OBZ boards keep their own layouts untouched.
+
 - **The listing gallery's tablet slide now shows the SpeakAnyWay app, not a
   printout.** The board sits inside the app's own header — board name, speech
   bar, play/clear/download — instead of being a printed page with its scan-me

--- a/app/services/boards/admin_builder/art_preview.rb
+++ b/app/services/boards/admin_builder/art_preview.rb
@@ -41,6 +41,12 @@ module Boards
       end
 
       def call
+        # The review grid is drawn in GRID order, not authored order, because
+        # BackTileAlignment moves each page's back tile into the cell its
+        # parent's folder tile occupies. Previewing the authored order would
+        # show the admin a layout the build isn't going to produce.
+        cells = BackTileAlignment.cell_indexes(pages)
+
         previewed = pages.map do |page|
           # `columns`/`tile_count` carry the page's OWN grid through to the view:
           # with mixed grids a page needn't match the main board, so the review
@@ -50,7 +56,7 @@ module Boards
             name: page[:name],
             columns: page[:columns].to_i,
             tile_count: page[:tile_count].to_i,
-            rows: page[:tiles].map { |tile| row_for(tile) },
+            rows: in_grid_order(page[:tiles], cells[page[:key]]).map { |tile| row_for(tile) },
           }
         end
 
@@ -73,6 +79,25 @@ module Boards
       private
 
       attr_reader :pages, :commercial_safe_only
+
+      # `cells[i]` is the cell tile `i` lands in; the grid reads the inverse.
+      # Any tile the permutation doesn't cover keeps its authored slot, so a
+      # missing or short array degrades to plain reading order.
+      def in_grid_order(tiles, cells)
+        return tiles if cells.blank?
+
+        ordered = Array.new(tiles.size)
+        leftover = []
+        tiles.each_with_index do |tile, index|
+          cell = cells[index]
+          if cell.is_a?(Integer) && ordered[cell].nil?
+            ordered[cell] = tile
+          else
+            leftover << tile
+          end
+        end
+        ordered.map { |tile| tile || leftover.shift }.compact
+      end
 
       def searcher
         # limit: 1 — the review grid shows what will actually be attached, not a

--- a/app/services/boards/admin_builder/back_tile_alignment.rb
+++ b/app/services/boards/admin_builder/back_tile_alignment.rb
@@ -1,0 +1,113 @@
+module Boards
+  module AdminBuilder
+    # Puts a page's way home WHERE THE WAY IN WAS: the back tile occupies the
+    # same grid cell as the folder tile that opens the page from its parent.
+    #
+    # Muscle memory is the whole point. A communicator who taps "Food" at the
+    # third cell of the bottom row should find "back" at the third cell of the
+    # bottom row, on every page, at every depth — not have to re-scan the grid
+    # because the drafter happened to write the back tile last.
+    #
+    # Nothing here touches the database. Admin builds lay tiles out in pure
+    # authored reading order (`Build#apply_reading_order!`: `x = i % columns`,
+    # `y = i / columns`), so a parent's folder-tile CELL is already known from
+    # that tile's INDEX in the parent page's list. The whole alignment is
+    # therefore a permutation over the plan, which is also what lets
+    # `ArtPreview` show the admin the layout that will actually be built.
+    #
+    # The move is a SWAP, not an insert: both tiles are 1x1, so trading cells
+    # keeps the grid fully packed and hands the displaced word the corner the
+    # back tile vacated. Inserting would open a hole and shift every tile after
+    # it.
+    module BackTileAlignment
+      module_function
+
+      # `{ page_key => [cell_index, ...] }` — entry `i` is the grid cell tile
+      # `i` should occupy. Identity for any page with nothing to align.
+      def cell_indexes(pages)
+        pages = Array(pages)
+        parents = parent_links(pages)
+
+        pages.to_h do |page|
+          [page[:key], page_cells(page, pages, parents)]
+        end
+      end
+
+      # Which tile opens each page, and from where: `{ page_key => { page:, index: } }`.
+      #
+      # BFS from the root so the SHALLOWEST parent wins when two pages link the
+      # same child — the way in a communicator is most likely to have taken.
+      # Pages unreachable from the root get no entry and are left alone.
+      def parent_links(pages)
+        by_key = pages.index_by { |page| page[:key] }
+        root = by_key[Plan::ROOT_KEY]
+        return {} if root.nil?
+
+        links = {}
+        queue = [root]
+        seen = Set.new([root[:key]])
+
+        while (page = queue.shift)
+          page[:tiles].each_with_index do |tile, index|
+            target = tile[:links_to].presence
+            next if target.nil? || target == page[:key] || seen.include?(target)
+
+            child = by_key[target]
+            next if child.nil?
+
+            seen << target
+            links[target] = { page: page, index: index }
+            queue << child
+          end
+        end
+
+        links
+      end
+
+      def page_cells(page, pages, parents)
+        identity = (0...page[:tiles].size).to_a
+        link = parents[page[:key]]
+        return identity if link.nil?
+
+        back = back_tile_index(page, link[:page])
+        return identity if back.nil?
+
+        target = mirrored_index(page, link)
+        return identity if target.nil? || target == back
+
+        identity.tap do |cells|
+          cells[back], cells[target] = cells[target], cells[back]
+        end
+      end
+
+      # The tile that goes back. Prefer one pointing at this page's actual
+      # parent; fall back to ROOT_KEY, which is what the drafters ask for
+      # (`SetDrafter`/`PageDrafter`: "one tile that goes back") and therefore
+      # what a second-level page usually carries.
+      def back_tile_index(page, parent)
+        index_of_link(page, parent[:key]) || index_of_link(page, Plan::ROOT_KEY)
+      end
+
+      def index_of_link(page, target)
+        page[:tiles].index { |tile| tile[:links_to].presence == target }
+      end
+
+      # The parent's cell, clamped into this page's grid. A page can carry its
+      # own `columns` (mixed grids are allowed) and is usually shorter than the
+      # root, so both axes have to be brought back in range — and the final
+      # clamp handles a ragged last row, where the mirrored column doesn't
+      # exist yet.
+      def mirrored_index(page, link)
+        parent_columns = link[:page][:columns].to_i
+        columns = page[:columns].to_i
+        count = page[:tiles].size
+        return nil if parent_columns < 1 || columns < 1 || count.zero?
+
+        x = [link[:index] % parent_columns, columns - 1].min
+        y = [link[:index] / parent_columns, (count - 1) / columns].min
+
+        [(y * columns) + x, count - 1].min
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -212,13 +212,24 @@ module Boards
       # Reading order: left to right, top to bottom, in the order the words were
       # authored. apply_layout! sorts by [y, x] and rewrites every tile's
       # position, so the layout — not creation order — decides the final order.
+      #
+      # The one departure from authored order is BackTileAlignment, which swaps
+      # a page's back tile into the cell its parent's folder tile occupies. It
+      # returns a cell index per tile, so the same `% columns` / `/ columns`
+      # math still produces the grid.
+      def cell_indexes
+        @cell_indexes ||= BackTileAlignment.cell_indexes(pages)
+      end
+
       def apply_reading_order!(board, board_images, page)
         columns = page[:columns].to_i
+        cells = cell_indexes[page[:key]] || []
         layout = board_images.each_with_index.map do |board_image, index|
+          cell = cells[index] || index
           {
             "i" => board_image.id.to_s,
-            "x" => index % columns,
-            "y" => index / columns,
+            "x" => cell % columns,
+            "y" => cell / columns,
             "w" => 1,
             "h" => 1,
           }

--- a/app/services/boards/nav_row_sync.rb
+++ b/app/services/boards/nav_row_sync.rb
@@ -62,9 +62,12 @@ module Boards
     end
 
     def children
-      Boards::PredictiveLinkSet
+      set_boards.reject { |b| b.id == @root.id }
+    end
+
+    def set_boards
+      @set_boards ||= Boards::PredictiveLinkSet
         .collect(@root, max_depth: MAX_DEPTH, exclude: ->(b) { b.user_id != @root.user_id })
-        .reject { |b| b.id == @root.id }
     end
 
     def sync_child!(child)
@@ -112,8 +115,55 @@ module Boards
         # the way home speaks its own label.
         data: (board_image.data || {}).merge(NAV_TILE_KEY => true).except("mute_name"),
       )
-      relocate!(child, board_image)
+      place_home_tile!(child, board_image)
       @result.tiles_written += 1
+    end
+
+    # The way home goes WHERE THE WAY IN WAS: the same cell as the folder tile
+    # that opens this page. A page in the nav region gets that for free — its
+    # self tile is written at the root's own cell (see #upsert_nav_tile!) — but
+    # a drawer-tucked page's anchor would otherwise land in the first free cell,
+    # somewhere different on every page.
+    #
+    # Swap rather than insert: the occupant takes the cell the anchor would have
+    # been given, so nothing is dropped and no hole opens up.
+    def place_home_tile!(child, board_image)
+      cell = mirrored_cell(child, except: board_image.id)
+      return relocate!(child, board_image) if cell.nil?
+
+      occupant = occupant_at(child, cell, except: board_image.id)
+      write_cell!(board_image, cell[0], cell[1])
+      relocate!(child, occupant) if occupant
+    end
+
+    # The cell of the tile that links to this page, clamped into its grid.
+    #
+    # The linking tile usually lives on the DRAWER board, not the root, and a
+    # drawer's content area can be taller than this page's — so a mirrored cell
+    # inside the nav region is refused outright rather than clamped into it,
+    # where it would fight the nav tiles this service owns.
+    def mirrored_cell(child, except:)
+      linker = BoardImage.where(board_id: set_boards.map(&:id), predictive_board_id: child.id)
+                         .where.not(id: except)
+                         .reorder(nil)
+                         .find { |bi| bi.layout.is_a?(Hash) && bi.layout["lg"].is_a?(Hash) }
+      return nil if linker.nil?
+
+      cell = linker.layout["lg"]
+      columns = [child.large_screen_columns.to_i, 1].max
+      y = cell["y"].to_i
+      return nil if y >= region.top_y
+
+      [[cell["x"].to_i, columns - 1].min.clamp(0, columns - 1), y]
+    end
+
+    def occupant_at(child, cell, except:)
+      child.board_images.reload.find do |bi|
+        next false if bi.id == except
+
+        at = bi.layout.is_a?(Hash) ? bi.layout["lg"] : nil
+        at.present? && at["x"].to_i == cell[0] && at["y"].to_i == cell[1]
+      end
     end
 
     # Make room for the nav region.

--- a/spec/services/boards/admin_builder/art_preview_spec.rb
+++ b/spec/services/boards/admin_builder/art_preview_spec.rb
@@ -157,6 +157,31 @@ RSpec.describe Boards::AdminBuilder::ArtPreview do
     end
   end
 
+  # The review screen draws a real grid, and Build swaps each page's back tile
+  # into its parent folder tile's cell. Previewing the authored order would show
+  # the admin a layout the build isn't going to produce.
+  it "draws a child page in grid order, with the back tile where its folder tile sits" do
+    pages = Boards::AdminBuilder::Plan.pages(
+      root: {
+        name: "Board", columns: 4, tile_count: 4,
+        tiles: [{ label: "i" }, { label: "Food", links_to: "food" }, { label: "want" }, { label: "more" }],
+      },
+      children: [{
+        key: "food", name: "Food",
+        tiles: [
+          { label: "apple" }, { label: "banana" }, { label: "hungry" },
+          { label: "back", links_to: Boards::AdminBuilder::Plan::ROOT_KEY },
+        ],
+      }],
+    )
+
+    result = described_class.new(pages: pages, commercial_safe_only: false).call
+
+    expect(result[:pages].last[:rows].map(&:label)).to eq(%w[apple back hungry banana])
+    # The root is never rearranged.
+    expect(result[:pages].first[:rows].map(&:label)).to eq(%w[i Food want more])
+  end
+
   it "ignores blank lines in the label list" do
     result = described_class.new(pages: pages_for(["apple", "", "  "]), commercial_safe_only: false).call
     expect(result[:total]).to eq(2)

--- a/spec/services/boards/admin_builder/back_tile_alignment_spec.rb
+++ b/spec/services/boards/admin_builder/back_tile_alignment_spec.rb
@@ -1,0 +1,157 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::BackTileAlignment do
+  def root_key = Boards::AdminBuilder::Plan::ROOT_KEY
+
+  # Terse page/tile builders — these specs are about indexes, so the labels
+  # exist only to be told apart.
+  def tile(label, links_to: nil)
+    { label: label, part_of_speech: "default", links_to: links_to }.compact
+  end
+
+  def page(key:, columns:, tiles:)
+    { key: key, name: key, columns: columns, tile_count: tiles.size, tiles: tiles }
+  end
+
+  describe ".cell_indexes" do
+    it "moves a page's back tile into the cell its folder tile occupies, swapping with the word there" do
+      root = page(key: root_key, columns: 4, tiles: [
+        tile("a"), tile("b"), tile("c"), tile("d"),
+        tile("e"), tile("Food", links_to: "food"), tile("g"), tile("h")
+      ])
+      food = page(key: "food", columns: 4, tiles: [
+        tile("apple"), tile("bread"), tile("cheese"), tile("dip"),
+        tile("egg"), tile("fig"), tile("grape"), tile("back", links_to: root_key)
+      ])
+
+      cells = described_class.cell_indexes([root, food])
+
+      # Folder tile is index 5 on a 4-wide root: x=1, y=1 -> cell 5 on the child.
+      expect(cells["food"][7]).to eq(5)
+      # The word that was in cell 5 takes the corner the back tile vacated.
+      expect(cells["food"][5]).to eq(7)
+      # Everything else keeps its authored slot.
+      expect(cells["food"].values_at(0, 1, 2, 3, 4, 6)).to eq([0, 1, 2, 3, 4, 6])
+      # The root itself is never rearranged.
+      expect(cells[root_key]).to eq((0..7).to_a)
+    end
+
+    it "leaves the page alone when the back tile already sits in the mirrored cell" do
+      root = page(key: root_key, columns: 2, tiles: [tile("a"), tile("Food", links_to: "food")])
+      food = page(key: "food", columns: 2, tiles: [tile("apple"), tile("back", links_to: root_key)])
+
+      expect(described_class.cell_indexes([root, food])["food"]).to eq([0, 1])
+    end
+
+    it "clamps x when the child grid is narrower than the parent's" do
+      root = page(key: root_key, columns: 6, tiles: Array.new(5) { |i| tile("a#{i}") } + [tile("Food", links_to: "food")])
+      food = page(key: "food", columns: 3, tiles: [
+        tile("apple"), tile("bread"), tile("cheese"),
+        tile("dip"), tile("egg"), tile("back", links_to: root_key)
+      ])
+
+      cells = described_class.cell_indexes([root, food])
+
+      # Folder tile is x=5, y=0 on a 6-wide root; the child only has columns 0-2.
+      expect(cells["food"][5]).to eq(2)
+      expect(cells["food"][2]).to eq(5)
+    end
+
+    it "clamps y into a ragged last row when the child is shorter than the parent" do
+      root = page(key: root_key, columns: 3, tiles: [
+        tile("a"), tile("b"), tile("c"),
+        tile("d"), tile("e"), tile("f"),
+        tile("g"), tile("h"), tile("i"),
+        tile("j"), tile("Food", links_to: "food")
+      ])
+      # Two full rows plus one cell: the mirrored y=3 doesn't exist here.
+      food = page(key: "food", columns: 3, tiles: [
+        tile("apple"), tile("bread"), tile("cheese"),
+        tile("dip"), tile("egg"), tile("fig"),
+        tile("back", links_to: root_key)
+      ])
+
+      cells = described_class.cell_indexes([root, food])
+
+      # y clamps to the last row (2); x=1 there would be cell 7, which doesn't
+      # exist either, so it clamps again to the last occupied cell.
+      expect(cells["food"][6]).to eq(6)
+      expect(cells["food"]).to eq((0..6).to_a)
+    end
+
+    it "mirrors a second-level page against its own parent, not the root" do
+      root = page(key: root_key, columns: 3, tiles: [tile("a"), tile("b"), tile("Food", links_to: "food")])
+      food = page(key: "food", columns: 3, tiles: [
+        tile("apple"), tile("Snacks", links_to: "snacks"), tile("back", links_to: root_key)
+      ])
+      snacks = page(key: "snacks", columns: 3, tiles: [
+        tile("chips"), tile("crackers"), tile("back", links_to: root_key)
+      ])
+
+      cells = described_class.cell_indexes([root, food, snacks])
+
+      # "Snacks" is index 1 on the food page, so the snacks page's way home
+      # goes to cell 1 — not cell 2, where the root's own folder tile sits.
+      expect(cells["snacks"][2]).to eq(1)
+      expect(cells["snacks"][1]).to eq(2)
+      # Food still mirrors the root's folder tile at index 2.
+      expect(cells["food"]).to eq([0, 1, 2])
+    end
+
+    it "prefers a back tile pointing at the actual parent over one pointing at the root" do
+      root = page(key: root_key, columns: 3, tiles: [tile("a"), tile("b"), tile("Food", links_to: "food")])
+      food = page(key: "food", columns: 3, tiles: [tile("apple"), tile("Snacks", links_to: "snacks"), tile("c")])
+      snacks = page(key: "snacks", columns: 3, tiles: [
+        tile("home", links_to: root_key), tile("chips"), tile("Food", links_to: "food")
+      ])
+
+      cells = described_class.cell_indexes([root, food, snacks])
+
+      # The "Food" tile is the real way back; it moves to cell 1.
+      expect(cells["snacks"][2]).to eq(1)
+      expect(cells["snacks"][0]).to eq(0)
+    end
+
+    it "uses the shallowest parent when two pages link the same child" do
+      root = page(key: root_key, columns: 3, tiles: [
+        tile("a"), tile("Food", links_to: "food"), tile("Snacks", links_to: "snacks")
+      ])
+      food = page(key: "food", columns: 3, tiles: [
+        tile("apple"), tile("Snacks", links_to: "snacks"), tile("back", links_to: root_key)
+      ])
+      snacks = page(key: "snacks", columns: 3, tiles: [
+        tile("chips"), tile("crackers"), tile("back", links_to: root_key)
+      ])
+
+      cells = described_class.cell_indexes([root, food, snacks])
+
+      # Reached from the root at index 2 (depth 1), not from food at index 1.
+      expect(cells["snacks"]).to eq([0, 1, 2])
+    end
+
+    it "leaves a page with no back tile in authored order" do
+      root = page(key: root_key, columns: 3, tiles: [tile("a"), tile("b"), tile("Food", links_to: "food")])
+      food = page(key: "food", columns: 3, tiles: [tile("apple"), tile("bread"), tile("cheese")])
+
+      expect(described_class.cell_indexes([root, food])["food"]).to eq([0, 1, 2])
+    end
+
+    it "leaves a page unreachable from the root alone" do
+      root = page(key: root_key, columns: 2, tiles: [tile("a"), tile("b")])
+      orphan = page(key: "orphan", columns: 2, tiles: [tile("x"), tile("back", links_to: root_key)])
+
+      expect(described_class.cell_indexes([root, orphan])["orphan"]).to eq([0, 1])
+    end
+
+    it "handles a single-page plan, an empty page and a self-link without raising" do
+      root = page(key: root_key, columns: 3, tiles: [tile("a"), tile("Home", links_to: root_key)])
+      empty = page(key: "empty", columns: 3, tiles: [])
+
+      cells = described_class.cell_indexes([root, empty])
+
+      expect(cells[root_key]).to eq([0, 1])
+      expect(cells["empty"]).to eq([])
+      expect(described_class.cell_indexes([])).to eq({})
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -218,6 +218,67 @@ RSpec.describe Boards::AdminBuilder::Build do
       expect(child.board_images.find { |bi| bi.label == "back" }.data["mute_name"]).to be(true)
     end
 
+    # The way home goes where the way in was: a communicator who taps "Food" at
+    # a given cell finds "back" at that same cell on the page it opens. The
+    # drafters write the back tile last, so without alignment it would always
+    # land in the bottom-right corner instead.
+    describe "back tile alignment" do
+      def mid_row_root
+        [
+          { "label" => "i", "part_of_speech" => "pronoun" },
+          { "label" => "Food", "part_of_speech" => "noun", "links_to" => "food" },
+          { "label" => "want", "part_of_speech" => "verb" },
+          { "label" => "more", "part_of_speech" => "important_function" },
+        ]
+      end
+
+      def page_with_back
+        food_page(tiles: [
+          { "label" => "apple", "part_of_speech" => "noun" },
+          { "label" => "banana", "part_of_speech" => "noun" },
+          { "label" => "hungry", "part_of_speech" => "adjective" },
+          { "label" => "back", "part_of_speech" => "social", "links_to" => Boards::AdminBuilder::Plan::ROOT_KEY },
+        ])
+      end
+
+      let(:aligned) do
+        build_record(tiles: mid_row_root, columns: 4, tile_count: 4, children: [page_with_back])
+      end
+
+      def cell(board_image)
+        [board_image.layout["lg"]["x"], board_image.layout["lg"]["y"]]
+      end
+
+      it "puts the back tile in the same cell as the folder tile that opens the page" do
+        root = described_class.new(admin_board_build: aligned).call
+        folder = root.board_images.find { |bi| bi.predictive_board_id.present? }
+        child = Board.find(folder.predictive_board_id)
+        back = child.board_images.find { |bi| bi.label == "back" }
+
+        expect(cell(folder)).to eq([1, 0])
+        expect(cell(back)).to eq(cell(folder))
+      end
+
+      # A swap, not an insert: the displaced word takes the corner the back
+      # tile vacated, so the grid stays packed and nothing shifts.
+      it "hands the corner to the word it displaced and renumbers positions to match" do
+        root = described_class.new(admin_board_build: aligned).call
+        child = Board.find(root.board_images.find { |bi| bi.predictive_board_id.present? }.predictive_board_id)
+
+        expect(cell(child.board_images.find { |bi| bi.label == "banana" })).to eq([3, 0])
+        expect(child.board_images.order(:position).map(&:label)).to eq(%w[apple back hungry banana])
+      end
+
+      it "leaves a page with no back tile in authored reading order" do
+        root = described_class.new(admin_board_build: build_record(
+          tiles: mid_row_root, columns: 4, tile_count: 4, children: [food_page],
+        )).call
+        child = Board.find(root.board_images.find { |bi| bi.predictive_board_id.present? }.predictive_board_id)
+
+        expect(child.board_images.order(:position).map(&:label)).to eq(%w[apple banana hungry eat])
+      end
+    end
+
     it "records every page on the build so publish and show can reach them" do
       root = described_class.new(admin_board_build: build).call
       boards = build.reload.art_report["boards"]

--- a/spec/services/boards/nav_row_sync_spec.rb
+++ b/spec/services/boards/nav_row_sync_spec.rb
@@ -167,5 +167,43 @@ RSpec.describe Boards::NavRowSync do
       expect(home_tiles.size).to eq(1)
       expect(home_tiles.first.label).to eq("Food")
     end
+
+    # The way home goes where the way in was. "Animals" sits at (1, 0) on the
+    # drawer, so that is where the anchor lands — not the first free cell.
+    it "puts the anchor in the same cell as the tile that opens the page" do
+      described_class.call(root)
+
+      home = animals.board_images.reload.find { |bi| bi.predictive_board_id == root.id }
+      expect([home.layout["lg"]["x"], home.layout["lg"]["y"]]).to eq([1, 0])
+    end
+
+    it "swaps with whatever occupied that cell rather than dropping it" do
+      tile(animals, "cat", x: 1, y: 0, position: 2)
+
+      described_class.call(root)
+
+      home = animals.board_images.reload.find { |bi| bi.predictive_board_id == root.id }
+      cat = animals.board_images.reload.find { |bi| bi.label == "cat" }
+      expect([home.layout["lg"]["x"], home.layout["lg"]["y"]]).to eq([1, 0])
+      expect(cat).to be_present
+      expect([cat.layout["lg"]["x"], cat.layout["lg"]["y"]]).not_to eq([1, 0])
+      # Still in the content area, not pushed into the nav region.
+      expect(cat.layout["lg"]["y"]).to eq(0)
+    end
+
+    # A drawer's content area can be taller than the page it opens, so a
+    # mirrored cell that would land inside the nav region is refused outright
+    # rather than clamped into it, where it would fight the nav tiles.
+    it "falls back to the first free cell when the mirrored cell is in the nav region" do
+      animals.board_images.destroy_all
+      drawer.board_images.find_by(label: "Animals").update_column(
+        :layout, { "lg" => { "x" => 3, "y" => 4, "w" => 1, "h" => 1 } }
+      )
+
+      described_class.call(root)
+
+      home = animals.board_images.reload.find { |bi| bi.predictive_board_id == root.id }
+      expect([home.layout["lg"]["x"], home.layout["lg"]["y"]]).to eq([0, 0])
+    end
   end
 end


### PR DESCRIPTION
A subboard's back tile now occupies the same `lg` cell as the tile that opens it from its parent, at every depth. Muscle memory only works if the way back is where the way in was — otherwise finding the way home means re-scanning the grid on every page, which is exactly what an AAC layout exists to prevent.

## What changed

Two paths needed different work, because one was already half-right.

**Admin builds** — tiles land in pure authored reading order (`Build#apply_reading_order!`: `x = i % columns`, `y = i / columns`), and both drafters ask the model for "one tile that goes back", which it reliably writes **last**. So every page's way home was parked in the bottom-right corner regardless of where its folder tile sat on the root.

New `Boards::AdminBuilder::BackTileAlignment` swaps it into the parent folder tile's cell. It's a **pure function over the plan** with no DB reads — reading-order cells are derivable from a tile's index, so the parent's cell is known from the plan alone. That's what lets `ArtPreview` render the same permutation; without it the admin approves a review grid the build won't produce.

- Parentage is BFS from `ROOT_KEY`, so the **shallowest** parent wins when two pages open the same child.
- x and y clamp into the child's own grid (pages may carry their own `columns`), and a final clamp handles a ragged last row.
- Back tile is the one pointing at the actual parent, falling back to `ROOT_KEY` (the drafters' convention, and what a second-level page usually carries).

**Board Builder** — nav-region pages already got this for free: `NavRowSync#upsert_nav_tile!` writes the self tile at the root's own cell. The gap was `ensure_home_tile!`, the fallback for a page `FolderPlacer` tucked into the "More" drawer, which took the first free cell. It now mirrors the cell of the tile that links to it — usually on the **drawer**, not the root.

Two rails there: a mirrored `y` inside the nav region is **refused, never clamped into it** (a drawer's content area can be taller than the page it opens, and clamping would put the anchor in a cell `upsert_nav_tile!` owns); and the link target stays the root, so the anchor mirrors the drawer tile's *position*, not its destination.

**Both paths swap rather than insert.** Both tiles are 1×1, so the displaced word takes the cell the back tile vacated — the grid stays packed and no hole opens. `Board#apply_layout!` sorts by `[y, x]` and renumbers `position`, so reading order downstream follows the aligned layout for free.

OBF/OBZ imports keep their authored layouts untouched, by decision.

## Reviewer notes

- **Known gap, deliberately not fixed here:** nothing guarantees an admin-built page *has* a back tile. `FolderTiles` and `PlanValidator#orphan_problems` only enforce the forward direction (a door *into* every child), and there's no admin-side `ensure_home_tile!`. This PR moves a back tile that exists; it does not create a missing one. Worth its own issue.
- `NavRowSync#children` was refactored to memoize `set_boards`, so the linking-tile lookup is scoped to the set and an unrelated board pointing at the page can't drive placement.
- Documented in `.claude-notes/board-builder.md` (both the user-facing wizard section and the admin builder section) and `CHANGELOG.md`.

## Test plan

15 new examples. Full run, all green:

- `spec/services/boards/admin_builder/back_tile_alignment_spec.rb` (new, 10 examples) — mirroring + swap, x clamp on a narrower child, y clamp into a ragged last row, second-level page mirroring its own parent, parent-link preferred over root-link, shallowest parent on a shared child, no back tile, unreachable page, empty/self-link edges.
- `spec/services/boards/admin_builder/build_spec.rb` — built child's back tile cell equals the root folder tile's cell; displaced word takes the corner and positions renumber; page with no back tile stays in authored order.
- `spec/services/boards/admin_builder/art_preview_spec.rb` — child page previews in grid order; root never rearranged.
- `spec/services/boards/nav_row_sync_spec.rb` — anchor lands in the linking tile's cell; swaps with the occupant rather than dropping it; falls back to first-free-cell when the mirrored cell is in the nav region.

```
bundle exec rspec spec/services/boards/admin_builder spec/services/boards/nav_row_sync_spec.rb \
  spec/services/boards/folder_placer_spec.rb spec/sidekiq/build_board_set_job_spec.rb \
  spec/sidekiq/build_board_set_job_grid_spec.rb spec/requests/admin/board_builds_spec.rb \
  spec/tasks/board_builder_sync_nav_rows_spec.rb spec/services/boards/board_group_creator_spec.rb
# 481 examples, 0 failures
```

Re-ran the admin_builder + nav_row_sync specs after rebasing onto `origin/main` (272 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)