### PR TITLE
feat(printables): protect boards that back an Etsy listing

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -115,6 +115,22 @@ stands alone. The trim-ready file reuses the **colour** cover — it is a colour
 print, only its board pages differ — and gets its own how-to-use page, because
 that page is the only thing that tells a reader where the QR went.
 
+**The permanence note lives on the credits and how-to-use pages, never on the
+cover.** A buyer's QR points at a board that may later change or move, so both
+pages tell them to make a free account and save their own copy — the credits
+page beside the QR itself, and how-to-use as step 6. Two placements are ruled
+out: the **cover**, because `RenderWrappers#cover_assigns` is shared verbatim
+with `RenderListingImages` and the cover therefore *is* the Etsy search
+thumbnail (a "may not stay online" line would ship as the product's first
+photo); and the **license page**, where the surrounding anti-redistribution
+terms make it read as a restriction on the buyer rather than a nudge. Word it as
+a next action, not a disclaimer — "isn't guaranteed forever" on a product page
+reads as a warning about what was just paid for. `credits` renders once and
+`MergePdf` binds the same bytes into all three files, and the how-to-use line
+sits outside step 1's `@variant` branch, so both are variant-independent by
+construction. None of this touches `api/boards/print.html.erb` or
+`layouts/pdf.html.erb`, which are shared with real users' PDF downloads.
+
 **`hide_header: true` is not the way to build the trim-ready page.** The QR
 lives *inside* the header block in `api/boards/print.html.erb`, so hiding the
 header takes the code with it — and the free audio companion is the single
@@ -407,6 +423,74 @@ rather than emptying the record.
 its PDFs and images with it. It cannot touch Etsy — this app implements no
 listing update or delete call — so the confirm dialog names the surviving draft
 id when one exists (`Admin::BoardPrintablesHelper#board_printable_delete_confirm`).
+The dialog also says how many boards will stop being protected, because this
+record is what freezes them (below).
+
+## Listed boards are protected
+
+Once a printable has an `etsy_listing_id`, every board it was rendered from is
+frozen: **deleting, unpublishing and renaming are refused; structural tile edits
+need an explicit confirm.** `Boards::MarketplaceProtection` is the single
+authority; `Board#marketplace_protected?` delegates to it.
+
+**Protection covers the whole printed tree, not the printable's root board.**
+The scope matches `board_printables.board_ids` (a jsonb array of integers, GIN
+indexed, matched with `@>`) unioned with `board_id`. Every interior page of a
+set carries its own QR pointing at its own `/pb/<slug>`, so deleting page 4 of a
+twelve-page set breaks the product exactly as badly as deleting the root. The
+`board_id` half of the union is belt-and-braces for a printable that failed
+before `Generate` wrote `board_ids`. Note the ids are **integers** — a string in
+that array silently matches nothing and every interior page quietly loses its
+protection.
+
+**Why `etsy_listing_id` and not a listing state.** The obvious design is a
+`draft / active / ended` column so an ended listing releases its boards. It
+models the wrong fact. What protection defends is a printed sheet with a QR on
+it, and ending an Etsy listing doesn't recall a laminated board off a fridge.
+The column would also be hand-maintained against a shop this app cannot read,
+and its one drift mode is the unsafe one: you end a listing, forget to flip the
+column, and the boards unprotect while the paper is still live. Release is
+therefore an explicit act — `BoardPrintable#waive_protection!`, stamped with who
+and when — not an inferred state. Equally, protection does **not** key on the
+printable merely existing: generating one to look at it is the normal way to use
+the admin, and locking a board every time would make the feature something to
+avoid.
+
+**Hard blocks vs confirm.** Deleting, unpublishing and renaming are refused
+outright — no request param clears them, only the waiver. Structural tile edits
+(layout, columns, adding/removing tiles, colors, tile art) return
+`board_marketplace_edit_confirmation_required` once and proceed on
+`confirm_marketplace_edit=true`. That param is deliberately not `confirm`, which
+`#update` already means "yes, cascade the publish" by — one click must not
+authorize the other thing. Reads, PDF exports and audio are never gated.
+
+Both refusals are **409**, alongside the existing `board_in_use` and
+`publish_cascade_confirmation_required`. Protection is checked **before**
+`Boards::UsageCheck`: `board_in_use` is confirmable and this is not, so
+answering with the confirmable one first would teach the client to retry into a
+wall. Cascades (`delete_subboards=true`, a builder `BoardGroup`, an unpublish
+cascade) are pre-checked and refused **whole** — skipping the protected member
+would delete its parent and leave it behind with a folder tile pointing at
+nothing, which is the corruption this exists to prevent. `Boards::PublishCascade`
+needs its own pre-check because `#apply!` writes with `update_all`, which skips
+callbacks entirely.
+
+The model guard (`Board#block_marketplace_protected_destroy`, `prepend: true`)
+**raises** rather than `throw :abort`, because the cascades that can reach a
+protected board ignore a false return — `BoardGroup` uses `destroy_all`,
+`Admin::BoardBuildsController` uses `reverse_each(&:destroy)`. Aborting there
+would destroy the group and leave the protected board orphaned, which is worse
+than the deletion. `prepend: true` matters too: without it every `dependent:
+:destroy` cascade runs and is rolled back to reach the same refusal.
+`Board#destroy_despite_marketplace_protection!` is a console/rake hatch and is
+never wired to a request param.
+
+`Board#rename_slug!` — the deliberate-rename hatch behind the internal API's
+`force_slug` and the `boards:rename_slug` rake task — raises on a protected
+board unless `allow_marketplace_protected_change` is also set. It is exactly the
+hatch that would silently 404 printed paper. `freeze_published_slug` still
+**reverts** rather than raising on the ordinary path, because the frontend
+re-derives the slug from the name on every rename; don't convert it.
 
 ## Storage layout
 

--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -694,6 +694,19 @@ board: { id, name }, usage: { referencing_boards, communicators, teams,
 builder_set, subboards } }` (counts exact, name lists capped at 10).
 Unreferenced boards delete in one step as before.
 
+- **Marketplace protection answers first, and can't be confirmed away.** A board
+  that backs an Etsy printable returns **409** `board_marketplace_protected`
+  before `UsageCheck` runs at all, with `blocked_action` and a `marketplace`
+  summary naming the listing. `board_in_use` is *confirmable* — the client's
+  correct response is to resend with `confirm=true` — and this one is not, so
+  putting the confirmable warning first would teach the client to retry into a
+  wall. Only one error key per response; don't merge the two payloads. The same
+  key covers the refused cascades (`blocked_boards` / `blocked_subboards`) and
+  the refused unpublish; structural tile edits get the separate, confirmable
+  `board_marketplace_edit_confirmation_required` and the
+  `confirm_marketplace_edit` param. Authority and rationale:
+  `.claude-notes/board-printables-etsy.md`.
+
 - **Subboards count as usage, and the cascade is opt-in.** `Boards::SubboardTree`
   walks the board's *outbound* folder links (`Boards::ReachableBoardIds`, an
   id-only BFS that handles cycles and caps the walk) and splits the tree into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   dead-end — so the shortcut simply doesn't appear. No passcode, email, or token
   is exposed.
 
+- **Boards that are sold as printables are now protected from accidental
+  changes.** Once a printable reaches Etsy, the boards it was built from — the
+  whole set, not just the first page — can no longer be deleted, unpublished or
+  renamed, and editing their tiles asks for a confirmation first. Printed copies
+  carry a QR code pointing at each page, and paper can't be re-issued, so a
+  rename or an unpublish would quietly 404 a sheet already in someone's hands.
+  The admin shows which boards are frozen and by which listing, and has a
+  deliberate "Release protection" button for when a product really is retired.
+
+- **Printables now tell buyers how to keep their own copy.** The about page and
+  the how-to-use page explain that a shared board can change or move over time,
+  and that making a free account and saving your own copy keeps the exact set of
+  words in this print. Nothing about the boards themselves changed.
+
 - **Generated marketplace copy now describes the printable it belongs to.**
   Every listing used to open with the same sentence and carry the same 13 tags,
   so a hospital-stay board and a hair-salon board were indistinguishable in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,12 @@ an explicit decision, not a drive-by edit.
 - **HTTP error semantics:** **402** = credit exhaustion only
   (`insufficient_credits`). **429** = true rate limiting only. **403** =
   permission/plan gates (`board_locked`, `pro_required`,
-  `communicator_in_fallback`, `myspeak_id_limit_reached`, …). Never leak
+  `communicator_in_fallback`, `myspeak_id_limit_reached`, …). **409** = state
+  conflicts, some confirmable (`board_in_use`,
+  `publish_cascade_confirmation_required`,
+  `board_marketplace_edit_confirmation_required`) and some not
+  (`board_marketplace_protected`) — an unconfirmable conflict is always
+  answered FIRST, or the client learns to retry into a wall. Never leak
   internals in API errors — generic messages only.
 - **`User#paid_plan?` is the single paid-tier gate.** It checks both
   `plan_type` and `plan_status`; `basic_trial` and Stripe `trialing` count as
@@ -307,6 +312,17 @@ an explicit decision, not a drive-by edit.
   silently reverts a slug change on a published board (reverts, never raises —
   the frontend re-derives the slug on every rename). Deliberate renames go
   through `Board#rename_slug!`.
+- **A board that backs a marketplace listing can't be deleted, unpublished or
+  renamed.** Same reason as the frozen slug, one step further: the board's
+  content was sold as a PDF and every printed page carries a QR pointing at its
+  own `/pb/<slug>`. `Boards::MarketplaceProtection` is the single authority and
+  covers the whole printed tree (`board_printables.board_ids`), not just the
+  printable's root — deleting an interior page breaks the product just as badly.
+  It keys on `etsy_listing_id`, never on a hand-maintained listing state: ending
+  an Etsy listing doesn't un-print paper, and such a column would only ever
+  drift in the unsafe direction. Release is the audited
+  `BoardPrintable#waive_protection!`. Details:
+  `.claude-notes/board-printables-etsy.md`.
 - **Downgrades retain, never delete.** Over-limit boards become read-only;
   over-limit communicators enter fallback mode (public MySpeak page stays
   up). No plan change destroys user content.

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -5,6 +5,15 @@ module Admin
     before_action :authenticate_user!
     before_action :require_admin!
 
