### PR TITLE
fix(boards): make a failed cover render report itself

### DIFF
--- a/.claude-notes/artifact-generation-services.md
+++ b/.claude-notes/artifact-generation-services.md
@@ -32,18 +32,18 @@ Renders any board to a print-ready PDF or PNG. **This is the poster generator.**
 - Attachments on Board: `preview_image` (PNG), `pdf_file` (PDF); URLs via `Board#preview_image_url` / `#pdf_url` (CDN-stable keys).
 - **A preview render must be bounded; a printable render must not be.** Grover waits on `networkidle0` with an effectively infinite global timeout (`config/initializers/grover.rb`), so a tile picture that *hangs* — an S3 key not written yet, art still coming back from `GenerateImagesJob` — never settles the page and the board ends up with no snapshot at all. `RenderAssetData` takes `image_load_deadline_ms:` (nil by default); the template swaps any tile still unloaded at that deadline for its label placeholder, which cancels the request. Only `GeneratePreviewAssets` passes a value (`IMAGE_LOAD_DEADLINE_MS`), plus a bounded `RENDER_TIMEOUT_MS` so a stalled render fails and retries instead of pinning a Sidekiq thread. Printable PDFs deliberately keep the nil default — they're a paid artifact, and a slow S3 read must not cost them the real symbol. A `<img>` that 404s is a different case and always falls back via `onerror`.
 - **A set renders ONE preview — the root. Every other page is thumbnailed from the folder tile that opens it** (`Boards::SubBoardThumbnails`, shared by `BuildBoardSetJob` and `ImportObzJob`). Rendering per page means one headless-Chrome run per sub-board on the shared `:default` queue (concurrency 10), and a real vocabulary set runs to 50-200 pages — one import would stall every other job behind it. The resolved tile image goes to the child's denormalized `display_image_url` COLUMN via `update_column`, so it never re-enqueues a preview. `purge_previews:` is true only for the Board Builder, whose sub-boards are deliberately never rendered; imports leave any later-earned preview in place, since an imported page is an ordinary board.
+- **That skip is about queue VOLUME, not about the page being unrenderable.** It guards the shared queue from the *bulk* enqueue paths. A request that names ONE board — someone clicking "Regenerate from tiles" — passes `run_generate_preview_job(force: true)` and renders like any other board. Without that opt-out a builder page could never earn a snapshot at all, and the button silently did nothing on it. Only the explicit endpoint may pass `force`; every automatic caller keeps the default.
 - **A render records its outcome, and the client polls that — not the URL.**
   `settings["preview_status"]` is one of `queued` / `ok` / `skipped` / `failed`,
   and `settings["preview_generated_at"]` advances on every successful render
   (`Board#record_preview_generated!`, written in the same save as the
   denormalized `preset_display_image_url` so a reader can't see one without the
   other). Both ride on `api_view` and `api_view_with_predictive_images`.
-  `POST generate_preview_image` refuses **422** — `preview_not_supported` for a
-  `builder_child` page, `board_has_no_tiles` for an empty board — instead of
-  enqueuing a job it knows will skip; `Board#preview_generation_blocker` mirrors
-  the job's own skip condition, so keep the two in step. `GenerateBoardPreviewJob`
-  stamps `skipped` on the builder-child return and `failed` from
-  `sidekiq_retries_exhausted`. The point of all of it: the endpoint only
+  `POST generate_preview_image` refuses **422** `board_has_no_tiles` for an
+  empty board (`Board#preview_generation_blocker`) — there is nothing to
+  photograph. `GenerateBoardPreviewJob` stamps `skipped` on the builder-child
+  return and `failed` from `sidekiq_retries_exhausted`. The point of all of it:
+  the endpoint only
   *enqueues*, so without a recorded outcome a silent skip, an exhausted render,
   and a worker that isn't draining are all indistinguishable from a slow
   success — which is how "Regenerate from tiles" could report success while

--- a/.claude-notes/artifact-generation-services.md
+++ b/.claude-notes/artifact-generation-services.md
@@ -60,6 +60,17 @@ Already ships the kit's safety + device tags as PNG **and** PDF with an embedded
 
 - `app/services/communicators/generate_device_tag.rb` — 1200×700, QR → `profile.public_url`, template `communicators/assets/device_tag.html.erb`. Default copy: "This device is my voice…".
 - `app/services/communicators/generate_safety_id_card.rb` — 1200×1800, QR + emergency notes, template `communicators/assets/safety_id_card.html.erb`.
