### PR TITLE
feat(board-builder): pick a different library picture for any tile

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1120,6 +1120,27 @@ Its own invariants:
   them. `resolve_all` runs only inside `Boards::AdminBuilder::Build`'s
   transaction, where creating blanks is the intended outcome. Asserted by spec
   on both `Board.count` and `Image.count`.
+- **The review screen's two per-tile controls are decided at BUILD time, not on
+  the screen.** "Regenerate with AI" (`plan["regenerate"]`, a list of labels)
+  and the picture picker (`plan["display_docs"]`, label => `docs.id`) both ride
+  the hidden-field resubmit through the HTML5 `form="build-form"` attribute, and
+  both are re-filtered against the plan in `create` rather than trusted — a
+  hand-edited field must not be able to name an arbitrary label, and a picked
+  doc is additionally checked to be library-owned (`user_id` nil or the default
+  admin) so a real user's upload can't be published onto a public board. Labels
+  are normalized through `Boards::ImageResolver.normalize` on the way in, which
+  is the form `Build#resolved` looks them up by.
+  **A pick beats a mark**: they are the same decision made two ways, and keeping
+  both would pin the chosen picture and then generate over it —
+  `Build#regenerate_image_ids` subtracts the picks, because
+  `unpin_regenerated_tiles!` would otherwise clear the very
+  `display_image_url` that carries the choice.
+  A pick moves the PICTURE only: the tile still resolves to its own `Image`, so
+  the word it speaks, its audio, and every other board using that word are
+  untouched. `ArtPreview` offers the alternatives by raising its
+  `Images::LabelSearch` limit to `CANDIDATE_LIMIT` — the `resolve` tier still
+  comes first, so result 1 is what gets attached and the rest are the offer.
+  Doc ids, not image ids: which doc an image resolves to moves as art is added.
 - **A board is authored as columns + a tile count, never rows.** Rows aren't
   stored anywhere — `Board#rows_for_screen_size` derives them from the tiles —
   so `admin_board_builds.tile_count` (and a child page's `tile_count` override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Pick a different picture for any tile on the board builder's review
+  screen.** The library often has more than one symbol for a word, and until now
+  the only way to reject the one it picked was to ask the AI for a brand new
+  one. Every tile with alternatives now carries a small picture chooser next to
+  its "regenerate with AI" box — choose one and the preview updates on the spot;
+  the board is built with exactly that picture. The choice applies to that board
+  only: nothing changes for anyone else using the same word, and nothing is
+  written until you press Build. (Admin only.)
+
 ### Fixed
 
 - **A printable's listing copy now counts the board pages a buyer prints, not

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -272,6 +272,7 @@ module Admin
         commercial_safe_only: @form[:commercial_safe_only],
       ).call
       @marked = marked_labels(@form)
+      @picked_docs = picked_docs(@form)
       @name_matches = duplicate_name_matches(@form[:name])
 
       render :preview
@@ -311,6 +312,11 @@ module Admin
           # rather than trusted from the resubmit, and stored normalized so
           # Boards::AdminBuilder::Build can look each one up in `resolved`.
           "regenerate" => marked_labels(@form),
+          # Per-label doc picks made on the review screen. A picked doc and an
+          # AI regeneration are the same decision made two ways, so a pick wins
+          # and the mark is dropped — otherwise the build would pin the chosen
+          # picture and then immediately generate over it.
+          "display_docs" => picked_docs(@form),
         },
       )
       BuildAdminBoardJob.perform_async(build.id)
@@ -700,6 +706,7 @@ module Admin
         allow_partial_row: false,
         allow_mixed_grids: false,
         regenerate: [],
+        display_docs: {},
       }
     end
 
@@ -757,7 +764,24 @@ module Admin
         allow_partial_row: checked?(params[:allow_partial_row]),
         allow_mixed_grids: checked?(params[:allow_mixed_grids]),
         regenerate: submitted_regenerate,
+        display_docs: submitted_display_docs,
       }.then { |form| with_folder_tiles(form) }
