### PR TITLE
feat(myspeak): reshape the care presets, add Sensory and Mobility

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -103,9 +103,10 @@ info** — medical details + emergency contacts + emergency notes
 ## Care sections — the second gated reveal
 
 `settings["care"]` holds optional, structured "how to support this person day to
-day" sections: Communication, Personal Care, Meals, Transportation, plus up to
-`MAX_CUSTOM_CARE_SECTIONS` parent-authored custom sections. They are mostly
-multiple-choice and short-answer, deliberately unlike the free-text bio.
+day" sections: Communication, Personal Care, Meals, Sensory, Mobility,
+Transportation, plus up to `MAX_CUSTOM_CARE_SECTIONS` parent-authored custom
+sections. They are mostly multiple-choice and short-answer, deliberately unlike
+the free-text bio.
 
 - **They are a third privacy tier, not a variant of the other two.** Not in
   `SAFETY_PAGE_KEYS` (never open on page-load) and not in
@@ -122,8 +123,9 @@ multiple-choice and short-answer, deliberately unlike the free-text bio.
   that actually matters. A care reveal also does **not** consume the hourly
   notify slot, so a real emergency reveal moments later still alerts.
 - **`Profile::CARE_SECTIONS` is the whole schema.** Each field is
-  `:multi_select`, `:single_select`, or `:short_text` with its option list.
-  `sanitize_care_settings` (a `before_save`, modelled on
+  `:multi_select` or `:short_text` with its option list. `:single_select` is
+  still supported by the sanitizer and the editor but **no field uses it** —
+  see the two shape rules below. `sanitize_care_settings` (a `before_save`, modelled on
   `sanitize_theme_settings`) is the only thing between a request body and an
   unauthenticated page, because `profile_params` permits `settings: {}`
   wholesale. It whitelists sections/fields/options, enforces the custom-key
@@ -162,14 +164,35 @@ multiple-choice and short-answer, deliberately unlike the free-text bio.
   deprecation window where the key stays in the constant (accepted by the
   sanitizer, hidden from the editor) until the data is migrated. Tracked in
   itty-bitty-frontend#679.
-- **Built-in sections carry `items` too** — the same label/value rows as a
-  custom section, same caps, same `clean_care_items`. The presets answer "which
-  of these applies"; the specific, provisional detail a parent needs to hand on
-  ("Drinks: watered-down apple juice, trying others") fits neither a chip nor the
-  shared `notes` field. A built-in section now survives on lines alone, so
-  `clean_builtin_care_section` returns nil only when values AND items are empty.
-  The key is omitted rather than stored as `[]`, and a row written before this
-  shipped round-trips unchanged.
+- **`DEPRECATED_CARE_OPTIONS` is empty, and that is not evidence nothing was
+  ever cut.** The reshape that dropped `echolalia`, the help-level scales, the
+  response-time field, and the per-section `notes` fields deleted them outright
+  from `CARE_SECTIONS`, because it landed **before the feature was announced**,
+  when no profile held a single care answer and there was nothing to protect.
+  That was a one-time licence and it has expired — every later change goes back
+  through the two steps above. Check before assuming otherwise: a care-data
+  count on the production console is the whole verification.
+- **Two shape rules govern every field, and `care_preset_reshape_spec.rb`
+  enforces them.** (1) Presets are **multi-select** — a single-select makes a
+  parent pick the one truest thing about someone whose support is layered
+  (independent at home, hand-over-hand at school), and a half-true chip on a
+  card a substitute reads is worse than no chip. This is also why the
+  "independent / some help / full help" scales are gone: they rated a person
+  where a helper needed something to *do*. (2) Option lists stay **short** —
+  six is the ceiling, and the one deliberate exception
+  (`communication.methods`) is named in the spec with its reason, so an
+  exception stays visible instead of becoming the norm.
+- **Built-in sections carry `items`, and they are the ONLY free-text surface.**
+  The same label/value rows as a custom section, same caps, same
+  `clean_care_items`. The presets answer "which of these applies"; the specific,
+  provisional detail a parent needs to hand on ("Bus: back left seat, by the
+  window") doesn't compress into a chip. There is deliberately **no
+  per-section `notes` field** — it sat next to the detail lines asking the same
+  question, so parents split one answer across two boxes. Short option lists are
+  only lossless *because* the lines are there. A built-in section survives on
+  lines alone, so `clean_builtin_care_section` returns nil only when values AND
+  items are empty. The key is omitted rather than stored as `[]`, and a row
+  written before this shipped round-trips unchanged.
 - **Care fields are never eligible for writing suggestions** — same rule as
   `SAFETY_SENSITIVE_KEYS`. Nothing here goes to OpenAI.
 - Care info is deliberately **not** on the Safety ID card or device tag; those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Care & routine notes: better questions, and you can pick more than one
+  answer.** Every care choice is now multi-select — support is layered, and
+  being forced to pick the single truest option meant a card that was only
+  half right. The "how much help do you need" and "how long to respond" ratings
+  are gone, replaced by things a helper can act on ("wait and pause", "keep my
+  device close", "food cut up"); `echolalia` is no longer offered as a
+  communication method; and the per-section "Good to know" box is gone, since
+  the detail lines added last release sat right beside it asking the same
+  question.
+
 ### Added
+
+- **Two new care sections: Sensory and Moving around.** Noise on the bus and
+  lights in a classroom cut across every other section and had nowhere to live,
+  and a wheelchair or a pair of AFOs is true all day rather than being a fact
+  about the trip to school. Sensory covers sound, touch, light, and what helps
+  when it's too much; Moving around covers equipment and the kind of support
+  someone needs.
 
 - **A failed renewal now has an end date.** `past_due` was designed as a grace
   state — Stripe keeps retrying the charge and access continues — but nothing

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -553,56 +553,102 @@ class Profile < ApplicationRecord
   #
   # NOTE: no care field may ever appear in a Suggestions::Registry context
   # allow-list. These are private care details, not copy to hand to OpenAI.
+  # Two rules shape every field below, and a new one should follow them:
+  #
+  #   1. Presets are MULTI-SELECT. A single-select forces a parent to pick the
+  #      one truest thing about a person whose support is layered — independent
+  #      at home, hand-over-hand at school — and a half-true chip on a card a
+  #      substitute reads is worse than no chip. It also collapses the
+  #      "independent / some help / full help" scales, which said little on
+  #      their own, into concrete supports someone can actually act on.
+  #   2. Presets stay SHORT (3-4 options) and answer "which of these applies".
+  #      Anything specific or provisional belongs in the section's detail lines
+  #      ("Bus: back left seat, by the window"), which every section carries.
+  #      That is what makes a short option list lossless rather than lossy.
+  #
+  # There is deliberately no per-section `notes` field: the detail lines are the
+  # free-text surface, and two of them side by side just split the same answer.
   CARE_SECTIONS = {
     "communication" => {
       fields: [
         { key: "methods", type: :multi_select,
-          options: %w[aac_device aac_book sign gestures some_speech echolalia
-                      writing eye_gaze partner_assisted facial_expressions] },
-        { key: "help_level", type: :single_select,
-          options: %w[independent needs_setup needs_prompts hand_over_hand
-                      partner_required] },
-        { key: "response_time", type: :single_select,
-          options: %w[right_away needs_time needs_lots_of_time] },
-        { key: "notes", type: :short_text },
+          options: %w[aac_device aac_book sign gestures some_speech eye_gaze
+                      partner_assisted] },
+        # Replaces a "how much help do you need" scale. What a helper needs is
+        # the thing to DO, not a rating — and "wait and pause" carries the only
+        # part of the old response_time field that changed anyone's behavior.
+        { key: "what_helps", type: :multi_select,
+          options: %w[keep_my_device_close model_on_my_device wait_and_pause
+                      offer_choices] },
       ],
     },
     "personal_care" => {
       fields: [
-        { key: "toileting", type: :single_select,
+        { key: "toileting", type: :multi_select,
           options: %w[independent needs_reminders needs_help toilet_training
                       pull_ups diapers] },
-        { key: "schedule", type: :single_select,
-          options: %w[on_request scheduled_times both] },
-        { key: "help_level", type: :single_select,
+        { key: "schedule", type: :multi_select,
+          options: %w[on_request scheduled_times] },
+        { key: "hygiene", type: :multi_select,
+          options: %w[handwashing toothbrushing face_and_hands hair_brushing] },
+        { key: "dressing", type: :multi_select,
           options: %w[independent some_help full_help] },
-        { key: "dressing", type: :single_select,
-          options: %w[independent some_help full_help] },
-        { key: "notes", type: :short_text },
       ],
     },
     "meals" => {
       fields: [
-        { key: "eating", type: :single_select,
-          options: %w[independent some_help full_help tube_fed] },
+        { key: "eating", type: :multi_select,
+          options: %w[food_cut_up needs_supervision fed_by_an_adult tube_fed] },
         { key: "textures", type: :multi_select,
           options: %w[regular soft chopped pureed thickened_liquids] },
+        # Utensils and vessels. Straw preferences used to be two chips here;
+        # they are a detail line now, where "no straw — he bites through them"
+        # can say why, which is the part a substitute actually needs.
         { key: "equipment", type: :multi_select,
-          options: %w[fork_and_spoon fingers specific_cup straw_only no_straw
-                      adapted_utensils] },
+          options: %w[fork_and_spoon fingers adapted_utensils specific_cup] },
         { key: "preferences", type: :short_text },
-        { key: "notes", type: :short_text },
+      ],
+    },
+    # Sensory is its own section rather than a sub-topic of Meals, deliberately:
+    # "won't eat anything cold" is a meals fact, but noise on the bus and lights
+    # in a classroom cut across every other section and had nowhere to live.
+    "sensory" => {
+      fields: [
+        { key: "sound", type: :multi_select,
+          options: %w[loud_noises_hurt uses_ear_defenders warn_before_alarms
+                      likes_music] },
+        { key: "touch", type: :multi_select,
+          options: %w[ask_before_touching dislikes_light_touch
+                      likes_deep_pressure] },
+        { key: "light", type: :multi_select,
+          options: %w[bright_light_hurts flickering_bothers prefers_dim] },
+        # The single most useful line on this section for someone with a
+        # distressed person in front of them.
+        { key: "calming", type: :short_text },
+      ],
+    },
+    # Split from Getting around on purpose. A wheelchair or a pair of AFOs is
+    # true all day, in every room — it is not a fact about the trip to school,
+    # and burying it under transportation meant nobody filled it in.
+    "mobility" => {
+      fields: [
+        { key: "equipment", type: :multi_select,
+          options: %w[wheelchair walker_or_gait_trainer braces_or_afos
+                      cane_or_crutches] },
+        { key: "support", type: :multi_select,
+          options: %w[independent standby_supervision hands_on_help
+                      help_with_transfers] },
       ],
     },
     "transportation" => {
       fields: [
-        { key: "mode", type: :multi_select,
-          options: %w[bus car_rider walker wheelchair_van parent_pickup] },
+        # "walks", not "walker" — with a Mobility section next door, `walker`
+        # reads as the device rather than "gets there on foot".
+        { key: "school_travel", type: :multi_select,
+          options: %w[bus car_rider walks wheelchair_van parent_pickup] },
         { key: "seating", type: :multi_select,
-          options: %w[harness car_seat booster wheelchair_securement
-                      specific_seat front_seat_only] },
+          options: %w[harness car_seat booster wheelchair_securement] },
         { key: "bus_info", type: :short_text },
-        { key: "notes", type: :short_text },
       ],
     },
   }.freeze
@@ -644,6 +690,13 @@ class Profile < ApplicationRecord
   # Shape: { "section" => { "field" => { "old_option" => "new_option_or_nil" } } }
   # A nil replacement means "no equivalent — drop it on remap", which still only
   # happens when someone deliberately runs the task.
+  #
+  # Empty on purpose, and NOT because nothing has ever been cut. The reshape
+  # that dropped echolalia, the help-level scales, and the per-section notes
+  # fields landed BEFORE the feature was announced, when no profile held a
+  # single care answer, so there was nothing to protect and the options were
+  # deleted outright. That is a one-time licence which has now expired: every
+  # later change has to go back through the two steps above.
   DEPRECATED_CARE_OPTIONS = {}.freeze
 
   def self.retired_care_options(section_key, field)
@@ -1222,9 +1275,10 @@ class Profile < ApplicationRecord
 
     # Detail lines. The preset chips answer "which of these applies"; the real
     # thing a parent needs to hand a substitute is usually specific and
-    # provisional — "Drinks: watered-down apple juice, trying others". That
-    # doesn't compress into a chip and doesn't belong buried in `notes`, so a
-    # built-in section carries the same label/value rows a custom one does.
+    # provisional — "Bus: back left seat, by the window". That doesn't compress
+    # into a chip, so a built-in section carries the same label/value rows a
+    # custom one does. These are the ONLY free-text surface on a built-in
+    # section, which is why the option lists above can stay short.
     items = clean_care_items(section["items"])
 
     return nil if clean_values.empty? && items.empty?

--- a/spec/models/care_option_retirement_spec.rb
+++ b/spec/models/care_option_retirement_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "retiring a care option" do
     Profile.create!(profileable: child, username: "retire-spec", slug: "retire-spec")
   end
 
-  # "some_speech" retired in favour of "gestures"; "echolalia" retired with no
+  # "some_speech" retired in favour of "gestures"; "eye_gaze" retired with no
   # replacement. Both are real keys, so the fixture stays valid.
   let(:deprecations) do
-    { "communication" => { "methods" => { "some_speech" => "gestures", "echolalia" => nil } } }
+    { "communication" => { "methods" => { "some_speech" => "gestures", "eye_gaze" => nil } } }
   end
 
   before do
@@ -44,7 +44,7 @@ RSpec.describe "retiring a care option" do
     end
 
     it "keeps one that has no replacement" do
-      expect(store_methods(%w[echolalia])).to eq(%w[echolalia])
+      expect(store_methods(%w[eye_gaze])).to eq(%w[eye_gaze])
     end
 
     it "still rejects an option that was never in the registry" do
@@ -66,22 +66,22 @@ RSpec.describe "retiring a care option" do
                        .find { |s| s[:key] == "communication" }[:fields]
                        .find { |f| f[:key] == "methods" }[:options]
 
-      expect(offered).not_to include("some_speech", "echolalia")
+      expect(offered).not_to include("some_speech", "eye_gaze")
       expect(offered).to include("sign", "gestures")
 
       field = Profile::CARE_SECTIONS.dig("communication", :fields)
                                     .find { |f| f[:key] == "methods" }
       expect(Profile.accepted_care_options("communication", field))
-        .to include("some_speech", "echolalia")
+        .to include("some_speech", "eye_gaze")
     end
   end
 
   describe "CareOptionRemap" do
     it "reports what a profile still holds" do
-      store_methods(%w[some_speech sign echolalia])
+      store_methods(%w[some_speech sign eye_gaze])
       expect(CareOptionRemap.hits_for(profile.reload)).to contain_exactly(
         "communication.methods.some_speech",
-        "communication.methods.echolalia",
+        "communication.methods.eye_gaze",
       )
     end
 
@@ -104,13 +104,13 @@ RSpec.describe "retiring a care option" do
     end
 
     it "drops a retired option that has no replacement" do
-      store_methods(%w[echolalia sign])
+      store_methods(%w[eye_gaze sign])
       result = CareOptionRemap.apply(profile.reload.settings["care"])
       expect(result.dig("sections", "communication", "values", "methods")).to eq(%w[sign])
     end
 
     it "removes the field entirely when nothing survives" do
-      store_methods(%w[echolalia])
+      store_methods(%w[eye_gaze])
       result = CareOptionRemap.apply(profile.reload.settings["care"])
       expect(result.dig("sections", "communication", "values")).not_to have_key("methods")
     end
@@ -131,7 +131,7 @@ RSpec.describe "retiring a care option" do
     it "leaves a remapped blob acceptable to the sanitizer" do
       # The remap output has to survive the very callback that made this
       # mechanism necessary.
-      store_methods(%w[some_speech echolalia])
+      store_methods(%w[some_speech eye_gaze])
       remapped = CareOptionRemap.apply(profile.reload.settings["care"])
 
       profile.update!(settings: profile.settings.merge("care" => remapped))

--- a/spec/models/care_preset_reshape_spec.rb
+++ b/spec/models/care_preset_reshape_spec.rb
@@ -1,0 +1,199 @@
+require "rails_helper"
+
+# The SHAPE of the care registry, as opposed to care_option_retirement_spec.rb,
+# which stubs DEPRECATED_CARE_OPTIONS to test the retirement mechanism and must
+# keep passing whatever the presets happen to say.
+#
+# These are the rules a new field has to follow, written as assertions so the
+# next person adding one finds out here rather than on a public page:
+#
+#   * every preset is multi-select
+#   * option lists stay short — specifics go in the detail lines
+#   * no built-in section carries a `notes` catch-all
+#
+# The content assertions below are deliberate too. They landed before the
+# feature was announced, when deleting an option destroyed nothing because
+# nothing was stored; a later change to any of them has to go through
+# DEPRECATED_CARE_OPTIONS instead.
+RSpec.describe "the care presets" do
+  def fields_for(section_key)
+    Profile::CARE_SECTIONS.fetch(section_key)[:fields]
+  end
+
+  def field(section_key, field_key)
+    fields_for(section_key).find { |f| f[:key] == field_key }
+  end
+
+  def every_field
+    Profile::CARE_SECTIONS.flat_map do |section_key, spec|
+      spec[:fields].map { |f| [section_key, f] }
+    end
+  end
+
+  describe "the rules every section follows" do
+    it "has no single-select field anywhere" do
+      # A single-select forces a parent to pick the one truest thing about
+      # someone whose support is layered. A half-true chip on a card a
+      # substitute reads is worse than no chip.
+      offenders = every_field.select { |_, f| f[:type] == :single_select }
+                             .map { |section, f| "#{section}.#{f[:key]}" }
+
+      expect(offenders).to be_empty
+    end
+
+    it "uses only the three types the sanitizer knows how to clean" do
+      types = every_field.map { |_, f| f[:type] }.uniq
+      expect(types - %i[multi_select short_text]).to be_empty
+    end
+
+    # The one list that outgrows the ceiling, on purpose. Every entry answers a
+    # different question for a helper: aac_book matters when the device is
+    # dead, eye_gaze and partner_assisted change what they physically do, and
+    # sign vs gestures is formal vs informal. Nothing here compresses.
+    WIDE_BY_DESIGN = ["communication.methods"].freeze
+
+    it "keeps every option list short enough to scan" do
+      # Six is the ceiling, not the target. A longer list is usually a sign the
+      # answer wanted to be a detail line; if it genuinely isn't, add it to
+      # WIDE_BY_DESIGN above with the reason, so the exception stays visible.
+      too_long = every_field.select { |section, f|
+        f[:options] && f[:options].length > 6 &&
+          WIDE_BY_DESIGN.exclude?("#{section}.#{f[:key]}")
+      }.map { |section, f| "#{section}.#{f[:key]} (#{f[:options].length})" }
+
+      expect(too_long).to be_empty
+    end
+
+    it "keeps even the exempt lists inside the sanitizer's multi-select cap" do
+      every_field.each do |section_key, f|
+        next unless f[:options]
+
+        expect(f[:options].length).to be <= Profile::MAX_CARE_MULTI_SELECT,
+                                      "#{section_key}.#{f[:key]} offers more than the sanitizer will store"
+      end
+    end
+
+    it "gives no built-in section a `notes` catch-all" do
+      # The detail lines ARE the free-text surface. Two of them side by side
+      # just split the same answer across two boxes.
+      expect(every_field.map { |_, f| f[:key] }).not_to include("notes")
+    end
+
+    it "has no duplicate field keys inside a section" do
+      Profile::CARE_SECTIONS.each_key do |section_key|
+        keys = fields_for(section_key).map { |f| f[:key] }
+        expect(keys).to eq(keys.uniq), "#{section_key} repeats a field key"
+      end
+    end
+
+    it "has no duplicate options inside a field" do
+      every_field.each do |section_key, f|
+        next unless f[:options]
+
+        expect(f[:options]).to eq(f[:options].uniq),
+                               "#{section_key}.#{f[:key]} repeats an option"
+      end
+    end
+  end
+
+  describe "sections" do
+    it "serves them in the order the editor renders" do
+      expect(Profile::CARE_SECTIONS.keys).to eq(
+        %w[communication personal_care meals sensory mobility transportation],
+      )
+    end
+
+    it "gives sensory its own section rather than a corner of meals" do
+      # Noise on the bus and lights in a classroom cut across every other
+      # section and had nowhere to live.
+      expect(fields_for("sensory").map { |f| f[:key] }).to eq(%w[sound touch light calming])
+    end
+
+    it "separates mobility from getting around" do
+      # A wheelchair or a pair of AFOs is true all day, in every room. It is
+      # not a fact about the trip to school.
+      expect(fields_for("mobility").map { |f| f[:key] }).to eq(%w[equipment support])
+      expect(field("mobility", "equipment")[:options]).to include("wheelchair", "braces_or_afos")
+    end
+  end
+
+  describe "options that were deliberately cut" do
+    def options_for(section_key, field_key)
+      field(section_key, field_key)&.fetch(:options, nil) || []
+    end
+
+    it "no longer offers echolalia as a communication method" do
+      expect(options_for("communication", "methods")).not_to include("echolalia")
+    end
+
+    it "replaced the help-level scales with concrete supports" do
+      expect(field("communication", "help_level")).to be_nil
+      expect(field("personal_care", "help_level")).to be_nil
+      expect(options_for("communication", "what_helps")).to include("wait_and_pause")
+    end
+
+    it "dropped the response-time field" do
+      # Knowing someone "needs time" changed nobody's behaviour; "wait and
+      # pause" tells a helper what to actually do.
+      expect(field("communication", "response_time")).to be_nil
+    end
+
+    it "dropped the seat-specific transportation chips" do
+      # Both were "which seat", which is a detail line, not a category.
+      expect(options_for("transportation", "seating"))
+        .not_to include("specific_seat", "front_seat_only")
+    end
+
+    it "dropped personal care's redundant `both` schedule option" do
+      # Redundant the moment the field went multi-select.
+      expect(options_for("personal_care", "schedule")).to eq(%w[on_request scheduled_times])
+    end
+
+    it "names the on-foot travel option `walks`, not `walker`" do
+      # With a Mobility section next door, `walker` reads as the device.
+      travel = options_for("transportation", "school_travel")
+      expect(travel).to include("walks")
+      expect(travel).not_to include("walker")
+    end
+  end
+
+  describe "the served registry" do
+    it "carries no trace of a cut option" do
+      serialized = Profile.care_registry_view.to_json
+
+      %w[echolalia response_time help_level specific_seat front_seat_only]
+        .each { |cut| expect(serialized).not_to include(cut) }
+    end
+  end
+
+  describe "round-tripping through the sanitizer" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:child) { FactoryBot.create(:child_account, user: user, owner: user) }
+    let(:profile) do
+      Profile.create!(profileable: child, username: "preset-spec", slug: "preset-spec")
+    end
+
+    it "stores every offered option on every section" do
+      # The reshape moved five fields from single- to multi-select. The
+      # sanitizer branches on type, so a field left behind would silently drop
+      # everything a parent picked for it.
+      sections = Profile::CARE_SECTIONS.each_with_object({}) do |(key, spec), acc|
+        values = spec[:fields].each_with_object({}) do |f, vals|
+          vals[f[:key]] = f[:type] == :short_text ? "a note" : f[:options]
+        end
+        acc[key] = { "enabled" => true, "values" => values }
+      end
+
+      profile.update!(settings: { "care" => { "sections" => sections } })
+      stored = profile.reload.settings.dig("care", "sections")
+
+      Profile::CARE_SECTIONS.each do |key, spec|
+        spec[:fields].each do |f|
+          expected = f[:type] == :short_text ? "a note" : f[:options]
+          expect(stored.dig(key, "values", f[:key])).to eq(expected),
+                                                        "#{key}.#{f[:key]} was dropped by the sanitizer"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -321,8 +321,7 @@ RSpec.describe Profile, type: :model do
             "enabled" => true,
             "values" => {
               "methods" => %w[aac_device gestures],
-              "help_level" => "needs_prompts",
-              "notes" => "Give me ten seconds to answer.",
+              "what_helps" => %w[wait_and_pause offer_choices],
             },
           },
         )
