### PR TITLE
fix(myspeak): condense the care plan onto half a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   medical detail. Both carry a QR code back to the live page, because paper
   goes out of date and the page doesn't.
 
+  It's built to stay short. A typical profile comes out at about half a page,
+  so it can go on a fridge or in a substitute teacher's folder without being a
+  stack — the emergency details sit in two columns, the day-to-day sections
+  flow in two more, and emergency questions you left blank are summed up in a
+  single line ("No allergies, conditions, medications, or notes were
+  provided") instead of taking a row each. Longer plans keep flowing onto as
+  many pages as they need; nothing is ever cut off to make it fit.
+
   Downloads live under **Print & share** on the communicator's page, and only
   the owner can generate them — they're never offered on the public MySpeak
   page. If you haven't filled in any care sections yet there's nothing to

--- a/app/services/communicators/care_plan_document.rb
+++ b/app/services/communicators/care_plan_document.rb
@@ -34,6 +34,17 @@ module Communicators
       emergency_notes
     ].freeze
 
+    # When false, blank emergency fields print as "None listed" on their own row
+    # — see the note in .claude-notes/care-plan-pdf-density-handoff.md before
+    # flipping this.
+    #
+    # The trade it makes: a reader in an emergency cannot distinguish "this child
+    # has no allergies" from "nobody filled in the allergies field" once the
+    # field is absent. #blank_emergency_field_names exists so the template can
+    # print one muted line naming what went unanswered, which keeps the honest
+    # signal at the cost of a line instead of ten.
+    OMIT_BLANK_EMERGENCY_FIELDS = true
+
     def initialize(profile, locale: I18n.locale)
       @profile = profile
       @locale = locale
@@ -49,18 +60,25 @@ module Communicators
       care_sections.any?
     end
 
-    # Emergency values, blanks included. Unlike the care sections, a blank
-    # emergency field is NOT omitted: "Allergies — none listed" and a missing
-    # Allergies heading read very differently to someone holding a distressed
-    # child, and only one of them is honest about having been asked.
+    # The emergency fields worth printing. Blank ones are dropped under
+    # OMIT_BLANK_EMERGENCY_FIELDS and named collectively by
+    # #blank_emergency_field_names instead.
     def emergency_fields
-      EMERGENCY_FIELDS.map do |key|
-        Field.new(
-          key: key,
-          label: I18n.t("care.document.emergency.#{key}", locale: locale),
-          type: :short_text,
-          values: [settings[key].to_s.strip.presence].compact,
-        )
+      fields = all_emergency_fields
+      return fields unless OMIT_BLANK_EMERGENCY_FIELDS
+
+      fields.select { |field| field.values.any? }
+    end
+
+    # Short, lowercase names for the emergency fields nobody answered, in
+    # EMERGENCY_FIELDS order — the template joins them into the one muted line
+    # that replaces ten "None listed" rows. Empty when nothing is being omitted,
+    # so the template needs no second condition.
+    def blank_emergency_field_names
+      return [] unless OMIT_BLANK_EMERGENCY_FIELDS
+
+      all_emergency_fields.reject { |field| field.values.any? }.map do |field|
+        I18n.t("care.document.emergency.blank_names.#{field.key}", locale: locale)
       end
     end
 
@@ -73,6 +91,17 @@ module Communicators
     end
 
     private
+
+    def all_emergency_fields
+      @all_emergency_fields ||= EMERGENCY_FIELDS.map do |key|
+        Field.new(
+          key: key,
+          label: I18n.t("care.document.emergency.#{key}", locale: locale),
+          type: :short_text,
+          values: [settings[key].to_s.strip.presence].compact,
+        )
+      end
+    end
 
     def settings
       @settings ||= profile.settings.is_a?(Hash) ? profile.settings : {}

--- a/app/services/communicators/generate_care_plan.rb
+++ b/app/services/communicators/generate_care_plan.rb
@@ -127,6 +127,7 @@ module Communicators
         # Resolved to a data: URI here, BEFORE the render, so the render itself
         # stays hermetic — the layout's no-network rule holds.
         avatar_data_url: avatar_data_url,
+        logo: logo_base64,
         public_url: public_url,
         qr_data_url: qr_data_url_for(public_url),
         emergency: config[:emergency],

--- a/app/services/communicators/generate_care_plan.rb
+++ b/app/services/communicators/generate_care_plan.rb
@@ -23,7 +23,9 @@ module Communicators
     # documents already generated. safety_info_signature only moves when the
     # PROFILE changes, so without this a redesign leaves every cached PDF stale
     # forever — a gap the existing card generators still have.
