### PR TITLE
fix(printables): version the PDF key so Regenerate isn't cached away

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -343,7 +343,8 @@ and the admin card shows a staleness badge. Bulk refresh:
 
 Images are written to a **versioned** blob key. CloudFront ignores query
 strings, so re-uploading to a stable key leaves the admin looking at the
-previous render (same lesson as `Boards::GeneratePreviewAssets`).
+previous render (same lesson as `Boards::GeneratePreviewAssets`). The same rule
+applies to the PDFs — see below.
 
 **Grover reads `device_scale_factor` only inside `viewport`.** A top-level one
 is accepted and silently ignored — that shipped every listing image at 816px
@@ -365,13 +366,21 @@ would be a worse surprise than stale marketing images — which the existing
 **Regenerate** button on the listing-images card re-renders. The redirect notice
 says so.
 
-A re-run can produce different filenames (the name carries the board slug) or a
-different variant set (one `full` file becomes a `color`/`low_ink` pair once the
-tree grows past one board), so `Generate` calls
-`BoardPrintable#purge_stale_pdfs!` with the keys it just wrote. That runs
-**after** the new files are attached — same rule as the listing images — so a
-failed re-render leaves the previous downloads in place rather than emptying the
-record.
+**Every re-run writes the PDFs to a fresh versioned key**
+(`board_printables/<id>/<hex>/<filename>`), for exactly the reason the listing
+images do: production serves these as `CDN_HOST + blob.key` and CloudFront
+caches by path, so re-uploading the regenerated document onto the deterministic
+key made **Regenerate a no-op from the outside** — the admin kept downloading
+the pre-edit PDF. The version sits in the key PATH, not the filename: the
+filename is the product's download name on a marketplace, and a buyer should not
+receive `core-words-9f2a.pdf`.
+
+Because the key moves every run, `BoardPrintable#purge_stale_pdfs!` — which
+`Generate` calls with the keys it just wrote — is now the only thing that
+removes the superseded document, not just the odd orphan from a renamed board or
+a grown tree. It runs **after** the new files are attached, same rule as the
+listing images, so a failed re-render leaves the previous downloads in place
+rather than emptying the record.
 
 `DELETE /admin/board_printables/:id` destroys the record; Active Storage purges
 its PDFs and images with it. It cannot touch Etsy — this app implements no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Regenerating a board printable now actually gives you the updated PDF.**
+  Editing a board and pressing Regenerate rebuilt the document correctly, but
+  the download kept handing back the old one — the new file was uploaded to the
+  same storage path, and the CDN in front of it goes on serving whatever it
+  cached there. Each run now writes to its own path, so the download is the
+  version you just generated. The file keeps its name, and the previous copy is
+  cleaned up once the new one is safely in place. (Admin only.)
 - **The board builder's AI draft buttons work again.** Every draft spun for two
   minutes and then failed. Two causes, both in the shared OpenAI call: the model
   rejects the temperature the drafters were sending, and the attempts that

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -96,8 +96,27 @@ class BoardPrintable < ApplicationRecord
   # unique index over active_storage_blobs.key.
   def storage_key_for(filename) = "board_printables/#{id}/#{filename}"
 
