### PR TITLE
feat(billing): give the past_due grace state an end date

### DIFF
--- a/.claude-notes/billing-and-plans.md
+++ b/.claude-notes/billing-and-plans.md
@@ -116,6 +116,33 @@ also routes terminal statuses (`unpaid`, `incomplete_expired` —
 that's a real payer's failed renewal, left in Stripe dunning
 (`handle_invoice_payment_failed`).
 
+### past_due is a grace state with an age, not an open-ended one
+
+`past_due` sits outside every other downgrade path on purpose: it is not in
+`User::UNPAID_STATUSES` (so `paid_plan?` stays true and
+`reconcile_stranded_plan!` no-ops on sign-in) and not in
+`TRIAL_LAPSED_STATUSES`. Nothing about signing in re-checks it — downgrades
+here are entirely webhook-driven — so when the terminal event never lands
+(dunning configured to leave the subscription `past_due`, or a missed
+webhook), a lapsed payer keeps paid limits indefinitely.
+
+`DowngradePastDueJob` (daily, 6:30am UTC) bounds that window:
+
+- **Entry is stamped in the model**, not the webhook —
+  `User#track_past_due_transition` (a `before_save` on `plan_status_changed?`)
+  writes `settings["past_due_since"]` on entry and deletes it on exit, so both
+  Stripe `invoice.payment_failed` and RevenueCat `BILLING_ISSUE` are covered by
+  one rule and a recovered payer re-enters with a fresh window.
+- Past `PAST_DUE_GRACE_DAYS` (default 30) → `apply_free_plan` + the
+  subscription-canceled email. Data is retained per the downgrade invariant.
+- **Stripe is consulted before any downgrade.** `active`/`trialing` means our
+  recovery webhook was missed, so the job heals the user back to `active`
+  instead; a Stripe error skips the user. An unreachable API is not evidence
+  that someone stopped paying.
+- Rows that predate the stamp are stamped on first sweep and age out one window
+  later — `updated_at` moves on every sign-in, so there is no honest historical
+  date to downgrade off of.
+
 Trial→paid is measured via `AnalyticsEvent`: `trial_started` (checkout),
 `trial_will_end` (Stripe pre-end webhook), `subscription_started` (fired on
 the non-active→active transition in the upsert; guarded so renewals don't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A failed renewal now has an end date.** `past_due` was designed as a grace
+  state — Stripe keeps retrying the charge and access continues — but nothing
+  ever ended the grace, so when the terminal cancel event never arrived (dunning
+  set to leave the subscription past_due, or a missed webhook) an account kept
+  paid limits indefinitely. Accounts past_due longer than `PAST_DUE_GRACE_DAYS`
+  (default 30) now drop to Free with a subscription-ended email. Nothing is
+  deleted: over-limit boards go read-only with one still editable, and
+  over-limit communicators enter fallback. If Stripe says the subscription is
+  paying again, the account is restored to active instead — and if Stripe can't
+  be reached, nothing changes.
+
 - **Care options can now be retired without destroying answers people already
   gave.** Removing a choice from the care registry used to erase it from every
   profile still holding it, the next time that profile was saved for any reason

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,6 +241,15 @@ class User < ApplicationRecord
   before_save :setup_limits, if: :plan_type_changed?
   before_save :update_vendor, if: :plan_type_changed?
 
+  # `past_due` is a grace state, not a downgrade — Stripe keeps retrying the
+  # charge and access continues — so it needs an age, not a status check.
+  # Stamping the entry moment here (rather than in each webhook) covers every
+  # source that writes the status: Stripe invoice.payment_failed and
+  # RevenueCat BILLING_ISSUE. DowngradePastDueJob times the grace window off
+  # this stamp; leaving past_due drops it, so a recovered payer re-enters the
+  # state with a fresh window.
+  before_save :track_past_due_transition, if: :plan_status_changed?
+
   # Reconcile communicator fallback mode whenever the plan changes (issue #255).
   # Runs after save (so the new slot limits in `settings` are persisted) and in
   # both directions: a downgrade flags over-limit communicators, a re-upgrade
@@ -1540,6 +1549,46 @@ class User < ApplicationRecord
   rescue => e
     Rails.logger.error "[User#reconcile_stranded_plan!] user=#{id} failed: #{e.class} #{e.message}"
     false
+  end
+
+  # Settings key holding the ISO8601 moment the account entered `past_due`.
+  # Written/cleared only by track_past_due_transition (and stamp_past_due!,
+  # which backfills rows that went past_due before the stamp existed).
+  PAST_DUE_SINCE_KEY = "past_due_since".freeze
+
+  def past_due?
+    plan_status.to_s == "past_due"
+  end
+
+  # When this account entered past_due, or nil if it isn't past_due or predates
+  # the stamp. Unparseable values read as nil so a junk stamp can never be
+  # treated as "long expired" — the job re-stamps instead.
+  def past_due_since
+    raw = settings.is_a?(Hash) ? settings[PAST_DUE_SINCE_KEY] : nil
+    return nil if raw.blank?
+
+    Time.zone.parse(raw.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  # Backfill the stamp for an account that was already past_due before the
+  # stamp existed. Grace deliberately starts now, not at some guessed date —
+  # `updated_at` moves on every sign-in, so there is no honest historical
+  # timestamp to recover.
+  def stamp_past_due!(at = Time.current)
+    self.settings ||= {}
+    settings[PAST_DUE_SINCE_KEY] = at.utc.iso8601
+    save!
+  end
+
+  def track_past_due_transition
+    self.settings ||= {}
+    if past_due?
+      settings[PAST_DUE_SINCE_KEY] ||= Time.current.utc.iso8601
+    else
+      settings.delete(PAST_DUE_SINCE_KEY)
+    end
   end
 
   def professional?

--- a/app/sidekiq/downgrade_past_due_job.rb
+++ b/app/sidekiq/downgrade_past_due_job.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# Ages out the `past_due` grace state.
+#
+# Background: `past_due` is deliberately excluded from every other downgrade
+# path — it is not in User::UNPAID_STATUSES (so `paid_plan?` stays true and
+# `reconcile_stranded_plan!` no-ops on sign-in) and not in the webhook's
+# TRIAL_LAPSED_STATUSES, because a real payer's failed renewal belongs in
+# Stripe dunning, not in an instant downgrade. The gap that left: nothing
+# ever ENDED the grace. When the terminal `customer.subscription.deleted` /
+# `unpaid` event never lands — dunning configured to leave the subscription
+# past_due, or a missed webhook — the account keeps paid limits forever.
+#
+# This job closes that hole without touching the dunning window itself:
+# past_due for longer than PAST_DUE_GRACE_DAYS (default 30) drops to Free
+# through Billing::PlanTransitions.apply_free_plan, so data is retained
+# (over-limit boards go read-only, over-limit communicators enter fallback,
+# free credits are granted, an editable board is pinned).
+#
+# Two rails matter here:
+#   1. Never downgrade blind. If the account still has a Stripe subscription,
+#      the job asks Stripe for its real status first: active/trialing means our
+#      recovery webhook was missed, so it heals the user back to `active`
+#      instead. A Stripe error skips the user entirely — an unreachable API is
+#      not evidence that someone stopped paying.
+#   2. Rows that went past_due before the stamp existed get stamped on first
+#      sweep and downgrade one grace window later, rather than being
+#      mass-downgraded off a guessed date.
+class DowngradePastDueJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 2
+
+  DEFAULT_GRACE_DAYS = 30
+
+  # plan_types with nothing to downgrade. basic_trial is owned by
+  # DowngradeSoftTrialJob; free is already the floor.
+  SKIPPED_PLAN_TYPES = %w[free basic_trial].freeze
+
+  # Stripe statuses that mean the subscription recovered and our `active`
+  # webhook was missed.
+  STRIPE_ACTIVE_STATUSES = %w[active trialing].freeze
+
+  def perform
+    stamped = 0
+    downgraded = 0
+    recovered = 0
+    skipped = 0
+
+    past_due_users.find_each do |user|
+      next if user.admin?
+
+      since = user.past_due_since
+      if since.nil?
+        user.stamp_past_due!
+        stamped += 1
+        Rails.logger.info "DowngradePastDueJob: stamped legacy past_due user=#{user.id} (grace starts now)"
+        next
+      end
+
+      next if since > grace_days.days.ago
+
+      case stripe_status(user)
+      when :active
+        heal_to_active!(user)
+        recovered += 1
+      when :unknown
+        skipped += 1
+      else
+        downgrade!(user)
+        downgraded += 1
+      end
+    rescue => e
+      Rails.logger.error "DowngradePastDueJob: failed for user #{user&.id} - #{e.class} #{e.message}"
+    end
+
+    Rails.logger.info "DowngradePastDueJob: downgraded=#{downgraded} recovered=#{recovered} " \
+                      "stamped=#{stamped} skipped=#{skipped} grace_days=#{grace_days}"
+  end
+
+  private
+
+  def grace_days
+    @grace_days ||= begin
+      configured = ENV["PAST_DUE_GRACE_DAYS"].to_i
+      configured.positive? ? configured : DEFAULT_GRACE_DAYS
+    end
+  end
+
+  def past_due_users
+    User
+      .where(plan_status: "past_due")
+      .where.not(plan_type: SKIPPED_PLAN_TYPES)
+      .where.not(plan_type: [nil, ""])
+  end
+
+  # :active when Stripe says the subscription recovered, :unknown when Stripe
+  # can't answer (never downgrade on that), :lapsed otherwise — including when
+  # there's no subscription left to check.
+  def stripe_status(user)
+    return :lapsed if user.stripe_subscription_id.blank?
+
+    subscription = Stripe::Subscription.retrieve(user.stripe_subscription_id)
+    STRIPE_ACTIVE_STATUSES.include?(subscription.status) ? :active : :lapsed
+  rescue Stripe::InvalidRequestError => e
+    # A subscription Stripe no longer knows about is gone, not unreachable.
+    Rails.logger.info "DowngradePastDueJob: user=#{user.id} subscription missing at Stripe (#{e.message})"
+    :lapsed
+  rescue => e
+    Rails.logger.error "DowngradePastDueJob: Stripe lookup failed for user=#{user.id} - #{e.class} #{e.message}"
+    :unknown
+  end
+
+  # The subscription is paying again and we missed the webhook. Clearing the
+  # status drops the stamp via User#track_past_due_transition.
+  def heal_to_active!(user)
+    user.update!(plan_status: "active")
+    Rails.logger.info "DowngradePastDueJob: user=#{user.id} still active at Stripe -> healed to active"
+  end
+
+  def downgrade!(user)
+    previous_plan = user.plan_type
+    Billing::PlanTransitions.apply_free_plan(user, "canceled")
+    UserMailer.subscription_canceled_email(user).deliver_later
+    Rails.logger.info "DowngradePastDueJob: user=#{user.id} #{previous_plan} -> free " \
+                      "(past_due beyond #{grace_days}d), data retained"
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -78,5 +78,11 @@ Sidekiq.configure_server do |config|
       "queue" => "default",
       "description" => "Daily (6am UTC) enforcer for time-boxed entitlements keyed on plan_expires_at. Scoped to 5-Year licenses (basic_5yr/pro_5yr): sends a renewal offer ~LICENSE_RENEWAL_NOTICE_LEAD_DAYS (default 60) before expiry (flags settings[\"renewal_notice_sent_at\"]), and past expiry drops the user to Free via Billing::PlanTransitions.apply_free_plan (data retained, over-limit boards read-only, over-limit communicators in fallback) + a license-ended email. partner_pro/clinician are intentionally excluded.",
     },
+    "downgrade_past_due" => {
+      "cron" => "30 6 * * *",
+      "class" => "DowngradePastDueJob",
+      "queue" => "default",
+      "description" => "Daily (6:30am UTC) grace-window enforcer for plan_status=past_due. Accounts past_due longer than PAST_DUE_GRACE_DAYS (default 30, stamped in settings[\"past_due_since\"]) drop to Free via Billing::PlanTransitions.apply_free_plan (data retained) plus a subscription-canceled email. Checks Stripe first: a subscription that's active/trialing again is healed back to active instead, and a Stripe error skips the user rather than downgrading blind. Rows that went past_due before the stamp existed are stamped on first sweep and age out one window later.",
+    },
   })
 end

