### PR TITLE
fix(printables): count board pages in listing copy, not the wrappers

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -157,6 +157,19 @@ Generated copy is only a default. It is written into
 `BoardPrintable#listing_copy_or_default` is what previews it before anything is
 saved.
 
+**Copy quotes `board_page_count`, never `page_count`.** The record's
+`page_count` is the true length of the merged PDFs, and every file is wrapped in
+a cover, a how-to-use page, a license and a credits page — so it sold a
+one-board printable, whose three board pages *are* the product, as a "7-page
+board PDF". `BoardPrintable#board_page_count` derives the honest number
+(`boards × DOWNLOAD_VARIANTS`) rather than storing it, so printables generated
+before it existed report correctly with no re-render. Both readers of
+`Printables::IncludedItems` — the Etsy description and the what's-included
+slide's "In your download" panel — must pass the same one, or the text and the
+gallery image quote different numbers to the same buyer. `page_count` stays the
+merged total: it is what the admin lists and what TPT's "Number of pages" field
+asks for.
+
 ## Gallery images
 
 `Boards::Printables::RenderListingImages` renders **six** square 2560px slides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **A printable's listing copy now counts the board pages a buyer prints, not
+  the front matter around them.** Every printable PDF is wrapped in a cover, a
+  how-to-use page, a license and a credits page, and the page count quoted in
+  the Etsy description and on the "In your download" panel of the gallery images
+  counted all of them — so a one-board printable, whose three board pages are
+  the whole product, was sold as a "7-page board PDF". It now reads "3-page
+  board PDF", and a set counts each board once per colour/low-ink/trim-ready
+  file. Existing printables report the corrected count without being
+  regenerated; the admin listing and TPT's "Number of pages" field still show
+  the real merged page total.
+
 - **A page's back tile now really does land where the tile that opens it sits.**
   On admin-built boards the alignment quietly did nothing whenever the parent's
   folder tile sat at the far right of its own last row — the most common place

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -191,6 +191,19 @@ class BoardPrintable < ApplicationRecord
     reload_files_association
   end
 
+  # The BOARD pages a buyer gets, which is what listing copy quotes.
+  #
+  # `page_count` is the true length of the merged PDFs and every file is
+  # wrapped in a cover, a how-to-use page, a license and a credits page — so it
+  # sold a one-board printable, whose three board pages are the whole product,
+  # as a "7-page board PDF". A buyer counts the boards they can print, not the
+  # front matter.
+  #
+  # Derived rather than stamped at generation time because CollectPages renders
+  # each board exactly once per download variant: the count is exact for
+  # printables generated before this existed, with no re-render.
+  def board_page_count = board_ids.to_a.size * DOWNLOAD_VARIANTS.size
+
   def etsy_published? = etsy_listing_id.present?
 
   # The copy an admin has saved, or the generated default when nothing has been

--- a/app/services/boards/printables/render_listing_images.rb
+++ b/app/services/boards/printables/render_listing_images.rb
@@ -181,7 +181,7 @@ module Boards
       # Root-scoped: this class is itself inside `Boards::Printables`, so a bare
       # `Printables::` resolves to that and never reaches the top-level module.
       def included_items
-        ::Printables::IncludedItems.all(board_count: board_count, page_count: printable.page_count)
+        ::Printables::IncludedItems.all(board_count: board_count, page_count: printable.board_page_count)
       end
 
       def render(template, assigns:)

--- a/app/services/etsy/listing_copy.rb
+++ b/app/services/etsy/listing_copy.rb
@@ -172,7 +172,7 @@ module Etsy
     end
 
     def included_section
-      items = Printables::IncludedItems.all(board_count: board_count, page_count: printable.page_count)
+      items = Printables::IncludedItems.all(board_count: board_count, page_count: printable.board_page_count)
 
       ["WHAT'S INCLUDED", "", *items.map { |i| "- #{i}" }].join("\n")
     end

