### PR TITLE
feat(board-builder): mark a tile for AI art on the art review screen

### DIFF
--- a/.claude-notes/admin-board-builder-handoff.md
+++ b/.claude-notes/admin-board-builder-handoff.md
@@ -243,6 +243,50 @@ plus aggregate `coverage_pct`, `missing[]`, `inexact[]`.
   labels. Coverage numbers don't show that a symbol is technically correct and
   visually wrong.
 
+##### "Regenerate with AI" marks
+
+Each cell carries a checkbox that marks its label for AI art. **The mark does
+not generate anything** — that is what keeps the review screen write-free, and
+the rail above holds unchanged: no Image, no Doc, no Board is written by
+`preview`. The mark is state only, and generation happens at build.
+
+- The checkboxes live in the grid but belong to the Build form below via the
+  HTML5 `form="build-form"` attribute. Change that id and every mark is
+  silently dropped on Build — the request spec asserts the pairing.
+- Marks are stored **normalized** (`Boards::ImageResolver.normalize`) in
+  `plan["regenerate"]`, which is the same key `Build#resolved` is indexed by.
+  They are re-filtered against the plan's labels in `create`, not trusted from
+  the resubmit.
+- A label repeated across pages is **one Image and one generation**, so the
+  boxes sharing a value move together (inline script in `preview.html.erb`),
+  which also mirrors them into the authoring form so re-previewing keeps them.
+- Marks are deliberately not carried by `duplicate` — art quality is a judgment
+  about one run.
+- Tiles with no library art render the box ticked and **disabled**: they are
+  generated either way, and a disabled input submits nothing.
+
+At build (`Boards::AdminBuilder::Build`):
+
+1. Marked labels resolve to their Images, **minus the blanks** — a label with
+   no art is already queued by the missing-art pass, and generating it twice is
+   two API calls for one picture.
+2. `display_image_url` on every tile in the set for those images is released to
+   **`nil`** (never `""` — that is the "this tile has no picture" marker).
+   `BoardImage#set_defaults` seeded it from the image's `src_url`, pinning the
+   tile to the art we're replacing. This covers child pages, which
+   `GenerateImagesJob` never touches — it only re-points board_images on the
+   single `board_id` it is handed.
+3. Queued through `ArtQueue.call(..., replace_current: true)`, which is a
+   separate call from the blanks purely because of that flag.
+
+`replace_current` exists because `Image#create_image_doc` sets `current: true`
+on the new doc but does **not** clear its siblings, so the rejected symbol would
+stay current alongside the new art. The job demotes the siblings only **after**
+a successful generation — clearing up front would leave the image with no
+current doc at all when the call fails, which is worse than stale art. Note
+`image.src_url` is left alone on purpose: the mark changes what this build
+shows, not the library-wide default.
+
 #### 4. `Boards::AdminBuilder::Build` + `BuildAdminBoardJob`
 
 Inside one transaction:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Admin board builder: mark a tile for AI art before you build it.** The art
+  review screen exists to catch a symbol the library got wrong — a word that
+  resolves to a picture of something else entirely — but until now the only fix
+  was to build the board and repair it afterwards. Each tile now carries a
+  "regenerate with AI" checkbox. Ticking it changes nothing on the review screen
+  (that screen still writes nothing at all); the board is still built with the
+  library's symbol, and AI art is generated over it right after, becoming that
+  image's current picture. Tiles with no library art are shown ticked and
+  greyed — they were always going to be generated.
+
 - **You can print a care plan for your communicator.** Everything you've
   filled in — how they communicate, personal care, meals, sensory, moving
   around, getting around, and any sections you wrote yourself — comes out as a

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -271,6 +271,7 @@ module Admin
         pages: pages_for(@form),
         commercial_safe_only: @form[:commercial_safe_only],
       ).call
+      @marked = marked_labels(@form)
       @name_matches = duplicate_name_matches(@form[:name])
 
       render :preview
@@ -306,6 +307,10 @@ module Admin
               "tiles" => Boards::AdminBuilder::Plan.stringify_tiles(child[:tiles]),
             }.compact
           end,
