### PR TITLE
feat(boards): let a tile be shown without its picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   about the trip to school. Sensory covers sound, touch, light, and what helps
   when it's too much; Moving around covers equipment and the kind of support
   someone needs.
+- **Tiles can now be shown without their picture.** The board editor's bulk
+  "Hide pictures" toggle sends `payload[:hide_pictures]` to
+  `PUT /api/board_images/update`, which blanks `display_image_url` on each
+  selected tile. The tile keeps its word, colors, and audio and still speaks —
+  only the picture stops being drawn, which is what a letter or keyboard board
+  wants. Switching the toggle back off restores the tile's default art. A blank
+  url is the "no picture" marker the app, the PDF/print renderer, board covers,
+  and printables already share (#683), so this works everywhere on day one
+  rather than only on screen. This is a different thing from `hidden` ("Hide
+  tiles"), which drops the tile from the board entirely. Omitting the param
+  leaves the tile's picture untouched, so layout- and color-only saves can't
+  disturb it.
 
 - **A failed renewal now has an end date.** `past_due` was designed as a grace
   state — Stripe keeps retrying the charge and access continues — but nothing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,27 @@ an explicit decision, not a drive-by edit.
   Client-called endpoints may reflect plan state but never grant credits. All
   credit movement goes through `CreditService` and the immutable
   `credit_transactions` ledger; grants are idempotent on event id.
+- **"Hide tiles" and "Hide pictures" are different questions, and neither is a
+  data flag you should invent.** `board_images.hidden` ("Hide tiles") drops the
+  tile from the board entirely — `visible_board_images` excludes it, so it
+  never reaches the Speak view. A **blank** `display_image_url` ("Hide
+  pictures") keeps the tile speaking and only stops its picture being drawn.
+  Conflating them is easy because the bulk param for `hidden` is still called
+  `hide_images` — read the param names carefully: `hide_images` → `hidden`,
+  `hide_pictures` → blank `display_image_url`.
+- **`display_image_url` has three states — `nil`, `""`, and a url — and `""` is
+  load-bearing.** Every resolver chains with a bare `||`
+  (`board_image.display_image_url || image.display_image_url(user) ||
+  image.src_url`), and `""` is truthy in Ruby, so a blank stops the chain and
+  means "this tile has no picture", while `nil` falls through to the shared
+  Image's art. Never "tidy" a blank to nil, and never wrap the chain in
+  `.presence` — that erased the marker and printed an apple on a Core Safety
+  colour tile (#683). `BoardImage#picture_hidden?` and `#unhide_picture!` are
+  where that distinction is written down; use them rather than comparing to
+  `""` by hand. Because it is the *same* marker the renderers already honour,
+  "Hide pictures" works in PDF exports, board covers, and printables without
+  any of them knowing the feature exists — which is exactly why it must not
+  become a second `data[...]` flag.
 - **`images.label` is a lowercase matching key; `display_label` is the text.**
   `Image#set_label` downcases and strips `label` on every write and captures
   the authored casing into `display_label`. Never look an image up with

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -114,6 +114,13 @@ class API::BoardImagesController < API::ApplicationController
     text_color = payload[:text_color] if payload[:text_color]
     hide_images = payload[:hide_images] if payload[:hide_images]
     hide_labels = payload[:hide_labels] if payload[:hide_labels]
+    # Read presence-first rather than truthiness-first like its neighbours: a
+    # caller that omits hide_pictures entirely must leave the flag alone, not
+    # silently clear it. (hide_images/hide_labels get away with the looser form
+    # only because the bulk drawer is their sole caller and always sends both.)
+    hide_pictures = if payload.key?(:hide_pictures)
+        ActiveModel::Type::Boolean.new.cast(payload[:hide_pictures])
+      end
     make_static = payload[:make_static] if payload[:make_static]
     new_board_name = payload[:new_board_name] if payload[:new_board_name]
     create_new_board = payload[:create_new_board] || !new_board_name.blank?
@@ -163,6 +170,20 @@ class API::BoardImagesController < API::ApplicationController
       else
         if board_image.data && board_image.data["hide_label"] == true
           board_image.data["hide_label"] = false
+        end
+      end
+      # "Hide pictures". A BLANK display_image_url is the app-wide marker for
+      # "this tile has no picture" — every resolver chains with a bare `||` and
+      # "" is truthy in Ruby, so the chain stops there rather than falling
+      # through to the shared Image's art. Using the same marker rather than a
+      # new flag is what makes this work in PDF exports, board covers, and
+      # printables (Boards::BoardPdfLayoutNormalizer) on day one.
+      # Must be "" and never nil, which would fall through and show the picture.
+      unless hide_pictures.nil?
+        if hide_pictures
+          board_image.display_image_url = ""
+        else
+          board_image.unhide_picture!
         end
       end
       if hide_images

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -300,6 +300,30 @@ class BoardImage < ApplicationRecord
     data && data["hide_label"] == true
   end
 
+  # Does this tile deliberately have no picture? A BLANK (not nil)
+  # display_image_url is the marker: every resolver chains with a bare `||`,
+  # and "" is truthy in Ruby, so the chain stops there instead of falling
+  # through to the shared Image's art. Honoured by the app, the PDF/print
+  # renderer, board covers, and printables alike — see
+  # Boards::BoardPdfLayoutNormalizer.
+  def picture_hidden?
+    !display_image_url.nil? && display_image_url.empty?
+  end
+
+  # Put the picture back on a tile whose picture was switched off. nil is the
+  # exact inverse of the blank marker: it lets the `||` chain fall through to
+  # the shared Image's art, which is the normal state for most tiles and works
+  # even for an image whose own doc hasn't been generated yet (where
+  # default_doc_url is itself blank, and would re-hide the tile).
+  #
+  # No-op unless the picture is actually off, so this can never overwrite a
+  # custom per-tile picture. Note the custom url is not recoverable once
+  # hidden — hiding overwrites it, and this restores the default art.
+  def unhide_picture!
+    return unless picture_hidden?
+    self.display_image_url = nil
+  end
+
   def is_dynamic?
     predictive_board_id.present? && predictive_board_id != board_id
   end

--- a/spec/requests/api/board_images_hide_pictures_spec.rb
+++ b/spec/requests/api/board_images_hide_pictures_spec.rb
@@ -1,0 +1,158 @@
+# spec/requests/api/board_images_hide_pictures_spec.rb
+#
+# Covers the bulk "Hide pictures" toggle on
+# PUT /api/board_images/update (BoardImagesController#update_multiple).
+# The frontend bulk-edit drawer sends payload[:hide_pictures].
+#
+# The mechanism is a BLANK display_image_url, which is already the app-wide
+# marker for "this tile has no picture" — every resolver chains with a bare
+# `||` and "" is truthy in Ruby, so the chain stops there instead of falling
+# through to the shared Image's art. Reusing that marker (rather than adding a
+# second flag) is what makes the toggle work in PDF exports, board covers, and
+# printables without teaching each renderer about it — see
+# Boards::BoardPdfLayoutNormalizer and its spec.
+#
+# This is NOT board_image.hidden ("Hide tiles"), which drops the tile from the
+# board entirely. Hide pictures keeps the tile — and its label, colors, and
+# audio — and it still speaks.
+
+require "rails_helper"
+
+RSpec.describe "BoardImages bulk hide_pictures", type: :request do
+  def j
+    JSON.parse(response.body) rescue {}
+  end
+
+  before do
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:authenticate_token!).and_return(true)
+    allow_any_instance_of(API::ApplicationController)
+      .to receive(:current_user).and_return(user)
+  end
+
+  let!(:user)  { create(:user) }
+  let!(:board) { create(:board, user: user) }
+  let!(:image) { create(:image, user: user, label: "cookie") }
+  let!(:board_image) do
+    create(:board_image, board: board, image: image).tap do |bi|
+      bi.update!(display_image_url: "https://example.com/cookie.png")
+    end
+  end
+
+  # as: :json on purpose — the bulk drawer posts a JSON body, so `false`
+  # arrives as a real boolean. Form-encoding would deliver the string "false",
+  # which is truthy in Ruby; see the "string 'false'" example below for why
+  # hide_pictures survives that and its older neighbours would not.
+  def put_payload(payload)
+    put "/api/board_images/update",
+        params: {
+          board_id: board.id,
+          board_image_ids: [board_image.id],
+          payload: payload,
+        },
+        as: :json
+  end
+
+  it "blanks the picture when hide_pictures is true" do
+    put_payload(hide_pictures: true)
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_image_url).to eq("")
+  end
+
+  # The whole point of "" over nil: nil falls through the `||` chain to the
+  # shared Image's art, so the tile would still show a picture.
+  it "blanks to an empty string, never nil" do
+    put_payload(hide_pictures: true)
+    expect(board_image.reload.display_image_url).not_to be_nil
+    expect(board_image.picture_hidden?).to be(true)
+  end
+
+  # nil is the exact inverse of "": it lets the `||` chain fall back through to
+  # the shared Image's art, so the tile shows a picture again.
+  it "puts the picture back when hide_pictures is false" do
+    board_image.update!(display_image_url: "")
+    put_payload(hide_pictures: false)
+    expect(response.status).to eq(200)
+    board_image.reload
+    expect(board_image.display_image_url).to be_nil
+    expect(board_image.picture_hidden?).to be(false)
+  end
+
+  # Un-hiding must never clobber a tile that already has art — including a
+  # custom per-tile picture the parent chose.
+  it "leaves an existing picture alone when hide_pictures is false" do
+    put_payload(hide_pictures: false)
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_image_url)
+      .to eq("https://example.com/cookie.png")
+  end
+
+  # The guard that makes this endpoint safe for callers that don't know about
+  # the toggle — a layout-only or color-only save must not turn pictures back on.
+  it "leaves the picture alone when hide_pictures is omitted" do
+    board_image.update!(display_image_url: "")
+    put_payload(bg_color: "#FF0000")
+    expect(response.status).to eq(200)
+    expect(board_image.reload.display_image_url).to eq("")
+  end
+
+  # The cast means a form-encoded client gets the same answer as a JSON one.
+  it "treats the string \"false\" as false" do
+    board_image.update!(display_image_url: "")
+    put "/api/board_images/update",
+        params: {
+          board_id: board.id,
+          board_image_ids: [board_image.id],
+          payload: { hide_pictures: "false" },
+        }
+    expect(response.status).to eq(200)
+    expect(board_image.reload.picture_hidden?).to be(false)
+  end
+
+  it "is independent of hidden — hiding pictures does not hide the tile" do
+    put_payload(hide_pictures: true)
+    expect(board_image.reload.hidden).to be(false)
+    expect(board_image.picture_hidden?).to be(true)
+  end
+
+  it "is independent of hide_labels" do
+    put_payload(hide_pictures: true, hide_labels: false)
+    board_image.reload
+    expect(board_image.picture_hidden?).to be(true)
+    expect(board_image.hide_label).to be(false)
+  end
+
+  it "serializes the blank picture on the board api view the editor reads" do
+    put_payload(hide_pictures: true)
+    tile = j.dig("board", "images")
+            &.find { |i| i["board_image_id"] == board_image.id.to_s }
+    expect(tile).to be_present
+    expect(tile["src"]).to eq("")
+  end
+
+  describe "the Speak view" do
+    it "serializes the blank picture on the native grid api view" do
+      board_image.update!(display_image_url: "")
+      tile = board.reload
+                  .api_view_for_native_grid(user)[:images]
+                  .find { |i| i[:board_image_id] == board_image.id.to_s }
+      expect(tile[:src]).to eq("")
+    end
+  end
+
+  describe "BoardImage#picture_hidden?" do
+    it "is false for a tile with a picture" do
+      expect(board_image.picture_hidden?).to be(false)
+    end
+
+    it "is false when the url was never set, since that falls through to the image" do
+      board_image.update_column(:display_image_url, nil)
+      expect(board_image.reload.picture_hidden?).to be(false)
+    end
+
+    it "is true only for a blank string" do
+      board_image.update!(display_image_url: "")
+      expect(board_image.reload.picture_hidden?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backend half of the board-editor bulk-actions work. Adds a bulk **Hide pictures** action so a tile can render as **just its word on its own colors** — what a letter or keyboard board wants — while still speaking normally.

`PUT /api/board_images/update` accepts `payload[:hide_pictures]` and **blanks `display_image_url`** on each selected tile.

### Why a blank url and not a new flag

A **blank** (not nil) `display_image_url` is already the app-wide marker for "this tile has no picture". Every resolver chains with a bare `||`:

```ruby
board_image.display_image_url || image.display_image_url(user) || image.src_url
```

and `""` is truthy in Ruby, so the chain stops there instead of falling through to the shared Image's art. #683 made `BoardPdfLayoutNormalizer` agree with that exactly.

Reusing the marker rather than inventing a `data["hide_image"]` flag means this works in **PDF exports, board covers, and printables** without teaching any of those renderers that the feature exists — and, more importantly, avoids a second mechanism for one user-visible outcome. That duplication is the confusion this whole change set exists to remove.

> An earlier revision of this PR did add a flag, on the mistaken reasoning that blanking the url would fall through to the Image's art. That's true for `nil` and false for `""`, which is the distinction #683 rests on. Rewritten.

### Un-hiding

`unhide_picture!` sets **nil** — the exact inverse, letting the chain fall back through to the Image's art. Deliberately not `default_doc_url`: that is itself blank for an image whose doc hasn't been generated yet, which would silently re-hide the tile. It no-ops unless the picture is actually off, so it can never overwrite a custom per-tile picture.

The known cost: hiding overwrites a *custom* per-tile url, so un-hiding restores the default art rather than that custom picture. Called out in the model comment.

### Not `hidden`

| Flag | Editor label | Effect |
|---|---|---|
| `board_images.hidden` | "Hide tiles" | Drops the tile from the board entirely — `visible_board_images` excludes it, so it never reaches the Speak view |
| blank `display_image_url` | "Hide pictures" | Tile stays and still speaks; only the picture stops being drawn |

The bulk param for `hidden` is still called `hide_images`, so the two param names are a letter apart in meaning: `hide_images` → `hidden`, `hide_pictures` → blank url. Both written down in `CLAUDE.md`, along with the three states of `display_image_url`.

### One decision worth reviewing

**The param is read presence-first.** Its neighbours use `x = payload[:x] if payload[:x]` plus an `else` that clears — fine while the bulk drawer is their only caller and always sends both, but it means any caller that omits the key silently clears the flag. `hide_pictures` is read with `payload.key?` and cast, so a layout-only or color-only save can't turn pictures back on. There's precedent for this shape in `internal/board_images_controller.rb`.

## Test plan

New `spec/requests/api/board_images_hide_pictures_spec.rb` — 13 examples covering hide, un-hide, blank-not-nil, omit-leaves-alone, never-clobber-an-existing-picture, independence from both `hidden` and `hide_labels`, serialization on both api views, and the three states of `display_image_url`.

```
bundle exec rspec spec/requests/api/board_images_hide_pictures_spec.rb
13 examples, 0 failures
```

Regression run including #683's normalizer spec:

```
bundle exec rspec spec/requests/api/board_images_hide_pictures_spec.rb \
  spec/services/boards/board_pdf_layout_normalizer_spec.rb \
  spec/models/board_image_spec.rb \
  spec/requests/api/board_images_label_case_spec.rb
60 examples, 0 failures
```

Rebased on `main` (post-#683, #678).

## Ships with

Frontend PR **brittanyjohns/itty-bitty-frontend#687** adds the "Hide pictures" toggle, renames "Hide images" → "Hide tiles", and makes hidden tiles visible in the editor. **Merge this first** — until it deploys, the frontend toggle sends a param the API ignores.

## Noticed in passing, not fixed here

`hide_labels`/`hide_images` are read truthiness-first, so a **form-encoded** client sending `hide_labels: false` delivers the string `"false"`, which is truthy in Ruby, and the flag flips the wrong way. Not reachable today — the frontend posts JSON, where `false` stays boolean — so I left it alone rather than widening this PR. `hide_pictures` casts, and has a test pinning the string case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
