### PR TITLE
feat(board-builder): group AI drafts into part-of-speech bands

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1237,6 +1237,57 @@ Its own invariants:
   admin-owned. Short drafts are returned rather than raised on, since the form
   can absorb them; only an unusable response is an error.
 
+- **The DRAFTED ORDER IS THE LAYOUT, so drafters arrange before the form sees
+  the words.** `Build#apply_reading_order!` is nothing but
+  `x = i % columns, y = i / columns` — whatever order a drafter puts in the
+  textarea is what an admin sees laid out and what a communicator scans. Left to
+  the model's own ordering, the Modified Fitzgerald colours the builder already
+  applies per tile came out as confetti: verb, noun, pronoun, noun.
+  `Boards::AdminBuilder::TileArrangement` is the single authority on that order —
+  a stable sort into `BAND_ORDER` (quick words first: pronoun, social,
+  important_function, question; then the sentence: verb, adverb, adjective,
+  preposition, determiner, conjunction, noun, default), with anything carrying
+  `links_to` sorted after every word band so doors and back tiles land on the
+  bottom rows like the rest of the app's navigation. `BAND_ORDER` must stay a
+  permutation of `ColorHelper::PARTS_OF_SPEECH` (spec'd), and the arrangement
+  itself must stay a **permutation only**: no tile added, dropped, relabelled or
+  relinked, so nothing downstream — `PlanValidator` counts, `FolderTiles` links,
+  `BackTileAlignment` mirroring — has to re-check it. Column-free on purpose:
+  bands can't be made to break on row boundaries without padding, and the grid
+  must be exactly full.
+  - Arrangement runs **inside the drafters**, never in the controller.
+    `FolderTiles.link` runs on every form round-trip, and re-sorting a
+    hand-edited list because the admin pressed a button is not the deal. For the
+    same reason `add_words` arranges only the NEW tiles it appends.
+  - `SetDrafter` arranges **after** `top_up`, or a follow-up call's words sit as
+    an ungrouped block on the end of a grouped board.
+  - Known limit: `FolderTiles.link` can *promote* an existing noun tile into a
+    door in place after drafting, and that one tile stays in the noun band.
+    Appended doors land last, which is correct.
+  - `TileArrangement` also corrects the part of speech from
+    `AacWordCategorizer::OVERRIDES` before sorting — a wrong POS is a wrong
+    colour and now a wrong band, and that table is already the app's authority
+    on the words models reliably miscall ("stop" as a verb, "more" as an
+    adjective). The OVERRIDES table **only**, never `.categorize`, which is one
+    paid call per word. Doors are exempt: a door's label is a page name, so
+    "Play" must not be recoloured because a word table knows the verb.
+
+- **Every drafter shares one system prompt, one set of word rules, and a JSON
+  schema.** `AdminBuilder::Drafting` owns all three: `SYSTEM_PROMPT` (sent as a
+  `system` message ahead of each drafter's own `user` message), `WORD_RULES` (the
+  rules that separate a board from a word list — combinatorial value, a way to
+  object and a way to redirect, no single-use nouns, no closed-set filler,
+  register follows the audience), and `tile_schema`. Each drafter defines its own
+  Structured Outputs schema from `tile_schema`, which pins `part_of_speech` to
+  a real enum instead of hoping prose holds. Strict mode requires every property
+  in `required` and forbids extras, so an optional field is **nullable**, not
+  absent. `Drafting.chat` retries down a ladder — schema+temperature → schema →
+  no schema — because `MODEL` is ENV-tunable and `create_chat` swallows an API
+  error into a debug log and returns nil, so a rejected parameter is
+  indistinguishable from "the AI had nothing to say" and would take drafting
+  down silently. `OpenAiClient#create_chat` now prefers an explicit
+  `response_format` over its `json_object` default, mirroring `create_completion`.
+
 - **A build can be a linked set, not just one board.** `plan["children"]` holds
   child pages (`key`, `name`, optional grid, tiles) and any tile may carry
   `links_to`, which becomes `predictive_board_id` — the same one-line link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,25 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **AI board drafts now come back laid out, not just filled in.** The order the
+  AI answers in is the order the tiles land on the grid, so a scrambled word list
+  was a scrambled board: a verb, a noun, a pronoun, another noun, and the
+  colour-coding that is supposed to help a communicator find a word reading as
+  confetti. Drafts are now grouped before they reach the form — the quick words
+  (I, you, yes, more, no, stop) in the opening cells, then verbs, then describing
+  words, then the topic words, with folder tiles and every "back" tile on the
+  bottom rows where the rest of the app keeps navigation. Words a model reliably
+  miscolours are corrected on the way ("stop" is a protest word, not an action
+  word), and the drafted list is still ordinary text you can edit — nothing is
+  re-sorted once you have touched it. (Admin only.)
+
+- **Better words on AI drafts.** The drafting prompts now ask for what makes a
+  board sayable rather than accurate: words that finish many sentences instead of
+  one, a way to object and a way to redirect on every board, no nouns that exist
+  only to be labelled, no days-of-the-week filler, and a register that matches
+  who the board is for. Folder pages are asked for the verbs and describing words
+  that belong to them, not just the things you would find there. (Admin only.)
+
 - **Words drafted with AI now come back lowercase, the way AAC tiles are
   written.** "Draft with AI" and "Draft the whole set with AI" were handing back
   Title Case — "Apple", "All Done" — and that casing followed the words all the

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -644,7 +644,13 @@ class OpenAiClient
     # temperature: 0.7,
     # response_format: { type: "json_object" },
     }
-    if format_json
+    # An explicit response_format wins over the `format_json` flag, same shape as
+    # create_completion: a caller that has a json_schema wants THAT schema, not
+    # the blanket json_object the flag asks for. Every existing caller sends
+    # nothing and keeps the behaviour it has always had.
+    if @opts[:response_format].present?
+      opts[:response_format] = @opts[:response_format]
+    elsif format_json
       opts[:response_format] = { type: "json_object" }
     end
     # Opt-in only, same shape as create_completion: every existing caller sends

--- a/app/services/boards/admin_builder/drafting.rb
+++ b/app/services/boards/admin_builder/drafting.rb
@@ -18,31 +18,116 @@ module Boards
       # at all.
       TEMPERATURE = ENV.fetch("OPENAI_ADMIN_BUILDER_TEMPERATURE", "0.4").freeze
 
+      # Sent ahead of every drafter's own prompt. The per-drafter prompts say
+      # what to build; this says who is building it and what is never negotiable
+      # whichever button was pressed. Kept short: it is prepended to four
+      # different prompts, and a long preamble competes with the instructions
+      # that actually differ between them.
+      SYSTEM_PROMPT = <<~PROMPT.freeze
+        You are a speech-language pathologist who builds AAC (Augmentative and
+        Alternative Communication) grid boards for nonspeaking communicators.
+
+        You are choosing which words earn a cell on a fixed grid a child will use
+        every day — not writing a vocabulary list about a topic. A board is judged
+        on what it lets someone SAY: request, refuse, comment, direct, repair. A
+        board that can only name things has failed even if every word on it is
+        correct.
+
+        These hold for every request, whatever else the instructions ask for:
+        - Return the EXACT tile count asked for. The grid is fixed and a partial
+          last row is visible dead cells on a real board.
+        - Every tile carries a part_of_speech from the list you are given. It sets
+          the tile's Modified Fitzgerald Key colour, so a wrong one miscolours the
+          board.
+        - Respond with JSON only — no prose, no code fences, no commentary.
+      PROMPT
+
+      # The word-selection rules every drafter shares, so the four prompts can't
+      # drift apart on what makes a good tile the way they once drifted on model
+      # and temperature. A drafter adds its own lines around this — what a page
+      # owes the set, what the main board owes every page — but never restates
+      # one of these.
+      #
+      # These are the rules that separate a board from a word list. Each one is
+      # here because a draft failed on it: pages of nouns nobody can say anything
+      # about, boards with no way to refuse, a preschool board that offered
+      # "Tuesday" and "purple" but not "again".
+      WORD_RULES = <<~RULES.freeze
+        - Favour words that can finish many different sentences over words that
+          finish one. "want", "more", "go" and "different" earn a cell on almost
+          any board; "cheeseburger" earns one only on a board about lunch.
+        - Every board needs a way to object and a way to redirect. Include at
+          least one of: no, not, stop, don't like. And at least one of: again,
+          different, something else, all done.
+        - A noun earns a cell if the communicator can say something ABOUT it, not
+          only name it. Skip nouns that exist to be labelled.
+        - No closed sets as filler: no letters, digits, days of the week, months,
+          or a run of colours, unless the topic is that thing.
+        - Match the register to who this is for. If an age or setting is given,
+          the words sound like that person's life — not a generic child's.
+        - No near-duplicates ("happy" and "glad", "big" and "large"). Each tile
+          costs a cell.
+        - Keep each label short — 1-2 words.
+        - A label is display text, not an identifier: separate words with a plain
+          space, never an underscore.
+      RULES
+
+      # The part-of-speech clause, shared for the same reason. Ordering is asked
+      # for here as well as enforced in Ruby by `TileArrangement`: a model
+      # composing a block of verbs picks better verbs than one emitting them
+      # scattered between nouns.
+      def self.part_of_speech_rules
+        <<~RULES
+          - Give every tile a part_of_speech from exactly this list:
+            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
+          - Classify by communicative function, not strict grammar: "more", "yes" and
+            "please" are social; "no", "not" and "stop" are important_function.
+          #{TileArrangement::PROMPT_RULE.rstrip}
+        RULES
+      end
+
       module_function
 
       # Returns the response content, or nil. Each drafter raises its own
       # GenerationError on nil — the error class is part of that drafter's
       # contract with its controller action.
       #