+- **A freshness key must never include the record's `updated_at`.** ActiveStorage's
+  attachment is `belongs_to :record, touch: true`, so *attaching* a generated
+  document moves `updated_at` — a signature stamped into blob metadata before the
+  attach is stale the instant it is written, and every later call re-renders
+  through headless Chrome. `Profile#safety_info_signature` (shared by all three
+  generators) carried it and therefore had no working cache at all. This hides
+  well: the value was truncated with `to_i`, so a generate that finished inside
+  the same wall-clock second as the previous save happened to match, and it
+  surfaced as an intermittently failing spec on slower CI rather than as a dead
+  cache. Sign the CONTENT the document renders (avatar blob id + checksum,
+  `settings`), never a timestamp the write itself moves.
 - Base class: `app/services/communicators/base_asset_generator.rb` — **the reusable pattern for any new printable.** Provides: `rendered_html(template:, locals:)` under the `asset_export` layout, `qr_data_url_for(url, size:)` (RQRCode), `logo_base64`, `avatar_data_url`, `generate_png_from_html` / `generate_pdf_from_html` (Grover), `attach_binary`, and signature-based caching (`attached_and_fresh?`).
 - Triggered by: `app/jobs/regenerate_safety_cards_job.rb`, `Profile#generate_attachments!`. Served by `app/controllers/api/profiles/assets_controller.rb` and `api/internal/profiles_controller.rb` (`safety_id_png_url`, `safety_id_pdf_url`, `device_tag_png_url`, `device_tag_pdf_url`).
 

--- a/.claude-notes/artifact-generation-services.md
+++ b/.claude-notes/artifact-generation-services.md
@@ -32,6 +32,26 @@ Renders any board to a print-ready PDF or PNG. **This is the poster generator.**
 - Attachments on Board: `preview_image` (PNG), `pdf_file` (PDF); URLs via `Board#preview_image_url` / `#pdf_url` (CDN-stable keys).
 - **A preview render must be bounded; a printable render must not be.** Grover waits on `networkidle0` with an effectively infinite global timeout (`config/initializers/grover.rb`), so a tile picture that *hangs* — an S3 key not written yet, art still coming back from `GenerateImagesJob` — never settles the page and the board ends up with no snapshot at all. `RenderAssetData` takes `image_load_deadline_ms:` (nil by default); the template swaps any tile still unloaded at that deadline for its label placeholder, which cancels the request. Only `GeneratePreviewAssets` passes a value (`IMAGE_LOAD_DEADLINE_MS`), plus a bounded `RENDER_TIMEOUT_MS` so a stalled render fails and retries instead of pinning a Sidekiq thread. Printable PDFs deliberately keep the nil default — they're a paid artifact, and a slow S3 read must not cost them the real symbol. A `<img>` that 404s is a different case and always falls back via `onerror`.
 - **A set renders ONE preview — the root. Every other page is thumbnailed from the folder tile that opens it** (`Boards::SubBoardThumbnails`, shared by `BuildBoardSetJob` and `ImportObzJob`). Rendering per page means one headless-Chrome run per sub-board on the shared `:default` queue (concurrency 10), and a real vocabulary set runs to 50-200 pages — one import would stall every other job behind it. The resolved tile image goes to the child's denormalized `display_image_url` COLUMN via `update_column`, so it never re-enqueues a preview. `purge_previews:` is true only for the Board Builder, whose sub-boards are deliberately never rendered; imports leave any later-earned preview in place, since an imported page is an ordinary board.
+- **A render records its outcome, and the client polls that — not the URL.**
+  `settings["preview_status"]` is one of `queued` / `ok` / `skipped` / `failed`,
+  and `settings["preview_generated_at"]` advances on every successful render
+  (`Board#record_preview_generated!`, written in the same save as the
+  denormalized `preset_display_image_url` so a reader can't see one without the
+  other). Both ride on `api_view` and `api_view_with_predictive_images`.
+  `POST generate_preview_image` refuses **422** — `preview_not_supported` for a
+  `builder_child` page, `board_has_no_tiles` for an empty board — instead of
+  enqueuing a job it knows will skip; `Board#preview_generation_blocker` mirrors
+  the job's own skip condition, so keep the two in step. `GenerateBoardPreviewJob`
+  stamps `skipped` on the builder-child return and `failed` from
+  `sidekiq_retries_exhausted`. The point of all of it: the endpoint only
+  *enqueues*, so without a recorded outcome a silent skip, an exhausted render,
+  and a worker that isn't draining are all indistinguishable from a slow
+  success — which is how "Regenerate from tiles" could report success while
+  never changing anything, across three separate rounds of fixes to the read
+  path. **Do not poll `preview_image_url` for this.** It changes only
+  incidentally (it happens to carry the versioned key), and it isn't the field
+  the thumbnail renders — `display_image_url` is, and the two agree only while
+  `display_image_source == "preview"`.
 - **Every path that finishes writing tile art re-enqueues the preview.** The snapshot is taken while art may still be in flight (`GenerateBoardJob` renders right after the tiles exist), so `GenerateImagesJob` re-enqueues `GenerateBoardPreviewJob` on completion — otherwise the all-placeholder snapshot becomes the board's cover permanently. The `.obf`/`.obz` import jobs enqueue it too: nothing else in the import path renders one, and `BoardGroup#preview_image_url` reads through to the root board's attachment.
 
 ## 4. Communicator card/tag generators — makes *per-communicator printables*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,16 +207,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   the same renderer. Covers already generated are refreshed by
   `rake board_covers:refresh_blanked_tile_covers`.
 
