### PR TITLE
feat(board-builder): lowercase AI drafts, better suggestions, reuse published boards

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1179,6 +1179,42 @@ Its own invariants:
   action is scoped through `AdminBoardBuild.builder_boards`, the same rail
   `Admin::VideoBoardsController` runs on. Boards are created unpublished;
   publishing is a separate confirmed POST that refuses an empty board.
+- **The set and the build's pointer at it commit together, under a row lock on
+  the build** (`Build#create_and_claim!`), and `art_report["boards"]` is written
+  in that same transaction — every page, not just the root. Both halves are
+  load-bearing. `BuildAdminBoardJob` is `retry: 2`, so a claim written *after*
+  the creating transaction left the boards committed with `board_id` still blank
+  whenever anything in between raised (the two art queries, the jsonb write) —
+  and the retry sailed past the "already built" guard and produced a second full
+  set. A stranded set stays `published: true` and appears in no build's
+  `art_report`, so `AdminBoardBuild#set_boards` can't see it: not listed on the
+  build page, skipped by publish/unpublish, left behind by destroy. The row lock
+  is the other half, because Sidekiq delivers at least once and two workers can
+  both read a blank `board_id` before either writes one.
+  `rake admin_board_builds:orphans` finds sets already stranded this way
+  (`UNPUBLISH=1` / `APPLY=1` to act). The other duplication route is two POSTs
+  to `create` — that makes two *builds*, and the preview page's submit guard is
+  what stops a double click causing it.
+- **A page can LINK an existing published admin board instead of building one.**
+  `children[i][existing_board_id]`, offered by `Boards::AdminBuilder::ExistingBoards`
+  whenever a published admin board carries the page's name (name match, ranked
+  same-grid-first; predictive and menu boards excluded because
+  `BoardImage#door_tile?` wouldn't read a tile pointing at one as a folder).
+  Creating a new page stays the default. Three rails:
+  `Plan.child_page` blanks a linked page's tiles at the single point every
+  consumer reads a page from, so validation, art resolution, preview and build
+  agree without each remembering the rule; the linked board is recorded under
+  `art_report["linked_boards"]` and **never** `["boards"]`, since that key is
+  what publish/unpublish/destroy iterate; and `Build#pin_as_main_board!` sets
+  `settings["builder_root"] = true` on it, because `check_is_sub_board` is a
+  `before_save` that would otherwise demote the board out of `main_boards` (and
+  out of `Boards::AdminSearch.base_scope`, so out of admin board search) on its
+  next unrelated save. The id is always re-resolved through
+  `ExistingBoards.find`, never `Board.find` — it arrives on a form post.
+  **Known gap:** a linked board keeps whatever back tile it already had, so it
+  has no way back to the new root. `data["back_tile"]` is not a runtime
+  behaviour — navigation is the static `predictive_board_id` — so a shared board
+  can only ever have one home until a "return to caller" nav exists.
 - **md/sm column counts are derived** via `Boards::ScreenColumns`, explicitly —
   `Board#set_screen_sizes` only fills them when nil, and
   `boards.medium/small_screen_columns` carry non-nil database defaults (8 and
@@ -1296,6 +1332,39 @@ AI drafting (Phase 2) fills the main word list only — pages are authored by ha
   never gives a child a grid of its own. Like every other AI path here it only
   fills the form. `Boards::AdminBuilder::WordList` is the single parser/renderer
   for the textarea format; `.render` is the exact inverse of `.parse`.
+  Two behaviours worth knowing before reading its output: a page's words are
+  deduped against the ROOT's as a hard filter (a word the main board carries is
+  reachable from every page, so a repeat spends a cell and buys nothing), and a
+  board more than `TOPUP_THRESHOLD` tiles short triggers ONE follow-up call
+  through `WordListDrafter`'s top-up prompt, capped at `MAX_TOPUPS` for the
+  whole draft. That means a single "Draft the whole set" click can make more
+  than one OpenAI call — specs that capture "the prompt" must take the *first*.
+
+- **Drafted labels are folded to lowercase; hand-typed ones are not.**
+  `Boards::AdminBuilder::LabelCasing` is the one place this happens, and it only
+  decides *which* labels are `Labels::CaseNormalizer`'s business — the casing
+  rules themselves stay in that single authority. The model answers in Title
+  Case no matter what the prompt says, and nothing downstream was catching it:
+  `Image#set_label` folds a plain leading capital only for a NEW image, and
+  never for a tile whose plan carries an explicit `display_label`. Two
+  carve-outs: a tile with `links_to` is a door and keeps its authored capital
+  ("Food", "Snack Time"), matching what `FolderTiles` already pins on the doors
+  it writes; and the model may set `"proper_noun": true`, honoured only when the
+  label actually carries a capital, because `CaseNormalizer` has no proper-noun
+  detection and would otherwise fold "Sarah". Words an admin types in the
+  textarea are authored input and are never folded.
+
+- **All three drafters share `Boards::AdminBuilder::Drafting`** for the OpenAI
+  call — model (`OPENAI_ADMIN_BUILDER_MODEL`, defaulting to `GTP_5_MODEL`) and
+  temperature (`OPENAI_ADMIN_BUILDER_TEMPERATURE`, `""` to send none) in one
+  place, because three copies of that call is how they drifted onto different
+  settings by accident. It retries once without the temperature if the first
+  attempt comes back empty: both knobs are ENV-tunable, not every model accepts
+  a custom temperature, and `create_chat` swallows an API error into a debug log
+  and returns nil — so a rejected temperature would look exactly like "the AI
+  had nothing to say". Note it calls `OpenAiClient.new(**opts)`, splatted: a
+  bare positional Hash moves the argument out of kwargs and breaks every spec
+  that stubs the constructor.
 
 - **`Boards::AdminBuilder::MetadataSuggester` fills the catalogue listing** —
   a plain-text description (`boards.description` renders as text on three of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A board builder page can reuse a board you've already published instead of
+  drafting a new one.** Most sets want a "Feelings" page, and the AI cheerfully
+  invented a slightly worse one every time. When a page's name matches a
+  published board of yours, the page now offers to link that board instead —
+  the folder tile opens it exactly as it is, and creating a fresh page stays the
+  default. A linked board is never touched by the build that points at it:
+  publishing, unpublishing or deleting the set leaves it alone. It keeps
+  whatever "back" tile it already had, so it has no way back to the new main
+  board — the review screen says so before you build. (Admin only.)
+
 - **Pick a different picture for any tile on the board builder's review
   screen.** The library often has more than one symbol for a word, and until now
   the only way to reject the one it picked was to ask the AI for a brand new
@@ -16,8 +26,36 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   only: nothing changes for anyone else using the same word, and nothing is
   written until you press Build. (Admin only.)
 
+### Changed
+
+- **Words drafted with AI now come back lowercase, the way AAC tiles are
+  written.** "Draft with AI" and "Draft the whole set with AI" were handing back
+  Title Case — "Apple", "All Done" — and that casing followed the words all the
+  way onto the built board. Words are now lowercased, while genuine capitals are
+  kept: proper nouns and brand names, words like "iPad" and "TV", the pronoun
+  "I", and folder tiles, which stay capitalized on purpose so a page you open
+  reads differently from a word you speak. Words you type yourself are never
+  changed.
+- **Better suggestions from "Draft the whole set with AI".** The main board now
+  starts from the same core-word spine a single board gets, every board aims for
+  a balance of verbs and function words rather than a wall of nouns, and pages
+  are asked for as places and routines ("Snack Time", "Going Home") instead of
+  categories of things ("Equipment", "Colors"). A page no longer repeats a word
+  the main board already carries, and a board that comes back well short of its
+  tile count is topped up automatically instead of leaving you to type the rest.
+  Drafting also runs on a stronger model. (Admin only.)
+
 ### Fixed
 
+- **Building a board set no longer occasionally creates the whole set twice.**
+  If a build hit an error in the moment after its boards were written but before
+  it recorded them, the automatic retry built a complete second copy — root and
+  every page — and the first copy was stranded: still published, invisible to
+  the build page, skipped by publish and unpublish, and left behind when the
+  build was deleted. A build now claims its boards in the same breath it creates
+  them, so a retry can never duplicate them, and a double click on "Build this
+  board" no longer starts two builds. Sets already stranded can be found and
+  cleaned up with `rake admin_board_builds:orphans`. (Admin only.)
 - **A printable's listing copy now counts the board pages a buyer prints, not
   the front matter around them.** Every printable PDF is wrapped in a cover, a
   how-to-use page, a license and a credits page, and the page count quoted in

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -25,6 +25,8 @@ module Admin
     DEFAULT_VOICE = "polly:kevin".freeze
 
     before_action :require_seed_admin!
+
+    helper_method :existing_board_matches
     before_action :set_build, only: %i[show update destroy publish unpublish duplicate regenerate_art]
 
     def index
@@ -300,12 +302,18 @@ module Admin
         plan: {
           "tiles" => Boards::AdminBuilder::Plan.stringify_tiles(@form[:tiles]),
           "children" => @form[:children].map do |child|
+            linked = child[:existing_board_id].presence&.to_i
             {
               "key" => child[:key],
               "name" => child[:name],
               "columns" => child[:columns].presence&.to_i,
               "tile_count" => child[:tile_count].presence&.to_i,
-              "tiles" => Boards::AdminBuilder::Plan.stringify_tiles(child[:tiles]),
+              # A linked page stores no word list. Plan.child_page blanks the
+              # tiles too, but keeping them out of the stored plan means
+              # re-opening the build through `duplicate` doesn't resurrect a
+              # word list the page never used.
+              "tiles" => linked ? [] : Boards::AdminBuilder::Plan.stringify_tiles(child[:tiles]),
+              "existing_board_id" => linked,
             }.compact
           end,
           # Marks made on the review screen. Re-filtered against the plan here
@@ -711,7 +719,7 @@ module Admin
     end
 
     def blank_child
-      { key: "", name: "", columns: "", tile_count: "", words: "", tiles: [] }
+      { key: "", name: "", columns: "", tile_count: "", words: "", tiles: [], existing_board_id: "" }
     end
 
     def form_from_build(build)
@@ -735,6 +743,7 @@ module Admin
           {
             key: page[:key], name: page[:name], columns: "", tile_count: "",
             words: tiles_to_words(page[:tiles]), tiles: page[:tiles],
+            existing_board_id: page[:existing_board_id].to_s,
           }
         end,
         commercial_safe_only: build.commercial_safe_only,
@@ -859,11 +868,29 @@ module Admin
           tile_count: child[:tile_count].to_s.strip,
           words: words,
           tiles: parse_tiles(words),
+          # "" when the picker is on "create a new page", which is the default.
+          # Validated as a real linkable board at build time, not here — this
+          # only has to survive the round trip.
+          existing_board_id: child[:existing_board_id].to_s.strip,
         }
         next if page[:key].blank? && page[:name].blank? && words.strip.blank?
 
         page
       end
+    end
+
+    # Published admin boards each page could point at instead of building a new
+    # one, keyed by the downcased page name the block carries. Recomputed on
+    # every round trip so renaming a page re-runs the lookup, in one query for
+    # the whole form.
+    #
+    # A helper rather than an ivar set per action: eleven actions render this
+    # form, and every one of them would have had to remember.
+    def existing_board_matches(form)
+      @existing_board_matches ||= Boards::AdminBuilder::ExistingBoards.matching(
+        Array(form[:children]).map { |child| child[:name] },
+        columns: form[:columns].to_i,
+      )
     end
 
     def checked?(value)

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -647,6 +647,9 @@ class OpenAiClient
     if format_json
       opts[:response_format] = { type: "json_object" }
     end
+    # Opt-in only, same shape as create_completion: every existing caller sends
+    # nothing and keeps the provider default it has always had.
+    opts[:temperature] = @opts[:temperature] if @opts[:temperature].present?
     begin
       response = openai_client.chat(
         parameters: opts,

--- a/app/services/boards/admin_builder/art_preview.rb
+++ b/app/services/boards/admin_builder/art_preview.rb
@@ -70,6 +70,11 @@ module Boards
             name: page[:name],
             columns: page[:columns].to_i,
             tile_count: page[:tile_count].to_i,
+            # A linked page has no tiles of its own and nothing to review — the
+            # board it points at is already built and already has its art. Its
+            # `rows` come out empty; the flag is what lets the review screen say
+            # so instead of drawing an empty grid.
+            linked_board: Plan.linked?(page) ? ExistingBoards.find(page[:existing_board_id]) : nil,
             rows: in_grid_order(page[:tiles], cells[page[:key]]).map { |tile| row_for(tile) },
           }
         end

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -26,18 +26,17 @@ module Boards
       end
 
       def call
+        # Already built. A build that died while finishing keeps its set and
+        # stays "failed" — the boards exist, and rebuilding them is the one
+        # thing that must not happen. The page's "Regenerate art" action is the
+        # recovery path for the art that never got queued.
         return build.board if build.board_id.present?
 
-        build.mark_building!
-        root = ActiveRecord::Base.transaction { create_set! }
+        root = create_and_claim!
+        # Another worker got there first and owns finishing this build.
+        return build.board if root.nil?
 
-        blank_image_ids = art_less_image_ids
-        regenerate_ids = regenerate_image_ids(blank_image_ids)
-        build.update!(board: root, status: "complete", art_report: art_report(root, blank_image_ids, regenerate_ids))
-        unpin_regenerated_tiles!(regenerate_ids)
-        queue_missing_art!(root, blank_image_ids)
-        queue_regenerated_art!(root, regenerate_ids)
-
+        finish!(root)
         root
       rescue StandardError => e
         build.mark_failed!(e.message)
@@ -47,6 +46,57 @@ module Boards
       private
 
       attr_reader :build
+
+      # The set and the build's pointer AT the set commit together, under a row
+      # lock on the build. Both halves are load-bearing — each one missing
+      # leaves a way to build the same set twice:
+      #
+      #   * **The claim is inside the transaction** because everything after it
+      #     can raise (two art queries and a jsonb write) and
+      #     BuildAdminBoardJob is `retry: 2`. With the claim outside, a failure
+      #     in that window left the boards committed but `board_id` still
+      #     blank, so the retry sailed straight past the guard and built a
+      #     second full set — root and every page. The orphaned first set stays
+      #     `published: true` and appears in no build's `art_report`, so
+      #     `set_boards` can't see it: it isn't listed on the build page,
+      #     publish/unpublish skip it, and destroying the build leaves it
+      #     behind. `rake admin_board_builds:orphans` finds the ones already
+      #     shipped this way.
+      #   * **The row lock** is what makes the guard mean anything with two
+      #     workers at once. Sidekiq delivers at least once, so two attempts can
+      #     both read a blank `board_id` before either writes one.
+      def create_and_claim!
+        build.with_lock do
+          next nil if build.board_id.present?
+
+          build.update!(status: "building", error_message: nil)
+          created = create_set!
+          # EVERY page, not just the root. `set_boards` reads
+          # art_report["boards"] and falls back to `[board_id]` alone, so a
+          # build that died before the full report was written owned its root
+          # and disowned its pages: destroy left them behind and
+          # publish/unpublish skipped them. `finish!` overwrites this with the
+          # complete report, which carries the same key.
+          build.update!(board: created, art_report: { "boards" => built_board_ids })
+          created
+        end
+      end
+
+      def built_board_ids
+        @built_boards.transform_values(&:id)
+      end
+
+      # Everything that is safe to redo. Deliberately outside the claim: none of
+      # it creates a board, so a failure here costs a retry rather than a
+      # duplicate set.
+      def finish!(root)
+        blank_image_ids = art_less_image_ids
+        regenerate_ids = regenerate_image_ids(blank_image_ids)
+        build.update!(status: "complete", art_report: art_report(root, blank_image_ids, regenerate_ids))
+        unpin_regenerated_tiles!(regenerate_ids)
+        queue_missing_art!(root, blank_image_ids)
+        queue_regenerated_art!(root, regenerate_ids)
+      end
 
       def admin
         @admin ||= User.find_by(id: User::DEFAULT_ADMIN_ID) ||
@@ -65,27 +115,71 @@ module Boards
         @resolved ||= Boards::ImageResolver.resolve_all(Plan.labels(pages), owner: admin)
       end
 
+      # Pages this build writes, and pages that just point at a board someone
+      # already published. A linked page is a link and nothing else — no Board
+      # row, no tiles, no layout — so it is held apart from `@built_boards`,
+      # which is what `art_report["boards"]` and therefore
+      # `AdminBoardBuild#set_boards` are built from. Publish, unpublish and
+      # destroy all iterate that list, and none of them may reach a board this
+      # build doesn't own.
+      def owned_pages = pages.reject { |page| Plan.linked?(page) }
+
       def create_set!
         # Pass 1 — every page's Board row, so pass 3 can link in any direction.
-        boards = pages.index_with { |page| new_board(page) }.transform_keys { |page| page[:key] }
+        boards = owned_pages.index_with { |page| new_board(page) }.transform_keys { |page| page[:key] }
+        @built_boards = boards
+        @linked_boards = resolve_linked_boards!
 
         # Pass 2 — tiles, in authored reading order per page.
-        tiles_by_key = pages.to_h do |page|
+        tiles_by_key = owned_pages.to_h do |page|
           [page[:key], page[:tiles].map { |tile| add_tile!(boards[page[:key]], tile) }]
         end
-        pages.each { |page| apply_reading_order!(boards[page[:key]], tiles_by_key[page[:key]], page) }
+        owned_pages.each { |page| apply_reading_order!(boards[page[:key]], tiles_by_key[page[:key]], page) }
 
         # Pass 3 — folder links. Every target already exists, cycles included.
-        link_pages!(boards, tiles_by_key)
+        link_pages!(boards.merge(@linked_boards), tiles_by_key)
 
-        pages.each do |page|
+        owned_pages.each do |page|
           board = boards[page[:key]]
           board.set_current_word_list
           board.save!
         end
 
-        @built_boards = boards
         boards[Plan::ROOT_KEY]
+      end
+
+      # Re-resolved through Boards::AdminBuilder::ExistingBoards rather than
+      # `Board.find`: the id came off a form post, and the scope is what keeps
+      # "link an existing board" from becoming "point a published admin set at
+      # any board in the database".
+      def resolve_linked_boards!
+        pages.select { |page| Plan.linked?(page) }.to_h do |page|
+          id = page[:existing_board_id]
+          board = ExistingBoards.find(id)
+          raise BuildError, "page #{page[:key].inspect} links to board #{id}, which isn't a linkable board" if board.nil?
+
+          pin_as_main_board!(board)
+          [page[:key], board]
+        end
+      end
+
+      # `Board#check_is_sub_board` is a before_save that flips `sub_board` on as
+      # soon as `parent_boards` finds anything pointing at the board. Linking
+      # gives this board a new parent, so the NEXT save for any unrelated reason
+      # would quietly demote a published board out of `main_boards` — and out of
+      # `Boards::AdminSearch.base_scope`, which is how it disappears from admin
+      # board search without anyone touching it.
+      #
+      # `builder_root` is the existing flag for exactly this ("pin it as a main
+      # board regardless of who links to it"). It keys off `builder_root`, not
+      # `admin_builder`, so setting it does NOT pull the board into any build's
+      # `set_boards`. Idempotent, and the only write this build makes to a board
+      # it does not own.
+      def pin_as_main_board!(board)
+        settings = board.settings || {}
+        return if settings["builder_root"] == true
+
+        board.update!(settings: settings.merge("builder_root" => true))
       end
 
       def new_board(page)
@@ -201,7 +295,7 @@ module Boards
       # No self-tile exception: nothing in an admin-built set is a you-are-here
       # anchor, so the "back to home" tile is a door like any other.
       def link_pages!(boards, tiles_by_key)
-        pages.each do |page|
+        owned_pages.each do |page|
           page[:tiles].each_with_index do |tile, index|
             target = tile[:links_to].presence
             next if target.nil?
@@ -327,9 +421,17 @@ module Boards
           # Tiles whose picture the admin picked by hand on the review screen.
           "picked_labels" => picked_doc_urls.keys,
           "slug" => root.slug,
+          # Boards this set POINTS AT but does not own. Kept out of "boards" on
+          # purpose: `set_boards` reads that key, and publish/unpublish/destroy
+          # iterate it. Recorded so `show` can list the whole set honestly and
+          # `rake admin_board_builds:orphans` doesn't mistake a linked board for
+          # a stranded one.
+          "linked_boards" => @linked_boards.transform_values(&:id),
           # key => board id, so `show` can list every page of the set and
           # publish can cascade over it without re-walking the link graph.
-          "boards" => @built_boards.transform_values(&:id),
+          # Also written at claim time (see #create_and_claim!) — this is the
+          # same value, re-stated as part of the complete report.
+          "boards" => built_board_ids,
         }
       end
 