-    LAYOUT_VERSION = 1
+    # 2: condensed layout — merged header band, two-column emergency grid,
+    #    omitted blank emergency fields, two-column care sections.
+    LAYOUT_VERSION = 2
 
     VARIANTS = {
       full: { attachment: :care_emergency_plan_pdf, filename: "care-and-emergency-plan", emergency: true },
@@ -110,12 +112,11 @@ module Communicators
 
     def template_assigns
       {
+        # No subtitle: the condensed band carries title · prepared-on · URL on
+        # one 7.5pt meta line, and "How to support Rosa day to day" is the one
+        # line on the old sheet a reader already knows. care.document.subtitle
+        # is left in the locale files for whoever brings it back.
         title: I18n.t("care.document.title.#{variant}", locale: locale),
-        subtitle: I18n.t(
-          "care.document.subtitle.#{variant}",
-          name: profile.safety_display_name,
-          locale: locale,
-        ),
         prepared_on: I18n.t(
           "care.document.prepared_on",
           date: I18n.l(Date.current, format: :long, locale: locale),
@@ -126,11 +127,11 @@ module Communicators
         # Resolved to a data: URI here, BEFORE the render, so the render itself
         # stays hermetic — the layout's no-network rule holds.
         avatar_data_url: avatar_data_url,
-        logo: logo_base64,
         public_url: public_url,
         qr_data_url: qr_data_url_for(public_url),
         emergency: config[:emergency],
         emergency_fields: config[:emergency] ? document.emergency_fields : [],
+        blank_emergency_field_names: config[:emergency] ? document.blank_emergency_field_names : [],
         emergency_contacts: config[:emergency] ? document.emergency_contacts : [],
         care_sections: document.care_sections,
       }

--- a/app/views/communicators/assets/_care_plan_row.html.erb
+++ b/app/views/communicators/assets/_care_plan_row.html.erb
@@ -1,14 +1,9 @@
-<%# One resolved care field. Select values render as chips (they're a picked
-    set); short_text renders as the parent's own sentence, verbatim. %>
+<%# One resolved care field, on one line: an uppercase label inline with its
+    value. Picked sets join with commas rather than "and" — this is a list of
+    what applies, not a sentence — and CareLabels already sentence-cases each
+    option. short_text is the parent's own words and prints verbatim.
+
+    The chip treatment is the commented-out alternative in the layout. %>
 <div class="row">
-  <div class="label"><%= field.label %></div>
-  <% if field.type == :short_text %>
-    <div class="value"><%= field.values.first %></div>
-  <% else %>
-    <div class="chips">
-      <% field.values.each do |value| %>
-        <span class="chip"><%= value %></span>
-      <% end %>
-    </div>
-  <% end %>
+  <span class="label"><%= field.label %></span><span class="value"><%= field.type == :short_text ? field.values.first : field.values.join(", ") %></span>
 </div>

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -11,17 +11,10 @@
     sections — it is what someone reaches for in a hurry, and it should not be
     on page 2. %>
 
-<div class="masthead">
-  <div>
-    <div class="eyebrow">SpeakAnyWay</div>
-    <h1><%= @title %></h1>
-  </div>
-  <% if @logo.present? %>
-    <img class="logo" src="data:image/png;base64,<%= @logo %>" alt="" />
-  <% end %>
-</div>
-
-<div class="identity">
+<%# One band, not a masthead plus an identity row. The public URL rides in the
+    meta line as plain text, which is what lets the QR come down to 44pt — the
+    sheet still works for someone without a phone camera out. %>
+<div class="band">
   <% if @avatar_data_url.present? %>
     <img class="avatar" src="<%= @avatar_data_url %>" alt="" />
   <% else %>
@@ -29,115 +22,82 @@
   <% end %>
 
   <div class="who">
-    <h2><%= @display_name %></h2>
-    <div class="sub"><%= @subtitle %></div>
+    <div class="eyebrow">SpeakAnyWay</div>
+    <h1><%= @display_name %></h1>
     <div class="meta">
-      <%= @prepared_on %><% if @pronouns.present? %> · <%= @pronouns %><% end %>
+      <%= @title %> · <%= @prepared_on %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>
     </div>
   </div>
 
   <% if @qr_data_url.present? %>
-    <div class="qr">
-      <img src="<%= @qr_data_url %>" alt="" />
-      <div class="url"><%= @public_url %></div>
-    </div>
+    <div class="qr"><img src="<%= @qr_data_url %>" alt="" /></div>
   <% end %>
 </div>
 
 <% if @emergency %>
-  <%# The emergency block always prints every field, blanks included. A missing
-      "Medications" heading and "Medications — none listed" read very
-      differently to someone holding a distressed child, and only one of them is
-      honest about having been asked. This is the same choice the safety ID card
-      already makes. %>
+  <%# Blank emergency fields are OMITTED and named collectively in the muted
+      line below — see CarePlanDocument::OMIT_BLANK_EMERGENCY_FIELDS, which is
+      the one line to flip to get the per-field "None listed" rows back. %>
   <section class="emergency">
-    <div class="section-keep">
-      <h2><%= t("care.document.emergency.heading") %></h2>
+    <h2><%= t("care.document.emergency.heading") %></h2>
 
-      <% first, *rest = @emergency_fields %>
-      <% if first %>
-        <div class="row">
-          <div class="label"><%= first.label %></div>
-          <div class="value">
-            <%= first.values.first.presence || content_tag(:span, t("care.document.none_listed"), class: "muted") %>
-          </div>
+    <div class="egrid">
+      <% @emergency_fields.each do |field| %>
+        <%# Free-text notes run long enough to want the full width. %>
+        <div class="f<%= " wide" if field.key == "emergency_notes" %>">
+          <span class="k"><%= field.label %></span><%= field.values.first %>
+        </div>
+      <% end %>
+
+      <% if @blank_emergency_field_names.any? %>
+        <div class="not-provided">
+          <%= t(
+                "care.document.emergency.not_provided",
+                fields: @blank_emergency_field_names.to_sentence(
+                  words_connector: t("care.document.emergency.blank_names_connectors.words_connector"),
+                  two_words_connector: t("care.document.emergency.blank_names_connectors.two_words_connector"),
+                  last_word_connector: t("care.document.emergency.blank_names_connectors.last_word_connector"),
+                ),
+              ) %>
         </div>
       <% end %>
     </div>
 
-    <% rest.each do |field| %>
-      <div class="row">
-        <div class="label"><%= field.label %></div>
-        <div class="value">
-          <%= field.values.first.presence || content_tag(:span, t("care.document.none_listed"), class: "muted") %>
-        </div>
-      </div>
-    <% end %>
-
     <div class="contacts">
-      <h3><%= t("care.document.emergency.contacts") %></h3>
       <% if @emergency_contacts.any? %>
         <% @emergency_contacts.each do |contact| %>
           <div class="contact">
-            <div>
-              <div class="name"><%= contact["name"].presence || t("care.document.emergency.relationship_unknown") %></div>
-              <% if contact["relationship"].present? %>
-                <div class="rel"><%= contact["relationship"] %></div>
-              <% end %>
-            </div>
-            <div class="phone"><%= contact["phone"] %></div>
+            <span class="name"><%= contact["name"].presence || t("care.document.emergency.relationship_unknown") %></span><% if contact["relationship"].present? %> <span class="rel">· <%= contact["relationship"] %></span><% end %> — <span class="phone"><%= contact["phone"] %></span>
           </div>
         <% end %>
       <% else %>
-        <div class="muted"><%= t("care.document.emergency.no_contacts") %></div>
+        <div class="contact muted"><%= t("care.document.emergency.no_contacts") %></div>
       <% end %>
     </div>
   </section>
 <% end %>
 
 <% if @care_sections.any? %>
-  <% @care_sections.each_with_index do |section, index| %>
-    <section class="care-section<%= " first" if index.zero? %>">
-      <%# Heading welded to its first row so a section can never open with its
-          title stranded alone at the foot of a page. Everything after this
-          flows — see the layout comment on why the whole section is not
-          break-inside: avoid.
+  <%# The heading sits above the loop, outside .cols. It can no longer strand at
+      the foot of a page: what follows it is a two-column flow, not one tall
+      element. %>
+  <div class="care-heading"><%= t("care.document.care_heading") %></div>
 
-          The "Day-to-day support" divider lives INSIDE the first section's
-          keep block rather than above the loop. Rendered as its own element it
-          was landing alone at the foot of page 1 with the first section
-          starting overleaf — verified in a real render, which is the only
-          place a break like that is visible. %>
-      <% first_row = section.fields.first %>
-      <div class="section-keep">
-        <% if index.zero? %>
-          <div class="care-heading"><%= t("care.document.care_heading") %></div>
+  <div class="cols">
+    <% @care_sections.each do |section| %>
+      <section class="care-section">
+        <h3><%= section.label %></h3>
+
+        <% section.fields.each do |field| %>
+          <%= render "communicators/assets/care_plan_row", field: field %>
         <% end %>
-        <h2><%= section.label %></h2>
 
-        <% if first_row %>
-          <%= render "communicators/assets/care_plan_row", field: first_row %>
-        <% elsif section.items.first %>
-          <div class="items">
-            <%= render "communicators/assets/care_plan_item", item: section.items.first %>
-          </div>
+        <% section.items.each do |item| %>
+          <%= render "communicators/assets/care_plan_item", item: item %>
         <% end %>
-      </div>
-
-      <% section.fields.drop(1).each do |field| %>
-        <%= render "communicators/assets/care_plan_row", field: field %>
-      <% end %>
-
-      <% remaining_items = first_row ? section.items : section.items.drop(1) %>
-      <% if remaining_items.any? %>
-        <div class="items">
-          <% remaining_items.each do |item| %>
-            <%= render "communicators/assets/care_plan_item", item: item %>
-          <% end %>
-        </div>
-      <% end %>
-    </section>
-  <% end %>
+      </section>
+    <% end %>
+  </div>
 <% end %>
 
 <div class="footnote">

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -25,11 +25,7 @@
   <% end %>
 
   <div class="who">
-    <div class="eyebrow">
-      <% if @logo.present? %>
-        <img src="data:image/png;base64,<%= @logo %>" alt="" />
-      <% end %>SpeakAnyWay
-    </div>
+    <div class="eyebrow">SpeakAnyWay</div>
     <h1><%= @display_name %></h1>
     <div class="meta">
       <%= @title %> · <%= @prepared_on %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>
@@ -108,8 +104,13 @@
 <% end %>
 
 <div class="footnote">
-  <%= t("care.document.live_page") %>
-  <% if @emergency %>
-    <%= t("care.document.confidential") %>
+  <% if @logo.present? %>
+    <img class="mark" src="data:image/png;base64,<%= @logo %>" alt="" />
   <% end %>
+  <span>
+    <%= t("care.document.live_page") %>
+    <% if @emergency %>
+      <%= t("care.document.confidential") %>
+    <% end %>
+  </span>
 </div>

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -104,13 +104,13 @@
 <% end %>
 
 <div class="footnote">
-  <% if @logo.present? %>
-    <img class="mark" src="data:image/png;base64,<%= @logo %>" alt="" />
-  <% end %>
   <span>
     <%= t("care.document.live_page") %>
     <% if @emergency %>
       <%= t("care.document.confidential") %>
     <% end %>
   </span>
+  <% if @logo.present? %>
+    <img class="mark" src="data:image/png;base64,<%= @logo %>" alt="" />
+  <% end %>
 </div>

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -14,6 +14,9 @@
 <%# One band, not a masthead plus an identity row. The public URL rides in the
     meta line as plain text, which is what lets the QR come down to 44pt — the
     sheet still works for someone without a phone camera out. %>
+<%# Painted once per sheet by Chrome, not part of the flow — see .page-frame. %>
+<div class="page-frame"></div>
+
 <div class="band">
   <% if @avatar_data_url.present? %>
     <img class="avatar" src="<%= @avatar_data_url %>" alt="" />
@@ -22,7 +25,11 @@
   <% end %>
 
   <div class="who">
-    <div class="eyebrow">SpeakAnyWay</div>
+    <div class="eyebrow">
+      <% if @logo.present? %>
+        <img src="data:image/png;base64,<%= @logo %>" alt="" />
+      <% end %>SpeakAnyWay
+    </div>
     <h1><%= @display_name %></h1>
     <div class="meta">
       <%= @title %> · <%= @prepared_on %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -73,6 +73,10 @@
         background: #fff;
         font-size: 9.5pt;
         line-height: 1.4;
+        /* Clearance inside .page-frame — see the note there. The frame sits on
+           the page content box and cannot be pushed outward, so the content is
+           pulled inward instead. */
+        padding: 9pt 11pt;
       }
 
       @page { size: letter; }