+    # Same net as the JSON side: an admin action that reaches a board frozen by
+    # a marketplace listing gets the explanation, not a 500.
+    rescue_from Board::MarketplaceProtectedError do |e|
+      redirect_back(
+        fallback_location: root_path,
+        alert: "\"#{e.board.name}\" is sold as a printable and can't be #{e.action}. Release protection on the printable first.",
+      )
+    end
+
     private
 
     def require_admin!

--- a/app/controllers/admin/board_builds_controller.rb
+++ b/app/controllers/admin/board_builds_controller.rb
@@ -443,6 +443,16 @@ module Admin
 
       name = @build.name
       set = @build.set_boards
+
+      # The whole set, not just the root: any page of a built tree can be the
+      # page a printable was sold from, and `set.reverse_each(&:destroy)` would
+      # otherwise hit the model guard mid-loop with the build row already gone.
+      blocked = Boards::MarketplaceProtection.protected_board_ids(set.map(&:id))
+      if blocked.any?
+        names = Board.where(id: blocked.to_a).pluck(:name).to_sentence
+        return redirect_to admin_dashboard_board_builds_path,
+                           alert: "#{names} #{blocked.size == 1 ? "is" : "are"} sold as a printable — release protection on the printable before deleting this build."
+      end
       # The build row first: admin_board_builds.board_id carries a foreign key,
       # so destroying the board while the build still points at it violates it.
       @build.destroy

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -31,6 +31,12 @@ module Admin
       @public_boards = sorted_boards(printable_boards).limit(PUBLIC_BOARD_LIMIT)
 
       @subboard_counts = direct_subboard_counts(@public_boards + @boards)
+      # One query for the whole picker. The partial takes this as a local; a
+      # per-row `board.marketplace_protected?` would be PUBLIC_BOARD_LIMIT
+      # queries.
+      @protected_board_ids = Boards::MarketplaceProtection.protected_board_ids(
+        (@public_boards + @boards).map(&:id),
+      )
     end
 
     def show
@@ -102,6 +108,28 @@ module Admin
 
       redirect_to admin_dashboard_board_printable_path(printable),
                   notice: "Regenerating from the current board… the listing images are now out of date, so re-render those when it finishes."
+    end
+
+    # Releases the boards this printable froze (Boards::MarketplaceProtection).
+    #
+    # The only supported way to unprotect a board: it's deliberate, it's
+    # attributable, and it leaves the listing pointer alone so the record still
+    # says which Etsy draft this was. Not reversible through the UI on purpose —
+    # re-protecting is publishing again.
+    def waive_protection
+      printable = BoardPrintable.find(params[:id])
+
+      if !printable.etsy_published?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable was never published to Etsy, so it isn't protecting anything."
+      elsif printable.protection_waived?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "Protection was already released #{printable.protection_waived_at.to_date}."
+      else
+        printable.waive_protection!(user: current_user, reason: params[:reason])
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    notice: "Protection released. These boards can be edited, renamed and deleted again — printed copies still point at them."
+      end
     end
 
     # Destroys the record and (via Active Storage) its PDFs and gallery images.

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -224,6 +224,14 @@ module Admin
       @user.soft_delete_account!(reason: "demo_cleanup", actor_id: current_user.id) unless @user.soft_deleted?
       redirect_to admin_dashboard_users_path,
                   notice: "Demo account #{email} deleted (content destroyed, row anonymized).", status: :see_other
+    rescue Board::MarketplaceProtectedError => e
+      # Ahead of the blanket rescue below, which would otherwise flatten this
+      # into "check logs". Shouldn't be reachable — only demo accounts get here
+      # and a demo board is never sold — but a silent mystery is the wrong
+      # failure mode for a guard whose whole job is to be explicable.
+      redirect_to admin_dashboard_user_path(params[:id]),
+                  alert: "\"#{e.board.name}\" is sold as a printable — release protection on the printable first.",
+                  status: :see_other
     rescue => e
       Rails.logger.error("[DemoCleanup] Failed to delete user #{params[:id]}: #{e.class} - #{e.message}")
       redirect_to admin_dashboard_user_path(params[:id]), alert: "Delete failed — check logs.", status: :see_other

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -4,6 +4,19 @@ module API
     skip_before_action :authenticate_token!, only: %i[authenticate_child_token! preset_colors]
     include ActiveStorage::SetCurrent
 
+    # Net for Board's marketplace-protection guards. The endpoints that can hit
+    # one check it up front and render a richer 409; this only catches the
+    # paths that reach a protected board indirectly (a cascade, a nested
+    # destroy), which would otherwise be a 500.
+    rescue_from Board::MarketplaceProtectedError do |e|
+      render json: {
+        error: "board_marketplace_protected",
+        message: "\"#{e.board.name}\" is sold as a printable — printed copies point at it, so it can't be #{e.action}. Release protection on the printable in the admin first.",
+        board: { id: e.board.id, name: e.board.name },
+        blocked_action: e.action,
+      }, status: :conflict
+    end
+
     # application_controller.rb
     rescue_from ActionController::InvalidAuthenticityToken do |e|
       Rails.logger.warn "CSRF fail UA=#{request.user_agent} IP=#{request.remote_ip} Origin=#{request.headers["Origin"]} Referrer=#{request.referer} Cookies?=#{request.cookies.present?}"

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -5,6 +5,9 @@ class API::BoardsController < API::ApplicationController
   before_action :check_board_view_edit_permissions, only: %i[update destroy]
   before_action :check_board_create_permissions, only: %i[ create clone create_from_template import_obf ]
   before_action :check_board_editable!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image set_display_image format_with_ai add_image associate_image associate_images remove_image generate_preview_image ]
+  # Declared AFTER check_board_editable! so the plan gate still answers first —
+  # a read-only board is 403 board_locked whether or not it's also for sale.
+  before_action :check_marketplace_edit_confirmed!, only: %i[ save_layout rearrange_images update regenerate_images recategorize_images update_to_default_docs set_colors update_preset_display_image set_display_image format_with_ai add_image associate_image associate_images remove_image ]
 
   def index
     limit_param = params[:limit].presence&.to_i
@@ -417,6 +420,19 @@ class API::BoardsController < API::ApplicationController
       return
     end
 
+    # Unpublishing and renaming a board that's sold as a printable are refused
+    # outright — no confirm clears them. Unpublishing 404s /pb/<slug> for every
+    # sheet already printed, and the name is the product's title. Both run
+    # before any attribute is assigned, so a refusal writes nothing. Released
+    # by waiving protection on the printable in the admin.
+    if unpublishing_requested?
+      return if render_marketplace_protection_conflict(@board, action: "unpublished")
+    end
+
+    if renaming_requested?
+      return if render_marketplace_protection_conflict(@board, action: "renamed", blocked_action: "rename")
+    end
+
     # Warn+confirm before cascading publish across a Board Builder set, mirroring
     # the delete flow. This runs BEFORE any attribute is assigned, so a declined
     # cascade writes nothing at all — the client re-sends the identical payload
@@ -437,6 +453,12 @@ class API::BoardsController < API::ApplicationController
       # NULL out) every non-NULL member.
       if [true, false].include?(target_published) && target_published != @board.published
         cascade = Boards::PublishCascade.new(@board)