+    end
+
+    # Docs the admin pinned on the review screen, as label => doc id. Keyed the
+    # same way marks are so a pick survives whatever casing the word was
+    # authored in. A blank value is "use the library's pick" and drops out here.
+    def submitted_display_docs
+      submitted = params[:display_docs]
+      # A hand-edited `display_docs=whatever` arrives as a String, not a hash.
+      return {} unless submitted.respond_to?(:to_unsafe_h)
+
+      submitted.to_unsafe_h.filter_map do |label, doc_id|
+        key = Boards::ImageResolver.normalize(label)
+        next if key.blank? || doc_id.to_i <= 0
+
+        [key, doc_id.to_i]
+      end.first(MAX_TILES).to_h
     end
 
     # Labels the admin ticked "regenerate with AI" on the review screen.
@@ -775,9 +799,28 @@ module Admin
     # still in the plan — the admin may have edited the list after ticking it,
     # and a hand-edited field must not be able to name an arbitrary label.
     def marked_labels(form)
-      planned = Boards::AdminBuilder::Plan.labels(pages_for(form))
-                                          .map { |label| Boards::ImageResolver.normalize(label) }
-      form[:regenerate] & planned
+      (form[:regenerate] & planned_labels(form)) - picked_docs(form).keys
+    end
+
+    # Label => doc id for tiles the admin pinned a specific picture to. Filtered
+    # the same way marks are — a pick only means anything if the word is still
+    # in the plan — and the doc id is checked against the library rather than
+    # trusted, so a hand-edited field can't pin a private user upload onto a
+    # public board.
+    def picked_docs(form)
+      picks = form[:display_docs].slice(*planned_labels(form))
+      return {} if picks.empty?
+
+      allowed = Doc.image_docs
+                   .where(id: picks.values, user_id: [nil, User::DEFAULT_ADMIN_ID])
+                   .pluck(:id)
+                   .to_set
+      picks.select { |_label, doc_id| allowed.include?(doc_id) }
+    end
+
+    def planned_labels(form)
+      Boards::AdminBuilder::Plan.labels(pages_for(form))
+                                .map { |label| Boards::ImageResolver.normalize(label) }
     end
 
     # Writes a folder tile onto the main board for any page nothing opens, and

--- a/app/models/admin_board_build.rb
+++ b/app/models/admin_board_build.rb
@@ -52,6 +52,14 @@ class AdminBoardBuild < ApplicationRecord
     Array((plan || {})["regenerate"])
   end
 
+  # Label => Doc id for tiles where the admin picked a different picture than
+  # the one the library would attach. Normalized on the way in, like
+  # regenerate_labels. The tile still resolves to its own Image — only the
+  # picture is pinned, through board_images.display_image_url.
+  def display_doc_ids
+    ((plan || {})["display_docs"] || {}).transform_values(&:to_i)
+  end
+
   def labels
     Boards::AdminBuilder::Plan.labels(pages)
   end

--- a/app/services/boards/admin_builder/art_preview.rb
+++ b/app/services/boards/admin_builder/art_preview.rb
@@ -17,13 +17,27 @@ module Boards
     # resolved to art labelled "too tired to speak as it uses a lot of my
     # energy…". Every one of those is surfaced for a human to look at.
     class ArtPreview
+      # How many library results to offer per label. One is what gets attached;
+      # the rest are what the admin can swap to on the review screen. Kept small
+      # on purpose — the point is "is there a better picture for this word",
+      # not a browsable library.
+      CANDIDATE_LIMIT = 6
+
+      # One alternative picture the admin may pin to a tile instead of the
+      # library's pick. `doc_id` is what gets submitted and stored: an image id
+      # would be ambiguous, since which doc an image resolves to moves as art
+      # is added to it.
+      Candidate = Struct.new(:doc_id, :image_id, :label, :url, :exact, keyword_init: true)
+
       Row = Struct.new(
-        :label, :image_id, :matched_label, :exact, :src, :original_url,
+        :label, :image_id, :doc_id, :matched_label, :exact, :src, :original_url,
         :source_type, :license, :commercial_safe, :attribution_required, :share_alike,
-        :links_to,
+        :links_to, :alternatives,
         keyword_init: true,
       ) do
         def found? = image_id.present?
+
+        def alternatives = self[:alternatives] || []
 
         def exact? = exact.present?
 
@@ -100,11 +114,13 @@ module Boards
       end
 
       def searcher
