### PR TITLE
fix(board-builder): loosen the admin word-list tile-count tolerance

### DIFF
--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -20,10 +20,12 @@ module Boards
     #
     # Both have an explicit, unticked escape hatch rather than being advisory.
     class PlanValidator
-      # A word list within this many tiles of the target is accepted as-is —
-      # close enough to not fuss over, without opening the door to a board
-      # that's meaningfully sparse or overflowing.
-      TILE_COUNT_TOLERANCE = 2
+      # A word list within this many tiles of the target is accepted as-is.
+      # Deliberately generous: the board is built from the words actually
+      # written, so a near-miss is a cosmetic gap at the end of the last row —
+      # not a reason to block a build. A tight tolerance turned every draft into
+      # a counting exercise.
+      TILE_COUNT_TOLERANCE = 20
 
       def initialize(pages:, allow_partial_row: false, allow_mixed_grids: false)
         @pages = Array(pages)

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -127,7 +127,7 @@
       </p>
       <p class="text-[11px] text-t3 mt-1">
         You need about <span id="cell-count" class="text-t1 font-medium">—</span> words
-        (within <%= Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE %>) —
+        (anything within <%= Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE %> is accepted) —
         <span id="word-count" class="text-t1 font-medium">0</span> so far.
         A tile count that isn’t a whole number of rows leaves dead cells at the end of the last row,
         so Tiles steps a whole row at a time unless you allow a partial row.

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -715,13 +715,13 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     before { sign_in admin }
 
     it "rejects a word list that doesn't match the tile count and preserves what was typed" do
-      params = form_params(tile_count: "8")
+      params = form_params(tile_count: "40")
 
       expect { post preview_admin_dashboard_board_builds_path, params: params }
         .to not_change(Board, :count).and not_change(Image, :count)
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("needs to be within 2 of 8")
+      expect(response.body).to include("needs to be within 20 of 40")
       expect(response.body).to include("Playground")
       expect(response.body).to include("swing | noun")
     end
@@ -817,7 +817,7 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     # The preview round trip is a hidden-field resubmit — create must re-derive
     # the plan rather than trusting it.
     it "re-validates the resubmitted plan instead of trusting the preview" do
-      expect { post admin_dashboard_board_builds_path, params: form_params(words: "i | pronoun") }
+      expect { post admin_dashboard_board_builds_path, params: form_params(tile_count: "40", words: "i | pronoun") }
         .not_to change(AdminBoardBuild, :count)
       expect(response).to have_http_status(:unprocessable_entity)
       expect(BuildAdminBoardJob.jobs).to be_empty

--- a/spec/services/boards/admin_builder/plan_validator_spec.rb
+++ b/spec/services/boards/admin_builder/plan_validator_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     labels.map { |label| { label: label, part_of_speech: "noun" } }
   end
 
+  # A word list of n throwaway labels, for the cases that need to be well past
+  # the (deliberately generous) tile-count tolerance.
+  def word_list(count)
+    tiles(*Array.new(count) { |i| "word#{i}" })
+  end
+
   def pages(root_tiles:, columns: 2, tile_count: 4, children: [])
     Boards::AdminBuilder::Plan.pages(
       root: { name: "Playground", columns: columns, tile_count: tile_count, tiles: root_tiles },
@@ -24,24 +30,24 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     end
 
     it "rejects a short plan and says how many to add" do
-      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more"), tile_count: 8))
-      expect(problems.first).to include("3 words for a 8-tile board (needs to be within 2 of 8)")
-      expect(problems.first).to include("Add 5")
+      problems = validate(pages: pages(root_tiles: tiles("i", "want", "more"), tile_count: 40))
+      expect(problems.first).to include("3 words for a 40-tile board (needs to be within 20 of 40)")
+      expect(problems.first).to include("Add 37")
     end
 
     it "accepts a plan within tolerance of the tile count" do
-      expect(validate(pages: pages(root_tiles: tiles("i", "want"), tile_count: 4))).to eq([])
+      expect(validate(pages: pages(root_tiles: word_list(30), tile_count: 40))).to eq([])
     end
 
     it "rejects a plan just past the tolerance" do
-      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4))
-      expect(problems.first).to include("1 words for a 4-tile board")
-      expect(problems.first).to include("Add 3")
+      problems = validate(pages: pages(root_tiles: word_list(10), tile_count: 40))
+      expect(problems.first).to include("10 words for a 40-tile board")
+      expect(problems.first).to include("Add 30")
     end
 
     # A one-board build must read exactly as it did before pages existed.
     it "does not prefix messages with a page name" do
-      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4))
+      problems = validate(pages: pages(root_tiles: word_list(10), tile_count: 40))
       expect(problems.first).not_to include("Playground:")
     end
 
@@ -49,8 +55,8 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     # columns × rows, so "allow a partial row" no longer excuses a short list —
     # it excuses a tile count that doesn't fill whole rows.
     it "rejects a short plan even with the partial-row escape hatch ticked" do
-      problems = validate(pages: pages(root_tiles: tiles("i"), tile_count: 4), allow_partial_row: true)
-      expect(problems.first).to include("needs to be within 2 of 4")
+      problems = validate(pages: pages(root_tiles: word_list(10), tile_count: 40), allow_partial_row: true)
+      expect(problems.first).to include("needs to be within 20 of 40")
     end
 
     it "accepts a short list once the tile count is lowered to match" do
@@ -61,11 +67,9 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     end
 
     it "rejects an over-full plan and says how many to remove" do
-      problems = validate(pages: pages(
-        root_tiles: tiles("i", "want", "more", "help", "stop", "go", "yes", "no"), tile_count: 4,
-      ))
-      expect(problems.first).to include("8 words for a 4-tile board")
-      expect(problems.first).to include("Remove 4")
+      problems = validate(pages: pages(root_tiles: word_list(30), tile_count: 4))
+      expect(problems.first).to include("30 words for a 4-tile board")
+      expect(problems.first).to include("Remove 26")
     end
 
     # The dead-cell rail, now stated on the size rather than on the word list.
@@ -132,8 +136,10 @@ RSpec.describe Boards::AdminBuilder::PlanValidator do
     end
 
     it "names the page in its own problems" do
-      problems = validate(pages: pages(root_tiles: root_with_folder, children: [child(tiles_list: tiles("apple"))]))
-      expect(problems).to include(a_string_including("Food: 1 words for a 4-tile board"))
+      problems = validate(pages: pages(
+        root_tiles: root_with_folder, children: [child(tiles_list: word_list(30))],
+      ))
+      expect(problems).to include(a_string_including("Food: 30 words for a 4-tile board"))
     end
 
     it "rejects a tile pointing at a page that doesn't exist" do


### PR DESCRIPTION
## What changed

`Boards::AdminBuilder::PlanValidator::TILE_COUNT_TOLERANCE` goes from **2** to **20**.

## Why

Within-2 was a blocker in practice: a 35-word draft for a 40-tile board was refused, so authoring turned into a counting exercise before anything could be built. The board is built from the words actually written — a near-miss just leaves a cosmetic gap at the end of the last row, not a broken build.

## Notes for review

- The form's live word counter (red threshold) and the helper copy both read the same constant, so they moved with it — no second number to keep in sync.
- The **partial-row** rule is untouched: a tile count that isn't a whole number of rows still needs the "allow a partial row" tick.
- Specs that were pinned to the old value now use gaps well past 20.

## Test plan

`bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder` — 399 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)