@@ -331,32 +330,32 @@ RSpec.describe Profile, type: :model do
           "enabled" => true,
           "values" => {
             "methods" => %w[aac_device gestures],
-            "help_level" => "needs_prompts",
-            "notes" => "Give me ten seconds to answer.",
+            "what_helps" => %w[wait_and_pause offer_choices],
           },
         )
       end
 
       # Detail lines on a BUILT-IN section. The chips answer "which of these
       # applies"; the specific, provisional thing a parent needs to pass on
-      # ("Drinks: watered-down apple juice, trying others") fits neither a chip
-      # nor a shared `notes` blob.
+      # ("Bus: back left seat, by the window") doesn't compress into a chip.
+      # They are the only free-text surface a built-in section has, which is
+      # what lets the option lists stay short.
       describe "detail lines on a built-in section" do
         it "keeps label/value rows alongside the preset values" do
           result = care(
             "meals" => {
-              "values" => { "eating" => "some_help" },
+              "values" => { "eating" => %w[food_cut_up] },
               "items" => [
-                { "label" => "Drinks", "value" => "Watered-down apple juice, trying others" },
+                { "label" => "Drinks", "value" => "Green straw cup only" },
                 { "label" => "Pieces", "value" => "Cut big pieces up" },
               ],
             },
           )
 
