### PR TITLE
fix(audio): stop tiles losing their audio_url to a too-early SaveAudioJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Tiles no longer end up silently missing their own audio.** When a board's
+  voice was set while its tiles were still being written, the job that fills in
+  each tile's audio could run before those tiles existed. It didn't fail — it
+  quietly skipped them, so the audio file was made but never attached to the
+  tile. A tile left that way stayed mute on every load and had no way to
+  recover. The audio work now waits until the tiles are actually saved. A
+  repair task (`tile_audio:backfill`) fixes tiles already affected, reusing
+  audio that was already generated wherever possible.
+
 - **The transient image-processing error that killed background jobs is fixed
   at the source.** Building a board set, importing an OBF file, or saving newly
   generated art could resize a tile picture in the middle of a database
@@ -100,6 +109,7 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   per page, and a set that could sit on "Still building your cover" for good if
   the retries ran out too. Renders are now queued once the whole set is safely
   written. (Admin only.)
+
 - **The board builder's AI draft buttons work again.** Every draft spun for two
   minutes and then failed. Two causes, both in the shared OpenAI call: the model
   rejects the temperature the drafters were sending, and the attempts that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,23 @@ an explicit decision, not a drive-by edit.
 - **External-service failures fail soft.** Redis blips, PostHog, Mailchimp,
   and geolocation errors are rescued and logged — they can never 500 a
   request or a webhook.
+- **A Sidekiq job that names a row must not be pushed from inside the
+  transaction that writes it.** Sidekiq is a separate process on a separate
+  connection, so it can dequeue before the commit and not see the row. Push
+  from an `after_*_commit` callback, or wrap the `perform_async` in
+  `ActiveRecord.after_all_transactions_commit { ... }` — which yields inline
+  when no transaction is open, so non-transactional callers are unaffected.
+  This bites hardest where one transaction writes many rows:
+  `Boards::AdminBuilder::Build` writes a whole board set inside a single
+  `build.with_lock`, and `Board#set_voice` runs from a `before_save`. **The
+  failure mode is silence, not an exception** — `SaveAudioJob` resolves its
+  tile with `find_by`, so a too-early job logs "BoardImage with ID ... not
+  found" and skips writing that tile's `audio_url`/`voice`; the audio file
+  still lands on the Image and playback falls back to it, so the board sounds
+  correct while the tile's own columns stay nil. Never "fix" a not-found job by
+  making the job retry or tolerate the miss — that hides the ordering bug.
+  Enqueues live behind `BoardImage#enqueue_voice_audio_job`, not at the call
+  sites, so the guard can't be forgotten by the next caller.
 - **Every admin page is gated by inheritance, never by an inline check.** HTML
   admin controllers inherit `Admin::ApplicationController`
   (`authenticate_user!` + `require_admin!`); JSON ones inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,23 +313,6 @@ an explicit decision, not a drive-by edit.
 - **External-service failures fail soft.** Redis blips, PostHog, Mailchimp,
   and geolocation errors are rescued and logged — they can never 500 a
   request or a webhook.
-- **A Sidekiq job that names a row must not be pushed from inside the
-  transaction that writes it.** Sidekiq is a separate process on a separate
-  connection, so it can dequeue before the commit and not see the row. Push
-  from an `after_*_commit` callback, or wrap the `perform_async` in
-  `ActiveRecord.after_all_transactions_commit { ... }` — which yields inline
-  when no transaction is open, so non-transactional callers are unaffected.
-  This bites hardest where one transaction writes many rows:
-  `Boards::AdminBuilder::Build` writes a whole board set inside a single
-  `build.with_lock`, and `Board#set_voice` runs from a `before_save`. **The
-  failure mode is silence, not an exception** — `SaveAudioJob` resolves its
-  tile with `find_by`, so a too-early job logs "BoardImage with ID ... not
-  found" and skips writing that tile's `audio_url`/`voice`; the audio file
-  still lands on the Image and playback falls back to it, so the board sounds
-  correct while the tile's own columns stay nil. Never "fix" a not-found job by
-  making the job retry or tolerate the miss — that hides the ordering bug.
-  Enqueues live behind `BoardImage#enqueue_voice_audio_job`, not at the call
-  sites, so the guard can't be forgotten by the next caller.
 - **Every admin page is gated by inheritance, never by an inline check.** HTML
   admin controllers inherit `Admin::ApplicationController`
   (`authenticate_user!` + `require_admin!`); JSON ones inherit