@@ -87,6 +91,27 @@
          acceptable failure. Do not add `column-fill: auto`. */
       .care-section, .row, .item, .contact { break-inside: avoid; }
       p { orphans: 3; widows: 3; }
+
+      /* ---- Page frame ----
+         Repeats on EVERY page: Chrome paints a position:fixed element once per
+         sheet in the print path, and its insets resolve against the page's
+         content box — inside the @page margins Grover supplies. A bordered
+         wrapper div cannot do this. It fragments, so the top edge would draw
+         only on page 1 and the bottom edge only on the last, leaving the middle
+         sheets framed on two sides.
+
+         inset MUST be 0. Negative insets look like the way to buy breathing
+         room between the frame and the text, but Chrome clips the fixed layer
+         to the page content box and the frame then paints on NO page at all —
+         a silent no-op that looks like the CSS was ignored. The clearance comes
+         from body padding instead, which is why that padding is not decorative
+         and must not be tuned away. */
+      .page-frame {
+        position: fixed;
+        inset: 0;
+        border: 0.75pt solid var(--rule);
+        border-radius: 10pt;
+      }
 
       /* ---- Header band ----
          One gradient band carrying the masthead and the identity block that
@@ -112,12 +137,25 @@
         border: 2pt solid rgba(255, 255, 255, 0.7);
       }
       .band .who { flex: 1 1 auto; min-width: 0; }
+      /* Logo on a white pad, not straight onto the gradient: the mark is bright
+         cyan-to-magenta itself and disappears into a band of the same hues. */
       .band .eyebrow {
+        display: flex;
+        align-items: center;
+        gap: 4pt;
         font-size: 6.5pt;
         font-weight: 800;
         letter-spacing: 0.16em;
         text-transform: uppercase;
         opacity: 0.9;
+      }
+      .band .eyebrow img {
+        width: 11pt;
+        height: 11pt;
+        display: block;
+        background: #fff;
+        border-radius: 999pt;
+        padding: 1pt;
       }
       .band h1 { font-size: 16pt; font-weight: 900; line-height: 1.1; margin: 1pt 0 2pt; }
       .band .meta { font-size: 7.5pt; font-weight: 600; opacity: 0.92; }

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -103,9 +103,23 @@
          inset MUST be 0. Negative insets look like the way to buy breathing
          room between the frame and the text, but Chrome clips the fixed layer
          to the page content box and the frame then paints on NO page at all —