-          expect(result["sections"]["meals"]["values"]).to eq("eating" => "some_help")
+          expect(result["sections"]["meals"]["values"]).to eq("eating" => %w[food_cut_up])
           expect(result["sections"]["meals"]["items"]).to eq(
             [
-              { "label" => "Drinks", "value" => "Watered-down apple juice, trying others" },
+              { "label" => "Drinks", "value" => "Green straw cup only" },
               { "label" => "Pieces", "value" => "Cut big pieces up" },
             ],
           )
@@ -377,7 +376,7 @@ RSpec.describe Profile, type: :model do
         end
 
         it "omits the key entirely rather than storing an empty list" do
-          result = care("meals" => { "values" => { "eating" => "some_help" } })
+          result = care("meals" => { "values" => { "eating" => %w[food_cut_up] } })
           expect(result["sections"]["meals"]).not_to have_key("items")
         end
 
@@ -401,7 +400,7 @@ RSpec.describe Profile, type: :model do
         it "drops rows that are neither labelled nor filled, keeping the rest" do
           result = care(
             "meals" => {
-              "values" => { "eating" => "some_help" },
+              "values" => { "eating" => %w[food_cut_up] },
               "items" => [
                 { "label" => "", "value" => "" },
                 { "label" => "Pieces", "value" => "" },
@@ -422,9 +421,9 @@ RSpec.describe Profile, type: :model do
         it "leaves a section stored before lines existed untouched" do
           # Backwards compatibility: rows written by the previous release have
           # no "items" key at all and must round-trip unchanged.
-          result = care("meals" => { "enabled" => true, "values" => { "eating" => "tube_fed" } })
+          result = care("meals" => { "enabled" => true, "values" => { "eating" => %w[tube_fed] } })
           expect(result["sections"]["meals"]).to eq(
-            "enabled" => true, "values" => { "eating" => "tube_fed" },
+            "enabled" => true, "values" => { "eating" => %w[tube_fed] },
           )
         end
       end
@@ -434,7 +433,7 @@ RSpec.describe Profile, type: :model do
           "communication" => {
             "values" => {
               "methods" => %w[aac_device not_a_method],
-              "help_level" => "wildly_invented",
+              "what_helps" => %w[wildly_invented],
               "sneaky_field" => "nope",
             },
           },
@@ -447,7 +446,7 @@ RSpec.describe Profile, type: :model do
 
       it "drops a built-in section whose every value was invalid" do
         profile.update!(settings: { "care" => { "sections" => {
-          "meals" => { "values" => { "eating" => "invented" } },
+          "meals" => { "values" => { "eating" => %w[invented] } },
         } } })
 
         expect(profile.reload.settings).not_to have_key("care")
@@ -455,42 +454,42 @@ RSpec.describe Profile, type: :model do
 
       it "strips markup from free text" do
         result = care(
-          "communication" => { "values" => { "notes" => "<script>alert(1)</script>Use <b>signs</b>" } },
+          "meals" => { "values" => { "preferences" => "<script>alert(1)</script>Likes <b>crunchy</b> food" } },
         )
 
-        expect(result["sections"]["communication"]["values"]["notes"]).to eq("alert(1)Use signs")
+        expect(result["sections"]["meals"]["values"]["preferences"]).to eq("alert(1)Likes crunchy food")
       end
 
       it "truncates over-long free text and caps multi-select length" do
         result = care(
-          "communication" => {
+          "meals" => {
             "values" => {
-              "notes" => "a" * 500,
-              "methods" => Profile::CARE_SECTIONS["communication"][:fields]
-                             .find { |f| f[:key] == "methods" }[:options],
+              "preferences" => "a" * 500,
+              "equipment" => Profile::CARE_SECTIONS["meals"][:fields]
+                               .find { |f| f[:key] == "equipment" }[:options],
             },
           },
         )
 
-        values = result["sections"]["communication"]["values"]
-        expect(values["notes"].length).to eq(Profile::CARE_SHORT_TEXT_MAX)
-        expect(values["methods"].length).to be <= Profile::MAX_CARE_MULTI_SELECT
+        values = result["sections"]["meals"]["values"]
+        expect(values["preferences"].length).to eq(Profile::CARE_SHORT_TEXT_MAX)
+        expect(values["equipment"].length).to be <= Profile::MAX_CARE_MULTI_SELECT
       end
 
       it "accepts a well-formed custom section" do
         result = care(
           "c_7f3a91" => {
             "custom" => true,
-            "title" => "Sensory",
-            "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+            "title" => "Bedtime",
+            "items" => [{ "label" => "Lights out", "value" => "7:30, door left open" }],
           },
         )
 
         expect(result["sections"]["c_7f3a91"]).to eq(
           "enabled" => true,
           "custom" => true,
-          "title" => "Sensory",
-          "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+          "title" => "Bedtime",
+          "items" => [{ "label" => "Lights out", "value" => "7:30, door left open" }],
         )
       end
 
@@ -516,7 +515,7 @@ RSpec.describe Profile, type: :model do
 
       it "caps the number of items in a custom section" do
         items = (1..Profile::MAX_CARE_CUSTOM_ITEMS + 3).map { |i| { "label" => "l#{i}", "value" => "v" } }
-        result = care("c_7f3a91" => { "title" => "Sensory", "items" => items })
+        result = care("c_7f3a91" => { "title" => "Bedtime", "items" => items })
 
         expect(result["sections"]["c_7f3a91"]["items"].length).to eq(Profile::MAX_CARE_CUSTOM_ITEMS)
       end
@@ -533,8 +532,8 @@ RSpec.describe Profile, type: :model do
       it "prunes order to surviving sections and appends any that were missing" do
         result = care(
           {
-            "communication" => { "values" => { "help_level" => "independent" } },
-            "meals" => { "values" => { "eating" => "some_help" } },
+            "communication" => { "values" => { "what_helps" => %w[wait_and_pause] } },
+            "meals" => { "values" => { "eating" => %w[food_cut_up] } },
           },
           %w[meals gone_section],
         )
@@ -554,18 +553,18 @@ RSpec.describe Profile, type: :model do
       end
 
       it "is true once a section is filled in" do
-        care("communication" => { "values" => { "help_level" => "independent" } })
+        care("communication" => { "values" => { "what_helps" => %w[wait_and_pause] } })
         expect(profile.has_care_info?).to eq(true)
       end
 
       it "is false when every section is disabled" do
-        care("communication" => { "enabled" => false, "values" => { "help_level" => "independent" } })
+        care("communication" => { "enabled" => false, "values" => { "what_helps" => %w[wait_and_pause] } })
         expect(profile.has_care_info?).to eq(false)
       end
     end
 
     describe "#safety_view / #care_details_view" do
-      before { care("communication" => { "values" => { "help_level" => "independent" } }) }
+      before { care("communication" => { "values" => { "what_helps" => %w[wait_and_pause] } }) }
 
       it "advertises care on the open page without shipping the data" do
         view = profile.safety_view

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -31,7 +31,10 @@ RSpec.describe "API::CareSections", type: :request do
         section["fields"].each_with_index do |field, idx|
           source = spec[:fields][idx]
           expect(field["type"]).to eq(source[:type].to_s)
-          expect(field["options"]).to eq(source[:options])
+          # OFFERED, not the raw constant: a retired option stays acceptable on
+          # save but must never be presented as a fresh choice.
+          expected = source[:options] && Profile.offered_care_options(section["key"], source)
+          expect(field["options"]).to eq(expected)
         end
       end
     end
@@ -40,12 +43,12 @@ RSpec.describe "API::CareSections", type: :request do
       get "/api/care_sections"
       body = JSON.parse(response.body)
 
-      notes = body["sections"]
-              .find { |s| s["key"] == "communication" }["fields"]
-              .find { |f| f["key"] == "notes" }
+      preferences = body["sections"]
+                    .find { |s| s["key"] == "meals" }["fields"]
+                    .find { |f| f["key"] == "preferences" }
 
-      expect(notes["type"]).to eq("short_text")
-      expect(notes).not_to have_key("options")
+      expect(preferences["type"]).to eq("short_text")
+      expect(preferences).not_to have_key("options")
     end
 
     it "serves every cap the sanitizer enforces" do

--- a/spec/requests/api/profiles_care_view_spec.rb
+++ b/spec/requests/api/profiles_care_view_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe "MySpeak care sections", type: :request do
         "sections" => {
           "communication" => {
             "enabled" => true,
-            "values" => { "methods" => %w[aac_device gestures], "help_level" => "needs_prompts" },
+            "values" => { "methods" => %w[aac_device gestures], "what_helps" => %w[wait_and_pause] },
           },
           "c_7f3a91" => {
             "custom" => true,
-            "title" => "Sensory",
-            "items" => [{ "label" => "Loud noises", "value" => "Headphones help" }],
+            "title" => "Bedtime",
+            "items" => [{ "label" => "Lights out", "value" => "7:30, door left open" }],
           },
         },
       },
@@ -48,8 +48,8 @@ RSpec.describe "MySpeak care sections", type: :request do
       expect(body["has_care_info"]).to be(true)
       expect(body["settings"]).not_to have_key("care")
       # The values themselves appear nowhere in the open response.
-      expect(response.body).not_to include("Headphones help")
-      expect(response.body).not_to include("needs_prompts")
+      expect(response.body).not_to include("7:30, door left open")
+      expect(response.body).not_to include("wait_and_pause")
     end
 
     it "reports has_care_info=false when no care section is filled in" do
@@ -81,8 +81,8 @@ RSpec.describe "MySpeak care sections", type: :request do
       expect(RecordProfileViewJob.jobs.last["args"]).to eq([profile.id, "127.0.0.1", nil, "care"])
 
       sections = JSON.parse(response.body).dig("settings", "care", "sections")
-      expect(sections["communication"]["values"]).to include("help_level" => "needs_prompts")
-      expect(sections["c_7f3a91"]["title"]).to eq("Sensory")
+      expect(sections["communication"]["values"]).to include("what_helps" => %w[wait_and_pause])
+      expect(sections["c_7f3a91"]["title"]).to eq("Bedtime")
     end
 
     it "never leaks emergency info through the care endpoint" do


### PR DESCRIPTION
Frontend companion: brittanyjohns/itty-bitty-frontend#686. **Merge this one first** — it owns the served registry.

## Why `echolalia` was still there

PR #676 ("reshape the care presets and add a Sensory section") was stacked on #675 and targeted `claude/care-option-retirement`. GitHub squash-merged **#675 into `main` at 21:49:19**, then merged **#676 into that now-squashed branch at 21:49:45** — 26 seconds later. Commit `aebf94d1` is orphaned and **never reached `main`**.

So on `main` today: `DEPRECATED_CARE_OPTIONS` is `{}`, `echolalia` is still offered, and there's no Sensory section. The frontend half shipped anyway (itty-bitty-frontend#682), which is why `en.json`/`es.json` have been carrying Sensory copy that nothing renders.

This recovers #676's intent and folds in a round of preset feedback.

## No deprecation dance, on purpose

The feature is unannounced and **no profile holds a single care answer**, so options are deleted outright instead of routed through `DEPRECATED_CARE_OPTIONS`. That constant stays `{}`, with a comment recording that this was a one-time licence and it has expired — every later change goes back through the two steps from #675, which are untouched and still covered.

⚠️ **Please confirm before merge** (this is the one real risk — `sanitize_care_settings` is a `before_save`, so it re-cleans the blob on any save):

```
Profile.where.not(settings: nil).count { |p| p.settings["care"].present? }
```

Must return `0` on production. If it doesn't, stop and use the two-step instead.

## Two rules now govern every field

Asserted in the new `care_preset_reshape_spec.rb`, so the next person adding a field finds out there rather than on a public page:

1. **Every preset is multi-select.** A single-select makes a parent pick the one truest thing about someone whose support is layered — independent at home, hand-over-hand at school — and a half-true chip on a card a substitute reads is worse than no chip. Same reasoning retires the independent/some_help/full_help scales: they rated a person where a helper needed something to *do*.
2. **Option lists stay short** (six is the ceiling). `communication.methods` is the one deliberate exception and is named in the spec *with its reason*, so an exception stays visible instead of becoming the norm.

## Changes

**Cut:** `echolalia`, `facial_expressions`, `writing`; both `help_level` fields; `response_time`; `specific_seat` / `front_seat_only`; `personal_care.schedule`'s `both` (redundant once multi); the two straw chips from `meals.equipment`; and **the per-section `notes` field everywhere** — it sat beside the detail lines from #674 asking the same question.

**Added:** `communication.what_helps` and `personal_care.hygiene` (concrete supports in place of the scales); a **Sensory** section; a **Mobility** section, split out because a wheelchair or a pair of AFOs is true all day rather than being a fact about the trip to school.

**Renamed:** `transportation.mode` → `school_travel`, and its `walker` option → `walks`, since with a Mobility section next door `walker` reads as the device.

## Test plan

`bundle exec rspec spec/models/profile_spec.rb spec/models/care_option_retirement_spec.rb spec/models/care_preset_reshape_spec.rb spec/requests/api/care_sections_spec.rb spec/requests/api/profiles_care_view_spec.rb spec/sidekiq/record_profile_view_job_spec.rb` — **154 examples, 0 failures.**

- `care_sections_spec` now asserts **offered** options rather than the raw constant, so a future retirement can't be served by accident.
- `care_option_retirement_spec`'s fixture used `echolalia`, whose comment claimed both keys were real; it now retires `eye_gaze`, so the fixture is honest again and the mechanism stays under test.
- Docs: `.claude-notes/safety-profiles.md` updated with both rules and the expired-licence note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)