-        # limit: 1 — the review grid shows what will actually be attached, not a
-        # menu of alternatives. `resolve: true` prepends exactly that pick.
+        # `resolve: true` puts what will ACTUALLY be attached first; everything
+        # after it is an alternative the admin can pin instead. The tiers are
+        # lazy, so asking for CANDIDATE_LIMIT still costs one lookup when the
+        # first tier fills it.
         @searcher ||= Images::LabelSearch.new(
           match: "exact",
-          limit: 1,
+          limit: CANDIDATE_LIMIT,
           commercial_safe: commercial_safe_only,
           resolve: true,
         )
@@ -116,17 +132,20 @@ module Boards
         key = label.downcase
         return @lookup[key] if @lookup.key?(key)
 
-        @lookup[key] = searcher.call(label).first
+        @lookup[key] = searcher.call(label)
       end
 
       def row_for(tile)
         label = tile[:label].to_s.strip
-        result = lookup(label)
+        results = lookup(label)
+        result = results.first
         return Row.new(label: label, exact: false, links_to: tile[:links_to]) if result.nil?
 
         Row.new(
           label: label,
           image_id: result[:id],
+          doc_id: result[:doc_id],
+          alternatives: candidates_for(label, results),
           matched_label: result[:label],
           exact: exact?(label, result[:label]),
           src: result[:src],
@@ -138,6 +157,25 @@ module Boards
           share_alike: result[:share_alike],
           links_to: tile[:links_to],
         )
+      end
+
+      # Every result the admin could pin, the library's own pick included, so
+      # the picker can offer a way back to the default. Rows with no processed
+      # thumbnail AND no original are dropped — an option with nothing to show
+      # is not a choice.
+      def candidates_for(label, results)
+        results.filter_map do |result|
+          url = result[:src].presence || result[:original_url].presence
+          next if url.blank? || result[:doc_id].blank?
+
+          Candidate.new(
+            doc_id: result[:doc_id],
+            image_id: result[:id],
+            label: result[:label],
+            url: url,
+            exact: exact?(label, result[:label]),
+          )
+        end
       end
 
       # `images.label` is the lowercase matching key, so casing never makes a

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -177,6 +177,12 @@ module Boards
         pos = tile[:part_of_speech].to_s
         attrs[:part_of_speech] = pos if pos.present? && pos != "default"
 
+        # A picture the admin picked on the review screen instead of the
+        # library's own. Pinned per TILE, not on the Image — every other board
+        # using this word keeps whatever the library resolves for it.
+        picked = picked_doc_urls[Boards::ImageResolver.normalize(tile[:label].to_s)]
+        attrs[:display_image_url] = picked if picked.present?
+
         display_label = tile[:display_label].to_s
         attrs[:display_label] = display_label if display_label.present?
 
@@ -254,10 +260,36 @@ module Boards
       # Minus the blanks: a label with no art is already queued by
       # queue_missing_art!, and generating it twice is two API calls for one
       # picture.
+      # Minus the picks too: a tile whose picture the admin chose by hand must
+      # not have AI art generated over it, and unpin_regenerated_tiles! would
+      # drop the pin that carries the choice.
       def regenerate_image_ids(blank_image_ids)
-        build.regenerate_labels
-             .filter_map { |label| resolved[label]&.id }
-             .uniq - blank_image_ids
+        (build.regenerate_labels - picked_doc_urls.keys)
+          .filter_map { |label| resolved[label]&.id }
+          .uniq - blank_image_ids
+      end
+
+      # Label => the URL of the Doc the admin pinned to that tile. Resolved in
+      # one query for the whole set, and a doc that has since been deleted just
+      # drops out — the tile falls back to the library's own art rather than
+      # failing the build over a picture.
+      #
+      # Prefers the 288px tile variant, but only when it is ALREADY processed:
+      # materializing it here would run an inline download+transform per tile
+      # inside the build transaction. The full-resolution original renders fine
+      # in the meantime.
+      def picked_doc_urls
+        @picked_doc_urls ||= begin
+          picks = build.display_doc_ids
+          docs = picks.any? ? Doc.where(id: picks.values.uniq).index_by(&:id) : {}
+          picks.filter_map do |label, doc_id|
+            doc = docs[doc_id]
+            next if doc.nil?
+
+            url = doc.tile_variant_processed? ? doc.tile_url : doc.display_url
+            [label, url] if url.present?
+          end.to_h
+        end
       end
 
       # A marked tile was built with the library's art, so BoardImage#set_defaults