--- a/spec/models/user_past_due_stamp_spec.rb
+++ b/spec/models/user_past_due_stamp_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe User, "past_due stamping" do
+  let(:user) { create(:user, plan_type: "basic", plan_status: "active") }
+
+  it "stamps the moment the account enters past_due" do
+    expect { user.update!(plan_status: "past_due") }
+      .to change { user.reload.past_due_since }.from(nil)
+
+    expect(user.past_due_since).to be_within(1.minute).of(Time.current)
+  end
+
+  it "keeps the original stamp across later saves while still past_due" do
+    user.update!(plan_status: "past_due")
+    original = user.reload.past_due_since
+
+    travel_to(2.days.from_now) do
+      user.update!(name: "Renamed")
+      user.update!(plan_status: "past_due")
+    end
+
+    expect(user.reload.past_due_since).to be_within(1.second).of(original)
+  end
+
+  it "clears the stamp when the account leaves past_due" do
+    user.update!(plan_status: "past_due")
+
+    expect { user.update!(plan_status: "active") }
+      .to change { user.reload.past_due_since }.to(nil)
+  end
+
+  it "clears the stamp when the account is downgraded to free" do
+    user.update!(plan_status: "past_due")
+
+    Billing::PlanTransitions.apply_free_plan(user, "canceled")
+
+    expect(user.reload.settings[User::PAST_DUE_SINCE_KEY]).to be_nil
+  end
+
+  it "reads an unparseable stamp as nil rather than as long-expired" do
+    user.update!(plan_status: "past_due")
+    user.update_column(:settings, user.settings.merge(User::PAST_DUE_SINCE_KEY => "not-a-date"))
+
+    expect(user.reload.past_due_since).to be_nil
+  end
+
+  it "does not treat past_due as unpaid on its own" do
+    user.update!(plan_status: "past_due")
+
+    expect(user.paid_plan?).to be true
+    expect(user.plan_stranded?).to be false
+  end
+end

