### PR TITLE
feat(myspeak): serve the care schema instead of duplicating it

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -131,9 +131,24 @@ multiple-choice and short-answer, deliberately unlike the free-text bio.
   **drops rather than rejects** — a stale frontend must not be able to 422 a
   parent out of saving. If nothing survives, the key is deleted so
   `has_care_info?` stays honest.
-- **The frontend registry must not drift.** `src/data/careSections.ts` mirrors
-  the option keys verbatim; a renamed key is silently dropped on save, not
-  reported.
+- **The registry is SERVED, not duplicated** — `GET /api/care_sections`
+  (`API::CareSectionsController`, unauthenticated like `preset_colors`; it is a
+  static schema with no user data in it). `Profile.care_registry_view` emits the
+  sections in registry order, every field's type, its options where it has them,
+  every cap the sanitizer enforces, and `CARE_CUSTOM_KEY_FORMAT` translated to
+  JavaScript anchors (Ruby's `\A`/`\z` don't compile in a JS RegExp).
+  `src/data/careSections.ts` keeps a bundled copy only as an offline/first-paint
+  fallback. **This is why editing CARE_SECTIONS is now safe to do alone** — the
+  frontend previously carried a hand-copied duplicate, and since
+  `sanitize_care_settings` DROPS an unrecognized key rather than rejecting it, a
+  rename deleted that answer from every profile with no error and no 422.
+- **Removing or renaming an option still deletes stored data.**
+  `sanitize_care_settings` is a `before_save`, not a check on the incoming
+  payload, so it re-cleans the whole blob on *every* profile save — an avatar
+  upload is enough. Retiring an option therefore needs a backfill first, or a
+  deprecation window where the key stays in the constant (accepted by the
+  sanitizer, hidden from the editor) until the data is migrated. Tracked in
+  itty-bitty-frontend#679.
 - **Care fields are never eligible for writing suggestions** — same rule as
   `SAFETY_SENSITIVE_KEYS`. Nothing here goes to OpenAI.
 - Care info is deliberately **not** on the Safety ID card or device tag; those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **The care schema is now served to the app** (`GET /api/care_sections`).
+  The editor's option chips came from a copy of the list hand-maintained in the
+  frontend, and `sanitize_care_settings` drops an option it doesn't recognize
+  rather than rejecting it — so renaming one here silently erased that answer
+  from every profile on its next save, with no error anywhere. The app now
+  renders whatever this endpoint sends. Changing the care options no longer
+  needs a matching frontend release.
+
+- **The care schema is now served to the app** ().
+  The editor's option chips came from a copy of the list hand-maintained in the
+  frontend, and  drops an option it doesn't recognize
+  rather than rejecting it — so renaming one here silently erased that answer
+  from every profile on its next save, with no error anywhere. The app now
+  renders whatever this endpoint sends. Changing the care options no longer
+  needs a matching frontend release.
+
 - **Care sections on a MySpeak page.** Beyond the intro and About Me blurb, a
   communicator's page can now carry optional, structured sections covering how
   they communicate, personal care, meals and snacks, and getting to and from

--- a/app/controllers/api/care_sections_controller.rb
+++ b/app/controllers/api/care_sections_controller.rb
@@ -1,0 +1,14 @@
+class API::CareSectionsController < API::ApplicationController
+  # The care schema the MySpeak editor renders from. Unauthenticated, like
+  # preset_colors: it is a static list of option keys with no user data in it,
+  # and gating it behind a token would mean an expired session renders an
+  # editor with no choices in it rather than a clear sign-in prompt.
+  skip_before_action :authenticate_token!, only: %i[index]
+
+  def index
+    # Static for the life of a deploy — safe to let clients and any proxy hold
+    # on to it. Changing CARE_SECTIONS ships a new deploy, which busts this.
+    expires_in 1.hour, public: true
+    render json: Profile.care_registry_view
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -621,6 +621,51 @@ class Profile < ApplicationRecord
   CARE_ITEM_VALUE_MAX = 200
   CARE_SHORT_TEXT_MAX = 300
 
