### PR TITLE
feat(myspeak): serve care labels instead of leaving them frontend-only

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -144,6 +144,37 @@ the free-text bio.
   frontend previously carried a hand-copied duplicate, and since
   `sanitize_care_settings` DROPS an unrecognized key rather than rejecting it, a
   rename deleted that answer from every profile with no error and no 422.
+- **The LABELS are served too, and the backend owns them.** `CareLabels`
+  (`app/services/care_labels.rb`) resolves a section / field / option key
+  against `config/locales/care.{en,es}.yml`; `care_registry_view` emits them as
+  `label` on each section and field plus an `option_labels` hash on each select
+  field. Ported verbatim from the frontend locale files, which were the only
+  place they existed — meaning nothing server-side could render care data for a
+  human, and a printed sheet can't say "Braces or afos".
+  - **Labels are ADDITIVE and must stay that way.** `options` stays an array of
+    plain strings because the deployed frontend parses it with `asStringList`,
+    which returns `[]` for objects — promoting options to `{key, label}` would
+    empty every section in the live editor. New information goes in sibling
+    keys, never by changing the shape of an existing one.
+  - **`option_labels` is deliberately wider than `options`:** offered ∪ retired
+    (`accepted_care_options`). A retired option is still stored on real profiles
+    and still has to render; it just must never be offered.
+  - The fallback is a hand-written `CareLabels.humanize`, not `String#humanize`
+    — the latter strips a trailing `_id` and consults inflections, so Ruby and
+    TypeScript could disagree on exactly the unlabeled keys where the fallback
+    is the only thing running.
+  - `spec/services/care_labels_spec.rb` fails the build if any section, field,
+    or accepted option lacks a label. It reads the raw `I18n.backend`
+    translation store rather than `I18n.exists?`/`I18n.t`, both of which follow
+    `config.i18n.fallbacks` — `I18n.exists?("care.sections.mobility", :fr)` is
+    **true** purely because `:fr` falls back to `:en`, which would make the
+    whole sweep a test that English exists. An anti-vacuity example asserts a
+    care-label-less locale still reports missing.
+  - The payload is locale-dependent, so `GET /api/care_sections` is
+    `expires_in 1.hour, public: false` — a shared cache keyed on the path alone
+    would hand a Spanish registry to an English client. `?locale=` is
+    whitelisted against `I18n.available_locales`, never symbolized from raw
+    params.
 - **Retiring an option is a TWO-STEP process, and step one is one line.**
   `Profile::DEPRECATED_CARE_OPTIONS` maps
   `section => field => { retired_key => replacement_or_nil }`. Adding a key

--- a/app/controllers/api/care_sections_controller.rb
+++ b/app/controllers/api/care_sections_controller.rb
@@ -6,9 +6,22 @@ class API::CareSectionsController < API::ApplicationController
   skip_before_action :authenticate_token!, only: %i[index]
 
   def index
-    # Static for the life of a deploy — safe to let clients and any proxy hold
-    # on to it. Changing CARE_SECTIONS ships a new deploy, which busts this.
-    expires_in 1.hour, public: true
-    render json: Profile.care_registry_view
+    # `private`, not `public`, since labels made this payload locale-dependent:
+    # a shared cache keyed on the path alone would hand a Spanish registry to
+    # an English client. Costs little — the client memoizes it per session.
+    expires_in 1.hour, public: false
+    render json: Profile.care_registry_view(locale: requested_locale)
+  end
+
+  private
+
+  # Whitelisted against available_locales rather than symbolized straight from
+  # the params — an unbounded `to_sym` on user input both grows the symbol
+  # table and lets an arbitrary string reach I18n.
+  def requested_locale
+    requested = params[:locale].to_s
+    return I18n.default_locale if requested.blank?
+
+    I18n.available_locales.find { |l| l.to_s == requested } || I18n.default_locale
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -731,16 +731,41 @@ class Profile < ApplicationRecord
   #
   # Sections are an ARRAY, not a hash: CARE_SECTIONS is insertion-ordered and
   # that order is the order the editor renders in.
