### PR TITLE
fix(board-builder): make AI drafting work on gpt-5-mini

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1417,6 +1417,21 @@ AI drafting (Phase 2) fills the main word list only — pages are authored by ha
   bare positional Hash moves the argument out of kwargs and breaks every spec
   that stubs the constructor.
 
+- **A reasoning model gets no temperature, a low reasoning effort and a longer
+  timeout — all three or drafting does not work at all.** `Drafting` decides by
+  model NAME (`REASONING_MODEL`, matching `gpt-5`/`o<n>`), so an ENV override to
+  another variant is covered. gpt-5 and the o-series 400 on any temperature but
+  the default, which the retry ladder can only recover from by spending a whole
+  extra call; and at the provider's default effort a 24-tile draft against a
+  json schema does not finish inside `OpenAiClient`'s 60s client timeout, so
+  both surviving attempts died on the timeout and every draft returned 422 after
+  two minutes. `REASONING_EFFORT` (default `minimal`) and `REQUEST_TIMEOUT`
+  (default 120s, passed through as the ruby-openai CLIENT option it is) are what
+  make it land. Measured on the same prompt: minimal 9s, low 48s, provider
+  default timed out — and minimal's list was the better board, so effort here
+  buys latency, not quality. The biggest single call is a set draft (root plus
+  four pages): 55s at minimal, 83s at low, which is what the 120s is sized for.
+
 - **`Boards::AdminBuilder::MetadataSuggester` fills the catalogue listing** —
   a plain-text description (`boards.description` renders as text on three of
   four frontend surfaces, so HTML would show up literally) and tags steered by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **The board builder's AI draft buttons work again.** Every draft spun for two
+  minutes and then failed. Two causes, both in the shared OpenAI call: the model
+  rejects the temperature the drafters were sending, and the attempts that
+  didn't send one ran past the 60s timeout before they could answer. Drafting
+  now sends no temperature to a model that only accepts the default, asks for
+  minimal reasoning effort, and allows longer for the answer — a word list comes
+  back in about 9 seconds and a four-page set in under a minute. (Admin only.)
 - **A printable's main listing photo now leads with the board itself, not one of
   its extra pages.** The three pages in the hero image fan out with the middle
   one in front, and that middle card is what shows in an Etsy search grid — but

--- a/app/models/open_ai_client.rb
+++ b/app/models/open_ai_client.rb
@@ -34,11 +34,14 @@ class OpenAiClient
     )
   end
 
+  # `request_timeout` is a CLIENT option in ruby-openai, not a chat parameter,
+  # so a caller that needs longer than the 60s default has to say so here.
+  # Opt-in: every existing caller sends nothing and keeps the default.
   def openai_client
     @openai_client ||= OpenAI::Client.new(
       access_token: ENV.fetch("OPENAI_ACCESS_TOKEN"),
       log_errors: true,
-      request_timeout: OPENAI_REQUEST_TIMEOUT_SECONDS,
+      request_timeout: @opts[:request_timeout].presence || OPENAI_REQUEST_TIMEOUT_SECONDS,
     )
   end
 
@@ -656,12 +659,20 @@ class OpenAiClient
     # Opt-in only, same shape as create_completion: every existing caller sends
     # nothing and keeps the provider default it has always had.
     opts[:temperature] = @opts[:temperature] if @opts[:temperature].present?
+    # Reasoning models (gpt-5, o-series) spend as long thinking as the effort
+    # asks for; a caller on a request-cycle timeout needs to be able to turn
+    # that down. Ignored by non-reasoning models' callers, who never send it.
+    opts[:reasoning_effort] = @opts[:reasoning_effort] if @opts[:reasoning_effort].present?
     begin
       response = openai_client.chat(
         parameters: opts,
       )
     rescue => e
-      Rails.logger.debug "**** ERROR **** \n#{e.message}\n"
+      # WARN, not DEBUG: production runs at :info, and a swallowed API error
+      # here is indistinguishable from "the model had nothing to say" at every
+      # call site. That is how a rejected `temperature` looked like an empty
+      # draft for a day. The message is OpenAI's own — no user data in it.
+      Rails.logger.warn "**** ERROR - create_chat **** \n#{e.class}: #{e.message}\n"
     end
     if response
       @role = response.dig("choices", 0, "message", "role")

--- a/app/services/boards/admin_builder/drafting.rb
+++ b/app/services/boards/admin_builder/drafting.rb
@@ -15,8 +15,29 @@ module Boards
       # Drafting is a counting exercise as much as a creative one — "EXACTLY 24
       # tiles, no near-duplicates, this part-of-speech balance" — and the
       # provider default wanders on all three. Set to "" to send no temperature