-         a silent no-op that looks like the CSS was ignored. The clearance comes
-         from body padding instead, which is why that padding is not decorative
-         and must not be tuned away. */
+         a silent no-op that looks like the CSS was ignored. Verified at -4pt,
+         not just at the larger values that might plausibly overflow the paper.
+
+         So the frame cannot move outward, and clearance has to come from the
+         content. Two different mechanisms are needed, because they cover
+         different pages:
+
+           page 1     body padding, below
+           every page .care-section padding-top, below
+
+         Body padding is laid out once, at the start of the flow, so it does
+         nothing for a page the document merely spills onto. A continuation
+         page begins at the page content box — flush against the frame — and
+         what lands there is always the top of a .care-section, since sections
+         are atomic. Padding on that box is what holds the text off the frame,
+         and it survives the fragmentation break where a margin would be
+         truncated. */
       .page-frame {
         position: fixed;
         inset: 0;
@@ -137,25 +151,12 @@
         border: 2pt solid rgba(255, 255, 255, 0.7);
       }
       .band .who { flex: 1 1 auto; min-width: 0; }
-      /* Logo on a white pad, not straight onto the gradient: the mark is bright
-         cyan-to-magenta itself and disappears into a band of the same hues. */
       .band .eyebrow {
-        display: flex;
-        align-items: center;
-        gap: 4pt;
         font-size: 6.5pt;
         font-weight: 800;
         letter-spacing: 0.16em;
         text-transform: uppercase;
         opacity: 0.9;
-      }
-      .band .eyebrow img {
-        width: 11pt;
-        height: 11pt;
-        display: block;
-        background: #fff;
-        border-radius: 999pt;
-        padding: 1pt;
       }
       .band h1 { font-size: 16pt; font-weight: 900; line-height: 1.1; margin: 1pt 0 2pt; }
       .band .meta { font-size: 7.5pt; font-weight: 600; opacity: 0.92; }
@@ -240,7 +241,12 @@
       .care-heading::after { content: ""; flex: 1; height: 1.5pt; background: var(--cyan); }
 
       .cols { column-count: 2; column-gap: 20pt; }
-      .care-section { margin-bottom: 8pt; }
+      /* padding-top, not margin-top: this is the clearance a section carries
+         onto a continuation page, where it starts flush against .page-frame.
+         A margin there would be truncated at the fragmentation break. It also
+         does duty as ordinary spacing between sections in a column, so the
+         margin below is trimmed to keep the rhythm even. */
+      .care-section { padding-top: 7pt; margin-bottom: 3pt; }
       .care-section h3 {
         font-size: 9.5pt;
         font-weight: 900;
@@ -289,12 +295,25 @@
 
       .muted { color: var(--muted); }
 
+      /* The logo sits here rather than in the band: on the gradient it needed a
+         white pad to stay legible against hues it shares, and down here on
+         white it needs nothing. Aligned to the first line of the note, not
+         centred on the block, so it doesn't drift when the note wraps. */
       .footnote {
         margin-top: 12pt;
         padding-top: 5pt;
         border-top: 0.75pt solid var(--rule);
         font-size: 7pt;
         color: var(--muted);
+        display: flex;
+        align-items: flex-start;
+        gap: 5pt;
+      }
+      .footnote .mark {
+        width: 13pt;
+        height: 13pt;
+        display: block;
+        flex: none;
       }
     </style>
   </head>

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -71,189 +71,191 @@
         font-family: Nunito, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
         color: var(--ink);
         background: #fff;
-        font-size: 10.5pt;
-        line-height: 1.45;
+        font-size: 9.5pt;
+        line-height: 1.4;
       }
 
       @page { size: letter; }
 
       /* ---- Page-break behaviour ----
 
-         Deliberately NOT `break-inside: avoid` on .care-section as a whole. A
-         built-in section can carry four fields plus eight detail lines of up to
-         200 characters, which comfortably exceeds a page — and an unbreakable
-         box taller than a page makes Chrome push the whole thing to the next
-         sheet and leave a dead half-page behind it.
-
-         Instead: keep the heading welded to its first row (.section-keep), and
-         let everything after that flow. break-after: avoid on a heading alone
-         has never been reliable in Chrome's print path; a wrapper with
-         break-inside: avoid is. The wrapper is the mechanism, the break-after
-         is only a hint. */
-      .section-keep { break-inside: avoid; }
-      .section-keep h2 { break-after: avoid; }
-      .row, .item, .contact { break-inside: avoid; }
+         A whole care section is atomic: `break-inside: avoid` on .care-section.
+         That is safe because a section is now half-width and its fields print
+         one line each — the tallest realistic one (Meals, four fields, one a
+         300-character short_text) is around 1.1in in a column. If one ever does
+         outgrow a column Chrome splits it rather than clipping it, which is the
+         acceptable failure. Do not add `column-fill: auto`. */
+      .care-section, .row, .item, .contact { break-inside: avoid; }
       p { orphans: 3; widows: 3; }
 