+          # Marks made on the review screen. Re-filtered against the plan here
+          # rather than trusted from the resubmit, and stored normalized so
+          # Boards::AdminBuilder::Build can look each one up in `resolved`.
+          "regenerate" => marked_labels(@form),
         },
       )
       BuildAdminBoardJob.perform_async(build.id)
@@ -694,6 +699,7 @@ module Admin
         commercial_safe_only: true,
         allow_partial_row: false,
         allow_mixed_grids: false,
+        regenerate: [],
       }
     end
 
@@ -750,7 +756,28 @@ module Admin
         commercial_safe_only: checked?(params[:commercial_safe_only]),
         allow_partial_row: checked?(params[:allow_partial_row]),
         allow_mixed_grids: checked?(params[:allow_mixed_grids]),
+        regenerate: submitted_regenerate,
       }.then { |form| with_folder_tiles(form) }
+    end
+
+    # Labels the admin ticked "regenerate with AI" on the review screen.
+    # Normalized through the resolver's own key so a mark survives whatever
+    # casing the word was authored in, and matches what Build looks up.
+    def submitted_regenerate
+      Array(params[:regenerate])
+        .map { |label| Boards::ImageResolver.normalize(label) }
+        .reject(&:blank?)
+        .uniq
+        .first(MAX_TILES)
+    end
+
+    # The round trip is not trusted. A mark only means anything if the word is
+    # still in the plan — the admin may have edited the list after ticking it,
+    # and a hand-edited field must not be able to name an arbitrary label.
+    def marked_labels(form)
+      planned = Boards::AdminBuilder::Plan.labels(pages_for(form))
+                                          .map { |label| Boards::ImageResolver.normalize(label) }
+      form[:regenerate] & planned
     end
 
     # Writes a folder tile onto the main board for any page nothing opens, and

--- a/app/models/admin_board_build.rb
+++ b/app/models/admin_board_build.rb
@@ -44,6 +44,14 @@ class AdminBoardBuild < ApplicationRecord
 
   def multi_page? = children.any?
 
+  # Labels the admin ticked "regenerate with AI" on the art review screen,
+  # already normalized by Boards::ImageResolver.normalize when they were
+  # stored. The library still supplies each of these tiles its symbol at build
+  # time; the mark only says "generate over it afterwards".
+  def regenerate_labels
+    Array((plan || {})["regenerate"])
+  end
+
   def labels
     Boards::AdminBuilder::Plan.labels(pages)
   end

--- a/app/services/boards/admin_builder/art_queue.rb
+++ b/app/services/boards/admin_builder/art_queue.rb
@@ -13,12 +13,18 @@ module Boards
       module_function
 
       # Returns how many images were queued.
-      def call(board:, image_ids:, topic: nil)
+      #
+      # `replace_current` is for images that already HAVE art and are being
+      # regenerated on purpose — it tells the job to demote the old docs once
+      # the new one lands, so the generated art is the image's current doc.
+      def call(board:, image_ids:, topic: nil, replace_current: false)
         ids = Array(image_ids).compact.uniq
         return 0 if ids.empty?
 
+        options = replace_current ? { "replace_current" => true } : {}
+
         seed_prompts!(ids, topic)
-        ids.each_slice(BATCH_SIZE) { |batch| GenerateImagesJob.perform_async(batch, board.id) }
+        ids.each_slice(BATCH_SIZE) { |batch| GenerateImagesJob.perform_async(batch, board.id, options) }
         ids.size
       end
 

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -32,8 +32,11 @@ module Boards
         root = ActiveRecord::Base.transaction { create_set! }
 
         blank_image_ids = art_less_image_ids
-        build.update!(board: root, status: "complete", art_report: art_report(root, blank_image_ids))
+        regenerate_ids = regenerate_image_ids(blank_image_ids)
+        build.update!(board: root, status: "complete", art_report: art_report(root, blank_image_ids, regenerate_ids))
+        unpin_regenerated_tiles!(regenerate_ids)
         queue_missing_art!(root, blank_image_ids)
