### PR TITLE
feat(myspeak): reshape the care presets and add a Sensory section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A Sensory section on the care card.** Sound, touch and light, plus a
+  "what helps when it's too much" line — the things that cut across a whole day
+  and had nowhere to live before. Noise on the bus and lights in a classroom
+  aren't a meals question, so it's its own section rather than a corner of
+  Meals.
+
+### Changed
+
+- **Fewer, sharper care choices.** The lists had grown longer than anyone reads.
+  Communication drops "facial expressions" (near-universal, so it said almost
+  nothing) and "writing", and folds "echolalia" into "some speech"; the
+  help-level and seating lists shrink to the choices that actually change what a
+  helper does. Anything removed has a better home in the detail lines added last
+  release. **Nobody loses an answer they already gave** — retired choices are
+  still accepted, they just aren't offered to anyone new.
+
 - **Care options can now be retired without destroying answers people already
   gave.** Removing a choice from the care registry used to erase it from every
   profile still holding it, the next time that profile was saved for any reason

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -594,6 +594,25 @@ class Profile < ApplicationRecord
         { key: "notes", type: :short_text },
       ],
     },
+    # Sensory is its own section rather than a sub-topic of Meals, deliberately:
+    # "won't eat anything cold" is a meals fact, but noise on the bus and lights
+    # in a classroom cut across every other section and had nowhere to live.
+    "sensory" => {
+      fields: [
+        { key: "sound", type: :multi_select,
+          options: %w[loud_noises_hurt uses_ear_defenders warn_before_alarms
+                      likes_music] },
+        { key: "touch", type: :multi_select,
+          options: %w[ask_before_touching dislikes_light_touch
+                      likes_deep_pressure] },
+        { key: "light", type: :multi_select,
+          options: %w[bright_light_hurts flickering_bothers prefers_dim] },
+        # The single most useful line on this section for someone with a
+        # distressed person in front of them.
+        { key: "calming", type: :short_text },
+        { key: "notes", type: :short_text },
+      ],
+    },
     "transportation" => {
       fields: [
         { key: "mode", type: :multi_select,
@@ -644,7 +663,36 @@ class Profile < ApplicationRecord
   # Shape: { "section" => { "field" => { "old_option" => "new_option_or_nil" } } }
   # A nil replacement means "no equivalent — drop it on remap", which still only
   # happens when someone deliberately runs the task.
-  DEPRECATED_CARE_OPTIONS = {}.freeze
+  DEPRECATED_CARE_OPTIONS = {
+    "communication" => {
+      "methods" => {
+        # Folded into some_speech: a product call, not a clinical one. Note for
+        # whoever revisits this — echolalia and "some speech" answer different
+        # questions for the person reading the card (whether they talk vs how to
+        # interpret what they say), and this app models gestalt language
+        # processing elsewhere. If parents ask for the distinction back, the
+        # option key can simply be re-added; the answers merged into some_speech
+        # are what can't be un-merged, so check care:audit_options first.
+        "echolalia" => "some_speech",
+        # Near-universal, so it carried almost no information as a checkbox.
+        "facial_expressions" => nil,
+        # Real but rare, and better as a detail line ("hand him a pen and he'll
+        # write it") than as a chip everyone scans past.
+        "writing" => nil,
+      },
+      "help_level" => {
+        "needs_setup" => "needs_prompts",
+        "hand_over_hand" => "partner_required",
+      },
+    },
+    "transportation" => {
+      "seating" => {
+        # Both are "which seat", which is a detail line, not a category.
+        "specific_seat" => nil,
+        "front_seat_only" => nil,
+      },
+    },
+  }.freeze
 
   def self.retired_care_options(section_key, field)
     DEPRECATED_CARE_OPTIONS.dig(section_key, field[:key])&.keys || []

--- a/spec/models/care_preset_reshape_spec.rb
+++ b/spec/models/care_preset_reshape_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+# The presets this release actually retires and adds. Distinct from
+# care_option_retirement_spec, which stubs DEPRECATED_CARE_OPTIONS to test the
+# MECHANISM and must keep passing once these particular retirements are
+# finished. This file asserts the current content, and is expected to change
+# when the content does.
+RSpec.describe "care preset reshape" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child_account, user: user, owner: user) }
+  let(:profile) do
+    Profile.create!(profileable: child, username: "reshape-spec", slug: "reshape-spec")
+  end
+
+  def offered(section_key, field_key)
+    Profile.care_registry_view[:sections]
+           .find { |s| s[:key] == section_key }[:fields]
+           .find { |f| f[:key] == field_key }[:options]
+  end
+
+  def store(section_key, values)
+    profile.update!(
+      settings: { "care" => { "sections" => { section_key => { "values" => values } } } },
+    )
+    profile.reload.settings.dig("care", "sections", section_key, "values")
+  end
+
+  describe "retired options" do
+    it "no longer offers them in the editor" do
+      expect(offered("communication", "methods"))
+        .to eq(%w[aac_device aac_book sign gestures some_speech eye_gaze partner_assisted])
+      expect(offered("communication", "help_level"))
+        .to eq(%w[independent needs_prompts partner_required])
+      expect(offered("transportation", "seating"))
+        .to eq(%w[harness car_seat booster wheelchair_securement])
+    end
+
+    it "still accepts them, so nobody loses an answer they already gave" do
+      # The reason retirement is two-step at all. Without this, every profile
+      # holding one of these would lose it on its next save for any reason.
+      expect(store("communication", "methods" => %w[echolalia writing facial_expressions]))
+        .to eq("methods" => %w[echolalia writing facial_expressions])
+      expect(store("communication", "help_level" => "hand_over_hand"))
+        .to eq("help_level" => "hand_over_hand")
+      expect(store("transportation", "seating" => %w[front_seat_only]))
+        .to eq("seating" => %w[front_seat_only])
+    end
+
+    it "keeps the ones that change what a helper physically does" do
+      # aac_book matters when the device is dead; partner_assisted and eye_gaze
+      # are access methods. Cutting these would lose real information.
+      expect(offered("communication", "methods"))
+        .to include("aac_book", "partner_assisted", "eye_gaze")
+    end
+
+    it "maps each retirement to a replacement or an explicit nil" do
+      Profile::DEPRECATED_CARE_OPTIONS.each do |section_key, fields|
+        fields.each do |field_key, mapping|
+          mapping.each do |retired, replacement|
+            expect(retired).to be_a(String)
+            next if replacement.nil?
+
+            live = Profile::CARE_SECTIONS.dig(section_key, :fields)
+                                         .find { |f| f[:key] == field_key }[:options]
+            expect(live).to include(replacement),
+              "#{section_key}.#{field_key}: #{retired} maps to #{replacement}, " \
+              "which is not an option anyone can be moved onto"
+          end
+        end
+      end
+    end
+
+    it "remaps echolalia onto some_speech without duplicating it" do
+      store("communication", "methods" => %w[echolalia some_speech sign])
+      remapped = CareOptionRemap.apply(profile.reload.settings["care"])
+      expect(remapped.dig("sections", "communication", "values", "methods"))
+        .to eq(%w[some_speech sign])
+    end
+  end
+
+  describe "the sensory section" do
+    it "is offered as its own section, not nested under meals" do
+      keys = Profile.care_registry_view[:sections].map { |s| s[:key] }
+      expect(keys).to include("sensory")
+      expect(Profile::CARE_SECTIONS.dig("meals", :fields).map { |f| f[:key] })
+        .not_to include("sound", "touch", "light")
+    end
+
+    it "stores its values through the sanitizer" do
+      expect(
+        store(
+          "sensory",
+          "sound" => %w[loud_noises_hurt uses_ear_defenders],
+          "touch" => %w[ask_before_touching],
+          "light" => %w[prefers_dim],
+          "calming" => "Headphones and a quiet corner.",
+        ),
+      ).to eq(
+        "sound" => %w[loud_noises_hurt uses_ear_defenders],
+        "touch" => %w[ask_before_touching],
+        "light" => %w[prefers_dim],
+        "calming" => "Headphones and a quiet corner.",
+      )
+    end
+
+    it "rejects an option outside its own registry" do
+      expect(store("sensory", "sound" => %w[loud_noises_hurt smells]))
+        .to eq("sound" => %w[loud_noises_hurt])
+    end
+
+    it "counts toward has_care_info? like any other section" do
+      store("sensory", "calming" => "A quiet corner.")
+      expect(profile.reload.has_care_info?).to be(true)
+    end
+  end
+
+  # The endpoint must never offer a choice the sanitizer would drop — that is
+  # the whole contract, and reshaping the registry is exactly when it could break.
+  it "offers only options that survive a save" do
+    sections = Profile.care_registry_view[:sections].each_with_object({}) do |section, acc|
+      values = section[:fields].each_with_object({}) do |field, vals|
+        case field[:type]
+        when :multi_select then vals[field[:key]] = field[:options]
+        when :single_select then vals[field[:key]] = field[:options].first
+        when :short_text then vals[field[:key]] = "a note"
+        end
+      end
+      acc[section[:key]] = { "enabled" => true, "values" => values }
+    end
+
+    profile.update!(settings: { "care" => { "sections" => sections } })
+    stored = profile.reload.settings["care"]["sections"]
+
+    Profile.care_registry_view[:sections].each do |section|
+      section[:fields].each do |field|
+        expected =
+          case field[:type]
+          when :multi_select then field[:options].first(Profile::MAX_CARE_MULTI_SELECT)
+          when :single_select then field[:options].first
+          when :short_text then "a note"
+          end
+        expect(stored.dig(section[:key], "values", field[:key])).to eq(expected),
+          "#{section[:key]}.#{field[:key]} was offered but dropped on save"
+      end
+    end
+  end
+end

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe "API::CareSections", type: :request do
         section["fields"].each_with_index do |field, idx|
           source = spec[:fields][idx]
           expect(field["type"]).to eq(source[:type].to_s)
-          expect(field["options"]).to eq(source[:options])
+          # OFFERED options, not the raw registry: an option that has been
+          # retired is still accepted on save but must never be presented as a
+          # fresh choice. See Profile::DEPRECATED_CARE_OPTIONS.
+          expected = source[:options] &&
+                     Profile.offered_care_options(section["key"], source)
+          expect(field["options"]).to eq(expected)
         end
       end
     end
@@ -88,6 +93,21 @@ RSpec.describe "API::CareSections", type: :request do
         %w[c_ABC123 c_abc12 c_abc1234 communication ../etc c_abcxyz].each do |key|
           expect(key).not_to match(Profile::CARE_CUSTOM_KEY_FORMAT)
           expect(key).not_to match(translated)
+        end
+      end
+    end
+
+    it "never offers an option that has been retired" do
+      get "/api/care_sections"
+      body = JSON.parse(response.body)
+
+      Profile::DEPRECATED_CARE_OPTIONS.each do |section_key, fields|
+        served = body["sections"].find { |s| s["key"] == section_key }
+        next unless served
+
+        fields.each do |field_key, mapping|
+          offered = served["fields"].find { |f| f["key"] == field_key }&.dig("options") || []
+          expect(offered).not_to include(*mapping.keys)
         end
       end
     end


### PR DESCRIPTION
Part 3 of brittanyjohns/itty-bitty-frontend#679. **Stacked on #675** (the retirement mechanism) — merge that first; this branch contains its commit.

Nothing here deletes a stored answer. Every retired option stays **accepted** on save and merely stops being **offered**, per #675.

## Retired

| Field | Retired | Goes to |
|---|---|---|
| `communication.methods` | `echolalia` | `some_speech` |
| | `facial_expressions` | dropped on remap |
| | `writing` | dropped on remap |
| `communication.help_level` | `needs_setup` | `needs_prompts` |
| | `hand_over_hand` | `partner_required` |
| `transportation.seating` | `specific_seat` | dropped on remap |
| | `front_seat_only` | dropped on remap |

Everything dropped has a better home in the **detail lines** shipped last release — "hand him a pen and he'll write it", "back left seat, by the window" — which is what makes cutting these lossless rather than lossy.

**Kept deliberately:** `aac_book` (matters when the device is dead), `partner_assisted` and `eye_gaze` (access methods that change what a helper physically does), `sign` vs `gestures` (formal signs vs informal — a helper is looking for different things).

### On echolalia → some_speech

This one is a **product decision, made explicitly**, and I want it visible rather than buried. I argued against it: the two answer different questions for the person reading the card — *whether they talk* vs *how to interpret what they say* — and a repeated question isn't an answer, which is exactly the misread this card exists to prevent. This app also models gestalt language processing elsewhere (`glp.ts`, the script collector, GLP board building).

Brittany's call, and she knows what parents actually say. The counter-argument is recorded in a code comment next to the mapping so whoever revisits it has the context.

**Asymmetry worth knowing:** re-adding the option key later is easy. The answers *merged into* `some_speech` are what can't be un-merged — so if there's any doubt, run `rake care:audit_options` before `care:remap_options` and keep the output.

## Added — a Sensory section

`sound`, `touch`, `light`, a **"what helps when it's too much"** line, and notes.

Its own section rather than a corner of Meals, deliberately: "won't eat anything cold" is a meals fact, but noise on the bus and lights in a classroom cut across everything and had nowhere to live. The "what helps" line is the single most useful field on it for someone with a distressed person in front of them.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/models/care_option_retirement_spec.rb spec/models/care_preset_reshape_spec.rb spec/requests/api/care_sections_spec.rb spec/requests/api/profiles_care_view_spec.rb` — **134 examples, 0 failures.**

- New `care_preset_reshape_spec.rb` asserts *this release's* content, kept separate from `care_option_retirement_spec.rb`, which stubs the constant to test the mechanism and must keep passing after these particular retirements are finished.
- One case asserts every retirement maps to a replacement that **actually exists**, so a typo can't strand people on a key nobody can be moved onto.
- The endpoint spec now asserts **offered** options rather than the raw registry, and gained a case proving no retired key is ever served. That change was required by the feature, not a loosened assertion.
- The whole-registry round-trip (offer everything → save → assert nothing dropped) still passes, now including Sensory.

## Frontend

A companion PR adds the Sensory labels and Spanish, and closes the known gap where the **public page** still renders care sections from the bundled copy — without that, Sensory would be editable but invisible on `/my/:slug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
