### PR TITLE
feat(profiles): expose sign_in_available on public MySpeak payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A communicator's public MySpeak page now says whether they can sign in.**
+  The public payload carries a `sign_in_available` boolean so the page can offer
+  a "Sign in as {name}" shortcut to the person it belongs to, instead of leaving
+  them to find the communicator sign-in screen on their own. It is false for
+  sandbox communicators, for anyone in fallback mode after a downgrade, for Free
+  plans, and for accounts with no passcode set — all cases where signing in would
+  dead-end — so the shortcut simply doesn't appear. No passcode, email, or token
+  is exposed.
+
 - **Generated marketplace copy now describes the printable it belongs to.**
   Every listing used to open with the same sentence and carry the same 13 tags,
   so a hospital-stay board and a hair-salon board were indistinguishable in

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -889,6 +889,20 @@ class ChildAccount < ApplicationRecord
     end
   end
 
+  # Public-page safe: is there actually a working private login behind this
+  # communicator's MySpeak page? `can_sign_in?` alone isn't enough — the passcode
+  # validations are commented out, so an `active` communicator with a blank
+  # passcode is representable and would 401 at ChildAuthsController#create.
+  #
+  # Called with no user_context on purpose: this answer ships on an
+  # unauthenticated payload, so it must never reflect an admin viewer.
+  def sign_in_available?
+    return false if archived?
+    return false if passcode.blank?
+
+    can_sign_in?
+  end
+
   def admin?
     user.admin?
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -360,6 +360,14 @@ class Profile < ApplicationRecord
   end
 
   # Public-facing communicator/safety page view — do NOT leak email / full settings
+  # Only communicator pages have a private login to offer. Users and vendors
+  # sign in through the normal user flow, so this is always false for them.
+  def communicator_sign_in_available?
+    return false unless profileable_type == "ChildAccount"
+
+    profileable.present? && profileable.sign_in_available?
+  end
+
   def safety_view
     {
       id: id,
@@ -396,6 +404,11 @@ class Profile < ApplicationRecord
       # If you need this for the UI, keep it minimal
       profileable_type: profileable_type,
       profileable_id: profileable_id,
+
+      # Whether this communicator has a working private login, so the public
+      # page can offer a "Sign in as {name}" CTA instead of dead-ending them.
+      # A bare boolean — never the passcode.
+      sign_in_available: communicator_sign_in_available?,
 
       claim_url: claim_url, # ok to show if you want the CTA
       public_about_html: safe_html(public_about&.body&.to_s),
@@ -439,7 +452,8 @@ class Profile < ApplicationRecord
       public_bio_html: safe_html(public_bio&.body&.to_s),
       # Use a minimal public-safe view instead of the full api_view which
       # leaks parent email, supporter/supervisor emails, and passcode.
-      communicator_account: profileable_type == "ChildAccount" ? profileable.public_api_view : nil
+      communicator_account: profileable_type == "ChildAccount" ? profileable.public_api_view : nil,
+      sign_in_available: communicator_sign_in_available?
     }
   end
 

--- a/spec/models/child_account_sign_in_available_spec.rb
+++ b/spec/models/child_account_sign_in_available_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# `sign_in_available?` is the public-page-safe answer to "is there a working
+# private login behind this communicator's MySpeak page?" It ships on an
+# unauthenticated payload, so it must be strictly narrower than `can_sign_in?`:
+# a blank passcode would 401 at ChildAuthsController#create even when the plan
+# rules say yes.
+RSpec.describe ChildAccount, "#sign_in_available?", type: :model do
+  let(:paid_user) { FactoryBot.create(:user, plan_type: "pro") }
+  let(:free_user) { FactoryBot.create(:user) }
+
+  it "is true for an active communicator with a passcode on a paid plan" do
+    account = FactoryBot.create(
+      :child_account, user: paid_user, owner: paid_user,
+      status: "active", passcode: "letmein1"
+    )
+
+    expect(account.sign_in_available?).to be(true)
+  end
+
+  it "is false for a sandbox communicator" do
+    account = FactoryBot.create(
+      :child_account, user: paid_user, owner: paid_user,
+      status: "sandbox", passcode: "letmein1"
+    )
+
+    expect(account.sign_in_available?).to be(false)
+  end
+
+  it "is false when the passcode is blank, even though can_sign_in? says yes" do
+    account = FactoryBot.create(
+      :child_account, user: paid_user, owner: paid_user,
+      status: "active", passcode: nil
+    )
+
+    expect(account.can_sign_in?).to be(true)
+    expect(account.sign_in_available?).to be(false)
+  end
+
+  it "is false for a communicator in fallback mode" do
+    account = FactoryBot.create(
+      :child_account, user: paid_user, owner: paid_user,
+      status: "active", passcode: "letmein1"
+    )
+    account.enter_fallback!
+
+    expect(account.reload.sign_in_available?).to be(false)
+  end
+
+  it "is false for an archived communicator" do
+    account = FactoryBot.create(
+      :child_account, user: paid_user, owner: paid_user,
+      status: "active", passcode: "letmein1"
+    )
+    account.update!(archived_at: Time.current)
+
+    expect(account.sign_in_available?).to be(false)
+  end
+
+  it "is false for a Free (non-trial) owner" do
+    account = FactoryBot.create(
+      :child_account, user: free_user, owner: free_user,
+      status: "active", passcode: "letmein1"
+    )
+    allow(account.user).to receive(:free_trial?).and_return(false)
+
+    expect(account.sign_in_available?).to be(false)
+  end
+end