-      # at all.
+      # at all. Ignored entirely on a reasoning model (see REASONING_MODEL).
       TEMPERATURE = ENV.fetch("OPENAI_ADMIN_BUILDER_TEMPERATURE", "0.4").freeze
+
+      # gpt-5 and the o-series accept ONLY the default temperature (1) and 400
+      # anything else, so sending one is a guaranteed wasted round trip that
+      # then looks like an empty draft. Matched on the model NAME rather than an
+      # allow-list, so an ENV override to another gpt-5 variant is covered.
+      REASONING_MODEL = MODEL.match?(/\A(gpt-5|o\d)/i)
+
+      # Those same models think for as long as the effort asks for, and at the
+      # provider default a 24-tile draft did not finish inside the 60s client
+      # timeout at all. Drafting is a tightly-specified list against a json
+      # schema, not a hard reasoning problem: measured against the same prompt,
+      # "minimal" answered in 9s where "low" took 48s and the provider default
+      # timed out — and the minimal list was the better board (more core, more
+      # negation, fewer topic nouns). Raise it here if drafts get worse.
+      REASONING_EFFORT = ENV.fetch("OPENAI_ADMIN_BUILDER_REASONING_EFFORT", "minimal").freeze
+
+      # Headroom over the 60s default, which a set draft does not fit inside:
+      # the biggest one (a root plus four pages, in a single call) measured 55s
+      # at minimal effort and 83s at low. An admin waits on this in the request
+      # cycle, so it buys headroom rather than patience.
+      REQUEST_TIMEOUT = Integer(ENV.fetch("OPENAI_ADMIN_BUILDER_TIMEOUT", 120))
 
       # Sent ahead of every drafter's own prompt. The per-drafter prompts say
       # what to build; this says who is building it and what is never negotiable
@@ -99,7 +120,7 @@ module Boards
       #
       # Two retries, both for the same reason: MODEL and TEMPERATURE are
       # ENV-tunable, not every model accepts a custom temperature or a json
-      # schema, and `create_chat` swallows an API error into a debug log and
+      # schema, and `create_chat` swallows an API error into a log line and
       # hands back nil content — so a rejected parameter looks exactly like "the
       # AI had nothing to say" and would take drafting down until someone read
       # the logs. Same reasoning as the image-model fallback in
@@ -115,18 +136,27 @@ module Boards
       end
 
       def with_temperature_retry(prompt:, content:, schema:)
-        result = call(prompt: prompt, content: content, schema: schema, temperature: TEMPERATURE.presence)
+        result = call(prompt: prompt, content: content, schema: schema, temperature: temperature)
         return result if result.present?
-        return nil if TEMPERATURE.blank?
+        return nil if temperature.blank?
 
         Rails.logger.warn("[AdminBuilder::Drafting] no content from #{MODEL} at " \
                           "temperature #{TEMPERATURE} — retrying without it")
         call(prompt: prompt, content: content, schema: schema, temperature: nil)
       end
 
+      # nil on a reasoning model: it would be rejected, and the retry that
+      # follows a rejection is a whole extra minute of an admin's afternoon.
+      def temperature
+        return nil if REASONING_MODEL
+
+        TEMPERATURE.presence
+      end
+
       def call(prompt:, content:, schema:, temperature:)
-        opts = { prompt: prompt, messages: messages_for(content) }
+        opts = { prompt: prompt, messages: messages_for(content), request_timeout: REQUEST_TIMEOUT }
         opts[:temperature] = temperature.to_f if temperature.present?
+        opts[:reasoning_effort] = REASONING_EFFORT if REASONING_MODEL && REASONING_EFFORT.present?
         opts[:response_format] = { type: "json_schema", json_schema: schema } if schema.present?
 
         # Splatted, not passed as one positional hash. `OpenAiClient#initialize`

--- a/spec/services/boards/admin_builder/drafting_spec.rb
+++ b/spec/services/boards/admin_builder/drafting_spec.rb
@@ -52,11 +52,50 @@ RSpec.describe Boards::AdminBuilder::Drafting do
       expect(calls.first).not_to have_key(:response_format)
     end
 