--- a/app/services/boards/admin_builder/drafting.rb
+++ b/app/services/boards/admin_builder/drafting.rb
@@ -1,0 +1,58 @@
+module Boards
+  module AdminBuilder
+    # The one OpenAI call every drafter on the admin Board Builder makes.
+    #
+    # SetDrafter, WordListDrafter and PageDrafter had three byte-identical copies
+    # of this, which is how they ended up on a different model and a different
+    # temperature from each other by accident rather than decision.
+    module Drafting
+      # These boards are authored by an admin, a few times a day, and every one
+      # of them ships to real communicators — so this path is worth a better
+      # model than the app's general-purpose default. Overridable per
+      # environment without a deploy.
+      MODEL = ENV.fetch("OPENAI_ADMIN_BUILDER_MODEL", OpenAiClient::GTP_5_MODEL).freeze
+
+      # Drafting is a counting exercise as much as a creative one — "EXACTLY 24
+      # tiles, no near-duplicates, this part-of-speech balance" — and the
+      # provider default wanders on all three. Set to "" to send no temperature
+      # at all.
+      TEMPERATURE = ENV.fetch("OPENAI_ADMIN_BUILDER_TEMPERATURE", "0.4").freeze
+
+      module_function
+
+      # Returns the response content, or nil. Each drafter raises its own
+      # GenerationError on nil — the error class is part of that drafter's
+      # contract with its controller action.
+      #
+      # The retry exists because MODEL and TEMPERATURE are both ENV-tunable and
+      # not every model accepts a custom temperature. `create_chat` swallows an
+      # API error into a debug log and hands back nil content, so without this a
+      # rejected temperature would look exactly like "the AI had nothing to say"
+      # and take drafting down until someone read the logs. Same reasoning as
+      # the image-model fallback in OpenAiClient#create_image.
+      def chat(prompt:, content:)
+        result = call(prompt: prompt, content: content, temperature: TEMPERATURE.presence)
+        return result if result.present?
+        return nil if TEMPERATURE.blank?
+
+        Rails.logger.warn("[AdminBuilder::Drafting] no content from #{MODEL} at " \
+                          "temperature #{TEMPERATURE} — retrying without it")
+        call(prompt: prompt, content: content, temperature: nil)
+      end
+
+      def call(prompt:, content:, temperature:)
+        opts = { prompt: prompt, messages: [{ role: "user", content: content }] }
+        opts[:temperature] = temperature.to_f if temperature.present?
+
+        # Splatted, not passed as one positional hash. `OpenAiClient#initialize`
+        # takes a positional `opts` either way, but every caller in the codebase
+        # writes it as keywords and the specs stub it that way — handing it a
+        # bare Hash moves the argument from kwargs to args and silently breaks
+        # those stubs.
+        client = OpenAiClient.new(**opts)
+        client.instance_variable_set(:@model, MODEL)
+        client.create_chat(true)[:content].presence
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/existing_boards.rb
+++ b/app/services/boards/admin_builder/existing_boards.rb
@@ -1,0 +1,90 @@
+module Boards
+  module AdminBuilder
+    # Published admin boards a page could point at instead of building a new one.
+    #
+    # A set's pages repeat across topics — most park, zoo and grocery boards want
+    # a "Feelings" page, and the drafter cheerfully invents a worse one every
+    # time. Offering the board that already exists is how the good one gets
+    # reused; building a new page stays the default, because a page tuned to
+    # this set's reading level is often still the right answer.
+    module ExistingBoards
+      # Per page name. Enough to recognise the right board, few enough to stay a
+      # dropdown rather than a search screen.
+      MAX_MATCHES = 5
+
+      module_function
+
+      # What may be linked. Deliberately NOT `Board.public_boards`: that scope
+      # requires `predefined`, and admin Board Builder boards are pointedly not
+      # predefined (see Build#new_board), so it would hide exactly the boards
+      # this page produces.
+      #
+      # Predictive boards are excluded because `BoardImage#door_tile?` reads a
+      # tile pointing at one as a dynamic WORD tile, not a folder — linking one
+      # would build a door that doesn't behave like a door.
+      def scope
+        Board.where(user_id: User::DEFAULT_ADMIN_ID, published: true)
+             .where("boards.board_type IS DISTINCT FROM 'menu'")
+             .where("boards.board_type IS DISTINCT FROM 'predictive'")
+             .where.not(parent_type: "Menu")
+      end
+
+      # Re-resolved from the scope rather than trusted: the id arrives on a form
+      # post, and `Board.find` on a raw param would let a hand-edited value
+      # point a published admin set at anyone's board.
+      def find(id)
+        return nil if id.blank?
+
+        scope.find_by(id: id.to_i)
+      end
+
+      # `{ "feelings" => [Match, ...] }`, keyed by the downcased page name so the
+      # view can look up each page block by the name in it. One query for every
+      # page on the form, plus one for the tile counts.
+      def matching(names, columns: nil)
+        wanted = Array(names).filter_map { |name| name.to_s.strip.downcase.presence }.uniq
+        return {} if wanted.empty?
+
+        boards = scope.where("lower(boards.name) IN (?)", wanted).to_a
+        return {} if boards.empty?
+
+        counts = tile_counts(boards.map(&:id))
+
+        boards.group_by { |board| board.name.to_s.downcase }
+              .transform_values do |list|
+                rank(list, columns).first(MAX_MATCHES).map { |board| Match.new(board, counts[board.id].to_i) }
+              end
+      end
+
+      # Same grid first, then most recently touched — the board someone has been
+      # maintaining is the one worth reusing.
+      def rank(boards, columns)
+        boards.sort_by do |board|
+          [board.large_screen_columns.to_i == columns.to_i ? 0 : 1, -board.updated_at.to_i]
+        end
+      end
+
+      # `reorder(nil)` is required, not tidy-up: BoardImage carries a default
+      # order on `position`, and Postgres rejects a GROUP BY whose ORDER BY
+      # names a column that is neither grouped nor aggregated.
+      def tile_counts(board_ids)
+        BoardImage.where(board_id: board_ids).reorder(nil).group(:board_id).count
+      end
+
+      # What the picker needs to say, without the view reaching into a Board and
+      # firing a count per option.
+      Match = Struct.new(:board, :tile_count) do
+        def id = board.id
+        def name = board.name
+        def slug = board.slug
+        def columns = board.large_screen_columns.to_i
+
+        def same_grid?(other_columns) = columns == other_columns.to_i
+
+        def summary
+          "#{columns} cols · #{tile_count} #{"tile".pluralize(tile_count)} · /pb/#{slug}"
+        end
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/label_casing.rb
+++ b/app/services/boards/admin_builder/label_casing.rb
@@ -1,0 +1,70 @@
+module Boards
+  module AdminBuilder
+    # What a drafted label looks like by the time it reaches the form: cleaned of
+    # identifier artifacts, and folded to the lowercase AAC default unless the
+    # capital was meant.
+    #
+    # The three drafters each grew their own `sanitize_label`, and none of them
+    # touched casing at all — so the model's Title Case ("Food", "All Done") went
+    # straight into the textarea an admin reads, and from there into the plan.
+    # `Image#set_label` folds a plain leading capital, but only when the Image is
+    # NEW, and never for a tile whose plan carries an explicit `display_label` —
+    # so by the time the fold could have happened, the capital had usually
+    # already won.
+    #
+    # Casing itself is NOT decided here. `Labels::CaseNormalizer` is the single
+    # authority for that and already knows the hard parts — "iPad", "TV",
+    # "McDonald's" and "HELP" survive, a standalone "i" is upcased, and the
+    # judgement is per word. This module only decides WHICH labels are the
+    # normalizer's business.
+    module LabelCasing
+      module_function
+
+      # Handed to every drafter's prompt so the three can't drift apart. Asking
+      # for lowercase up front matters as much as folding afterwards: the model
+      # picks better words when it isn't also composing a title.
+      PROMPT_RULE = <<~RULE.freeze
+        - Write every label in LOWERCASE. These are word tiles, not sentences or
+          titles — "apple", not "Apple"; "all done", not "All Done".
+        - The only exceptions are proper nouns (a person, a place, a brand) and
+          words with a deliberate internal capital like "iPad" or "TV". Set
+          "proper_noun": true on any tile whose capital is deliberate, and leave
+          it off every other tile.
+      RULE
+
+      # The model occasionally answers a multi-word label snake_cased, like an
+      # identifier rather than the tile text it's meant to be — underscores have
+      # no legitimate place in display text, so they're folded to spaces rather
+      # than left for the admin to notice and retype. Distinct from
+      # `Keys.normalize`: a page "key" is meant to be underscored.
+      def sanitize(raw)
+        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
+      end
+
+      # `door` is a tile with a `links_to` — a folder tile or a way back. A
+      # category tile's label is authored, not defaulted ("Food", "Play"), and an
+      # AAC board leans on that capital to separate a page you open from a word
+      # you speak. `FolderTiles` already pins `display_label` on the doors it
+      # writes for exactly this reason; keeping model-written doors unfolded is
+      # what makes the two agree.
+      #
+      # `proper_noun` is the model's own claim, and it is only honoured when the
+      # label actually carries a capital — an over-eager flag on "apple" would
+      # otherwise be a silent no-op that looks like a rule.
+      def apply(label, part_of_speech: nil, proper_noun: false, door: false)
+        text = label.to_s
+        return text if door
+        return text if proper_noun && text.match?(/\p{Upper}/)
+
+        Labels::CaseNormalizer.normalize(text, part_of_speech: part_of_speech)
+      end
+
+      # Reads the model's flag off a raw tile hash. Tolerant of the string
+      # "true", which JSON mode returns often enough to be worth handling.
+      def proper_noun?(tile)
+        value = tile["proper_noun"]
+        value == true || value.to_s.strip.downcase == "true"
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/page_drafter.rb
+++ b/app/services/boards/admin_builder/page_drafter.rb
@@ -50,16 +50,10 @@ module Boards
       end
 
       def generate_via_openai