+        queue_regenerated_art!(root, regenerate_ids)
 
         root
       rescue StandardError => e
@@ -244,7 +247,38 @@ module Boards
         Image.where(id: resolved.values.map(&:id).uniq).where.missing(:docs).pluck(:id)
       end
 
-      def art_report(root, blank_image_ids)
+      # Images behind the tiles the admin marked "regenerate with AI" on the
+      # review screen. `resolved` is keyed by the resolver's normalized label,
+      # which is exactly the form the marks were stored in.
+      #
+      # Minus the blanks: a label with no art is already queued by
+      # queue_missing_art!, and generating it twice is two API calls for one
+      # picture.
+      def regenerate_image_ids(blank_image_ids)
+        build.regenerate_labels
+             .filter_map { |label| resolved[label]&.id }
+             .uniq - blank_image_ids
+      end
+
+      # A marked tile was built with the library's art, so BoardImage#set_defaults
+      # seeded `display_image_url` from the image's src_url — pinning the tile to
+      # the picture we are about to replace. Release the pin so the tile falls
+      # through to the image's own current doc once generation lands.
+      #
+      # It must be NIL, never "": a blank display_image_url is the marker for
+      # "this tile has no picture" and would print the label with no art at all.
+      #
+      # Covers the whole set, not just the root. GenerateImagesJob only re-points
+      # board_images on the single board_id it is handed, so a repeated word on a
+      # child page would otherwise keep the old art forever.
+      def unpin_regenerated_tiles!(image_ids)
+        return if image_ids.empty?
+
+        BoardImage.where(board_id: @built_boards.values.map(&:id), image_id: image_ids)
+                  .update_all(display_image_url: nil)
+      end
+
+      def art_report(root, blank_image_ids, regenerate_ids = [])
         total = Plan.labels(pages).size
         missing = resolved.select { |_, image| blank_image_ids.include?(image.id) }.keys
 
@@ -254,6 +288,10 @@ module Boards
           "coverage_pct" => total.zero? ? 0 : (((total - missing.size) / total.to_f) * 100).round,
           "missing_labels" => missing,
           "queued_image_ids" => blank_image_ids,
+          # Tiles the admin marked for AI art despite the library having a
+          # picture for them — `show` reports these separately from the blanks.
+          "regenerated_labels" => resolved.select { |_, image| regenerate_ids.include?(image.id) }.keys,
+          "regenerated_image_ids" => regenerate_ids,
           "slug" => root.slug,
           # key => board id, so `show` can list every page of the set and
           # publish can cascade over it without re-walking the link graph.
@@ -265,6 +303,13 @@ module Boards
       # rows it references exist.
       def queue_missing_art!(root, image_ids)
         ArtQueue.call(board: root, image_ids: image_ids, topic: build.topic)
+      end
+
+      # Separate call from the blanks because of `replace_current`: these images
+      # already carry a library doc, and the generated one has to become the
+      # current doc or the build would show the symbol the admin just rejected.
+      def queue_regenerated_art!(root, image_ids)
+        ArtQueue.call(board: root, image_ids: image_ids, topic: build.topic, replace_current: true)
       end
     end
   end

--- a/app/sidekiq/generate_images_job.rb
+++ b/app/sidekiq/generate_images_job.rb
@@ -2,7 +2,16 @@ class GenerateImagesJob
   include Sidekiq::Job
   sidekiq_options queue: :ai_images, retry: 1, backtrace: true
 
-  def perform(image_ids, board_id = nil)
+  # `options` is a trailing optional arg so jobs already enqueued with two
+  # arguments keep running after a deploy.
+  #
+  # options["replace_current"] — the image ALREADY has art and this run is
+  # replacing it (the admin builder's "regenerate with AI" mark). Image#create_image_doc
+  # sets `current: true` on the new doc but does NOT clear its siblings, so
+  # without this the old library doc stays current alongside the new one.
+  def perform(image_ids, board_id = nil, options = {})
+    options = (options || {}).with_indifferent_access
+    replace_current = options[:replace_current].present?
     images = Image.where(id: image_ids)
     return if images.empty?
 