--- a/spec/requests/api/profiles_spec.rb
+++ b/spec/requests/api/profiles_spec.rb
@@ -233,6 +233,64 @@ RSpec.describe "API::Profiles", type: :request do
     end
   end
 
+  # The public MySpeak page offers a "Sign in as {name}" CTA, but only when the
+  # communicator actually has a working private login. Sandbox/fallback/Free
+  # accounts would dead-end at the login endpoint, so the flag hides the CTA.
+  describe "GET /api/profiles/public/:slug (sign_in_available flag)" do
+    let(:owner) { FactoryBot.create(:user, plan_type: "pro") }
+
+    def public_body_for(child)
+      profile = Profile.create!(
+        profileable: child,
+        username: "sign-in-#{SecureRandom.hex(3)}",
+        slug: "sign-in-#{SecureRandom.hex(3)}",
+      )
+      get "/api/profiles/public/#{profile.slug}"
+      expect(response).to have_http_status(:ok)
+      JSON.parse(response.body)
+    end
+
+    it "is true for an active communicator with a passcode" do
+      child = FactoryBot.create(
+        :child_account, user: owner, owner: owner,
+        name: "Ada", status: "active", passcode: "letmein1"
+      )
+
+      expect(public_body_for(child)["sign_in_available"]).to be(true)
+    end
+
+    it "is false for a sandbox communicator" do
+      child = FactoryBot.create(
+        :child_account, user: owner, owner: owner,
+        name: "Ada", status: "sandbox"
+      )
+
+      expect(public_body_for(child)["sign_in_available"]).to be(false)
+    end
+
+    it "is false for a communicator in fallback mode" do
+      child = FactoryBot.create(
+        :child_account, user: owner, owner: owner,
+        name: "Ada", status: "active", passcode: "letmein1"
+      )
+      child.enter_fallback!
+
+      expect(public_body_for(child.reload)["sign_in_available"]).to be(false)
+    end
+
+    it "never exposes the passcode alongside the flag" do
+      child = FactoryBot.create(
+        :child_account, user: owner, owner: owner,
+        name: "Ada", status: "active", passcode: "letmein1"
+      )
+      body = public_body_for(child)
+
+      expect(body["sign_in_available"]).to be(true)
+      expect(body).not_to have_key("passcode")
+      expect(response.body).not_to include("letmein1")
+    end
+  end
+
   describe "GET /api/profiles/public/:slug (legacy slug fallback)" do
     let(:owner) { FactoryBot.create(:user) }
     let(:child) { FactoryBot.create(:child_account, user: owner, owner: owner, name: "Emma") }


### PR DESCRIPTION
## Summary

A communicator's public MySpeak page (`/my/:slug`) is often the first thing they land on — it's the URL behind the QR code and the link in a text — but it offers them no way in. This adds the one piece of data the frontend needs to fix that: a `sign_in_available` boolean on the unauthenticated profile payload, so the page can offer a "Sign in as {name}" shortcut *only when it will actually work*.

- **`ChildAccount#sign_in_available?`** — reuses the existing `can_sign_in?` rules (sandbox, `fallback_mode?` and non-paid owners are already false) and adds the guard those rules miss: passcode validations are commented out, so an `active` communicator with a blank passcode is representable and would 401 at `ChildAuthsController#create`. Also guards `archived?`.
- **`sign_in_available` on `Profile#safety_view` and `#public_page_view`** — a bare boolean, via a small `communicator_sign_in_available?` helper so the two serializers can't drift.

Called with **no `user_context`** on purpose: the answer ships on an unauthenticated payload, so it must never reflect an admin viewer.

**Privacy:** the only new information is "a login exists." The username is already public and `/accounts/sign-in` is already a public route. No passcode, email or token is touched — there's a spec asserting the passcode never appears in the response body.

Frontend counterpart follows in `itty-bitty-frontend`. The field is optional there, so neither side blocks the other and there's no broken intermediate state.

## Noticed while working (not fixed here)

`ChildAuthsController#create` has its `can_sign_in?` enforcement **commented out** — only the fallback 403 and the plaintext credential match actually gate login today. Nothing here depends on it, but it means this flag and the login endpoint can disagree for a Free-plan `active` communicator who has a passcode (flag says no, login would let them in). Worth its own issue rather than folding into this PR.

## Test plan

`bundle exec rspec spec/models/child_account_sign_in_available_spec.rb spec/requests/api/profiles_spec.rb` — **47 examples, 0 failures.**

- **Model** (new spec): true for active + passcode on a paid plan; false for sandbox, for a blank passcode (asserting `can_sign_in?` is true in that same case, so the guard is doing real work), for fallback mode, for archived, and for a Free non-trial owner.
- **Request**: `GET /api/profiles/public/:slug` returns `true` for a signable communicator, `false` for sandbox and for fallback mode, and never exposes the passcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)