### PR TITLE
fix(board-builder): stop marking a committed build set "failed"

### DIFF
--- a/.claude-notes/board-builder.md
+++ b/.claude-notes/board-builder.md
@@ -1195,6 +1195,25 @@ Its own invariants:
   (`UNPUBLISH=1` / `APPLY=1` to act). The other duplication route is two POSTs
   to `create` — that makes two *builds*, and the preview page's submit guard is
   what stops a double click causing it.
+- **A failure once the set is committed is a WARNING, not a failed build.**
+  `Build#call` splits on whether `board_id` is committed: `mark_failed!` means
+  nothing was produced, `mark_finished_with_warning!` means the boards exist,
+  are published and are correct and only the recoverable tail
+  (`finish!` — art report, unpin, art queueing) is outstanding.
+  `AdminBoardBuild#warning?` / `#needs_finishing?` are the two predicates, and
+  `finish!` clears `error_message` on the run that makes good on it. The trap
+  this closes: **`create_and_claim!` can raise from the commit itself** —
+  after_commit callbacks run inside `with_lock`, so a transient
+  ActiveStorage/vips failure in one of them propagates out with every board
+  already written (a real ENOENT on an image_processing tempfile did exactly
+  this). Paired with `call`'s unconditional "already built" early return, that
+  made `BuildAdminBoardJob`'s `retry: 2` a no-op: the build kept a red badge
+  forever, `art_report` stayed the claim-time stub, and no AI art was ever
+  queued for its blank tiles. `call` now re-runs `finish!` for a set it already
+  owns (never `create_set!`), and `POST /admin/board_builds/:id/finish`
+  re-queues the job by hand for a row already stuck this way. `finish!` reads
+  `built_boards` / `linked_boards` back from `art_report` when there was no
+  create pass, which is what makes a repair run possible at all.
 - **A page can LINK an existing published admin board instead of building one.**
   `children[i][existing_board_id]`, offered by `Boards::AdminBuilder::ExistingBoards`
   whenever a published admin board carries the page's name (name match, ranked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **A board build that finished writing its boards is no longer reported as
+  failed.** The builder created the whole set, published it and got it right,
+  then hit a transient image-processing error on the way out — and the build
+  page painted the lot red, which read as "this produced nothing, build it
+  again". It now says the boards are fine and only the finishing step didn't
+  run, with a "Finish build" button that completes it. That step matters
+  beyond the badge: it's what queues AI art for tiles the symbol library had no
+  picture for, so those tiles used to stay blank forever. Retries can repair a
+  build now instead of skipping it, and a build is never rebuilt on top of a
+  set it already created. (Admin only.)
+
 - **Regenerating a board printable now actually gives you the updated PDF.**
   Editing a board and pressing Regenerate rebuilt the document correctly, but
   the download kept handing back the old one — the new file was uploaded to the

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -27,7 +27,7 @@ module Admin
     before_action :require_seed_admin!
 
     helper_method :existing_board_matches
-    before_action :set_build, only: %i[show update destroy publish unpublish duplicate regenerate_art]
+    before_action :set_build, only: %i[show update destroy publish unpublish duplicate regenerate_art finish]
 
     def index
       @builds = AdminBoardBuild.includes(:board, :created_by).recent.limit(100)
@@ -416,6 +416,22 @@ module Admin
       queued = Boards::AdminBuilder::ArtQueue.call(board: root, image_ids: image_ids, topic: @build.topic)
       redirect_to admin_dashboard_board_build_path(@build),
                   notice: "Queued art for #{queued} #{"tile".pluralize(queued)}."
+    end
+
+    # Re-run the tail of a build whose set is already written: the art report
+    # and the art queueing that a failure at or after the commit skipped.
+    # Re-queues the same job, which never rebuilds a set it already owns — so
+    # this is the recovery path for a build stuck showing "failed" (or a
+    # warning) over boards that are perfectly fine.
+    def finish
+      unless @build.needs_finishing?
+        return redirect_to admin_dashboard_board_build_path(@build),
+                           notice: "Nothing left to finish — this build is complete."
+      end
+
+      BuildAdminBoardJob.perform_async(@build.id)
+      redirect_to admin_dashboard_board_build_path(@build),
+                  notice: "Finishing the build — reload in a moment."
     end
 
     def destroy