@@ -61,6 +70,11 @@ class GenerateImagesJob
           end
 
           new_doc.update(source_type: "OpenAI")
+
+          # Only AFTER a successful generation. Clearing up front would leave
+          # the image with no current doc at all when the call fails, which is
+          # worse than the stale art we're replacing.
+          image.docs.where.not(id: new_doc.id).update_all(current: false) if replace_current
 
           # if image.menu? && image.image_prompt.include?(Menu::PROMPT_ADDITION)
           #   image.update!(

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -283,6 +283,16 @@
     </div>
   </template>
 
+  <%# "Regenerate with AI" marks made on the review screen, carried so that
+      changing a word and looking again doesn't silently drop them. The script
+      in preview.html.erb rewrites these as the boxes are ticked; `create`
+      re-filters whatever arrives against the plan either way. %>
+  <div data-regenerate-marks hidden>
+    <% Array(@form[:regenerate]).each do |label| %>
+      <%= hidden_field_tag "regenerate[]", label, id: nil %>
+    <% end %>
+  </div>
+
   <div class="flex items-center gap-3">
     <%= submit_tag "Preview the art",
           class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -51,6 +51,10 @@
         <p class="text-[11px] text-t3">not commercially safe</p>
       </div>
     <% end %>
+    <div>
+      <p class="text-2xl font-semibold text-t1" data-marked-count><%= @marked.size %></p>
+      <p class="text-[11px] text-t3">marked for AI regeneration</p>
+    </div>
   </div>
 
   <% if @preview[:inexact].any? %>
@@ -104,6 +108,28 @@
           <% if row.found? && row.commercial_safe == false %>
             <p class="text-[10px] text-t3 truncate" title="<%= row.license %>">not commercial-safe</p>
           <% end %>
+
+          <%# The mark rides the build form below via the HTML5 `form`
+              attribute, so the cell needs no form of its own. Nothing is
+              generated here — preview still writes nothing. A word repeated
+              across pages is one Image and one generation, so the boxes
+              sharing a value are kept in step by the script at the bottom. %>
+          <% key = Boards::ImageResolver.normalize(row.label) %>
+          <% if row.found? %>
+            <label class="flex items-center gap-1.5 mt-1.5 cursor-pointer" title="Build with the library symbol, then generate new AI art over it">
+              <%= check_box_tag "regenerate[]", key, @marked.include?(key),
+                    form: "build-form", id: nil, class: "cursor-pointer",
+                    data: { regenerate_mark: key } %>
+              <span class="text-[10px] text-t2">regenerate with AI</span>
+            </label>
+          <% else %>
+            <%# Already queued by the build — shown ticked so the grid reads
+                consistently, disabled so it can't be un-asked for. %>
+            <label class="flex items-center gap-1.5 mt-1.5" title="No library art, so this is generated either way">
+              <%= check_box_tag "regenerate[]", key, true, form: "build-form", id: nil, disabled: true %>
+              <span class="text-[10px] text-t3">always generated</span>
+            </label>
+          <% end %>
         </div>
       </div>
     <% end %>
@@ -120,7 +146,10 @@
 
   <%# Hidden-field resubmit of exactly what was previewed. `create` re-parses
       and re-validates it from scratch — the round trip is not trusted. %>
-  <%= form_tag admin_dashboard_board_builds_path, method: :post do %>
+  <%# `id` is load-bearing: every per-tile "regenerate with AI" checkbox in the
+      grid above points at this form with the HTML5 `form` attribute, which is
+      what lets the marks submit with Build without wrapping the whole page. %>
+  <%= form_tag admin_dashboard_board_builds_path, method: :post, id: "build-form" do %>
     <%= hidden_field_tag :name, @form[:name] %>
     <%= hidden_field_tag :topic, @form[:topic] %>
     <%= hidden_field_tag :audience, @form[:audience] %>
@@ -147,3 +176,50 @@
 <h2 class="text-xs font-semibold uppercase tracking-widest text-t2 mb-4">Or change something and look again</h2>
 
 <%= render "form" %>