@@ -454,7 +437,19 @@ an explicit decision, not a drive-by edit.
   generation. The trap is that the enqueue is usually two or three calls deep
   and invisible from the transaction: `Board#apply_layout!` queues a cover
   render, and `BoardImage`'s create callback queues audio, so writing a board
-  set inside one transaction fans out a job per page.
+  set inside one transaction fans out a job per page. **`RecordNotFound` is the
+  loud failure; silence is the other one** — a job that resolves its row with
+  `find_by` instead of `find` just skips the write. `SaveAudioJob` does exactly
+  that: it logs "BoardImage with ID ... not found" and never fills in that
+  tile's `audio_url`/`voice`, while the audio FILE still lands on the Image, so
+  the board sounds right and only the tile's own columns are empty. Those tiles
+  don't self-heal either — `Board#api_view_with_images` only re-enqueues when
+  `board_image.voice != voice_to_play`, and `set_defaults` stamps the tile with
+  the board's voice, so the serializer ships `audio_url: nil` forever
+  (`rake tile_audio:missing_report` finds them). Never "fix" a not-found job by
+  making it retry or tolerate the miss — that hides the ordering bug. Audio
+  enqueues live behind `BoardImage#enqueue_voice_audio_job`, not at the call
+  sites, so the guard can't be forgotten by the next caller.
 - **An ActiveStorage variant must never be rendered inside an open
   transaction.** Rendering writes the variant's bytes from an `after_commit`
   callback, but image_processing's output tempfile is closed AND UNLINKED the

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -458,7 +458,9 @@ class API::BoardImagesController < API::ApplicationController
       @board_image.set_voice_audio!(url, voice)
     else
       @board_image.set_voice_audio!(@board_image.audio_url, voice)
-      SaveAudioJob.perform_async(@board_image.image_id, voice, @board_image.id)
+      # set_voice_audio! has just pinned the tile to `voice`, so the enqueue
+      # reads the same value off the record.
+      @board_image.enqueue_voice_audio_job
     end
 
     @board_image.board.broadcast_board_update!

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -2075,7 +2075,12 @@ class Board < ApplicationRecord
         if voice_to_play.present? && @board_image.voice != voice_to_play && !using_custom_audio
           current_audio_url = @board_image.audio_url_for_voice(voice_to_play)
           unless current_audio_url
-            SaveAudioJob.perform_async(@image.id, voice_to_play, @board_image.id)
+            # Serializing is a read, but not always outside a transaction: the
+            # builder writes a set and serializes the root inside the same one,
+            # and those tiles are precisely the ones with no audio yet. Enqueue
+            # through BoardImage so the deferral is the enqueue's business
+            # rather than each call site's.
+            @board_image.enqueue_voice_audio_job(voice_to_play)
             current_audio_url = @board_image.audio_url
           end
         else
@@ -2287,7 +2292,12 @@ class Board < ApplicationRecord
         if voice_to_play.present? && @board_image.voice != voice_to_play && !using_custom_audio
           current_audio_url = @board_image.audio_url_for_voice(voice_to_play)
           unless current_audio_url
-            SaveAudioJob.perform_async(@image.id, voice_to_play, @board_image.id)
+            # Serializing is a read, but not always outside a transaction: the
+            # builder writes a set and serializes the root inside the same one,
+            # and those tiles are precisely the ones with no audio yet. Enqueue
+            # through BoardImage so the deferral is the enqueue's business
+            # rather than each call site's.
+            @board_image.enqueue_voice_audio_job(voice_to_play)
             current_audio_url = @board_image.audio_url
           end
         else

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -604,11 +604,36 @@ class BoardImage < ApplicationRecord
   def create_voice_audio
     current_audio_url = audio_url_for_voice(voice, language)
     unless current_audio_url
-      SaveAudioJob.perform_async(image_id, voice, id)
+      enqueue_voice_audio_job
       return
     end
     self.audio_url = current_audio_url
     save
