### PR TITLE
fix(care-plan): drop the "Prepared <date>" line from care documents

### DIFF
--- a/app/services/communicators/generate_care_plan.rb
+++ b/app/services/communicators/generate_care_plan.rb
@@ -112,16 +112,15 @@ module Communicators
 
     def template_assigns
       {
-        # No subtitle: the condensed band carries title · prepared-on · URL on
-        # one 7.5pt meta line, and "How to support Rosa day to day" is the one
-        # line on the old sheet a reader already knows. care.document.subtitle
-        # is left in the locale files for whoever brings it back.
+        # No subtitle: the condensed band carries title · URL on one 7.5pt meta
+        # line, and "How to support Rosa day to day" is the one line on the old
+        # sheet a reader already knows. care.document.subtitle is left in the
+        # locale files for whoever brings it back.
+        #
+        # No prepared-on date either: the sheet lives in a backpack or a school
+        # folder for a whole year, and a printed date only makes a still-current
+        # plan look stale. care.document.prepared_on stays in the locale files.
         title: I18n.t("care.document.title.#{variant}", locale: locale),
-        prepared_on: I18n.t(
-          "care.document.prepared_on",
-          date: I18n.l(Date.current, format: :long, locale: locale),
-          locale: locale,
-        ),
         display_name: profile.safety_display_name,
         pronouns: (profile.settings || {})["pronouns"].presence,
         # Resolved to a data: URI here, BEFORE the render, so the render itself

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -28,7 +28,7 @@
     <div class="eyebrow">SpeakAnyWay</div>
     <h1><%= @display_name %></h1>
     <div class="meta">
-      <%= @title %> · <%= @prepared_on %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>
+      <%= @title %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>
     </div>
   </div>
 

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -192,6 +192,15 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(render_html).to include(profile.public_url)
     end
 
+    # The sheet lives in a folder for a school year — a printed date only makes
+    # a still-current plan look stale, so the band carries no "Prepared ...".
+    it "prints no prepared-on date" do
+      html = render_html
+
+      expect(html).not_to include("Prepared")
+      expect(html).not_to include(I18n.l(Date.current, format: :long))
+    end
+
     # The density change, pinned: one gradient band instead of masthead +
     # identity, and the care sections in two newspaper columns.
     it "renders one header band and flows the care sections into columns" do


### PR DESCRIPTION
## What changed

Removed the `Prepared <date>` segment from the care plan header band.

- `app/views/communicators/assets/care_plan.html.erb` — the meta line is now `title · pronouns · URL`.
- `app/services/communicators/generate_care_plan.rb` — dropped the `prepared_on` template assign, with a comment recording why.
- `spec/services/communicators/generate_care_plan_spec.rb` — new example pinning that neither "Prepared" nor today's long-form date appears in the rendered HTML.

## Why

The care plan is a sheet that lives in a backpack or a school office folder for a whole school year. A printed preparation date doesn't tell a reader anything useful and only makes a still-current plan look stale.

## Notes for a reviewer

The `care.document.prepared_on` keys are left in `config/locales/care.en.yml` and `care.es.yml` rather than deleted — same convention the file already follows for `care.document.subtitle`, which was similarly dropped from the render and kept in the locales for whoever brings it back.

## Test plan

```
bundle exec rspec spec/services/communicators/generate_care_plan_spec.rb spec/services/communicators/care_plan_document_spec.rb
```

57 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)