### PR TITLE
feat(myspeak): make retiring a care option survivable

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -142,7 +142,20 @@ multiple-choice and short-answer, deliberately unlike the free-text bio.
   frontend previously carried a hand-copied duplicate, and since
   `sanitize_care_settings` DROPS an unrecognized key rather than rejecting it, a
   rename deleted that answer from every profile with no error and no 422.
-- **Removing or renaming an option still deletes stored data.**
+- **Retiring an option is a TWO-STEP process, and step one is one line.**
+  `Profile::DEPRECATED_CARE_OPTIONS` maps
+  `section => field => { retired_key => replacement_or_nil }`. Adding a key
+  there makes `care_registry_view` stop OFFERING it while
+  `sanitize_care_settings` keeps ACCEPTING it — so nobody picks it fresh and
+  nobody loses what they already wrote. Then `rake care:audit_options` reports
+  who still holds one and `rake care:remap_options` (dry-run by default,
+  `DRY_RUN=false` to apply, `PROFILE_ID=n` to scope) moves them onto their
+  replacements via `CareOptionRemap` (`app/services/`). Only once the audit
+  reports zero is it safe to delete the key from `CARE_SECTIONS` and from
+  `DEPRECATED_CARE_OPTIONS`. **Do not skip to the delete** — see below.
+  A rename is a remove plus an add: deprecate the old key, add the new one, map
+  old => new.
+- **Removing an option WITHOUT deprecating it still deletes stored data.**
   `sanitize_care_settings` is a `before_save`, not a check on the incoming
   payload, so it re-cleans the whole blob on *every* profile save — an avatar
   upload is enough. Retiring an option therefore needs a backfill first, or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Care options can now be retired without destroying answers people already
+  gave.** Removing a choice from the care registry used to erase it from every
+  profile still holding it, the next time that profile was saved for any reason
+  at all. A retired option is now still accepted on save while no longer being
+  offered, and `rake care:audit_options` / `rake care:remap_options` move the
+  stored answers onto their replacements before the option is finally deleted.
+
 - **Care sections take detail lines, not just pick-from-a-list answers.** The
   preset choices answer "which of these applies"; the thing you actually need to
   pass on to a substitute is usually specific and still changing — "Drinks:

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -621,6 +621,51 @@ class Profile < ApplicationRecord
   CARE_ITEM_VALUE_MAX = 200
   CARE_SHORT_TEXT_MAX = 300
 
+  # Options a parent may still HAVE but is no longer OFFERED.
+  #
+  # sanitize_care_settings is a before_save, so it re-cleans the whole care blob
+  # every time a profile is saved for ANY reason — an avatar upload is enough.
+  # That means deleting an option from CARE_SECTIONS doesn't just stop offering
+  # it: it silently erases that answer from every profile still holding it, the
+  # next time anything touches them. No error, no 422, and nothing left to
+  # restore from.
+  #
+  # So retiring an option is two steps, not one:
+  #
+  #   1. Move the key here. The sanitizer keeps ACCEPTING it, so stored answers
+  #      survive, and the editor stops OFFERING it (care_registry_view omits
+  #      deprecated keys). Nobody new can pick it; nobody loses what they wrote.
+  #   2. Once `rake care:remap_options` has moved the stored answers onto their
+  #      replacements — and the reports say zero remain — delete the entry here.
+  #
+  # A rename is a remove plus an add: deprecate the old key, add the new one,
+  # and map old => new below.
+  #
+  # Shape: { "section" => { "field" => { "old_option" => "new_option_or_nil" } } }
+  # A nil replacement means "no equivalent — drop it on remap", which still only
+  # happens when someone deliberately runs the task.
+  DEPRECATED_CARE_OPTIONS = {}.freeze
+
+  def self.retired_care_options(section_key, field)
+    DEPRECATED_CARE_OPTIONS.dig(section_key, field[:key])&.keys || []
+  end
+
+  # Every option the SANITIZER will accept: everything in the registry, plus
+  # anything already lifted out of it but not yet migrated. A union rather than
+  # a sum, so it holds whether the key is still listed in CARE_SECTIONS or not.
+  def self.accepted_care_options(section_key, field)
+    (field[:options] || []) | retired_care_options(section_key, field)
+  end
+
+  # What the editor should OFFER — the registry minus anything retired. Doing
+  # the subtraction here is what makes retirement a ONE-line edit: add the key
+  # to DEPRECATED_CARE_OPTIONS and it stops being offered while staying
+  # acceptable. Deleting it from CARE_SECTIONS in the same breath is exactly the
+  # move that destroys stored answers, so don't make that the required step.
+  def self.offered_care_options(section_key, field)
+    (field[:options] || []) - retired_care_options(section_key, field)
+  end
+
   # The care schema as the editor needs it — the whole registry, its caps, and
   # the custom-key format, in one payload.
   #
