### PR TITLE
fix(profiles): record bio audio independently of intro, and cache audio blobs

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -4,6 +4,25 @@
 > This file is the authoritative doc for this subsystem — update it (not CLAUDE.md)
 > when behavior changes. CLAUDE.md keeps only the cross-cutting invariants.
 
+## Spoken intro / bio audio
+
+`SaveProfileAudioJob` → `Profile#update_audio(:intro | :bio)` pre-renders each
+field to an mp3 through Polly and attaches it (`intro_audio` / `bio_audio`),
+which is what `safety_view` publishes as `intro_audio_url` / `bio_audio_url`.
+
+**Each field is gated on its own text, never on `intro`.** The guard used to be
+`return unless intro.present?` at the top of the method — above the branch that
+picks which field it is rendering — so a profile with an About me and no intro
+got neither clip. This is a latency bug, not a missing-feature one: when a clip
+is absent the public page falls back to synthesizing on **every tap**
+(`POST /api/images/generate_audio`, measured 0.5s warm and 3.8s cold), so
+"Hear me" / "Read aloud" sit silent for seconds each time they are pressed.
+Anything that stops a clip being pre-generated has that cost.
+
+`enqueue_audio_job_if_needed` already tracks the two fields independently
+(`saved_change_to_bio? || (bio.present? && !bio_audio.attached?)`), so a
+profile that was skipped under the old guard re-enqueues on its next save.
+
 ## Safety-profile view alerts (issue #384)
 
 Public safety (MySpeak) pages have two surfaces. The **open page**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,19 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   repair task (`tile_audio:backfill`) fixes tiles already affected, reusing
   audio that was already generated wherever possible.
 
+- **A MySpeak page with an "About me" but no intro now gets its spoken audio.**
+  The recording step bailed out whenever the intro was empty, and it did so
+  before deciding which field it was working on — so the About me audio was
+  skipped too. The public page then had to generate speech from scratch on
+  every tap of "Read aloud", which is what made the button feel slow. Each
+  field is now recorded on its own.
+
+- **Audio and images are served with caching headers.** Files went out telling
+  browsers nothing about how long they could be kept, so the same unchanging
+  clip was downloaded again every time it played. New uploads now carry a
+  long-lived caching header; `rake audio:backfill_cache_control APPLY=1`
+  applies it to files already stored.
+
 - **The transient image-processing error that killed background jobs is fixed
   at the source.** Building a board set, importing an OBF file, or saving newly
   generated art could resize a tile picture in the middle of a database

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -964,8 +964,6 @@ class Profile < ApplicationRecord
   end
 
   def update_audio(audio_type)
-    return unless intro.present?
-
     voice = profileable&.respond_to?(:voice) ? (profileable.voice || "polly:kevin") : "polly:kevin"
     language = profileable&.respond_to?(:language) ? (profileable.language || "en") : "en"
     text = ""
@@ -977,6 +975,14 @@ class Profile < ApplicationRecord
       Rails.logger.error "Invalid audio type #{audio_type} for profile #{slug}"
       return
     end
+
+    # Gate on the field being synthesized, not on `intro`. This guard used to
+    # be `return unless intro.present?` at the top of the method, so a profile
+    # with a bio and no intro never got bio audio either — and the public page
+    # falls back to synthesizing on every tap when a clip is missing, which is
+    # a multi-second wait each time. A blank field is also not worth a Polly
+    # call in its own right.
+    return if text.blank?
 
     synth_io = VoiceService.synthesize_speech(text: text, voice_value: voice, language: language)
     return unless synth_io

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,14 @@ amazon:
   region: <%= ENV.fetch("AWS_REGION", "us-east-1") %>
   bucket: <%= ENV.fetch("AWS_BUCKET") { "itty-bitty-boards-#{ENV.fetch("RAILS_ENV", "development")}" } %>
   public: true