-      # The retry exists because MODEL and TEMPERATURE are both ENV-tunable and
-      # not every model accepts a custom temperature. `create_chat` swallows an
-      # API error into a debug log and hands back nil content, so without this a
-      # rejected temperature would look exactly like "the AI had nothing to say"
-      # and take drafting down until someone read the logs. Same reasoning as
-      # the image-model fallback in OpenAiClient#create_image.
-      def chat(prompt:, content:)
-        result = call(prompt: prompt, content: content, temperature: TEMPERATURE.presence)
+      # `schema` is an OpenAI Structured Outputs `json_schema` value. It pins the
+      # part_of_speech enum and the tile shape at the API rather than in prose,
+      # which is the difference between a bad value being impossible and being
+      # quietly downgraded to grey by the drafter's own fallback.
+      #
+      # Two retries, both for the same reason: MODEL and TEMPERATURE are
+      # ENV-tunable, not every model accepts a custom temperature or a json
+      # schema, and `create_chat` swallows an API error into a debug log and
+      # hands back nil content — so a rejected parameter looks exactly like "the
+      # AI had nothing to say" and would take drafting down until someone read
+      # the logs. Same reasoning as the image-model fallback in
+      # `OpenAiClient#create_image`.
+      def chat(prompt:, content:, schema: nil)
+        result = with_temperature_retry(prompt: prompt, content: content, schema: schema)
+        return result if result.present?
+        return nil if schema.blank?
+
+        Rails.logger.warn("[AdminBuilder::Drafting] no content from #{MODEL} with a json schema " \
+                          "— retrying without it")
+        with_temperature_retry(prompt: prompt, content: content, schema: nil)
+      end
+
+      def with_temperature_retry(prompt:, content:, schema:)
+        result = call(prompt: prompt, content: content, schema: schema, temperature: TEMPERATURE.presence)
         return result if result.present?
         return nil if TEMPERATURE.blank?
 
         Rails.logger.warn("[AdminBuilder::Drafting] no content from #{MODEL} at " \
                           "temperature #{TEMPERATURE} — retrying without it")
-        call(prompt: prompt, content: content, temperature: nil)
+        call(prompt: prompt, content: content, schema: schema, temperature: nil)
       end
 
-      def call(prompt:, content:, temperature:)
-        opts = { prompt: prompt, messages: [{ role: "user", content: content }] }
+      def call(prompt:, content:, schema:, temperature:)
+        opts = { prompt: prompt, messages: messages_for(content) }
         opts[:temperature] = temperature.to_f if temperature.present?
+        opts[:response_format] = { type: "json_schema", json_schema: schema } if schema.present?
 
         # Splatted, not passed as one positional hash. `OpenAiClient#initialize`
         # takes a positional `opts` either way, but every caller in the codebase
@@ -52,6 +137,36 @@ module Boards
         client = OpenAiClient.new(**opts)
         client.instance_variable_set(:@model, MODEL)
         client.create_chat(true)[:content].presence
+      end
+
+      def messages_for(content)
+        [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: content },
+        ]
+      end
+
+      # Builds a Structured Outputs schema for a list of tiles. Strict mode
+      # requires EVERY property to be listed in `required` and forbids extra
+      # ones, so what is optional in the plan is modelled as nullable here
+      # rather than omitted — a tile that opens nothing sends `"links_to": null`.
+      #
+      # `links:` is false for WordListDrafter, which has no concept of a link and
+      # would only invite the model to invent page keys that don't exist.
+      def tile_schema(links: true)
+        properties = {
+          label: { type: "string" },
+          part_of_speech: { type: "string", enum: ColorHelper::PARTS_OF_SPEECH },
+          proper_noun: { type: "boolean" },
+        }
+        properties[:links_to] = { type: %w[string null] } if links
+
+        {
+          type: "object",
+          additionalProperties: false,
+          required: properties.keys.map(&:to_s),
+          properties: properties,
+        }
       end
     end
   end

--- a/app/services/boards/admin_builder/page_drafter.rb
+++ b/app/services/boards/admin_builder/page_drafter.rb
@@ -22,6 +22,21 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES = 144
 
+      # Links are in the schema because a page owes the set exactly one: the way
+      # home. `link_for` drops anything else the model puts there.
+      SCHEMA = {
+        name: "aac_page_word_list",
+        strict: true,
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["tiles"],
+          properties: {
+            tiles: { type: "array", items: Drafting.tile_schema },
+          },
+        },
+      }.freeze
+
       # `topic` is the whole board's subject and is optional context — the page
       # title is the actual input, and a page can be drafted before the board
       # has a topic at all.
@@ -50,7 +65,7 @@ module Boards
       end
 
       def generate_via_openai
-        content = Drafting.chat(prompt: subject, content: build_prompt)
+        content = Drafting.chat(prompt: subject, content: build_prompt, schema: SCHEMA)
         raise GenerationError, "OpenAI returned no content" if content.blank?
 
         content
@@ -74,33 +89,27 @@ module Boards
           - No other tile has "links_to" — this page opens nothing further.
 
           Word rules:
-          - A board for talking, not a vocabulary list. Favour words that finish a
-            sentence over words that name a thing.
           - This is a page, not the main board: the main board already carries the core
             words the whole set leans on, so spend these cells on #{subject} rather than
             repeating "I", "want", "more" and "help".
-          - No near-duplicates ("happy" and "glad", "big" and "large"). Each tile costs a
-            cell.
-          - Keep each label short — 1-2 words.
-          - Concrete and age-appropriate.
+          - A page still has to be sayable on its own terms. Carry the verbs and the
+            describing words that belong to #{subject} — what you DO there and what it
+            is LIKE — not only the things you would find there.
           - Aim for roughly this balance: 30-40% verbs and core function words,
             15-20% pronouns and determiners, 15-20% describing words, 25-35% topic
             nouns. A page that is mostly nouns is a picture dictionary, not an AAC
             page.
-          - A label is display text, not an identifier: separate words with a plain
-            space, never an underscore.
+          #{Drafting::WORD_RULES.rstrip}
           #{LabelCasing::PROMPT_RULE.rstrip}
-          - Give every tile a part_of_speech from exactly this list:
-            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
-          - Classify by communicative function, not strict grammar: "more", "yes" and
-            "please" are social; "no", "not" and "stop" are important_function.
+          #{Drafting.part_of_speech_rules.rstrip}
 