+  end
+
+  # SaveAudioJob names a tile by id, so it must never be pushed from inside the
+  # transaction that writes that tile. `Board#set_voice` is a `before_save`
+  # callback, so every caller reaches here mid-transaction — and on a board
+  # built by `Boards::AdminBuilder::Build` that is the single `build.with_lock`
+  # transaction the whole set is written in.
+  #
+  # The failure is silent, which is why it survived: the job does
+  # `image.board_images.find_by(id:)`, so a row that isn't committed yet gives
+  # nil, not RecordNotFound. It logs "BoardImage with ID ... not found" and
+  # skips writing the tile's own `audio_url`/`voice`. The audio file still lands
+  # on the Image, so playback falls back to the image's audio and the board
+  # sounds fine — the tile's columns just stay nil forever.
+  #
+  # `after_all_transactions_commit` yields immediately when no transaction is
+  # open, so the callers that were already outside one are unchanged.
+  def enqueue_voice_audio_job
+    job_image_id = image_id
+    job_voice = voice
+    job_board_image_id = id
+
+    ActiveRecord.after_all_transactions_commit do
+      SaveAudioJob.perform_async(job_image_id, job_voice, job_board_image_id)
+    end
   end
 
   def user
@@ -892,10 +917,14 @@ class BoardImage < ApplicationRecord
     self.display_label = normalized_default_label(image.display_label) if display_label.blank?
   end
 
+  # Reached as an `after_create_commit`, so the enclosing transaction has
+  # already committed and `enqueue_voice_audio_job` pushes inline. Routed
+  # through the same helper anyway: the guard then belongs to the enqueue, not
+  # to one caller's choice of callback.
   def create_voice_audio_after_create
     current_audio_url = audio_url_for_voice(voice, language)
     unless current_audio_url
-      SaveAudioJob.perform_async(image_id, voice, id)
+      enqueue_voice_audio_job
       return
     end
     self.audio_url = current_audio_url

--- a/app/models/board_image.rb
+++ b/app/models/board_image.rb
@@ -626,9 +626,15 @@ class BoardImage < ApplicationRecord
   #
   # `after_all_transactions_commit` yields immediately when no transaction is
   # open, so the callers that were already outside one are unchanged.
-  def enqueue_voice_audio_job
+  #
+  # `for_voice` is for the read paths, which enqueue the voice the VIEWER is
+  # about to hear rather than the one stored on the tile — that difference is
+  # the whole reason they enqueue. Everything is captured into locals: the
+  # block can run long after the caller moved on to the next tile, and
+  # `Board#api_view_with_images` reassigns `@board_image` on every iteration.
+  def enqueue_voice_audio_job(for_voice = nil)
     job_image_id = image_id
-    job_voice = voice
+    job_voice = for_voice || voice
     job_board_image_id = id
 
     ActiveRecord.after_all_transactions_commit do