--- a/app/models/admin_board_build.rb
+++ b/app/models/admin_board_build.rb
@@ -79,9 +79,30 @@ class AdminBoardBuild < ApplicationRecord
   def failed? = status == "failed"
   def in_flight? = %w[pending building].include?(status)
 
+  # A set that got written but whose recoverable tail didn't finish — the
+  # boards exist and are correct, the art report and art queueing don't.
+  # `error_message` on a COMPLETE build is a warning, not a failure: only
+  # `mark_failed!` (which is reached solely when nothing was committed) means
+  # the build produced nothing.
+  def warning? = complete? && error_message.present?
+
+  # Work `Boards::AdminBuilder::Build#finish!` still owes this build. True for
+  # a warned build and for the historical rows that were marked `failed` after
+  # their set had already committed — both are repaired by re-running the job,
+  # which never rebuilds a set it already owns.
+  def needs_finishing? = board_id.present? && !(complete? && error_message.blank?)
+
   def mark_building! = update!(status: "building", error_message: nil)
 
+  # Nothing was committed — the build produced no boards at all.
   def mark_failed!(message)
     update!(status: "failed", error_message: message.to_s.truncate(1000))
+  end
+
+  # The set IS committed; only the tail failed. Deliberately not "failed": a
+  # red badge on a built, published, correct set sends an admin to rebuild
+  # something that already exists.
+  def mark_finished_with_warning!(message)
+    update!(status: "complete", error_message: message.to_s.truncate(1000))
   end
 end

--- a/app/services/boards/admin_builder/build.rb
+++ b/app/services/boards/admin_builder/build.rb
@@ -25,12 +25,18 @@ module Boards
         @build = admin_board_build
       end
 
+      # Rebuilding a set this build already owns is the one thing that must not
+      # happen; leaving a committed set marked "failed" is the other. Both are
+      # decided by the same fact — whether `board_id` is committed — so the
+      # guard and the rescue read it the same way.
       def call
-        # Already built. A build that died while finishing keeps its set and
-        # stays "failed" — the boards exist, and rebuilding them is the one
-        # thing that must not happen. The page's "Regenerate art" action is the
-        # recovery path for the art that never got queued.
-        return build.board if build.board_id.present?
+        # Already built. Never re-create the set; DO re-run the recoverable
+        # tail if it never finished. This used to return unconditionally, which
+        # made BuildAdminBoardJob's retry a no-op: a build that died at or
+        # after its commit kept the "failed" badge forever, with a stub
+        # art_report and — the part that actually costs something — no AI art
+        # ever queued for its blank tiles.
+        return finish_owned_set! if build.board_id.present?
 
         root = create_and_claim!
         # Another worker got there first and owns finishing this build.
@@ -39,13 +45,47 @@ module Boards
         finish!(root)
         root
       rescue StandardError => e
-        build.mark_failed!(e.message)
+        # Committed or not is what separates a FAILED build from a built set
+        # with an unfinished tail, and `create_and_claim!` can raise from the
+        # commit itself: the transaction's after_commit callbacks run inside
+        # `with_lock`, so an ActiveStorage/vips blow-up in one of them
+        # propagates out with every board already written, published and
+        # correct. Calling that "failed" hid a good set behind a red badge that
+        # no retry could clear.
+        if committed_set?
+          build.mark_finished_with_warning!(e.message)
+        else
+          build.mark_failed!(e.message)
+        end
         raise
       end
 
       private
 
       attr_reader :build
+
+      # Re-run the tail for a set this build already owns. Safe to repeat by
+      # construction — `finish!` is the half deliberately kept outside the
+      # claim precisely because none of it creates a board — and the art queue
+      # is recomputed from what actually has no picture, so a tile whose art
+      # landed in the meantime isn't generated a second time.
+      def finish_owned_set!
+        root = build.board
+        return root unless build.needs_finishing?
+
+        finish!(root)
+        root
+      end
+
+      # Read from the database, not from the in-memory record: the raise we're
+      # classifying can come from the commit, and the attribute is already
+      # written on `build` by then either way. A build whose row has gone is
+      # not a committed set.
+      def committed_set?
+        build.reload.board_id.present?
+      rescue ActiveRecord::RecordNotFound
+        false
+      end
 
       # The set and the build's pointer AT the set commit together, under a row
       # lock on the build. Both halves are load-bearing — each one missing
@@ -83,7 +123,31 @@ module Boards
       end
 
       def built_board_ids