-          Respond in JSON format:
+          Respond in JSON format — every tile carries "proper_noun" and "links_to",
+          with null where there is no link:
           {
             "tiles": [
-              { "label": "apple", "part_of_speech": "noun" },
-              { "label": "hungry", "part_of_speech": "adjective" },
-              { "label": "back", "part_of_speech": "social", "links_to": "#{Plan::ROOT_KEY}" }
+              { "label": "hungry", "part_of_speech": "adjective", "proper_noun": false, "links_to": null },
+              { "label": "apple", "part_of_speech": "noun", "proper_noun": false, "links_to": null },
+              { "label": "back", "part_of_speech": "social", "proper_noun": false, "links_to": "#{Plan::ROOT_KEY}" }
             ]
           }
 
@@ -108,9 +117,14 @@ module Boards
         PROMPT
       end
 
+      # Arranged for the same reason as every other drafter: the order here is
+      # the grid layout. The back tile carries `links_to`, so it sorts into the
+      # bottom band — which keeps `BackTileAlignment`'s mirror-swap a move
+      # between navigation cells rather than one that pulls a word out of its
+      # colour block.
       def parse_response(raw)
         data = JSON.parse(raw)
-        tiles = dedupe(Array(data["tiles"])).first(tile_count)
+        tiles = TileArrangement.arrange(dedupe(Array(data["tiles"])).first(tile_count))
 
         # Only a response with nothing usable in it is an error — this fills a
         # textarea, so a short draft is survivable and the form's counter shows

--- a/app/services/boards/admin_builder/set_drafter.rb
+++ b/app/services/boards/admin_builder/set_drafter.rb
@@ -33,6 +33,32 @@ module Boards
       # spend six sequential API calls papering over while the admin waits.
       MAX_TOPUPS = 3
 
+      SCHEMA = {
+        name: "aac_board_set",
+        strict: true,
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          required: %w[root pages],
+          properties: {
+            root: { type: "array", items: Drafting.tile_schema },
+            pages: {
+              type: "array",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                required: %w[key name tiles],
+                properties: {
+                  key: { type: "string" },
+                  name: { type: "string" },
+                  tiles: { type: "array", items: Drafting.tile_schema },
+                },
+              },
+            },
+          },
+        },
+      }.freeze
+
       # `pages` are the pages the admin already named on the form, as
       # `{ key:, name: }` hashes. They are used verbatim and the model only
       # invents the rest — so a page count below the number of names would
@@ -87,7 +113,7 @@ module Boards
       end
 
       def generate_via_openai
-        content = Drafting.chat(prompt: topic, content: build_prompt)
+        content = Drafting.chat(prompt: topic, content: build_prompt, schema: SCHEMA)
         raise GenerationError, "OpenAI returned no content" if content.blank?
 
         content
@@ -134,15 +160,13 @@ module Boards
             the tile before they open it.
 
           Main board rules:
-          - Start the main board with these core words, in this order, before any topic
-            words — they are what makes the whole set usable for something other than
-            labelling, and they belong on the board every page returns to:
+          - The main board must include these core words — they are what makes the whole
+            set usable for something other than labelling, and they belong on the board
+            every page returns to:
             #{spine_for_size.join(", ")}
-          - Then the folder tiles, then whatever main-board topic words still fit.
+          - Then the folder tiles, and whatever main-board topic words still fit.
 
           Word rules:
-          - Boards for talking, not vocabulary lists. Favour words that finish a sentence
-            over words that name a thing.
           - Aim for roughly this balance across each board:
             30-40% verbs and core function words (the words that do the communicating),
             15-20% pronouns and determiners, 15-20% describing words, 25-35% topic nouns.
@@ -150,33 +174,32 @@ module Boards
           - A page must NOT repeat a word that is already on the main board. The
             communicator reaches those from the main board, so a repeat spends a cell and
             buys nothing.
-          - No near-duplicates within a board ("happy" and "glad"). Each tile costs a cell.
-          - Keep each label short — 1-2 words.
-          - A label is display text, not an identifier: separate words with a plain
-            space, never an underscore. (Page "key" values are the one exception —
-            those are underscored on purpose, per the structure rules above.)
+          - A page still has to be sayable on its own terms: carry the verbs and
+            describing words that belong to THAT page — what you do there and what it is
+            like — not only the things you would find there.
+          #{Drafting::WORD_RULES.rstrip}
+          - The underscore rule has one exception: page "key" values are underscored on
+            purpose, per the structure rules above.
           #{LabelCasing::PROMPT_RULE.rstrip}
-          - Give every tile a part_of_speech from exactly this list:
-            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
-          - Classify by communicative function, not strict grammar: "more", "yes" and
-            "please" are social; "no", "not" and "stop" are important_function.
+          #{Drafting.part_of_speech_rules.rstrip}
 