-        client = OpenAiClient.new(
-          prompt: subject,
-          messages: [{ role: "user", content: build_prompt }],
-        )
-        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
-        result = client.create_chat(true)
+        content = Drafting.chat(prompt: subject, content: build_prompt)
+        raise GenerationError, "OpenAI returned no content" if content.blank?
 
-        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
-
-        result[:content]
+        content
       end
 
       def build_prompt
@@ -89,8 +83,13 @@ module Boards
             cell.
           - Keep each label short — 1-2 words.
           - Concrete and age-appropriate.
+          - Aim for roughly this balance: 30-40% verbs and core function words,
+            15-20% pronouns and determiners, 15-20% describing words, 25-35% topic
+            nouns. A page that is mostly nouns is a picture dictionary, not an AAC
+            page.
           - A label is display text, not an identifier: separate words with a plain
             space, never an underscore.
+          #{LabelCasing::PROMPT_RULE.rstrip}
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -133,20 +132,24 @@ module Boards
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)
 
-          label = sanitize_label(tile["label"] || tile["word"])
+          label = LabelCasing.sanitize(tile["label"] || tile["word"])
           next if label.blank?
           next unless seen.add?(label.downcase)
 
-          { label: label, part_of_speech: part_of_speech_for(tile), links_to: link_for(tile) }.compact
-        end
-      end
+          part_of_speech = part_of_speech_for(tile)
+          links_to = link_for(tile)
 