+
+<script>
+  (function () {
+    var boxes = Array.prototype.slice.call(
+      document.querySelectorAll("input[data-regenerate-mark]")
+    );
+    if (!boxes.length) return;
+
+    var count = document.querySelector("[data-marked-count]");
+    // Mirror into the authoring form below, so pressing "Preview the art"
+    // again keeps the marks instead of starting from nothing.
+    var mirror = document.querySelector("[data-regenerate-marks]");
+
+    function sync(label, checked) {
+      // The same word on two pages is ONE image and one generation, so the
+      // boxes that share a label have to move together.
+      boxes.forEach(function (box) {
+        if (box.dataset.regenerateMark === label) box.checked = checked;
+      });
+
+      var marked = [];
+      boxes.forEach(function (box) {
+        if (box.checked && marked.indexOf(box.dataset.regenerateMark) === -1) {
+          marked.push(box.dataset.regenerateMark);
+        }
+      });
+
+      if (count) count.textContent = marked.length;
+      if (mirror) {
+        mirror.innerHTML = "";
+        marked.forEach(function (value) {
+          var input = document.createElement("input");
+          input.type = "hidden";
+          input.name = "regenerate[]";
+          input.value = value;
+          mirror.appendChild(input);
+        });
+      }
+    }
+
+    boxes.forEach(function (box) {
+      box.addEventListener("change", function () {
+        sync(box.dataset.regenerateMark, box.checked);
+      });
+    });
+  })();
+</script>

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -139,6 +139,14 @@
         Generated: <%= Array(@build.art_report["missing_labels"]).join(", ") %>
       </p>
     <% end %>
+    <% regenerated = Array(@build.art_report["regenerated_labels"]) %>
+    <% if regenerated.any? %>
+      <%# These tiles DID have library art — the admin rejected it on the review
+          screen, so AI art was generated over it and made the current doc. %>
+      <p class="text-[11px] text-t3 mt-2">
+        Marked for AI regeneration: <%= regenerated.join(", ") %>
+      </p>
+    <% end %>
     <% if @missing_art_count.positive? %>
       <%= button_to "Generate the missing art", regenerate_art_admin_dashboard_board_build_path(@build), method: :post,
             class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1 mt-3",

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -107,6 +107,59 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  describe "marking a tile for AI regeneration" do
+    before { sign_in admin }
+
+    it "offers a mark on every tile without generating anything on preview" do
+      expect { post preview_admin_dashboard_board_builds_path, params: form_params(regenerate: ["swing"]) }
+        .to not_change(Board, :count)
+        .and not_change(Image, :count)
+        .and not_change(Doc, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("regenerate[]")
+      expect(response.body).to include("marked for AI regeneration")
+    end
+
+    # The checkboxes sit in the grid, well above the Build form. The HTML5
+    # `form` attribute is what makes them submit with it — without the matching
+    # id every mark is silently dropped on Build.
+    it "points every mark at the build form" do
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response.body).to include('id="build-form"')
+      expect(response.body.scan(/<input[^>]*name="regenerate\[\]"[^>]*>/).size).to eq(4)
+      response.body.scan(/<input[^>]*name="regenerate\[\]"[^>]*>/).each do |input|
+        expect(input).to include('form="build-form"')
+      end
+    end
+
+    it "keeps the mark ticked when the same form is previewed again" do
+      post preview_admin_dashboard_board_builds_path, params: form_params(regenerate: ["swing"])
+
+      # The mark rides the build form via the HTML5 `form` attribute.
+      expect(response.body).to match(/name="regenerate\[\]"[^>]*value="swing"[^>]*checked/)
+    end
+
+    it "stores the marks on the build, normalized" do
+      post admin_dashboard_board_builds_path, params: form_params(regenerate: ["Swing"])
+
+      expect(AdminBoardBuild.last.regenerate_labels).to eq(["swing"])
+    end
+
+    it "drops a mark for a label that isn't in the plan" do
+      post admin_dashboard_board_builds_path, params: form_params(regenerate: %w[swing slide])
+
+      expect(AdminBoardBuild.last.regenerate_labels).to eq(["swing"])
+    end
+
+    it "stores no marks when nothing was ticked" do
+      post admin_dashboard_board_builds_path, params: form_params
+
+      expect(AdminBoardBuild.last.regenerate_labels).to eq([])
+    end
+  end
+
   describe "child pages" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/art_queue_spec.rb