+  # Everything on this service is addressed by its Active Storage blob key,
+  # which is random and never rewritten in place — a key's bytes are fixed for
+  # the life of the object, so it is safe to cache forever. Without this the
+  # objects go out with no Cache-Control at all, which leaves both the browser
+  # and CloudFront re-fetching an unchanging mp3 on every play. Applies to new
+  # uploads only; `rake audio:backfill_cache_control` covers existing blobs.
+  upload:
+    cache_control: "public, max-age=31536000, immutable"
 
 # Same bucket/credentials as `amazon`, but WITHOUT public: true (defaults to
 # public: false). That's what routes ActiveStorage's `.url` through the

--- a/lib/tasks/audio_cache_control.rake
+++ b/lib/tasks/audio_cache_control.rake
@@ -1,0 +1,73 @@
+# Backfill Cache-Control on blobs already in S3.
+#
+# `config/storage.yml` sets `upload.cache_control` on the `amazon` service, but
+# that only applies at PUT time — every object uploaded before it stays with no
+# Cache-Control header, so the browser and CloudFront keep re-fetching an mp3
+# whose bytes can never change. This rewrites the header in place with a
+# same-key copy (S3 has no "set metadata" verb; COPY onto itself with
+# REPLACE is the documented way).
+#
+#   bin/rails audio:backfill_cache_control                 # audio blobs, dry run
+#   bin/rails audio:backfill_cache_control APPLY=1         # actually write
+#   bin/rails audio:backfill_cache_control APPLY=1 ALL=1   # every public blob
+#
+# Safe to re-run: copying an object onto itself with identical bytes is
+# idempotent, and blobs that already carry the header are skipped.
+namespace :audio do
+  CACHE_CONTROL = "public, max-age=31536000, immutable".freeze
+
+  desc "Backfill Cache-Control on existing S3 blobs (APPLY=1 to write, ALL=1 for every content type)"
+  task backfill_cache_control: :environment do
+    apply = ENV["APPLY"] == "1"
+    every = ENV["ALL"] == "1"
+
+    service = ActiveStorage::Blob.service
+    unless service.respond_to?(:bucket)
+      abort "Active Storage service #{service.class} is not S3-backed — nothing to do."
+    end
+
+    scope = ActiveStorage::Blob.all
+    scope = scope.where("content_type LIKE ?", "audio/%") unless every
+
+    total = scope.count
+    puts "#{apply ? "Applying" : "Dry run"} over #{total} blob(s)#{every ? "" : " (audio only)"}."
+
+    updated = 0
+    skipped = 0
+    missing = 0
+
+    scope.find_each.with_index do |blob, i|
+      object = service.bucket.object(blob.key)
+
+      unless object.exists?
+        missing += 1
+        next
+      end
+
+      if object.cache_control.to_s == CACHE_CONTROL
+        skipped += 1
+        next
+      end
+
+      if apply
+        # copy_from onto the same key with REPLACE rewrites the metadata
+        # without re-uploading from our side.
+        object.copy_from(
+          object,
+          cache_control: CACHE_CONTROL,
+          content_type: blob.content_type,
+          metadata_directive: "REPLACE",
+          acl: "public-read"
+        )
+      end
+
+      updated += 1
+      puts "  [#{i + 1}/#{total}] #{blob.key} (#{blob.content_type})" if (updated % 50).zero? || total < 50
+    rescue StandardError => e
+      warn "  FAILED #{blob.key}: #{e.class}: #{e.message}"
+    end
+
+    puts "Done. #{apply ? "updated" : "would update"}=#{updated} already_set=#{skipped} missing_in_bucket=#{missing}"
+    puts "Re-run with APPLY=1 to write." unless apply
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -729,4 +729,51 @@ RSpec.describe Profile, type: :model do
       expect(Profile.slug_available?("emma-jones")).to be(false)
     end
   end