-- **"Regenerate from tiles" now tells you what actually happened.** The button
-  only ever queued the work and answered "started", so every way it could fail
-  looked identical to a slow success: a page whose cover comes from the folder
-  tile that opens it was skipped in silence, a snapshot that failed to render
-  gave up out of sight, and either way you were told the cover would "appear
-  shortly" when it never would. A board that can't build a cover from its tiles
-  now says so immediately and explains why, a failed render reports itself
-  instead of disappearing, and the app watches the render's own result rather
-  than guessing from the picture's address — so a regenerated cover that
-  happens to look the same still counts as done.
+- **"Regenerate from tiles" works on every board, and tells you what actually
+  happened.** Pages inside a built or imported board set were skipped outright —
+  they take their cover from the folder tile that opens them, and asking for a
+  fresh snapshot quietly did nothing. Asking for one page at a time now renders
+  it like any other board. (Building or importing a whole set still doesn't
+  render every page: a large set is hundreds of pages, and doing them all would
+  hold up everything else in the queue.) The button also only ever queued the
+  work and answered "started", so every way it could fail looked identical to a
+  slow success — a snapshot that failed to render gave up out of sight, and you
+  were told the cover would "appear shortly" when it never would. A failed
+  render now reports itself, a board with no tiles yet says so immediately, and
+  the app watches the render's own result rather than guessing from the
+  picture's address — so a regenerated cover that happens to look the same still
+  counts as done.
 
 - **Saving one part of a communicator's settings no longer wipes the rest.**
   The communicator screen saves settings from several different places, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   the same renderer. Covers already generated are refreshed by
   `rake board_covers:refresh_blanked_tile_covers`.
 
+- **Printed care plans, safety cards, and device tags stop rebuilding
+  themselves.** Each one is meant to be built once and reused until something
+  it shows actually changes. Saving the finished document quietly counted as a
+  change to the communicator, so the saved copy was already considered
+  out-of-date the moment it was written — and every later download rebuilt it
+  from scratch. Downloads that used to take seconds now return the copy
+  already made, and a real edit still rebuilds it.
+
 - **"Regenerate from tiles" works on every board, and tells you what actually
   happened.** Pages inside a built or imported board set were skipped outright —
   they take their cover from the folder tile that opens them, and asking for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   the same renderer. Covers already generated are refreshed by
   `rake board_covers:refresh_blanked_tile_covers`.
 
+- **"Regenerate from tiles" now tells you what actually happened.** The button
+  only ever queued the work and answered "started", so every way it could fail
+  looked identical to a slow success: a page whose cover comes from the folder
+  tile that opens it was skipped in silence, a snapshot that failed to render
+  gave up out of sight, and either way you were told the cover would "appear
+  shortly" when it never would. A board that can't build a cover from its tiles
+  now says so immediately and explains why, a failed render reports itself
+  instead of disappearing, and the app watches the render's own result rather
+  than guessing from the picture's address — so a regenerated cover that
+  happens to look the same still counts as done.
+
 - **Saving one part of a communicator's settings no longer wipes the rest.**
   The communicator screen saves settings from several different places, and
   each one sent only the handful of values it knew about — so saving from one

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1332,7 +1332,6 @@ class API::BoardsController < API::ApplicationController
   # button. 422 rather than 403/402: nothing here is a permission or credit
   # gate, it's a request that this board can't satisfy.
   PREVIEW_BLOCKER_MESSAGES = {
-    "preview_not_supported" => "This page's cover comes from the folder tile that opens it.",
     "board_has_no_tiles" => "Add a tile to this board first, then build a cover from it.",
   }.freeze
 
@@ -1351,7 +1350,9 @@ class API::BoardsController < API::ApplicationController
       return
     end
 
-    @board.run_generate_preview_job
+    # force: this request names one board, so it renders even for a page the
+    # bulk enqueue paths deliberately skip.
+    @board.run_generate_preview_job(force: true)
     render json: {
       status: "queued",
       preview_status: @board.preview_status,

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1328,10 +1328,35 @@ class API::BoardsController < API::ApplicationController
     render json: @board.api_view_with_images(current_user)
   end
 
+  # Reasons a cover can't be built, phrased for the person who clicked the
+  # button. 422 rather than 403/402: nothing here is a permission or credit
+  # gate, it's a request that this board can't satisfy.
+  PREVIEW_BLOCKER_MESSAGES = {
+    "preview_not_supported" => "This page's cover comes from the folder tile that opens it.",
+    "board_has_no_tiles" => "Add a tile to this board first, then build a cover from it.",
+  }.freeze
+
   def generate_preview_image
     set_board
+    return if @board.nil? # set_board already rendered 404
+
+    # Refuse synchronously what the job would only skip. Enqueuing here would
+    # answer "ok" and leave the client polling for a snapshot that is never
+    # coming.
+    if (blocker = @board.preview_generation_blocker)
+      render json: {
+        error: PREVIEW_BLOCKER_MESSAGES.fetch(blocker, "This board can't build a cover from its tiles."),
+        code: blocker,
+      }, status: :unprocessable_content
+      return
+    end
+
     @board.run_generate_preview_job
-    render json: { status: "ok", message: "Preview image generation job started" }
+    render json: {
+      status: "queued",
+      preview_status: @board.preview_status,
+      preview_generated_at: @board.preview_generated_at,
+    }
   end
 
   # Designate this board as the user's editable board. On a downgraded (free)

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -291,6 +291,9 @@ class Board < ApplicationRecord
   end
 
   def run_generate_preview_job
+    # Clear any previous outcome up front, so a run that follows a failure isn't
+    # aborted by the stale "failed" its predecessor left behind.
+    mark_preview_queued!
     GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true }) # Generate PNG preview without header
     # GenerateBoardPreviewJob.perform_async(id, { "generate_pdf" => true }) # PDF with header for sharing
   end