@@ -640,7 +685,9 @@ class Profile < ApplicationRecord
           key: key,
           fields: spec[:fields].map do |field|
             out = { key: field[:key], type: field[:type] }
-            out[:options] = field[:options] if field[:options]
+            # Offered, not accepted: a retired option stays valid on save but is
+            # never presented as a fresh choice.
+            out[:options] = offered_care_options(key, field) if field[:options]
             out
           end,
         }
@@ -1151,16 +1198,21 @@ class Profile < ApplicationRecord
     CARE_SECTIONS.fetch(key)[:fields].each do |field|
       raw_value = raw_values[field[:key]]
 
+      # Validated against ACCEPTED options — what's offered now plus anything
+      # retired but not yet migrated — so retiring an option can't delete a
+      # parent's stored answer behind their back. See DEPRECATED_CARE_OPTIONS.
+      accepted = self.class.accepted_care_options(key, field)
+
       cleaned =
         case field[:type]
         when :multi_select
           next unless raw_value.is_a?(Array)
           raw_value.map(&:to_s).uniq
-                   .select { |v| field[:options].include?(v) }
+                   .select { |v| accepted.include?(v) }
                    .first(MAX_CARE_MULTI_SELECT)
         when :single_select
           value = raw_value.to_s
-          value if field[:options].include?(value)
+          value if accepted.include?(value)
         when :short_text
           care_text(raw_value, CARE_SHORT_TEXT_MAX)
         end

--- a/app/services/care_option_remap.rb
+++ b/app/services/care_option_remap.rb
@@ -1,0 +1,66 @@
+# Moving stored care answers off options that have been retired.
+#
+# Lives here rather than in lib/tasks/care.rake so it autoloads and unit-tests
+# like anything else — the rake tasks are a thin shell over it. See
+# Profile::DEPRECATED_CARE_OPTIONS for why retirement is a two-step process.
+module CareOptionRemap
+  module_function
+
+  # Human-readable "section.field.option" labels for every retired option a
+  # profile still holds.
+  def hits_for(profile)
+    care = profile.settings.is_a?(Hash) ? profile.settings["care"] : nil
+    sections = care.is_a?(Hash) ? care["sections"] : nil
+    return [] unless sections.is_a?(Hash)
+
+    hits = []
+    Profile::DEPRECATED_CARE_OPTIONS.each do |section_key, fields|
+      values = sections.dig(section_key, "values")
+      next unless values.is_a?(Hash)
+
+      fields.each do |field_key, mapping|
+        held = Array(values[field_key])
+        mapping.each_key do |retired|
+          hits << "#{section_key}.#{field_key}.#{retired}" if held.include?(retired)
+        end
+      end
+    end
+    hits
+  end
+
+  # Returns a rewritten care blob, or nil when nothing changed. A retired option
+  # with a nil replacement is dropped; one whose replacement is already present
+  # collapses rather than duplicating.
+  def apply(care)
+    sections = care["sections"]
+    return nil unless sections.is_a?(Hash)
+
+    out = Marshal.load(Marshal.dump(care))
+    touched = false
+
+    Profile::DEPRECATED_CARE_OPTIONS.each do |section_key, fields|
+      values = out.dig("sections", section_key, "values")
+      next unless values.is_a?(Hash)
+
+      fields.each do |field_key, mapping|
+        current = values[field_key]
+
+        if current.is_a?(Array)
+          next unless current.any? { |v| mapping.key?(v) }
+
+          values[field_key] = current
+                              .map { |v| mapping.key?(v) ? mapping[v] : v }
+                              .compact.uniq
+          values.delete(field_key) if values[field_key].empty?
+          touched = true
+        elsif mapping.key?(current)
+          replacement = mapping[current]
+          replacement ? values[field_key] = replacement : values.delete(field_key)
+          touched = true
+        end
+      end
+    end
+
+    touched ? out : nil
+  end
+end