-        @built_boards.transform_values(&:id)
+        built_boards.transform_values(&:id)
+      end
+
+      # `create_set!` fills both of these in as it goes. A repair run has no
+      # create pass — the set is already written — so they are read back from
+      # the report the claim wrote, which carries exactly these two keys for
+      # exactly this reason. Only the ids are ever used downstream.
+      #
+      # `built_boards` is scoped through `builder_boards` and `linked_boards`
+      # deliberately is not: the whole point of the split is that this build
+      # OWNS the first list and merely points at the second.
+      def built_boards
+        @built_boards ||= boards_from_report("boards", AdminBoardBuild.builder_boards)
+      end
+
+      def linked_boards
+        @linked_boards ||= boards_from_report("linked_boards", Board.all)
+      end
+
+      def boards_from_report(key, scope)
+        stored = (build.art_report || {})[key]
+        return {} unless stored.is_a?(Hash)
+
+        found = scope.where(id: stored.values).index_by(&:id)
+        stored.filter_map { |page_key, id| [page_key, found[id]] if found[id] }.to_h
       end
 
       # Everything that is safe to redo. Deliberately outside the claim: none of
@@ -92,7 +156,14 @@ module Boards
       def finish!(root)
         blank_image_ids = art_less_image_ids
         regenerate_ids = regenerate_image_ids(blank_image_ids)
-        build.update!(status: "complete", art_report: art_report(root, blank_image_ids, regenerate_ids))
+        # `error_message: nil` clears the warning a previous attempt left
+        # behind — this is the run that made good on it, and a stale warning on
+        # a finished build keeps `needs_finishing?` true forever.
+        build.update!(
+          status: "complete",
+          error_message: nil,
+          art_report: art_report(root, blank_image_ids, regenerate_ids),
+        )
         unpin_regenerated_tiles!(regenerate_ids)
         queue_missing_art!(root, blank_image_ids)
         queue_regenerated_art!(root, regenerate_ids)
@@ -117,7 +188,7 @@ module Boards
 
       # Pages this build writes, and pages that just point at a board someone
       # already published. A linked page is a link and nothing else — no Board
-      # row, no tiles, no layout — so it is held apart from `@built_boards`,
+      # row, no tiles, no layout — so it is held apart from `built_boards`,
       # which is what `art_report["boards"]` and therefore
       # `AdminBoardBuild#set_boards` are built from. Publish, unpublish and
       # destroy all iterate that list, and none of them may reach a board this
@@ -137,7 +208,7 @@ module Boards
         owned_pages.each { |page| apply_reading_order!(boards[page[:key]], tiles_by_key[page[:key]], page) }
 
         # Pass 3 — folder links. Every target already exists, cycles included.
-        link_pages!(boards.merge(@linked_boards), tiles_by_key)
+        link_pages!(boards.merge(linked_boards), tiles_by_key)
 
         owned_pages.each do |page|
           board = boards[page[:key]]
@@ -400,7 +471,7 @@ module Boards
       def unpin_regenerated_tiles!(image_ids)
         return if image_ids.empty?
 
-        BoardImage.where(board_id: @built_boards.values.map(&:id), image_id: image_ids)
+        BoardImage.where(board_id: built_boards.values.map(&:id), image_id: image_ids)
                   .update_all(display_image_url: nil)
       end
 
@@ -426,7 +497,7 @@ module Boards
           # iterate it. Recorded so `show` can list the whole set honestly and
           # `rake admin_board_builds:orphans` doesn't mistake a linked board for
           # a stranded one.
-          "linked_boards" => @linked_boards.transform_values(&:id),
+          "linked_boards" => linked_boards.transform_values(&:id),
           # key => board id, so `show` can list every page of the set and
           # publish can cascade over it without re-walking the link graph.
           # Also written at claim time (see #create_and_claim!) — this is the

--- a/app/views/admin/board_builds/index.html.erb
+++ b/app/views/admin/board_builds/index.html.erb
@@ -32,6 +32,9 @@
             <% case build.status %>
             <% when "complete" %>
               <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">built</span>
+              <% if build.warning? %>
+                <span class="bg-amber-900/60 text-amber-300 inline-block text-xs rounded px-2 py-0.5">unfinished</span>
+              <% end %>
             <% when "failed" %>
               <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5">failed</span>
             <% else %>

--- a/app/views/admin/board_builds/show.html.erb
+++ b/app/views/admin/board_builds/show.html.erb
@@ -18,6 +18,9 @@
       <% case @build.status %>
       <% when "complete" %>
         <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">built</span>