@@ -393,6 +396,84 @@ class Board < ApplicationRecord
     # break the caller — fall back to the seed column via #display_image_url.
     Rails.logger.warn("Board#preview_image_url failed for board #{id}: #{e.class}: #{e.message}")
     nil
+  end
+
+  # ── Preview render lifecycle ──────────────────────────────────────────────
+  #
+  # "Regenerate from tiles" enqueues a job, so the endpoint can only ever report
+  # that it *queued* something. Without a recorded outcome every failure mode —
+  # a builder_child page that is never rendered, a Grover render that exhausts
+  # its retries, a worker that isn't draining — is indistinguishable from a slow
+  # success, and the client can only time out and guess. These three states are
+  # what let it say which happened.
+  PREVIEW_STATUSES = %w[queued ok skipped failed].freeze
+
+  def preview_status
+    settings.is_a?(Hash) ? settings["preview_status"] : nil
+  end
+
+  # The stamp a client polls on. Deliberately NOT `preview_image_url`: that
+  # string only changes incidentally (it happens to carry a versioned S3 key),
+  # and it is not the field the thumbnail renders — `display_image_url` is, and
+  # the two agree only while `display_image_source == "preview"`.
+  def preview_generated_at
+    settings.is_a?(Hash) ? settings["preview_generated_at"] : nil
+  end
+
+  # Why a regeneration request cannot produce a cover, or nil when it can.
+  # Answered synchronously in the controller so the request is refused outright
+  # rather than enqueuing a job whose only possible outcome is a poll that times
+  # out. Mirrors GenerateBoardPreviewJob's own skip condition — keep the two
+  # together.
+  def preview_generation_blocker
+    return "preview_not_supported" if settings.is_a?(Hash) && settings["builder_child"]
+    return "board_has_no_tiles" if board_images.empty?
+    nil
+  end
+
+  def mark_preview_queued!
+    return false unless persisted?
+    merged = (settings.is_a?(Hash) ? settings : {}).merge("preview_status" => "queued")
+    self.settings = merged
+    # update_column: a status flag must not fire callbacks or bump updated_at —
+    # that timestamp keys the boards#index cache, and enqueuing a render is not
+    # itself a change to the board.
+    update_column(:settings, merged)
+    true
+  end
+
+  # One write for the whole outcome: the denormalized snapshot URL plus the
+  # status and stamp. Split across two saves, a reader could observe a refreshed
+  # URL with a stale stamp (or the reverse) — which is the ambiguity this whole
+  # lifecycle exists to remove.
+  def record_preview_generated!
+    self.settings ||= {}
+    # Only overwrite the snapshot with a URL that actually resolved.
+    # #preview_image_url returns nil rather than raising when Active Storage
+    # can't build a URL (the Disk service outside a request, e.g. inside a
+    # Sidekiq job in dev/test) — assigning that would clobber a good URL with
+    # nothing.
+    resolved_url = preview_image.attached? ? preview_image_url : nil
+    settings["preset_display_image_url"] = resolved_url if resolved_url.present?
+    settings["preview_generated_at"] = Time.current.iso8601
+    settings["preview_status"] = "ok"
+    save
+  end
+
+  def mark_preview_failed!
+    return false unless persisted?
+    merged = (settings.is_a?(Hash) ? settings : {}).merge("preview_status" => "failed")
+    self.settings = merged
+    update_column(:settings, merged)
+    true
+  end
+
+  def mark_preview_skipped!
+    return false unless persisted?
+    merged = (settings.is_a?(Hash) ? settings : {}).merge("preview_status" => "skipped")
+    self.settings = merged
+    update_column(:settings, merged)
+    true
   end
 
   def pdf_url
@@ -2135,6 +2216,8 @@ class Board < ApplicationRecord
       audio_url: audio_url,
       display_image_url: display_image_url || preview_image_url,
       display_image_source: display_image_source,
+      preview_status: preview_status,
+      preview_generated_at: preview_generated_at,
       # floating_words: words,
       common_words: Board.common_words,
       user_id: user_id,
@@ -2559,6 +2642,8 @@ class Board < ApplicationRecord
       display_image_url: @display_image_url || @preview_image_url,
       preview_image_url: @preview_image_url,
       display_image_source: display_image_source,
+      preview_status: preview_status,
+      preview_generated_at: preview_generated_at,
       board_type: board_type,
       user_id: user_id,
       voice: voice,

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -290,11 +290,18 @@ class Board < ApplicationRecord
     schedule_translations_for(language)
   end
 
