### PR TITLE
fix(board-builder): stop a ragged last row from stranding the back tile

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1141,8 +1141,12 @@ Its own invariants:
   `ArtPreview` render the same permutation — otherwise the admin approves a grid
   the build won't produce. Parentage is BFS from `ROOT_KEY`, so the *shallowest*
   parent wins when two pages open the same child; x and y are clamped into the
-  child's own grid (pages may carry their own `columns`) and the final clamp
-  handles a ragged last row. A **swap, not an insert** — both tiles are 1×1, so
+  child's own grid (pages may carry their own `columns`). A ragged last row is
+  resolved **by backing up a row in the same column, never by sliding along the
+  row** — the column is what muscle memory is anchored to, and clamping to the
+  last occupied cell made the alignment a no-op for the common case where the
+  parent's folder tile sits at the far right of its own last row (the back tile
+  was already written last, i.e. in that corner). A **swap, not an insert** — both tiles are 1×1, so
   the grid stays packed and the displaced word takes the corner.
   `Board#apply_layout!` sorts by `[y, x]` and renumbers `position`, so reading
   order downstream follows the aligned layout for free.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **A page's back tile now really does land where the tile that opens it sits.**
+  On admin-built boards the alignment quietly did nothing whenever the parent's
+  folder tile sat at the far right of its own last row — the most common place
+  for it — because the page it opens usually has a shorter last row, and the
+  mirrored cell was slid along that row to the final tile: exactly the
+  bottom-right corner the back tile was already written into. It now backs up a
+  row and keeps the column, so the way home sits directly under the column you
+  tapped to get there.
+
 - **Only a communicator's owner can generate their Safety ID card or device
   tag.** The endpoints that build those printables checked that you were signed
   in but never checked *whose* communicator you were asking about — so any

--- a/app/services/boards/admin_builder/back_tile_alignment.rb
+++ b/app/services/boards/admin_builder/back_tile_alignment.rb
@@ -94,19 +94,25 @@ module Boards
 
       # The parent's cell, clamped into this page's grid. A page can carry its
       # own `columns` (mixed grids are allowed) and is usually shorter than the
-      # root, so both axes have to be brought back in range — and the final
-      # clamp handles a ragged last row, where the mirrored column doesn't
-      # exist yet.
+      # root, so both axes have to be brought back in range.
+      #
+      # The COLUMN is what muscle memory is anchored to, so a ragged last row is
+      # resolved by backing UP a row in the same column — never by sliding along
+      # the row to the last tile, which is how a bottom-right folder tile used
+      # to mirror straight back into the bottom-right corner it was supposed to
+      # move away from.
       def mirrored_index(page, link)
         parent_columns = link[:page][:columns].to_i
         columns = page[:columns].to_i
         count = page[:tiles].size
         return nil if parent_columns < 1 || columns < 1 || count.zero?
 
-        x = [link[:index] % parent_columns, columns - 1].min
-        y = [link[:index] / parent_columns, (count - 1) / columns].min
+        # `count - 1` too: a page with fewer tiles than columns has no such
+        # column at all, and a negative row is not a cell.
+        x = [link[:index] % parent_columns, columns - 1, count - 1].min
+        y = [link[:index] / parent_columns, (count - 1 - x) / columns].min
 
-        [(y * columns) + x, count - 1].min
+        (y * columns) + x
       end
     end
   end

--- a/spec/services/boards/admin_builder/back_tile_alignment_spec.rb
+++ b/spec/services/boards/admin_builder/back_tile_alignment_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Boards::AdminBuilder::BackTileAlignment do
       expect(cells["food"][2]).to eq(5)
     end
 