--- a/spec/sidekiq/downgrade_past_due_job_spec.rb
+++ b/spec/sidekiq/downgrade_past_due_job_spec.rb
@@ -1,0 +1,169 @@
+require "rails_helper"
+
+RSpec.describe DowngradePastDueJob, type: :job do
+  subject(:job) { described_class.new }
+
+  # A past_due Basic user whose grace window has already elapsed.
+  def create_lapsed_user(overrides = {})
+    since = overrides.delete(:past_due_since) { 45.days.ago }
+    attrs = {
+      plan_type: "basic",
+      plan_status: "past_due",
+      stripe_customer_id: "cus_test123",
+      stripe_subscription_id: "sub_test123",
+    }.merge(overrides)
+    user = FactoryBot.create(:user, **attrs)
+    if since
+      user.settings = (user.settings || {}).merge(User::PAST_DUE_SINCE_KEY => since.utc.iso8601)
+      user.save!
+    else
+      # Simulate a row that went past_due before the stamp existed: strip what
+      # the model callback just wrote, without firing callbacks again.
+      user.update_column(:settings, (user.settings || {}).except(User::PAST_DUE_SINCE_KEY))
+    end
+    user
+  end
+
+  def stub_stripe_status(status)
+    allow(Stripe::Subscription).to receive(:retrieve).and_return(double(status: status))
+  end
+
+  before { stub_stripe_status("past_due") }
+
+  describe "#perform" do
+    context "when the grace window has elapsed and Stripe confirms no recovery" do
+      it "drops the user to free" do
+        user = create_lapsed_user
+
+        expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+        expect(user.plan_status).to eq("canceled")
+        expect(user.paid_plan_type).to eq("basic")
+        expect(user.paid_plan?).to be false
+      end
+
+      it "retains the user's boards, locking the over-limit ones instead of deleting" do
+        user = create_lapsed_user
+        create(:board, user: user)
+        newest = create(:board, user: user)
+
+        expect { job.perform }.not_to change { user.boards.count }
+        expect(user.reload.editable_board_id).to eq(newest.id)
+      end
+
+      it "clears the past_due stamp on the way out" do
+        user = create_lapsed_user
+
+        job.perform
+
+        expect(user.reload.settings[User::PAST_DUE_SINCE_KEY]).to be_nil
+      end
+
+      it "emails the user that the subscription ended" do
+        user = create_lapsed_user
+
+        expect(UserMailer).to receive(:subscription_canceled_email).with(user_matching(user)).and_call_original
+
+        job.perform
+      end
+    end
+
+    context "when the account is still inside the grace window" do
+      it "leaves the plan alone" do
+        user = create_lapsed_user(past_due_since: 5.days.ago)
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+        expect(user.plan_status).to eq("past_due")
+      end
+    end
+
+    context "when the account went past_due before the stamp existed" do
+      it "stamps it and defers the downgrade to a later run" do
+        user = create_lapsed_user(past_due_since: nil)
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+        expect(user.past_due_since).to be_within(1.minute).of(Time.current)
+      end
+
+      it "downgrades once that fresh window elapses" do
+        user = create_lapsed_user(past_due_since: nil)
+        job.perform
+
+        user.stamp_past_due!(45.days.ago)
+
+        expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+      end
+    end
+
+    context "when Stripe says the subscription recovered" do
+      it "heals the user back to active instead of downgrading" do
+        user = create_lapsed_user
+        stub_stripe_status("active")
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+        expect(user.plan_status).to eq("active")
+        expect(user.settings[User::PAST_DUE_SINCE_KEY]).to be_nil
+      end
+    end
+
+    context "when Stripe cannot be reached" do
+      it "skips the user rather than downgrading blind" do
+        user = create_lapsed_user
+        allow(Stripe::Subscription).to receive(:retrieve).and_raise(Stripe::APIConnectionError.new("down"))
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+        expect(user.plan_status).to eq("past_due")
+      end
+    end
+
+    context "when Stripe no longer knows the subscription" do
+      it "treats it as lapsed and downgrades" do
+        user = create_lapsed_user
+        allow(Stripe::Subscription).to receive(:retrieve).and_raise(Stripe::InvalidRequestError.new("no such sub", "id"))
+
+        expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+      end
+    end
+
+    context "when the account has no Stripe subscription (RevenueCat billing issue)" do
+      it "downgrades without a Stripe call" do
+        user = create_lapsed_user(stripe_subscription_id: nil)
+        expect(Stripe::Subscription).not_to receive(:retrieve)
+
+        expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+      end
+    end
+
+    context "with accounts the job does not own" do
+      it "leaves admins alone" do
+        admin = create_lapsed_user(role: "admin")
+
+        expect { job.perform }.not_to change { admin.reload.plan_type }
+      end
+
+      it "leaves basic_trial users to DowngradeSoftTrialJob" do
+        user = create_lapsed_user(plan_type: "basic_trial")
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+      end
+
+      it "leaves users who are not past_due alone" do
+        user = create_lapsed_user(plan_status: "active", past_due_since: nil)
+
+        expect { job.perform }.not_to change { user.reload.plan_type }
+      end
+    end
+
+    it "honors PAST_DUE_GRACE_DAYS" do
+      user = create_lapsed_user(past_due_since: 10.days.ago)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("PAST_DUE_GRACE_DAYS").and_return("7")
+
+      expect { job.perform }.to change { user.reload.plan_type }.from("basic").to("free")
+    end
+  end
+
+  # apply_free_plan reloads/saves the user, so identity is by id, not object.
+  def user_matching(user)
+    satisfy { |arg| arg.id == user.id }
+  end
+end