-  def run_generate_preview_job
+  # `force:` bypasses the job's builder_child skip. Pass it ONLY for a request
+  # that names one board — a person clicking "Regenerate from tiles". The skip
+  # exists to protect the shared :default queue from the automatic callers: an
+  # .obz import or a Board Builder run enqueues per page, and a real vocabulary
+  # set is 50-200 pages, each one a headless-Chrome render. One deliberate click
+  # is not that, and refusing it left those pages with no way to ever earn a
+  # snapshot.
+  def run_generate_preview_job(force: false)
     # Clear any previous outcome up front, so a run that follows a failure isn't
     # aborted by the stale "failed" its predecessor left behind.
     mark_preview_queued!
-    GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true }) # Generate PNG preview without header
+    GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true, "force" => force }) # Generate PNG preview without header
     # GenerateBoardPreviewJob.perform_async(id, { "generate_pdf" => true }) # PDF with header for sharing
   end
 
@@ -423,10 +430,13 @@ class Board < ApplicationRecord
   # Why a regeneration request cannot produce a cover, or nil when it can.
   # Answered synchronously in the controller so the request is refused outright
   # rather than enqueuing a job whose only possible outcome is a poll that times
-  # out. Mirrors GenerateBoardPreviewJob's own skip condition — keep the two
-  # together.
+  # out.
+  #
+  # A board with no tiles is the only thing that qualifies: there is nothing to
+  # take a picture of. A builder_child page is NOT blocked — it renders like any
+  # other board when the request is explicit (see #run_generate_preview_job's
+  # `force:`); it is only skipped when something enqueues it in bulk.
   def preview_generation_blocker
-    return "preview_not_supported" if settings.is_a?(Hash) && settings["builder_child"]
     return "board_has_no_tiles" if board_images.empty?
     nil
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -914,9 +914,26 @@ class Profile < ApplicationRecord
     name.presence || username.presence || "My Device"
   end
 