+        # Before the confirm, and not confirmable: #apply! writes with
+        # update_all, so a protected member page would be unpublished with no
+        # callback to stop it.
+        blocked = cascade.blocked_board_ids(published: target_published)
+        return if render_marketplace_cascade_conflict_for_unpublish(blocked)
+
         if cascade.needed?(published: target_published) && params[:confirm].to_s != "true"
           render json: {
                    error: "publish_cascade_confirmation_required",
@@ -1245,6 +1267,32 @@ class API::BoardsController < API::ApplicationController
   # and the client can opt into the cascade with delete_subboards=true.
   def destroy
     usage = Boards::UsageCheck.new(@board)
+
+    # Marketplace protection is checked FIRST and separately from UsageCheck.
+    # `board_in_use` is a confirmable 409 — the client's correct response is to
+    # resend with confirm=true — and this one can't be confirmed away. Showing
+    # the confirmable warning first would teach the client to retry into a wall.
+    return if render_marketplace_protection_conflict(@board, action: "deleted")
+
+    if (group = usage.builder_group)
+      # The group cascade destroys every member board, so a protected member
+      # has to be caught before group.destroy! reaches the model guard — a raise
+      # from inside destroy_all would be a 500, not a 409.
+      blocked = Boards::MarketplaceProtection.protected_board_ids(
+        group.board_group_boards.pluck(:board_id),
+      )
+      return if render_marketplace_cascade_conflict(blocked, key: :blocked_boards)
+    elsif params[:delete_subboards].to_s == "true"
+      # Refuse the WHOLE cascade rather than skipping the protected child:
+      # skipping would delete the parent and leave the protected page behind
+      # with a folder tile pointing at nothing, which is the corruption this
+      # feature exists to prevent.
+      blocked = Boards::MarketplaceProtection.protected_board_ids(
+        usage.subboard_tree&.deletable_ids || [],
+      )
+      return if render_marketplace_cascade_conflict(blocked, key: :blocked_subboards)
+    end
+
     if usage.in_use? && params[:confirm].to_s != "true"
       render json: {
                error: "board_in_use",
@@ -1631,6 +1679,128 @@ class API::BoardsController < API::ApplicationController
       board_limit: current_user.board_limit,
       editable_board_id: current_user.effective_editable_board_id,
     }, status: :forbidden
+  end
+
+  # ---- Marketplace protection -------------------------------------------
+  #
+  # A board whose content was sold as a printable is frozen: printed sheets
+  # carry a QR pointing at /pb/<slug> and paper can't be re-issued. Deleting,
+  # unpublishing and renaming are refused outright (released only by an admin
+  # waiver on the printable); structural tile edits are refused once and then
+  # allowed with an explicit confirm.
+  #
+  # All of these are 409 — a state conflict on the resource, the same code the
+  # existing board_in_use / publish_cascade warnings use. Never 403, which is
+  # reserved for permission and plan gates.
+
+  # Renders and returns true when the board itself is protected.
+  def render_marketplace_protection_conflict(board, action:, blocked_action: nil)
+    protection = board.marketplace_protection
+    return false unless protection.protected?
+
+    noun = protection.role == :root ? "board" : "page"
+    render json: {
+      error: "board_marketplace_protected",
+      message: "\"#{board.name}\" is #{protection.role == :root ? "sold as a printable" : "part of a printable that's for sale"} — printed copies point at this #{noun}, so it can't be #{action}. Release protection on the printable in the admin first.",
+      board: { id: board.id, name: board.name },
+      blocked_action: blocked_action || action,
+      marketplace: protection.summary,
+    }, status: :conflict
+    true
+  end
+
+  # Renders and returns true when a cascade would take a protected board with
+  # it. The cascade is refused whole — never partially applied.
+  def render_marketplace_cascade_conflict(blocked_ids, key:)
+    return false if blocked_ids.blank?
+
+    boards = Board.where(id: blocked_ids.to_a).pluck(:id, :name).map { |id, name| { id: id, name: name } }
+    render json: {
+      error: "board_marketplace_protected",
+      message: "Deleting \"#{@board.name}\" would also delete #{boards.size == 1 ? "a board" : "#{boards.size} boards"} sold as a printable. Release protection in the admin first.",
+      board: { id: @board.id, name: @board.name },
+      blocked_action: "deleted",
+      key => boards,
+    }, status: :conflict
+    true
+  end
+
+  def render_marketplace_cascade_conflict_for_unpublish(blocked_ids)
+    return false if blocked_ids.blank?
+
+    boards = Board.where(id: blocked_ids.to_a).pluck(:id, :name).map { |id, name| { id: id, name: name } }
+    render json: {
+      error: "board_marketplace_protected",
+      message: "Unpublishing \"#{@board.name}\" would take #{boards.size == 1 ? "a page" : "#{boards.size} pages"} sold as a printable offline. Release protection in the admin first.",
+      board: { id: @board.id, name: @board.name },
+      blocked_action: "unpublish",
+      blocked_boards: boards,
+    }, status: :conflict
+    true
+  end
+
+  # Structural tile edits: warn once, then proceed on confirm_marketplace_edit.
+  # Deliberately NOT `confirm`, which #update already means "yes, cascade the
+  # publish" by — reusing it would let one click authorize the other thing.
+  def check_marketplace_edit_confirmed!
+    set_board if @board.nil?
+    return if @board.nil?
+    return unless marketplace_edit_is_structural?
+    return if params[:confirm_marketplace_edit].to_s == "true"
+
+    protection = @board.marketplace_protection
+    return unless protection.protected?
+
+    render json: {
+      error: "board_marketplace_edit_confirmation_required",
+      message: "\"#{@board.name}\" is sold as a printable. Changing it means the paper a buyer holds and the board online stop matching.",
+      board: { id: @board.id, name: @board.name },
+      marketplace: protection.summary,
+    }, status: :conflict
+  end
+
+  # Every gated action except #update is structural by definition. #update is
+  # the general-purpose save, so it only counts when the payload actually
+  # touches structure — a favorite/tags/category save shouldn't prompt.
+  #
+  # Reads raw params rather than `board_params`, which calls
+  # `params.require(:board)` and would raise on the image_ids_to_remove-only
+  # payload (itself a structural edit: it removes tiles).
+  # `name` is deliberately absent: renaming is refused outright inside #update,
+  # and listing it here would let the softer before_action answer first — a
+  # confirmable 409 in front of an unconfirmable one, which is the ordering
+  # this feature avoids everywhere else. It would also fire on the ordinary
+  # save that re-sends the board's existing name unchanged.
+  MARKETPLACE_STRUCTURAL_KEYS = %w[
+    number_of_columns small_screen_columns medium_screen_columns
+    large_screen_columns word_list layout
+  ].freeze
+
+  # Same shape as the publish-cascade guard: raw booleans only, so a malformed
+  # value can't read as "unpublish".
+  def unpublishing_requested?
+    return false if params[:image_ids_to_remove].present?
+    return false unless params[:board].respond_to?(:key?) && params[:board].key?("published")
+
+    target = ActiveModel::Type::Boolean.new.cast(params[:board]["published"])
+    target == false && @board.published?
+  end
+
+  def renaming_requested?
+    return false if params[:image_ids_to_remove].present?
+
+    incoming = params.dig(:board, :name)
+    incoming.present? && incoming.to_s != @board.name.to_s
+  end
+
+  def marketplace_edit_is_structural?
+    return true unless action_name == "update"
+    return true if params[:image_ids_to_remove].present?
+
+    board_payload = params[:board]
+    return false if board_payload.blank?
+
+    MARKETPLACE_STRUCTURAL_KEYS.any? { |key| board_payload.key?(key) }
   end
 
   def boards_for_user

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -45,7 +45,23 @@ module Admin
       base = "Delete this printable and its PDFs? This can't be undone."
       return base unless printable.etsy_published?
 
-      "#{base} Etsy draft #{printable.etsy_listing_id} stays on Etsy — remove it there yourself."
+      # The second sentence is the less obvious consequence: this record is what
+      # freezes its boards, so deleting it makes them deletable and renameable
+      # again while the listing is still up.
+      "#{base} Etsy draft #{printable.etsy_listing_id} stays on Etsy — remove it there yourself. " \
+      "The #{pluralize(printable.protected_board_ids.size, "board")} it protects will no longer be protected."
+    end
+
+    def marketplace_protection_badge
+      "bg-amber-900/60 text-amber-300"
+    end
+
+    # The confirm on the release button. Names the listing id, because that's
+    # the thing an admin should go look at before deciding the paper is dead.
+    def waive_protection_confirm(printable)
+      "Release protection on #{pluralize(printable.protected_board_ids.size, "board")}? " \
+      "Etsy listing #{printable.etsy_listing_id} may still be live, and printed copies keep pointing at these boards. " \
+      "They become deletable, renameable and unpublishable again."
     end
 
     # The list is capped at PUBLIC_BOARD_LIMIT, so which boards you see depends

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -107,6 +107,28 @@ class Board < ApplicationRecord
   # `freeze_published_slug`.
   attr_accessor :allow_slug_change
 
+  # Console/rake-only hatches for a board frozen by a marketplace listing. They
+  # are never wired to a request param: the supported way to release a board is
+  # BoardPrintable#waive_protection!, which leaves an audit trail. A param would
+  # turn the hard block into a warning with extra steps.
+  attr_accessor :allow_marketplace_protected_destroy
+  attr_accessor :allow_marketplace_protected_change
+
+  # Raised, not `throw :abort`, because the cascades that can reach a protected
+  # board ignore a false return: BoardGroup destroys its members with
+  # `destroy_all` and Admin::BoardBuildsController with `reverse_each(&:destroy)`.
+  # Aborting there would destroy the group and leave the protected board behind,
+  # orphaned — worse than the deletion it was meant to prevent.
+  class MarketplaceProtectedError < StandardError
+    attr_reader :board, :action
+
+    def initialize(board, action)
+      @board = board
+      @action = action
+      super("Board #{board.id} backs a marketplace listing and cannot be #{action}")
+    end
+  end
+
   validates :slug, uniqueness: true
 
   include UtilHelper
@@ -231,6 +253,12 @@ class Board < ApplicationRecord
   # dynamic_board_id/phrase_board_id) and scenarios. Off-request because the
   # JSONB scans aren't indexed.
   after_destroy :enqueue_destroy_cleanup
+
+  # prepend: true so the guard runs BEFORE the dependent: :destroy cascades.
+  # Without it every board_image, child_board and printable is destroyed first
+  # and then rolled back — a lot of work to arrive at the same refusal.
+  before_destroy :block_marketplace_protected_destroy, prepend: true
+  before_save :block_marketplace_protected_unpublish
 
   def enqueue_destroy_cleanup
     BoardDestroyCleanupJob.perform_async(id)
@@ -1569,16 +1597,71 @@ class Board < ApplicationRecord
     published? && slug.present?
   end
 
+  # The other printed-paper freeze, and the stronger one: this board's content
+  # was sold as a PDF, and the QR on that PDF resolves to it. See
+  # Boards::MarketplaceProtection for what counts and why it's permanent.
+  # Not memoized on the board: waiving protection in the admin has to take
+  # effect for the delete that follows it in the same request.
+  def marketplace_protection
+    Boards::MarketplaceProtection.new(self)
+  end
+
+  def marketplace_protected?
+    return false if new_record?
+
+    marketplace_protection.protected?
+  end
+
   # The deliberate rename path. Used by the admin/internal API and the
   # `boards:rename_slug` rake task — never by an ordinary board update.
   # Callers are responsible for reprinting anything already in the wild.
   def rename_slug!(requested_slug)
+    # The deliberate-rename hatch is exactly the one that would silently 404 a
+    # printed QR, so a marketplace-protected board needs its own second opt-in
+    # on top of it.
+    if marketplace_protected? && !allow_marketplace_protected_change
+      raise MarketplaceProtectedError.new(self, "slug-renamed")
+    end
+
     self.allow_slug_change = true
     generate_unique_slug(requested_slug)
     save
   ensure
     self.allow_slug_change = false
   end
+
+  # Console/rake hatch. The supported admin release is
+  # BoardPrintable#waive_protection!.
+  def destroy_despite_marketplace_protection!
+    self.allow_marketplace_protected_destroy = true
+    destroy!
+  ensure
+    self.allow_marketplace_protected_destroy = false
+  end
+
+  def block_marketplace_protected_destroy
+    return if allow_marketplace_protected_destroy
+    return unless marketplace_protected?
+
+    raise MarketplaceProtectedError.new(self, "deleted")
+  end
+  private :block_marketplace_protected_destroy
+
+  # Unpublishing is the quietest way to break a printed board: /pb/<slug> stops
+  # resolving for every sheet already in the wild, with no redirect. Raises
+  # rather than reverting (unlike freeze_published_slug) because `published` is
+  # only ever sent when someone deliberately toggles it — a silent revert would
+  # leave the admin looking at "Published" after clicking Unpublish.
+  def block_marketplace_protected_unpublish
+    return if new_record?
+    return if allow_marketplace_protected_change
+    return unless published_change_to_be_saved
+    return unless published_was && !published
+    return unless marketplace_protected?
+
+    raise MarketplaceProtectedError.new(self, "unpublished")
+  end
+  private :block_marketplace_protected_unpublish
 
   # Reverts a slug change on an already-published board rather than rejecting
   # the save: the frontend re-derives the slug from the name on every rename
@@ -2629,8 +2712,13 @@ class Board < ApplicationRecord
     @display_image_url = display_image_url
     @preview_image_url = preview_image_url
 
+    # Admin-only, and only computed for admins: it costs a query, and which of
+    # Brittany's boards are for sale is not a fact a member needs.
+    @marketplace_protection = nil
+
     if viewing_user && viewing_user.admin?
       @in_a_public_group = in_a_public_group?
+      @marketplace_protection = marketplace_protection.summary
     end
     {
       id: id,
@@ -2639,6 +2727,8 @@ class Board < ApplicationRecord
       bg_color: bg_color,
       text_color: text_color,
       tags: tags,
+      marketplace_protected: @marketplace_protection.present?,
+      marketplace_protection: @marketplace_protection,
       user_name: user.to_s,
       name: name,
       is_template: is_template,

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -77,6 +77,7 @@ class BoardPrintable < ApplicationRecord
 
   belongs_to :board
   belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :protection_waived_by, class_name: "User", optional: true
 
   has_many_attached :files
 
@@ -226,6 +227,32 @@ class BoardPrintable < ApplicationRecord
   def board_page_count = board_ids.to_a.size * DOWNLOAD_VARIANTS.size
 
   def etsy_published? = etsy_listing_id.present?
+
+  # Whether this printable freezes the boards it was rendered from.
+  #
+  # Keyed on `etsy_listing_id`, NOT on the record existing: generating a
+  # printable to look at it is the normal way to use the admin, and locking a
+  # board every time would make the feature something to avoid. It is also not
+  # keyed on any "is the listing still live" state — the thing protection
+  # defends is a printed sheet with a QR on it, and ending an Etsy listing
+  # doesn't un-print that sheet. Release is the explicit waiver below.
+  def protects_board? = etsy_published? && protection_waived_at.nil?
+
+  def protection_waived? = protection_waived_at.present?
+
+  def waive_protection!(user:, reason: nil)
+    update!(
+      protection_waived_at: Time.current,
+      protection_waived_by: user,
+      protection_waived_reason: reason.presence,
+    )
+  end
+
+  # Every board this printable was rendered from — the root plus each page of
+  # the tree. `board_ids` is written by Boards::Printables::Generate; the root
+  # is unioned in because a printable that failed before that write still has a
+  # real `board_id`.
+  def protected_board_ids = (board_ids.to_a + [board_id]).compact.uniq
 
   # The copy an admin has saved, or the generated default when nothing has been
   # saved yet — so the show page can preview a listing before anyone edits it.

--- a/app/services/boards/marketplace_protection.rb
+++ b/app/services/boards/marketplace_protection.rb
@@ -1,0 +1,95 @@
+module Boards
+  # Read-only "does a marketplace listing depend on this board?" check.
+  #
+  # A board is protected when a BoardPrintable that reached Etsy
+  # (`etsy_listing_id` present, protection not waived) was rendered from it.
+  # That covers the WHOLE printed tree, not just the printable's root board:
+  # every interior page carries its own QR pointing at its own `/pb/<slug>`, so
+  # deleting page 4 of a twelve-page set breaks the product exactly as badly as
+  # deleting the root.
+  #
+  # Protection is permanent by design. It defends printed paper — an Etsy
+  # listing can be ended, but that doesn't recall a laminated board off a
+  # fridge. BoardPrintable#waive_protection! is the one deliberate way out.
+  #
+  # Sibling of Boards::UsageCheck, and deliberately separate from it: usage is a
+  # confirmable warning ("this is still in use, delete anyway?"), this is not.
+  class MarketplaceProtection
+    def initialize(board)
+      @board = board
+      @board_id = board.is_a?(Board) ? board.id : board.to_i
+    end
+
+    def protected? = printables.any?
+
+    # The printables whose product depends on this board.
+    def printables
+      @printables ||= self.class.protecting_scope([board_id]).to_a
+    end
+
+    # :root when the board is the printable's own board, :page when it is an
+    # interior page of the printed tree. Only used for wording.
+    def role
+      return nil unless protected?
+
+      printables.any? { |p| p.board_id == board_id } ? :root : :page
+    end
+
+    def summary
+      return nil unless protected?
+
+      {
+        role: role,
+        printables: printables.map { |printable| printable_summary(printable) },
+      }
+    end
+
+    # One query for many boards. Used wherever a cascade or a list would
+    # otherwise run this per board.
+    def self.protected_board_ids(ids)
+      ids = Array(ids).map { |id| id.is_a?(Board) ? id.id : id.to_i }.uniq
+      return Set.new if ids.empty?
+
+      protecting_scope(ids).flat_map(&:protected_board_ids).to_set & ids.to_set
+    end
+
+    # The printables protecting any of `ids`.
+    #
+    # `board_ids` is a jsonb array of INTEGERS (Boards::Printables::Generate
+    # writes `collected[:boards].map(&:id)`), so `?|` — which compares text
+    # keys — would never match; containment against a json array of the same
+    # integers is what works, and it's what the GIN index on board_ids serves.
+    # The `board_id IN (...)` half is belt-and-braces for a printable that
+    # failed before board_ids was written.
+    def self.protecting_scope(ids)
+      ids = Array(ids).map { |id| id.is_a?(Board) ? id.id : id.to_i }.uniq
+      return BoardPrintable.none if ids.empty?
+
+      containment = ids.map { "board_printables.board_ids @> ?" }.join(" OR ")
+      BoardPrintable
+        .where.not(etsy_listing_id: nil)
+        .where(protection_waived_at: nil)
+        .where(
+          "board_printables.board_id IN (?) OR (#{containment})",
+          ids,
+          *ids.map { |id| [id].to_json },
+        )
+    end
+
+    private
+
+    attr_reader :board, :board_id
+
+    def printable_summary(printable)
+      {
+        id: printable.id,
+        etsy_listing_id: printable.etsy_listing_id,
+        etsy_listing_url: printable.etsy_listing_url,
+        root_board: {
+          id: printable.board_id,
+          name: printable.board&.name,
+        },
+      }
+    end
+  end
+end

--- a/app/services/boards/marketplace_protection.rb
+++ b/app/services/boards/marketplace_protection.rb
@@ -61,19 +61,27 @@ module Boards
     # integers is what works, and it's what the GIN index on board_ids serves.
     # The `board_id IN (...)` half is belt-and-braces for a printable that
     # failed before board_ids was written.
+    #
+    # `@>` means "contains ALL of", so a single condition can't ask for "any of
+    # these ids" — it needs one `@>` per id, OR'd. Composed with ActiveRecord's
+    # #or rather than by interpolating the ORs into one SQL string: the
+    # interpolated version was safe (the fragment is a fixed literal repeated
+    # `ids.size` times, and every id is bound) but it read as SQL injection to
+    # Brakeman, and "trust me, the interpolation has no user input in it" is a
+    # bad thing to have to re-verify. Each condition here is a literal with a
+    # bind param, which is checkable at a glance.
     def self.protecting_scope(ids)
       ids = Array(ids).map { |id| id.is_a?(Board) ? id.id : id.to_i }.uniq
       return BoardPrintable.none if ids.empty?
 
-      containment = ids.map { "board_printables.board_ids @> ?" }.join(" OR ")
+      matching = ids.reduce(BoardPrintable.where(board_id: ids)) do |scope, id|
+        scope.or(BoardPrintable.where("board_printables.board_ids @> ?", [id].to_json))
+      end
+
       BoardPrintable
         .where.not(etsy_listing_id: nil)
         .where(protection_waived_at: nil)
-        .where(
-          "board_printables.board_id IN (?) OR (#{containment})",
-          ids,
-          *ids.map { |id| [id].to_json },
-        )
+        .merge(matching)
     end
 
     private

--- a/app/services/boards/publish_cascade.rb
+++ b/app/services/boards/publish_cascade.rb
@@ -39,6 +39,18 @@ module Boards
       }
     end
 
+    # Members frozen by a marketplace listing that this cascade would unpublish.
+    #
+    # #apply! writes with update_all, which skips callbacks — so Board's own
+    # marketplace guard never fires for a member and an unpublish would silently
+    # 404 the QR on a printed page. The caller must check this before applying.
+    # Only unpublishing is checked: publishing a board can't break printed paper.
+    def blocked_board_ids(published:)
+      return Set.new if published
+
+      MarketplaceProtection.protected_board_ids(member_boards_to_change(published).pluck(:id))
+    end
+
     # Flips the members only — the root is saved by the caller through the
     # normal update path. update_all skips callbacks on purpose: a built set
     # can be dozens of boards and only one boolean column changes. It also

--- a/app/views/admin/board_printables/_board_option.html.erb
+++ b/app/views/admin/board_printables/_board_option.html.erb
@@ -1,4 +1,7 @@
 <% subboard_count = (defined?(subboard_counts) && subboard_counts ? subboard_counts[board.id] : nil).to_i %>
+<%# Passed down as a Set built once in the controller — a per-row lookup here
+    would be one query per row across PUBLIC_BOARD_LIMIT rows. %>
+<% board_protected = defined?(protected_board_ids) && protected_board_ids ? protected_board_ids.include?(board.id) : false %>
 <tr class="admin-hover-row transition-colors" style="border-bottom: 1px solid var(--border-light);">
   <td class="px-3 py-2">
     <div class="text-t1 font-medium"><%= board.name %></div>
@@ -10,6 +13,12 @@
       <%= link_to "Open ↗", board_public_page_url(board), target: "_blank", rel: "noopener",
                   class: "text-t2 hover:text-accent underline transition-colors",
                   title: "Open this board in a new tab" %>
+      <% if board_protected %>
+        <span class="inline-block rounded px-1.5 py-0.5 <%= marketplace_protection_badge %> font-medium"
+              title="Already sold as a printable — this board can't be deleted, renamed or unpublished">
+          Protected
+        </span>
+      <% end %>
     </div>
   </td>
   <td class="px-3 py-2 whitespace-nowrap">

--- a/app/views/admin/board_printables/_board_table.html.erb
+++ b/app/views/admin/board_printables/_board_table.html.erb
@@ -33,7 +33,8 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: "board_option", collection: boards, as: :board, locals: { subboard_counts: subboard_counts } %>
+      <%= render partial: "board_option", collection: boards, as: :board,
+                 locals: { subboard_counts: subboard_counts, protected_board_ids: @protected_board_ids } %>
     </tbody>
   </table>
 </div>

--- a/app/views/admin/board_printables/_etsy.html.erb
+++ b/app/views/admin/board_printables/_etsy.html.erb
@@ -36,6 +36,32 @@
       To replace this draft, delete it in Etsy first — the app won't create a second listing for the
       same printable, because a duplicate in a live shop is easy to miss and hard to undo.
     </p>
+
+    <%# Protection is turned on by the listing id, so it belongs on this card.
+        Every board in the printed tree is covered, not just the root — each
+        interior page carries its own QR. %>
+    <div class="mt-4 pt-4 border-t border-white/10">
+      <% if @printable.protection_waived? %>
+        <p class="text-[11px] text-t3">
+          Protection released <%= @printable.protection_waived_at.strftime("%b %-d, %Y") %><%=
+            " by #{@printable.protection_waived_by.email}" if @printable.protection_waived_by %>.
+          These boards can be deleted, renamed and unpublished again.
+          <%= "Reason: #{@printable.protection_waived_reason}" if @printable.protection_waived_reason.present? %>
+        </p>
+      <% else %>
+        <div class="flex items-start justify-between gap-4">
+          <p class="text-[11px] text-t3">
+            <span class="inline-block px-1.5 py-0.5 rounded <%= marketplace_protection_badge %> font-medium mr-1">Protected</span>
+            <%= pluralize(@printable.protected_board_ids.size, "board") %> in this printable can't be deleted,
+            renamed or unpublished — printed copies carry a QR pointing at each page.
+          </p>
+          <%= button_to "Release protection", waive_protection_admin_dashboard_board_printable_path(@printable),
+                method: :post,
+                class: "shrink-0 text-xs font-medium px-3 py-2 rounded admin-card-alt text-t2 hover:text-t1 cursor-pointer",
+                form: { data: { turbo_confirm: waive_protection_confirm(@printable) } } %>
+        </div>
+      <% end %>
+    </div>
   <% elsif !@etsy_configured %>
     <p class="text-xs text-t3">
       Etsy isn't configured. Set <code>ETSY_KEYSTRING</code>, <code>ETSY_SHARED_SECRET</code>,

--- a/app/views/admin/board_printables/show.html.erb
+++ b/app/views/admin/board_printables/show.html.erb
@@ -24,6 +24,24 @@
   <%= link_to "← All printables", admin_dashboard_board_printables_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
 </div>
 
+<%# Above the status card, because it changes what the buttons on that card
+    will do — Delete printable releases these boards. The release button itself
+    lives on the Etsy card, next to the listing id that turned protection on. %>
+<% if @printable.protects_board? %>
+  <div class="admin-card border rounded-xl px-5 py-4 mb-6 border-amber-500/40">
+    <p class="text-sm text-t1">
+      <span class="inline-block px-1.5 py-0.5 rounded <%= marketplace_protection_badge %> text-xs font-medium mr-1">Protected</span>
+      <%= pluralize(@printable.protected_board_ids.size, "board") %> can't be deleted, renamed or unpublished
+      while this printable is on Etsy.
+    </p>
+    <p class="text-[11px] text-t3 mt-1">
+      Printed copies carry a QR pointing at each page — <code>/pb/&lt;slug&gt;</code> has no redirect behind it,
+      so a rename or an unpublish 404s paper that's already in someone's hands. Tile edits still work,
+      but ask for a confirmation first. Release protection on the Etsy card below.
+    </p>
+  </div>
+<% end %>
+
 <div class="admin-card border rounded-xl p-5 mb-6">
   <div class="flex items-center gap-3 mb-4">
     <span class="<%= board_printable_status_badge(@printable.status) %> inline-block text-xs rounded px-2.5 py-1"><%= @printable.status %></span>

--- a/app/views/api/board_printables/credits.html.erb
+++ b/app/views/api/board_printables/credits.html.erb
@@ -32,6 +32,16 @@
         <% if @public_url.present? %>
           <p class="qr-url"><%= @public_url %></p>
         <% end %>
+        <%# The reader is looking at the QR, which is the thing that can one day
+            stop resolving — so this is where the permanence note belongs, not
+            on the cover (which doubles as the Etsy thumbnail) or the license
+            page (where it would read as a restriction on the buyer). Worded as
+            a next action rather than a disclaimer: on a product page,
+            "not guaranteed" reads as a warning about what was just paid for. %>
+        <p class="qr-note">
+          Shared boards can change or move over time. Make a free account and
+          save your own copy — it stays in your account, exactly as it is here.
+        </p>
       </div>
     <% end %>
 

--- a/app/views/api/board_printables/how_to_use.html.erb
+++ b/app/views/api/board_printables/how_to_use.html.erb
@@ -112,12 +112,14 @@
       <div class="step wide">
         <span class="num">6</span>
         <div>
-          <p class="lead">Editing online</p>
+          <%# Deliberately outside step 1's @variant branch, so this copy is
+              identical in the colour, low-ink and trim-ready files. %>
+          <p class="lead">Save your own copy</p>
           <p>
             To change a picture or a word online, create a free account at
             speakanyway.com and save your own copy first — the shared version isn't
-            yours to edit. Your copy also keeps this exact set of words, since a
-            shared board can change over time and may stop matching this print.
+            yours to edit. Your copy keeps this exact set of words and stays in
+            your account, even if the shared board later changes or moves.
           </p>
         </div>
       </div>

--- a/app/views/layouts/pdf_printable.html.erb
+++ b/app/views/layouts/pdf_printable.html.erb
@@ -285,6 +285,17 @@
         color: var(--blue-mid);
       }
 