+  # The care schema as the editor needs it — the whole registry, its caps, and
+  # the custom-key format, in one payload.
+  #
+  # This lives beside CARE_SECTIONS deliberately. The frontend used to carry a
+  # hand-copied duplicate of every option key, and sanitize_care_settings drops
+  # an unrecognized key rather than rejecting it — so a rename here silently
+  # deleted the parent's answer on their next save, with no error and no 422.
+  # Serving the registry means a change to the constant reaches the editor
+  # without a frontend deploy, and there is no second copy to drift.
+  #
+  # Sections are an ARRAY, not a hash: CARE_SECTIONS is insertion-ordered and
+  # that order is the order the editor renders in.
+  def self.care_registry_view
+    {
+      sections: CARE_SECTIONS.map do |key, spec|
+        {
+          key: key,
+          fields: spec[:fields].map do |field|
+            out = { key: field[:key], type: field[:type] }
+            out[:options] = field[:options] if field[:options]
+            out
+          end,
+        }
+      end,
+      limits: {
+        max_custom_sections: MAX_CUSTOM_CARE_SECTIONS,
+        max_custom_items: MAX_CARE_CUSTOM_ITEMS,
+        max_multi_select: MAX_CARE_MULTI_SELECT,
+        title_max: CARE_TITLE_MAX,
+        item_label_max: CARE_ITEM_LABEL_MAX,
+        item_value_max: CARE_ITEM_VALUE_MAX,
+        short_text_max: CARE_SHORT_TEXT_MAX,
+      },
+      custom_key_format: js_custom_key_format,
+    }
+  end
+
+  # Ruby anchors \A and \z are not valid in a JavaScript RegExp, so translate
+  # rather than shipping Regexp#source raw — a consumer that compiled it would
+  # throw. Derived from the constant on purpose: a hand-written copy of the
+  # pattern is exactly the kind of duplicate this endpoint exists to remove.
+  def self.js_custom_key_format
+    CARE_CUSTOM_KEY_FORMAT.source.sub('\A', "^").sub('\z', "$")
+  end
+
   PUBLIC_PAGE_KEYS = %w[
     public_page
     socials

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,10 @@ Rails.application.routes.draw do
     get "audio/play", to: "audio#play"
 
     get "preset_colors", to: "application#preset_colors"
+    # The MySpeak care schema. Static reference data, no auth — see the
+    # controller. The editor renders its option chips from this rather than
+    # from a hand-copied duplicate of Profile::CARE_SECTIONS.
+    get "care_sections", to: "care_sections#index"
     get "voices", to: "application#voice_options"
 
     get "public_boards", to: "boards#public_boards"

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+# The care registry is served so the frontend stops carrying a hand-copied
+# duplicate of Profile::CARE_SECTIONS. sanitize_care_settings DROPS an option
+# key it doesn't recognize rather than rejecting it, so a drifted copy deleted a
+# parent's answer on their next save with no error and no 422 — which is why
+# these assertions are about the payload matching the constant exactly, not
+# about it matching a fixture of what the constant happened to say.
+RSpec.describe "API::CareSections", type: :request do
+  describe "GET /api/care_sections" do
+    it "is readable without a token" do
+      get "/api/care_sections"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "serves every section in registry order" do
+      get "/api/care_sections"
+      body = JSON.parse(response.body)
+
+      expect(body["sections"].map { |s| s["key"] }).to eq(Profile::CARE_SECTIONS.keys)
+    end
+
+    it "serves every field with its type, and its options where it has them" do
+      get "/api/care_sections"
+      body = JSON.parse(response.body)
+
+      body["sections"].each do |section|
+        spec = Profile::CARE_SECTIONS.fetch(section["key"])
+        expect(section["fields"].map { |f| f["key"] }).to eq(spec[:fields].map { |f| f[:key] })
+
+        section["fields"].each_with_index do |field, idx|
+          source = spec[:fields][idx]
+          expect(field["type"]).to eq(source[:type].to_s)
+          expect(field["options"]).to eq(source[:options])
+        end
+      end
+    end
+
+    it "omits options for a short_text field rather than sending an empty list" do
+      get "/api/care_sections"
+      body = JSON.parse(response.body)
+
+      notes = body["sections"]
+              .find { |s| s["key"] == "communication" }["fields"]
+              .find { |f| f["key"] == "notes" }
+
+      expect(notes["type"]).to eq("short_text")
+      expect(notes).not_to have_key("options")
+    end
+
+    it "serves every cap the sanitizer enforces" do
+      get "/api/care_sections"
+      limits = JSON.parse(response.body)["limits"]
+
+      expect(limits).to eq(
+        "max_custom_sections" => Profile::MAX_CUSTOM_CARE_SECTIONS,
+        "max_custom_items" => Profile::MAX_CARE_CUSTOM_ITEMS,
+        "max_multi_select" => Profile::MAX_CARE_MULTI_SELECT,
+        "title_max" => Profile::CARE_TITLE_MAX,
+        "item_label_max" => Profile::CARE_ITEM_LABEL_MAX,
+        "item_value_max" => Profile::CARE_ITEM_VALUE_MAX,
+        "short_text_max" => Profile::CARE_SHORT_TEXT_MAX,
+      )
+    end
+
+    describe "custom_key_format" do
+      # Ruby's \A and \z are not valid in a JavaScript RegExp, so the pattern is
+      # translated on the way out. A consumer that compiled Regexp#source raw
+      # would throw.
+      it "is a pattern JavaScript can compile" do
+        get "/api/care_sections"
+        pattern = JSON.parse(response.body)["custom_key_format"]
+
+        expect(pattern).to eq("^c_[0-9a-f]{6}$")
+        expect(pattern).not_to include("\\A")
+        expect(pattern).not_to include("\\z")
+      end
+
+      it "accepts and rejects exactly what the Ruby constant does" do
+        get "/api/care_sections"
+        translated = Regexp.new(JSON.parse(response.body)["custom_key_format"])
+
+        %w[c_abc123 c_000000 c_ffffff].each do |key|
+          expect(key).to match(Profile::CARE_CUSTOM_KEY_FORMAT)
+          expect(key).to match(translated)
+        end
+
+        %w[c_ABC123 c_abc12 c_abc1234 communication ../etc c_abcxyz].each do |key|
+          expect(key).not_to match(Profile::CARE_CUSTOM_KEY_FORMAT)
+          expect(key).not_to match(translated)
+        end
+      end
+    end
+
+    # The payload's whole job is to be the thing the sanitizer will accept. If
+    # these two ever disagree, the editor offers a choice that vanishes on save.
+    it "offers only options sanitize_care_settings will keep" do
+      get "/api/care_sections"
+      body = JSON.parse(response.body)
+
+      user = FactoryBot.create(:user)
+      child = FactoryBot.create(:child_account, user: user, owner: user)
+      profile = Profile.create!(profileable: child, username: "care-registry", slug: "care-registry")
+      sections = body["sections"].each_with_object({}) do |section, acc|
+        values = section["fields"].each_with_object({}) do |field, vals|
+          case field["type"]
+          when "multi_select" then vals[field["key"]] = field["options"]
+          when "single_select" then vals[field["key"]] = field["options"].first
+          when "short_text" then vals[field["key"]] = "a note"
+          end
+        end
+        acc[section["key"]] = { "enabled" => true, "values" => values }
+      end
+
+      profile.update!(settings: { "care" => { "sections" => sections } })
+      stored = profile.reload.settings["care"]["sections"]
+
+      body["sections"].each do |section|
+        section["fields"].each do |field|
+          expected =
+            case field["type"]
+            when "multi_select" then field["options"].first(Profile::MAX_CARE_MULTI_SELECT)
+            when "single_select" then field["options"].first
+            when "short_text" then "a note"
+            end
+          expect(stored.dig(section["key"], "values", field["key"])).to eq(expected),
+            "#{section["key"]}.#{field["key"]} was dropped by the sanitizer"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part 1 of brittanyjohns/itty-bitty-frontend#679. Frontend side follows in a companion PR; the editor itself shipped in brittanyjohns/itty-bitty-frontend#677.

## The problem

`Profile::CARE_SECTIONS` appears in exactly one file and only inside `sanitize_care_settings`. It was never serialized, so the MySpeak care editor rendered its option chips from a **hand-copied duplicate** in the frontend (`src/data/careSections.ts`).

The sanitizer validates by **dropping**. An option key it doesn't recognize is discarded with no error and no 422 — so a rename here erased that answer from every profile on its next save, and the parent's experience is "saving is broken."

## What this adds

`GET /api/care_sections`:

```json
{
  "sections": [
    { "key": "communication",
      "fields": [
        { "key": "methods", "type": "multi_select", "options": ["aac_device", "..."] },
        { "key": "notes", "type": "short_text" }
      ] }
  ],
  "limits": { "max_custom_sections": 4, "max_custom_items": 8, "...": "..." },
  "custom_key_format": "^c_[0-9a-f]{6}$"
}
```

- **Sections are an array**, because `CARE_SECTIONS` is insertion-ordered and that order is the order the editor renders in.
- **`options` is omitted** for `short_text` rather than sent as an empty list.
- **The caps ship too**, so the client can stop a parent before they type something the server would silently trim.
- `Profile.care_registry_view` lives directly beside the constant, so a change to one is visibly a change to the other.

## Two decisions worth a look

**Unauthenticated**, following the `preset_colors` precedent. It's a static schema with no user data in it, and gating it behind a token means an expired session renders an editor with *no choices in it* rather than a clear sign-in prompt. Cached an hour; a deploy busts it.

**`custom_key_format` is translated, not raw.** Ruby's `\A`/`\z` aren't valid in a JavaScript `RegExp`, so shipping `Regexp#source` would hand the client a pattern that throws on compile. It's derived from the constant rather than hand-written — a second copy of the pattern is the same class of bug this endpoint exists to remove — and a spec asserts the translated pattern accepts and rejects exactly what the Ruby one does.

## ⚠️ What this does NOT fix

`sanitize_care_settings` is a **`before_save`**, not a check on the incoming payload. It re-cleans the entire care blob on *every* profile save — an avatar upload is enough.

So removing or renaming an option **still silently deletes stored answers**, from every profile holding that value, the next time that profile is touched for any reason. This change makes such an edit *reach the editor*; it does not make it *safe*. Retiring an option still needs a backfill first, or a deprecation window where the key stays in the constant (accepted by the sanitizer, hidden from the editor) until the data is migrated. Written up in itty-bitty-frontend#679 and now in `.claude-notes/safety-profiles.md`.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/requests/api/profiles_care_view_spec.rb spec/requests/api/profiles_spec.rb spec/requests/api/care_sections_spec.rb` — **137 examples, 0 failures.**

The 8 new examples assert the payload against `Profile::CARE_SECTIONS` **itself**, not against a fixture of what it currently says — a fixture would just be a third copy to drift. The one that earns its keep builds a payload from every option the endpoint serves, saves it through the real model, and asserts nothing was dropped: the endpoint cannot offer a choice that disappears on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