+  # Freshness key for the generated communicator documents (safety ID card,
+  # device tag, care plan). It must describe the CONTENT they render and
+  # nothing else.
+  #
+  # Deliberately excludes `updated_at`: ActiveStorage's attachment
+  # `belongs_to :record, touch: true`, so ATTACHING a generated document moves
+  # it. The signature is stamped into the blob's metadata *before* the attach,
+  # which meant it was stale the instant it was written — the next call
+  # recomputed a different key, missed, and re-rendered through headless
+  # Chrome. It only ever appeared to work because the value is truncated to
+  # whole seconds (`to_i`), so a generate that finished inside the same
+  # wall-clock second as the previous save happened to match. That is also why
+  # it read as a flaky spec rather than a broken cache.
+  #
+  # Nothing meaningful is lost. These documents render the avatar (covered by
+  # the blob id + checksum) and the care/emergency answers (covered by
+  # `settings`). The communicator's name comes from `profileable`, whose
+  # changes never touched this timestamp anyway.
   def safety_info_signature
     [
-      updated_at&.to_i,
       avatar_attachment&.blob_id,
       avatar_attachment&.blob&.checksum,
       settings.to_json

--- a/app/services/boards/generate_preview_assets.rb
+++ b/app/services/boards/generate_preview_assets.rb
@@ -12,12 +12,15 @@ module Boards
     def call(generate_png: true, generate_pdf: false)
       if generate_png
         attach_png
-        # Refresh the denormalized snapshot to the *current* preview URL in the
-        # same operation that produced the PNG. Doing it here (rather than in a
-        # post-job reload step) closes the window where a fetch between attach
-        # and write saw the old snapshot, and makes the synchronous callers
-        # (Board#generate_previews) keep the snapshot fresh too.
-        board.update_preset_display_image_url(board.preview_image_url) if board.preview_image.attached?
+        # Refresh the denormalized snapshot to the *current* preview URL, and
+        # record the outcome, in the same operation that produced the PNG. Doing
+        # it here (rather than in a post-job reload step) closes the window where
+        # a fetch between attach and write saw the old snapshot, and makes the
+        # synchronous callers (Board#generate_previews) keep the snapshot fresh
+        # too. `preview_generated_at` is what the client polls on — it advances
+        # on every successful render, including one that produces a
+        # byte-identical picture.
+        board.record_preview_generated!
       end
       attach_pdf if generate_pdf
     end

--- a/app/sidekiq/generate_board_preview_job.rb
+++ b/app/sidekiq/generate_board_preview_job.rb
@@ -2,6 +2,18 @@ class GenerateBoardPreviewJob
   include Sidekiq::Job
   sidekiq_options retry: 3, queue: :default
 
+  # A render that exhausts its retries used to vanish into the dead set, while
+  # the client kept polling and eventually said "Still building your cover" —
+  # advice that would never come true. Record the failure on the board so the
+  # API can report it.
+  sidekiq_retries_exhausted do |msg, ex|
+    board_id = msg["args"]&.first
+    Rails.logger.error(
+      "GenerateBoardPreviewJob exhausted retries for board #{board_id}: #{ex&.class}: #{ex&.message}"
+    )
+    Board.find_by(id: board_id)&.mark_preview_failed!
+  end
+
   def perform(board_id, options = {})
     screen_size = options["screen_size"] || options["screenSize"] || "lg"
     hide_colors = options["hide_colors"] || options["hideColors"] || false
@@ -19,7 +31,18 @@ class GenerateBoardPreviewJob
     # source (clone_with_images, grid/layout saves, blueprint add_image) — by the
     # time this async job runs, the builder_child flag is committed. The root
     # (builder_root) and all non-builder boards still render normally.
-    return if board.settings.is_a?(Hash) && board.settings["builder_child"]
+    #
+    # Record the skip rather than returning silently: an unrecorded no-op is
+    # indistinguishable from a slow success to anything watching, which is how
+    # this button could appear to work while never doing anything.
+    if board.settings.is_a?(Hash) && board.settings["builder_child"]
+      Rails.logger.info(
+        "GenerateBoardPreviewJob skipped board #{board_id}: builder_child page — " \
+        "its cover comes from the folder tile that opens it"
+      )
+      board.mark_preview_skipped!
+      return
+    end
 
     # GeneratePreviewAssets attaches the PNG and refreshes the preset display
     # image URL atomically, so there's no post-attach reload/write race here.

--- a/app/sidekiq/generate_board_preview_job.rb
+++ b/app/sidekiq/generate_board_preview_job.rb
@@ -32,10 +32,16 @@ class GenerateBoardPreviewJob
     # time this async job runs, the builder_child flag is committed. The root
     # (builder_root) and all non-builder boards still render normally.
     #
+    # `force` opts out: it marks a request that names ONE board — someone
+    # clicking "Regenerate from tiles". The skip is about queue volume, not
+    # about these pages being unrenderable, so a single deliberate render is
+    # allowed through. Without that they could never earn a snapshot at all.
+    #
     # Record the skip rather than returning silently: an unrecorded no-op is
     # indistinguishable from a slow success to anything watching, which is how
     # this button could appear to work while never doing anything.
-    if board.settings.is_a?(Hash) && board.settings["builder_child"]
+    force = options["force"] || options["forceRender"] || false
+    if !force && board.settings.is_a?(Hash) && board.settings["builder_child"]
       Rails.logger.info(
         "GenerateBoardPreviewJob skipped board #{board_id}: builder_child page — " \
         "its cover comes from the folder tile that opens it"

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -494,17 +494,20 @@ RSpec.describe "API::Boards", type: :request do
       expect(cover_board.reload.preview_status).to eq("queued")
     end
 
-    it "refuses a builder_child page with 422 rather than enqueuing" do
+    # The job skips builder_child pages when something enqueues them in bulk —
+    # an .obz import is 50-200 headless-Chrome renders on the shared queue. One
+    # deliberate click is not that, and refusing it left those pages unable to
+    # ever earn a snapshot.
+    it "renders a builder_child page anyway when the request is explicit" do
       cover_board.update_column(:settings, cover_board.settings.to_h.merge("builder_child" => true))
 
-      expect(GenerateBoardPreviewJob).not_to receive(:perform_async)
+      expect(GenerateBoardPreviewJob).to receive(:perform_async)
+        .with(cover_board.id, hash_including("force" => true))
 
       post "/api/boards/#{cover_board.id}/generate_preview_image", headers: auth_headers(user)
 
-      expect(response).to have_http_status(:unprocessable_content)
-      body = JSON.parse(response.body)
-      expect(body["code"]).to eq("preview_not_supported")
-      expect(body["error"]).to be_present
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["status"]).to eq("queued")
     end
 
     it "refuses a board with no tiles with 422 rather than enqueuing" do

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -462,6 +462,69 @@ RSpec.describe "API::Boards", type: :request do
     end
   end
 
+  describe "POST /api/boards/:id/generate_preview_image" do
+    # The endpoint only enqueues, so its whole job is to be honest about
+    # whether a cover is actually coming. Answering "ok" for a board that can
+    # never render one leaves the client polling for a minute and then telling
+    # the user to reload for something that will never arrive.
+    let(:cover_board) { create(:board, user: user, name: "Cover Board") }
+
+    before { create(:board_image, board: cover_board) }
+
+    it "queues a render and returns the pre-render stamp as a baseline" do
+      cover_board.update!(settings: cover_board.settings.to_h.merge("preview_generated_at" => "2026-08-01T00:00:00Z"))
+
+      expect(GenerateBoardPreviewJob).to receive(:perform_async).with(cover_board.id, anything)
+
+      post "/api/boards/#{cover_board.id}/generate_preview_image", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["status"]).to eq("queued")
+      expect(body["preview_generated_at"]).to eq("2026-08-01T00:00:00Z")
+      expect(body["preview_status"]).to eq("queued")
+    end
+
+    it "clears a previous failure so the next run isn't judged by it" do
+      cover_board.mark_preview_failed!
+      allow(GenerateBoardPreviewJob).to receive(:perform_async)
+
+      post "/api/boards/#{cover_board.id}/generate_preview_image", headers: auth_headers(user)
+
+      expect(cover_board.reload.preview_status).to eq("queued")
+    end
+
+    it "refuses a builder_child page with 422 rather than enqueuing" do
+      cover_board.update_column(:settings, cover_board.settings.to_h.merge("builder_child" => true))
+
+      expect(GenerateBoardPreviewJob).not_to receive(:perform_async)
+
+      post "/api/boards/#{cover_board.id}/generate_preview_image", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+      expect(body["code"]).to eq("preview_not_supported")
+      expect(body["error"]).to be_present
+    end
+
+    it "refuses a board with no tiles with 422 rather than enqueuing" do
+      empty_board = create(:board, user: user, name: "Empty Board")
+
+      expect(GenerateBoardPreviewJob).not_to receive(:perform_async)
+
+      post "/api/boards/#{empty_board.id}/generate_preview_image", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["code"]).to eq("board_has_no_tiles")
+    end
+
+    it "returns 404 for a board that doesn't exist" do
+      post "/api/boards/0/generate_preview_image", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "DELETE /api/boards/:id" do
     context "when unauthenticated" do
       it "returns 401" do

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -237,6 +237,26 @@ RSpec.describe Communicators::GenerateCarePlan do
       described_class.call(profile.reload, variant: :full)
     end
 