+      /* Sits under the URL on the about page. Narrower than the card so it
+         wraps to two or three short lines instead of one wide one. */
+      .qr-card .qr-note {
+        font-size: 8.5pt;
+        line-height: 1.35;
+        color: var(--ink);
+        max-width: 2.9in;
+        text-align: center;
+        text-wrap: balance;
+      }
+
       .cover-footer {
         flex: 0 0 auto;
         padding: 0 0.9in 0.55in;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
         post :publish_to_etsy
         post :regenerate_listing_images
         post :regenerate
+        post :waive_protection
       end
     end
   end

--- a/db/migrate/20260817120000_add_protection_waiver_to_board_printables.rb
+++ b/db/migrate/20260817120000_add_protection_waiver_to_board_printables.rb
@@ -1,0 +1,20 @@
+# A board backing a published printable is protected from deletion, unpublish
+# and rename (Boards::MarketplaceProtection). Protection keys on
+# `etsy_listing_id` and is otherwise permanent — what it defends is printed
+# paper carrying a QR, and ending an Etsy listing doesn't un-print that. The
+# waiver is the one deliberate, audited way back out.
+#
+# The GIN index backs the `board_ids @> '[123]'` containment lookup, which is
+# how a CHILD page of a printed tree is recognised as protected.
+class AddProtectionWaiverToBoardPrintables < ActiveRecord::Migration[8.0]
+  def change
+    add_column :board_printables, :protection_waived_at, :datetime
+    add_column :board_printables, :protection_waived_by_id, :bigint
+    add_column :board_printables, :protection_waived_reason, :string
+
+    add_index :board_printables, :protection_waived_by_id
+    add_index :board_printables, :board_ids, using: :gin
+
+    add_foreign_key :board_printables, :users, column: :protection_waived_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_12_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -241,10 +241,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_12_120000) do
     t.string "etsy_listing_url"
     t.datetime "etsy_published_at"
     t.text "etsy_error"