-  def self.care_registry_view
+  #
+  # Labels ride along too, resolved through CareLabels — the backend owns the
+  # display strings as well as the schema now, so a server-rendered care sheet
+  # and the on-screen card read identically and there is no second copy to
+  # drift. See config/locales/care.en.yml.
+  #
+  # LABELS ARE ADDITIVE, AND MUST STAY THAT WAY. `options` is an array of plain
+  # STRINGS and has to remain one: the deployed frontend parses it with
+  # `asStringList(field?.options)` (src/data/careSections.ts), which yields []
+  # for an array of objects — every section would silently lose its choices and
+  # fall back to the bundled copy. So labels arrive as SIBLING keys (`label`,
+  # `option_labels`) that an older client simply ignores.
+  def self.care_registry_view(locale: I18n.locale)
     {
+      locale: locale.to_s,
       sections: CARE_SECTIONS.map do |key, spec|
         {
           key: key,
+          label: CareLabels.section(key, locale: locale),
           fields: spec[:fields].map do |field|
-            out = { key: field[:key], type: field[:type] }
-            # Offered, not accepted: a retired option stays valid on save but is
-            # never presented as a fresh choice.
-            out[:options] = offered_care_options(key, field) if field[:options]
+            out = {
+              key: field[:key],
+              type: field[:type],
+              label: CareLabels.field(key, field[:key], locale: locale),
+            }
+            if field[:options]
+              # Offered, not accepted: a retired option stays valid on save but is
+              # never presented as a fresh choice.
+              out[:options] = offered_care_options(key, field)
+              # Labels, though, cover ACCEPTED — offered plus retired. A retired
+              # option is still stored on real profiles and still has to render;
+              # it just must never be offered. So this map is deliberately the
+              # wider of the two.
+              out[:option_labels] = CareLabels.options_map(key, field, locale: locale)
+            end
             out
           end,
         }

--- a/app/services/care_labels.rb
+++ b/app/services/care_labels.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Resolves Profile::CARE_SECTIONS keys to human-readable text.
+#
+# The schema (Profile::CARE_SECTIONS) stores only keys — `what_helps`,
+# `thickened_liquids`. This is the single place those become words, for both
+# the served registry (Profile.care_registry_view) and anything that renders
+# care data server-side. Strings live in config/locales/care.{en,es}.yml.
+#
+# Mirrors the resolution in the frontend's CareModal.tsx, deliberately:
+# `sections.<key>`, `fields.<section>.<field>`, `options.<section>.<field>.<option>`,
+# each falling back to a humanized key. Same key shape, same fallback, so the
+# printed sheet and the on-screen card can't disagree.
+module CareLabels
+  class << self
+    def section(key, locale: I18n.locale)
+      translate("care.sections.#{key}", key, locale)
+    end
+
+    def field(section_key, field_key, locale: I18n.locale)
+      translate("care.fields.#{section_key}.#{field_key}", field_key, locale)
+    end
+
+    # An option key is only unique per section AND field — `meals.equipment`
+    # and `mobility.equipment` are different fields with entirely different
+    # option sets. Never key an option label on the option alone.
+    def option(section_key, field_key, option_key, locale: I18n.locale)
+      translate(
+        "care.options.#{section_key}.#{field_key}.#{option_key}",
+        option_key,
+        locale,
+      )
+    end
+
+    # Every ACCEPTED option for a field, labeled — offered plus anything
+    # retired into DEPRECATED_CARE_OPTIONS. A retired option is no longer
+    # offered as a fresh choice but is still stored on real profiles and still
+    # has to render, so the label map is wider than the option list.
+    def options_map(section_key, field, locale: I18n.locale)
+      Profile.accepted_care_options(section_key, field).index_with do |option_key|
+        option(section_key, field[:key], option_key, locale: locale)
+      end
+    end
+
+    # Deliberately NOT String#humanize: that strips a trailing `_id` and
+    # consults ActiveSupport inflections, so Ruby and TypeScript could disagree
+    # on exactly the keys nobody has labeled yet — which is the only time the
+    # fallback runs. This is a transliteration of the frontend's humanize().
+    def humanize(key)
+      spaced = key.to_s.tr("_", " ").strip
+      return spaced if spaced.empty?
+
+      spaced[0].upcase + spaced[1..]
+    end
+
+    private
+
+    # `default:` rather than a rescue so a missing key is a fallback, not an
+    # exception — an unlabeled option must still render as something true
+    # rather than blanking the row it sits in.
+    def translate(path, fallback_key, locale)
+      I18n.t(path, locale: locale, default: humanize(fallback_key))
+    end
+  end
+end

--- a/config/locales/care.en.yml
+++ b/config/locales/care.en.yml
@@ -1,0 +1,145 @@
+# Human-readable labels for Profile::CARE_SECTIONS.
+#
+# The backend owns the care SCHEMA (Profile::CARE_SECTIONS, #673 "serve the
+# care schema instead of duplicating it") but stored only keys — `what_helps`,
+# `thickened_liquids`. The display strings lived solely in the frontend, at
+# src/locales/{en,es}.json under marketing.publicProfile.care.*, so nothing
+# server-side could render care data for a human. Humanizing a key is not good
+# enough for a printed sheet a parent hands to a school office: `aac_device`
+# humanizes to "Aac device" and `braces_or_afos` to "Braces or afos".
+#
+# So labels follow the schema. These were ported verbatim from the frontend
+# locale files and are now served on GET /api/care_sections, which makes this
+# side the source of truth for both.
+#
+# Every section, field, and ACCEPTED option (offered, plus anything retired
+# into Profile::DEPRECATED_CARE_OPTIONS) needs an entry here —
+# spec/services/care_labels_spec.rb fails the build otherwise. A retired
+# option is still stored on real profiles and still has to render.
+#
+# Resolve through CareLabels, never I18n.t directly, so the humanize fallback
+# stays identical to the frontend's.
+en:
+  care:
+    sections:
+      communication: Communication
+      personal_care: Personal care
+      meals: Meals & snacks
+      sensory: Sensory
+      mobility: Moving around
+      transportation: Getting around
+    fields:
+      communication:
+        methods: How I communicate
+        what_helps: What helps me
+      personal_care:
+        toileting: Toileting
+        schedule: Schedule
+        hygiene: Help with hygiene
+        dressing: Dressing
+      meals:
+        eating: What helps at meals
+        textures: Textures
+        equipment: Utensils & cups
+        preferences: Preferences
+      sensory:
+        sound: Sound
+        touch: Touch
+        light: Light
+        calming: What helps when it's too much
+      mobility:
+        equipment: Equipment I use
+        support: Help I need moving around
+      transportation:
+        school_travel: To & from school
+        seating: Seating
+        bus_info: Bus info
+    options:
+      communication:
+        methods:
+          aac_device: AAC device
+          aac_book: AAC book
+          sign: Sign
+          gestures: Gestures
+          some_speech: Some speech
+          eye_gaze: Eye gaze
+          partner_assisted: Partner assisted
+        what_helps:
+          keep_my_device_close: Keep my device close
+          model_on_my_device: Model on my device
+          wait_and_pause: Wait and pause
+          offer_choices: Offer choices
+      personal_care:
+        toileting:
+          independent: Independent
+          needs_reminders: Needs reminders
+          needs_help: Needs help
+          toilet_training: Toilet training
+          pull_ups: Pull-ups
+          diapers: Diapers
+        schedule:
+          on_request: On request
+          scheduled_times: Scheduled times
+        hygiene:
+          handwashing: Handwashing
+          toothbrushing: Toothbrushing
+          face_and_hands: Face and hands
+          hair_brushing: Hair brushing
+        dressing:
+          independent: Independent
+          some_help: Some help
+          full_help: Full help
+      meals:
+        eating:
+          food_cut_up: Food cut up
+          needs_supervision: Needs supervision
+          fed_by_an_adult: Fed by an adult
+          tube_fed: Tube fed
+        textures:
+          regular: Regular
+          soft: Soft
+          chopped: Chopped
+          pureed: Pureed
+          thickened_liquids: Thickened liquids
+        equipment:
+          fork_and_spoon: Fork and spoon
+          fingers: Fingers
+          adapted_utensils: Adapted utensils
+          specific_cup: Specific cup
+      sensory:
+        sound:
+          loud_noises_hurt: Loud noises hurt
+          uses_ear_defenders: Uses ear defenders
+          warn_before_alarms: Warn me before alarms
+          likes_music: Likes music
+        touch:
+          ask_before_touching: Ask before touching
+          dislikes_light_touch: Dislikes light touch
+          likes_deep_pressure: Likes deep pressure
+        light:
+          bright_light_hurts: Bright light hurts
+          flickering_bothers: Flickering bothers me
+          prefers_dim: Prefers dim light
+      mobility:
+        equipment:
+          wheelchair: Wheelchair
+          walker_or_gait_trainer: Walker or gait trainer
+          braces_or_afos: Braces or AFOs
+          cane_or_crutches: Cane or crutches
+        support:
+          independent: Independent
+          standby_supervision: Standby supervision
+          hands_on_help: Hands-on help
+          help_with_transfers: Help with transfers
+      transportation:
+        school_travel:
+          bus: Bus
+          car_rider: Car rider
+          walks: Walks
+          wheelchair_van: Wheelchair van
+          parent_pickup: Parent pickup
+        seating:
+          harness: Harness
+          car_seat: Car seat
+          booster: Booster
+          wheelchair_securement: Wheelchair securement

--- a/config/locales/care.es.yml
+++ b/config/locales/care.es.yml
@@ -1,0 +1,145 @@
+# Human-readable labels for Profile::CARE_SECTIONS.
+#
+# The backend owns the care SCHEMA (Profile::CARE_SECTIONS, #673 "serve the
+# care schema instead of duplicating it") but stored only keys — `what_helps`,
+# `thickened_liquids`. The display strings lived solely in the frontend, at
+# src/locales/{en,es}.json under marketing.publicProfile.care.*, so nothing
+# server-side could render care data for a human. Humanizing a key is not good
+# enough for a printed sheet a parent hands to a school office: `aac_device`
+# humanizes to "Aac device" and `braces_or_afos` to "Braces or afos".
+#
+# So labels follow the schema. These were ported verbatim from the frontend
+# locale files and are now served on GET /api/care_sections, which makes this
+# side the source of truth for both.
+#
+# Every section, field, and ACCEPTED option (offered, plus anything retired
+# into Profile::DEPRECATED_CARE_OPTIONS) needs an entry here —
+# spec/services/care_labels_spec.rb fails the build otherwise. A retired
+# option is still stored on real profiles and still has to render.
+#
+# Resolve through CareLabels, never I18n.t directly, so the humanize fallback
+# stays identical to the frontend's.
+es:
+  care:
+    sections:
+      communication: Communication
+      personal_care: Personal care
+      meals: Meals & snacks
+      sensory: Sensorial
+      mobility: Moving around
+      transportation: Getting around
+    fields:
+      communication:
+        methods: How I communicate
+        what_helps: What helps me
+      personal_care:
+        toileting: Toileting
+        schedule: Schedule
+        hygiene: Help with hygiene
+        dressing: Dressing
+      meals:
+        eating: What helps at meals
+        textures: Textures
+        equipment: Utensils & cups
+        preferences: Preferences
+      sensory:
+        sound: Sonido
+        touch: Tacto
+        light: Luz
+        calming: Qué ayuda cuando es demasiado
+      mobility:
+        equipment: Equipment I use
+        support: Help I need moving around
+      transportation:
+        school_travel: To & from school
+        seating: Seating
+        bus_info: Bus info
+    options:
+      communication:
+        methods:
+          aac_device: AAC device
+          aac_book: AAC book
+          sign: Sign
+          gestures: Gestures
+          some_speech: Some speech
+          eye_gaze: Eye gaze
+          partner_assisted: Partner assisted
+        what_helps:
+          keep_my_device_close: Keep my device close
+          model_on_my_device: Model on my device
+          wait_and_pause: Wait and pause
+          offer_choices: Offer choices
+      personal_care:
+        toileting:
+          independent: Independent
+          needs_reminders: Needs reminders
+          needs_help: Needs help
+          toilet_training: Toilet training
+          pull_ups: Pull-ups
+          diapers: Diapers
+        schedule:
+          on_request: On request
+          scheduled_times: Scheduled times
+        hygiene:
+          handwashing: Handwashing
+          toothbrushing: Toothbrushing
+          face_and_hands: Face and hands
+          hair_brushing: Hair brushing
+        dressing:
+          independent: Independent
+          some_help: Some help
+          full_help: Full help
+      meals:
+        eating:
+          food_cut_up: Food cut up
+          needs_supervision: Needs supervision
+          fed_by_an_adult: Fed by an adult
+          tube_fed: Tube fed
+        textures:
+          regular: Regular
+          soft: Soft
+          chopped: Chopped
+          pureed: Pureed
+          thickened_liquids: Thickened liquids
+        equipment:
+          fork_and_spoon: Fork and spoon
+          fingers: Fingers
+          adapted_utensils: Adapted utensils
+          specific_cup: Specific cup
+      sensory:
+        sound:
+          loud_noises_hurt: Los ruidos fuertes molestan
+          uses_ear_defenders: Usa orejeras
+          warn_before_alarms: Avísame antes de las alarmas
+          likes_music: Le gusta la música
+        touch:
+          ask_before_touching: Pregunta antes de tocar
+          dislikes_light_touch: No le gusta el roce suave
+          likes_deep_pressure: Le gusta la presión profunda
+        light:
+          bright_light_hurts: La luz brillante molesta
+          flickering_bothers: El parpadeo molesta
+          prefers_dim: Prefiere luz tenue
+      mobility:
+        equipment:
+          wheelchair: Wheelchair
+          walker_or_gait_trainer: Walker or gait trainer
+          braces_or_afos: Braces or AFOs
+          cane_or_crutches: Cane or crutches
+        support:
+          independent: Independent
+          standby_supervision: Standby supervision
+          hands_on_help: Hands-on help
+          help_with_transfers: Help with transfers
+      transportation:
+        school_travel:
+          bus: Bus
+          car_rider: Car rider
+          walks: Walks
+          wheelchair_van: Wheelchair van
+          parent_pickup: Parent pickup
+        seating:
+          harness: Harness
+          car_seat: Car seat
+          booster: Booster
+          wheelchair_securement: Wheelchair securement

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -95,6 +95,93 @@ RSpec.describe "API::CareSections", type: :request do
       end
     end
 
+    describe "labels" do
+      it "labels every section and field" do
+        get "/api/care_sections"
+        body = JSON.parse(response.body)
+
+        body["sections"].each do |section|
+          expect(section["label"]).to eq(CareLabels.section(section["key"]))
+
+          section["fields"].each do |field|
+            expect(field["label"]).to eq(CareLabels.field(section["key"], field["key"]))
+          end
+        end
+      end
+
+      # THE non-breaking assertion. The deployed frontend reads `options` with
+      # asStringList(), which returns [] for anything that isn't an array of
+      # strings — so promoting options to {key:, label:} objects would empty
+      # every section in the live editor. Labels must stay a sibling key.
+      it "keeps options as a flat array of strings" do
+        get "/api/care_sections"
+        body = JSON.parse(response.body)
+
+        options = body["sections"].flat_map { |s| s["fields"] }.filter_map { |f| f["options"] }
+
+        expect(options).to be_present
+        expect(options.flatten).to all(be_a(String))
+      end
+
+      it "omits option_labels for a short_text field, like options" do
+        get "/api/care_sections"
+        body = JSON.parse(response.body)
+
+        preferences = body["sections"]
+                      .find { |s| s["key"] == "meals" }["fields"]
+                      .find { |f| f["key"] == "preferences" }
+
+        expect(preferences).not_to have_key("option_labels")
+      end
+
+      # option_labels is deliberately WIDER than options: a retired option is
+      # no longer offered but is still stored on real profiles, so it still has
+      # to render. Stubbed because DEPRECATED_CARE_OPTIONS is empty today —
+      # the first real retirement must not be the first exercise of this path.
+      it "labels a retired option that options no longer offers" do
+        stub_const("Profile::DEPRECATED_CARE_OPTIONS",
+                   { "meals" => { "textures" => { "minced" => nil } } })
+
+        get "/api/care_sections"
+        textures = JSON.parse(response.body)["sections"]
+                       .find { |s| s["key"] == "meals" }["fields"]
+                       .find { |f| f["key"] == "textures" }
+
+        expect(textures["options"]).not_to include("minced")
+        expect(textures["option_labels"]).to include("minced" => "Minced")
+      end
+
+      it "serves Spanish labels when asked, and echoes the locale" do
+        get "/api/care_sections", params: { locale: "es" }
+        body = JSON.parse(response.body)
+
+        sound = body["sections"]
+                .find { |s| s["key"] == "sensory" }["fields"]
+                .find { |f| f["key"] == "sound" }
+
+        expect(body["locale"]).to eq("es")
+        expect(sound["option_labels"]["likes_music"]).to eq("Le gusta la música")
+      end
+
+      it "falls back to the default locale for an unknown or malformed one" do
+        ["kl", "", "../../etc/passwd"].each do |bogus|
+          get "/api/care_sections", params: { locale: bogus }
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)["locale"]).to eq(I18n.default_locale.to_s)
+        end
+      end
+
+      # The payload varies by locale now, so a shared/proxy cache keyed on the
+      # path alone would serve a Spanish registry to an English client.
+      it "is not publicly cacheable" do
+        get "/api/care_sections"
+
+        expect(response.headers["Cache-Control"]).to include("private")
+        expect(response.headers["Cache-Control"]).not_to include("public")
+      end
+    end
+
     # The payload's whole job is to be the thing the sanitizer will accept. If
     # these two ever disagree, the editor offers a choice that vanishes on save.
     it "offers only options sanitize_care_settings will keep" do

