### PR TITLE
fix(pdf): honour a blanked tile picture in board exports and previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Printed boards now match what's on screen.** A tile you've cleared the
+  picture off — the colour swatches on Core Safety, for instance, which show
+  the word on a coloured square — was printing a symbol anyway: an apple on
+  "red", a crayon on "blue". The sheet borrowed the stock picture for the word
+  instead of honouring that the tile has none. This affected the downloadable
+  PDF, the board's cover image, and the printables, since all three come off
+  the same renderer. Covers already generated are refreshed by
+  `rake board_covers:refresh_blanked_tile_covers`.
+
 - **Saving one part of a communicator's settings no longer wipes the rest.**
   The communicator screen saves settings from several different places, and
   each one sent only the handful of values it knew about — so saving from one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,6 +387,23 @@ an explicit decision, not a drive-by edit.
   Unverified accounts hold zero welcome tokens and zero AI credits and are
   refused image generation (403 `email_verification_required`); they can still
   sign in and use the app — **verification never gates authentication**.
+- **A blank `board_images.display_image_url` means "this tile has no picture"
+  — resolve tile art with a bare `||`, never `.presence`.** The app stops on
+  the blank because `""` is truthy in Ruby
+  (`Board#api_view_with_predictive_images`), and every Grover render must agree
+  with it: `Boards::BoardPdfLayoutNormalizer` feeds `Boards::RenderAssetData`,
+  which is the sole input to the downloadable PDF, the board cover PNG
+  (`Boards::GeneratePreviewAssets`), and the whole printables pipeline. Wrapping
+  the chain in `.presence` treated the marker as absent and fell through to the
+  underlying `Image`'s library art, so a Core Safety colour tile the app draws
+  as the word "red" on a red square printed an apple. Note the print template
+  needs no help here — a blank `image_url` already renders the label via the
+  **transparent** `generate_placeholder_image` SVG, so the tile's `bg_color`
+  shows through and the swatch matches the screen. Two related traps: covers are
+  cached artifacts, so a renderer fix leaves them stale until reprocessed
+  (`rake board_covers:refresh_blanked_tile_covers`); and `BoardImage#set_defaults`
+  seeds `display_image_url` from `image.src_url` on create, so a spec must write
+  the blank *after* creating the tile.
 
 ## Subsystem map (read the spoke before working in the area)
 

--- a/app/services/boards/board_pdf_layout_normalizer.rb
+++ b/app/services/boards/board_pdf_layout_normalizer.rb
@@ -65,10 +65,23 @@ module Boards
     # fabricated a picture on label-only tiles (e.g. an "I feel" header) that
     # the app renders as text. A blank result lets the print template draw the
     # label via generate_placeholder_image, matching what the user sees on screen.
+    #
+    # Note the BARE `||` on every link — never `.presence`. A blank
+    # board_image.display_image_url is a deliberate "this tile has no picture"
+    # marker, and the app stops on it because "" is truthy in Ruby. Wrapping
+    # these in `.presence` treated the marker as absent and fell through to the
+    # underlying image's library art: the Core Safety colour tiles, which the
+    # app draws as the word "red" on a red square, printed an apple instead.
+    # Matching api_view's operator exactly is what keeps print and screen in
+    # agreement — anything cleverer here diverges from what the user sees.
+    #
+    # No viewing user: the PDF endpoint is unauthenticated, so there is nobody
+    # whose doc preference we could resolve. Image#display_doc already falls
+    # back to the image owner's doc when handed nil.
     def tile_display_src(board_image)
-      board_image.display_image_url.presence ||
-        board_image.image&.display_image_url(@current_user).presence ||
-        board_image.image&.src_url.presence
+      board_image.display_image_url ||
+        board_image.image&.display_image_url(nil) ||
+        board_image.image&.src_url
     end
 
     attr_reader :board, :screen_size

--- a/lib/tasks/board_covers.rake
+++ b/lib/tasks/board_covers.rake
@@ -51,4 +51,55 @@ namespace :board_covers do
     puts "board_covers:backfill_source — #{verb}: #{to_custom} custom, #{to_preview} preview; legacy flags cleared on #{flags_cleared} board(s)."
     puts "(dry run — re-run with DRY_RUN=false to apply)" if dry_run
   end