+    t.datetime "protection_waived_at"
+    t.bigint "protection_waived_by_id"
+    t.string "protection_waived_reason"
     t.index ["board_id", "status"], name: "index_board_printables_on_board_id_and_status"
     t.index ["board_id"], name: "index_board_printables_on_board_id"
+    t.index ["board_ids"], name: "index_board_printables_on_board_ids", using: :gin
     t.index ["created_by_id"], name: "index_board_printables_on_created_by_id"
     t.index ["etsy_listing_id"], name: "index_board_printables_on_etsy_listing_id"
+    t.index ["protection_waived_by_id"], name: "index_board_printables_on_protection_waived_by_id"
   end
 
   create_table "board_screenshot_cells", force: :cascade do |t|
@@ -1164,6 +1169,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_12_120000) do
   add_foreign_key "board_images", "images"
   add_foreign_key "board_printables", "boards"
   add_foreign_key "board_printables", "users", column: "created_by_id"
+  add_foreign_key "board_printables", "users", column: "protection_waived_by_id"
   add_foreign_key "board_screenshot_cells", "board_screenshot_imports"
   add_foreign_key "board_screenshot_imports", "users"
   add_foreign_key "boards", "users"

--- a/spec/models/board_marketplace_protection_spec.rb
+++ b/spec/models/board_marketplace_protection_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+# The model-level half of marketplace protection: the guards that fire no
+# matter which code path reaches the board. The controllers check up front and
+# render a 409; these exist so a cascade, a rake task or a console session can't
+# get around it.
+RSpec.describe "Board marketplace protection" do
+  let(:user) { FactoryBot.create(:user) }
+  let(:root) { FactoryBot.create(:board, user: user, name: "Daily Routines", published: true, slug: "daily-routines") }
+  let(:page) { FactoryBot.create(:board, user: user, name: "Snack Time", published: true, slug: "snack-time") }
+
+  def publish_printable!(boards: [root, page])
+    BoardPrintable.create!(
+      board: root,
+      status: "complete",
+      board_ids: boards.map(&:id),
+      etsy_listing_id: 1234567890,
+    )
+  end
+
+  describe "deletion" do
+    it "refuses to destroy a protected board" do
+      publish_printable!
+
+      expect { root.destroy }.to raise_error(Board::MarketplaceProtectedError)
+      expect(Board.exists?(root.id)).to be true
+    end
+
+    it "refuses an interior page of the printed tree" do
+      publish_printable!
+
+      expect { page.destroy! }.to raise_error(Board::MarketplaceProtectedError)
+      expect(Board.exists?(page.id)).to be true
+    end
+
+    it "leaves an unprotected board alone" do
+      other = FactoryBot.create(:board, user: user)
+
+      expect { other.destroy! }.not_to raise_error
+    end
+
+    # The guard is prepend: true, so it fires before the dependent: :destroy
+    # cascades. Without that, every tile and printable is destroyed and rolled
+    # back to reach the same refusal.
+    it "does not destroy the board's tiles on the way to refusing" do
+      publish_printable!
+      image = FactoryBot.create(:image)
+      root.add_image(image.id)
+
+      expect { root.destroy }.to raise_error(Board::MarketplaceProtectedError)
+      expect(root.reload.board_images.count).to eq(1)
+    end
+
+    # Raise rather than throw :abort, because this is the caller that would
+    # swallow a false return: BoardGroup destroys its members with destroy_all,
+    # which checks nothing. Aborting there would destroy the group and leave the
+    # protected board orphaned — worse than the deletion.
+    it "aborts a BoardGroup cascade whole, leaving every member intact" do
+      # builder: true is what makes the group OWN its members and cascade the
+      # destroy — a plain group only drops its memberships.
+      group = FactoryBot.create(:board_group, user: user, builder: true)
+      group.boards << root
+      group.boards << page
+      publish_printable!
+
+      expect { group.destroy }.to raise_error(Board::MarketplaceProtectedError)
+      expect(Board.exists?(root.id)).to be true
+      expect(Board.exists?(page.id)).to be true
+      expect(BoardGroup.exists?(group.id)).to be true
+    end
+
+    it "goes through once protection is waived" do
+      printable = publish_printable!
+      printable.waive_protection!(user: user)
+
+      expect { page.reload.destroy! }.not_to raise_error
+    end
+
+    # Console/rake hatch. Deliberately not reachable from any request param.
+    it "has an explicit console escape hatch" do
+      publish_printable!
+
+      expect { page.destroy_despite_marketplace_protection! }.not_to raise_error
+      expect(Board.exists?(page.id)).to be false
+    end
+  end
+
+  describe "unpublishing" do
+    it "refuses to unpublish a protected board" do
+      publish_printable!
+
+      expect { root.update!(published: false) }.to raise_error(Board::MarketplaceProtectedError)
+      expect(root.reload.published).to be true
+    end
+
+    it "allows publishing, which can't break printed paper" do
+      publish_printable!
+      root.update_column(:published, false)
+
+      expect { root.reload.update!(published: true) }.not_to raise_error
+    end
+
+    it "allows an ordinary save that doesn't touch published" do
+      publish_printable!
+
+      expect { root.update!(description: "a description") }.not_to raise_error
+    end
+  end
+
+  describe "slugs" do
+    # freeze_published_slug REVERTS rather than raising, because the frontend
+    # re-derives the slug from the name on every rename. That must stay true for
+    # a protected board too — the raise belongs on the deliberate hatch, not on
+    # the ordinary save.
+    it "still reverts an ordinary slug change silently, without raising" do
+      publish_printable!
+
+      expect { root.update!(slug: "something-else") }.not_to raise_error
+      expect(root.reload.slug).to eq("daily-routines")
+    end
+
+    # rename_slug! is the "I really mean it" hatch — and it's exactly the one
+    # that would 404 a printed QR.
+    it "refuses the deliberate rename hatch" do
+      publish_printable!
+
+      expect { root.rename_slug!("brand-new-slug") }.to raise_error(Board::MarketplaceProtectedError)
+      expect(root.reload.slug).to eq("daily-routines")
+    end
+
+    it "renames when the second opt-in is set" do
+      publish_printable!
+      root.allow_marketplace_protected_change = true
+
+      root.rename_slug!("brand-new-slug")
+
+      expect(root.reload.slug).to eq("brand-new-slug")
+    end
+  end
+end