--- a/lib/tasks/tile_audio_backfill.rake
+++ b/lib/tasks/tile_audio_backfill.rake
@@ -1,0 +1,142 @@
+namespace :tile_audio do
+  # Backfill for tiles left with no `audio_url` by a SaveAudioJob that was
+  # pushed from inside the transaction that created the tile. Sidekiq dequeued
+  # before the commit, `image.board_images.find_by(id:)` returned nil, and the
+  # job logged "BoardImage with ID ... not found" and moved on — so the audio
+  # FILE was written to the Image, but the tile's own `audio_url`/`voice`
+  # columns were never filled in.
+  #
+  # These tiles do not heal themselves. `Board#api_view_with_images` only
+  # re-enqueues when `board_image.voice != voice_to_play`, and `set_defaults`
+  # stamps the tile with the board's voice at creation — so the comparison is
+  # equal, the else branch hands the serializer a nil `audio_url`, and the tile
+  # ships mute on every subsequent load.
+  #
+  # Two windows produced them:
+  #   * Everything created inside a transaction before #303 moved
+  #     `create_voice_audio_after_create` to `after_create_commit`.
+  #   * `Board#set_voice`, which runs from a `before_save` callback and pushed
+  #     the job inline, until it was routed through
+  #     `BoardImage#enqueue_voice_audio_job`.
+  #
+  # Repair is cheap for most rows: the tile's Image is asked first whether a
+  # file already exists for that voice, and it usually DOES — the original job
+  # got that far before failing to find the tile. Only a tile with no matching
+  # file falls through to a fresh SaveAudioJob.
+  #
+  #   bin/rails tile_audio:missing_report                  # dry run, whole database
+  #   bin/rails tile_audio:missing_report ADMIN_BUILT=1
+  #   bin/rails tile_audio:backfill APPLY=1 BOARD_ID=5827
+  #   bin/rails tile_audio:backfill APPLY=1 LIMIT=500
+  #
+  # Env: BOARD_ID, USER_ID, ADMIN_BUILT=1 (scope) · LIMIT (cap rows touched)
+  #      SAMPLE (rows to print, default 25) · ENQUEUE=0 (repair only from files
+  #      that already exist; never queue Polly work)
+
+  # A tile playing a parent's recording is not missing anything — `audio_url`
+  # holds the recording, and a blank one there means the upload failed, which is
+  # a different problem with a different fix. Never let this task push such a
+  # tile back onto a synthesized voice.
+  missing_audio_scope = lambda do
+    # Table-qualified: `boards` carries a `data` column too, so an unqualified
+    # reference is ambiguous the moment anything joins the two.
+    scope = BoardImage.where(audio_url: [nil, ""])
+                      .where("board_images.data->>'using_custom_audio' IS DISTINCT FROM 'true'")
+
+    if ENV["BOARD_ID"].present?
+      scope = scope.where(board_id: ENV["BOARD_ID"].to_i)
+    elsif ENV["USER_ID"].present?
+      scope = scope.where(board_id: Board.where(user_id: ENV["USER_ID"].to_i).select(:id))
+    elsif ENV["ADMIN_BUILT"] == "1"
+      admin_built = Board.where("settings->>? = 'true'", AdminBoardBuild::BUILDER_SETTING)
+      scope = scope.where(board_id: admin_built.select(:id))
+    end
+
+    scope
+  end
+
+  desc "Report tiles whose audio_url was never written (dry run)"
+  task missing_report: :environment do
+    scope = missing_audio_scope.call
+    total = scope.count
+    sample_size = (ENV["SAMPLE"].presence || 25).to_i
+
+    puts "Tiles with no audio_url: #{total}"
+
+    if total.zero?
+      puts "Nothing to backfill."
+    else
+      # `reorder(nil)`: BoardImage carries a default position order, which
+      # Postgres rejects alongside GROUP BY.
+      by_board = scope.reorder(nil).group(:board_id).count.sort_by { |_, count| -count }
+      puts "Across #{by_board.size} boards. Worst offenders:"
+      by_board.first(sample_size).each do |board_id, count|
+        board = Board.find_by(id: board_id)
+        name = (board&.name || "(deleted)").to_s.truncate(40)
+        admin_built = board&.settings.is_a?(Hash) && board.settings[AdminBoardBuild::BUILDER_SETTING] == true
+        puts format("  board %-8s %-40s %4d tiles%s", board_id, name, count, admin_built ? "  [admin-built]" : "")
+      end
+
+      # The split that decides urgency. A tile whose `voice` differs from its
+      # board's still hits the re-enqueue branch in
+      # `Board#api_view_with_images` and repairs itself on the next board load.
+      # A tile whose voice MATCHES takes the else branch, is serialized with a
+      # nil `audio_url`, and stays mute forever — those are the ones a backfill
+      # is actually for.
+      stuck = scope.joins(:board).where("board_images.voice = boards.voice").count
+      puts "Of those, #{stuck} will never self-heal (tile voice matches the board's) — " \
+           "#{total - stuck} repair themselves on the next board load."
+
+      # How many can be repaired straight from a file that already exists tells
+      # you what the backfill actually costs: those rows are a column write, the
+      # rest are Polly calls.
+      sampled = scope.includes(:image).limit(sample_size).to_a
+      resolvable = sampled.count do |board_image|
+        board_image.audio_url_for_voice(board_image.voice, board_image.language).present?
+      end
+      puts "Of the #{sampled.size} sampled, #{resolvable} already have an audio file to point at."
+      puts "Re-run with APPLY=1 on tile_audio:backfill to repair."
+    end
+  end
+
+  desc "Repair tiles whose audio_url was never written (APPLY=1 to write)"
+  task backfill: :environment do
+    apply = ENV["APPLY"] == "1"
+    enqueue = ENV["ENQUEUE"] != "0"
+    limit = ENV["LIMIT"].presence&.to_i
+
+    repaired = 0
+    enqueued = 0
+    skipped = 0
+
+    # `find_each` ignores a scope's limit, so a capped run has to iterate the
+    # limited relation directly. Uncapped runs keep the batching.
+    scope = missing_audio_scope.call.includes(:image)
+    rows = limit ? scope.limit(limit).to_a : scope
+
+    iterate = lambda do |&block|
+      rows.respond_to?(:find_each) && limit.nil? ? rows.find_each(&block) : rows.each(&block)
+    end
+
+    iterate.call do |board_image|
+      existing = board_image.audio_url_for_voice(board_image.voice, board_image.language)
+
+      if existing.present?
+        repaired += 1
+        board_image.update_columns(audio_url: existing) if apply
+      elsif enqueue
+        enqueued += 1
+        # Goes through the same guarded enqueue the app uses, so the task can
+        # never reintroduce the ordering bug it exists to clean up.
+        board_image.enqueue_voice_audio_job if apply
+      else
+        skipped += 1
+      end
+    end
+
+    puts "#{apply ? 'Repaired' : 'Would repair'} #{repaired} tiles from audio files that already exist."
+    puts "#{apply ? 'Queued' : 'Would queue'} #{enqueued} SaveAudioJob pushes for tiles with no file yet."
+    puts "Skipped #{skipped} tiles with no file (ENQUEUE=0)." if skipped.positive?
+    puts "Dry run — nothing written. Re-run with APPLY=1." unless apply
+  end
+end