+
+  # Re-render the cover PNG for boards whose cached cover was generated while
+  # Boards::BoardPdfLayoutNormalizer wrongly resolved art for BLANKED tiles.
+  #
+  # A board_image with display_image_url = "" means "this tile has no picture" —
+  # the app draws the word over the tile's bg_color. The normalizer used to
+  # `.presence` that marker away and fall through to the underlying image's
+  # library art, so every Grover render (cover PNG, downloadable PDF, printables)
+  # printed a symbol the app never shows: an apple on the "red" colour tile.
+  # The renderer is fixed; the covers are cached artifacts and stay wrong until
+  # they're regenerated, which is what this does.
+  #
+  # Only boards that actually render wrong are touched — a blanked tile whose
+  # image has no src_url looked the same before and after the fix.
+  # GenerateBoardPreviewJob skips builder_child sub-boards on its own, so no
+  # extra filtering is needed here.
+  #
+  # These are Grover (headless Chrome) renders, so a large batch is real Sidekiq
+  # load. Read the dry-run count before applying.
+  #
+  #   rake board_covers:refresh_blanked_tile_covers                # dry run, all
+  #   DRY_RUN=false rake board_covers:refresh_blanked_tile_covers  # apply all
+  #   DRY_RUN=false USER_ID=740 rake board_covers:refresh_blanked_tile_covers
+  desc "Re-render covers for boards with blanked tiles that used to print borrowed art (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task refresh_blanked_tile_covers: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+
+    scope = Board.where(
+      id: BoardImage.joins(:image)
+                    .where(display_image_url: "")
+                    .where.not(images: { src_url: [nil, ""] })
+                    .select(:board_id),
+    )
+    scope = scope.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    total = scope.count
+    puts "board_covers:refresh_blanked_tile_covers — #{total} board(s) with blanked tiles over arted images."
+
+    if dry_run
+      puts "(dry run — re-run with DRY_RUN=false to enqueue #{total} Grover render(s))"
+      next
+    end
+
+    enqueued = 0
+    scope.find_each do |board|
+      GenerateBoardPreviewJob.perform_async(board.id, { "generate_png" => true })
+      enqueued += 1
+    end
+
+    puts "board_covers:refresh_blanked_tile_covers — enqueued #{enqueued} preview render(s)."
+  end
 end

--- a/spec/services/boards/board_pdf_layout_normalizer_spec.rb
+++ b/spec/services/boards/board_pdf_layout_normalizer_spec.rb
@@ -38,5 +38,30 @@ RSpec.describe Boards::BoardPdfLayoutNormalizer, type: :service do
       # other callers (Board Builder folder covers, OBF export) rely on that.
       expect(board_image.tile_image_url).to eq("https://cdn.example/tired-face.png")
     end
+
+    it "honours a blanked display_image_url even when the image HAS art" do
+      # The Core Safety colour-tile case: 'red' is stored with an empty-string
+      # display_image_url, which the app treats as "no picture" ("" is truthy in
+      # Ruby, so api_view's `||` chain stops there) and draws as the word on a
+      # red square. The underlying library image for "red" does have art — an
+      # apple — and the PDF used to fall through and print it.
+      image = create(:image, label: "red", src_url: "https://cdn.example/apple.png")
+      # BoardImage#set_defaults seeds display_image_url from image.src_url on
+      # create, so the blank has to be written afterwards — which is also how
+      # real tiles get it (a later save from the editor).
+      add_tile(image).update_column(:display_image_url, "")
+
+      expect(tile_for("red")["image_url"]).to be_blank
+    end
+
+    it "still falls through to the image's art when display_image_url is nil" do
+      # The boundary on the other side of the fix: nil is NOT the "no picture"
+      # marker — it just means the tile never got its own override — so the
+      # underlying image's art must still resolve.
+      image = create(:image, label: "cat", src_url: "https://cdn.example/cat.png")
+      add_tile(image).update_column(:display_image_url, nil)
+
+      expect(tile_for("cat")["image_url"]).to eq("https://cdn.example/cat.png")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Reported as "the PDF should not be different than the board": on **Core Safety**, the app renders the colour tiles as coloured squares with the word centred, while the exported PDF renders them as symbols — an apple on *red*, a crayon on *blue*, a leaf on *green*.