### PR DESCRIPTION
## Summary

`past_due` was designed as a grace state — Stripe keeps retrying the charge and access continues — but nothing ever **ended** the grace. It's excluded from every downgrade path on purpose (not in `User::UNPAID_STATUSES`, so `paid_plan?` stays true and `reconcile_stranded_plan!` no-ops on sign-in; not in the webhook's `TRIAL_LAPSED_STATUSES`, since a real payer's failed renewal belongs in dunning). Downgrades here are entirely webhook-driven and sign-in never re-checks the status — so when the terminal `customer.subscription.deleted` / `unpaid` event never lands (dunning configured to leave the subscription past_due, or a missed webhook), the account keeps paid limits indefinitely.

Found while looking at a real account: `basic` / `past_due` since January, last sign-in January, still holding a 100-board limit and 2 paid communicator slots in August.

## What changed

**`DowngradePastDueJob`** (daily, 6:30am UTC). Past `PAST_DUE_GRACE_DAYS` (default 30) → `Billing::PlanTransitions.apply_free_plan` + `subscription_canceled_email`. Data retained per the downgrade invariant: over-limit boards read-only with one still editable, communicators to fallback, free credits granted.

Two rails worth reviewing closely:

- **Never downgrade blind.** If the account still has a `stripe_subscription_id`, the job asks Stripe for the real status first. `active`/`trialing` means our recovery webhook was missed → heal back to `active` instead. A Stripe error **skips** the user; an unreachable API is not evidence that someone stopped paying.
- **No mass-downgrade of the legacy cohort.** Rows with no stamp are stamped on first sweep and age out one window later. `updated_at` moves on every sign-in, so there's no honest historical date to downgrade off of.