--- a/spec/requests/admin/board_printables_protection_spec.rb
+++ b/spec/requests/admin/board_printables_protection_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+# The admin half of marketplace protection: the banner that explains why a
+# board is frozen, and the one deliberate way to release it.
+RSpec.describe "Admin::BoardPrintables marketplace protection", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+  let(:root) { create(:board, user: admin, name: "Daily Routines", published: true) }
+  let(:page) { create(:board, user: admin, name: "Snack Time", published: true) }
+
+  let(:printable) do
+    BoardPrintable.create!(
+      board: root,
+      status: "complete",
+      board_ids: [root.id, page.id],
+      etsy_listing_id: 1234567890,
+    )
+  end
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+    sign_in admin
+  end
+
+  describe "the show page" do
+    it "explains that the printable's boards are frozen" do
+      get admin_dashboard_board_printable_path(printable)
+
+      expect(response.body).to include("Protected")
+      expect(response.body).to include("2 boards")
+      expect(response.body).to include("renamed or unpublished")
+      expect(response.body).to include("Release protection")
+    end
+
+    it "says nothing when the printable never reached Etsy" do
+      unpublished = BoardPrintable.create!(board: root, status: "complete", board_ids: [root.id])
+
+      get admin_dashboard_board_printable_path(unpublished)
+
+      expect(response.body).not_to include("Release protection")
+    end
+  end
+
+  describe "POST waive_protection" do
+    it "releases the boards and records who did it" do
+      post waive_protection_admin_dashboard_board_printable_path(printable)
+
+      expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
+      expect(printable.reload.protection_waived_at).to be_present
+      expect(printable.protection_waived_by).to eq(admin)
+      expect(root.reload.marketplace_protected?).to be false
+    end
+
+    # The listing pointer is deliberately untouched — the record still has to
+    # say which Etsy draft this was.
+    it "keeps the Etsy listing id" do
+      post waive_protection_admin_dashboard_board_printable_path(printable)
+
+      expect(printable.reload.etsy_listing_id).to eq(1234567890)
+    end
+
+    it "lets the board be deleted afterwards" do
+      post waive_protection_admin_dashboard_board_printable_path(printable)
+
+      expect { page.reload.destroy! }.not_to raise_error
+    end
+
+    it "refuses when the printable was never published" do
+      unpublished = BoardPrintable.create!(board: root, status: "complete", board_ids: [root.id])
+
+      post waive_protection_admin_dashboard_board_printable_path(unpublished)
+
+      expect(flash[:alert]).to include("isn't protecting anything")
+      expect(unpublished.reload.protection_waived_at).to be_nil
+    end
+
+    it "is a no-op when protection was already released" do
+      printable.waive_protection!(user: admin)
+      first_stamp = printable.reload.protection_waived_at
+
+      post waive_protection_admin_dashboard_board_printable_path(printable)
+
+      expect(flash[:alert]).to include("already released")
+      expect(printable.reload.protection_waived_at).to eq(first_stamp)
+    end
+
+    it "is closed to non-admins" do
+      sign_in create(:user)
+
+      post waive_protection_admin_dashboard_board_printable_path(printable)
+
+      expect(response).to redirect_to(root_path)
+      expect(printable.reload.protection_waived_at).to be_nil
+    end
+  end
+
+  describe "the board picker" do
+    it "badges a board that's already sold as a printable" do
+      printable
+
+      get admin_dashboard_board_printables_path(board_search: "Snack Time")
+
+      expect(response.body).to include("Protected")
+    end
+  end
+end