-          Respond in JSON format:
+          Respond in JSON format — every tile carries "proper_noun" and "links_to",
+          with null where there is no link:
           {
             "root": [
-              { "label": "i", "part_of_speech": "pronoun" },
-              { "label": "want", "part_of_speech": "verb" },
-              { "label": "Snack Time", "part_of_speech": "noun", "links_to": "snack_time" }
+              { "label": "i", "part_of_speech": "pronoun", "proper_noun": false, "links_to": null },
+              { "label": "want", "part_of_speech": "verb", "proper_noun": false, "links_to": null },
+              { "label": "Snack Time", "part_of_speech": "noun", "proper_noun": false, "links_to": "snack_time" }
             ],
             "pages": [
               {
                 "key": "snack_time",
                 "name": "Snack Time",
                 "tiles": [
-                  { "label": "hungry", "part_of_speech": "adjective" },
-                  { "label": "open it", "part_of_speech": "verb" },
-                  { "label": "Goldfish", "part_of_speech": "noun", "proper_noun": true },
-                  { "label": "back", "part_of_speech": "social", "links_to": "#{Plan::ROOT_KEY}" }
+                  { "label": "open it", "part_of_speech": "verb", "proper_noun": false, "links_to": null },
+                  { "label": "hungry", "part_of_speech": "adjective", "proper_noun": false, "links_to": null },
+                  { "label": "Goldfish", "part_of_speech": "noun", "proper_noun": true, "links_to": null },
+                  { "label": "back", "part_of_speech": "social", "proper_noun": false, "links_to": "#{Plan::ROOT_KEY}" }
                 ]
               }
             ]
@@ -223,14 +246,18 @@ module Boards
         # fills the form and the counter shows the gap.
         raise GenerationError, "AI returned no usable words" if root_tiles.empty?
 
-        root_tiles = top_up(root_tiles, subject: topic)
+        # Arranged AFTER the top-up, not before: a top-up is a second OpenAI call
+        # whose words are appended to the list, so arranging first would leave
+        # them as an ungrouped block on the end of a grouped board. Arranging is
+        # a permutation, so doing it last costs nothing and fixes that.
+        root_tiles = TileArrangement.arrange(top_up(root_tiles, subject: topic))
         # What a page may not repeat. Resolved from the root AFTER its top-up so
         # a word the top-up added is covered too.
         taken = root_tiles.map { |tile| tile[:label] }
 
         children = shells.map do |page|
           tiles = clean_tiles(page[:tiles], known_keys: keys + [Plan::ROOT_KEY], taken: taken)
-          page.merge(tiles: top_up(tiles, subject: page[:name], taken: taken))
+          page.merge(tiles: TileArrangement.arrange(top_up(tiles, subject: page[:name], taken: taken)))
         end
 
         # The count is echoed back because pinned pages can raise it above what

--- a/app/services/boards/admin_builder/tile_arrangement.rb
+++ b/app/services/boards/admin_builder/tile_arrangement.rb
@@ -1,0 +1,105 @@
+module Boards
+  module AdminBuilder
+    # Puts a drafted tile list in the order it should be READ ON THE GRID.
+    #
+    # **The drafted order IS the layout.** `Build#apply_reading_order!` does
+    # nothing but `x = cell % columns, y = cell / columns`, so whatever order a
+    # drafter hands to the form is exactly what an admin sees laid out — and
+    # what a communicator scans. Left to the model's own ordering, the Modified
+    # Fitzgerald colours the builder already applies per tile come out as
+    # confetti: a verb, a noun, a pronoun, a noun. Same words, much harder board.
+    #
+    # So: a stable sort into part-of-speech bands. Like words land contiguous,
+    # each colour reads as a block, and the quick words a communicator needs
+    # first (pronouns, yes/no/more, stop) are in the opening cells rather than
+    # wherever the model happened to put them.
+    #
+    # **This is a PERMUTATION and nothing else.** No tile is added, dropped,
+    # relabelled or relinked, so nothing downstream can be affected by it:
+    # counts still satisfy PlanValidator, `FolderTiles` still finds every link,
+    # and `BackTileAlignment` still mirrors the same set of tiles. Keep it that
+    # way — the moment this can change a count it becomes something preview has
+    # to re-check.
+    #
+    # Column-free on purpose. Bands can't be made to break on row boundaries
+    # without padding the grid, and the grid must be exactly full.
+    module TileArrangement
+      # Top to bottom. Quick words first — pronouns, then the social words and
+      # the protest words, then question words — because those are what a
+      # communicator reaches for under pressure and the top-left cells are the
+      # cheapest to reach. Then the sentence: verb, how, what kind, where, which,
+      # and the topic nouns last.
+      #
+      # Interpolated into every drafter's prompt (`PROMPT_RULE`), so the order
+      # the model is asked for and the order Ruby enforces cannot drift.
+      BAND_ORDER = %w[
+        pronoun
+        social
+        important_function
+        question
+        verb
+        adverb
+        adjective
+        preposition
+        determiner
+        conjunction
+        noun
+        default
+      ].freeze
+
+      # Doors and back tiles sort after every word band. The app's boards put
+      # navigation on the bottom row (see `.claude-notes/board-builder.md`), and
+      # a back tile in the bottom band keeps `BackTileAlignment`'s mirror-swap a
+      # bottom-to-bottom move instead of dragging a word out of its colour block.
+      LINK_BAND = BAND_ORDER.size
+
+      PROMPT_RULE = <<~RULE.freeze
+        - Group the tiles by part of speech and list the groups in exactly this
+          order, with any tile that has a "links_to" last of all:
+          #{BAND_ORDER.join(", ")}
+          Tiles are laid out left to right in the order you list them, so a
+          grouped list is what puts like words next to each other on the grid.
+      RULE
+
+      module_function
+
+      # `tiles` are Plan tile hashes (`{ label:, part_of_speech:, links_to: }`).
+      # Idempotent: sorting an already-arranged list returns it unchanged.
+      def arrange(tiles)
+        Array(tiles)
+          .map { |tile| correct_part_of_speech(tile) }
+          .each_with_index
+          .sort_by { |tile, index| [band_for(tile), index] }
+          .map(&:first)
+      end
+
+      def band_for(tile)
+        return LINK_BAND if tile[:links_to].present?
+
+        BAND_ORDER.index(tile[:part_of_speech].to_s) || BAND_ORDER.index("default")
+      end
+
+      # A wrong part of speech is a wrong colour AND now a wrong band, so it is
+      # worth correcting before sorting rather than leaving for an admin to
+      # spot. `AacWordCategorizer::OVERRIDES` is already keyed by communicative
+      # function — the exact thing the prompts ask for, and the exact thing
+      # models get wrong ("stop" as a verb, "more" as an adjective).
+      #
+      # The OVERRIDES table only, never `AacWordCategorizer.categorize`: that
+      # falls through to one paid OpenAI call PER WORD, which would turn a
+      # 144-tile draft into 144 requests to fix colours a schema-constrained
+      # response mostly got right.
+      def correct_part_of_speech(tile)
+        tile = tile.dup
+        # A door's label is a page name, not a word — "Play" opens a page and
+        # must not be recoloured because a word table happens to know "play".
+        return tile if tile[:links_to].present?
+
+        key = AacWordCategorizer.normalize(tile[:label])
+        override = AacWordCategorizer::OVERRIDES[key]
+        tile[:part_of_speech] = override if override.present?
+        tile
+      end
+    end
+  end
+end

--- a/app/services/boards/admin_builder/word_list_drafter.rb
+++ b/app/services/boards/admin_builder/word_list_drafter.rb
@@ -27,6 +27,22 @@ module Boards
       # 12x12, matching the controller's grid ceiling.
       MAX_TILES = 144
 
+      # No `links_to`: this drafter replaces a whole word list and knows nothing
+      # about the pages in the set, so a link it invented would name a page that
+      # doesn't exist. `FolderTiles` writes the doors back in afterwards.
+      SCHEMA = {
+        name: "aac_word_list",
+        strict: true,
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["tiles"],
+          properties: {
+            tiles: { type: "array", items: Drafting.tile_schema(links: false) },
+          },
+        },
+      }.freeze
+
       # existing_labels switches the prompt from "draft a whole board" to "add
       # N more tiles to one that already has these" — used when topping up a
       # list an admin already started rather than replacing it.
@@ -48,7 +64,7 @@ module Boards
       attr_reader :topic, :tile_count, :audience, :existing_labels
 
       def generate_via_openai
-        content = Drafting.chat(prompt: topic, content: build_prompt)
+        content = Drafting.chat(prompt: topic, content: build_prompt, schema: SCHEMA)
         raise GenerationError, "OpenAI returned no content" if content.blank?
 
         content
@@ -71,37 +87,29 @@ module Boards
           Generate EXACTLY #{tile_count} tiles — the board is a fixed grid and a partial
           last row leaves visible dead cells.
 
-          Start with these core words, in this order, before any topic words:
+          The board must include these core words — they are what makes it usable for
+          something other than labelling:
           #{spine_for_size.join(", ")}
 
-          Then fill the rest with topic words, aiming for roughly this balance across the
+          Fill the rest with topic words, aiming for roughly this balance across the
           whole list:
           - 30-40% verbs and core function words (the words that do the communicating)
           - 15-20% pronouns and determiners
           - 15-20% describing words
           - 25-35% topic nouns
+          A board that is mostly nouns is a picture dictionary, not an AAC board.
 
           Rules:
-          - A board for talking, not a vocabulary list. Favour words that finish a
-            sentence over words that name a thing.
-          - No near-duplicates ("happy" and "glad", "big" and "large"). Each tile costs a
-            cell.
-          - Keep each label short — 1-2 words.
-          - Concrete and age-appropriate.
-          - A label is display text, not an identifier: separate words with a plain
-            space, never an underscore.
+          #{Drafting::WORD_RULES.rstrip}
           #{LabelCasing::PROMPT_RULE.rstrip}
-          - Give every tile a part_of_speech from exactly this list:
-            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
-          - Classify by communicative function, not strict grammar: "more", "yes" and
-            "please" are social; "no", "not" and "stop" are important_function.
+          #{Drafting.part_of_speech_rules.rstrip}
 
           Respond in JSON format:
           {
             "tiles": [
-              { "label": "i", "part_of_speech": "pronoun" },
-              { "label": "want", "part_of_speech": "verb" },
-              { "label": "all done", "part_of_speech": "social" }
+              { "label": "i", "part_of_speech": "pronoun", "proper_noun": false },
+              { "label": "want", "part_of_speech": "verb", "proper_noun": false },
+              { "label": "all done", "part_of_speech": "social", "proper_noun": false }
             ]
           }
 
@@ -125,25 +133,20 @@ module Boards
           topic words the board doesn't have yet.
 
           Rules:
-          - A board for talking, not a vocabulary list. Favour words that finish a
-            sentence over words that name a thing.
+          - Read the existing list before choosing: fill what it is MISSING. If it has
+            no way to refuse or redirect, that is the first gap to close; if it is all
+            nouns, add the verbs and describing words that make them sayable.
           - No near-duplicates of each other or of the existing words ("happy" next to
-            "glad", "big" next to "large"). Each tile costs a cell.
-          - Keep each label short — 1-2 words.
-          - Concrete and age-appropriate.
-          - A label is display text, not an identifier: separate words with a plain
-            space, never an underscore.
+            "glad", "big" next to "large").
+          #{Drafting::WORD_RULES.rstrip}
           #{LabelCasing::PROMPT_RULE.rstrip}