@@ -292,6 +324,8 @@ module Boards
           # picture for them — `show` reports these separately from the blanks.
           "regenerated_labels" => resolved.select { |_, image| regenerate_ids.include?(image.id) }.keys,
           "regenerated_image_ids" => regenerate_ids,
+          # Tiles whose picture the admin picked by hand on the review screen.
+          "picked_labels" => picked_doc_urls.keys,
           "slug" => root.slug,
           # key => board id, so `show` can list every page of the set and
           # publish can cascade over it without re-walking the link graph.

--- a/app/services/images/label_search.rb
+++ b/app/services/images/label_search.rb
@@ -146,6 +146,11 @@ module Images
         id: image.id,
         label: image.label,
         match: kind,
+        # The Doc the URLs below describe. Callers that let a human PICK one of
+        # several results (the board builder's review screen) need to name the
+        # exact picture afterwards, and an image id can't do that — which doc
+        # an image resolves to changes as art is added.
+        doc_id: doc.id,
         # doc.tile_url materializes the ActiveStorage variant synchronously
         # (download original + libvips transform + upload) on first access.
         # This endpoint can return up to MAX_LIMIT results in one response,

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -293,6 +293,14 @@
     <% end %>
   </div>
 
+  <%# Same deal for per-tile picture picks: label => doc id. Re-validated by
+      `preview`/`create` against the plan and against the library. %>
+  <div data-doc-picks hidden>
+    <% (@form[:display_docs] || {}).each do |label, doc_id| %>
+      <%= hidden_field_tag "display_docs[#{label}]", doc_id, id: nil, data: { mirror_for: label } %>
+    <% end %>
+  </div>
+
   <div class="flex items-center gap-3">
     <%= submit_tag "Preview the art",
           class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -55,6 +55,10 @@
       <p class="text-2xl font-semibold text-t1" data-marked-count><%= @marked.size %></p>
       <p class="text-[11px] text-t3">marked for AI regeneration</p>
     </div>
+    <div>
+      <p class="text-2xl font-semibold text-t1" data-picked-count><%= @picked_docs.size %></p>
+      <p class="text-[11px] text-t3">pinned to a different library picture</p>
+    </div>
   </div>
 
   <% if @preview[:inexact].any? %>
@@ -85,10 +89,15 @@
 
   <div class="builder-grid mb-8" style="--cols: <%= page[:columns] %>;">
     <% page[:rows].each do |row| %>
+      <% key = Boards::ImageResolver.normalize(row.label) %>
+      <% picked_doc = @picked_docs[key] %>
+      <% picked_url = row.alternatives.find { |candidate| candidate.doc_id == picked_doc }&.url %>
       <div class="admin-card border rounded-xl overflow-hidden <%= "border-amber-500" if row.found? && !row.exact %><%= "border-red-500" unless row.found? %>">
         <div class="aspect-square admin-card-alt flex items-center justify-center overflow-hidden">
           <% if row.display_url.present? %>
-            <img src="<%= row.display_url %>" alt="<%= row.label %>" loading="lazy" class="w-full h-full object-contain">
+            <img src="<%= picked_url.presence || row.display_url %>" alt="<%= row.label %>" loading="lazy"
+                 class="w-full h-full object-contain" data-tile-art="<%= key %>"
+                 data-default-art="<%= row.display_url %>">
           <% else %>
             <span class="text-[11px] text-t3 px-2 text-center">no art</span>
           <% end %>
@@ -114,7 +123,6 @@
               generated here — preview still writes nothing. A word repeated
               across pages is one Image and one generation, so the boxes
               sharing a value are kept in step by the script at the bottom. %>
-          <% key = Boards::ImageResolver.normalize(row.label) %>
           <% if row.found? %>
             <label class="flex items-center gap-1.5 mt-1.5 cursor-pointer" title="Build with the library symbol, then generate new AI art over it">
               <%= check_box_tag "regenerate[]", key, @marked.include?(key),