+    # Regression: the signature used to include profile.updated_at, and
+    # ActiveStorage's attachment `belongs_to :record, touch: true` — so the
+    # attach that STORED the signature also moved the value the signature was
+    # built from. The cached document was stale the instant it was written and
+    # every later call re-rendered through headless Chrome. It read as a flaky
+    # spec rather than a dead cache only because the value was truncated to
+    # whole seconds: a generate finishing inside the same second as the
+    # previous save happened to match, and a slower machine didn't.
+    #
+    # The touch is simulated in a later second so the assertion doesn't depend
+    # on how long a render takes.
+    it "survives the touch that attaching the document performs" do
+      render_html
+
+      travel_to(3.seconds.from_now) { profile.touch }
+
+      expect(Grover).not_to receive(:new)
+      described_class.call(profile.reload, variant: :full)
+    end
+
     it "re-renders when regenerate is asked for" do
       render_html
 

--- a/spec/sidekiq/generate_board_preview_job_spec.rb
+++ b/spec/sidekiq/generate_board_preview_job_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
       expect(board.reload.preview_status).to eq("skipped")
     end
 
+    # The skip is about queue volume — one render per page across a 50-200 page
+    # import — not about these pages being unrenderable. An explicit,
+    # single-board request passes force and renders like any other board.
+    it "renders anyway when the request is forced" do
+      board.update_column(:settings, board.settings.merge("builder_child" => true))
+
+      described_class.new.perform(board.id, "generate_png" => true, "force" => true)
+
+      board.reload
+      expect(board.preview_image).to be_attached
+      expect(board.preview_status).to eq("ok")
+    end
+
     it "still generates for the builder_root board" do
       board.update_column(:settings, board.settings.merge("builder_root" => true))
 

--- a/spec/sidekiq/generate_board_preview_job_spec.rb
+++ b/spec/sidekiq/generate_board_preview_job_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
       expect(board.settings).not_to have_key("preset_display_image_url")
     end
 
+    it "records the skip so it isn't mistaken for a slow success" do
+      board.update_column(:settings, board.settings.merge("builder_child" => true))
+
+      described_class.new.perform(board.id, "generate_png" => true)
+
+      expect(board.reload.preview_status).to eq("skipped")
+    end
+
     it "still generates for the builder_root board" do
       board.update_column(:settings, board.settings.merge("builder_root" => true))
 
@@ -76,6 +84,49 @@ RSpec.describe GenerateBoardPreviewJob, type: :job do
   describe "sidekiq options" do
     it "retries on failure" do
       expect(described_class.sidekiq_options["retry"]).to eq(3)
+    end
+  end
+
+  describe "when retries are exhausted" do
+    # Without this the render dies into the dead set while the client keeps
+    # polling and is eventually told the cover "will appear shortly" — advice
+    # that never comes true.
+    it "marks the board's preview as failed" do
+      described_class.sidekiq_retries_exhausted_block.call(
+        { "args" => [board.id] },
+        RuntimeError.new("grover exploded"),
+      )
+
+      expect(board.reload.preview_status).to eq("failed")
+    end
+
+    it "does not raise when the board has since been deleted" do
+      missing_id = board.id
+      board.destroy
+
+      expect {
+        described_class.sidekiq_retries_exhausted_block.call(
+          { "args" => [missing_id] }, RuntimeError.new("grover exploded")
+        )
+      }.not_to raise_error
+    end
+  end
+
+  describe "recording a successful render" do
+    it "advances preview_generated_at and marks the status ok" do
+      described_class.new.perform(board.id, "generate_png" => true)
+      first_stamp = board.reload.preview_generated_at
+
+      expect(first_stamp).to be_present
+      expect(board.preview_status).to eq("ok")
+
+      travel_to(2.minutes.from_now) do
+        described_class.new.perform(board.id, "generate_png" => true)
+      end
+
+      # The stamp must advance even when the rendered PNG is byte-identical —
+      # it is what the client polls on.
+      expect(board.reload.preview_generated_at).to be > first_stamp
     end
   end
 end