-      # The model occasionally answers a multi-word label snake_cased, like an
-      # identifier rather than the tile text it's meant to be — underscores have
-      # no legitimate place in display text, so they're folded to spaces rather
-      # than left for the admin to notice and retype.
-      def sanitize_label(raw)
-        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
+          {
+            label: LabelCasing.apply(
+              label,
+              part_of_speech: part_of_speech,
+              proper_noun: LabelCasing.proper_noun?(tile),
+              door: links_to.present?,
+            ),
+            part_of_speech: part_of_speech,
+            links_to: links_to,
+          }.compact
+        end
       end
 
       # An unrecognized value would be rejected by PlanValidator on preview, so

--- a/app/services/boards/admin_builder/plan.rb
+++ b/app/services/boards/admin_builder/plan.rb
@@ -36,16 +36,30 @@ module Boards
       end
 
       def child_page(child, root_page)
+        existing_board_id = child[:existing_board_id].presence&.to_i
+
         {
           key: child[:key].to_s.strip,
           name: child[:name].to_s,
           columns: child[:columns].presence&.to_i || root_page[:columns],
           tile_count: child[:tile_count].presence&.to_i || root_page[:tile_count],
-          tiles: Array(child[:tiles]),
+          # A linked page has no word list of its own — the board it points at
+          # already has its tiles. Blanked HERE, at the one place every consumer
+          # reads a page from, so validation, art resolution, the preview and
+          # the build all agree without each having to remember the rule. A
+          # words textarea that a stale browser posted anyway is ignored rather
+          # than half-honoured.
+          tiles: existing_board_id ? [] : Array(child[:tiles]),
+          existing_board_id: existing_board_id,
           # Whether the grid was authored on this page or inherited — the
           # mixed-grid check only has something to say about an authored one.
           inherits_grid: child[:columns].blank? && child[:tile_count].blank?,
-        }
+        }.compact
+      end
+
+      # This page points at a board that already exists; nothing builds it.
+      def linked?(page)
+        page[:existing_board_id].present?
       end
 
       def root?(page)
@@ -73,6 +87,7 @@ module Boards
               columns: child["columns"],
               tile_count: child["tile_count"],
               tiles: symbolize_tiles(child["tiles"]),
+              existing_board_id: child["existing_board_id"],
             }
           end,
         )

--- a/app/services/boards/admin_builder/plan_validator.rb
+++ b/app/services/boards/admin_builder/plan_validator.rb
@@ -96,6 +96,14 @@ module Boards
       def page_problems(page)
         problems = []
         problems << prefixed(page, "give the page a name.") if multi_page? && page[:name].blank?
+
+        # A linked page builds nothing: the board it points at already has its
+        # tiles, its grid and its art. Every check below is about a word list
+        # this page doesn't have. It still needs a name (above) and still has to
+        # be opened by something (orphan_problems) — those are about the door on
+        # the main board, which this page does own.
+        return problems if Plan.linked?(page)
+
         problems.concat(count_problems(page))
         problems.concat(label_problems(page))
         problems.concat(part_of_speech_problems(page))
@@ -169,6 +177,9 @@ module Boards
 
         pages.drop(1).filter_map do |page|
           next if page[:inherits_grid]
+          # A linked board's grid is its own and not ours to rule on — the whole
+          # point of reusing it is taking it as it is.
+          next if Plan.linked?(page)
 
           grid = [page[:columns].to_i, page[:tile_count].to_i]
           next if grid == root_grid

--- a/app/services/boards/admin_builder/set_drafter.rb
+++ b/app/services/boards/admin_builder/set_drafter.rb
@@ -24,6 +24,15 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES_PER_PAGE = 144
 
+      # A board this close to its target is left alone: PlanValidator tolerates
+      # a much wider gap than this, so a follow-up call would be paying for
+      # cosmetics.
+      TOPUP_THRESHOLD = 5
+      # Ceiling on follow-up calls for one draft, root and pages together. A set
+      # whose every board comes back short is a prompt problem, not something to
+      # spend six sequential API calls papering over while the admin waits.
+      MAX_TOPUPS = 3
+
       # `pages` are the pages the admin already named on the form, as
       # `{ key:, name: }` hashes. They are used verbatim and the model only
       # invents the rest — so a page count below the number of names would
@@ -36,6 +45,7 @@ module Boards
         @pinned = clean_pinned(pages)
         @page_count = [page_count.to_i, @pinned.size].max.clamp(0, MAX_PAGES)
         @pinned = @pinned.first(@page_count)
+        @topups = 0
       end
 
       def call
@@ -77,16 +87,19 @@ module Boards
       end
 
       def generate_via_openai
-        client = OpenAiClient.new(
-          prompt: topic,
-          messages: [{ role: "user", content: build_prompt }],
-        )
-        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
-        result = client.create_chat(true)
+        content = Drafting.chat(prompt: topic, content: build_prompt)
+        raise GenerationError, "OpenAI returned no content" if content.blank?
 
-        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
+        content
+      end
 
-        result[:content]
+      # A small grid can't carry the whole spine, so ask for as much of it as
+      # fits rather than for words that were never going to be there. The folder
+      # tiles are subtracted first — they are not optional, so a grid with fewer
+      # cells than pages has no room for core words at all.
+      def spine_for_size
+        spine = WordListDrafter::CORE_SPINE
+        spine.first((tile_count - page_count).clamp(0, spine.size))
       end
 
       def build_prompt
@@ -112,16 +125,37 @@ module Boards
             "#{Plan::ROOT_KEY}". It counts towards that page's #{tile_count} tiles.
           - No other tile has "links_to".
 
+          What a page should BE:
+          - A page is a place the communicator goes, an activity they do, or a routine they
+            move through — not a category of things. For a board about the park: good pages
+            are "Playground", "Snack Time", "Going Home"; bad pages are "Equipment",
+            "Animals", "Colors", which are lists to read rather than places to talk from.
+          - Name a page for the moment it serves, so a communicator can guess what is behind
+            the tile before they open it.
+
+          Main board rules:
+          - Start the main board with these core words, in this order, before any topic
+            words — they are what makes the whole set usable for something other than
+            labelling, and they belong on the board every page returns to:
+            #{spine_for_size.join(", ")}
+          - Then the folder tiles, then whatever main-board topic words still fit.
+
           Word rules:
           - Boards for talking, not vocabulary lists. Favour words that finish a sentence
             over words that name a thing.
-          - The main board carries the core words the whole set leans on — pronouns, verbs,
-            and words like "more", "stop", "help". Pages carry their own subject's words.
+          - Aim for roughly this balance across each board:
+            30-40% verbs and core function words (the words that do the communicating),
+            15-20% pronouns and determiners, 15-20% describing words, 25-35% topic nouns.
+            A board that is mostly nouns is a picture dictionary, not an AAC board.
+          - A page must NOT repeat a word that is already on the main board. The
+            communicator reaches those from the main board, so a repeat spends a cell and
+            buys nothing.
           - No near-duplicates within a board ("happy" and "glad"). Each tile costs a cell.
           - Keep each label short — 1-2 words.
           - A label is display text, not an identifier: separate words with a plain
             space, never an underscore. (Page "key" values are the one exception —
             those are underscored on purpose, per the structure rules above.)