-      /* ---- Masthead ---- */
-      .masthead {
+      /* ---- Header band ----
+         One gradient band carrying the masthead and the identity block that
+         used to sit under it. The URL rides in .meta as plain text — these get
+         photocopied and handed to people who don't have a phone camera out —
+         which is what lets the QR shrink to a glanceable 44pt. */
+      .band {
         background: var(--brand-gradient);
         color: #fff;
-        padding: 14pt 18pt;
+        border-radius: 9pt;
+        padding: 9pt 12pt;
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        border-radius: 10pt;
+        gap: 11pt;
       }
-      .masthead .eyebrow {
-        font-size: 8pt;
-        font-weight: 800;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-        opacity: 0.92;
-      }
-      .masthead h1 { font-size: 19pt; font-weight: 900; line-height: 1.15; }
-      .masthead img.logo { height: 30pt; width: auto; display: block; }
-
-      /* ---- Identity ---- */
-      .identity {
-        display: flex;
-        gap: 14pt;
-        align-items: center;
-        padding: 14pt 0 12pt;
-        border-bottom: 1.5pt solid var(--rule);
-      }
-      .identity .avatar {
-        width: 74pt; height: 74pt;
+      .band .avatar,
+      .band .avatar-placeholder {
+        width: 46pt; height: 46pt;
         border-radius: 999pt;
+        flex: none;
         object-fit: cover;
-        border: 2.5pt solid var(--cyan);
         background: var(--cyan-tint);
-        flex: none;
+        border: 2pt solid rgba(255, 255, 255, 0.7);
       }
-      .identity .avatar-placeholder {
-        width: 74pt; height: 74pt;
-        border-radius: 999pt;
-        background: var(--cyan-tint);
-        border: 2.5pt solid var(--cyan);
-        flex: none;
-      }
-      .identity .who { flex: 1 1 auto; min-width: 0; }
-      .identity h2 { font-size: 17pt; font-weight: 900; line-height: 1.15; }
-      .identity .sub { color: var(--muted); font-size: 9.5pt; margin-top: 2pt; }
-      .identity .meta { color: var(--muted); font-size: 8.5pt; margin-top: 5pt; }
-
-      .qr { text-align: center; flex: none; width: 96pt; }
-      .qr img { width: 76pt; height: 76pt; display: block; margin: 0 auto; }
-      /* The URL is printed as text under the QR on purpose: these get
-         photocopied and handed to people who don't have a phone camera out. */
-      .qr .url {
+      .band .who { flex: 1 1 auto; min-width: 0; }
+      .band .eyebrow {
         font-size: 6.5pt;
-        color: var(--muted);
-        word-break: break-all;
-        line-height: 1.25;
-        margin-top: 3pt;
+        font-weight: 800;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        opacity: 0.9;
       }
+      .band h1 { font-size: 16pt; font-weight: 900; line-height: 1.1; margin: 1pt 0 2pt; }
+      .band .meta { font-size: 7.5pt; font-weight: 600; opacity: 0.92; }
+      .band .qr {
+        flex: none;
+        background: #fff;
+        border-radius: 5pt;
+        padding: 3pt;
+        line-height: 0;
+      }
+      .band .qr img { width: 44pt; height: 44pt; display: block; }
 
-      /* ---- Emergency block ---- */
+      /* ---- Emergency block ----
+         Two columns, each cell one line: label inline with its value. Long
+         free text (notes) spans both. */
       .emergency {
-        border: 2pt solid var(--alert);
-        border-radius: 8pt;
-        padding: 11pt 13pt 12pt;
-        margin-top: 14pt;
+        border: 1.5pt solid var(--alert);
+        border-radius: 7pt;
+        padding: 8pt 10pt;
+        margin-top: 10pt;
         background: var(--alert-tint);
       }
       .emergency h2 {
-        font-size: 12.5pt;
+        font-size: 10pt;
         font-weight: 900;
         color: var(--alert);
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        margin-bottom: 7pt;
-      }
-      .emergency .row { margin-bottom: 5pt; }
-      .emergency .row:last-child { margin-bottom: 0; }
-
-      .contacts { margin-top: 9pt; }
-      .contacts h3 {
-        font-size: 9pt;
-        font-weight: 800;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color: var(--alert);
         margin-bottom: 5pt;
-      }
-      .contact {
         display: flex;
-        justify-content: space-between;
-        gap: 10pt;
-        padding: 4pt 0;
-        border-top: 0.75pt solid rgba(179, 38, 30, 0.25);
+        align-items: center;
+        gap: 5pt;
       }
+      .emergency h2::after { content: ""; flex: 1; height: 1pt; background: rgba(179, 38, 30, 0.28); }
+
+      .egrid { display: grid; grid-template-columns: 1fr 1fr; gap: 2pt 16pt; }
+      .egrid .f { font-size: 9.5pt; line-height: 1.35; }
+      .egrid .f .k {
+        font-size: 7.5pt;
+        font-weight: 900;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+        color: var(--alert);
+        margin-right: 4pt;
+      }
+      .egrid .f.wide { grid-column: 1 / -1; }
+      /* One muted line naming the fields nobody answered — the honest signal
+         that the old "None listed" rows carried, at a tenth of the height. */
+      .not-provided {
+        grid-column: 1 / -1;
+        font-size: 7.5pt;
+        font-style: italic;
+        color: var(--muted);
+        margin-top: 3pt;
+      }
+
+      .contacts {
+        margin-top: 6pt;
+        padding-top: 5pt;
+        border-top: 1pt solid rgba(179, 38, 30, 0.28);
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2pt 16pt;
+      }
+      .contact { font-size: 9.5pt; }
       .contact .name { font-weight: 800; }
-      .contact .rel { color: var(--muted); font-size: 9pt; }
-      .contact .phone { font-weight: 800; white-space: nowrap; }
+      .contact .rel { color: var(--muted); font-weight: 600; }
+      .contact .phone { font-weight: 900; white-space: nowrap; }
 
       /* ---- Care sections ---- */
-      /* Sits inside the first section's .section-keep, not above the loop, so
-         it can't strand at the foot of a page with the first section overleaf.
-         The margin collapses against the section's own top margin, hence the
-         .first override below. */
       .care-heading {
-        font-size: 12.5pt;
+        font-size: 9.5pt;
         font-weight: 900;
         color: var(--navy);
         text-transform: uppercase;
-        letter-spacing: 0.06em;
-        margin-bottom: 6pt;
+        letter-spacing: 0.09em;
+        margin: 12pt 0 6pt;
+        display: flex;
+        align-items: center;
+        gap: 6pt;
       }
+      .care-heading::after { content: ""; flex: 1; height: 1.5pt; background: var(--cyan); }
 
-      .care-section { margin-top: 12pt; }
-      .care-section.first { margin-top: 18pt; }
-      .care-section h2 {
-        font-size: 12pt;
+      .cols { column-count: 2; column-gap: 20pt; }
+      .care-section { margin-bottom: 8pt; }
+      .care-section h3 {
+        font-size: 9.5pt;
         font-weight: 900;
         color: var(--navy);
-        padding-bottom: 3pt;
-        border-bottom: 1.5pt solid var(--cyan);
-        margin-bottom: 6pt;
+        padding-bottom: 1.5pt;
+        border-bottom: 1pt solid var(--cyan);
+        margin-bottom: 3pt;
       }
 
-      .row { margin-bottom: 5pt; }
+      .row { margin-bottom: 2.5pt; line-height: 1.35; }
       .row .label {
-        font-size: 8.5pt;
-        font-weight: 800;
+        font-size: 7.5pt;
+        font-weight: 900;
+        letter-spacing: 0.06em;
         text-transform: uppercase;
-        letter-spacing: 0.07em;
         color: var(--muted);
+        margin-right: 4pt;
       }
-      .row .value { font-size: 10.5pt; }
+      .row .value { font-size: 9.5pt; }
 
-      .chips { display: flex; flex-wrap: wrap; gap: 4pt; margin-top: 2pt; }
+      /* The alternative treatment: multi_select values as chips rather than a
+         comma-joined sentence. Text won — it is calmer and roughly half the
+         height — but the mockup showed both, so the styles stay. Switching is
+         the :multi_select branch in _care_plan_row.html.erb plus these rules. */
+      /*
+      .row.chips { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2.5pt; }
+      .row.chips .label { flex: none; margin-right: 1pt; }
       .chip {
         background: var(--cyan-tint);
-        border: 0.75pt solid var(--cyan);
+        border: 0.6pt solid var(--cyan);
         border-radius: 999pt;
-        padding: 1.5pt 7pt;
-        font-size: 9.5pt;
+        padding: 0.5pt 5pt;
+        font-size: 8pt;
         font-weight: 700;
+        color: var(--navy);
       }
+      */
 
-      .items { margin-top: 6pt; }
       .item {
-        padding: 3pt 0;
-        border-top: 0.75pt solid var(--rule);
-        font-size: 10pt;
+        padding: 1.5pt 0;
+        border-top: 0.6pt solid var(--rule);
+        font-size: 9pt;
+        line-height: 1.35;
       }
       .item .k { font-weight: 800; }
 
       .muted { color: var(--muted); }
 
       .footnote {
-        margin-top: 20pt;
-        padding-top: 8pt;
+        margin-top: 12pt;
+        padding-top: 5pt;
         border-top: 0.75pt solid var(--rule);
-        font-size: 8pt;
+        font-size: 7pt;
         color: var(--muted);
       }
     </style>

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -297,8 +297,12 @@
 
       /* The logo sits here rather than in the band: on the gradient it needed a
          white pad to stay legible against hues it shares, and down here on
-         white it needs nothing. Aligned to the first line of the note, not
-         centred on the block, so it doesn't drift when the note wraps. */
+         white it needs nothing.
+
+         Opposite corner from the note, and centred rather than top-aligned. A
+         14pt mark next to a 7pt line has no top edge worth sharing — aligning
+         their tops hangs the mark most of a line below the text and reads as
+         a mistake. In the corner it answers to nothing but the frame. */
       .footnote {
         margin-top: 12pt;
         padding-top: 5pt;
@@ -306,12 +310,13 @@
         font-size: 7pt;
         color: var(--muted);
         display: flex;
-        align-items: flex-start;
-        gap: 5pt;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10pt;
       }
       .footnote .mark {
-        width: 13pt;
-        height: 13pt;
+        width: 14pt;
+        height: 14pt;
         display: block;
         flex: none;
       }

--- a/config/locales/care.en.yml
+++ b/config/locales/care.en.yml
@@ -168,3 +168,19 @@ en:
         contacts: Who to call
         no_contacts: No emergency contacts listed.
         relationship_unknown: Contact
+        # Printed once, muted, under the emergency grid when blank fields are
+        # omitted. %{fields} is the joined blank_names list below.
+        not_provided: No %{fields} were provided.
+        # Short lowercase forms, for that one line only — the grid uses the
+        # full labels above.
+        blank_names:
+          allergies: allergies
+          medical_conditions: conditions
+          medications: medications
+          other_conditions: other conditions
+          emergency_notes: notes
+        # "or", not "and": the sentence says none of these were answered.
+        blank_names_connectors:
+          words_connector: ", "
+          two_words_connector: " or "
+          last_word_connector: ", or "

--- a/config/locales/care.es.yml
+++ b/config/locales/care.es.yml
@@ -168,3 +168,14 @@ es:
         contacts: A quién llamar
         no_contacts: No hay contactos de emergencia.
         relationship_unknown: Contacto
+        not_provided: No se indicaron %{fields}.
+        blank_names:
+          allergies: alergias
+          medical_conditions: afecciones médicas
+          medications: medicamentos
+          other_conditions: otras afecciones
+          emergency_notes: notas
+        blank_names_connectors:
+          words_connector: ", "
+          two_words_connector: " ni "
+          last_word_connector: " ni "

--- a/spec/services/communicators/care_plan_document_spec.rb
+++ b/spec/services/communicators/care_plan_document_spec.rb
@@ -213,15 +213,41 @@ RSpec.describe Communicators::CarePlanDocument do
       }
     end
 
-    it "exposes every emergency field, blanks included" do
+    # Blank fields cost a row each and print nothing but "None listed", which is
+    # what pushed a near-empty profile onto two pages.
+    it "exposes only the emergency fields that were answered" do
       doc = with_care({ "sections" => {} }, emergency)
 
       fields = doc.emergency_fields.index_by(&:key)
-      expect(fields.keys).to eq(described_class::EMERGENCY_FIELDS)
+      expect(fields.keys).to eq(%w[allergies medications])
       expect(fields["allergies"].values).to eq(["peanuts"])
-      # Blank rather than omitted: a missing "Medical conditions" heading and
-      # "Medical conditions — none listed" read very differently to a responder.
-      expect(fields["medical_conditions"].values).to be_empty
+    end
+
+    # The omitted fields are still accounted for — one muted line naming them
+    # keeps "nobody answered this" distinguishable from "there is nothing here".
+    it "names the blank emergency fields, in reading order" do
+      doc = with_care({ "sections" => {} }, emergency)
+
+      expect(doc.blank_emergency_field_names)
+        .to eq(["conditions", "other conditions", "notes"])
+    end
+
+    it "names nothing when every field is answered" do
+      answered = described_class::EMERGENCY_FIELDS.index_with { "something" }
+      doc = with_care({ "sections" => {} }, answered)
+
+      expect(doc.emergency_fields.length).to eq(described_class::EMERGENCY_FIELDS.length)
+      expect(doc.blank_emergency_field_names).to be_empty
+    end
+
+    # The flag is the documented one-line revert. If it is ever flipped back,
+    # every field returns and nothing is summarised.
+    it "keeps every field and names none when OMIT_BLANK_EMERGENCY_FIELDS is off" do
+      stub_const("#{described_class}::OMIT_BLANK_EMERGENCY_FIELDS", false)
+      doc = with_care({ "sections" => {} }, emergency)
+
+      expect(doc.emergency_fields.map(&:key)).to eq(described_class::EMERGENCY_FIELDS)
+      expect(doc.blank_emergency_field_names).to be_empty
     end
 
     it "exposes contacts through Profile#safety_contacts" do

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -121,16 +121,30 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html).to include("AAC device")
     end
 
-    # "Medications: none listed" and a missing Medications heading say different
-    # things to a school nurse, and only one of them is honest about having been
-    # asked. Matches what the safety ID card already does.
-    it "prints an empty emergency field as 'None listed' rather than omitting it" do
+    # Under OMIT_BLANK_EMERGENCY_FIELDS a blank field costs no row. The honest
+    # signal — nobody answered — survives as one muted line naming them, which
+    # is the whole reason that line exists.
+    it "omits an empty emergency field and names it in the not-provided line" do
       profile.update!(settings: { "care" => care }.merge(emergency.except("medications")))
 
       html = render_html(variant: :full)
 
-      expect(html).to include("Medications")
-      expect(html).to include("None listed")
+      # The rendered cell, not the bare word — "Medications" also appears in a
+      # layout comment, and the label is what costs a row.
+      expect(html).to include(%(<span class="k">Allergies</span>))
+      expect(html).not_to include(%(<span class="k">Medications</span>))
+      expect(html).to include("No medications or other conditions were provided.")
+    end
+
+    it "drops the not-provided line entirely when every field is answered" do
+      profile.update!(settings: { "care" => care }.merge(
+        emergency.merge("other_conditions" => "zzglasseszz"),
+      ))
+
+      html = render_html(variant: :full)
+
+      expect(html).to include("zzglasseszz")
+      expect(html).not_to include("were provided")
     end
 
     it "attaches to care_emergency_plan_pdf" do
@@ -171,8 +185,36 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html).to include("off by seven")
     end
 
-    it "prints the public URL as text beside the QR, for a photocopied sheet" do
+    # The URL moved out from under the QR into the band's meta line when the
+    # header was condensed. It still has to be readable text: these get
+    # photocopied and handed to people without a phone camera out.
+    it "prints the public URL as text in the header band" do
       expect(render_html).to include(profile.public_url)
+    end
+
+    # The density change, pinned: one gradient band instead of masthead +
+    # identity, and the care sections in two newspaper columns.
+    it "renders one header band and flows the care sections into columns" do
+      html = render_html
+
+      expect(html).to include(%(class="band"))
+      expect(html).not_to include(%(class="masthead"))
+      expect(html).not_to include(%(class="identity"))
+      expect(html).to include(%(class="cols"))
+      expect(html).to include("column-count: 2")
+    end
+
+    # .section-keep and its heading-welding are gone; a whole section is atomic
+    # now. A stray wrapper left behind would silently defeat break-inside.
+    it "keeps no section-keep wrapper" do
+      expect(render_html).not_to include("section-keep")
+    end
+
+    it "joins multi-select values as text rather than chips" do
+      html = render_html
+
+      expect(html).to include("AAC device, Eye gaze")
+      expect(html).not_to include(%(class="chip"))
     end
 
     # The layout's no-network rule. A font or image fetched mid-render fails

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -204,6 +204,22 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html).to include("column-count: 2")
     end
 