+    # gpt-5 and the o-series 400 on any temperature but the default, so sending
+    # one is a guaranteed wasted round trip that then looks like an empty draft
+    # and costs a second call to recover from.
+    context "on a reasoning model" do
+      before { stub_const("#{described_class}::REASONING_MODEL", true) }
+
+      it "sends no temperature at all" do
+        calls = stub_client("{}")
+        described_class.chat(prompt: "the park", content: "draft")
+
+        expect(calls.first).not_to have_key(:temperature)
+      end
+
+      it "turns the reasoning effort down so the draft lands inside the timeout" do
+        calls = stub_client("{}")
+        described_class.chat(prompt: "the park", content: "draft")
+
+        expect(calls.first[:reasoning_effort]).to eq(described_class::REASONING_EFFORT)
+      end
+
+      # Nothing left to drop, so an empty first call is the end of it.
+      it "does not retry a call it never put a temperature on" do
+        calls = stub_client(nil, nil)
+
+        expect(described_class.chat(prompt: "the park", content: "draft")).to be_nil
+        expect(calls.size).to eq(1)
+      end
+    end
+
+    it "asks for more than the 60s client default, which a draft does not finish in" do
+      calls = stub_client("{}")
+      described_class.chat(prompt: "the park", content: "draft")
+
+      expect(calls.first[:request_timeout]).to eq(described_class::REQUEST_TIMEOUT)
+      expect(described_class::REQUEST_TIMEOUT).to be > OpenAiClient::OPENAI_REQUEST_TIMEOUT_SECONDS
+    end
+
     # MODEL and TEMPERATURE are both ENV-tunable and `create_chat` swallows an
-    # API error into a debug log, handing back nil — so a rejected parameter
+    # API error into a log line, handing back nil — so a rejected parameter
     # looks exactly like "the AI had nothing to say". Without these retries that
     # would take drafting down until someone read the logs.
     context "when the first call comes back empty" do
+      before { stub_const("#{described_class}::REASONING_MODEL", false) }
+
       it "retries without the temperature" do
         calls = stub_client(nil, "{}")
 
@@ -64,6 +103,13 @@ RSpec.describe Boards::AdminBuilder::Drafting do
         expect(calls.size).to eq(2)
         expect(calls.first).to have_key(:temperature)
         expect(calls.last).not_to have_key(:temperature)
+      end
+
+      it "sends no reasoning effort to a model that has none" do
+        calls = stub_client("{}")
+        described_class.chat(prompt: "the park", content: "draft")
+
+        expect(calls.first).not_to have_key(:reasoning_effort)
       end
 
       it "then retries without the schema, and keeps the schema off both attempts" do


### PR DESCRIPTION
## Summary

The admin Board Builder's AI draft buttons were failing on every request: `POST /admin/board_builds/draft` ran for **121s and returned 422**. Prod logs showed all four attempts of the retry ladder failing:

| # | attempt | result |
|---|---|---|
| 1 | temperature 0.4 + schema | instant 400 — `'temperature' does not support 0.4 with this model` |
| 2 | no temperature + schema | 60.0s timeout (`OPENAI_REQUEST_TIMEOUT=60`) |
| 3 | temperature 0.4, no schema | instant 400 again |
| 4 | no temperature, no schema | 60.0s timeout |

Two independent causes:

1. **gpt-5 / o-series accept only the default temperature (1)** and 400 anything else, so half the ladder was spent recovering from a guaranteed rejection.
2. **At the provider's default reasoning effort, a 24-tile draft against a json schema doesn't finish inside the 60s client timeout** — so the only attempts that could have worked were cut off.

## Changes

- `Drafting` detects a reasoning model by NAME (`REASONING_MODEL`, `gpt-5`/`o<n>`), so an ENV override to another variant is covered, and sends **no temperature** to one. The temperature retry stays as the backstop for a non-reasoning model.
- New `REASONING_EFFORT` (default `minimal`) and `REQUEST_TIMEOUT` (default 120s), both ENV-tunable without a deploy.
- `OpenAiClient` gains opt-in passthrough for `reasoning_effort` and a per-call `request_timeout` (a ruby-openai **client** option, not a chat parameter). Every existing caller is unchanged.
- `create_chat`'s swallowed-API-error log goes debug → **warn**. Production runs at `:info`, which is why a rejected parameter looked like an empty draft at every call site.

Measured against the same prompt on the live API:

| effort | word list (24 tiles) | set draft (root + 4 pages) |
|---|---|---|
| provider default | timed out at 60s | timed out |
| low | 48.2s | 82.7s |
| **minimal** | **9.2s** | **55.1s** |

Minimal also produced the *better* board (`I, you, my, yes, all done, hi, more, again, no, not, stop, help, what, where, want, go, play, look, big, hot, to, the, swing, slide`) — core-heavy, with negation and repair, and only two topic nouns. Effort here was buying latency, not quality.

## Test plan

- `bundle exec rspec spec/services/boards/admin_builder spec/models/open_ai_client_spec.rb spec/requests/admin` → **696 examples, 0 failures**
- New specs cover: no temperature on a reasoning model, the reasoning effort being sent, no retry when there was never a temperature to drop, the longer timeout being asked for, and no `reasoning_effort` leaking to a non-reasoning model. Existing retry-ladder specs kept, pinned to a non-reasoning model.
- Live API verification against the real drafters (numbers in the table above), run from a dev console.

Docs: `.claude-notes/board-builder.md` invariant + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)