+++ b/spec/services/boards/admin_builder/art_queue_spec.rb
@@ -16,7 +16,25 @@ RSpec.describe Boards::AdminBuilder::ArtQueue do
     expect(described_class.call(board: board, image_ids: ids)).to eq(7)
     expect(GenerateImagesJob.jobs.size).to eq(3)
     expect(GenerateImagesJob.jobs.map { |job| job["args"].first.size }).to eq([3, 3, 1])
-    expect(GenerateImagesJob.jobs.first["args"].last).to eq(board.id)
+    expect(GenerateImagesJob.jobs.first["args"][1]).to eq(board.id)
+  end
+
+  # These images already carry a library doc, so the generated one has to be
+  # promoted over it or the build shows the symbol the admin just rejected.
+  it "tells the job to replace the current doc when regenerating over existing art" do
+    id = image("swing").id
+
+    described_class.call(board: board, image_ids: [id], replace_current: true)
+
+    expect(GenerateImagesJob.jobs.first["args"][2]).to eq("replace_current" => true)
+  end
+
+  it "sends no replace option for ordinary missing-art generation" do
+    id = image("swing").id
+
+    described_class.call(board: board, image_ids: [id])
+
+    expect(GenerateImagesJob.jobs.first["args"][2]).to eq({})
   end
 
   it "does nothing when there is nothing to queue" do

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -163,6 +163,96 @@ RSpec.describe Boards::AdminBuilder::Build do
     end
   end
 
+  # The review screen is where a wrong symbol gets caught. A marked tile is
+  # still built with the library's art — the mark only says "generate over it".
+  describe "tiles marked for AI regeneration" do
+    def marked_build(labels, tiles: four_tiles, **overrides)
+      build_record(tiles: tiles, **overrides).tap do |build|
+        build.update!(plan: build.plan.merge("regenerate" => labels))
+      end
+    end
+
+    it "queues generation for a marked label that already has library art" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      build = marked_build(["swing"])
+
+      described_class.new(admin_board_build: build).call
+
+      queued = GenerateImagesJob.jobs.flat_map { |job| job["args"].first }
+      expect(queued).to eq([Image.find_by(label: "swing").id])
+      expect(build.reload.art_report["regenerated_labels"]).to eq(["swing"])
+    end
+
+    # `Image#create_image_doc` sets current on the new doc but doesn't clear the
+    # old one, so the job has to be told this is a replacement.
+    it "tells the job to make the generated doc current" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+
+      described_class.new(admin_board_build: marked_build(["swing"])).call
+
+      expect(GenerateImagesJob.jobs.first["args"][2]).to eq("replace_current" => true)
+    end
+
+    # A label with no art is already queued by the missing-art pass; generating
+    # it twice is two API calls for one picture.
+    it "does not queue a marked label twice when it had no art to begin with" do
+      build = marked_build(%w[i want more swing])
+
+      described_class.new(admin_board_build: build).call
+
+      queued = GenerateImagesJob.jobs.flat_map { |job| job["args"].first }
+      expect(queued.size).to eq(4)
+      expect(queued.uniq.size).to eq(4)
+      expect(build.reload.art_report["regenerated_labels"]).to be_empty
+    end
+
+    # BoardImage#set_defaults seeds display_image_url from the image's src_url,
+    # pinning the tile to the art we are about to replace. It must be released
+    # to NIL — a blank "" is the marker for "this tile has no picture" and would
+    # print the label with no art at all.
+    it "releases the marked tiles from the art they were built with" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      board = described_class.new(admin_board_build: marked_build(["swing"])).call
+
+      swing = board.board_images.find_by(image_id: Image.find_by(label: "swing").id)
+      expect(swing.display_image_url).to be_nil
+      expect(swing.display_image_url).not_to eq("")
+    end
+
+    it "releases the marked tile on a child page too, not just the root" do
+      %w[i want more swing apple].each { |label| image_with_art(label: label) }
+      root = [
+        { "label" => "i", "part_of_speech" => "pronoun" },
+        { "label" => "want", "part_of_speech" => "verb" },
+        { "label" => "swing", "part_of_speech" => "noun" },
+        { "label" => "Food", "part_of_speech" => "noun", "links_to" => "food" },
+      ]
+      children = [{
+        "key" => "food", "name" => "Food",
+        "tiles" => [
+          { "label" => "apple", "part_of_speech" => "noun" },
+          { "label" => "swing", "part_of_speech" => "noun" },
+        ],
+      }]
+      build = marked_build(["swing"], tiles: root, children: children)
+
+      described_class.new(admin_board_build: build).call
+
+      swing_id = Image.find_by(label: "swing").id
+      tiles = BoardImage.where(board_id: build.reload.set_boards.map(&:id), image_id: swing_id)
+      expect(tiles.count).to eq(2)
+      expect(tiles.map(&:display_image_url).uniq).to eq([nil])
+    end
+
+    it "leaves unmarked tiles pinned to their library art" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      board = described_class.new(admin_board_build: marked_build(["swing"])).call
+
+      want = board.board_images.find_by(image_id: Image.find_by(label: "want").id)
+      expect(want.display_image_url).to eq(Image.find_by(label: "want").src_url)
+    end
+  end
+
   describe "a linked set" do
     def root_with_folder
       [

--- a/spec/sidekiq/generate_images_job_spec.rb
+++ b/spec/sidekiq/generate_images_job_spec.rb
@@ -140,4 +140,57 @@ RSpec.describe GenerateImagesJob, type: :job do
       }.not_to change { GenerateBoardPreviewJob.jobs.size }
     end
   end