+    # The frame is a position:fixed layer so Chrome repeats it per sheet. Its
+    # inset must stay 0 — a negative one is clipped to the page content box and
+    # the frame then paints on no page at all, which looks like the CSS was
+    # ignored rather than like a bug.
+    it "carries a page frame pinned to the page content box" do
+      html = render_html
+
+      expect(html).to include(%(class="page-frame"))
+      expect(html).to match(/\.page-frame\s*\{[^}]*position:\s*fixed/m)
+      expect(html).to match(/\.page-frame\s*\{[^}]*inset:\s*0/m)
+    end
+
+    it "shows the logo in the header band" do
+      expect(render_html).to include(%(<img src="data:image/png;base64,))
+    end
+
     # .section-keep and its heading-welding are gone; a whole section is atomic
     # now. A stray wrapper left behind would silently defeat break-inside.
     it "keeps no section-keep wrapper" do

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -216,8 +216,13 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html).to match(/\.page-frame\s*\{[^}]*inset:\s*0/m)
     end
 
-    it "shows the logo in the header band" do
-      expect(render_html).to include(%(<img src="data:image/png;base64,))
+    it "signs the document with the logo in the footnote" do
+      html = render_html
+
+      expect(html).to include(%(<img class="mark" src="data:image/png;base64,))
+      # Below the care sections, not up in the band — on the gradient the mark
+      # shares its own hues and needs a white pad to survive.
+      expect(html.index(%(class="mark"))).to be > html.index(%(class="band"))
     end
 
     # .section-keep and its heading-welding are gone; a whole section is atomic


### PR DESCRIPTION
Follow-up to #685. The sample render — one emergency contact, twelve care
values, zero detail lines — came to **two pages**, and almost none of it was
content: ~2.6in of masthead plus identity block, five emergency fields each
printing "None listed" on its own line, care rows stacking the field label
above its values, and a single column so a two-word answer occupied the full
7.5in text width.

Same data now lands at **roughly half a page**. Matches
`marketing/drafts/care-plan-pdf-redesign-v1.html`, Option A.

## What changed

- **One header band.** Masthead and identity collapse into a single 0.82in
  gradient band. The public URL moves into the meta line as plain text, which
  is what lets the QR come down 76pt → 44pt — the sheet still works for
  someone without a phone camera out, which is why the URL was printed in the
  first place.
- **Emergency block is a two-column grid**, label inline with value, one line
  per field; notes span both columns. Contacts join the same grid as one line
  each (`**Name** · Relationship — 216-555-0142`) instead of a bordered flex
  row costing three times the height for the same information.
- **Blank emergency fields are omitted** and named collectively in one muted
  line. See the flag below.
- **Multi-select care values render as comma-joined text** rather than chips.
  The chip CSS stays in the layout, commented, as the alternative the mockup
  showed alongside it — switching back is the partial branch plus uncommenting.
- **Care sections flow in two newspaper columns**, each section atomic
  (`break-inside: avoid`).

That last one replaces the `.section-keep` machinery, deleted here along with
the layout comment arguing for it. That comment argued a section can exceed a
page so the whole thing must not be `break-inside: avoid` — true when every
field burned two full-width lines, and no longer true at half-width with one
line per field. The tallest realistic section (Meals, four fields, one a
300-character `short_text`) is about 1.1in in a column. "Day-to-day support"
moves back above the loop, outside the columns: it can no longer strand,
because what follows it is a column flow rather than a single tall element.

`LAYOUT_VERSION` 1 → 2. `attached_and_fresh?` short-circuits on the signature
and `safety_info_signature` only moves when the *profile* changes, so without
the bump every profile already holding a PDF keeps serving the two-page
version and the redesign looks like it never shipped.

## Flag, on the record

> A reader in an emergency cannot distinguish "this child has no allergies"
> from "nobody filled in the allergies field" when the field is absent. The
> muted summary line mitigates this but does not eliminate it. Called out here
> so the decision is on the record.

`Communicators::CarePlanDocument::OMIT_BLANK_EMERGENCY_FIELDS` is the one-line
revert, and specs pin both sides of it.

## Test plan

`bundle exec rspec spec/services/communicators/ spec/requests/api/profiles_care_plan_spec.rb spec/services/boards/printables/render_wrappers_spec.rb`
→ **100 examples, 0 failures.**

- `care_plan_document_spec.rb` — added: only answered fields are exposed; the
  blank ones are named in reading order; nothing is named when all are
  answered; flipping `OMIT_BLANK_EMERGENCY_FIELDS` off restores every field.
- `generate_care_plan_spec.rb` — updated the "None listed" example to assert
  omission plus the not-provided line; added examples pinning the single band,
  the column flow, the absence of `.section-keep`, and comma-joined values.
- `render_wrappers_spec.rb` (reads `pdf_printable`'s style block, not this
  layout) — green, untouched.
- `profiles_care_plan_spec.rb` — green, untouched; the controller contract
  didn't move.

**Visual acceptance, which is the real test.** Two PDFs rendered through the
actual Grover path:

| Profile | Pages | Result |
|---|---|---|
| Sparse (1 contact, no emergency fields, 12 care values) | 1 | content ends at ~49% of the page |
| Maximal (all 6 sections + 3 detail lines each, 4 custom sections × 8 items, 5 contacts, 300-char `short_text`) | 3 | nothing clipped, every section intact, columns break sanely |

Both sample PDFs are in the session output for Brittany to drag onto this PR —
`gh` has no API for PR attachments, so they cannot be uploaded from here.

## Docs

CHANGELOG entry for #685 extended with the density behaviour rather than given
its own entry — the feature is in the same unreleased block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
