### PR TITLE
fix(security): make communicator asset generation owner-only

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -198,6 +198,25 @@ the free-text bio.
 - Care info is deliberately **not** on the Safety ID card or device tag; those
   are emergency artifacts.
 
+## Generating the printables is owner-only
+
+`API::Profiles::AssetsController` (`POST /api/profiles/:id/safety_id`,
+`/device_tag`) gates on `ChildAccount#editable_by?` — owner or admin, the same
+rule as `API::ProfilesController#update`. Deliberately **not** team-wide: an
+SLP supervisor can be on the team and still not mint these.
+
+The gate is load-bearing because the actions return
+`Profile#url_for_attachment`, which is an **unsigned `CDN_HOST + key` URL**, not
+a signed or expiring one. Serving one for a profile the caller doesn't own
+publishes that communicator's allergies, medications and ICE contacts
+permanently, to anyone the link reaches. Sequential ids are not a defense. The
+controller authenticated but never authorized until this was fixed; the guard
+is a `before_action` so a non-owner can't even trigger a `regenerate`.
+
+Fail-closed in two places worth keeping: an unrecognized `profileable_type`
+is refused rather than allowed, and `profileable` is `optional: true`, so an
+orphaned profile safe-navigates to nil and 403s instead of raising.
+
 ## About Me (public bio) vs emergency notes (private)
 
 The MySpeak page has two distinct free-text fields that were historically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Only a communicator's owner can generate their Safety ID card or device
+  tag.** The endpoints that build those printables checked that you were signed
+  in but never checked *whose* communicator you were asking about — so any
+  signed-in account could request another family's Safety ID card and be handed
+  a working link to it, allergies, medications, emergency contacts and all. They
+  now answer the same way the rest of the emergency info does: owner (or a
+  SpeakAnyWay admin) only, and everyone else is refused before anything is
+  generated. Note for SLPs and other team members: generating these two
+  printables was never meant to be yours to do, and now isn't — ask the family
+  to download and share them.
+
 ### Changed
 
 - **Care & routine notes: better questions, and you can pick more than one

--- a/app/controllers/api/profiles/assets_controller.rb
+++ b/app/controllers/api/profiles/assets_controller.rb
@@ -1,6 +1,7 @@
 # app/controllers/api/profiles/assets_controller.rb
 class API::Profiles::AssetsController < API::ApplicationController
   before_action :set_profile
+  before_action :require_owner!
 
   def safety_id
     Rails.logger.info "Generating safety ID for Profile ID: #{@profile.id}, Regenerate: #{params[:regenerate]}"
@@ -40,6 +41,37 @@ class API::Profiles::AssetsController < API::ApplicationController
     end
 
     head :not_found unless @profile
+  end
+
+  # Authentication alone is not authorization here. Both actions hand back
+  # `url_for_attachment`, which is an UNSIGNED CloudFront URL — so serving one
+  # for someone else's profile publishes that communicator's allergies,
+  # medications, and emergency contacts to whoever asked, permanently. Profile
+  # ids are sequential, so "they'd have to guess the id" is not a defense.
+  #
+  # Mirrors the gate on API::ProfilesController#update, which has always had
+  # one; this controller was simply never given it.
+  def require_owner!
+    return if owner_of_profile?
+
+    render json: { error: "not_owner" }, status: :forbidden
+  end
+
+  # Closed by default: an unrecognized profileable type is refused rather than
+  # allowed, so adding a new one can't silently open this up. `profileable` is
+  # `optional: true`, so an orphaned profile safe-navigates to nil and is
+  # refused — a 403 rather than a 500.
+  def owner_of_profile?
+    return false unless current_user
+
+    case @profile.profileable_type
+    when "ChildAccount"
+      @profile.profileable&.editable_by?(current_user)
+    when "User"
+      @profile.profileable_id == current_user.id || current_user.admin?
+    else
+      current_user.admin?
+    end
   end
 
   def truthy?(value)

--- a/spec/requests/api/profiles_owner_protection_spec.rb
+++ b/spec/requests/api/profiles_owner_protection_spec.rb
@@ -71,6 +71,110 @@ RSpec.describe "API::Profiles owner protection", type: :request do
     end
   end
 