--- a/app/services/printables/included_items.rb
+++ b/app/services/printables/included_items.rb
@@ -15,6 +15,10 @@ module Printables
     # times (color, low-ink, trim-ready) and arrives as THREE files, so quoting
     # a single page count badly understates it.
     #
+    # `page_count` is BOARD pages — `BoardPrintable#board_page_count`, never the
+    # record's `page_count`, which counts the cover, how-to-use, license and
+    # credits pages wrapping every file and so oversells what a buyer prints.
+    #
     # "Trim-ready" rather than "header-less": the buyer-facing name has to say
     # what it's FOR. The band is what gets cut off before laminating, and this
     # is the copy that survives the cut.

--- a/spec/models/board_printable_spec.rb
+++ b/spec/models/board_printable_spec.rb
@@ -93,6 +93,31 @@ RSpec.describe BoardPrintable do
     end
   end
 
+  describe "#board_page_count" do
+    let(:board) { FactoryBot.create(:board) }
+
+    # A one-board printable merges to seven pages — cover, how-to-use, the
+    # three board pages, license, credits — and only the three are the product.
+    it "counts each board once per download variant, ignoring the wrappers" do
+      printable = described_class.create!(board: board, board_ids: [board.id], page_count: 7)
+
+      expect(printable.board_page_count).to eq(3)
+    end
+
+    it "scales with the boards in a bundle" do
+      other = FactoryBot.create(:board)
+      printable = described_class.create!(board: board, board_ids: [board.id, other.id], page_count: 18)
+
+      expect(printable.board_page_count).to eq(6)
+    end
+
+    # Nothing has been walked yet, so the copy has to fall back to a headline
+    # with no number rather than claiming zero pages.
+    it "is zero before the printable has been generated" do
+      expect(described_class.create!(board: board).board_page_count).to eq(0)
+    end
+  end
+
   describe "#etsy_published?" do
     let(:board) { FactoryBot.create(:board) }
     let(:printable) { described_class.create!(board: board, board_ids: [board.id]) }

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe Boards::Printables::RenderListingImages do
   let(:board) { create(:board, user: owner, name: "Core Words") }
   let(:other) { create(:board, user: owner, name: "Feelings") }
 
+  # 7 is what one board really merges to — cover, how-to-use, the three board
+  # pages, license, credits — so a slide quoting `page_count` is visibly wrong.
   let(:printable) do
-    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 7)
   end
 
   # Grover shells out to headless Chrome; the specs care about what gets
@@ -163,6 +165,27 @@ RSpec.describe Boards::Printables::RenderListingImages do
     described_class.new(printable: printable).call
 
     expect(slide_html[2]).to include("Core Words", "Feelings")
+  end
+
+  # The "In your download" panel is read against the listing description, so it
+  # counts what the description counts: board pages, never the cover,
+  # how-to-use, license and credits pages wrapped around them.
+  describe "the in-your-download panel" do
+    it "quotes a single board's three board pages, not the merged seven" do
+      described_class.new(printable: printable).call
+
+      expect(slide_html[2]).to include("3-page board PDF")
+      expect(slide_html[2]).not_to include("7-page")
+    end
+
+    it "counts every board in a set once per variant across the three files" do
+      printable.update!(board_ids: [board.id, other.id], include_subboards: true, page_count: 26)
+
+      described_class.new(printable: printable).call
+
+      expect(slide_html[2]).to include("2 boards, 6 pages")
+      expect(slide_html[2]).not_to include("26 pages")
+    end
   end
 
   # The one claim a buyer is least likely to believe from text alone.

--- a/spec/services/etsy/listing_copy_spec.rb
+++ b/spec/services/etsy/listing_copy_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Etsy::ListingCopy do
   let(:owner) { create(:user) }
   let(:board) { create(:board, user: owner, name: "core words") }
 