--- a/spec/services/care_labels_spec.rb
+++ b/spec/services/care_labels_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The care schema is served, so a CARE_SECTIONS edit reaches the editor without
+# a frontend deploy — but a label is not derived from a key, so the same edit
+# can silently ship an option that renders as "Braces or afos". This file is the
+# guard: every key the schema can produce must resolve to a real label, in every
+# locale, or the build fails naming the missing path.
+RSpec.describe CareLabels do
+  # The locales care labels are actually shipped in. I18n.available_locales
+  # lists twelve; the other ten have no care strings and legitimately fall back
+  # to English, so sweeping all of them would demand translations we aren't
+  # writing. Add a locale here when its care.<locale>.yml lands.
+  CARE_LOCALES = %i[en es].freeze
+
+  # Reads the raw translation store rather than I18n.exists? / I18n.t, both of
+  # which follow config.i18n.fallbacks. `I18n.exists?("care.sections.mobility",
+  # :fr)` is TRUE purely because :fr falls back to :en — so a fallback-aware
+  # check reports every locale as complete and this whole file becomes a test
+  # that English exists. Verified: with the store read below, :fr reports the
+  # key missing and :es reports it present.
+  def stored_label(path, locale)
+    I18n.backend.send(:init_translations) unless I18n.backend.initialized?
+
+    I18n.backend.translations[locale]&.dig(*path.split(".").map(&:to_sym))
+  end
+
+  def missing_keys_for(locale)
+    missing = []
+
+    Profile::CARE_SECTIONS.each do |section_key, spec|
+      section_path = "care.sections.#{section_key}"
+      missing << section_path if stored_label(section_path, locale).blank?
+
+      spec[:fields].each do |field|
+        field_path = "care.fields.#{section_key}.#{field[:key]}"
+        missing << field_path if stored_label(field_path, locale).blank?
+
+        # ACCEPTED, not offered: a retired option has left the registry but is
+        # still stored on real profiles and still has to render.
+        Profile.accepted_care_options(section_key, field).each do |option_key|
+          option_path = "care.options.#{section_key}.#{field[:key]}.#{option_key}"
+          missing << option_path if stored_label(option_path, locale).blank?
+        end
+      end
+    end
+
+    missing
+  end
+
+  CARE_LOCALES.each do |locale|
+    it "labels every section, field, and accepted option in :#{locale}" do
+      missing = missing_keys_for(locale)
+
+      expect(missing).to be_empty,
+                         "Missing care labels in :#{locale} —\n  #{missing.join("\n  ")}"
+    end
+  end
+
+  # Proves the sweep above is not vacuous. A locale we ship no care labels for
+  # must report them missing; if this ever goes green, the checker has started
+  # following fallbacks again and every other example here is worthless.
+  it "reports care labels as missing for a locale that has none" do
+    expect(missing_keys_for(:fr)).not_to be_empty
+  end
+
+  # The reverse sweep. A label left behind after a section or field is deleted
+  # is dead weight that reads as though the schema still has it.
+  it "has no label for a section that no longer exists" do
+    labeled = I18n.t("care.sections", locale: :en).keys.map(&:to_s)
+
+    expect(labeled - Profile::CARE_SECTIONS.keys).to be_empty
+  end
+
+  it "has no label for a field that no longer exists" do
+    orphans = I18n.t("care.fields", locale: :en).flat_map do |section_key, fields|
+      live = Profile::CARE_SECTIONS.dig(section_key.to_s, :fields)&.map { |f| f[:key] } || []
+      (fields.keys.map(&:to_s) - live).map { |f| "#{section_key}.#{f}" }
+    end
+
+    expect(orphans).to be_empty
+  end
+
+  describe "the retirement path" do
+    # DEPRECATED_CARE_OPTIONS is empty today (per #678, nothing was stranded by
+    # the preset reshape because no profile held care data yet). Stub it so the
+    # mechanism is tested rather than today's empty constant — the first real
+    # retirement must not be the first time this code path runs.
+    it "keeps labeling an option after it is retired out of the registry" do
+      field = Profile::CARE_SECTIONS.dig("meals", :fields).find { |f| f[:key] == "textures" }
+
+      stub_const("Profile::DEPRECATED_CARE_OPTIONS",
+                 { "meals" => { "textures" => { "minced" => nil } } })
+
+      expect(Profile.offered_care_options("meals", field)).not_to include("minced")
+      expect(Profile.accepted_care_options("meals", field)).to include("minced")
+      expect(described_class.options_map("meals", field)).to include("minced" => "Minced")
+    end
+  end
+
+  describe ".humanize" do
+    # Transliterated from the frontend's humanize() in CareModal.tsx rather
+    # than delegating to String#humanize, which strips a trailing _id and
+    # consults inflections. The two sides must agree on exactly the keys
+    # nobody has labeled — the only time either fallback runs.
+    it "upcases the first letter and replaces underscores" do
+      expect(described_class.humanize("keep_my_device_close")).to eq("Keep my device close")
+    end
+
+    it "does not strip a trailing _id the way String#humanize does" do
+      expect(described_class.humanize("parent_id")).to eq("Parent id")
+      expect("parent_id".humanize).to eq("Parent")
+    end
+
+    it "handles a blank key without raising" do
+      expect(described_class.humanize("")).to eq("")
+      expect(described_class.humanize(nil)).to eq("")
+    end
+  end
+
+  describe "resolution" do
+    it "resolves a section, field, and option to their labels" do
+      expect(described_class.section("mobility")).to eq("Moving around")
+      expect(described_class.field("communication", "what_helps")).to eq("What helps me")
+      expect(described_class.option("meals", "textures", "thickened_liquids"))
+        .to eq("Thickened liquids")
+    end
+
+    # `equipment` exists on both meals and mobility with entirely different
+    # options. Keying an option label on anything less than section + field
+    # would cross them.
+    it "scopes an option label to its section and field" do
+      expect(described_class.option("meals", "equipment", "specific_cup")).to eq("Specific cup")
+      expect(described_class.option("mobility", "equipment", "wheelchair")).to eq("Wheelchair")
+    end
+
+    it "falls back to a humanized key rather than blanking an unlabeled option" do
+      expect(described_class.option("meals", "textures", "extra_crunchy")).to eq("Extra crunchy")
+    end
+
+    it "resolves in Spanish where a translation exists" do
+      expect(described_class.option("sensory", "sound", "likes_music", locale: :es))
+        .to eq("Le gusta la música")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Profile::CARE_SECTIONS` stores only keys — `what_helps`, `thickened_liquids`, `braces_or_afos`. The human strings existed **only** in the frontend, at `src/locales/{en,es}.json` under `marketing.publicProfile.care.*`. Rails had none.

That means nothing server-side can render care data for a person. Humanizing a key isn't good enough for anything printed and handed to a school office — `aac_device` → "Aac device", `braces_or_afos` → "Braces or afos".

#673 made the backend the source of truth for the care **schema**, precisely because a hand-copied frontend duplicate drifted silently and `sanitize_care_settings` deletes an unrecognized key with no error. Labels follow the schema for exactly the same reason.

Groundwork for the Care Plan PDF. **No user-visible change**, hence no CHANGELOG entry.

## What's here

- **`config/locales/care.{en,es}.yml`** — ported verbatim from the frontend locale files. Generated by script rather than retyped, so the port is provably faithful. The Spanish file inherits the frontend's partly-untranslated state as-is; inventing translations here would be worse than carrying the honest gap.
- **`CareLabels`** — the single resolver (`section` / `field` / `option` / `options_map`). Same key shape and same fallback as the frontend's `CareModal.tsx`, so the printed sheet and the on-screen card can't disagree.
- **`Profile.care_registry_view`** now serves labels, and **`GET /api/care_sections`** takes a whitelisted `?locale=`.

## The two things worth reviewing carefully

**1. Labels are additive, deliberately.** `options` stays an array of plain strings. The deployed frontend parses it with `asStringList(field?.options)`, which returns `[]` for an array of objects — so promoting options to `{key, label}` would silently empty every section in the live editor until a frontend deploy caught up. Labels arrive as sibling keys (`label`, `option_labels`) that an older client ignores.

The proof: **the pre-existing `care_sections_spec.rb` assertions pass untouched**, including the one pinning `field["options"] == Profile.offered_care_options(...)`. A new example asserts options are all `String` so this can't regress.

**2. `option_labels` is wider than `options`** — accepted (offered ∪ retired), not offered. A retired option has left the registry but is still stored on real profiles and still has to render; it just must never be offered as a fresh choice. Tested with a stubbed `DEPRECATED_CARE_OPTIONS`, since the constant is empty today — the first real retirement shouldn't be the first time that path runs.

## A trap this PR had to route around

My first version of the completeness spec used `I18n.exists?(key, locale)` and passed for all twelve `available_locales` — including `:fr`, `:ko`, `:ja`, which have no care strings at all.

`I18n.exists?` **follows `config.i18n.fallbacks`**. `I18n.exists?("care.sections.mobility", :fr)` is `true` purely because `:fr` falls back to `:en`. The sweep had degenerated into "does English exist", and would have passed with `care.es.yml` deleted entirely.

The spec now reads the raw `I18n.backend.translations` store, scopes to the locales we actually ship care labels for, and carries an **anti-vacuity example** asserting that a locale with no care labels still reports them missing — if that ever goes green, the checker has started following fallbacks again and every other example in the file is worthless.

## Test plan

```
bundle exec rspec spec/services/care_labels_spec.rb spec/requests/api/care_sections_spec.rb
# 28 examples, 0 failures

bundle exec rspec spec/models/care_preset_reshape_spec.rb \
  spec/models/care_option_retirement_spec.rb \
  spec/requests/api/profiles_care_view_spec.rb
# 42 examples, 0 failures
```

New coverage: every section/field/accepted option is labeled in `en` and `es`; reverse sweep for labels orphaned by a deleted section or field; the retirement path; `humanize` divergence from `String#humanize`; option labels scoped per section+field (`meals.equipment` vs `mobility.equipment`); `?locale=es`; unknown/malformed locale falls back without raising; `Cache-Control: private`.

## Follow-up (not this PR)

`careSections.ts` / `CareModal.tsx` can drop their own label lookups in favour of the served ones, deleting the last copy. Worth an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)