+  # The asset endpoints hand back an UNSIGNED CloudFront URL for an artifact
+  # that prints allergies, medications and emergency contacts. Authentication
+  # was never enough here — the id is the only thing standing between a signed-in
+  # stranger and another family's emergency info, and ids are sequential.
+  describe "communicator asset endpoints" do
+    let(:fake_attachment) { instance_double(ActiveStorage::Attached::One, attached?: true) }
+
+    before do
+      allow(Communicators::GenerateSafetyIdCard).to receive(:call).and_return(true)
+      allow(Communicators::GenerateDeviceTag).to receive(:call).and_return(true)
+      allow_any_instance_of(Profile).to receive(:safety_id_png).and_return(fake_attachment)
+      allow_any_instance_of(Profile).to receive(:device_tag_png).and_return(fake_attachment)
+      allow_any_instance_of(Profile).to receive(:url_for_attachment)
+        .and_return("https://cdn.example.test/asset.png")
+    end
+
+    describe "POST /api/profiles/:id/safety_id" do
+      it "allows the parent owner" do
+        post "/api/profiles/#{child_profile.id}/safety_id", headers: auth_headers(parent)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["url"]).to be_present
+      end
+
+      it "blocks the SLP supervisor with 403 not_owner" do
+        post "/api/profiles/#{child_profile.id}/safety_id", headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      end
+
+      # The guard is a before_action for this reason: a non-owner must not be
+      # able to trigger a render (or a regenerate) on someone else's profile,
+      # even if the URL were withheld from the response.
+      it "does not generate anything for a non-owner" do
+        post "/api/profiles/#{child_profile.id}/safety_id",
+             params: { regenerate: true },
+             headers: auth_headers(slp)
+
+        expect(Communicators::GenerateSafetyIdCard).not_to have_received(:call)
+      end
+
+      it "never leaks the asset URL to a non-owner" do
+        post "/api/profiles/#{child_profile.id}/safety_id", headers: auth_headers(slp)
+
+        expect(response.body).not_to include("cdn.example.test")
+      end
+
+      it "allows a system admin" do
+        post "/api/profiles/#{child_profile.id}/safety_id", headers: auth_headers(admin)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /api/profiles/:id/device_tag" do
+      it "allows the parent owner" do
+        post "/api/profiles/#{child_profile.id}/device_tag", headers: auth_headers(parent)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "blocks the SLP supervisor with 403 not_owner" do
+        post "/api/profiles/#{child_profile.id}/device_tag", headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      end
+    end
+
+    # `profileable` is optional: true, so a profile can outlive its
+    # communicator. Fail closed with a 403 rather than raising on nil.
+    it "refuses an orphaned profile instead of raising" do
+      child_profile.update_columns(profileable_id: nil)
+
+      post "/api/profiles/#{child_profile.id}/safety_id", headers: auth_headers(parent)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    describe "a User-owned profile" do
+      let(:slp_profile) do
+        Profile.create!(
+          profileable: slp,
+          username: "slp-#{SecureRandom.hex(2)}",
+          slug: "slp-#{SecureRandom.hex(2)}",
+        )
+      end
+
+      it "allows the user to generate their own device tag" do
+        post "/api/profiles/#{slp_profile.id}/device_tag", headers: auth_headers(slp)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "blocks another user from generating it" do
+        post "/api/profiles/#{slp_profile.id}/device_tag", headers: auth_headers(parent)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("not_owner")
+      end
+    end
+  end
+
   describe "PATCH /api/profiles/:id (User-owned profile)" do
     let(:user_profile) do
       Profile.create!(


### PR DESCRIPTION
## Summary

`API::Profiles::AssetsController` authenticated requests but never authorized them. `set_profile` did `Profile.find_by(id: params[:id])` with no ownership check, and both actions returned `Profile#url_for_attachment` — an **unsigned, permanent `CDN_HOST + key` URL**.

So any signed-in user could:

```
POST /api/profiles/<any id>/safety_id
```

and receive a working, non-expiring link to another family's Safety ID card, which prints **allergies, medical conditions, medications, and emergency contacts**. Profile ids are sequential, so guessing isn't a barrier.

`API::ProfilesController#update` has had the correct gate since #214 (`profile.profileable.editable_by?(current_user)` → 403 `not_owner`). This controller was simply never given one — `spec/requests/api/profiles_owner_protection_spec.rb` covered `#update` only.

Found while planning the Care Plan PDF work, which adds a third action to this same controller. Splitting it out so it can ship on its own.

## The fix

A `before_action :require_owner!` covering every action in the controller.

- **A `before_action`, not an inline check** — a non-owner must not be able to trigger a render, or a `regenerate`, on someone else's profile, even if the URL were withheld from the response body. (Also the repo's stated rule for gating.)
- **Fails closed on an unknown `profileable_type`** — adding a new one can't silently open this up.
- **Fails closed on a nil `profileable`** — the association is `optional: true`, so an orphaned profile safe-navigates to nil and answers 403 rather than raising a 500.

## ⚠️ Behavior change

An SLP supervisor who is on the team but is not the owner could previously generate these two printables and now gets `403 not_owner`. That matches the permissions matrix (`marketing/.claude-notes/handoff-workflow.md`) — the safety/emergency profile is owner-only — but it is a change for existing team members, so it's called out in the CHANGELOG in plain language.

## Test plan

Extended `spec/requests/api/profiles_owner_protection_spec.rb` with a `communicator asset endpoints` block:

- owner → 200 + `{ url: }`; SLP supervisor → 403 `not_owner`; admin → 200
- **the generator is never called for a non-owner** (proves the chain halts before any work)
- **the asset URL never appears in a non-owner's response body**
- a User-owned profile: the user can generate their own, another user gets 403
- an orphaned profile 403s rather than raising

```
bundle exec rspec spec/requests/api/profiles_owner_protection_spec.rb
# 14 examples, 0 failures
```

Confirmed the specs are not vacuous — stashing the controller change alone produces **5 failures**.

Also ran the neighbouring suites that touch these endpoints or generators, all green (24 examples):

```
bundle exec rspec spec/requests/api/internal/profiles_spec.rb \
  spec/requests/api/internal/marketing_artifacts_spec.rb \
  spec/services/communicators
```

Grover is stubbed throughout; no headless Chrome needed.

## Docs

- `CHANGELOG.md` — Unreleased → Fixed, including the SLP-facing note
- `.claude-notes/safety-profiles.md` — new "Generating the printables is owner-only" section recording *why* the gate is load-bearing (unsigned CDN URLs), so it isn't relaxed later

🤖 Generated with [Claude Code](https://claude.com/claude-code)