### PR TITLE
feat(myspeak): let built-in care sections carry detail lines

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -149,6 +149,14 @@ multiple-choice and short-answer, deliberately unlike the free-text bio.
   deprecation window where the key stays in the constant (accepted by the
   sanitizer, hidden from the editor) until the data is migrated. Tracked in
   itty-bitty-frontend#679.
+- **Built-in sections carry `items` too** — the same label/value rows as a
+  custom section, same caps, same `clean_care_items`. The presets answer "which
+  of these applies"; the specific, provisional detail a parent needs to hand on
+  ("Drinks: watered-down apple juice, trying others") fits neither a chip nor the
+  shared `notes` field. A built-in section now survives on lines alone, so
+  `clean_builtin_care_section` returns nil only when values AND items are empty.
+  The key is omitted rather than stored as `[]`, and a row written before this
+  shipped round-trips unchanged.
 - **Care fields are never eligible for writing suggestions** — same rule as
   `SAFETY_SENSITIVE_KEYS`. Nothing here goes to OpenAI.
 - Care info is deliberately **not** on the Safety ID card or device tag; those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Care sections take detail lines, not just pick-from-a-list answers.** The
+  preset choices answer "which of these applies"; the thing you actually need to
+  pass on to a substitute is usually specific and still changing — "Drinks:
+  watered-down apple juice, we're trying others", "Pieces: cut big ones up",
+  "Won't eat anything cold". Every built-in section now takes up to eight
+  label/value lines alongside its presets, the same rows a section you write
+  yourself already had.
+
+- **The care schema is now served to the app** (`GET /api/care_sections`).
+  The editor's option chips came from a copy of the list hand-maintained in the
+  frontend, and `sanitize_care_settings` drops an option it doesn't recognize
+  rather than rejecting it — so renaming one here silently erased that answer
+  from every profile on its next save, with no error anywhere. The app now
+  renders whatever this endpoint sends. Changing the care options no longer
+  needs a matching frontend release.
+
 - **Text tiles: a tile picture rendered from typed text.** New
   `POST /api/board_images/:id/create_text_image` renders the tile's word in a
   chosen font, size, weight, case, alignment and colors, and attaches the PNG
@@ -18,14 +34,6 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   bucket so it never competes with paid AI work, and an identical repeat request
   is served without re-rendering. `POST /api/images/generate` now rejects
   `style=text` (422) rather than silently falling back to an AI style.
-
-- **The care schema is now served to the app** ().
-  The editor's option chips came from a copy of the list hand-maintained in the
-  frontend, and  drops an option it doesn't recognize
-  rather than rejecting it — so renaming one here silently erased that answer
-  from every profile on its next save, with no error anywhere. The app now
-  renders whatever this endpoint sends. Changing the care options no longer
-  needs a matching frontend release.
 
 - **Care sections on a MySpeak page.** Beyond the intro and About Me blurb, a
   communicator's page can now carry optional, structured sections covering how

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1168,19 +1168,26 @@ class Profile < ApplicationRecord
       clean_values[field[:key]] = cleaned if cleaned.present?
     end
 
-    return nil if clean_values.empty?
+    # Detail lines. The preset chips answer "which of these applies"; the real
+    # thing a parent needs to hand a substitute is usually specific and
+    # provisional — "Drinks: watered-down apple juice, trying others". That
+    # doesn't compress into a chip and doesn't belong buried in `notes`, so a
+    # built-in section carries the same label/value rows a custom one does.
+    items = clean_care_items(section["items"])
 
-    { "enabled" => care_enabled?(section["enabled"]), "values" => clean_values }
+    return nil if clean_values.empty? && items.empty?
+
+    cleaned = { "enabled" => care_enabled?(section["enabled"]), "values" => clean_values }
+    cleaned["items"] = items if items.any?
+    cleaned
   end
 
-  def clean_custom_care_section(section)
-    title = care_text(section["title"], CARE_TITLE_MAX)
-    return nil if title.blank?
+  # Shared by built-in and custom sections — same caps, same stripping, same
+  # "a row with neither a label nor a value isn't a row" rule.
+  def clean_care_items(raw_items)
+    return [] unless raw_items.is_a?(Array)
 
-    raw_items = section["items"]
-    raw_items = [] unless raw_items.is_a?(Array)
-
-    items = raw_items.filter_map do |item|
+    raw_items.filter_map do |item|
       next unless item.is_a?(Hash)
 
       label = care_text(item["label"], CARE_ITEM_LABEL_MAX)
@@ -1189,6 +1196,13 @@ class Profile < ApplicationRecord
 
       { "label" => label.to_s, "value" => value.to_s }
     end.first(MAX_CARE_CUSTOM_ITEMS)
+  end
+
+  def clean_custom_care_section(section)
+    title = care_text(section["title"], CARE_TITLE_MAX)
+    return nil if title.blank?
+
+    items = clean_care_items(section["items"])
 
     return nil if items.empty?
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -337,6 +337,98 @@ RSpec.describe Profile, type: :model do
         )
       end
 