--- a/app/services/care_option_remap.rb
+++ b/app/services/care_option_remap.rb
@@ -35,7 +35,10 @@ module CareOptionRemap
     sections = care["sections"]
     return nil unless sections.is_a?(Hash)
 
-    out = Marshal.load(Marshal.dump(care))
+    # deep_dup, not Marshal round-trip: same deep copy for a plain
+    # Hash/Array/String blob, without handing Brakeman a deserialization
+    # warning (and without Marshal's habit of resurrecting arbitrary objects).
+    out = care.deep_dup
     touched = false
 
     Profile::DEPRECATED_CARE_OPTIONS.each do |section_key, fields|

--- a/lib/tasks/care.rake
+++ b/lib/tasks/care.rake
@@ -1,0 +1,65 @@
+# Migrating retired care options off the profiles that still hold them.
+#
+# Retiring an option is deliberately two steps (see
+# Profile::DEPRECATED_CARE_OPTIONS): deprecate it so stored answers survive
+# while the editor stops offering it, then run this to move those answers onto
+# their replacements. Only once this reports zero remaining is it safe to delete
+# the option from the constant — because sanitize_care_settings is a before_save
+# and would otherwise erase the leftovers the next time anything saved a profile.
+namespace :care do
+  desc "Report profiles still holding retired care options (care:remap_options to fix)"
+  task audit_options: :environment do
+    counts = Hash.new(0)
+    profiles = 0
+
+    Profile.where.not(settings: nil).find_each do |profile|
+      hits = CareOptionRemap.hits_for(profile)
+      next if hits.empty?
+
+      profiles += 1
+      hits.each { |hit| counts[hit] += 1 }
+    end
+
+    if counts.empty?
+      puts "No profile holds a retired care option. Safe to delete them from " \
+           "Profile::DEPRECATED_CARE_OPTIONS."
+      next
+    end
+
+    puts "#{profiles} profile(s) still hold retired options:"
+    counts.sort_by { |_, n| -n }.each { |label, n| puts "  #{label}: #{n}" }
+    puts "\nRun `rake care:remap_options DRY_RUN=false` to migrate them."
+  end
+
+  desc "Move retired care options onto their replacements (DRY_RUN=false to apply)"
+  task remap_options: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    scope = Profile.where.not(settings: nil)
+    scope = scope.where(id: ENV["PROFILE_ID"]) if ENV["PROFILE_ID"].present?
+
+    changed = 0
+    scope.find_each do |profile|
+      care = profile.settings["care"]
+      next unless care.is_a?(Hash)
+
+      remapped = CareOptionRemap.apply(care)
+      next unless remapped
+
+      changed += 1
+      if dry_run
+        puts "would update profile #{profile.id} (#{profile.slug})"
+      else
+        # update_column, deliberately: a normal save would run
+        # sanitize_care_settings, which is fine, but it would also fire the
+        # profile's other callbacks (audio regeneration, safety-card renders)
+        # on every row. This task changes stored option keys, nothing else.
+        profile.update_column(:settings, profile.settings.merge("care" => remapped))
+        puts "updated profile #{profile.id} (#{profile.slug})"
+      end
+    end
+
+    puts dry_run ?
+      "\nDRY RUN — #{changed} profile(s) would change. Re-run with DRY_RUN=false to apply." :
+      "\nDone — #{changed} profile(s) updated."
+  end
+end