+  # page_count 7 is what a one-board printable really merges to: cover,
+  # how-to-use, the three board pages, license, credits. The copy must quote
+  # the three, so a fixture that agreed with it would prove nothing.
   def printable(**attrs)
     BoardPrintable.create!(
-      { board: board, status: "complete", board_ids: [board.id], page_count: 6 }.merge(attrs),
+      { board: board, status: "complete", board_ids: [board.id], page_count: 7 }.merge(attrs),
     )
   end
 
@@ -78,8 +81,11 @@ RSpec.describe Etsy::ListingCopy do
       expect(description).to include("2 boards, 6 pages — 3 PDFs (full color + low-ink + trim-ready)")
     end
 
-    it "describes a single board as an n-page PDF" do
-      expect(build["description"]).to include("6-page board PDF — color, low-ink + trim-ready")
+    # The cover, how-to-use, license and credits pages are not what a buyer is
+    # counting — three board pages is the product.
+    it "counts board pages, not the wrapper pages around them" do
+      expect(build["description"]).to include("3-page board PDF — color, low-ink + trim-ready")
+      expect(build["description"]).not_to include("7-page")
     end
 
     it "omits the boards section for a single-board printable" do


### PR DESCRIPTION
## Summary

A printable's listing copy quoted `board_printables.page_count`, which is the true length of the merged PDFs — and every file is wrapped in a cover, a how-to-use page, a license and a credits page. So a one-board printable, whose three board pages *are* the product, was sold as a **"7-page board PDF"** ([printable 16](https://670kd.hatchboxapp.com/admin/board_printables/16)). A buyer counts the boards they can print, not the front matter.

`BoardPrintable#board_page_count` now derives the honest number and both copy surfaces read it.

| | before | after |
|---|---|---|
| 1 board | `7-page board PDF — color, low-ink + trim-ready` | `3-page board PDF — color, low-ink + trim-ready` |
| 2 boards | `2 boards, 26 pages — 3 PDFs …` | `2 boards, 6 pages — 3 PDFs …` |
| 9 boards | `9 boards, 39 pages — 3 PDFs …` | `9 boards, 27 pages — 3 PDFs …` |

## What changed

- **`BoardPrintable#board_page_count`** — `boards × DOWNLOAD_VARIANTS`. **Derived, not stored**, because `CollectPages` renders each board exactly once per download variant: existing printables report the corrected count with **no re-render and no migration**. (Their gallery images still need re-rendering to pick up the new footer text, since those are baked PNGs.)
- **Both readers of `Printables::IncludedItems` pass it** — `Etsy::ListingCopy#included_section` (the description) and `RenderListingImages#included_items` (the "In your download" panel on both what's-included slides, colour and low-ink). They're read together by one buyer, so passing different counts is the failure mode worth guarding.

## Deliberately unchanged

`page_count` keeps its meaning — the real merged page total. It's what the admin index/show list and what TPT's "Number of pages" form field asks for, which is a question about the file, not about the product.

## Test plan

`bundle exec rspec spec/services/boards/printables spec/services/printables spec/services/etsy spec/models/board_printable_spec.rb spec/requests/admin/board_printables_spec.rb` → **295 examples, 0 failures**.

New coverage:
- `BoardPrintable#board_page_count` — single board, set, and ungenerated (0, so the headline drops the number rather than claiming zero pages)
- `Etsy::ListingCopy` — asserts `3-page board PDF` and `not_to include("7-page")`
- `RenderListingImages` — the in-your-download panel for **single and multi board**, asserting the set case reads `2 boards, 6 pages` and not `26 pages`

The fixtures deliberately set `page_count` to the real wrapper-inclusive totals (7 and 26) so any regression that routes `page_count` back into the copy fails visibly, rather than passing on a fixture that happens to agree.

## Docs

`.claude-notes/board-printables-etsy.md` gains the invariant (copy quotes `board_page_count`, never `page_count`, and both readers must pass the same one); CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)