+          #{LabelCasing::PROMPT_RULE.rstrip}
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -130,15 +164,18 @@ module Boards
           Respond in JSON format:
           {
             "root": [
-              { "label": "I", "part_of_speech": "pronoun" },
-              { "label": "Food", "part_of_speech": "noun", "links_to": "food" }
+              { "label": "i", "part_of_speech": "pronoun" },
+              { "label": "want", "part_of_speech": "verb" },
+              { "label": "Snack Time", "part_of_speech": "noun", "links_to": "snack_time" }
             ],
             "pages": [
               {
-                "key": "food",
-                "name": "Food",
+                "key": "snack_time",
+                "name": "Snack Time",
                 "tiles": [
-                  { "label": "apple", "part_of_speech": "noun" },
+                  { "label": "hungry", "part_of_speech": "adjective" },
+                  { "label": "open it", "part_of_speech": "verb" },
+                  { "label": "Goldfish", "part_of_speech": "noun", "proper_noun": true },
                   { "label": "back", "part_of_speech": "social", "links_to": "#{Plan::ROOT_KEY}" }
                 ]
               }
@@ -175,13 +212,26 @@ module Boards
 
       def parse_response(raw)
         data = JSON.parse(raw)
-        children = clean_children(Array(data["pages"]))
-        child_keys = children.map { |child| child[:key] }
-        root_tiles = clean_tiles(Array(data["root"]), known_keys: child_keys)
+        # Keys are settled before any tile is cleaned, because a tile's link is
+        # only kept when it names a page that survived.
+        shells = page_shells(Array(data["pages"]))
+        keys = shells.map { |page| page[:key] }
+
+        root_tiles = clean_tiles(Array(data["root"]), known_keys: keys)
 
         # Only a response with nothing usable in it is an error — a short draft
         # fills the form and the counter shows the gap.
         raise GenerationError, "AI returned no usable words" if root_tiles.empty?
+
+        root_tiles = top_up(root_tiles, subject: topic)
+        # What a page may not repeat. Resolved from the root AFTER its top-up so
+        # a word the top-up added is covered too.
+        taken = root_tiles.map { |tile| tile[:label] }
+
+        children = shells.map do |page|
+          tiles = clean_tiles(page[:tiles], known_keys: keys + [Plan::ROOT_KEY], taken: taken)
+          page.merge(tiles: top_up(tiles, subject: page[:name], taken: taken))
+        end
 
         # The count is echoed back because pinned pages can raise it above what
         # the form asked for, and the notice compares against what was actually
@@ -191,9 +241,8 @@ module Boards
         raise GenerationError, "Failed to parse AI response: #{e.message}"
       end
 
-      # Keys are cleaned before any tile is, because a tile's link is only kept
-      # when it names a page that survived.
-      def clean_children(raw_pages)
+      # The pages, keyed and named but with their tiles still raw.
+      def page_shells(raw_pages)
         seen = Set.new
 
         pages = raw_pages.filter_map do |page|
@@ -206,12 +255,37 @@ module Boards
           { key: key, name: page["name"].to_s.strip.presence || key.titleize, tiles: Array(page["tiles"]) }
         end
 
-        pages = apply_pinned(pages).first(page_count)
+        apply_pinned(pages).first(page_count)
+      end
 
-        keys = pages.map { |page| page[:key] }
-        pages.map do |page|
-          page.merge(tiles: clean_tiles(page[:tiles], known_keys: keys + [Plan::ROOT_KEY]))
-        end
+      # A board that came back well short used to just sit in the form with a
+      # warning on it, leaving the admin to type the rest by hand — which is the
+      # job they pressed the button to avoid. One follow-up call fills the gap,
+      # reusing WordListDrafter's existing top-up prompt (`existing_labels:` is
+      # what switches it into that mode) so the filler words know what not to
+      # repeat.
+      #
+      # Bounded twice over: nothing under TOPUP_THRESHOLD is worth a paid call
+      # (the grid tolerates it and the notice says so), and MAX_TOPUPS caps the
+      # whole draft so a set of consistently short pages can't turn one click
+      # into six sequential API calls. A failed top-up is not an error — the
+      # short list is still a usable draft.
+      def top_up(tiles, subject:, taken: [])
+        short = tile_count - tiles.size
+        return tiles if short <= TOPUP_THRESHOLD || subject.blank? || @topups >= MAX_TOPUPS
+
+        @topups += 1
+        extra = WordListDrafter.new(
+          topic: subject,
+          tile_count: short,
+          audience: audience.presence,
+          existing_labels: (taken + tiles.map { |tile| tile[:label] }).uniq,
+        ).call
+
+        (tiles + extra).first(tile_count)
+      rescue WordListDrafter::GenerationError => e
+        Rails.logger.warn("[SetDrafter] top-up failed for #{subject.inspect}: #{e.message}")
+        tiles
       end
 
       # The admin's key and name win even when the model paraphrased them: a
@@ -238,31 +312,34 @@ module Boards
         Keys.normalize(value)
       end
 
-      def clean_tiles(raw_tiles, known_keys:)
-        seen = Set.new
+      # `taken` seeds the dedupe set with labels a page must not repeat — the
+      # root's words, when cleaning a page. Dedupe was per-board, so a core word
+      # the root already carries came back on every page and spent a cell buying
+      # nothing: the communicator can already reach it from the main board.
+      def clean_tiles(raw_tiles, known_keys:, taken: [])
+        seen = Set.new(taken.map(&:downcase))
 
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)
 
-          label = sanitize_label(tile["label"] || tile["word"])
+          label = LabelCasing.sanitize(tile["label"] || tile["word"])
           next if label.blank?
           next unless seen.add?(label.downcase)
 
+          part_of_speech = part_of_speech_for(tile)
+          links_to = link_for(tile, known_keys)
+
           {
-            label: label,
-            part_of_speech: part_of_speech_for(tile),
-            links_to: link_for(tile, known_keys),
+            label: LabelCasing.apply(
+              label,
+              part_of_speech: part_of_speech,
+              proper_noun: LabelCasing.proper_noun?(tile),
+              door: links_to.present?,
+            ),
+            part_of_speech: part_of_speech,
+            links_to: links_to,
           }.compact
         end.first(tile_count)
-      end
-
-      # The model occasionally answers a multi-word label snake_cased, like an
-      # identifier rather than the tile text it's meant to be — underscores
-      # have no legitimate place in display text, so they're folded to spaces
-      # rather than left for the admin to notice and retype. Distinct from
-      # normalize_key: a page "key" is meant to be underscored.
-      def sanitize_label(raw)
-        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
       end
 
       def part_of_speech_for(tile)

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -48,16 +48,10 @@ module Boards
       attr_reader :topic, :tile_count, :audience, :existing_labels
 
       def generate_via_openai
-        client = OpenAiClient.new(
-          prompt: topic,
-          messages: [{ role: "user", content: build_prompt }],
-        )
-        client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
-        result = client.create_chat(true)
+        content = Drafting.chat(prompt: topic, content: build_prompt)
+        raise GenerationError, "OpenAI returned no content" if content.blank?
 
-        raise GenerationError, "OpenAI returned no content" if result[:content].blank?
-
-        result[:content]
+        content
       end
 
       # A small grid can't carry the whole spine, so ask for as much of it as
@@ -96,6 +90,7 @@ module Boards
           - Concrete and age-appropriate.
           - A label is display text, not an identifier: separate words with a plain
             space, never an underscore.
+          #{LabelCasing::PROMPT_RULE.rstrip}
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -104,8 +99,9 @@ module Boards
           Respond in JSON format:
           {
             "tiles": [
-              { "label": "I", "part_of_speech": "pronoun" },
-              { "label": "want", "part_of_speech": "verb" }
+              { "label": "i", "part_of_speech": "pronoun" },
+              { "label": "want", "part_of_speech": "verb" },
+              { "label": "all done", "part_of_speech": "social" }
             ]
           }
 
@@ -137,6 +133,7 @@ module Boards
           - Concrete and age-appropriate.
           - A label is display text, not an identifier: separate words with a plain
             space, never an underscore.
+          #{LabelCasing::PROMPT_RULE.rstrip}
           - Give every tile a part_of_speech from exactly this list:
             #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
           - Classify by communicative function, not strict grammar: "more", "yes" and
@@ -183,20 +180,20 @@ module Boards
         raw_tiles.filter_map do |tile|
           next unless tile.is_a?(Hash)
 
-          label = sanitize_label(tile["label"] || tile["word"])
+          label = LabelCasing.sanitize(tile["label"] || tile["word"])
           next if label.blank?
           next unless seen.add?(label.downcase)
 
-          { label: label, part_of_speech: part_of_speech_for(tile) }
+          part_of_speech = part_of_speech_for(tile)
+          {
+            label: LabelCasing.apply(
+              label,
+              part_of_speech: part_of_speech,
+              proper_noun: LabelCasing.proper_noun?(tile),
+            ),
+            part_of_speech: part_of_speech,
+          }
         end
-      end
-
-      # The model occasionally answers a multi-word label snake_cased, like an
-      # identifier rather than the tile text it's meant to be — underscores
-      # have no legitimate place in display text, so they're folded to spaces
-      # rather than left for the admin to notice and retype.
-      def sanitize_label(raw)
-        raw.to_s.strip.tr("_", " ").squeeze(" ").strip
       end
 
       # An unrecognized value would be rejected by PlanValidator on preview, so

--- a/app/views/admin/board_builds/_form.html.erb
+++ b/app/views/admin/board_builds/_form.html.erb
@@ -220,6 +220,32 @@
               <button type="button" class="remove-page text-t3 hover:text-t1 text-sm leading-none px-1 pb-2 cursor-pointer" title="Remove page">&times;</button>
             </div>
           </div>
+          <%# Only rendered when a published admin board already carries this
+              page's name. Building a new page stays the default — a page tuned
+              to this set is often still the right answer — so this is an offer,
+              not a prompt. %>
+          <% matches = existing_board_matches(@form)[child[:name].to_s.strip.downcase] %>
+          <% if matches.present? %>
+            <div class="mb-2 page-link-picker">
+              <label class="block text-[11px] font-medium text-t2 mb-1">
+                There's already a published board called "<%= child[:name] %>"
+              </label>
+              <select name="children[<%= index %>][existing_board_id]"
+                      class="page-existing-board admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none">
+                <option value="">Create a new page for this set</option>
+                <% matches.each do |match| %>
+                  <option value="<%= match.id %>" <%= "selected" if child[:existing_board_id].to_s == match.id.to_s %>>
+                    Link "<%= match.name %>" — <%= match.summary %><%= " · different grid" unless match.same_grid?(@form[:columns]) %>
+                  </option>
+                <% end %>
+              </select>
+              <p class="text-[11px] text-t3 mt-1 page-link-note" <%= "hidden" if child[:existing_board_id].blank? %>>
+                This page won't be built — the folder tile opens that board as it already is,
+                and nothing about it changes. Note it has no way back to this main board:
+                its own back tile still goes wherever it already went.
+              </p>
+            </div>
+          <% end %>
           <div class="flex justify-end mb-2">
             <%# formaction, not a second form: the drafter has to see this page's
                 name, tile count and the board's topic. name/value on the submit
@@ -411,7 +437,10 @@
 
     function reindexPages() {
       pages.querySelectorAll(".page-block").forEach(function (block, i) {
-        block.querySelectorAll("input, textarea").forEach(function (field) {
+        // `select` is in here for the existing-board picker. Leaving it out
+        // renumbered every field on a moved block except that one, which then
+        // linked the wrong page to the wrong board.
+        block.querySelectorAll("input, textarea, select").forEach(function (field) {
           field.name = field.name.replace(/children\[\w*\]/, "children[" + i + "]");
         });
         // The per-page draft button posts its index as a submit value rather
@@ -427,6 +456,45 @@
       reindexPages();
       syncTileFields();
     });
+
+    // A page pointing at an existing board authors nothing: its word list and
+    // grid belong to that board. The server ignores them either way
+    // (Plan.child_page blanks a linked page's tiles), so this is about not
+    // inviting the admin to type a word list that will be thrown away.
+    function syncLinkedPage(block) {
+      var picker = block.querySelector(".page-existing-board");
+      if (!picker) return;
+
+      var linked = !!picker.value;
+      var note = block.querySelector(".page-link-note");
+      if (note) note.hidden = !linked;
+
+      block
+        .querySelectorAll('textarea[name$="[words]"], input[name$="[columns]"], input[name$="[tile_count]"]')
+        .forEach(function (field) {
+          field.disabled = linked;
+          field.classList.toggle("opacity-40", linked);
+        });
+
+      var draft = block.querySelector(".draft-page");
+      if (draft) {
+        draft.disabled = linked;
+        draft.classList.toggle("opacity-40", linked);
+      }
+    }
+
+    function syncAllLinkedPages() {
+      pages.querySelectorAll(".page-block").forEach(syncLinkedPage);
+    }
+
+    // Delegated: page blocks are added after load, and the picker only appears
+    // once a name has been round-tripped to the server.
+    pages.addEventListener("change", function (event) {
+      if (!event.target.classList.contains("page-existing-board")) return;
+      syncLinkedPage(event.target.closest(".page-block"));
+    });
+
+    syncAllLinkedPages();
 
     pages.addEventListener("click", function (event) {
       if (!event.target.classList.contains("remove-page")) return;

--- a/app/views/admin/board_builds/preview.html.erb
+++ b/app/views/admin/board_builds/preview.html.erb
@@ -83,10 +83,32 @@
       Page “<%= page[:key] %>” — <%= page[:name] %>
     <% end %>
     <span class="text-t3 font-normal normal-case tracking-normal">
-      · <%= page[:columns] %> columns · <%= page[:rows].size %> of <%= page[:tile_count] %> tiles, in reading order
+      <% if page[:linked_board] %>
+        · linked, not built
+      <% else %>
+        · <%= page[:columns] %> columns · <%= page[:rows].size %> of <%= page[:tile_count] %> tiles, in reading order
+      <% end %>
     </span>
   </h2>
 
+  <%# A linked page has nothing to review: the board it opens is already built
+      and already has its art. Drawing its empty grid would read as a broken
+      page rather than a deliberate one. %>
+  <% if page[:linked_board] %>
+    <div class="admin-card border rounded-xl p-4 mb-8">
+      <p class="text-xs text-t2">
+        Opens the existing board
+        <a href="/pb/<%= page[:linked_board].slug %>" target="_blank" rel="noopener"
+           class="text-accent hover:underline"><%= page[:linked_board].name %></a>
+        (<%= page[:linked_board].large_screen_columns %> columns).
+      </p>
+      <p class="text-[11px] text-t3 mt-1">
+        Nothing about that board changes, and this build never publishes, unpublishes or
+        deletes it. It has no way back to this main board — its own back tile still goes
+        wherever it already went.
+      </p>
+    </div>
+  <% else %>
   <div class="builder-grid mb-8" style="--cols: <%= page[:columns] %>;">
     <% page[:rows].each do |row| %>
       <% key = Boards::ImageResolver.normalize(row.label) %>
@@ -168,6 +190,7 @@
       </div>
     <% end %>
   </div>
+  <% end %>
 <% end %>
 
 <div class="admin-card border rounded-xl p-5 mb-8">
@@ -197,7 +220,11 @@
     <%= hidden_field_tag :allow_partial_row, @form[:allow_partial_row] ? "1" : "0" %>
     <%= hidden_field_tag :allow_mixed_grids, @form[:allow_mixed_grids] ? "1" : "0" %>
     <% @form[:children].each_with_index do |child, index| %>
-      <% %i[key name columns tile_count words].each do |field| %>
+      <%# existing_board_id is in this list because it is the whole difference
+          between a page this build writes and a page that points at a board
+          someone already published. Leaving it out silently turned every
+          reviewed link back into a freshly-built page. %>
+      <% %i[key name columns tile_count words existing_board_id].each do |field| %>
         <%= hidden_field_tag "children[#{index}][#{field}]", child[field], id: nil %>
       <% end %>
     <% end %>
@@ -316,5 +343,27 @@
         syncPicks(select.dataset.docPick, select.value);
       });
     });
+
+    // `create` makes an AdminBoardBuild and queues a job per POST, so a double
+    // click is two builds and two complete sets of boards — with no shared id
+    // between them, nothing downstream can tell they were the same intent.
+    // Disabling the button outright would drop it from the submission, so the
+    // guard is on the submit event and the button is only greyed after.
+    var buildForm = document.getElementById("build-form");
+    if (buildForm) {
+      var submitting = false;
+      buildForm.addEventListener("submit", function (event) {
+        if (submitting) {
+          event.preventDefault();
+          return;
+        }
+        submitting = true;
+        var button = buildForm.querySelector('input[type="submit"]');
+        if (button) {
+          button.classList.add("opacity-50", "pointer-events-none");
+          button.value = "Building…";
+        }
+      });
+    }
   })();
 </script>

