### PR TITLE
fix(boards): queue the cover render after the transaction commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Boards built from the admin dashboard now get their covers.** Every page of
+  a built set queued its cover render before the set had finished saving, so the
+  render went looking for a board that wasn't there yet and failed — one dead job
+  per page, and a set that could sit on "Still building your cover" for good if
+  the retries ran out too. Renders are now queued once the whole set is safely
+  written. (Admin only.)
 - **The board builder's AI draft buttons work again.** Every draft spun for two
   minutes and then failed. Two causes, both in the shared OpenAI call: the model
   rejects the temperature the drafters were sending, and the attempts that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,6 +425,19 @@ an explicit decision, not a drive-by edit.
   (`rake board_covers:refresh_blanked_tile_covers`); and `BoardImage#set_defaults`
   seeds `display_image_url` from `image.src_url` on create, so a spec must write
   the blank *after* creating the tile.
+- **A Sidekiq job that names a row must not be pushed from inside the
+  transaction that writes it.** `perform_async` hits Redis immediately and the
+  worker reads on its own connection, so it can dequeue before the commit and
+  die on `RecordNotFound` — and a rolled-back transaction leaves a job pointing
+  at a row that will never exist. Nothing in the app enables transactional push,
+  and these are plain `Sidekiq::Job`s, so `enqueue_after_transaction_commit`
+  doesn't apply either. Wrap the push in
+  `ActiveRecord.after_all_transactions_commit` (a no-op outside a transaction)
+  or hoist it past the `end`, as `Boards::AdminBuilder::Build` does for art
+  generation. The trap is that the enqueue is usually two or three calls deep
+  and invisible from the transaction: `Board#apply_layout!` queues a cover
+  render, and `BoardImage`'s create callback queues audio, so writing a board
+  set inside one transaction fans out a job per page.
 
 ## Subsystem map (read the spoke before working in the area)
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -299,9 +299,23 @@ class Board < ApplicationRecord
   # snapshot.
   def run_generate_preview_job(force: false)
     # Clear any previous outcome up front, so a run that follows a failure isn't
-    # aborted by the stale "failed" its predecessor left behind.
+    # aborted by the stale "failed" its predecessor left behind. This one stays
+    # inside any open transaction on purpose: it's a write on this board's own
+    # row, so it lands or rolls back with the board it describes.
     mark_preview_queued!
-    GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true, "force" => force }) # Generate PNG preview without header
+    # The push waits for the transaction. Sidekiq writes to Redis the instant
+    # perform_async is called, and the worker reads the board on its own
+    # database connection — so a push from inside an open transaction can be
+    # picked up before the row it names is committed, and the render dies on
+    # RecordNotFound. That's not hypothetical: the admin Board Builder writes a
+    # whole set inside one transaction (Boards::AdminBuilder::Build), and
+    # #apply_layout! enqueues from in there once per page, so a build logged one
+    # dead render per page of the set. A rolled-back transaction never pushes at
+    # all, which is also right — that board no longer exists. Outside a
+    # transaction the block runs inline, so every other caller is unchanged.
+    ActiveRecord.after_all_transactions_commit do
+      GenerateBoardPreviewJob.perform_async(id, { "generate_png" => true, "hide_header" => true, "force" => force }) # Generate PNG preview without header
+    end
     # GenerateBoardPreviewJob.perform_async(id, { "generate_pdf" => true }) # PDF with header for sharing
   end
 

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -389,6 +389,52 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe "#run_generate_preview_job" do
+    let(:user)  { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+
+    around { |example| Sidekiq::Testing.fake! { example.run } }
+    before { GenerateBoardPreviewJob.jobs.clear }
+
+    it "pushes immediately when no transaction is open" do
+      board.run_generate_preview_job
+
+      expect(GenerateBoardPreviewJob.jobs.size).to eq(1)
+      expect(GenerateBoardPreviewJob.jobs.last["args"].first).to eq(board.id)
+    end
+
+    # The render runs in a Sidekiq worker on its own connection, so it cannot
+    # see rows a still-open transaction hasn't committed. Pushing mid-transaction
+    # is what made an admin Board Builder run log RecordNotFound per page.
+    it "holds the push until the enclosing transaction commits" do
+      Board.transaction do
+        board.run_generate_preview_job
+        expect(GenerateBoardPreviewJob.jobs).to be_empty
+      end
+
+      expect(GenerateBoardPreviewJob.jobs.size).to eq(1)
+      expect(GenerateBoardPreviewJob.jobs.last["args"].first).to eq(board.id)
+    end
+
+    it "never pushes when the enclosing transaction rolls back" do
+      Board.transaction do
+        board.run_generate_preview_job
+        raise ActiveRecord::Rollback
+      end
+
+      expect(GenerateBoardPreviewJob.jobs).to be_empty
+    end
+
+    # The status flag is a write on the board's own row, so it belongs inside
+    # the transaction: it lands or rolls back with the board it describes.
+    it "still marks the board queued inside the transaction" do
+      Board.transaction do
+        board.run_generate_preview_job
+        expect(board.reload.settings["preview_status"]).to eq("queued")
+      end
+    end
+  end
+
   describe ".find_or_create_images_from_word_list" do
     let(:user) { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user) }

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -163,6 +163,26 @@ RSpec.describe Boards::AdminBuilder::Build do
     end
   end
 