+
+  # The public MySpeak page falls back to synthesizing on EVERY tap when a clip
+  # is missing (a multi-second wait each time), so "which fields get a clip" is
+  # the difference between an instant button and a dead-feeling one.
+  describe "#update_audio" do
+    let(:profile) { Profile.new(profileable: child, username: "emma").tap(&:save!) }
+
+    before do
+      allow(VoiceService).to receive(:synthesize_speech).and_return(StringIO.new("mp3-bytes"))
+    end
+
+    it "generates bio audio when there is a bio but no intro" do
+      profile.update_columns(intro: nil, bio: "I love trains.")
+
+      profile.update_audio(:bio)
+
+      expect(VoiceService).to have_received(:synthesize_speech)
+        .with(hash_including(text: "I love trains."))
+      expect(profile.reload.bio_audio).to be_attached
+    end
+
+    it "generates intro audio when there is an intro but no bio" do
+      profile.update_columns(intro: "Hi, I'm Emma.", bio: nil)
+
+      profile.update_audio(:intro)
+
+      expect(VoiceService).to have_received(:synthesize_speech)
+        .with(hash_including(text: "Hi, I'm Emma."))
+      expect(profile.reload.intro_audio).to be_attached
+    end
+
+    it "does not call the synthesizer for a blank field" do
+      profile.update_columns(intro: "Hi, I'm Emma.", bio: "")
+
+      profile.update_audio(:bio)
+
+      expect(VoiceService).not_to have_received(:synthesize_speech)
+      expect(profile.reload.bio_audio).not_to be_attached
+    end
+
+    it "ignores an unknown audio type" do
+      profile.update_columns(intro: "Hi, I'm Emma.", bio: "I love trains.")
+
+      expect(profile.update_audio(:nickname)).to be_nil
+      expect(VoiceService).not_to have_received(:synthesize_speech)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two backend causes of the "huge delay on Hear Me / Read aloud" report on `/my/:slug`.

**1. `Profile#update_audio` skipped bio audio whenever intro was blank.** The guard was `return unless intro.present?`, sitting *above* the branch that decides which field it is rendering — so `update_audio(:bio)` returned immediately for any profile with an About me and no intro. Each field is now gated on its own text.

This is a latency bug, not a missing feature. When a clip is absent the public page falls through to `playUnsavedAudio` → `POST /api/images/generate_audio`, a full Polly synthesis **per tap** — measured against staging:

| | |
|---|---|
| warm | ~0.5s |
| cold | 3.8s |

**2. Public blobs carried no `Cache-Control`.** Every play re-fetched an mp3 whose bytes can never change (Active Storage keys are random and never rewritten in place). Added `upload.cache_control` to the `amazon` service, plus `rake audio:backfill_cache_control` for objects already in the bucket — the upload option only applies at PUT time.

Frontend half of the fix: brittanyjohns/itty-bitty-frontend (warms the clips so a tap never starts the fetch).

## Test plan

- `bundle exec rspec spec/models/profile_spec.rb` — 95 examples, 0 failures (4 new `#update_audio` cases: bio-without-intro, intro-without-bio, blank field, unknown type).
- Confirmed the new bio-without-intro spec **fails** with the old guard restored and passes with the fix, so it actually pins the regression.
- `spec/requests/api/profiles_owner_protection_spec.rb`, `profiles_care_plan_spec.rb`, `spec/models/profile_view_spec.rb` — 33 examples, 0 failures.
- `rake -T audio` lists the new task; verified `ActiveStorage::Service::S3Service` accepts the `upload:` key and merges it (`{cache_control:…, acl:"public-read"}`).

## Notes

- `config/storage.yml` is Active Storage *application* config, not deployment/server config — flagging it since the repo rule is worded broadly.
- The rake task defaults to a **dry run**; `APPLY=1` writes. It is idempotent and skips objects that already carry the header.
- I could not inspect the CloudFront distribution from here, so I have verified the origin header is now set but **not** that CloudFront's TTL config will cache it. Worth a look at the distribution's Min/Default TTL — responses currently come back `x-cache: Miss from cloudfront` on repeat requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)