-          - Give every tile a part_of_speech from exactly this list:
-            #{ColorHelper::PARTS_OF_SPEECH.join(", ")}
-          - Classify by communicative function, not strict grammar: "more", "yes" and
-            "please" are social; "no", "not" and "stop" are important_function.
+          #{Drafting.part_of_speech_rules.rstrip}
 
           Respond in JSON format:
           {
             "tiles": [
-              { "label": "swing", "part_of_speech": "noun" },
-              { "label": "push", "part_of_speech": "verb" }
+              { "label": "swing", "part_of_speech": "noun", "proper_noun": false },
+              { "label": "push", "part_of_speech": "verb", "proper_noun": false }
             ]
           }
 
@@ -151,9 +154,18 @@ module Boards
         PROMPT
       end
 
+      # Arranged, not just deduped: the drafted order IS the grid layout
+      # downstream (`Build#apply_reading_order!`), so grouping the list by part
+      # of speech here is what puts like words next to each other on the board.
+      # `TileArrangement.arrange` is a permutation, so the count the caller sees
+      # is unaffected.
+      #
+      # In top-up mode this arranges only the NEW tiles — the caller appends them
+      # to a list the admin may have typed by hand, and re-sorting someone's
+      # authored order because they asked for a few more words is not the deal.
       def parse_response(raw)
         data = JSON.parse(raw)
-        tiles = dedupe(Array(data["tiles"])).first(tile_count)
+        tiles = TileArrangement.arrange(dedupe(Array(data["tiles"])).first(tile_count))
 
         # Unlike Boards::AiPageGenerator — which builds from its response — this
         # only fills a textarea, so a short draft is survivable: the form's

--- a/spec/models/open_ai_client_spec.rb
+++ b/spec/models/open_ai_client_spec.rb
@@ -118,6 +118,38 @@ RSpec.describe OpenAiClient do
     end
   end
 
+  describe "#create_chat" do
+    let(:messages) { [{ role: "user", content: "hello" }] }
+
+    def captured_parameters(opts)
+      client = described_class.new(opts)
+      chat_client = instance_double(OpenAI::Client)
+      allow(client).to receive(:openai_client).and_return(chat_client)
+
+      captured = nil
+      allow(chat_client).to receive(:chat) do |parameters:|
+        captured = parameters
+        { "choices" => [{ "message" => { "role" => "assistant", "content" => "{}" } }] }
+      end
+
+      client.create_chat
+      captured
+    end
+
+    it "asks for a json object by default" do
+      expect(captured_parameters(messages: messages)[:response_format]).to eq({ type: "json_object" })
+    end
+
+    # A caller that has a json_schema wants THAT schema — the blanket
+    # json_object would throw away the enum and the required keys it defines.
+    it "prefers an explicit response_format over the json_object default" do
+      schema = { type: "json_schema", json_schema: { name: "thing", strict: true, schema: {} } }
+
+      expect(captured_parameters(messages: messages, response_format: schema)[:response_format])
+        .to eq(schema)
+    end
+  end
+
   describe "language-aware prompts" do
     subject(:client) { described_class.new({}) }
 

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1189,6 +1189,36 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
       }.to not_change(Board, :count).and not_change(Image, :count).and not_change(AdminBoardBuild, :count)
     end
 