--- a/spec/requests/api/boards_marketplace_protection_spec.rb
+++ b/spec/requests/api/boards_marketplace_protection_spec.rb
@@ -1,0 +1,211 @@
+require "rails_helper"
+
+# A board whose content was sold as a printable is frozen: printed sheets carry
+# a QR pointing at /pb/<slug> and paper can't be re-issued. Deleting,
+# unpublishing and renaming are refused outright; structural tile edits are
+# refused once and then allowed with confirm_marketplace_edit=true.
+#
+# Everything here is 409 — a state conflict, matching the existing board_in_use
+# and publish_cascade warnings. 403 stays reserved for permission/plan gates.
+RSpec.describe "API::Boards marketplace protection", type: :request do
+  # Admin: the boards that back a listing are the shop owner's own, and it
+  # keeps the plan-limit read-only lock (403 board_locked) out of the way, so
+  # every status asserted below is protection's own.
+  let(:user) { create(:admin_user) }
+  let(:root) { create(:board, user: user, name: "Daily Routines", published: true, slug: "daily-routines") }
+  let(:page) { create(:board, user: user, name: "Snack Time", published: true, slug: "snack-time") }
+
+  def publish_printable!(boards: [root, page])
+    BoardPrintable.create!(
+      board: root,
+      status: "complete",
+      board_ids: boards.map(&:id),
+      etsy_listing_id: 1234567890,
+      etsy_listing_url: "https://www.etsy.com/listing/1234567890",
+    )
+  end
+
+  def body = JSON.parse(response.body)
+
+  describe "DELETE /api/boards/:id" do
+    it "refuses a protected board with 409 and the listing details" do
+      publish_printable!
+
+      delete "/api/boards/#{root.id}", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_protected")
+      expect(body["board"]).to include("id" => root.id, "name" => "Daily Routines")
+      expect(body["marketplace"]["printables"].first["etsy_listing_id"]).to eq(1234567890)
+      expect(Board.exists?(root.id)).to be true
+    end
+
+    it "refuses an interior page of the printed tree" do
+      publish_printable!
+
+      delete "/api/boards/#{page.id}", headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_protected")
+      expect(body["marketplace"]["role"]).to eq("page")
+    end
+
+    # This 409 is not confirmable. board_in_use is — the client's correct
+    # response there is to resend with confirm=true — so the two must not be
+    # answered by the same key or the client learns to retry into a wall.
+    it "is not cleared by confirm=true" do
+      publish_printable!
+
+      delete "/api/boards/#{root.id}", params: { confirm: "true" }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_protected")
+      expect(Board.exists?(root.id)).to be true
+    end
+
+    # Protection is checked before UsageCheck: showing the confirmable warning
+    # first would teach the client to retry into the unconfirmable one.
+    it "answers before board_in_use when the board is both" do
+      publish_printable!
+      create(:board_image, board: create(:board, user: user), predictive_board_id: root.id)
+
+      delete "/api/boards/#{root.id}", headers: auth_headers(user)
+
+      expect(body["error"]).to eq("board_marketplace_protected")
+    end
+
+    it "still deletes a board whose printable never reached Etsy" do
+      BoardPrintable.create!(board: root, status: "complete", board_ids: [root.id])
+
+      delete "/api/boards/#{root.id}", headers: auth_headers(user)
+
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(root.id)).to be false
+    end
+
+    it "deletes once protection is waived" do
+      publish_printable!.waive_protection!(user: user)
+
+      delete "/api/boards/#{page.id}", headers: auth_headers(user)
+
+      expect(response.status).to be_in([200, 204])
+      expect(Board.exists?(page.id)).to be false
+    end
+
+    describe "delete_subboards=true with a protected child" do
+      # Refuse the cascade WHOLE rather than skipping the protected child:
+      # skipping deletes the parent and leaves the page behind with a folder
+      # tile pointing at nothing, which is the corruption this prevents.
+      it "deletes nothing at all" do
+        parent = create(:board, user: user, name: "Parent")
+        create(:board_image, board: parent, predictive_board_id: page.id)
+        publish_printable!(boards: [page])
+
+        delete "/api/boards/#{parent.id}",
+               params: { delete_subboards: "true", confirm: "true" },
+               headers: auth_headers(user)
+
+        expect(response).to have_http_status(:conflict)
+        expect(body["error"]).to eq("board_marketplace_protected")
+        expect(body["blocked_subboards"].map { |b| b["id"] }).to include(page.id)
+        expect(Board.exists?(parent.id)).to be true
+        expect(Board.exists?(page.id)).to be true
+      end
+    end
+  end
+
+  describe "PUT /api/boards/:id" do
+    it "refuses to unpublish a protected board" do
+      publish_printable!
+
+      put "/api/boards/#{root.id}", params: { board: { published: false } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_protected")
+      expect(body["blocked_action"]).to eq("unpublished")
+      expect(root.reload.published).to be true
+    end
+
+    it "refuses to rename a protected board" do
+      publish_printable!
+
+      put "/api/boards/#{root.id}", params: { board: { name: "Something Else" } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["blocked_action"]).to eq("rename")
+      expect(root.reload.name).to eq("Daily Routines")
+    end
+
+    it "allows a save that re-sends the same name" do
+      publish_printable!
+
+      put "/api/boards/#{root.id}",
+          params: { board: { name: "Daily Routines", description: "hello" } },
+          headers: auth_headers(user)
+
+      expect(response).to have_http_status(:success)
+      expect(root.reload.description).to eq("hello")
+    end
+
+    # A favorite/tags/category save isn't structural, so it shouldn't prompt.
+    it "does not prompt on a non-structural save" do
+      publish_printable!
+
+      put "/api/boards/#{root.id}", params: { board: { category: "routines" } }, headers: auth_headers(user)
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "structural tile edits" do
+    it "warns once, then goes through with confirm_marketplace_edit" do
+      publish_printable!
+      image = create(:image)
+
+      put "/api/boards/#{root.id}/associate_image",
+           params: { image_id: image.id },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_edit_confirmation_required")
+      expect(root.reload.board_images.count).to eq(0)
+
+      put "/api/boards/#{root.id}/associate_image",
+           params: { image_id: image.id, confirm_marketplace_edit: "true" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:success)
+      expect(root.reload.board_images.count).to eq(1)
+    end
+
+    # Deliberately NOT `confirm`, which #update already means "yes, cascade the
+    # publish" by. One click must not authorize the other thing.
+    it "is not satisfied by the publish-cascade confirm param" do
+      publish_printable!
+      image = create(:image)
+
+      put "/api/boards/#{root.id}/associate_image",
+           params: { image_id: image.id, confirm: "true" },
+           headers: auth_headers(user)
+
+      expect(response).to have_http_status(:conflict)
+      expect(body["error"]).to eq("board_marketplace_edit_confirmation_required")
+    end
+  end
+
+  # SpeakAnyWay is an AAC app: reading a board, loading it and playing its audio
+  # are never gated, throttled or broken. Protection is about writes only.
+  describe "reads on a protected board" do
+    before { publish_printable! }
+
+    it "serves the board" do
+      get "/api/boards/#{root.id}", headers: auth_headers(user)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "serves the PDF" do
+      get "/api/boards/#{root.id}/pdf", headers: auth_headers(user)
+      expect(response.status).to be_in([200, 302])
+    end
+  end
+end

--- a/spec/requests/api/boards_marketplace_protection_spec.rb
+++ b/spec/requests/api/boards_marketplace_protection_spec.rb
@@ -204,6 +204,10 @@ RSpec.describe "API::Boards marketplace protection", type: :request do
     end
 
     it "serves the PDF" do
+      # Same stub as board_pdf_spec: CI has no Chrome, and what's under test
+      # here is that the request isn't gated, not that Grover works.
+      allow(Grover).to receive(:new).and_return(instance_double(Grover, to_pdf: "%PDF-fake"))
+
       get "/api/boards/#{root.id}/pdf", headers: auth_headers(user)
       expect(response.status).to be_in([200, 302])
     end

--- a/spec/services/boards/marketplace_protection_spec.rb
+++ b/spec/services/boards/marketplace_protection_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe Boards::MarketplaceProtection do
+  let(:user) { FactoryBot.create(:user) }
+  let(:root) { FactoryBot.create(:board, user: user, name: "Daily Routines") }
+  let(:page) { FactoryBot.create(:board, user: user, name: "Snack Time") }
+  let(:unrelated) { FactoryBot.create(:board, user: user, name: "Something Else") }
+
+  def printable(listing_id: 1234567890, boards: [root, page], **attrs)
+    BoardPrintable.create!(
+      board: root,
+      status: "complete",
+      board_ids: boards.map(&:id),
+      etsy_listing_id: listing_id,
+      etsy_listing_url: "https://www.etsy.com/listing/#{listing_id}",
+      **attrs,
+    )
+  end
+
+  it "protects the board the printable was generated from" do
+    printable
+
+    expect(described_class.new(root).protected?).to be true
+    expect(described_class.new(root).role).to eq(:root)
+  end
+
+  # The whole point of covering board_ids: every interior page of a printed set
+  # carries its own QR pointing at its own /pb/<slug>, so deleting page 4 breaks
+  # the product exactly as badly as deleting the root.
+  it "protects an interior page of the printed tree" do
+    printable
+
+    expect(described_class.new(page).protected?).to be true
+    expect(described_class.new(page).role).to eq(:page)
+  end
+
+  it "leaves boards the printable never covered alone" do
+    printable
+
+    expect(described_class.new(unrelated).protected?).to be false
+  end
+
+  # Generating a printable to look at it is the normal way to use the admin.
+  # Locking a board every time would make the feature something to avoid.
+  it "does not protect until the printable reaches Etsy" do
+    BoardPrintable.create!(board: root, status: "complete", board_ids: [root.id, page.id])
+
+    expect(described_class.new(root).protected?).to be false
+    expect(described_class.new(page).protected?).to be false
+  end
+
+  it "stops protecting once protection is waived" do
+    record = printable
+    expect(described_class.new(root).protected?).to be true
+
+    record.waive_protection!(user: user, reason: "listing ended")
+
+    expect(described_class.new(root).protected?).to be false
+    expect(described_class.new(page).protected?).to be false
+  end
+
+  # A printable that failed before Generate wrote board_ids still names a real
+  # board through its belongs_to, and that board is still what was sold.
+  it "falls back to board_id when board_ids was never written" do
+    printable(boards: [])
+
+    expect(described_class.new(root).protected?).to be true
+  end
+
+  # board_ids holds INTEGERS (Boards::Printables::Generate writes
+  # `collected[:boards].map(&:id)`). The `@>` containment lookup compares JSON
+  # values, so a string would silently never match and every interior page
+  # would quietly lose its protection.
+  it "matches on integer board_ids, not strings" do
+    record = printable
+    expect(record.reload.board_ids).to all(be_a(Integer))
+
+    record.update_column(:board_ids, [page.id.to_s])
+
+    expect(described_class.new(page).protected?).to be false
+  end
+
+  describe ".protected_board_ids" do
+    it "returns only the protected ids from the batch, in one query" do
+      printable
+
+      result = described_class.protected_board_ids([root.id, page.id, unrelated.id])
+
+      expect(result).to eq(Set[root.id, page.id])
+    end
+
+    it "is empty for an empty batch" do
+      expect(described_class.protected_board_ids([])).to eq(Set.new)
+    end
+
+    it "accepts Board records as well as ids" do
+      printable
+
+      expect(described_class.protected_board_ids([page])).to eq(Set[page.id])
+    end
+  end
+
+  describe "#summary" do
+    it "names the listing and the printable's root board" do
+      printable
+
+      summary = described_class.new(page).summary
+
+      expect(summary[:role]).to eq(:page)
+      expect(summary[:printables].first).to include(
+        etsy_listing_id: 1234567890,
+        root_board: { id: root.id, name: "Daily Routines" },
+      )
+    end
+
+    it "is nil when nothing protects the board" do
+      expect(described_class.new(unrelated).summary).to be_nil
+    end
+  end
+end

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -190,7 +190,23 @@ RSpec.describe Boards::Printables::RenderWrappers do
     it "warns that a shared board can drift from the print" do
       render
 
-      expect(rendered[:how_to_use]).to include("may stop matching this print")
+      expect(rendered[:how_to_use]).to include("even if the shared board later changes or moves")
+    end
+
+    # The point of the step is the buyer's own copy, which is the only thing
+    # that survives the shared board changing. It sits outside step 1's variant
+    # branch, so all three files say it identically.
+    it "tells the buyer to save their own copy, in every variant" do
+      render(board_count: 4)
+
+      [
+        rendered[:how_to_use],
+        rendered[:how_to_use_low_ink],
+        rendered[:how_to_use_trim_ready],
+      ].each do |html|
+        expect(html).to include("Save your own copy")
+        expect(html).to include("even if the shared board later changes or moves")
+      end
     end
 
     # The QR opens a web page, not a native app — three pages used to describe
@@ -220,6 +236,36 @@ RSpec.describe Boards::Printables::RenderWrappers do
 
     expect(rendered[:credits]).to include("About SpeakAnyWay")
     expect(rendered[:credits]).to include("data:image/png;base64,")
+  end
+
+  describe "the permanence note" do
+    # Sits beside the QR, which is the thing that can one day stop resolving.
+    it "sits under the QR on the credits page" do
+      render
+
+      expect(rendered[:credits]).to include("can change or move over time")
+      expect(rendered[:credits]).to include("save your own copy")
+    end
+
+    # The cover assigns are shared verbatim with RenderListingImages, so the
+    # cover IS the Etsy search thumbnail. A "may not stay online" line there
+    # reads as a disclaimer about the thing the buyer is about to pay for.
+    it "never appears on the cover" do
+      render(board_count: 4)
+
+      [rendered[:cover], rendered[:cover_low_ink]].each do |html|
+        expect(html).not_to include("can change or move over time")
+        expect(html).not_to include("save your own copy")
+      end
+    end
+
+    # Surrounded by the anti-redistribution terms it would read as a limit on
+    # the buyer's rights rather than a helpful nudge.
+    it "never appears on the license page" do
+      render
+
+      expect(rendered[:license]).not_to include("can change or move over time")
+    end
   end
 
   # MergePdf emits a separate low-ink FILE for a set, and it opens on its own


### PR DESCRIPTION
## What & why

A board whose content was sold as a printable had no protection at all. `Board has_many :board_printables, dependent: :destroy` and `Boards::UsageCheck` never looked at printables, so **deleting a board silently destroyed the only record of its Etsy listing** — and `Etsy::Client` implements no delete call to clean up after it. Unpublishing was quieter still: `/pb/<slug>` is what every printed QR encodes, with no redirect behind it, so a flip of `published` 404s laminated paper already in someone's hands.

Backend + admin only.

## Two design decisions worth reviewing

**No new listing table.** `board_printables` already carries `board_id`, `board_ids`, `etsy_listing_id`, `etsy_listing_url`, `etsy_published_at`. A second table would duplicate it, so protection is derived from what's there.

**Protection keys on `etsy_listing_id`, not a `draft/active/ended` state column.** The obvious design models the wrong fact: what protection defends is a printed sheet with a QR on it, and ending an Etsy listing doesn't recall a laminated board off a fridge. Such a column would also be hand-maintained against a shop this app cannot read, and its one drift mode is the unsafe one — you end a listing, forget to flip the column, and the boards unprotect while the paper is still live. Release is instead an explicit, audited act: `BoardPrintable#waive_protection!` stamped with who and when, behind a **Release protection** button.

Protection deliberately does *not* trigger on a printable merely existing — generating one to look at it is the normal way to use the admin, and locking a board every time would make the feature something to avoid.

## What changed

**`Boards::MarketplaceProtection`** (new) is the single authority, shaped like its sibling `Boards::UsageCheck`. It covers the **whole printed tree** — matching `board_printables.board_ids` (jsonb array of integers, new GIN index, `@>` containment) unioned with `board_id` — because every interior page carries its own QR pointing at its own `/pb/<slug>`. Deleting page 4 of a twelve-page set breaks the product as badly as deleting the root.

**Enforcement**
- **Delete / unpublish / rename** → 409 `board_marketplace_protected`, not clearable by any request param. Checked **before** `Boards::UsageCheck`: `board_in_use` is confirmable and this isn't, so answering with the confirmable one first would teach the client to retry into a wall.
- **Structural tile edits** → 409 `board_marketplace_edit_confirmation_required` once, then proceed on `confirm_marketplace_edit=true`. Deliberately *not* `confirm`, which `#update` already spends on the publish cascade — one click must not authorize the other thing.
- **Model guard raises**, never `throw :abort`, with `prepend: true`. The cascades that can reach a protected board ignore a false return (`BoardGroup` uses `destroy_all`, `Admin::BoardBuildsController` uses `reverse_each(&:destroy)`), so aborting would destroy the group and leave the board orphaned — worse than the deletion. `prepend` keeps the `dependent: :destroy` cascades from running and rolling back to reach the same refusal.
- **Cascades are refused whole** (`delete_subboards`, builder group, unpublish cascade). Skipping the protected member would delete its parent and leave it behind with a folder tile pointing at nothing — the exact corruption this prevents.
- Admin banner, picker badge (one batched query, no N+1), console/rake escape hatch that is never wired to a request param.

**Two holes the original design didn't anticipate, both closed:**
- `Boards::PublishCascade#apply!` writes with `update_all`, which skips callbacks entirely — a protected member page would have been unpublished with nothing to stop it. It now has its own pre-check.
- `Board#rename_slug!` — the deliberate-rename hatch behind `force_slug` and the rake task — is precisely what would silently 404 printed paper, so it needs a second opt-in. `freeze_published_slug` still **reverts rather than raises** on the ordinary path, because the frontend re-derives the slug from the name on every rename.

**Reads, PDF exports and audio are never gated**, per the AAC invariant.

**Buyer-facing PDF note.** The credits QR card and how-to-use step 6 now explain that a shared board can change or move, and that a free account keeps this exact set of words. Wrapper templates only — the shared `api/boards/print` + `layouts/pdf` pair backing real users' downloads is byte-identical. The **cover is deliberately excluded**: `RenderWrappers#cover_assigns` is shared verbatim with `RenderListingImages`, so the cover *is* the Etsy search thumbnail, and a "may not stay online" line would ship as the product's first photo. Worded as a next action rather than a disclaimer — "isn't guaranteed forever" on a product page reads as a warning about what was just paid for.

## Test plan

49 new examples across four spec files, plus extensions to `render_wrappers_spec`.

```
bundle exec rspec spec/services/boards/marketplace_protection_spec.rb \
  spec/models/board_marketplace_protection_spec.rb \
  spec/requests/api/boards_marketplace_protection_spec.rb \
  spec/requests/admin/board_printables_protection_spec.rb
```

Notable cases: an interior page of the tree is protected; `confirm=true` does **not** bypass; protection answers before `board_in_use`; `delete_subboards` with a protected child deletes **nothing**; a `BoardGroup` cascade aborts leaving every member intact; `board_ids` holds integers so `@>` matches (a string would silently unprotect every page); the ordinary slug rename still reverts silently without raising; the notice is absent from the cover and license pages; and an AAC-invariant block asserting `show`/`pdf` are unaffected.

Regression set run green: `boards_destroy`, `boards_published_slug_freeze`, `boards_publish_cascade`, `board_printable`, all of `spec/requests/admin/`, `board_spec`, `spec/services/boards/`, `spec/services/boards/printables/` — **660 examples, 0 failures**. Targeted set re-run after rebasing onto `origin/main`: 100 examples, 0 failures. Migration applied locally.

## Reviewer notes

⚠️ **The frontend doesn't know the two new 409 keys yet**, so a structural edit on a protected board will surface a raw error in the board editor until it's taught. That's the safety property working, but it reads as a bug. Handoff written to `.claude-notes/marketplace-protection-frontend-handoff.md` (untracked, local). `Board#api_view` now carries `marketplace_protected` / `marketplace_protection`, **computed for admins only** — it costs a query, and which boards are for sale isn't a member's business.

⚠️ **Worth eyeballing one regenerated PDF.** The how-to-use copy is the same length as what it replaced, but an overflow there silently pushes the page to two and changes `page_count`.

Docs updated: `.claude-notes/board-printables-etsy.md` (new "Listed boards are protected" section + the cover trap), `.claude-notes/boards-and-teams.md` (error keys + ordering rule), `CLAUDE.md` (one invariant bullet + 409 semantics), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)