A `board_image` with a blank `display_image_url` means **"this tile has no picture."** The app stops there because `""` is truthy in Ruby (`Board#api_view_with_predictive_images`) and draws the label over the tile's `bg_color`. `Boards::BoardPdfLayoutNormalizer` wrapped the same three-step chain in `.presence`, which erased the marker and fell through to the underlying `Image`'s library art.

Confirmed against production — `GET /api/boards/core-safety` serialises the `red` tile as:

```
label = 'red'   src = ''   display_image_url = ''   bg_color = '#FF7070'
```

This is the same failure mode #463 fixed once. That fix covered *"the tile's own image has no art"*; it left uncovered *"the tile was explicitly blanked while its image does have art"* — which is these colour tiles.

**Blast radius.** The normalizer feeds `Boards::RenderAssetData`, the sole input to every Grover render: the downloadable PDF, the board **cover PNG** (`GeneratePreviewAssets`), the internal render endpoint, and the printables pipeline. All of them fabricated pictures on blanked tiles.

## Changes

- **`board_pdf_layout_normalizer.rb`** — resolve tile art with a bare `||`, never `.presence`, so the renderer matches `api_view_with_predictive_images` exactly. Correctness is by construction: same column, same operator, so it cannot diverge from what the user sees.
  - Also made explicit that there is no viewing user. The ivar passed to `Image#display_image_url` was **never assigned in the class** — always `nil`. The PDF endpoint is unauthenticated, and `Image#display_doc` already falls back to the image owner.
- **`board_covers:refresh_blanked_tile_covers`** — re-renders covers for boards whose cached PNG is wrong. Dry-run by default, `DRY_RUN=false` to apply, `USER_ID=N` to scope. Scoped to blanked tiles over *arted* images, since a blanked tile whose image has no art looked the same before and after.
- Specs, CHANGELOG, and a cross-cutting invariant in `CLAUDE.md`.

No template change was needed: a blank `image_url` already draws the label via the **transparent** `generate_placeholder_image` SVG, so `bg_color` shows through and the swatch matches the screen.

## Test plan

- `bundle exec rspec spec/services/boards/board_pdf_layout_normalizer_spec.rb` → **4 examples, 0 failures**. Two new cases: blanked-but-arted resolves blank (the Core Safety case); `nil` still falls through to the image's art (the boundary on the other side of the fix).
  - Note `BoardImage#set_defaults` seeds `display_image_url` from `image.src_url` on create, so the blank has to be written after — which is also how real tiles get it.
- **Rendered the real pipeline.** Built a board matching the Core Safety shape (arted core tiles + blanked colour tiles) and ran it through Grover both ways. Before: paint-splat symbols borrowed onto the colour tiles. After: coloured squares with the word, while `no` and `help` keep their symbols and captions.
  - One scare worth recording: an early "after" render also blanked `no`/`help`. That was the 8s `image_load_deadline_ms` timing out on a cold CDN fetch — the real PDF path passes no deadline, and re-rendering that way was clean.
- **Backfill task** — validated the scope query and ran the dry run against the dev DB.
- Full suite: **5084 examples, 25 failures**. None are in the PDF, normalizer, or covers code. All 11 affected files pass **155/155 in isolation both with and without this change**, so they are pre-existing order-dependent pollution. A same-seed full-suite baseline comparison was started but cut short to ship this — flagging it as unfinished rather than claiming a clean suite.

## Follow-ups (not in this PR)

- Already-generated `BoardPrintable` PDFs stay stale; they regenerate on the printables pipeline's next run. I didn't re-render paid artefacts as a drive-by.
- Worth a look separately: how these rows got `""` instead of `NULL`. The "remove picture" paths write `nil`, so the empty string arrives from somewhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)