### PR DESCRIPTION
## Summary

"Regenerate from tiles" reports success on production while the cover never changes — the fourth round on this symptom (#138, #408, #588, #663/#669).

Those four all fixed the **read** path, and it is now sound: `Board#display_image_url` resolves the live attachment ahead of the column and the settings snapshot, `versioned_preview_key` writes a fresh S3 path per run so neither CloudFront nor the `cdn-images` service worker can serve a stale copy, and `boards#show` has no ETag. If the cover isn't changing, **a new PNG isn't being attached** — the problem is on the write path.

The reason this keeps coming back is that every failure mode of that write path is currently indistinguishable from success:

- `generate_preview_image` returned `{status: "ok"}` unconditionally — it only enqueues.
- `GenerateBoardPreviewJob` returned silently for any `builder_child` board: no log, no marker.
- A Grover failure retried 3× and landed in the Sidekiq dead set with nothing user-visible.
- The client could therefore only ever say "Cover updated" or "Still building your cover — it'll appear shortly", the latter being untrue in all three cases.

This PR makes the outcome observable. **It is not itself the root-cause fix** for the reported board — it's what identifies which of the above is happening.

## Changes

- **`Board`** gains a preview lifecycle: `preview_status` (`queued`/`ok`/`skipped`/`failed`) and `preview_generated_at`, which advances on every successful render *including one whose PNG is byte-identical*. `record_preview_generated!` writes the denormalized `preset_display_image_url` and the stamp in **one** save, so a reader can't observe a refreshed URL beside a stale stamp. Both fields ride on `api_view` and `api_view_with_predictive_images`.
- **`generate_preview_image`** refuses **422** `board_has_no_tiles` — nothing to photograph — instead of enqueuing a job that can't produce anything. 422 rather than 403/402: nothing here is a permission or credit gate. On success it returns the pre-render stamp as a poll baseline.
- **A `builder_child` page now renders on an explicit request.** The job's skip is about queue *volume*, not about the page being unrenderable: it guards the shared `:default` queue from the bulk enqueue paths, where an `.obz` import or builder run is 50-200 headless-Chrome renders. `run_generate_preview_job(force:)` opts out, and only the `generate_preview_image` endpoint passes it — every automatic caller keeps the skip. Without this those pages could never earn a snapshot at all; the button silently did nothing on them.
- **`GenerateBoardPreviewJob`** logs and stamps the `builder_child` skip rather than returning silently, and stamps `failed` from `sidekiq_retries_exhausted`.

Counterpart frontend PR: brittanyjohns/itty-bitty-frontend#688 — it polls `preview_generated_at` rather than `preview_image_url`, which isn't the field the thumbnail renders and changes only incidentally.

## Test plan

`bundle exec rspec spec/services/boards/generate_preview_assets_spec.rb spec/sidekiq/generate_board_preview_job_spec.rb spec/requests/api/boards_spec.rb spec/models/board_spec.rb` — **194 examples, 0 failures.**

New coverage:
- `generate_preview_image` queues and returns the baseline stamp; clears a prior `failed` so the next run isn't judged by it; renders a `builder_child` page when forced; refuses a tile-less board with 422 + code and **without** enqueuing; 404s for a missing board.
- The job records `skipped` on the builder-child return and renders anyway when `force` is passed, `failed` on exhausted retries (and doesn't raise when the board has since been deleted), and advances `preview_generated_at` across two renders of identical content.

Docs: `.claude-notes/artifact-generation-services.md` §3 gains the write-path contract; `CHANGELOG.md` entry added.

## Follow-up

Root cause on the reported board still needs a production read — whether `preview_image.blob.created_at` moves on a click separates "the job never ran / failed" from "the render works and the picture is unchanged". The worker log now names which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also in this PR: a document cache that invalidated itself

Rebasing onto `main` surfaced a failing spec in `generate_care_plan_spec.rb` (from #685). It is **not** caused by the cover work, but it blocks this branch, and it turned out to be a real bug rather than a flaky test.

`Profile#safety_info_signature` included the record's `updated_at`, and ActiveStorage's attachment is `belongs_to :record, touch: true` — so **attaching** a generated document moved the value its own signature was built from. The signature is stamped into blob metadata *before* the attach, so the cached document was stale the instant it was written; every later call recomputed a different key, missed, and re-rendered through headless Chrome. The care plan, safety ID card, and device tag all share that signature, so none of them had a working cache.

It stayed hidden because the value was truncated with `to_i`: a generate finishing inside the same wall-clock second as the previous save happened to match. That is why it presented as an intermittently failing freshness spec on slower CI instead of as a dead cache — `main` is green on luck, not correctness.

Fixed by signing the **content** the documents render (avatar blob id + checksum, `settings`) and dropping the timestamp. Nothing meaningful is lost: the communicator's name comes from `profileable`, whose changes never moved this timestamp anyway.

The new regression test simulates the attach's touch landing in a later second, so it doesn't depend on render speed. Verified it **fails** without the fix and passes with it.