+    # End to end through the real drafter, because the textarea order IS the
+    # grid layout: whatever lands here is what Build#apply_reading_order! lays
+    # out, so a scrambled draft is a scrambled board.
+    it "fills the textarea in band order, with the folder tile last" do
+      allow_any_instance_of(OpenAiClient).to receive(:create_chat).and_return(
+        role: "assistant",
+        content: {
+          "root" => [
+            { "label" => "swing", "part_of_speech" => "noun" },
+            { "label" => "Food", "part_of_speech" => "noun", "links_to" => "food" },
+            { "label" => "go", "part_of_speech" => "verb" },
+            { "label" => "I", "part_of_speech" => "pronoun" },
+          ],
+          "pages" => [
+            { "key" => "food", "name" => "Food",
+              "tiles" => [{ "label" => "back", "part_of_speech" => "social", "links_to" => "__root__" },
+                          { "label" => "apple", "part_of_speech" => "noun" },
+                          { "label" => "eat", "part_of_speech" => "verb" }] },
+          ],
+        }.to_json,
+      )
+
+      post draft_set_admin_dashboard_board_builds_path,
+           params: form_params(words: "", page_count: "1", columns: "2", tile_count: "4")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("I | pronoun\ngo | verb\nswing | noun\nFood | noun | &gt;food")
+      expect(response.body).to include("eat | verb\napple | noun\nback | social | &gt;__root__")
+    end
+
     it "reports a generation failure without losing what was typed" do
       allow(Boards::AdminBuilder::SetDrafter).to receive(:new).and_raise(
         Boards::AdminBuilder::SetDrafter::GenerationError, "OpenAI returned no content",

--- a/spec/services/boards/admin_builder/drafting_spec.rb
+++ b/spec/services/boards/admin_builder/drafting_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::Drafting do
+  let(:schema) do
+    { name: "test_schema", strict: true, schema: { type: "object", properties: {} } }
+  end
+
+  # Captures every OpenAiClient.new(**opts) and answers with `contents` in turn,
+  # so a retry can be told apart from the call it retried.
+  def stub_client(*contents)
+    calls = []
+    queue = contents.dup
+
+    allow(OpenAiClient).to receive(:new) do |opts|
+      calls << opts
+      content = queue.shift
+      instance_double(OpenAiClient, create_chat: { role: "assistant", content: content })
+        .tap { |double| allow(double).to receive(:instance_variable_set) }
+    end
+
+    calls
+  end
+
+  describe ".chat" do
+    it "returns the content of a successful call" do
+      stub_client("{}")
+
+      expect(described_class.chat(prompt: "the park", content: "draft me a board")).to eq("{}")
+    end
+
+    it "sends the shared system prompt ahead of the drafter's own" do
+      calls = stub_client("{}")
+      described_class.chat(prompt: "the park", content: "draft me a board")
+
+      expect(calls.first[:messages]).to eq([
+        { role: "system", content: described_class::SYSTEM_PROMPT },
+        { role: "user", content: "draft me a board" },
+      ])
+    end
+
+    it "sends a json schema when given one" do
+      calls = stub_client("{}")
+      described_class.chat(prompt: "the park", content: "draft", schema: schema)
+
+      expect(calls.first[:response_format]).to eq({ type: "json_schema", json_schema: schema })
+    end
+
+    it "sends no response_format when given no schema" do
+      calls = stub_client("{}")
+      described_class.chat(prompt: "the park", content: "draft")
+
+      expect(calls.first).not_to have_key(:response_format)
+    end
+
+    # MODEL and TEMPERATURE are both ENV-tunable and `create_chat` swallows an
+    # API error into a debug log, handing back nil — so a rejected parameter
+    # looks exactly like "the AI had nothing to say". Without these retries that
+    # would take drafting down until someone read the logs.
+    context "when the first call comes back empty" do
+      it "retries without the temperature" do
+        calls = stub_client(nil, "{}")
+
+        expect(described_class.chat(prompt: "the park", content: "draft")).to eq("{}")
+        expect(calls.size).to eq(2)
+        expect(calls.first).to have_key(:temperature)
+        expect(calls.last).not_to have_key(:temperature)
+      end
+
+      it "then retries without the schema, and keeps the schema off both attempts" do
+        calls = stub_client(nil, nil, "{}")
+
+        expect(described_class.chat(prompt: "the park", content: "draft", schema: schema)).to eq("{}")
+        expect(calls.size).to eq(3)
+        expect(calls.first[:response_format]).to be_present
+        expect(calls.last).not_to have_key(:response_format)
+      end
+
+      it "gives up and returns nil when nothing works" do
+        calls = stub_client(nil, nil, nil, nil)
+
+        expect(described_class.chat(prompt: "the park", content: "draft", schema: schema)).to be_nil
+        expect(calls.size).to eq(4)
+      end
+
+      it "does not retry a schema-less call a second time" do
+        calls = stub_client(nil, nil)
+
+        expect(described_class.chat(prompt: "the park", content: "draft")).to be_nil
+        expect(calls.size).to eq(2)
+      end
+    end
+  end
+
+  describe ".tile_schema" do
+    # Structured Outputs strict mode requires every property in `required` and
+    # forbids extras, so an optional field is modelled as nullable rather than
+    # left out.
+    it "pins the part of speech to the Fitzgerald key" do
+      expect(described_class.tile_schema.dig(:properties, :part_of_speech, :enum))
+        .to eq(ColorHelper::PARTS_OF_SPEECH)
+    end
+
+    it "requires every property it defines and forbids the rest" do
+      schema = described_class.tile_schema
+
+      expect(schema[:additionalProperties]).to be(false)
+      expect(schema[:required]).to match_array(%w[label part_of_speech proper_noun links_to])
+    end
+
+    it "makes an optional link nullable rather than absent" do
+      expect(described_class.tile_schema.dig(:properties, :links_to, :type)).to eq(%w[string null])
+    end
+
+    # WordListDrafter replaces a whole word list and knows nothing about the
+    # pages in the set, so a link it invented would name a page that doesn't
+    # exist.
+    it "omits links entirely when asked to" do
+      schema = described_class.tile_schema(links: false)
+
+      expect(schema[:properties]).not_to have_key(:links_to)
+      expect(schema[:required]).not_to include("links_to")
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/page_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/page_drafter_spec.rb
@@ -18,14 +18,20 @@ RSpec.describe Boards::AdminBuilder::PageDrafter do
       .and_return({ role: "assistant", content: content })
   end
 
-  def captured_prompt
-    prompt = nil
+  # The drafter's own prompt is the USER message — Drafting prepends a shared
+  # system message ahead of it.
+  def captured_prompt(&block)
+    captured_opts(&block)[:messages].find { |message| message[:role] == "user" }[:content]
+  end
+
+  def captured_opts
+    opts = nil
     allow(OpenAiClient).to receive(:new).and_wrap_original do |original, **kwargs|
-      prompt = kwargs[:messages].first[:content]
+      opts = kwargs
       original.call(**kwargs)
     end
     yield
-    prompt
+    opts
   end
 
   let(:four_tiles) do
@@ -41,13 +47,16 @@ RSpec.describe Boards::AdminBuilder::PageDrafter do
   before { stub_ai(four_tiles) }
 
   describe "#call" do
-    it "returns labels with parts of speech and the back link" do
+    # Band order, not the model's: the drafted order is the grid layout. The
+    # back tile carries a link, so it sorts into the navigation band last — which
+    # is where BackTileAlignment expects to find it.
+    it "returns labels with parts of speech, grouped, with the back link last" do
       result = described_class.new(page_name: "Food", tile_count: 4).call
 
       expect(result).to eq([
-        { label: "apple", part_of_speech: "noun" },
-        { label: "hungry", part_of_speech: "adjective" },
         { label: "eat", part_of_speech: "verb" },
+        { label: "hungry", part_of_speech: "adjective" },
+        { label: "apple", part_of_speech: "noun" },
         { label: "back", part_of_speech: "social", links_to: root },
       ])
     end
@@ -113,6 +122,23 @@ RSpec.describe Boards::AdminBuilder::PageDrafter do
       expect(prompt).not_to include("a board about:")
       expect(prompt).not_to include("It is for:")
     end
+
+    it "carries the shared word rules and the band order" do
+      prompt = captured_prompt { described_class.new(page_name: "Food", tile_count: 4).call }
+
+      expect(prompt).to include(Boards::AdminBuilder::Drafting::WORD_RULES.rstrip)
+      expect(prompt).to include(Boards::AdminBuilder::TileArrangement::BAND_ORDER.join(", "))
+      # A page of nouns is the failure this drafter is most prone to.
+      expect(prompt).to include("what you DO there and what it")
+    end
+
+    it "is sent behind the shared system prompt, under a json schema" do
+      opts = captured_opts { described_class.new(page_name: "Food", tile_count: 4).call }
+
+      expect(opts[:messages].map { |message| message[:role] }).to eq(%w[system user])
+      expect(opts[:messages].first[:content]).to eq(Boards::AdminBuilder::Drafting::SYSTEM_PROMPT)
+      expect(opts.dig(:response_format, :json_schema, :name)).to eq("aac_page_word_list")
+    end
   end
 
   describe "cleanup of what the model returns" do
@@ -122,7 +148,7 @@ RSpec.describe Boards::AdminBuilder::PageDrafter do
       stub_ai(ai_tiles(tile("apple", "noun"), tile("Apple", "noun"), tile("eat", "verb")))
 
       expect(described_class.new(page_name: "Food", tile_count: 4).call.map { |t| t[:label] })
-        .to eq(%w[apple eat])
+        .to eq(%w[eat apple])
     end
 
     it "folds a snake_cased label back to display text" do

--- a/spec/services/boards/admin_builder/set_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/set_drafter_spec.rb
@@ -38,10 +38,12 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
     it "returns the root tiles and one child page" do
       result = draft
 
+      # Band order, not the model's — the drafted order is the grid layout, and
+      # the folder tile sorts into the navigation band at the end.
       expect(result[:root_tiles]).to eq([
         { label: "I", part_of_speech: "pronoun" },
-        { label: "want", part_of_speech: "verb" },
         { label: "more", part_of_speech: "social" },
+        { label: "want", part_of_speech: "verb" },
         { label: "Food", part_of_speech: "noun", links_to: "food" },
       ])
       expect(result[:children].size).to eq(1)
@@ -91,7 +93,8 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
                      pages: [{ "key" => "food", "name" => "Food",
                                "tiles" => [tile("back", "social", "__root__")] }]))
 
-      expect(labels(columns: 3, tile_count: 3)).to eq(["apple", "all done", "Food"])
+      # "all done" leads: it is social, and apple is a noun.
+      expect(labels(columns: 3, tile_count: 3)).to eq(["all done", "apple", "Food"])
     end
 
     it "keeps a folder tile's authored capital" do
@@ -191,7 +194,7 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
       stub_ai(ai_set(root: [tile("go", "verb"), tile("Go", "verb"), tile("stop", "important_function")], pages: []))
 
       expect(draft(columns: 3, tile_count: 3, page_count: 1)[:root_tiles].map { |t| t[:label] })
-        .to eq(%w[go stop])
+        .to eq(%w[stop go])
     end
 
     it "falls back to default for a part of speech outside the Fitzgerald key" do
@@ -331,18 +334,42 @@ RSpec.describe Boards::AdminBuilder::SetDrafter do
   end
 
   describe "the prompt" do
-    def prompt_for(**args)
+    def opts_for(**args)
       captured = nil
       allow(OpenAiClient).to receive(:new) do |opts|
         # The FIRST call only. `valid_set` is a 4-tile fixture and these
         # examples ask for 24, so the short-draft top-up fires a second call —
         # WordListDrafter's prompt, which is not what any of this describes.
-        captured ||= opts[:messages].first[:content]
+        captured ||= opts
         instance_double(OpenAiClient, create_chat: { role: "assistant", content: valid_set })
           .tap { |double| allow(double).to receive(:instance_variable_set) }
       end
       described_class.new(**{ topic: "the playground", columns: 6, tile_count: 24, page_count: 2 }.merge(args)).call
       captured
+    end
+
+    # This drafter's own prompt is the USER message — Drafting prepends a shared
+    # system message ahead of it.
+    def prompt_for(**args)
+      opts_for(**args)[:messages].find { |message| message[:role] == "user" }[:content]
+    end
+
+    it "is sent behind the shared system prompt, under a json schema" do
+      opts = opts_for
+
+      expect(opts[:messages].map { |message| message[:role] }).to eq(%w[system user])
+      expect(opts[:messages].first[:content]).to eq(Boards::AdminBuilder::Drafting::SYSTEM_PROMPT)
+      expect(opts.dig(:response_format, :json_schema, :name)).to eq("aac_board_set")
+      expect(opts.dig(:response_format, :json_schema, :schema, :properties, :pages, :items,
+                      :properties, :tiles, :items, :properties, :part_of_speech, :enum))
+        .to eq(ColorHelper::PARTS_OF_SPEECH)
+    end
+
+    it "carries the shared word rules and the band order" do
+      prompt = prompt_for
+
+      expect(prompt).to include(Boards::AdminBuilder::Drafting::WORD_RULES.rstrip)
+      expect(prompt).to include(Boards::AdminBuilder::TileArrangement::BAND_ORDER.join(", "))
     end
 
     it "asks for exactly the requested tile count on every page" do