--- a/spec/lib/tasks/tile_audio_backfill_spec.rb
+++ b/spec/lib/tasks/tile_audio_backfill_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "tile_audio rake tasks", type: :task do
+  ENV_KEYS = %w[APPLY ENQUEUE LIMIT SAMPLE BOARD_ID USER_ID ADMIN_BUILT].freeze
+
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  around do |example|
+    original = ENV.to_hash.slice(*ENV_KEYS)
+    ENV_KEYS.each { |k| ENV.delete(k) }
+    example.run
+    ENV_KEYS.each { |k| ENV[k] = original[k] }
+  end
+
+  def run_task(name)
+    task = Rake::Task[name]
+    task.reenable
+    task.invoke
+  end
+
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user, voice: "polly:kevin") }
+  let(:image) { create(:image, label: "hello", user_id: user.id) }
+
+  # The defect's signature: the tile exists, its voice matches the board's, and
+  # audio_url was never written because the job couldn't see the row.
+  let!(:orphaned_tile) do
+    tile = create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    tile.update_columns(audio_url: nil, voice: "polly:kevin")
+    tile
+  end
+
+  before { SaveAudioJob.clear }
+
+  describe "tile_audio:missing_report" do
+    before { allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil) }
+
+    it "reports the tile and writes nothing" do
+      expect { run_task("tile_audio:missing_report") }
+        .to output(/Tiles with no audio_url: 1/).to_stdout
+
+      expect(orphaned_tile.reload.audio_url).to be_nil
+      expect(SaveAudioJob.jobs).to be_empty
+    end
+
+    # The tile's voice matches its board's, so Board#api_view_with_images takes
+    # the else branch and never re-enqueues — this one stays mute forever.
+    it "counts a voice-matching tile as one that will never self-heal" do
+      expect { run_task("tile_audio:missing_report") }
+        .to output(/1 will never self-heal/).to_stdout
+    end
+
+    it "counts a voice-mismatched tile as self-healing" do
+      orphaned_tile.update_columns(voice: "polly:joanna")
+
+      expect { run_task("tile_audio:missing_report") }
+        .to output(/0 will never self-heal/).to_stdout
+    end
+
+    it "reports nothing once the tile has audio" do
+      orphaned_tile.update_columns(audio_url: "https://cdn.example.com/hello_kevin.mp3")
+
+      expect { run_task("tile_audio:missing_report") }
+        .to output(/Nothing to backfill/).to_stdout
+    end
+  end
+
+  describe "tile_audio:backfill" do
+    context "when the Image already has a file for the voice" do
+      before do
+        allow_any_instance_of(BoardImage)
+          .to receive(:audio_url_for_voice).and_return("https://cdn.example.com/hello_kevin.mp3")
+      end
+
+      it "is a dry run by default" do
+        expect { run_task("tile_audio:backfill") }.to output(/Would repair 1 tiles/).to_stdout
+        expect(orphaned_tile.reload.audio_url).to be_nil
+      end
+
+      it "points the tile at the existing file under APPLY=1, with no Polly work" do
+        ENV["APPLY"] = "1"
+
+        expect { run_task("tile_audio:backfill") }.to output(/Repaired 1 tiles/).to_stdout
+
+        expect(orphaned_tile.reload.audio_url).to eq("https://cdn.example.com/hello_kevin.mp3")
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+    end
+
+    context "when no audio file exists for the voice" do
+      before { allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil) }
+
+      it "queues SaveAudioJob under APPLY=1" do
+        ENV["APPLY"] = "1"
+
+        expect { run_task("tile_audio:backfill") }.to output(/Queued 1 SaveAudioJob/).to_stdout
+
+        expect(SaveAudioJob.jobs.size).to eq(1)
+        expect(SaveAudioJob.jobs.first["args"])
+          .to eq([orphaned_tile.image_id, orphaned_tile.voice, orphaned_tile.id])
+      end
+
+      it "skips rather than queues Polly work under ENQUEUE=0" do
+        ENV["APPLY"] = "1"
+        ENV["ENQUEUE"] = "0"
+
+        expect { run_task("tile_audio:backfill") }.to output(/Skipped 1 tiles/).to_stdout
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+    end
+
+    context "with a tile playing a parent's recording" do
+      before do
+        allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil)
+        orphaned_tile.update_columns(data: { "using_custom_audio" => true })
+      end
+
+      # A custom-audio tile with a blank audio_url means the upload failed —
+      # a different problem. Pushing it back onto a synthesized voice would
+      # silently replace a parent's recording.
+      it "is left alone" do
+        ENV["APPLY"] = "1"
+
+        expect { run_task("tile_audio:backfill") }.to output(/Repaired 0 tiles/).to_stdout
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+    end
+
+    it "honours LIMIT" do
+      allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil)
+      second = create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+      second.update_columns(audio_url: nil)
+      ENV["APPLY"] = "1"
+      ENV["LIMIT"] = "1"
+
+      expect { run_task("tile_audio:backfill") }.to output(/Queued 1 SaveAudioJob/).to_stdout
+      expect(SaveAudioJob.jobs.size).to eq(1)
+    end
+  end
+end

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -278,6 +278,63 @@ RSpec.describe BoardImage, type: :model do
     end
   end
 