+        <% if @build.warning? %>
+          <span class="bg-amber-900/60 text-amber-300 inline-block text-xs rounded px-2 py-0.5 ml-1">unfinished</span>
+        <% end %>
       <% when "failed" %>
         <span class="bg-red-900/60 text-red-300 inline-block text-xs rounded px-2 py-0.5">failed</span>
       <% else %>
@@ -36,9 +39,21 @@
         <p class="text-xs text-t2 mt-2">The build is queued — reload in a moment.</p>
       <% end %>
 
-      <% if @build.failed? %>
+      <% if @build.warning? %>
+        <p class="text-xs text-amber-400 mt-2 max-w-xl font-mono"><%= @build.error_message %></p>
+        <p class="text-xs text-t2 mt-1">
+          The set below was written and is fine — only the art report and art queueing didn't finish.
+          Use “Finish build” to run them again.
+        </p>
+      <% elsif @build.failed? %>
         <p class="text-xs text-red-400 mt-2 max-w-xl font-mono"><%= @build.error_message %></p>
-        <p class="text-xs text-t2 mt-1">The word list is saved below — nothing needs re-typing.</p>
+        <% if @build.needs_finishing? %>
+          <p class="text-xs text-t2 mt-1">
+            The set below was still written — use “Finish build” rather than rebuilding.
+          </p>
+        <% else %>
+          <p class="text-xs text-t2 mt-1">The word list is saved below — nothing needs re-typing.</p>
+        <% end %>
       <% end %>
 
       <% if @board %>
@@ -63,6 +78,11 @@
     </div>
 
     <div class="flex items-center gap-2">
+      <% if @build.needs_finishing? %>
+        <%= button_to "Finish build", finish_admin_dashboard_board_build_path(@build), method: :post,
+              class: "text-xs font-medium px-3 py-2 rounded bg-amber-600 hover:bg-amber-500 text-white cursor-pointer",
+              title: "Re-run the art report and art queueing. Never rebuilds the boards." %>
+      <% end %>
       <% if @board %>
         <%= link_to "Open board ↗", board_app_url(@board), target: "_blank", rel: "noopener",
               class: "text-xs font-medium px-3 py-2 rounded border admin-input text-t1 hover:text-accent transition-colors",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
         post :unpublish
         get :duplicate
         post :regenerate_art
+        post :finish
       end
     end
     get "feedback", to: "feedback#index", as: :dashboard_feedback

--- a/spec/models/admin_board_build_spec.rb
+++ b/spec/models/admin_board_build_spec.rb
@@ -21,6 +21,41 @@ RSpec.describe AdminBoardBuild do
     expect(build.audience).to eq("an early communicator")
   end
 
+  # `error_message` means two different things depending on whether a set got
+  # committed: on a FAILED build it's "nothing was produced", on a COMPLETE one
+  # it's "the boards are fine, the tail isn't".
+  describe "failure vs. warning" do
+    def record(**attrs)
+      described_class.create!({ name: "Playground", columns_count: 2, tile_count: 4 }.merge(attrs))
+    end
+
+    it "treats an error on a complete build as a warning with work outstanding" do
+      build = record(board: FactoryBot.create(:board), status: "complete", error_message: "tempfile vanished")
+
+      expect(build).to be_warning
+      expect(build).to be_needs_finishing
+    end
+
+    it "treats a clean complete build as finished" do
+      build = record(board: FactoryBot.create(:board), status: "complete")
+
+      expect(build).not_to be_warning
+      expect(build).not_to be_needs_finishing
+    end
+
+    # The historical shape: a post-commit failure that got marked "failed"
+    # anyway. The set exists, so the recovery is to finish it, not rebuild it.
+    it "still has work outstanding when a failed build owns a set" do
+      build = record(board: FactoryBot.create(:board), status: "failed", error_message: "Errno::ENOENT")
+
+      expect(build).to be_needs_finishing
+    end
+
+    it "has nothing to finish when a failed build produced no set" do
+      expect(record(status: "failed", error_message: "boom")).not_to be_needs_finishing
+    end
+  end
+
   it "survives its board being destroyed, with board_id nullified" do
     board = FactoryBot.create(:board)
     build = described_class.create!(name: "Playground", columns_count: 2, tile_count: 4, board: board)

--- a/spec/requests/admin/board_builds_spec.rb
+++ b/spec/requests/admin/board_builds_spec.rb
@@ -1754,6 +1754,67 @@ RSpec.describe "Admin::BoardBuilds (dashboard)", type: :request do
     end
   end
 