@@ -122,6 +130,32 @@
                     data: { regenerate_mark: key } %>
               <span class="text-[10px] text-t2">regenerate with AI</span>
             </label>
+
+            <%# Swap the picture without generating anything: the library often
+                has several pictures for a word, and picking one is cheaper and
+                surer than asking the AI for a new one. Rides the build form
+                through the same `form` attribute the mark does. Only the
+                PICTURE moves — the tile still resolves to its own Image, so
+                nothing here changes what the word says or what any other board
+                sees. %>
+            <% if row.alternatives.size > 1 %>
+              <%= select_tag "display_docs[#{key}]",
+                    options_for_select(
+                      [["library pick", ""]] +
+                        row.alternatives.drop(1).map.with_index(2) do |candidate, position|
+                          [candidate.exact ? "art #{position} · #{candidate.label}" : "art #{position} · “#{candidate.label}”",
+                           candidate.doc_id]
+                        end,
+                      picked_doc,
+                    ),
+                    form: "build-form", id: nil,
+                    class: "w-full mt-1.5 text-[10px] rounded admin-card-alt border px-1 py-0.5 cursor-pointer",
+                    title: "Use a different picture from the library for this tile",
+                    data: {
+                      doc_pick: key,
+                      urls: row.alternatives.to_h { |candidate| [candidate.doc_id, candidate.url] }.to_json,
+                    } %>
+            <% end %>
           <% else %>
             <%# Already queued by the build — shown ticked so the grid reads
                 consistently, disabled so it can't be un-asked for. %>
@@ -182,8 +216,6 @@
     var boxes = Array.prototype.slice.call(
       document.querySelectorAll("input[data-regenerate-mark]")
     );
-    if (!boxes.length) return;
-
     var count = document.querySelector("[data-marked-count]");
     // Mirror into the authoring form below, so pressing "Preview the art"
     // again keeps the marks instead of starting from nothing.
@@ -219,6 +251,69 @@
     boxes.forEach(function (box) {
       box.addEventListener("change", function () {
         sync(box.dataset.regenerateMark, box.checked);
+      });
+    });
+
+    // Doc picks. Same two jobs as the marks: keep every cell showing the same
+    // word in step, and mirror the choice into the authoring form below so
+    // pressing "Preview the art" again doesn't throw the picks away.
+    var picks = Array.prototype.slice.call(document.querySelectorAll("[data-doc-pick]"));
+    var pickMirror = document.querySelector("[data-doc-picks]");
+
+    function art(label, docId) {
+      document.querySelectorAll('[data-tile-art="' + label + '"]').forEach(function (img) {
+        var urls = {};
+        var select = document.querySelector('[data-doc-pick="' + label + '"]');
+        if (select) urls = JSON.parse(select.dataset.urls || "{}");
+        img.src = urls[docId] || img.dataset.defaultArt;
+      });
+    }
+
+    function syncPicks(label, value) {
+      picks.forEach(function (select) {
+        if (select.dataset.docPick === label) select.value = value;
+      });
+      art(label, value);
+
+      // A picked picture and an AI regeneration are the same decision made two
+      // ways; the build drops the mark, so don't leave it ticked here either.
+      if (value) {
+        boxes.forEach(function (box) {
+          if (box.dataset.regenerateMark === label && box.checked && !box.disabled) {
+            box.checked = false;
+            sync(label, false);
+          }
+        });
+      }
+
+      var pickedCount = document.querySelector("[data-picked-count]");
+      if (pickedCount) {
+        var chosen = [];
+        picks.forEach(function (select) {
+          if (select.value && chosen.indexOf(select.dataset.docPick) === -1) {
+            chosen.push(select.dataset.docPick);
+          }
+        });
+        pickedCount.textContent = chosen.length;
+      }
+
+      if (!pickMirror) return;
+      pickMirror.innerHTML = "";
+      picks.forEach(function (select) {
+        if (!select.value) return;
+        if (pickMirror.querySelector('[data-mirror-for="' + select.dataset.docPick + '"]')) return;
+        var input = document.createElement("input");
+        input.type = "hidden";
+        input.name = "display_docs[" + select.dataset.docPick + "]";
+        input.value = select.value;
+        input.setAttribute("data-mirror-for", select.dataset.docPick);
+        pickMirror.appendChild(input);
+      });
+    }
+
+    picks.forEach(function (select) {
+      select.addEventListener("change", function () {
+        syncPicks(select.dataset.docPick, select.value);
       });
     });
   })();

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -147,6 +147,15 @@
         Marked for AI regeneration: <%= regenerated.join(", ") %>
       </p>
     <% end %>