-    it "clamps y into a ragged last row when the child is shorter than the parent" do
+    it "backs up a row, keeping the column, when the mirrored cell is past a ragged last row" do
       root = page(key: root_key, columns: 3, tiles: [
         tile("a"), tile("b"), tile("c"),
         tile("d"), tile("e"), tile("f"),
@@ -73,10 +73,27 @@ RSpec.describe Boards::AdminBuilder::BackTileAlignment do
 
       cells = described_class.cell_indexes([root, food])
 
-      # y clamps to the last row (2); x=1 there would be cell 7, which doesn't
-      # exist either, so it clamps again to the last occupied cell.
-      expect(cells["food"][6]).to eq(6)
-      expect(cells["food"]).to eq((0..6).to_a)
+      # Column 1 is what the eye is anchored to, so y drops from 3 to the last
+      # row that HAS a column 1 (row 1, cell 4) rather than sliding along the
+      # ragged row to the final tile.
+      expect(cells["food"][6]).to eq(4)
+      expect(cells["food"][4]).to eq(6)
+    end
+
+    it "keeps the back tile out of the bottom-right corner it was written in" do
+      # The Bedtime Routine shape: a wide root whose folder tile sits at the far
+      # right of the last row, and a child whose own last row stops short of
+      # that column. Clamping to the last cell used to leave the back tile in
+      # the corner the drafter wrote it into — a no-op alignment.
+      root = page(key: root_key, columns: 8, tiles: Array.new(38) { |i| tile("w#{i}") } + [tile("bedtime", links_to: "bedtime")])
+      bedtime = page(key: "bedtime", columns: 8, tiles: Array.new(34) { |i| tile("b#{i}") } + [tile("back", links_to: root_key)])
+
+      cells = described_class.cell_indexes([root, bedtime])
+
+      # Folder tile is x=6, y=4; the child's last row holds only 3 tiles, so the
+      # way home lands at x=6 on the row above (cell 30) — directly over it.
+      expect(cells["bedtime"][34]).to eq(30)
+      expect(cells["bedtime"][30]).to eq(34)
     end
 
     it "mirrors a second-level page against its own parent, not the root" do


### PR DESCRIPTION
## What

`Boards::AdminBuilder::BackTileAlignment#mirrored_index` ended with
`[(y * columns) + x, count - 1].min`. When the mirrored cell fell past a
ragged last row, that clamp slid it **along the row** to the last tile.

Because the drafters ask for "one tile that goes back" and the model writes it
last, the back tile is *already* the last tile — so whenever the parent's folder
tile sat at the far right of its own last row (the common case), the alignment
resolved to the tile's current cell and did nothing.

Concretely, on the Bedtime Routine board: root's "bedtime" folder tile is at
x=6, y=4 (cell 38); the Bedtime page has 35 tiles, so its last row holds 3.
Cell 38 → clamped to 34 → bottom-right corner, unchanged.

## Fix

Resolve a ragged last row by backing **up** a row in the same column
(`y = min(y, (count - 1 - x) / columns)`), and drop the final index clamp. The
column is what muscle memory is anchored to. For the board above that gives
cell 30 — directly under "sleepy", the column the communicator tapped.

Also clamps `x` to `count - 1`: a page with fewer tiles than columns has no such
column, and the old final clamp was masking a negative row there.

## Notes for the reviewer

- Pure function over the plan — no DB reads — so `ArtPreview` shows the same
  permutation the build produces.
- `NavRowSync` (Board Builder path) writes real x/y with an occupant swap and
  doesn't share this clamp; untouched.
- OBF/OBZ imports keep their authored layouts; untouched.
- Existing boards don't move retroactively — this affects new builds only.

## Test plan

- Rewrote the ragged-last-row spec, which had been asserting the buggy no-op
  (`cells["food"] == (0..6).to_a`).
- Added a regression case built from the Bedtime Routine's exact shape
  (8-wide root, folder tile at cell 38; 35-tile child).
- `bundle exec rspec spec/services/boards/admin_builder/back_tile_alignment_spec.rb spec/services/boards/admin_builder/art_preview_spec.rb spec/services/boards/admin_builder/build_spec.rb` → **62 examples, 0 failures**.

Docs: `CHANGELOG.md` + `.claude-notes/board-builder.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)