--- a/spec/models/care_option_retirement_spec.rb
+++ b/spec/models/care_option_retirement_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+# Retiring a care option is the one edit that can silently destroy a parent's
+# data: sanitize_care_settings is a before_save, so it re-cleans the whole blob
+# every time a profile is saved for ANY reason. Delete an option from
+# CARE_SECTIONS and the next avatar upload erases that answer everywhere.
+#
+# DEPRECATED_CARE_OPTIONS is what makes retirement survivable. These specs stub
+# it rather than depending on whatever happens to be retired today, so they keep
+# testing the mechanism after the current retirements are finished and removed.
+RSpec.describe "retiring a care option" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child_account, user: user, owner: user) }
+  let(:profile) do
+    Profile.create!(profileable: child, username: "retire-spec", slug: "retire-spec")
+  end
+
+  # "some_speech" retired in favour of "gestures"; "echolalia" retired with no
+  # replacement. Both are real keys, so the fixture stays valid.
+  let(:deprecations) do
+    { "communication" => { "methods" => { "some_speech" => "gestures", "echolalia" => nil } } }
+  end
+
+  before do
+    stub_const("Profile::DEPRECATED_CARE_OPTIONS", deprecations)
+  end
+
+  def store_methods(methods)
+    profile.update!(
+      settings: {
+        "care" => {
+          "sections" => { "communication" => { "values" => { "methods" => methods } } },
+        },
+      },
+    )
+    profile.reload.settings.dig("care", "sections", "communication", "values", "methods")
+  end
+
+  describe "the sanitizer" do
+    it "keeps a retired option a parent already had" do
+      # The whole point. Without this, saving the profile for any reason at all
+      # would drop the answer.
+      expect(store_methods(%w[some_speech sign])).to eq(%w[some_speech sign])
+    end
+
+    it "keeps one that has no replacement" do
+      expect(store_methods(%w[echolalia])).to eq(%w[echolalia])
+    end
+
+    it "still rejects an option that was never in the registry" do
+      expect(store_methods(%w[telepathy sign])).to eq(%w[sign])
+    end
+
+    it "survives a re-save, which is what a before_save would otherwise break" do
+      store_methods(%w[some_speech])
+      profile.update!(username: "retire-spec-renamed")
+      expect(
+        profile.reload.settings.dig("care", "sections", "communication", "values", "methods"),
+      ).to eq(%w[some_speech])
+    end
+  end
+
+  describe "the registry endpoint" do
+    it "stops offering a retired option while still accepting it" do
+      offered = Profile.care_registry_view[:sections]
+                       .find { |s| s[:key] == "communication" }[:fields]
+                       .find { |f| f[:key] == "methods" }[:options]
+
+      expect(offered).not_to include("some_speech", "echolalia")
+      expect(offered).to include("sign", "gestures")
+
+      field = Profile::CARE_SECTIONS.dig("communication", :fields)
+                                    .find { |f| f[:key] == "methods" }
+      expect(Profile.accepted_care_options("communication", field))
+        .to include("some_speech", "echolalia")
+    end
+  end
+
+  describe "CareOptionRemap" do
+    it "reports what a profile still holds" do
+      store_methods(%w[some_speech sign echolalia])
+      expect(CareOptionRemap.hits_for(profile.reload)).to contain_exactly(
+        "communication.methods.some_speech",
+        "communication.methods.echolalia",
+      )
+    end
+
+    it "reports nothing for a profile holding only live options" do
+      store_methods(%w[sign])
+      expect(CareOptionRemap.hits_for(profile.reload)).to be_empty
+    end
+
+    it "moves a retired option onto its replacement" do
+      store_methods(%w[some_speech sign])
+      result = CareOptionRemap.apply(profile.reload.settings["care"])
+      expect(result.dig("sections", "communication", "values", "methods"))
+        .to eq(%w[gestures sign])
+    end
+
+    it "collapses rather than duplicating when the replacement is already there" do
+      store_methods(%w[some_speech gestures])
+      result = CareOptionRemap.apply(profile.reload.settings["care"])
+      expect(result.dig("sections", "communication", "values", "methods")).to eq(%w[gestures])
+    end
+
+    it "drops a retired option that has no replacement" do
+      store_methods(%w[echolalia sign])
+      result = CareOptionRemap.apply(profile.reload.settings["care"])
+      expect(result.dig("sections", "communication", "values", "methods")).to eq(%w[sign])
+    end
+
+    it "removes the field entirely when nothing survives" do
+      store_methods(%w[echolalia])
+      result = CareOptionRemap.apply(profile.reload.settings["care"])
+      expect(result.dig("sections", "communication", "values")).not_to have_key("methods")
+    end
+
+    it "returns nil when there is nothing to change, so the task skips the row" do
+      store_methods(%w[sign])
+      expect(CareOptionRemap.apply(profile.reload.settings["care"])).to be_nil
+    end
+
+    it "does not mutate the blob it was given" do
+      store_methods(%w[some_speech])
+      care = profile.reload.settings["care"]
+      before = Marshal.load(Marshal.dump(care))
+      CareOptionRemap.apply(care)
+      expect(care).to eq(before)
+    end
+
+    it "leaves a remapped blob acceptable to the sanitizer" do
+      # The remap output has to survive the very callback that made this
+      # mechanism necessary.
+      store_methods(%w[some_speech echolalia])
+      remapped = CareOptionRemap.apply(profile.reload.settings["care"])
+
+      profile.update!(settings: profile.settings.merge("care" => remapped))
+      expect(
+        profile.reload.settings.dig("care", "sections", "communication", "values", "methods"),
+      ).to eq(%w[gestures])
+    end
+  end
+
+  describe "with nothing retired (the steady state)" do
+    before { stub_const("Profile::DEPRECATED_CARE_OPTIONS", {}) }
+
+    it "offers exactly what it accepts" do
+      field = Profile::CARE_SECTIONS.dig("communication", :fields)
+                                    .find { |f| f[:key] == "methods" }
+      expect(Profile.accepted_care_options("communication", field)).to eq(field[:options])
+      expect(Profile.offered_care_options("communication", field)).to eq(field[:options])
+    end
+
+    it "reports and remaps nothing" do
+      store_methods(%w[sign])
+      expect(CareOptionRemap.hits_for(profile.reload)).to be_empty
+      expect(CareOptionRemap.apply(profile.reload.settings["care"])).to be_nil
+    end
+  end
+end