+    <% picked = Array(@build.art_report["picked_labels"]) %>
+    <% if picked.any? %>
+      <%# The library had more than one picture for these words and the admin
+          chose which one on the review screen. Pinned per TILE — the shared
+          Image is untouched, so no other board moves. %>
+      <p class="text-[11px] text-t3 mt-2">
+        Pinned to a picked picture: <%= picked.join(", ") %>
+      </p>
+    <% end %>
     <% if @missing_art_count.positive? %>
       <%= button_to "Generate the missing art", regenerate_art_admin_dashboard_board_build_path(@build), method: :post,
             class: "text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1 mt-3",

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -160,6 +160,107 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  describe "picking a different picture for a tile" do
+    before { sign_in admin }
+
+    # Two library images for the same word: one gets attached, the other is the
+    # alternative the picker offers.
+    def two_arted_images(label)
+      [1, 2].map do |n|
+        image = Image.create!(label: label, user: seed_admin, private: false)
+        # OpenAI art is commercial-safe, so both candidates survive the
+        # commercial_safe_only filter the form defaults to.
+        doc = image.docs.create!(user: seed_admin, source_type: "OpenAI", raw: label)
+        doc.image.attach(
+          io: StringIO.new(file_fixture("sample.png").read),
+          filename: "#{label}-#{n}.png",
+          content_type: "image/png",
+        )
+        doc
+      end
+    end
+
+    it "offers the alternatives on the review screen without writing anything" do
+      two_arted_images("swing")
+
+      expect { post preview_admin_dashboard_board_builds_path, params: form_params }
+        .to not_change(Board, :count).and not_change(Image, :count).and not_change(Doc, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('name="display_docs[swing]"')
+      expect(response.body).to include("pinned to a different library picture")
+    end
+
+    # Same rail as the regenerate marks: the picker sits in the grid, well
+    # above the Build form, and only submits with it because of the HTML5
+    # `form` attribute.
+    it "points the picker at the build form" do
+      two_arted_images("swing")
+
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response.body).to match(/<select[^>]*name="display_docs\[swing\]"[^>]*form="build-form"/)
+    end
+
+    it "offers no picker for a label with only one library picture" do
+      two_arted_images("swing").first
+
+      post preview_admin_dashboard_board_builds_path, params: form_params
+
+      expect(response.body).not_to include('name="display_docs[want]"')
+    end
+
+    it "stores the pick on the build, keyed by normalized label" do
+      alternative = two_arted_images("swing").last
+
+      post admin_dashboard_board_builds_path,
+           params: form_params(display_docs: { "Swing" => alternative.id.to_s })
+
+      expect(AdminBoardBuild.last.display_doc_ids).to eq("swing" => alternative.id)
+    end
+
+    it "drops a pick for a label that isn't in the plan" do
+      alternative = two_arted_images("slide").last
+
+      post admin_dashboard_board_builds_path,
+           params: form_params(display_docs: { "slide" => alternative.id.to_s })
+
+      expect(AdminBoardBuild.last.display_doc_ids).to eq({})
+    end
+
+    # The round trip is not trusted. A doc belonging to a real user can be
+    # attached to a shared library image, and this screen builds PUBLIC boards
+    # — a hand-edited field must not be able to publish someone's own upload.
+    it "refuses a doc that isn't the library's" do
+      image = Image.create!(label: "swing", user: seed_admin, private: false)
+      theirs = image.docs.create!(user: create(:user), source_type: Doc::SOURCE_TYPE_USER, raw: "swing")
+
+      post admin_dashboard_board_builds_path,
+           params: form_params(display_docs: { "swing" => theirs.id.to_s })
+
+      expect(AdminBoardBuild.last.display_doc_ids).to eq({})
+    end
+
+    # A picked picture and an AI regeneration are the same decision made two
+    # ways. Keeping both would pin the choice and then generate over it.
+    it "drops the regeneration mark for a label that was also picked" do
+      alternative = two_arted_images("swing").last
+
+      post admin_dashboard_board_builds_path,
+           params: form_params(regenerate: ["swing"], display_docs: { "swing" => alternative.id.to_s })
+
+      build = AdminBoardBuild.last
+      expect(build.regenerate_labels).to eq([])
+      expect(build.display_doc_ids).to eq("swing" => alternative.id)
+    end
+
+    it "stores no picks when nothing was chosen" do
+      post admin_dashboard_board_builds_path, params: form_params
+
+      expect(AdminBoardBuild.last.display_doc_ids).to eq({})
+    end
+  end
+
   describe "child pages" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/art_preview_spec.rb