--- a/spec/services/boards/admin_builder/tile_arrangement_spec.rb
+++ b/spec/services/boards/admin_builder/tile_arrangement_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe Boards::AdminBuilder::TileArrangement do
+  def tile(label, part_of_speech, links_to: nil)
+    { label: label, part_of_speech: part_of_speech }.tap do |raw|
+      raw[:links_to] = links_to if links_to
+    end
+  end
+
+  def labels(tiles)
+    described_class.arrange(tiles).map { |arranged| arranged[:label] }
+  end
+
+  describe "the bands themselves" do
+    # A part of speech with no band would sort to the "default" fallback and be
+    # coloured for one thing while sitting with another.
+    it "covers every part of speech the Fitzgerald key defines" do
+      expect(described_class::BAND_ORDER).to match_array(ColorHelper::PARTS_OF_SPEECH)
+    end
+  end
+
+  describe ".arrange" do
+    it "groups like words together, quick words first and nouns last" do
+      tiles = [
+        tile("swing", "noun"), tile("go", "verb"), tile("I", "pronoun"),
+        tile("slide", "noun"), tile("push", "verb"), tile("you", "pronoun")
+      ]
+
+      expect(labels(tiles)).to eq(%w[I you go push swing slide])
+    end
+
+    it "keeps the drafted order inside a band" do
+      tiles = [tile("I", "pronoun"), tile("you", "pronoun"), tile("it", "pronoun"), tile("my", "pronoun")]
+
+      expect(labels(tiles)).to eq(%w[I you it my])
+    end
+
+    # The app puts navigation on the bottom row, and a back tile in the bottom
+    # band keeps BackTileAlignment's mirror-swap a move between navigation cells.
+    it "sorts anything that links somewhere after every word band" do
+      tiles = [
+        tile("Food", "noun", links_to: "food"),
+        tile("back", "social", links_to: Boards::AdminBuilder::Plan::ROOT_KEY),
+        tile("apple", "noun"),
+        tile("I", "pronoun"),
+      ]
+
+      expect(labels(tiles)).to eq(["I", "apple", "Food", "back"])
+    end
+
+    it "sorts an unrecognized part of speech into the default band" do
+      tiles = [tile("swing", "gerund"), tile("apple", "noun"), tile("I", "pronoun")]
+
+      expect(labels(tiles)).to eq(%w[I apple swing])
+    end
+
+    it "sorts a tile with no part of speech at all into the default band" do
+      tiles = [{ label: "swing" }, tile("I", "pronoun")]
+
+      expect(labels(tiles)).to eq(%w[I swing])
+    end
+
+    it "returns an empty list unchanged" do
+      expect(described_class.arrange([])).to eq([])
+      expect(described_class.arrange(nil)).to eq([])
+    end
+  end
+
+  # This is a permutation and nothing else: PlanValidator checks counts, and a
+  # step that could change one would have to be re-checked at preview.
+  describe "what it must never change" do
+    let(:tiles) do
+      [tile("swing", "noun"), tile("go", "verb"), tile("Food", "noun", links_to: "food"), tile("I", "pronoun")]
+    end
+
+    it "keeps every tile, with its label and its link" do
+      arranged = described_class.arrange(tiles)
+
+      expect(arranged.size).to eq(tiles.size)
+      expect(arranged.map { |t| t[:label] }).to match_array(tiles.map { |t| t[:label] })
+      expect(arranged.find { |t| t[:label] == "Food" }[:links_to]).to eq("food")
+    end
+
+    it "leaves the caller's tiles alone" do
+      original = tiles.map(&:dup)
+      described_class.arrange(tiles)
+
+      expect(tiles).to eq(original)
+    end
+
+    it "is idempotent" do
+      once = described_class.arrange(tiles)
+
+      expect(described_class.arrange(once)).to eq(once)
+    end
+  end
+
+  # A wrong part of speech is a wrong colour AND a wrong band, and these are the
+  # words models most reliably get wrong. AacWordCategorizer::OVERRIDES is
+  # already the app's authority for them, so the drafters and the rest of the
+  # app agree on what colour "stop" is.
+  describe "correcting the part of speech" do
+    it "moves a protest word out of the verbs" do
+      tiles = [tile("go", "verb"), tile("stop", "verb"), tile("I", "pronoun")]
+
+      expect(labels(tiles)).to eq(%w[I stop go])
+      expect(described_class.arrange(tiles).find { |t| t[:label] == "stop" }[:part_of_speech])
+        .to eq("important_function")
+    end
+
+    it "reclassifies a request word as social" do
+      expect(described_class.arrange([tile("more", "adjective")]).first[:part_of_speech]).to eq("social")
+    end
+
+    it "matches the override table case- and space-insensitively" do
+      expect(described_class.arrange([tile("All  Done", "verb")]).first[:part_of_speech]).to eq("social")
+    end
+
+    it "leaves a word the table says nothing about alone" do
+      expect(described_class.arrange([tile("swing", "noun")]).first[:part_of_speech]).to eq("noun")
+    end
+
+    # A door's label is a page NAME, not a word: "Play" opens a page, and
+    # recolouring it because a word table knows the verb "play" would take it out
+    # of the navigation band the whole set relies on.
+    it "never recolours a tile that opens a page" do
+      arranged = described_class.arrange([tile("Stop", "noun", links_to: "stop")])
+
+      expect(arranged.first[:part_of_speech]).to eq("noun")
+      expect(arranged.first[:links_to]).to eq("stop")
+    end
+  end
+end

--- a/spec/services/boards/admin_builder/word_list_drafter_spec.rb
+++ b/spec/services/boards/admin_builder/word_list_drafter_spec.rb
@@ -18,13 +18,15 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
   before { stub_ai(four_tiles) }
 
   describe "#call" do
-    it "returns labels with parts of speech" do
+    # Returned in TileArrangement's band order, not the model's: the drafted
+    # order is the grid layout, so grouping happens before the form sees it.
+    it "returns labels with parts of speech, grouped by band" do
       result = described_class.new(topic: "the playground", tile_count: 4).call
 
       expect(result).to eq([
         { label: "I", part_of_speech: "pronoun" },
-        { label: "want", part_of_speech: "verb" },
         { label: "more", part_of_speech: "social" },
+        { label: "want", part_of_speech: "verb" },
         { label: "swing", part_of_speech: "noun" },
       ])
     end
@@ -63,7 +65,7 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       stub_ai(ai_tiles(["go", "verb"], ["Go", "verb"], ["stop", "important_function"]))
 
       result = described_class.new(topic: "the playground", tile_count: 3).call
-      expect(result.map { |tile| tile[:label] }).to eq(%w[go stop])
+      expect(result.map { |tile| tile[:label] }).to eq(%w[stop go])
     end
 
     it "falls back to default for a part of speech outside the Fitzgerald key" do
@@ -90,12 +92,12 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
     # The model sometimes answers a multi-word label snake_cased, like an
     # identifier, instead of the tile text it's meant to be.
     it "folds underscores in a label to spaces" do
-      stub_ai(ai_tiles(["please_wait", "social"], ["all__done", "important_function"]))
+      stub_ai(ai_tiles(["please_wait", "social"], ["good__job", "social"]))
 
       expect(described_class.new(topic: "the playground", tile_count: 2).call)
         .to eq([
           { label: "please wait", part_of_speech: "social" },
-          { label: "all done", part_of_speech: "important_function" },
+          { label: "good job", part_of_speech: "social" },
         ])
     end
   end
@@ -140,10 +142,10 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
   end
 
   describe "the prompt" do
-    def prompt_for(**args)
+    def opts_for(**args)
       captured = nil
       allow(OpenAiClient).to receive(:new) do |opts|