+  describe "#create_voice_audio" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+    let(:image) { FactoryBot.create(:image, label: "hello", user_id: user.id) }
+    let!(:board_image) do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    end
+
+    before do
+      # No audio for the voice yet -> the SaveAudioJob branch.
+      allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil)
+      SaveAudioJob.clear
+    end
+
+    it "pushes SaveAudioJob inline when no transaction is open" do
+      board_image.create_voice_audio
+
+      expect(SaveAudioJob.jobs.size).to eq(1)
+      expect(SaveAudioJob.jobs.first["args"]).to eq([board_image.image_id, board_image.voice, board_image.id])
+    end
+
+    it "holds the push until the enclosing transaction commits" do
+      # Board#set_voice calls this from a before_save callback, so in
+      # Boards::AdminBuilder::Build the push lands inside the one
+      # build.with_lock transaction that writes the whole set. SaveAudioJob
+      # resolves the tile with find_by, so a job that beats the commit finds
+      # nothing, logs, and silently leaves audio_url/voice nil.
+      ActiveRecord::Base.transaction do
+        board_image.create_voice_audio
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+
+      expect(SaveAudioJob.jobs.size).to eq(1)
+      expect(SaveAudioJob.jobs.first["args"]).to eq([board_image.image_id, board_image.voice, board_image.id])
+    end
+
+    it "holds the push until the OUTERMOST transaction commits" do
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.transaction(requires_new: true) do
+          board_image.create_voice_audio
+        end
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+
+      expect(SaveAudioJob.jobs.size).to eq(1)
+    end
+
+    it "never pushes when the transaction rolls back" do
+      ActiveRecord::Base.transaction do
+        board_image.create_voice_audio
+        raise ActiveRecord::Rollback
+      end
+
+      expect(SaveAudioJob.jobs).to be_empty
+    end
+  end
+
   describe "#tile_image_url" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user) }

--- a/spec/models/board_image_spec.rb
+++ b/spec/models/board_image_spec.rb
@@ -335,6 +335,47 @@ RSpec.describe BoardImage, type: :model do
     end
   end
 
