### PR TITLE
fix(auth): return email_taken from sign_up so the form can offer sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   the detail lines added last release sat right beside it asking the same
   question.
 
+### Fixed
+
+- **Signing up with an email that already has an account no longer dead-ends.**
+  The signup endpoint now tells the app *why* it refused (`error_code:
+  "email_taken"`) instead of only handing back a validation sentence, so the
+  form can offer to sign the person in rather than printing "Email has already
+  been taken" at them. Same contract the email-only checkout signup already
+  used. A soft-deleted account's email also returned a server error instead of
+  this message — it now takes the same path.
+
 ### Added
 
 - **You can print a care plan for your communicator.** Everything you've

--- a/app/controllers/api/v1/auths_controller.rb
+++ b/app/controllers/api/v1/auths_controller.rb
@@ -16,7 +16,17 @@ module API
         return if reject_disposable_email(email)
 
         user = User.new(email: email, password: password, password_confirmation: password_confirmation, name: name)
-        if user.save
+        # A soft-deleted account keeps its row (User has a `deleted_at: nil`
+        # default scope) but still holds the unique index on `email`, so
+        # `validatable` sees no conflict and the INSERT is what fails. Same
+        # rescue as `email_signup` — without it this path 500s.
+        begin
+          saved = user.save
+        rescue ActiveRecord::RecordNotUnique
+          render json: { error: "Email has already been taken", error_code: "email_taken" }, status: :unprocessable_content
+          return
+        end
+        if saved
           Rails.logger.info "New user signed up: #{user.email} at #{Time.now}"
           # result = Stripe::Customer.create({ email: user.email })
           if platform != "ios" && platform != "android"
@@ -75,7 +85,14 @@ module API
           })
           render json: { token: user.authentication_token, user: user.api_view }
         else
-          render json: { error: user.errors.full_messages.join(", ") }, status: :unprocessable_content
+          # `error_code` is additive — the message keeps carrying every
+          # validation failure verbatim, so an older client is unaffected. It
+          # lets the signup form pivot a returning user to sign-in instead of
+          # printing a raw validation string. Matches `email_signup`'s contract.
+          email_taken = user.errors.details[:email].any? { |detail| detail[:error] == :taken }
+          body = { error: user.errors.full_messages.join(", ") }
+          body[:error_code] = "email_taken" if email_taken
+          render json: body, status: :unprocessable_content
         end
       end
 

--- a/spec/requests/api/auth_spec.rb
+++ b/spec/requests/api/auth_spec.rb
@@ -196,6 +196,40 @@ RSpec.describe "API::V1::Auth", type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    describe "duplicate email" do
+      it "returns email_taken so the form can offer sign-in instead" do
+        create(:user, email: "taken@example.com")
+
+        post "/api/v1/users", params: valid_params.merge(email: "taken@example.com")
+
+        expect(response).to have_http_status(:unprocessable_content)
+        body = JSON.parse(response.body)
+        expect(body["error_code"]).to eq("email_taken")
+        expect(body["error"]).to include("Email has already been taken")
+      end
+
+      # A soft-deleted account is invisible to the uniqueness validation (the
+      # default scope hides it) but still owns the unique index, so the failure
+      # surfaces at INSERT. Without the rescue this 500s.
+      it "returns email_taken when the unique index rejects the insert" do
+        allow_any_instance_of(User).to receive(:save).and_raise(ActiveRecord::RecordNotUnique.new("duplicate key"))
+
+        post "/api/v1/users", params: valid_params
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)["error_code"]).to eq("email_taken")
+      end
+
+      it "omits error_code for validation failures that are not a taken email" do
+        post "/api/v1/users", params: valid_params.merge(password: "abc", password_confirmation: "abc")
+
+        expect(response).to have_http_status(:unprocessable_content)
+        body = JSON.parse(response.body)
+        expect(body).not_to have_key("error_code")
+        expect(body["error"]).to be_present
+      end
+    end
   end
 
   describe "GET /api/v1/users/current" do


### PR DESCRIPTION
## Summary

Someone who already has an account and tries to sign up again hit a dead end: `POST /api/v1/users` returned only a validation sentence, so the frontend had nothing to branch on and printed **"Email has already been taken"** as a raw red error string with no way forward.

The email-only checkout signup (`email_signup`) already returned `error_code: "email_taken"` and had purpose-written copy behind it. This brings the primary endpoint — the one free signups use — onto the same contract.

- **`error_code: "email_taken"`** is set when the failure is an email-uniqueness error. It's **additive**: the message still carries every validation failure verbatim via `full_messages.join(", ")`, so an older frontend is unaffected, and non-duplicate validation errors get no code.
- **Rescues `ActiveRecord::RecordNotUnique`.** `User` has a `default_scope { where(deleted_at: nil) }` and a plain unique index on `email`, so a **soft-deleted** account's email is invisible to the `validatable` uniqueness check but still owns the index — the failure surfaced at INSERT and **500'd** rather than returning 422. `email_signup` already had this rescue; `sign_up` did not.

The frontend half (the recovery callout that consumes this) is in `itty-bitty-frontend` — see that PR. This one ships first; it's purely additive, so the two aren't order-coupled.

## Test plan

`bundle exec rspec spec/requests/api/auth_spec.rb spec/requests/api/v1/email_signup_spec.rb` — **39 examples, 0 failures.**

Three new examples in the previously-uncovered `POST /api/v1/users (sign_up)` duplicate-email case:
- duplicate email → 422 with `error_code: "email_taken"`
- stubbed `RecordNotUnique` race → 422 with the same body, not a 500
- a non-email validation failure (short password) → 422 with **no** `error_code`

Verified live against a local server:
```
duplicate  → {"error":"Email has already been taken","error_code":"email_taken"}  422
short pw   → {"error":"Password is too short (minimum is 6 characters)"}          422
```

CHANGELOG updated. No migration, no config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)