--- a/lib/tasks/admin_board_builds.rake
+++ b/lib/tasks/admin_board_builds.rake
@@ -1,0 +1,80 @@
+# Finds admin Board Builder boards that no build owns.
+#
+# `Boards::AdminBuilder::Build` used to claim its set AFTER the transaction that
+# created it, so a failure in the window between (two art queries and a jsonb
+# write) left the boards committed with `admin_board_builds.board_id` still
+# blank. BuildAdminBoardJob is `retry: 2`, so the retry rebuilt the whole set —
+# root and every page — and the first set was stranded: published, in no build's
+# `art_report["boards"]`, and therefore invisible to `AdminBoardBuild#set_boards`.
+# The build page can't list it, publish/unpublish skip it, and destroying the
+# build leaves it standing.
+#
+# The claim now commits with the boards, so no new orphans are produced. This
+# task is for the ones already shipped.
+#
+#   bin/rails admin_board_builds:orphans                  # report only
+#   bin/rails admin_board_builds:orphans UNPUBLISH=1      # take them off /pb/
+#   bin/rails admin_board_builds:orphans APPLY=1          # destroy them
+#
+# Env: LIMIT (cap the number acted on), OLDER_THAN_DAYS (skip anything newer, so
+# a build still running can't be mistaken for an orphan — defaults to 1).
+namespace :admin_board_builds do
+  desc "Report (or clean up) admin-builder boards that no AdminBoardBuild owns"
+  task orphans: :environment do
+    apply = ENV["APPLY"] == "1"
+    unpublish = ENV["UNPUBLISH"] == "1"
+    limit = ENV["LIMIT"].presence&.to_i
+    older_than = Integer(ENV.fetch("OLDER_THAN_DAYS", 1))
+
+    # Every board id any build points at: its root, plus every page recorded in
+    # the art report. Read in one pass rather than per board.
+    owned = Set.new
+    AdminBoardBuild.find_each do |build|
+      owned << build.board_id if build.board_id
+      owned.merge(Array(build.art_report.presence&.dig("boards")&.values))
+      owned.merge(Array(build.art_report.presence&.dig("linked_boards")&.values))
+    end
+
+    scope = AdminBoardBuild.builder_boards
+                           .where.not(id: owned.to_a.compact)
+                           .where(created_at: ..older_than.days.ago)
+                           .order(:created_at)
+    scope = scope.limit(limit) if limit
+
+    orphans = scope.to_a
+
+    if orphans.empty?
+      puts "No orphaned admin-builder boards. #{owned.size} board(s) are owned by a build."
+      next
+    end
+
+    puts "#{orphans.size} orphaned admin-builder board(s) — owned by no AdminBoardBuild:"
+    orphans.each do |board|
+      puts format(
+        "  #%-8d %-40s %2d cols · %3d tiles · %-9s · /pb/%s · %s",
+        board.id,
+        board.name.to_s.truncate(40),
+        board.number_of_columns.to_i,
+        board.board_images.count,
+        board.published? ? "published" : "draft",
+        board.slug,
+        board.created_at.to_date,
+      )
+    end
+
+    if apply
+      # Children first: a page's back tile is a predictive_board_id onto the
+      # root, and destroying the root first leaves those dangling for as long as
+      # the loop runs. Same ordering the controller's destroy uses.
+      roots, pages = orphans.partition { |board| board.settings.to_h["builder_root"] }
+      (pages + roots).each(&:destroy)
+      puts "\nDestroyed #{orphans.size} board(s)."
+    elsif unpublish
+      count = orphans.count(&:published?)
+      orphans.each { |board| board.update!(published: false) }
+      puts "\nUnpublished #{count} board(s). Re-run with APPLY=1 to destroy them."
+    else
+      puts "\nReport only. UNPUBLISH=1 to take them off /pb/, APPLY=1 to destroy them."
+    end
+  end
+end

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1723,4 +1723,71 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       expect(queued_ids).not_to include(generating_image.id)
     end
   end
+
+  describe "linking a page to an existing board" do
+    before { sign_in admin }
+
+    let!(:existing) do
+      board = Board.new(name: "Feelings", user: seed_admin, parent: seed_admin, published: true,
+                        board_type: "static", large_screen_columns: 2, number_of_columns: 2)
+      board.generate_unique_slug
+      board.save!
+      board
+    end
+
+    def page_params(overrides = {})
+      form_params(children: { "0" => { key: "feelings", name: "Feelings", words: "" }.merge(overrides) })
+    end
+
+    it "offers a published admin board with the page's name" do
+      post preview_admin_dashboard_board_builds_path, params: page_params
+
+      expect(response.body).to include("There's already a published board called")
+      expect(response.body).to include(%(name="children[0][existing_board_id]"))
+      expect(response.body).to include(%(value="#{existing.id}"))
+    end
+
+    it "offers nothing when no published admin board matches the page name" do
+      post preview_admin_dashboard_board_builds_path,
+           params: page_params(key: "nowhere", name: "Nowhere")
+
+      expect(response.body).not_to include(%(name="children[0][existing_board_id]"))
+    end
+
+    # A page with no word list would normally fail validation — a linked one has
+    # nothing to validate, because the board it points at is already built.
+    it "previews a linked page without demanding a word list for it" do
+      post preview_admin_dashboard_board_builds_path,
+           params: page_params(existing_board_id: existing.id.to_s)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("linked, not built")
+      expect(response.body).to include("Opens the existing board")
+    end
+
+    it "stores the link in the plan and builds nothing for that page" do
+      post admin_dashboard_board_builds_path,
+           params: page_params(existing_board_id: existing.id.to_s, words: "happy | adjective")
+
+      build = AdminBoardBuild.last
+      child = build.plan["children"].first
+
+      expect(child["existing_board_id"]).to eq(existing.id)
+      # The words a stale browser posted for a linked page are not stored — the
+      # page has no word list of its own.
+      expect(child["tiles"]).to eq([])
+      expect(BuildAdminBoardJob.jobs.size).to eq(1)
+    end
+
+    it "keeps the link across the preview round trip" do
+      post preview_admin_dashboard_board_builds_path,
+           params: page_params(existing_board_id: existing.id.to_s)
+
+      # The build form re-posts the reviewed plan as hidden fields; the link has
+      # to be one of them or Build would create a fresh page instead.
+      expect(response.body).to include(
+        %(<input type="hidden" name="children[0][existing_board_id]" value="#{existing.id}" autocomplete="off" />),
+      )
+    end
+  end
 end

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -504,6 +504,95 @@ RSpec.describe Boards::AdminBuilder::Build do
     end
   end
 