+  describe "#enqueue_voice_audio_job" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+    let(:image) { FactoryBot.create(:image, label: "hello", user_id: user.id) }
+    let!(:board_image) do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    end
+
+    before { SaveAudioJob.clear }
+
+    it "enqueues the tile's own voice by default" do
+      board_image.update_columns(voice: "polly:kevin")
+
+      board_image.enqueue_voice_audio_job
+
+      expect(SaveAudioJob.jobs.first["args"]).to eq([image.id, "polly:kevin", board_image.id])
+    end
+
+    # The read paths enqueue the voice the VIEWER is about to hear, which by
+    # definition differs from the one stored on the tile.
+    it "enqueues an explicit voice when given one" do
+      board_image.update_columns(voice: "polly:kevin")
+
+      board_image.enqueue_voice_audio_job("polly:joanna")
+
+      expect(SaveAudioJob.jobs.first["args"]).to eq([image.id, "polly:joanna", board_image.id])
+    end
+
+    it "captures its arguments rather than reading them back when the block runs" do
+      # Board#api_view_with_images reassigns @board_image on every iteration,
+      # so a block that read from the record at commit time would enqueue the
+      # wrong tile.
+      ActiveRecord::Base.transaction do
+        board_image.enqueue_voice_audio_job("polly:joanna")
+        board_image.voice = "polly:matthew"
+      end
+
+      expect(SaveAudioJob.jobs.first["args"]).to eq([image.id, "polly:joanna", board_image.id])
+    end
+  end
+
   describe "#tile_image_url" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user) }

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1350,4 +1350,48 @@ RSpec.describe Board, type: :model do
       expect(view[:in_a_public_group]).to be(false)
     end
   end
+
+  describe "#api_view_with_predictive_images audio enqueue" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user, voice: "polly:kevin") }
+    let(:image) { FactoryBot.create(:image, label: "hello", user_id: user.id) }
+    let!(:board_image) do
+      FactoryBot.create(:board_image, board: board, image: image, skip_create_voice_audio: true)
+    end
+
+    before do
+      # Tile is pinned to a different voice than the board, so the serializer
+      # takes the re-enqueue branch, and no file exists for the board's voice.
+      board_image.update_columns(voice: "polly:joanna", audio_url: nil)
+      allow_any_instance_of(BoardImage).to receive(:audio_url_for_voice).and_return(nil)
+      SaveAudioJob.clear
+    end
+
+    it "enqueues inline when serializing outside a transaction" do
+      board.api_view_with_predictive_images(user, false, "polly:kevin")
+
+      expect(SaveAudioJob.jobs.size).to eq(1)
+      expect(SaveAudioJob.jobs.first["args"]).to eq([image.id, "polly:kevin", board_image.id])
+    end
+
+    # The builder writes a set and serializes the root inside one transaction,
+    # and those tiles are exactly the ones with no audio yet.
+    it "holds the enqueue until the enclosing transaction commits" do
+      ActiveRecord::Base.transaction do
+        board.api_view_with_predictive_images(user, false, "polly:kevin")
+        expect(SaveAudioJob.jobs).to be_empty
+      end
+
+      expect(SaveAudioJob.jobs.size).to eq(1)
+    end
+
+    it "never enqueues when the transaction rolls back" do
+      ActiveRecord::Base.transaction do
+        board.api_view_with_predictive_images(user, false, "polly:kevin")
+        raise ActiveRecord::Rollback
+      end
+
+      expect(SaveAudioJob.jobs).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Summary

A tile could end up with `audio_url` and `voice` permanently nil, because `SaveAudioJob` was pushed from inside the transaction that wrote the tile.

`BoardImage#create_voice_audio` pushed inline, and its caller `Board#set_voice` runs from a **`before_save`** callback — so every call was mid-transaction. Where that transaction also writes the tiles (`Boards::AdminBuilder::Build` writes a whole set inside one `build.with_lock`), Sidekiq could dequeue before the commit.

**The failure was silent rather than loud.** `SaveAudioJob` resolves its tile with `find_by`, so an uncommitted row gives nil, not `RecordNotFound`. It logged `BoardImage with ID ... not found` and skipped the write. The audio *file* still landed on the Image, so the board sounded correct — only the tile's own columns stayed empty.