**The stamp** lives in the model (`User#track_past_due_transition`, a `before_save` on `plan_status_changed?`) rather than in the webhook, so Stripe `invoice.payment_failed` and RevenueCat `BILLING_ISSUE` are both covered by one rule, and a recovered payer who lapses again gets a fresh window. Leaving `past_due` deletes the stamp.

This does not change what `past_due` means mid-dunning — only that it now has an end.

## Test plan

- `spec/sidekiq/downgrade_past_due_job_spec.rb` + `spec/models/user_past_due_stamp_spec.rb` — 21 examples, 0 failures. Covers: downgrade past the window, boards retained, stamp cleared, email sent, inside-window no-op, legacy row stamped then downgraded on a later run, Stripe-recovered heal, Stripe unreachable skip, subscription-missing-at-Stripe downgrade, no-subscription (RevenueCat) downgrade, admin / `basic_trial` / not-past_due exclusions, `PAST_DUE_GRACE_DAYS` override.
- Regression: `spec/models/user_plan_types_spec.rb`, `user_plan_limits_spec.rb`, `user_lifecycle_spec.rb`, `spec/sidekiq/downgrade_soft_trial_job_spec.rb`, `spec/services/billing` — 70 examples, 0 failures.
- Regression: `spec/requests/api/webhooks_payment_failed_spec.rb`, `webhooks_plan_type_spec.rb`, `webhooks_subscription_canceled_email_spec.rb`, `revenue_cat_webhook_spec.rb`, `lifecycle_integration_spec.rb` — 66 examples, 0 failures.

Docs: new "past_due is a grace state with an age" section in `.claude-notes/billing-and-plans.md`, plus a CHANGELOG entry.

## Notes for review

1. **30 days is a proposed default,** not a decision — it's `PAST_DUE_GRACE_DAYS`, tune at will.
2. **This treats the symptom.** If the root cause is Stripe's dunning end-behavior set to leave subscriptions past_due instead of canceling, fixing that setting is the real repair and this job becomes the backstop. Checking `sub_1SoXVVGfsUBE8bl3ot0YTGkR` in Stripe would tell us which.
3. Worth counting the cohort (`plan_status = 'past_due'` with a paid `plan_type`) before this runs in prod, to know how many accounts the first eligible sweep touches — note it's one grace window after deploy, not immediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