+  # Reusing a board someone already published, instead of drafting a worse copy
+  # of it. The rail that matters: this build never owns the linked board, so
+  # nothing it does — publish, unpublish, destroy — may reach it.
+  describe "a page linked to an existing board" do
+    let(:existing) do
+      Board.create!(
+        name: "Feelings", user: admin, parent: admin, published: true,
+        board_type: "static", large_screen_columns: 2, number_of_columns: 2, slug: "feelings-abc",
+      )
+    end
+
+    def root_with_folder
+      [
+        { "label" => "i", "part_of_speech" => "pronoun" },
+        { "label" => "want", "part_of_speech" => "verb" },
+        { "label" => "more", "part_of_speech" => "important_function" },
+        { "label" => "Feelings", "part_of_speech" => "noun", "links_to" => "feelings" },
+      ]
+    end
+
+    def linked_build(board_id: existing.id, tiles: [])
+      build_record(
+        tiles: root_with_folder,
+        children: [{ "key" => "feelings", "name" => "Feelings",
+                     "existing_board_id" => board_id, "tiles" => tiles }],
+      )
+    end
+
+    it "builds no board for the page and opens the existing one" do
+      root = described_class.new(admin_board_build: linked_build).call
+
+      # The root, and the board that was already there. Nothing new for the page.
+      expect(Board.count).to eq(2)
+      folder = root.board_images.order(:position).find { |bi| bi.label == "feelings" }
+      expect(folder.predictive_board_id).to eq(existing.id)
+      expect(folder.data["mute_name"]).to be(true)
+    end
+
+    it "keeps the linked board out of the set publish and destroy walk" do
+      build = linked_build
+      described_class.new(admin_board_build: build).call
+
+      expect(build.reload.set_boards.map(&:id)).not_to include(existing.id)
+      expect(build.art_report["boards"].values).not_to include(existing.id)
+      expect(build.art_report["linked_boards"]).to eq("feelings" => existing.id)
+    end
+
+    # check_is_sub_board is a before_save: linking gives the board a parent, so
+    # the next unrelated save would drop it out of main_boards and out of admin
+    # board search without anyone touching it.
+    it "pins the linked board as a main board so a later save can't demote it" do
+      described_class.new(admin_board_build: linked_build).call
+
+      expect(existing.reload.settings["builder_root"]).to be(true)
+
+      existing.update!(description: "unrelated edit")
+      expect(existing.reload.sub_board).to be(false)
+    end
+
+    # The whole point of reusing it is taking it as it is.
+    it "changes nothing else about the linked board" do
+      before_attrs = existing.slice(:name, :published, :large_screen_columns, :description)
+
+      expect { described_class.new(admin_board_build: linked_build).call }
+        .not_to change { existing.reload.board_images.count }
+      expect(existing.slice(:name, :published, :large_screen_columns, :description)).to eq(before_attrs)
+    end
+
+    # Plan.child_page blanks a linked page's tiles, so a stale browser posting a
+    # word list can't quietly build a second copy of the page.
+    it "ignores a word list posted for a linked page" do
+      build = linked_build(tiles: [{ "label" => "happy", "part_of_speech" => "adjective" }])
+      described_class.new(admin_board_build: build).call
+
+      expect(Board.count).to eq(2)
+      expect(Image.where(label: "happy")).to be_empty
+    end
+
+    # The id arrives on a form post. Resolving it through ExistingBoards rather
+    # than Board.find is what stops a hand-edited value pointing a published
+    # admin set at an arbitrary board.
+    it "refuses an id that isn't a linkable board" do
+      unpublished = Board.create!(name: "Private", user: create(:user), published: false)
+
+      expect { described_class.new(admin_board_build: linked_build(board_id: unpublished.id)).call }
+        .to raise_error(described_class::BuildError, /isn't a linkable board/)
+    end
+  end
+
   describe "failure" do
     it "records the error, writes no board, and re-raises so Sidekiq retries" do
       build = build_record(tiles: four_tiles)
@@ -534,6 +623,57 @@ RSpec.describe Boards::AdminBuilder::Build do
 
       expect { described_class.new(admin_board_build: build.reload).call }.not_to change(Board, :count)
       expect(build.reload.board_id).to eq(board.id)
+    end
+
+    # The bug this pins: the set used to be claimed AFTER the transaction that
+    # created it, so anything that raised in between — the two art queries, the
+    # art_report write — left the boards committed with board_id still blank.
+    # BuildAdminBoardJob is `retry: 2`, so the retry walked straight past the
+    # "already built" guard and created the whole set a second time. The first
+    # set stayed published and in no build's art_report, which made it invisible
+    # to set_boards: not listed on the build page, skipped by publish/unpublish,
+    # and left behind by destroy.
+    context "when the build dies after the set is committed" do
+      let(:build) { build_record(tiles: four_tiles, children: [child_page]) }
+
+      let(:child_page) do
+        { "key" => "food", "name" => "Food", "columns" => 2, "tile_count" => 4,
+          "tiles" => [{ "label" => "apple", "part_of_speech" => "noun" },
+                      { "label" => "back", "part_of_speech" => "social", "links_to" => "__root__" }] }
+      end
+
+      before do
+        # Fails in the window: after create_set! commits, before the art report
+        # lands. Once, so the "retry" runs for real.
+        calls = 0
+        allow_any_instance_of(described_class).to receive(:art_less_image_ids) do
+          calls += 1
+          raise ActiveRecord::StatementInvalid, "connection lost" if calls == 1
+
+          []
+        end
+      end
+
+      it "claims the set anyway, so a retry never builds a second one" do
+        expect { described_class.new(admin_board_build: build).call }
+          .to raise_error(ActiveRecord::StatementInvalid)
+
+        # The boards committed, and the build owns them.
+        expect(build.reload.board_id).to be_present
+        built = Board.where(name: %w[Playground Food]).count
+        expect(built).to eq(2)
+
+        expect { described_class.new(admin_board_build: build.reload).call }.not_to change(Board, :count)
+        expect(Board.where(name: "Playground").count).to eq(1)
+        expect(Board.where(name: "Food").count).to eq(1)
+      end
+
+      it "leaves no board that set_boards can't see" do
+        expect { described_class.new(admin_board_build: build).call }.to raise_error(StandardError)
+
+        orphans = AdminBoardBuild.builder_boards.where.not(id: build.reload.set_boards.map(&:id))
+        expect(orphans).to be_empty
+      end
     end
   end
 

--- a/spec/services/boards/admin_builder/existing_boards_spec.rb
+++ b/spec/services/boards/admin_builder/existing_boards_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::ExistingBoards do
+  let!(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  # Slugs are unique and several examples deliberately create same-named
+  # boards, so each one gets its own suffixed slug the way Build does.
+  def admin_board(name:, columns: 6, **overrides)
+    board = Board.new({
+      name: name, user: admin, parent: admin, published: true, board_type: "static",
+      large_screen_columns: columns, number_of_columns: columns,
+    }.merge(overrides))
+    board.generate_unique_slug
+    board.save!
+    board
+  end
+
+  describe ".matching" do
+    it "finds a published admin board by name, case-insensitively" do
+      board = admin_board(name: "Feelings")
+
+      expect(described_class.matching(["feelings"]).keys).to eq(["feelings"])
+      expect(described_class.matching(["FEELINGS"])["feelings"].map(&:id)).to eq([board.id])
+    end
+
+    it "reports the grid and tile count the picker shows" do
+      board = admin_board(name: "Feelings", columns: 4)
+      2.times { |i| board.add_image(Image.create!(label: "w#{i}", user_id: admin.id).id) }
+
+      match = described_class.matching(["Feelings"])["feelings"].first
+
+      expect(match.columns).to eq(4)
+      expect(match.tile_count).to eq(2)
+      expect(match.summary).to include("4 cols", "2 tiles")
+    end
+
+    it "puts a board on the same grid first" do
+      other = admin_board(name: "Feelings", columns: 8)
+      same = admin_board(name: "Feelings", columns: 6)
+
+      ranked = described_class.matching(["Feelings"], columns: 6)["feelings"].map(&:id)
+
+      expect(ranked).to eq([same.id, other.id])
+    end
+
+    it "is empty when nothing matches, and costs no query with no names" do
+      admin_board(name: "Feelings")
+
+      expect(described_class.matching(["Nowhere"])).to eq({})
+      expect(described_class.matching([])).to eq({})
+      expect(described_class.matching([nil, "  "])).to eq({})
+    end
+
+    it "caps the options offered per page" do
+      (described_class::MAX_MATCHES + 2).times { admin_board(name: "Feelings") }
+
+      expect(described_class.matching(["Feelings"])["feelings"].size).to eq(described_class::MAX_MATCHES)
+    end
+  end
+
+  describe "what may be linked" do
+    it "excludes an unpublished board and one owned by someone else" do
+      admin_board(name: "Feelings", published: false)
+      admin_board(name: "Feelings", user: create(:user))
+
+      expect(described_class.matching(["Feelings"])).to eq({})
+    end
+
+    # BoardImage#door_tile? reads a tile pointing at a predictive board as a
+    # dynamic WORD tile, so linking one would build a door that isn't a door.
+    it "excludes a predictive board" do
+      admin_board(name: "Feelings", board_type: "predictive")
+
+      expect(described_class.matching(["Feelings"])).to eq({})
+    end
+
+    it "excludes a menu board" do
+      admin_board(name: "Feelings", board_type: "menu")
+
+      expect(described_class.matching(["Feelings"])).to eq({})
+    end
+
+    # Board.public_boards keys on `predefined`, which admin Board Builder boards
+    # deliberately are not — using that scope here would hide exactly the boards
+    # this page produces.
+    it "includes a builder board, which is published but not predefined" do
+      board = admin_board(name: "Feelings", predefined: false,
+                          settings: { "admin_builder" => true })
+
+      expect(described_class.matching(["Feelings"])["feelings"].map(&:id)).to eq([board.id])
+    end
+  end
+
+  describe ".find" do
+    it "returns a linkable board and nothing else" do
+      board = admin_board(name: "Feelings")
+      unpublished = admin_board(name: "Hidden", published: false)
+
+      expect(described_class.find(board.id)).to eq(board)
+      expect(described_class.find(board.id.to_s)).to eq(board)
+      expect(described_class.find(unpublished.id)).to be_nil
+      expect(described_class.find(nil)).to be_nil
+      expect(described_class.find("")).to be_nil
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/label_casing_spec.rb
+++ b/spec/services/boards/admin_builder/label_casing_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::LabelCasing do
+  describe ".sanitize" do
+    it "folds an identifier-style label back into display text" do
+      expect(described_class.sanitize("snack_time")).to eq("snack time")
+      expect(described_class.sanitize("  all   done  ")).to eq("all done")
+    end
+
+    it "survives a nil" do
+      expect(described_class.sanitize(nil)).to eq("")
+    end
+  end
+
+  describe ".apply" do
+    it "folds the model's Title Case down to the AAC lowercase default" do
+      expect(described_class.apply("Food")).to eq("food")
+      expect(described_class.apply("All Done")).to eq("all done")
+    end
+
+    # Delegated to Labels::CaseNormalizer, which judges per word. Asserted here
+    # because these are the cases a future "simplification" would break.
+    it "leaves a capital that is past the first letter alone" do
+      expect(described_class.apply("iPad")).to eq("iPad")
+      expect(described_class.apply("TV")).to eq("TV")
+      expect(described_class.apply("McDonald's")).to eq("McDonald's")
+      expect(described_class.apply("HELP")).to eq("HELP")
+    end
+
+    it "keeps the standalone pronoun capitalized" do
+      expect(described_class.apply("i")).to eq("I")
+      expect(described_class.apply("I")).to eq("I")
+    end
+
+    # A category tile's label is authored: an AAC board leans on the capital to
+    # separate a page you open from a word you speak.
+    it "never touches a door tile" do
+      expect(described_class.apply("Food", door: true)).to eq("Food")
+      expect(described_class.apply("Snack Time", door: true)).to eq("Snack Time")
+    end
+
+    # CaseNormalizer has no proper-noun detection and would fold "Sarah" — the
+    # model's own flag is the only signal there is.
+    it "keeps a label the model flagged as a proper noun" do
+      expect(described_class.apply("Sarah", proper_noun: true)).to eq("Sarah")
+      expect(described_class.apply("Sarah")).to eq("sarah")
+    end
+
+    # An over-eager flag on a word with no capital would otherwise be a silent
+    # no-op dressed up as a rule.
+    it "ignores the flag when the label carries no capital" do
+      expect(described_class.apply("apple", proper_noun: true)).to eq("apple")
+    end
+
+    it "sentence-cases a phrase rather than lowercasing it" do
+      expect(described_class.apply("i want more", part_of_speech: "phrase")).to eq("I want more")
+    end
+  end
+
+  describe ".proper_noun?" do
+    it "accepts the boolean and the string the model actually returns" do
+      expect(described_class.proper_noun?({ "proper_noun" => true })).to be(true)
+      expect(described_class.proper_noun?({ "proper_noun" => "true" })).to be(true)
+    end
+
+    it "is false for anything else" do
+      expect(described_class.proper_noun?({})).to be(false)
+      expect(described_class.proper_noun?({ "proper_noun" => false })).to be(false)
+      expect(described_class.proper_noun?({ "proper_noun" => "no" })).to be(false)
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/set_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/set_drafter_spec.rb
@@ -77,12 +77,74 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
     end
   end
 
+  # The model answers in Title Case no matter what the prompt says, and these
+  # labels go straight into the textarea the admin reads and on into the plan —
+  # Image#set_label only folds a NEW image, and never one whose tile carries an
+  # explicit display_label, so nothing downstream was catching it.
+  describe "casing" do
+    def labels(**overrides)
+      draft(**overrides)[:root_tiles].map { |tile| tile[:label] }
+    end
+
+    it "folds a drafted word to the lowercase AAC default" do
+      stub_ai(ai_set(root: [tile("Apple", "noun"), tile("All Done", "social"), tile("Food", "noun", "food")],
+                     pages: [{ "key" => "food", "name" => "Food",
+                               "tiles" => [tile("back", "social", "__root__")] }]))
+
+      expect(labels(columns: 3, tile_count: 3)).to eq(["apple", "all done", "Food"])
+    end
+
+    it "keeps a folder tile's authored capital" do
+      stub_ai(ai_set(root: [tile("Snack Time", "noun", "snack_time")],
+                     pages: [{ "key" => "snack_time", "name" => "Snack Time",
+                               "tiles" => [tile("back", "social", "__root__")] }]))
+
+      expect(labels(columns: 1, tile_count: 1)).to eq(["Snack Time"])
+    end
+
+    it "keeps a label the model flagged as a proper noun" do
+      root = [tile("Goldfish", "noun").merge("proper_noun" => true),
+              tile("Cracker", "noun"),
+              tile("Food", "noun", "food")]
+      stub_ai(ai_set(root: root, pages: [{ "key" => "food", "name" => "Food",
+                                           "tiles" => [tile("back", "social", "__root__")] }]))
+
+      expect(labels(columns: 3, tile_count: 3)).to eq(["Goldfish", "cracker", "Food"])
+    end
+
+    it "folds page words too, not just the root's" do
+      stub_ai(ai_set(root: [tile("Food", "noun", "food")],
+                     pages: [{ "key" => "food", "name" => "Food",
+                               "tiles" => [tile("Hungry", "adjective"), tile("Back", "social", "__root__")] }]))
+
+      page = draft(columns: 2, tile_count: 2)[:children].first
+
+      expect(page[:tiles].map { |t| t[:label] }).to eq(["hungry", "Back"])
+    end
+  end
+
+  # A page repeating a core word off the main board spends a cell on something
+  # the communicator can already reach from the board every page returns to.
+  describe "cross-page duplication" do
+    it "drops a page word the main board already carries" do
+      stub_ai(ai_set(
+                root: [tile("want", "verb"), tile("Food", "noun", "food")],
+                pages: [{ "key" => "food", "name" => "Food",
+                          "tiles" => [tile("want", "verb"), tile("apple", "noun")] }],
+              ))
+
+      page = draft(columns: 2, tile_count: 2)[:children].first
+
+      expect(page[:tiles].map { |t| t[:label] }).to eq(["apple"])
+    end
+  end
+
   describe "cleanup of what the model returns" do
     it "drops a link pointing at a page that isn't in the set" do
       stub_ai(ai_set(root: [tile("Toys", "noun", "toys")], pages: []))
 
       expect(draft(columns: 1, tile_count: 1, page_count: 1)[:root_tiles])
-        .to eq([{ label: "Toys", part_of_speech: "noun" }])
+        .to eq([{ label: "toys", part_of_speech: "noun" }])
     end
 
     it "keeps a child's link back to the root" do
@@ -97,7 +159,7 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
     it "drops a root tile linking to the root" do
       stub_ai(ai_set(root: [tile("Home", "social", "__root__")], pages: []))
 
-      expect(draft(columns: 1, tile_count: 1)[:root_tiles]).to eq([{ label: "Home", part_of_speech: "social" }])
+      expect(draft(columns: 1, tile_count: 1)[:root_tiles]).to eq([{ label: "home", part_of_speech: "social" }])
     end
 
     it "normalizes a page key to lowercase letters, numbers and underscores" do
@@ -272,7 +334,10 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
     def prompt_for(**args)
       captured = nil
       allow(OpenAiClient).to receive(:new) do |opts|
-        captured = opts[:messages].first[:content]
+        # The FIRST call only. `valid_set` is a 4-tile fixture and these
+        # examples ask for 24, so the short-draft top-up fires a second call —
+        # WordListDrafter's prompt, which is not what any of this describes.
+        captured ||= opts[:messages].first[:content]
         instance_double(OpenAiClient, create_chat: { role: "assistant", content: valid_set })
           .tap { |double| allow(double).to receive(:instance_variable_set) }
       end


### PR DESCRIPTION
Three things on `/admin/dashboard/board_builds`, plus a duplication bug found along the way.

## 1. Drafted words come back lowercase

All three drafters ran a raw label through their own `sanitize_label`, which folded underscores and nothing else — so the model's Title Case ("Apple", "All Done") reached the textarea and the built board. `Image#set_label` folds a plain leading capital only for a **new** image, and never for a tile carrying an explicit `display_label`, so nothing downstream caught it.

New `Boards::AdminBuilder::LabelCasing` decides *which* labels are `Labels::CaseNormalizer`'s business; the casing rules stay in that one authority. Two carve-outs:

- **Door tiles keep their capital** ("Food", "Snack Time") — an AAC board leans on that to separate a page you open from a word you speak, and `FolderTiles` already pins it on the doors it writes.
- **Proper nouns** — the model may set `"proper_noun": true`, honoured only when the label actually carries a capital. `CaseNormalizer` has no proper-noun detection and would otherwise fold "Sarah".

Words typed by hand are authored input and never folded.

## 2. Better suggestions

- `SetDrafter` gets the core-word spine and part-of-speech balance `WordListDrafter` already had.
- Pages are asked for as **places and routines** ("Snack Time", "Going Home") rather than categories of nouns ("Equipment", "Colors"), with examples.
- A page word the root already carries is hard-filtered — the communicator reaches it from the main board, so a repeat spends a cell and buys nothing.
- A board more than `TOPUP_THRESHOLD` short gets **one** follow-up call through `WordListDrafter`'s existing top-up prompt, capped by `MAX_TOPUPS` for the whole draft.
- All three drafters share `Boards::AdminBuilder::Drafting` — ENV-tunable model (`OPENAI_ADMIN_BUILDER_MODEL`, default `GTP_5_MODEL`) and temperature, with a retry that drops the temperature if the model rejects it, because `create_chat` swallows an API error into a debug log and a rejected temperature would look exactly like "the AI had nothing to say".

## 3. A page can link an existing published board

Offered whenever a published admin board carries the page's name; **creating a new page stays the default**. Three rails:

- `Plan.child_page` blanks a linked page's tiles at the single point every consumer reads a page from, so validation, art resolution, preview and build agree without each remembering the rule.
- The board is recorded under `art_report["linked_boards"]` and **never** `["boards"]` — that key is what `set_boards` returns and what publish/unpublish/destroy iterate. This build must never touch a board it doesn't own.
- `builder_root` is pinned on it, because `check_is_sub_board` is a `before_save` that would otherwise demote a linked board out of `main_boards` (and out of admin board search) on its next unrelated save.

**Known gap, surfaced in the UI:** a linked board keeps whatever back tile it had, so it has no way back to the new root. `data["back_tile"]` is not runtime behaviour — navigation is the static `predictive_board_id` — so a shared board can only ever have one home. Follow-up issue below.

## 4. Fix: a build could create its whole set twice

The set was claimed **after** the transaction that created it, so anything raising in between (two art queries, the jsonb write) left the boards committed with `board_id` still blank. `BuildAdminBoardJob` is `retry: 2`, so the retry walked past the "already built" guard and produced a second full set. The first was stranded: still `published`, in no build's `art_report`, invisible to `set_boards` — not listed on the build page, skipped by publish/unpublish, left behind by destroy.

The claim now commits with the boards under a row lock on the build, and `art_report["boards"]` is written there too so **pages** are owned from the start, not just the root. `rake admin_board_builds:orphans` finds already-stranded sets (`UNPUBLISH=1` / `APPLY=1` to act). The preview page's submit guard closes the other route — two POSTs to `create`.

## Test plan

`521 examples, 0 failures` across:

```
bundle exec rspec spec/services/boards/admin_builder/ spec/requests/admin/board_builds_spec.rb \
  spec/services/labels/ spec/models/admin_board_build_spec.rb spec/models/board_image_spec.rb
```

New coverage:
- `label_casing_spec.rb` — fold, the deliberate-capital cases, doors, the proper-noun flag and its no-capital no-op.
- `existing_boards_spec.rb` — name match, grid ranking, the cap, and what may/may not be linked (unpublished, other-owner, predictive, menu; builder boards *are* included, since `Board.public_boards` requires `predefined` and would hide them).
- `build_spec.rb` — linked page builds no board and mutates nothing but the `builder_root` pin; stays out of `set_boards`; a posted word list for a linked page is ignored; a non-linkable id is refused. Plus the duplication regression: a build that dies after the set commits claims it anyway, and leaves no board `set_boards` can't see.
- `set_drafter_spec.rb` — casing on root and pages, door capitals, proper nouns, cross-page dedupe.
- `board_builds_spec.rb` — the picker appears only on a real match, a linked page previews without a word list, the link survives the preview round trip and lands in the stored plan.

Two failures the new specs caught and fixed in this branch: `BoardImage`'s default order broke a grouped count (`reorder(nil)`), and `reindexPages()` renumbered `input, textarea` but not `select`, which would have linked the wrong page to the wrong board after a move.

## Not in this PR

Making back tiles dynamic (route to the session root instead of a fixed board). The seam is small — `BoardNativeGridPage` already tracks `rootBoardId` — but it changes behaviour for every existing back tile in the app, so it wants its own change. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)