+  # The recovery path for a build whose set committed but whose tail didn't
+  # run — including the rows that were marked "failed" before a post-commit
+  # failure stopped meaning "the build failed".
+  describe "POST finish" do
+    before { sign_in admin }
+
+    it "re-queues the build job for a build stuck with a warning" do
+      build = create_build(board: built_board, status: "complete", error_message: "tempfile vanished")
+
+      post finish_admin_dashboard_board_build_path(build)
+
+      expect(response).to redirect_to(admin_dashboard_board_build_path(build))
+      expect(BuildAdminBoardJob.jobs.map { |job| job["args"].first }).to eq([build.id])
+    end
+
+    it "re-queues for a historical build left marked failed over a committed set" do
+      build = create_build(board: built_board, status: "failed", error_message: "Errno::ENOENT")
+
+      post finish_admin_dashboard_board_build_path(build)
+
+      expect(BuildAdminBoardJob.jobs.size).to eq(1)
+    end
+
+    it "queues nothing for a build that already finished cleanly" do
+      build = create_build(board: built_board, status: "complete")
+
+      post finish_admin_dashboard_board_build_path(build)
+
+      expect(BuildAdminBoardJob.jobs).to be_empty
+      expect(flash[:notice]).to match(/nothing left to finish/i)
+    end
+
+    # A failed build with no set is a rebuild, not a finish — the form below
+    # still holds the word list.
+    it "offers the button on the build page, and says the boards are fine" do
+      build = create_build(board: built_board, status: "complete", error_message: "tempfile vanished")
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).to include(finish_admin_dashboard_board_build_path(build))
+      expect(response.body).to include("Finish build")
+      expect(response.body).to match(/was written and is fine/i)
+    end
+
+    it "does not offer the button on a build that finished cleanly" do
+      build = create_build(board: built_board, status: "complete")
+
+      get admin_dashboard_board_build_path(build)
+
+      expect(response.body).not_to include("Finish build")
+    end
+
+    it "queues nothing for a failed build that never produced a set" do
+      build = create_build(status: "failed", error_message: "boom")
+
+      post finish_admin_dashboard_board_build_path(build)
+
+      expect(BuildAdminBoardJob.jobs).to be_empty
+    end
+  end
+
   describe "linking a page to an existing board" do
     before { sign_in admin }
 

--- a/spec/services/boards/admin_builder/build_spec.rb
+++ b/spec/services/boards/admin_builder/build_spec.rb
@@ -694,6 +694,64 @@ RSpec.describe Boards::AdminBuilder::Build do
         orphans = AdminBoardBuild.builder_boards.where.not(id: build.reload.set_boards.map(&:id))
         expect(orphans).to be_empty
       end
+
+      # A committed set is not a failed build. The boards exist, are published
+      # and are correct; only the recoverable tail is outstanding, and marking
+      # that "failed" sent an admin to rebuild something that already existed.
+      it "records a warning on a complete build rather than marking it failed" do
+        expect { described_class.new(admin_board_build: build).call }
+          .to raise_error(ActiveRecord::StatementInvalid)
+
+        build.reload
+        expect(build.status).to eq("complete")
+        expect(build.error_message).to match(/connection lost/)
+        expect(build).to be_warning
+        expect(build).to be_needs_finishing
+      end
+
+      # The bug this pins: `call` used to return unconditionally as soon as
+      # `board_id` was set, so BuildAdminBoardJob's retry was a no-op. The badge
+      # stayed red forever, art_report stayed the claim-time stub, and — the
+      # part that actually costs something — no AI art was ever queued for the
+      # blank tiles.
+      it "finishes the tail on the retry instead of returning early" do
+        expect { described_class.new(admin_board_build: build).call }.to raise_error(StandardError)
+        expect(build.reload.art_report.keys).to eq(%w[boards])
+
+        described_class.new(admin_board_build: build.reload).call
+
+        build.reload
+        expect(build.status).to eq("complete")
+        expect(build.error_message).to be_nil
+        expect(build).not_to be_warning
+        expect(build).not_to be_needs_finishing
+        expect(build.art_report).to include("tile_count", "coverage_pct", "slug")
+      end
+
+      it "queues the art the failed attempt never got to" do
+        allow(Boards::AdminBuilder::ArtQueue).to receive(:call).and_call_original
+
+        expect { described_class.new(admin_board_build: build).call }.to raise_error(StandardError)
+        expect(Boards::AdminBuilder::ArtQueue).not_to have_received(:call)
+
+        described_class.new(admin_board_build: build.reload).call
+
+        expect(Boards::AdminBuilder::ArtQueue).to have_received(:call).at_least(:once)
+      end
+    end
+
+    # A build that finished cleanly has nothing left to redo, so the retry must
+    # still be the no-op it always was — `finish!` re-queries art and re-writes
+    # the report, which is wasted work on a build with no outstanding tail.
+    it "does not re-run the tail for a build that already completed cleanly" do
+      build = build_record(tiles: four_tiles)
+      described_class.new(admin_board_build: build).call
+      report = build.reload.art_report
+
+      expect_any_instance_of(described_class).not_to receive(:finish!)
+      described_class.new(admin_board_build: build.reload).call
+
+      expect(build.reload.art_report).to eq(report)
     end
   end
 