**And those tiles never recover.** `set_defaults` stamps the tile with the board's voice, so the re-enqueue branch in `Board#api_view_with_images` (`board_image.voice != voice_to_play`) is never taken. The else branch hands the serializer `audio_url: nil` on every subsequent load.

## What changed

Enqueues now go through `BoardImage#enqueue_voice_audio_job`, which wraps `perform_async` in `ActiveRecord.after_all_transactions_commit` — inline when no transaction is open, deferred to the **outermost** commit otherwise, never pushed on rollback. Putting the guard on the enqueue rather than at each call site is the point: the next caller can't forget it.

Call sites moved onto it:

| Site | Was it broken? |
|---|---|
| `BoardImage#create_voice_audio` | **Yes** — `Board#set_voice` is a `before_save`, so always in a transaction |
| `Board#api_view_with_predictive_images` / `#api_view_for_native_grid` | Defensive — only controller actions pass `voice_to_play` today, but the builder serializes its root inside its write transaction |
| `board_images#reset_audio` | No — already outside a transaction; moved for uniformity |
| `BoardImage#create_voice_audio_after_create` | No — already `after_create_commit` (#303); routed through the helper anyway |

`enqueue_voice_audio_job` takes an optional voice, because the read paths enqueue the voice the *viewer* is about to hear rather than the one stored on the tile. Arguments are captured into locals — the block can run long after the caller moved on, and the serializer reassigns `@board_image` every iteration.

## Backfill

Existing affected tiles don't self-heal, so this adds `lib/tasks/tile_audio_backfill.rake`:

```bash
bin/rails tile_audio:missing_report                  # dry run
bin/rails tile_audio:backfill APPLY=1 LIMIT=500
```

Measured against a production-like dev database (boards through 2026-07-13):

```
Tiles with no audio_url: 273, across 36 boards
  148 will never self-heal (tile voice matches the board's)
  125 repair themselves on the next board load
Worst: 6349 "abc starter" (41), 4504 "Grocery Shopping" (27), 3163 "fair food" (24)
```

Most rows repair from an audio file that already exists — a column write, no Polly call (4 of 5 sampled). Only a tile with no file falls through to a fresh job. Custom-audio tiles are excluded: a blank `audio_url` there is a failed upload, and rewriting it would silently replace a parent's recording. Dry-run by default, `APPLY=1` to write.

**Recommend running `tile_audio:missing_report` on production before deciding to apply** — the numbers above are from a dev snapshot with `AdminBoardBuild.count == 0`, so it predates the admin builder being used and can't speak to admin-built boards specifically.

## Notes

- Rebased onto `origin/main` after #697/#701 landed. Those fixed `run_generate_preview_job` and `Doc` variant rendering with the same `after_all_transactions_commit` pattern; this covers the audio enqueues they didn't touch.
- The rebase left CLAUDE.md with two copies of the "Sidekiq job that names a row" invariant. Collapsed to one, keeping #697's more general wording and folding in the silent-`find_by` failure mode.

## Test plan

`541 examples, 0 failures` across `spec/models/board_image_spec.rb`, `spec/models/board_spec.rb`, `spec/lib/tasks/tile_audio_backfill_spec.rb`, `spec/requests/api/board_images_audio_spec.rb`, `spec/services/boards/admin_builder`.

New coverage:
- `#create_voice_audio` — pushes inline with no transaction open; held until the enclosing transaction commits; held until the **outermost** commit (nested `requires_new`); never pushed on rollback.
- `#enqueue_voice_audio_job` — uses the tile's voice by default, an explicit voice when given one, and captures its arguments rather than reading them back at commit time.
- `#api_view_with_predictive_images` — inline outside a transaction, deferred inside one, never on rollback.
- The rake task — dry-run default, repair-from-existing-file, queue-when-no-file, `ENQUEUE=0`, `LIMIT`, custom-audio tiles left alone, and the self-heal split.

**Both new fixes were verified to fail against the old code** before being kept (3/4 and 2/3 respectively; the inline cases correctly pass either way).

## Follow-ups not in this PR

Two more enqueues fit the same invariant but sit outside what this PR set out to fix — flagging rather than folding in:

- `Board#enqueue_destroy_cleanup` (board.rb:236) is `after_destroy`, not `after_destroy_commit`, so a rolled-back destroy still scrubs pointers.
- `UpdateUserBoardsJob.perform_async(@cloned_board.id, ...)` (board.rb:1411) names a freshly cloned board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