+      # Detail lines on a BUILT-IN section. The chips answer "which of these
+      # applies"; the specific, provisional thing a parent needs to pass on
+      # ("Drinks: watered-down apple juice, trying others") fits neither a chip
+      # nor a shared `notes` blob.
+      describe "detail lines on a built-in section" do
+        it "keeps label/value rows alongside the preset values" do
+          result = care(
+            "meals" => {
+              "values" => { "eating" => "some_help" },
+              "items" => [
+                { "label" => "Drinks", "value" => "Watered-down apple juice, trying others" },
+                { "label" => "Pieces", "value" => "Cut big pieces up" },
+              ],
+            },
+          )
+
+          expect(result["sections"]["meals"]["values"]).to eq("eating" => "some_help")
+          expect(result["sections"]["meals"]["items"]).to eq(
+            [
+              { "label" => "Drinks", "value" => "Watered-down apple juice, trying others" },
+              { "label" => "Pieces", "value" => "Cut big pieces up" },
+            ],
+          )
+        end
+
+        it "keeps a section that has only lines and no preset values" do
+          result = care(
+            "meals" => { "items" => [{ "label" => "Temperature", "value" => "Won't eat cold food" }] },
+          )
+
+          expect(result["sections"]["meals"]["values"]).to eq({})
+          expect(result["sections"]["meals"]["items"].length).to eq(1)
+        end
+
+        it "still drops a section with neither values nor lines" do
+          result = care("meals" => { "items" => [{ "label" => " ", "value" => "" }] })
+          expect(result).to be_nil
+        end
+
+        it "omits the key entirely rather than storing an empty list" do
+          result = care("meals" => { "values" => { "eating" => "some_help" } })
+          expect(result["sections"]["meals"]).not_to have_key("items")
+        end
+
+        it "applies the same caps and stripping as a custom section" do
+          result = care(
+            "meals" => {
+              "items" => Array.new(Profile::MAX_CARE_CUSTOM_ITEMS + 3) do
+                { "label" => "l" * (Profile::CARE_ITEM_LABEL_MAX + 5),
+                  "value" => "<b>v</b>" + "v" * (Profile::CARE_ITEM_VALUE_MAX + 5) }
+              end,
+            },
+          )
+
+          items = result["sections"]["meals"]["items"]
+          expect(items.length).to eq(Profile::MAX_CARE_CUSTOM_ITEMS)
+          expect(items.first["label"].length).to eq(Profile::CARE_ITEM_LABEL_MAX)
+          expect(items.first["value"]).not_to include("<b>")
+          expect(items.first["value"].length).to eq(Profile::CARE_ITEM_VALUE_MAX)
+        end
+
+        it "drops rows that are neither labelled nor filled, keeping the rest" do
+          result = care(
+            "meals" => {
+              "values" => { "eating" => "some_help" },
+              "items" => [
+                { "label" => "", "value" => "" },
+                { "label" => "Pieces", "value" => "" },
+                { "label" => "", "value" => "No straws" },
+                "not a hash",
+              ],
+            },
+          )
+
+          expect(result["sections"]["meals"]["items"]).to eq(
+            [
+              { "label" => "Pieces", "value" => "" },
+              { "label" => "", "value" => "No straws" },
+            ],
+          )
+        end
+
+        it "leaves a section stored before lines existed untouched" do
+          # Backwards compatibility: rows written by the previous release have
+          # no "items" key at all and must round-trip unchanged.
+          result = care("meals" => { "enabled" => true, "values" => { "eating" => "tube_fed" } })
+          expect(result["sections"]["meals"]).to eq(
+            "enabled" => true, "values" => { "eating" => "tube_fed" },
+          )
+        end
+      end
+
       it "drops unknown sections, unknown fields, and out-of-registry options" do
         result = care(
           "communication" => {


### PR DESCRIPTION
Part 2 of brittanyjohns/itty-bitty-frontend#679. Frontend follows in a companion PR.

## Why

The preset chips answer *"which of these applies."* What a parent actually needs to hand a substitute is usually specific and still changing:

> Drinks: watered-down apple juice, we're trying others
> Pieces: cut big ones up
> Won't eat anything cold

None of that is a chip. Putting it all in the shared `notes` field loses the structure that makes the sheet skimmable — which was the whole reason for chips over a second free-text bio.

## What this does

**Reuses the shape we already had.** A custom section carries up to 8 label/value rows; every built-in section now takes the same rows alongside its presets. Same cap, same stripping, same "a row with neither a label nor a value isn't a row" rule — now shared in `clean_care_items` rather than duplicated.

No new sanitizer concept, no new mental model for the parent, and the editor already renders repeatable rows.

Alternatives considered are written up on #679 — briefly: a free-text qualifier hanging off a chip ties every specific to a preset that may not exist, and parent-authored chips turn the option whitelist into free text while still not holding "trying others."

## Compatibility

- A section now survives on **lines alone**, so `clean_builtin_care_section` returns nil only when values *and* items are empty.
- `items` is **omitted, not stored as `[]`**, when there are none.
- A section written before this shipped **round-trips untouched** — pinned by its own spec, because `sanitize_care_settings` is a `before_save` and re-cleans every stored blob on every profile save. A regression here wouldn't wait for a care edit to bite.

**Merge/deploy this before the frontend companion.** The currently-deployed frontend doesn't know about `items` and would drop them when it rewrites the care blob — harmless in practice, since nothing can create a line until the frontend ships, but the safe order is backend first.

## Test plan

- `bundle exec rspec spec/models/profile_spec.rb` — **91 examples, 0 failures** (7 new, covering: lines beside presets, lines with no presets, still-dropped when both empty, key omitted when empty, caps + markup stripping, partial rows, and the backwards-compatibility round-trip).
- `bundle exec rspec spec/requests/api/care_sections_spec.rb spec/requests/api/profiles_care_view_spec.rb` — 16 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
