### PR TITLE
fix(printables): front the root board in the listing hero fan

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -291,6 +291,14 @@ Rules that hold across the slides:
   sixth the size the header is just the slide's own title band again, so
   `hide_header: true` gives the board the whole tile; on the tablet it is the
   tell that the screen is really a photographed printout.
+- **The root board sits in the MIDDLE of the hero fan, not first.**
+  `.hero-stage.fan` draws the middle card in front and unrotated, so the middle
+  slot — not the first — is what a buyer sees in the Etsy search grid. Board ids
+  arrive in tree order, which put the root in the rotated back card and promoted
+  whichever subboard came second: a keyboard page, or a sparse fringe page.
+  `RenderListingImages#hero_tiles` moves the root into the centre slot after the
+  failed renders are dropped, so a subboard that failed to render can't shift it
+  back off centre.
 - **Thumbnails are trimmed by measurement, not calculation.** How much of a
   Letter sheet a board fills depends on its shape; a 12x3 grid leaves over half
   the page blank and reads as a broken image. The header renders ~24mm against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **A printable's main listing photo now leads with the board itself, not one of
+  its extra pages.** The three pages in the hero image fan out with the middle
+  one in front, and that middle card is what shows in an Etsy search grid — but
+  the main board was being dealt into the back of the fan, so the page selling
+  the listing was whatever came next in the set: a keyboard page, or a
+  half-empty one. The main board now sits in the middle, in front. Existing
+  listings pick it up the next time their images are regenerated. (Admin only.)
 - **Building a board set no longer occasionally creates the whole set twice.**
   If a build hit an error in the moment after its boards were written but before
   it recorded them, the automatic retry built a complete second copy — root and

--- a/app/services/boards/printables/render_listing_images.rb
+++ b/app/services/boards/printables/render_listing_images.rb
@@ -112,6 +112,7 @@ module Boards
           next unless thumb
 
           {
+            board_id: tile.board_id,
             label: tile.label,
             data_uri: thumb.data_uri,
             landscape: thumb.landscape,
@@ -134,8 +135,27 @@ module Boards
           title: Boards::AssetRendering.board_title_for(board),
           headline: ::Printables::SlideCopy.hero_headline(board_count: board_count, topic: printable.topic),
           background: BrandAssets.scene_data_uri_for(board),
-          thumbnails: tiles_from(hero_thumbnails).first(HERO_TILES),
+          thumbnails: hero_tiles,
         )
+      end
+
+      # The ROOT board goes in the middle of the fan, because the middle card is
+      # the one drawn in front and uncropped (`.hero-stage.fan` in
+      # `layouts/listing_image.html.erb`). Board ids arrive in tree order, so
+      # the root landed in the first slot — the rotated card at the BACK — and
+      # the page a buyer actually saw in the search grid was whichever subboard
+      # happened to be second: a keyboard page, or a mostly-empty fringe page.
+      # The root is the densest, most recognisable page in the set and the one
+      # the listing is named after; it is what the thumbnail has to show.
+      def hero_tiles
+        tiles = tiles_from(hero_thumbnails).first(HERO_TILES)
+        return tiles if tiles.size < 2
+
+        root_index = tiles.index { |tile| tile[:board_id] == board.id }
+        center = tiles.size / 2
+        return tiles if root_index.nil? || root_index == center
+
+        tiles.dup.tap { |t| t.insert(center, t.delete_at(root_index)) }
       end
 
       def whats_included_assigns(low_ink:)

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -159,6 +159,46 @@ RSpec.describe Boards::Printables::RenderListingImages do
     expect(hero_boards).to eq(described_class::HERO_TILES)
   end
 
+  # The middle card of the fan is the one drawn in front and uncropped, and the
+  # hero is the search-grid thumbnail. Tree order puts the root first, which is
+  # the rotated card at the BACK — so what sold the listing was whichever
+  # subboard came second, typically the sparsest page in the set.
+  describe "the hero fan" do
+    # The stubbed thumbnails are the only data URIs whose payload is a bare
+    # slug, so a full match up to the closing quote can't collide with the
+    # logo's or the QR's real base64.
+    def hero_board_order
+      slide_html.first.scan(%r{data:image/png;base64,([a-z0-9-]+)"}).flatten
+    end
+
+    it "puts the root board in the middle, in front of its subboards" do
+      third = create(:board, user: owner, name: "Places")
+      printable.update!(board_ids: [board.id, other.id, third.id], include_subboards: true)
+      stub_thumbnail_renders!
+
+      described_class.new(printable: printable).call
+
+      expect(hero_board_order).to eq(%w[feelings core-words places])
+    end
+
+    it "fronts the root board when a set only has two pages" do
+      printable.update!(board_ids: [board.id, other.id], include_subboards: true)
+      stub_thumbnail_renders!
+
+      described_class.new(printable: printable).call
+
+      expect(hero_board_order).to eq(%w[feelings core-words])
+    end
+
+    it "leaves a single-board hero alone" do
+      stub_thumbnail_renders!
+
+      described_class.new(printable: printable).call
+
+      expect(hero_board_order).to eq(%w[core-words])
+    end
+  end
+
   it "names the boards in a set on the what's-included slide" do
     printable.update!(board_ids: [board.id, other.id], include_subboards: true)
 
@@ -283,6 +323,17 @@ RSpec.describe Boards::Printables::RenderListingImages do
         expect(block).to include("var(--safe-x)"),
                          "#{selector} sets a side inset Etsy will crop through:\n#{block}"
       end
+    end
+  end
+
+  # Real thumbnails all decode to the same stubbed bytes, so the board a card is
+  # showing is only distinguishable when each render is keyed to its board.
+  def stub_thumbnail_renders!
+    allow(Boards::Printables::RenderPageThumbnails).to receive(:new) do |boards:, **_opts|
+      instance_double(
+        Boards::Printables::RenderPageThumbnails,
+        call: boards.to_h { |b| [b.id, thumbnail_for(b)] },
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

The main listing photo for a board printable was leading with the wrong page.

`.hero-stage.fan` (in `layouts/listing_image.html.erb`) draws its **middle** card in front and unrotated — the outer two are rotated and partly covered. That middle card is what shows as the thumbnail in an Etsy search grid. But hero thumbnails arrive in board-tree order, so the root board landed in slot 1, the rotated card at the *back*, and the page fronting the listing was whatever came second in the set: the QWERTY keyboard on "In an Emergency", a mostly-empty "People" page on Core 60.

`RenderListingImages#hero_tiles` now moves the root board into the centre slot.

- Runs **after** `tiles_from` drops boards whose render failed, so a failed subboard can't shift the root back off centre.
- Two-page sets front the root as well (slot 2 is the front card there too).
- A single-page hero is untouched.
- `tiles_from` now carries `board_id` so the root is identifiable; the what's-included slide ignores the extra key.

No new renders — this is a reorder of thumbnails that were already being rendered.

## Reviewer notes

Gallery images are **cached artifacts**. Live Etsy drafts keep their old hero until the printable's listing images are regenerated from `/admin/board_printables/:id` and the photos are re-uploaded. Nothing here backfills existing listings.

## Test plan

```bash
bundle exec rspec spec/services/boards/printables spec/services/printables
```

172 examples, 0 failures.

Three new specs in `render_listing_images_spec.rb` cover the three cases: a three-page set puts the root in the middle, a two-page set fronts it, and a single-board hero is left alone.

Docs: CHANGELOG entry under Fixed, plus a rail in `.claude-notes/board-printables-etsy.md` recording that the middle slot — not the first — is the one that sells the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)