-        captured = opts[:messages].first[:content]
+        captured = opts
         instance_double(OpenAiClient, create_chat: { role: "assistant", content: four_tiles })
           .tap { |double| allow(double).to receive(:instance_variable_set) }
       end
@@ -151,15 +153,40 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       captured
     end
 
+    # The drafter's own prompt is the USER message — Drafting prepends a shared
+    # system message ahead of it.
+    def prompt_for(**args)
+      opts_for(**args)[:messages].find { |message| message[:role] == "user" }[:content]
+    end
+
     it "asks for exactly the grid's worth of tiles" do
       expect(prompt_for(topic: "the playground", tile_count: 24)).to include("EXACTLY 24 tiles")
     end
 
-    it "carries the core spine, in order, ahead of topic words" do
+    it "is sent behind the shared system prompt" do
+      messages = opts_for(topic: "the playground", tile_count: 4)[:messages]
+
+      expect(messages.first[:role]).to eq("system")
+      expect(messages.first[:content]).to eq(Boards::AdminBuilder::Drafting::SYSTEM_PROMPT)
+      expect(messages.map { |message| message[:role] }).to eq(%w[system user])
+    end
+
+    # The enum is what makes an unusable part_of_speech impossible rather than
+    # silently downgraded to grey by `part_of_speech_for`.
+    it "constrains the response with a json schema" do
+      response_format = opts_for(topic: "the playground", tile_count: 4)[:response_format]
+
+      expect(response_format[:type]).to eq("json_schema")
+      expect(response_format.dig(:json_schema, :strict)).to be(true)
+      expect(response_format.dig(:json_schema, :schema, :properties, :tiles, :items, :properties,
+                                 :part_of_speech, :enum)).to eq(ColorHelper::PARTS_OF_SPEECH)
+    end
+
+    it "carries the core spine ahead of topic words" do
       prompt = prompt_for(topic: "the playground", tile_count: 24)
 
       expect(prompt).to include(described_class::CORE_SPINE.join(", "))
-      expect(prompt).to include("before any topic words")
+      expect(prompt).to include("must include these core words")
     end
 
     # A 2x2 board can't carry sixteen core words; asking for them would
@@ -179,6 +206,16 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       expect(prompt).to include("15-20% describing words")
       expect(prompt).to include("25-35% topic nouns")
       expect(prompt).to include("No near-duplicates")
+    end
+
+    # A board that can't refuse or redirect is the failure mode these rules
+    # exist for; the balance targets alone never caught it.
+    it "carries the shared word-selection rules and the band order" do
+      prompt = prompt_for(topic: "the playground", tile_count: 24)
+
+      expect(prompt).to include(Boards::AdminBuilder::Drafting::WORD_RULES.rstrip)
+      expect(prompt).to include("Every board needs a way to object and a way to redirect")
+      expect(prompt).to include(Boards::AdminBuilder::TileArrangement::BAND_ORDER.join(", "))
     end
 
     it "constrains the part of speech to the Fitzgerald key" do
@@ -209,7 +246,7 @@ RSpec.describe Boards::AdminBuilder::WordListDrafter do
       it "drops the mandatory core-spine recitation" do
         prompt = prompt_for(topic: "the playground", tile_count: 2, existing_labels: %w[i want])
 
-        expect(prompt).not_to include("before any topic words")
+        expect(prompt).not_to include("must include these core words")
       end
     end
   end


### PR DESCRIPTION
## Why

On `/admin/board_builds`, "Draft with AI" produced word lists that read fine but laid out badly — related words scattered across the grid.

The cause is structural: **the drafted word order IS the grid layout.** `Build#apply_reading_order!` does nothing but `x = i % columns; y = i / columns`, so whatever a drafter puts in the textarea is what an admin sees laid out and what a communicator scans. Nothing in the admin builder ever grouped tiles semantically, so the Modified Fitzgerald colours the builder already applies per tile came out as confetti: verb, noun, pronoun, noun.

Separately, the prompts were solid on counting and casing but thin on AAC word *selection*, and every drafter sent a single bare `user` message with no system role.

## What changed

**`Boards::AdminBuilder::TileArrangement`** (new) — the single authority on drafted order. A stable sort into `BAND_ORDER`:

> quick words first — `pronoun, social, important_function, question` — then the sentence: `verb, adverb, adjective, preposition, determiner, conjunction, noun, default`

Anything carrying `links_to` (folder doors, `__root__` back tiles) sorts after every word band, so navigation lands on the bottom rows like the rest of the app.

It is a **permutation only** — no tile added, dropped, relabelled or relinked — so `Build`, `BackTileAlignment`, `FolderTiles`, `PlanValidator`, the controller and every view are untouched. It also corrects `part_of_speech` from `AacWordCategorizer::OVERRIDES` before sorting, since a wrong POS is now a wrong *band* as well as a wrong colour. The OVERRIDES table only — never `.categorize`, which is one paid API call per word.

**Where it runs.** Inside the drafters, never the controller: `FolderTiles.link` runs on every form round-trip and must not re-sort a hand-edited list. `add_words` arranges only the new tiles it appends; `SetDrafter` arranges *after* `top_up` so a follow-up call's words merge into the bands rather than forming a block on the end.

**Prompts** — a shared `Drafting::SYSTEM_PROMPT` (SLP framing; there was no system role at all before) and `Drafting::WORD_RULES`: combinatorial value over single-use nouns, a way to object *and* a way to redirect on every board, no closed-set filler, register follows the audience. Pages are now asked for the verbs and describing words that belong to them, not just the things you'd find there. Shared constants so the four prompts can't drift the way they once drifted on model and temperature.

**Structured Outputs** — each drafter sends a real `json_schema` with `part_of_speech` as an enum instead of hoping prose holds. `OpenAiClient#create_chat` now prefers an explicit `response_format` over its `json_object` default, mirroring what `create_completion` already did (backward compatible — no existing caller sets it).

## Reviewer notes

- **The retry ladder is load-bearing.** `MODEL` is ENV-tunable and `create_chat` swallows an API error into a debug log and returns nil, so an unsupported schema is indistinguishable from "the AI had nothing to say" and would take drafting down silently. `Drafting.chat` therefore falls back schema+temperature → schema → no schema, the same shape as the existing temperature retry and the image-model fallback in `OpenAiClient#create_image`.
- **Strict mode means optional fields are nullable, not absent** — every property must be in `required`, so a tile that opens nothing sends `"links_to": null`. The JSON examples in the prompts were updated to match, or they'd contradict the schema.
- **Known limit, noted in code and docs:** `FolderTiles.link` runs after drafting and can *promote* an existing noun tile into a door in place; that one tile stays in the noun band. Appended doors land last, which is correct.
- **`BAND_ORDER` must stay a permutation of `ColorHelper::PARTS_OF_SPEECH`** — there's a spec for it. The prompt text derives from the constant, so reordering the bands is a one-line change.
- Row 1 leads with pronouns rather than the protest words. If "no / stop / not" should be the first cells instead, that's a reorder of `BAND_ORDER` and nothing else.
- Admin-only surface — no user-facing behaviour outside `/admin/board_builds`.

## Test plan

`bundle exec rspec spec/services/boards/admin_builder spec/requests/admin/board_builds_spec.rb spec/models/open_ai_client_spec.rb` → **514 examples, 0 failures.**

New specs:
- `tile_arrangement_spec.rb` — band order; stability within a band; links sorted last; unknown/missing POS → default band; OVERRIDES applied; doors never recoloured; idempotent; label/count/link preservation; caller's tiles not mutated; `BAND_ORDER` covers the Fitzgerald key.
- `drafting_spec.rb` — closes an existing gap (the retry path had no spec): system message, schema passthrough, and each rung of the fallback ladder.

Updated: the three drafter specs (band order + prompt capture now reads the `user` message), `open_ai_client_spec.rb` (`response_format` passthrough), and an end-to-end request spec that drives the real `SetDrafter` and asserts the textarea comes back in band order with the folder tile last.

Docs: `.claude-notes/board-builder.md` (the invariant + the known limit) and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)