+++ b/spec/services/boards/admin_builder/art_preview_spec.rb
@@ -187,4 +187,38 @@ RSpec.describe Boards::AdminBuilder::ArtPreview do
     expect(result[:total]).to eq(2)
     expect(result[:pages].first[:rows].size).to eq(3)
   end
+  # The review screen lets an admin pin a different picture without asking the
+  # AI for a new one, so the row has to carry the other library candidates —
+  # and its own doc, so "the library's pick" is nameable.
+  describe "alternatives" do
+    it "offers every library candidate for the label, its own pick first" do
+      first = image_with_doc(label: "apple")
+      second = image_with_doc(label: "apple")
+
+      row = described_class.new(pages: pages_for(["apple"]), commercial_safe_only: false).call[:pages].first[:rows].first
+
+      expect(row.alternatives.map(&:image_id)).to contain_exactly(first.id, second.id)
+      expect(row.alternatives.first.image_id).to eq(row.image_id)
+      expect(row.alternatives.first.doc_id).to eq(row.doc_id)
+      expect(row.alternatives.map(&:url)).to all(be_present)
+    end
+
+    it "is empty for a label with no art at all" do
+      row = described_class.new(pages: pages_for(["nonexistentwordxyz"]), commercial_safe_only: false).call[:pages].first[:rows].first
+
+      expect(row).not_to be_found
+      expect(row.alternatives).to be_empty
+    end
+
+    # Same rule as everything else on this screen: reading the alternatives
+    # must not create anything.
+    it "writes nothing while collecting them" do
+      image_with_doc(label: "apple")
+      image_with_doc(label: "apple")
+
+      expect {
+        described_class.new(pages: pages_for(%w[apple]), commercial_safe_only: false).call
+      }.to not_change(Image, :count).and not_change(Doc, :count)
+    end
+  end
 end

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -567,4 +567,75 @@ RSpec.describe Boards::AdminBuilder::Build do
       expect(child.tags).not_to include(*build.tags)
     end
   end
+  # A doc the admin picked on the review screen instead of the library's own.
+  # Only the PICTURE moves: the tile still resolves to its own Image, so the
+  # word it speaks and every other board using it are untouched.
+  describe "tiles pinned to a picked doc" do
+    # No attachment, for the same reason image_with_art has none: attaching
+    # defers the upload to after_commit, and this service opens its own
+    # transaction, so the deferred upload fires mid-build against a consumed
+    # stream. Doc#display_url falls back to original_image_url when nothing is
+    # attached, which is a real shape in the library (imported docs).
+    def alternate_doc(image)
+      image.docs.create!(
+        user_id: admin.id, source_type: "OpenAI", raw: image.label,
+        original_image_url: "https://example.com/#{image.label}-alt.png",
+      )
+    end
+
+    def picked_build(picks)
+      build_record(tiles: four_tiles).tap do |build|
+        build.update!(plan: build.plan.merge("display_docs" => picks))
+      end
+    end
+
+    it "pins the picked doc onto the tile and leaves the resolved image alone" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      swing = Image.find_by(label: "swing")
+      doc = alternate_doc(swing)
+      build = picked_build("swing" => doc.id)
+
+      board = described_class.new(admin_board_build: build).call
+      tile = board.board_images.joins(:image).find_by(images: { label: "swing" })
+
+      expect(tile.image_id).to eq(swing.id)
+      expect(tile.display_image_url).to eq("https://example.com/swing-alt.png")
+      expect(build.reload.art_report["picked_labels"]).to eq(["swing"])
+    end
+
+    it "leaves every other tile on the library's own art" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      doc = alternate_doc(Image.find_by(label: "swing"))
+
+      board = described_class.new(admin_board_build: picked_build("swing" => doc.id)).call
+      other = board.board_images.joins(:image).find_by(images: { label: "want" })
+
+      expect(other.display_image_url).not_to eq("https://example.com/swing-alt.png")
+    end
+
+    # A pick and a regeneration are the same decision made two ways. Generating
+    # over a picked tile would throw the choice away — and unpinning it would
+    # delete the pin that carries it.
+    it "does not regenerate a label that was also marked" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      doc = alternate_doc(Image.find_by(label: "swing"))
+      build = picked_build("swing" => doc.id)
+      build.update!(plan: build.plan.merge("regenerate" => ["swing"]))
+
+      board = described_class.new(admin_board_build: build).call
+      tile = board.board_images.joins(:image).find_by(images: { label: "swing" })
+
+      expect(build.reload.art_report["regenerated_labels"]).to be_empty
+      expect(tile.display_image_url).to eq("https://example.com/swing-alt.png")
+    end
+
+    # A picture is not worth failing a build over.
+    it "falls back to the library art when the picked doc is gone" do
+      four_tiles.each { |tile| image_with_art(label: tile["label"]) }
+      build = picked_build("swing" => 0)
+
+      expect { described_class.new(admin_board_build: build).call }.not_to raise_error
+      expect(build.reload.art_report["picked_labels"]).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## What