+
+  # The admin builder's "regenerate with AI" mark: the image already HAS art,
+  # and Image#create_image_doc sets current on the new doc without clearing its
+  # siblings, so the rejected symbol would stay current alongside it.
+  describe "replacing the current doc" do
+    let(:plain_board) { FactoryBot.create(:board, user: user, board_type: "dynamic") }
+    let!(:old_doc) { image.docs.create!(user_id: user.id, source_type: "OpenAI", raw: "old", current: true) }
+
+    # `current: true` mirrors what Image#create_image_doc does to the doc it
+    # returns — the gap this job closes is the SIBLINGS it leaves behind.
+    def stub_generated_doc
+      new_doc = image.docs.create!(user_id: user.id, source_type: "OpenAI", raw: "new", current: true)
+      allow_any_instance_of(Image).to receive(:create_image_doc).and_return(new_doc)
+      allow(new_doc).to receive(:tile_url).and_return("https://cdn.example/generated.png")
+      new_doc
+    end
+
+    before { plain_board.add_image(image.id) }
+
+    it "demotes the old doc and leaves the generated one current" do
+      new_doc = stub_generated_doc
+
+      described_class.new.perform([image.id], plain_board.id, "replace_current" => true)
+
+      expect(new_doc.reload.current).to be(true)
+      expect(old_doc.reload.current).to be(false)
+    end
+
+    # Clearing up front would leave the image with no current doc at all when
+    # the call fails — worse than the stale art we're replacing.
+    it "leaves the existing current doc alone when generation fails" do
+      allow_any_instance_of(Image).to receive(:create_image_doc).and_return(nil)
+
+      described_class.new.perform([image.id], plain_board.id, "replace_current" => true)
+
+      expect(old_doc.reload.current).to be(true)
+    end
+
+    it "does not demote anything for an ordinary missing-art run" do
+      stub_generated_doc
+
+      described_class.new.perform([image.id], plain_board.id)
+
+      expect(old_doc.reload.current).to be(true)
+    end
+
+    # Jobs enqueued before this argument existed are still in the queue.
+    it "still runs when called with the old two-argument signature" do
+      stub_generated_doc
+
+      expect { described_class.new.perform([image.id], plain_board.id) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a per-tile **"regenerate with AI"** checkbox to the admin Board Builder's art review screen (`/admin/dashboard/board_builds` → Preview).

## Why

The review screen exists to catch a symbol the library got wrong — the classic case is `my` resolving to art labelled *"too tired to speak as it uses a lot of my energy…"*. But the grid was entirely non-interactive: no button, no checkbox, no per-tile control anywhere. The only fix for a bad symbol was to build the board and repair it afterwards, which is exactly the expensive path the two-step flow was designed to avoid.

## How it works

Ticking a box **generates nothing**. Preview still writes no `Image`, no `Doc`, no `Board` — the rail documented in `Admin::BoardBuildsController`'s header and `Boards::AdminBuilder::ArtPreview` is unchanged. The mark is state only; generation happens at build. The board is still built with the library's symbol, and AI art is generated over it right after, becoming that image's current doc.

Tiles with no library art render ticked and **disabled** ("always generated") — they were queued either way, and a disabled input submits nothing.

### The round trip

- Checkboxes sit in the grid but belong to the Build form below via the HTML5 `form="build-form"` attribute — no page restructuring. **Change that id and every mark is silently dropped on Build**; a spec asserts the pairing.
- Marks are normalized with `Boards::ImageResolver.normalize` (the key `Build#resolved` is indexed by) and stored in the existing `plan` jsonb as `plan["regenerate"]` — no migration.
- The resubmit is not trusted: `create` re-filters marks against the plan's own labels, so a hand-edited field can't name an arbitrary library image.
- A word repeated across pages is **one Image and one generation**, so boxes sharing a label move together, and are mirrored into the authoring form so editing the word list and re-previewing doesn't lose them.
- Marks are deliberately not carried by `duplicate` — art quality is a judgment about one run.

### At build

1. Marked labels resolve to their Images, **minus the blanks** — a label with no art is already queued by the missing-art pass, and generating it twice is two API calls for one picture.
2. `display_image_url` on those tiles is released to **`nil`** across the whole set. `BoardImage#set_defaults` seeded it from the image's `src_url`, pinning the tile to the art we're replacing. It must be `nil`, never `""` — that blank is the "this tile has no picture" marker. This covers child pages, which `GenerateImagesJob` never touches (it only re-points board_images on the single `board_id` it is handed).
3. Queued via `ArtQueue.call(..., replace_current: true)`.

### The current-doc fix

`Image#create_image_doc` sets `current: true` on the new doc but does **not** clear its siblings — so the rejected symbol would stay current alongside the new art. `GenerateImagesJob` now demotes the siblings, but only **after** a successful generation: clearing up front would leave the image with no current doc at all when the call fails, which is worse than the stale art we're replacing.

## Reviewer notes

- **`GenerateImagesJob#perform` gained a trailing optional `options` hash.** Safe for jobs already enqueued with two args (covered by a spec). `Boards::AdminBuilder::ArtQueue` is the only caller that passes it.
- **These are shared library Images owned by the default admin.** Marking one regenerates the art any board falls back to for that label. Existing boards are mostly insulated — their `board_images.display_image_url` is pinned — and `image.src_url` is deliberately left alone, so the library-wide default doesn't move. But it is a library-wide write and worth knowing.

## Test plan

```
bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder \
  spec/sidekiq/generate_images_job_spec.rb spec/models/board_spec.rb \
  spec/requests/api/internal/board_images_spec.rb
```

**578 examples, 0 failures.**

New coverage:
- `preview` changes neither `Board.count`, `Image.count` **nor `Doc.count`** when marks are submitted; marks stay ticked on re-preview; every checkbox points at `#build-form`.
- Marks are stored normalized; a label not in the plan is dropped.
- A marked label with library art is queued with `replace_current`; a marked label with no art is queued exactly once, not twice.
- `display_image_url` is `nil` (not `""`) on marked tiles across root *and* child pages; unmarked tiles stay pinned.
- Siblings are demoted on success, and the pre-existing current doc survives a failed generation.

Docs: `.claude-notes/admin-board-builder-handoff.md` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)