+  # Every page's layout is applied inside the set's transaction, and
+  # Board#apply_layout! enqueues a cover render. The render worker reads on its
+  # own connection, so a push from inside the transaction raced the commit and
+  # died on RecordNotFound — one dead job per page of the set.
+  describe "the cover render it queues" do
+    before { GenerateBoardPreviewJob.jobs.clear }
+
+    it "pushes no render while the set's transaction is still open" do
+      open_transactions_at_push = []
+      allow(GenerateBoardPreviewJob).to receive(:perform_async) do |_board_id, _options|
+        open_transactions_at_push << ActiveRecord.all_open_transactions.size
+      end
+
+      described_class.new(admin_board_build: build_record(tiles: four_tiles)).call
+
+      expect(open_transactions_at_push).not_to be_empty
+      expect(open_transactions_at_push).to all(eq(0))
+    end
+  end
+
   # The review screen is where a wrong symbol gets caught. A marked tile is
   # still built with the library's art — the mark only says "generate over it".
   describe "tiles marked for AI regeneration" do


### PR DESCRIPTION
## What

`Board#run_generate_preview_job` now defers its `perform_async` with `ActiveRecord.after_all_transactions_commit` instead of pushing to Redis immediately.

## Why

Building a board set from the admin dashboard logged one `ActiveRecord::RecordNotFound` per page in Sidekiq:

```
ActiveRecord::RecordNotFound: Couldn't find Board with 'id'=6041
GenerateBoardPreviewJob  6044, {"generate_png"=>true, "hide_header"=>true, "force"=>false}
ActiveRecord::RecordNotFound: Couldn't find Board with 'id'=6044
```

`Boards::AdminBuilder::Build` writes the whole set inside one transaction (`build.with_lock`). Per page, `apply_reading_order!` calls `Board#apply_layout!`, which ends in `run_generate_preview_job` → `perform_async`. Sidekiq writes to Redis the instant that's called, and the render worker reads the board on its own database connection — so it can dequeue before the transaction that created the row has committed.

A build whose transaction rolls back is worse: those ids never exist, so the job burns all three retries and marks a phantom board `preview_failed`.

The trap is already called out in `Build`'s header comment for AI generation ("Sidekiq can otherwise pick the job up before the rows it references exist") — the preview enqueue was just buried two calls deep inside `apply_layout!` and invisible from the transaction. Nothing enables transactional push, and these are plain `Sidekiq::Job`s, so Rails' `enqueue_after_transaction_commit` doesn't apply either.

## Notes for review

- **`mark_preview_queued!` deliberately stays inside the transaction.** It's a write on the board's own row, so it lands or rolls back with the board it describes. Only the Redis push is deferred.
- **No rescue around the deferred push.** Swallowing a Redis error would leave the board reading `preview_status: "queued"` with no render ever coming — precisely the ambiguity that status lifecycle exists to remove. This matches every other `perform_async` site in the model.
- **Behavior outside a transaction is unchanged** — `after_all_transactions_commit` yields inline when no joinable transaction is open, so the editor/API callers push exactly as before.
- **Existing dead jobs:** ones naming boards that did commit will succeed if retried from the dead set; ones from a rolled-back build name ids that never existed and should be cleared.
- **Same bug class, different job (not in this PR):** `BoardImage`'s create callback pushes `SaveAudioJob` from inside the same transaction. That job is tolerant (`find_by` + log), so it doesn't error — it silently skips writing the tile's own `audio_url`/`voice` and playback falls back to the Image's audio. Filed as a follow-up rather than bundled here.

## Docs

- `CHANGELOG.md` — user-facing entry under Fixed.
- `CLAUDE.md` — new cross-cutting invariant: a Sidekiq job that names a row must not be pushed from inside the transaction that writes it, with the two known enqueues that hide behind other calls.

## Test plan

Tests written first — the build spec reproduced the bug directly (`expected [1] to all eq 0`: pushed with a transaction still open).

New coverage:
- `spec/models/board_spec.rb` — `#run_generate_preview_job`: pushes inline with no transaction open, holds until an enclosing transaction commits, never pushes on rollback, still marks the board queued inside the transaction.
- `spec/services/boards/admin_builder/build_spec.rb` — a full admin build pushes no render while the set's transaction is still open.

Ran:

```
bundle exec rspec spec/models/board_spec.rb spec/services/boards/admin_builder/build_spec.rb \
  spec/requests/api/boards_spec.rb spec/requests/admin/board_builds_spec.rb \
  spec/sidekiq/generate_board_preview_job_spec.rb spec/sidekiq/generate_images_job_spec.rb \
  spec/sidekiq/import_obz_job_spec.rb spec/sidekiq/import_from_obf_job_spec.rb \
  spec/services/boards/sub_board_thumbnails_spec.rb spec/services/boards/generate_preview_assets_spec.rb
```

All green — 49 examples in `build_spec`, 148 in `board_builds_spec`, 239 across the rest, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)