+  # The same, with a version segment ahead of the filename — so the buyer-facing
+  # download name is untouched while the path a CDN caches on is new.
+  def versioned_storage_key_for(filename)
+    "board_printables/#{id}/#{SecureRandom.hex(4)}/#{filename}"
+  end
+
+  # A regenerated PDF must land on a NEW key. Production serves these straight
+  # off CloudFront (CDN_HOST + the blob key, see #url_for_file) and CloudFront
+  # caches by path while ignoring query strings, so re-uploading the fresh
+  # document to the deterministic key left "Regenerate" looking like a no-op:
+  # the admin, and anything else holding the URL, kept getting the previous PDF
+  # long after the board had changed. Same lesson as #attach_image! and
+  # Boards::GeneratePreviewAssets.
+  #
+  # The version lives in the key PATH rather than the filename because the
+  # filename is the product's name on a marketplace download — a buyer should
+  # not receive "core-words-9f2a.pdf". Superseded versions are cleaned up by
+  # #purge_stale_pdfs! once the new files are attached.
   def attach_pdf!(filename:, bytes:, variant:)
     attach_blob!(
+      key: versioned_storage_key_for(filename),
       filename: filename,
       bytes: bytes,
       content_type: "application/pdf",
@@ -116,6 +135,7 @@ class BoardPrintable < ApplicationRecord
 
     filename = "#{variant.dasherize}-#{SecureRandom.hex(4)}.png"
     attach_blob!(
+      key: storage_key_for(filename),
       filename: filename,
       bytes: bytes,
       content_type: "image/png",
@@ -166,12 +186,13 @@ class BoardPrintable < ApplicationRecord
     LISTING_IMAGE_ORDER.all? { |variant| variants.include?(variant) }
   end
 
-  # PDFs left over from an earlier generation of this same record. A re-run
-  # overwrites the deterministic key when the filename matches, but the filename
-  # carries the board slug and the variant set depends on how many boards the
-  # walk found — so a renamed board, or a subboard added since the first run,
-  # leaves a stale download sitting next to the fresh one. Purged AFTER the new
-  # files are attached, so a failed re-render never empties the record.
+  # PDFs left over from an earlier generation of this same record. Every re-run
+  # writes to a fresh versioned key (see #attach_pdf!), so this is what keeps a
+  # regenerated printable from accumulating one downloadable file per run — and
+  # it is the only thing that removes the superseded document, which is exactly
+  # why it must be handed THIS run's keys rather than matching on filename.
+  # Purged AFTER the new files are attached, so a failed re-render never empties
+  # the record.
   def purge_stale_pdfs!(keep_keys)
     stale = pdf_files.reject { |f| keep_keys.include?(f.key) }
     return if stale.empty?
@@ -233,10 +254,10 @@ class BoardPrintable < ApplicationRecord
     files_attachments.reset
   end
 
-  def attach_blob!(filename:, bytes:, content_type:, metadata:)
-    key = storage_key_for(filename)
-    # Purge anything already at the deterministic key first, same reason as
+  def attach_blob!(key:, filename:, bytes:, content_type:, metadata:)
+    # Purge anything already at this key first, same reason as
     # MarketingAsset#attach_pdf! — create_and_upload! would otherwise collide.
+    # Versioned keys can't collide, so this only ever fires for the images.
     files.find { |f| f.key == key }&.purge
 
     blob = ActiveStorage::Blob.create_and_upload!(

--- a/app/services/boards/printables/generate.rb
+++ b/app/services/boards/printables/generate.rb
@@ -37,9 +37,9 @@ module Boards
           printable.attach_pdf!(filename: file.filename, bytes: file.bytes, variant: file.variant)
         end
 
-        # A re-run of the same record can produce different filenames (renamed
-        # board) or a different variant set (a subboard added since last time),
-        # so anything not written by THIS run is a stale download.
+        # Every re-run writes to fresh versioned keys, so anything not written
+        # by THIS run is a superseded download — including the previous run's
+        # copy of a file with the very same name.
         printable.purge_stale_pdfs!(blobs.map(&:key))
 
         printable.update!(

--- a/spec/services/boards/printables/generate_spec.rb
+++ b/spec/services/boards/printables/generate_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Boards::Printables::Generate do
     end
   end
 
-  # The deterministic storage key is scoped by record id, so this only has to
+  # The storage key is scoped by record id and versioned per run, so this has to
   # survive a re-run of the SAME record — which is what a Sidekiq retry does.
   it "can regenerate the same record without colliding on the blob key" do
     printable = printable_for
@@ -152,6 +152,37 @@ RSpec.describe Boards::Printables::Generate do
     expect { described_class.new(printable: printable).call }.not_to raise_error
 
     expect(printable.reload.files.count).to eq(1)
+  end
+
+  # The bug this guards: production serves these off CloudFront as CDN_HOST +
+  # the blob key, and CloudFront caches by path — so re-running onto the same
+  # key left "Regenerate" downloading the PREVIOUS document, with none of the
+  # board edits that motivated the re-run.
+  it "gives a regenerated PDF a new storage key so a CDN can't serve the old one" do
+    printable = printable_for
+
+    described_class.new(printable: printable).call
+    first_key = printable.reload.pdf_files.first.key
+
+    described_class.new(printable: printable).call
+    second = printable.reload.pdf_files.first
+
+    expect(second.key).not_to eq(first_key)
+    # Same product, same download name — only the cached path moved.
+    expect(second.filename.to_s).to eq("core-words.pdf")
+    expect(second.key).to start_with("board_printables/#{printable.id}/")
+    expect(second.key).to end_with("/core-words.pdf")
+  end
+
+  it "leaves exactly one downloadable file per variant after a regenerate" do
+    printable = printable_for(include_subboards: true)
+    link(root, create(:board, user: user, name: "Food"))
+
+    described_class.new(printable: printable).call
+    described_class.new(printable: printable).call
+
+    expect(printable.reload.files_view.map { |f| f[:variant] })
+      .to eq(BoardPrintable::DOWNLOAD_VARIANTS)
   end
 
   # The admin "Regenerate" action re-runs this on a record that already has


### PR DESCRIPTION
## The bug

Pressing **Regenerate** on a board printable after editing the board gave you back the *old* PDF. Nothing about the render was wrong — the pipeline re-walked the tree and produced the updated document every time. The problem was where it landed.

`BoardPrintable#attach_pdf!` wrote to a deterministic storage key (`board_printables/<id>/<slug>.pdf`), and production serves these files as `CDN_HOST + blob.key` (`#url_for_file`). CloudFront caches by path and ignores query strings, so re-uploading the regenerated document onto the same key left the CDN serving whatever it had cached there. The fresh bytes were in S3; nobody could reach them.

This is the same trap the codebase already documents twice — `attach_image!` and `Boards::GeneratePreviewAssets` both version their keys for exactly this reason. The PDF path never got the treatment.

## The fix

- **`attach_pdf!` writes to a versioned key**: `board_printables/<id>/<hex>/<filename>`. The version sits in the key **path**, not the filename, because the filename is the product's download name on a marketplace — a buyer should not receive `core-words-9f2a.pdf`. `attach_blob!` now takes its key from the caller; listing images keep their existing scheme (their filename already carries a hex).
- **`purge_stale_pdfs!` does more work than it used to.** Previously the same-key overwrite implicitly replaced the old document and this only swept up orphans (a renamed board, a tree that grew past one board). Now that the key moves every run, it is the only thing that removes the superseded copy. Behavior is unchanged: it still runs *after* the new files are attached, so a failed re-render leaves the previous downloads in place rather than emptying the record.

## Reviewer notes

- **Existing printables stay stale until regenerated once.** Records generated before this change still carry their old deterministic keys, and the CDN copy at that path is still whatever it cached. The next regenerate moves them onto a versioned path and they're correct from then on. No backfill task — the affected set is admin-created printables, and regenerating is the action that surfaces the problem anyway.
- **Filenames are unchanged**, which matters for `Etsy::PublishBoardPrintable` — it uploads `file.filename.to_s`, not the URL, so nothing about the marketplace contract moves.
- Nothing here touches `listing_copy`, `etsy_listing_id`, or the gallery images.

## Test plan

Two new specs in `spec/services/boards/printables/generate_spec.rb`:
- a regenerated PDF gets a new storage key while keeping its filename (the actual regression)
- a re-run leaves exactly one file per variant — no accumulation now that keys don't collide

```
bundle exec rspec spec/services/boards/printables spec/models/board_printable_spec.rb \
  spec/requests/admin/board_printables_spec.rb spec/requests/api/admin/board_printables_spec.rb spec/sidekiq
```

**597 examples, 0 failures, 1 pending** (the pending is pre-existing).

## Docs

- `.claude-notes/board-printables-etsy.md` — the regeneration section now records the versioned-key rule and why `purge_stale_pdfs!` carries the weight.
- `CHANGELOG.md` — `Fixed` entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)