### PR DESCRIPTION
## What happened

Build 21 (\"Core 84\") shows a red **failed** badge over a board that was built correctly, published, and is live at `/pb/core-84-28a0cafa`. Production Sidekiq logs:

```
BuildAdminBoardJob jid=93b557b74e7dd2d8868f900b args=[21]
Errno::ENOENT: No such file or directory @ rb_file_s_size - /tmp/image_processing20260815-1570588-t1vrdb.webp
app/services/boards/admin_builder/build.rb:69:in `create_and_claim!'
```

Line 69 is `build.with_lock do` — not any line *inside* the block. The exception came out of the transaction's **commit phase**: after-commit callbacks run inside `with_lock`, so a transient ActiveStorage/vips tile-variant failure in one of them propagates out with every board already written and committed. `Build#call`'s `rescue` then called `mark_failed!` on a set that was completely fine.

It was also permanent. `call` returned unconditionally as soon as `board_id` was set, which made `BuildAdminBoardJob`'s `retry: 2` a no-op — the badge stayed red forever, `art_report` stayed the claim-time stub, and `finish!` never ran. That last part costs something real: **no AI art was ever queued for the tiles the symbol library had no picture for**, so they stay blank indefinitely.

## Changes

**1. Failure vs. warning.** The rescue splits on the one fact that distinguishes them — whether `board_id` is committed:

- nothing committed → `mark_failed!` (unchanged)
- set committed → `mark_finished_with_warning!`: status `complete`, message carried as an amber \"unfinished\" warning

`AdminBoardBuild#warning?` / `#needs_finishing?` are the predicates; `finish!` clears `error_message` on the run that makes good on it.

**2. A retry can repair.** `call` now re-runs `finish!` for a set it already owns — never `create_set!`, so the never-rebuild-a-set guarantee is intact. This required rehydrating `built_boards` / `linked_boards` from `art_report` (which already carries both keys), since a repair run has no create pass.

**3. `POST /admin/board_builds/:id/finish`** — a \"Finish build\" button for rows already stuck this way, including build 21. Re-queues the same job.

Also: amber \"unfinished\" chip on the index so a stuck build is visible from the list.

## Not addressed here

The `Errno::ENOENT` itself is a symptom — a `/tmp` image_processing tempfile vanishing, most likely disk pressure or tempfile GC on the prod box. Three occurrences in 36 hours (Aug 14 16:26, Aug 15 17:47, Aug 15 20:09). Filed separately.

## Test plan

- \`bundle exec rspec spec/services/boards/admin_builder spec/models/admin_board_build_spec.rb spec/requests/admin/board_builds_spec.rb spec/requests/admin/access_control_spec.rb\` → **526 examples, 0 failures**
- \`bin/rails zeitwerk:check\` → clean

New coverage:
- a post-commit failure records a warning on a `complete` build rather than marking it failed
- the retry finishes the tail instead of returning early, and queues the art the failed attempt never got to
- a cleanly-completed build does **not** re-run the tail
- `POST finish` re-queues for a warned build and for a historical `failed`-over-a-committed-set row; queues nothing for a clean build or a failed build with no set
- the show page offers the button and says the boards are fine; a clean build gets no button
- model-level predicates across all four states

## Docs

- `.claude-notes/board-builder.md` — new invariant: a failure once the set is committed is a warning, not a failed build, and why `create_and_claim!` can raise from the commit itself
- `CHANGELOG.md` — user-facing entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)