On the admin Board Builder's **Review the art** screen, any tile whose word has more than one library picture now carries a small picker beside its existing "regenerate with AI" box. Choosing one swaps the preview image on the spot; the board is built with exactly that picture.

Until now the only way to reject a symbol was to ask the AI for a brand new one — slower, costs credits, and often the library already had a better picture for the word.

## How

- `Images::LabelSearch` results carry `doc_id`. An image id can't name a picture: which doc an image resolves to moves as art is added to it.
- `Boards::AdminBuilder::ArtPreview` raises its per-label limit to `CANDIDATE_LIMIT` (6) and exposes `row.alternatives`. The `resolve` tier is still first, so result 1 remains what actually gets attached and the rest are the offer. Tiers are lazy, so an exact hit still costs one lookup.
- The picker rides the same rails the regenerate marks do: hidden-field resubmit through `form="build-form"`, stored on `plan["display_docs"]` as label => doc id, and re-filtered against the plan in `create` rather than trusted.
- `Boards::AdminBuilder::Build` sets `board_images.display_image_url` on that tile only.

## Reviewer notes

- **Only the picture moves.** The tile still resolves to its own `Image`, so the word it speaks, its audio, and every other board using that word are untouched — this is the per-tile `display_image_url` pin the renderers already honour, so it carries into PDF exports and covers for free.
- **A pick beats a regenerate mark** for the same label. They're the same decision made two ways, and keeping both would pin the chosen picture and then generate over it — `unpin_regenerated_tiles!` would clear the very pin that carries the choice.
- **A picked doc is checked to be library-owned** (`user_id` nil or the default admin). These boards are published publicly, and a real user's own upload can be attached to a shared library image — a hand-edited field must not be able to publish it.
- **Preview still writes nothing**, alternatives included — asserted on `Board`, `Image` and `Doc` counts.
- A picked doc that has since been deleted falls back to the library art rather than failing the build.
- Not done deliberately: *Duplicate* doesn't restore picks — it doesn't restore regenerate marks either, and I kept the two consistent rather than changing that on the side.

## Test plan

`bundle exec rspec spec/requests/admin/board_builds_spec.rb spec/services/boards/admin_builder spec/services/images` — **583 examples, 0 failures** (also ran green alongside `spec/requests/api/internal`, which consumes the `LabelSearch` payload: 746 total).

New coverage: alternatives on `ArtPreview` (offered, empty when no art, writes nothing), the pin in `Build` (applies, leaves other tiles alone, beats the mark, survives a deleted doc), and the request path (picker rendered and pointed at the build form, stored normalized, plan-filtered, non-library doc refused, mark dropped).

Docs: new invariant bullet in `.claude-notes/board-builder.md`, CHANGELOG entry under Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)