--- a/spec/models/care_option_retirement_spec.rb
+++ b/spec/models/care_option_retirement_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "retiring a care option" do
     it "does not mutate the blob it was given" do
       store_methods(%w[some_speech])
       care = profile.reload.settings["care"]
-      before = Marshal.load(Marshal.dump(care))
+      before = care.deep_dup
       CareOptionRemap.apply(care)
       expect(care).to eq(before)
     end


### PR DESCRIPTION
Prerequisite for Part 3 of brittanyjohns/itty-bitty-frontend#679 (pruning and reshaping the care presets). **No presets change here** — this is only the mechanism that makes changing them safe.

## The problem

`sanitize_care_settings` is a **`before_save`**, not a check on the incoming payload. It re-cleans the entire care blob every time a profile is saved for *any* reason — an avatar upload is enough.

So deleting an option from `CARE_SECTIONS` didn't just stop offering it. It **silently erased that answer from every profile still holding it**, the next time anything touched them. No error, no 422, nothing to restore from. That made pruning the presets — the whole point of serving the registry — the most dangerous edit in the model.

## Retirement is now two steps, and step one is one line

1. Add the key to **`DEPRECATED_CARE_OPTIONS`**. `care_registry_view` stops **offering** it; `sanitize_care_settings` keeps **accepting** it. Nobody picks it fresh; nobody loses what they wrote.
2. Once `rake care:audit_options` reports zero profiles still holding it, delete it from both constants.

```ruby
DEPRECATED_CARE_OPTIONS = {
  "communication" => { "methods" => { "some_speech" => "gestures", "echolalia" => nil } },
}
```

A rename is a remove plus an add: deprecate the old key, add the new one, map old ⇒ new. A `nil` replacement means "no equivalent — drop on remap", which still only happens when someone deliberately runs the task.

**Why the subtraction lives in `offered_care_options`** rather than requiring the key to be deleted from `CARE_SECTIONS`: making that delete part of step one would reintroduce the exact hazard this exists to remove. `accepted_care_options` is a union, so it holds whether or not the key is still listed.

## The migration

- `rake care:audit_options` — who still holds a retired option, counted per option.
- `rake care:remap_options` — moves them. **Dry-run by default**; `DRY_RUN=false` to apply, `PROFILE_ID=n` to scope.

`CareOptionRemap` lives in `app/services/`, not in the rake file, so it unit-tests like anything else. It collapses rather than duplicating when the replacement is already present, drops an option mapped to `nil`, removes the field when nothing survives, and returns `nil` when there's nothing to do so the task skips the row. It uses `update_column` — the point is to change stored option keys, not to re-fire audio regeneration and safety-card renders across every row.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/models/care_option_retirement_spec.rb spec/requests/api/care_sections_spec.rb spec/requests/api/profiles_care_view_spec.rb` — **123 examples, 0 failures** (16 new).

The specs **stub `DEPRECATED_CARE_OPTIONS`** rather than depending on whatever happens to be retired today, so they keep testing the mechanism after the current retirements are finished and removed — including a steady-state case where nothing is retired at all. The one that earns its keep saves a profile for an unrelated reason and asserts the retired answer is still there, which is precisely what the `before_save` would otherwise destroy.

## What's next

With this in, Part 3 can proceed. I'd like to bring you the **specific** proposed cuts and additions (which options to retire, what Sensory should contain) for a yes before touching them — deleting choices families depend on is a product call, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
