### PR TITLE
feat(menus): size a menu board's grid from its tile count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **A board made from a menu photo now fits its own grid.** Menu boards were
+  always built eight tiles wide no matter what the photo held, so a six-item
+  café menu arrived as one long strip and a forty-item diner menu as a wide
+  block with a ragged last row. The grid is now sized from the number of items
+  actually found on the menu, squaring up whenever the count allows it — nine
+  items land 3×3, sixteen land 4×4, twenty-five land 5×5 — and a very long menu
+  gets taller rather than squeezing tiles too small to hit on a tablet. The
+  board also now reports the same width it is drawn at; the two had drifted
+  apart (laid out at eight columns, described as six).
 - **AI board drafts now come back laid out, not just filled in.** The order the
   AI answers in is the order the tiles land on the grid, so a scrambled word list
   was a scrambled board: a verb, a noun, a pronoun, another noun, and the

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -111,16 +111,32 @@ class Menu < ApplicationRecord
       board.name = self.name || "Board for Doc #{id}"
       board.token_limit = token_limit
       board.description = new_doc.processed
-      board.number_of_columns = 6
       board.save!
       new_doc.update!(board_id: board.id)
       create_images_from_description(board)
+      apply_grid_columns!(board)
       board.reset_layouts
       board
     rescue => e
       Rails.logger.error "**** ERROR **** \n#{e.message}\n#{e.backtrace}\n"
       nil
     end
+  end
+
+  # The tile count isn't known until the vision result has been turned into
+  # tiles, so the grid is sized here rather than at board-create time: a menu
+  # board gets the squarest grid its own item count allows.
+  def apply_grid_columns!(board)
+    tile_count = board.board_images.reset.size
+    return if tile_count.zero?
+
+    columns = Boards::GridFit.columns_for(tile_count)
+    board.large_screen_columns = columns
+    board.medium_screen_columns = Boards::ScreenColumns.derive(columns, "md")
+    board.small_screen_columns = Boards::ScreenColumns.derive(columns, "sm")
+    # Keep the serialized value in step with the value the layout math reads.
+    board.number_of_columns = columns
+    board.save!
   end
 
   def public_url

--- a/app/services/boards/grid_fit.rb
+++ b/app/services/boards/grid_fit.rb
@@ -1,0 +1,37 @@
+module Boards
+  # Picks the grid width that makes the squarest, tightest grid for a known
+  # tile count. A menu board's tile count isn't known until the vision result
+  # has been turned into tiles, so its columns are chosen from the real count
+  # here rather than guessed at board-create time.
+  #
+  # Boards::ScreenColumns stays the authority for deriving md/sm from the
+  # large-screen count this returns.
+  module GridFit
+    module_function
+
+    MIN_COLUMNS = 2
+    # Ceiling on the large-screen grid so a long menu gets taller, not
+    # narrower-per-tile than a finger can hit on a tablet.
+    MAX_COLUMNS = 8
+
+    def columns_for(tile_count, min_columns: MIN_COLUMNS, max_columns: MAX_COLUMNS)
+      count = tile_count.to_i
+      return min_columns if count < 1
+
+      ideal = Math.sqrt(count).ceil
+      low = [ideal - 2, min_columns].max
+      high = [[ideal + 2, max_columns].min, low].max
+
+      # Lowest score wins; ties go to the wider grid, since screens are landscape.
+      (low..high).min_by { |columns| [score(count, columns), -columns] }
+    end
+
+    # Empty trailing cells cost 1 each; every step away from square costs 2,
+    # so "square with a couple of gaps" beats "exact fit but a long strip".
+    def score(count, columns)
+      rows = (count / columns.to_f).ceil
+      empty = (columns * rows) - count
+      empty + (2 * (columns - rows).abs)
+    end
+  end
+end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -57,6 +57,61 @@ RSpec.describe Menu, type: :model do
     end
   end
 
+  describe "#create_board_from_menu_image grid columns" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:menu) { FactoryBot.create(:menu, user: user, name: "Joe's Diner") }
+    let(:board) do
+      FactoryBot.create(:board, user: user, board_type: "menu", large_screen_columns: 8,
+                                medium_screen_columns: 6, small_screen_columns: 4,
+                                parent_type: "Menu", parent_id: menu.id)
+    end
+    let(:doc) { menu.docs.create!(user: user, processed: { "menu_items" => [] }.to_json) }
+
+    # Stand in for the real image build: the only thing the grid math cares
+    # about is how many tiles the menu ended up with.
+    def build_with_tiles(tile_count)
+      allow(menu).to receive(:create_images_from_description) do |b|
+        tile_count.times { FactoryBot.create(:board_image, board: b) }
+      end
+      menu.create_board_from_menu_image(doc, board.id)
+      board.reload
+    end
+
+    it "sizes the grid to an exact square when the item count allows one" do
+      build_with_tiles(16)
+
+      expect(board.large_screen_columns).to eq(4)
+      expect(board.rows_for_screen_size("lg")).to eq(4)
+    end
+
+    it "derives the medium and small counts from the large one" do
+      build_with_tiles(16)
+
+      expect(board.medium_screen_columns).to eq(Boards::ScreenColumns.derive(4, "md"))
+      expect(board.small_screen_columns).to eq(Boards::ScreenColumns.derive(4, "sm"))
+    end
+
+    it "keeps number_of_columns in step with the grid the layout uses" do
+      build_with_tiles(9)
+
+      expect(board.large_screen_columns).to eq(3)
+      expect(board.number_of_columns).to eq(board.get_number_of_columns("lg"))
+    end
+
+    it "lays every tile out inside the chosen width" do
+      build_with_tiles(10)
+
+      expect(board.large_screen_columns).to eq(4)
+      expect(board.layout["lg"].map { |cell| cell["x"] }.max).to eq(3)
+    end
+
+    it "leaves the board's columns alone when no tiles were created" do
+      build_with_tiles(0)
+
+      expect(board.large_screen_columns).to eq(8)
+    end
+  end
+
   describe "#create_images_from_description image budget" do
     let(:user) { FactoryBot.create(:user) }
     let(:menu) { FactoryBot.create(:menu, user: user, token_limit: 10) }

--- a/spec/services/boards/grid_fit_spec.rb
+++ b/spec/services/boards/grid_fit_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Boards::GridFit do
+  describe ".columns_for" do
+    it "returns the root for a perfect square so the grid is exactly square" do
+      { 4 => 2, 9 => 3, 16 => 4, 25 => 5, 36 => 6, 49 => 7, 64 => 8 }.each do |tiles, columns|
+        expect(described_class.columns_for(tiles)).to eq(columns),
+          "expected #{tiles} tiles to lay out #{columns}x#{columns}, got #{described_class.columns_for(tiles)}"
+      end
+    end
+
+    it "prefers a near-square grid with a gap over an exact but strip-shaped fit" do
+      # 10 tiles fit exactly at 5x2, but 4x3 with two gaps is the squarer grid.
+      expect(described_class.columns_for(10)).to eq(4)
+      # 24 fits exactly at 6x4; 5x5 with one gap is squarer.
+      expect(described_class.columns_for(24)).to eq(5)
+    end
+
+    it "breaks a tie toward the wider grid" do
+      expect(described_class.columns_for(6)).to eq(3)  # 3x2, not 2x3
+      expect(described_class.columns_for(12)).to eq(4) # 4x3, not 3x4
+      expect(described_class.columns_for(30)).to eq(6) # 6x5, not 5x6
+    end
+
+    it "caps the width so a long menu gets taller instead of denser" do
+      expect(described_class.columns_for(81)).to eq(described_class::MAX_COLUMNS)
+      expect(described_class.columns_for(100)).to eq(described_class::MAX_COLUMNS)
+    end
+
+    it "never drops below the minimum width" do
+      expect(described_class.columns_for(1)).to eq(described_class::MIN_COLUMNS)
+      expect(described_class.columns_for(0)).to eq(described_class::MIN_COLUMNS)
+      expect(described_class.columns_for(nil)).to eq(described_class::MIN_COLUMNS)
+    end
+
+    it "honors caller-supplied bounds" do
+      expect(described_class.columns_for(100, max_columns: 12)).to eq(10)
+      expect(described_class.columns_for(9, max_columns: 2)).to eq(2)
+    end
+
+    it "never leaves more empty cells than a full row" do
+      (1..100).each do |tiles|
+        columns = described_class.columns_for(tiles)
+        rows = (tiles / columns.to_f).ceil
+        expect((columns * rows) - tiles).to be < columns
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

A board built from a menu photo now picks its column count from the number of items actually found on the menu, squaring up whenever the count allows it.

Menu boards were always built eight tiles wide no matter what the photo held — a six-item café menu arrived as one long strip, a forty-item diner menu as a wide block with a ragged last row.

New `Boards::GridFit.columns_for(tile_count)` picks the squarest, tightest width: empty trailing cells cost 1 each and every step away from square costs 2, so "square with a gap or two" beats "exact fit but a long strip". Ties go to the wider grid, since screens are landscape.

```
9 → 3×3    16 → 4×4    25 → 5×5    36 → 6×6    49 → 7×7    64 → 8×8
10 → 4×3   12 → 4×3    20 → 5×4    24 → 5×5    100 → 8×13 (capped)
```

Capped at 8 columns so a long menu gets taller rather than squeezing tiles below a tappable size on an iPad.

`Menu#apply_grid_columns!` runs after the tiles exist and before `reset_layouts`, deriving md/sm through the existing `Boards::ScreenColumns`.

## Also fixes a real mismatch

The two column values had drifted apart. Layout math reads `large_screen_columns` (8, set in the controller) via `BoardsHelper#get_number_of_columns`, while `api_view` and `BoardImage#calucate_position` read `number_of_columns` (6, hardcoded in `Menu#create_board_from_menu_image`). So every menu board was laid out eight wide and described itself as six. Both now get the fitted value.

## Notes for a reviewer

- **Scope is menu boards only.** The non-square `ideal_columns_for` case-ladder is still duplicated in `api/generated_boards_controller.rb` and `api/internal/generated_boards_controller.rb`. `GridFit` is written as a shared service those could adopt later, but nothing else changes behavior here.
- The controller's `8 / 6 / 4` placeholders (`menus_controller.rb:116` and `:74`) are deliberately left alone — they only shape the board while its status is `pending`, and the model overwrites them once tiles land.
- `board.board_images.reset` before counting is load-bearing: `board_images_count` is a counter-cache column and the in-memory board is stale right after tile creation.

## Test plan

```bash
bundle exec rspec spec/services/boards/grid_fit_spec.rb spec/models/menu_spec.rb spec/requests/api/menus_spec.rb spec/sidekiq/enhance_image_description_job_spec.rb spec/controllers/api/menus_controller_spec.rb
```

**36 examples, 0 failures.**

- New `spec/services/boards/grid_fit_spec.rb` (7 examples): perfect squares return their root; near-square-with-a-gap beats strip-shaped exact fits (10→4, 24→5); tie-breaking toward the wider grid; the cap holds; `0`/`nil` floor at `MIN_COLUMNS`; plus a sweep over 1–100 asserting gaps never exceed a full row.
- New `#create_board_from_menu_image grid columns` block in `spec/models/menu_spec.rb` (5 examples): the exact-square case, md/sm derivation, `number_of_columns` staying in step with `get_number_of_columns("lg")`, real `layout["lg"]` cell positions staying inside the chosen width, and the no-tiles no-op leaving columns untouched.

CHANGELOG entry added under Unreleased → Changed. No docs/spoke changes — this is a behavior fix inside one build path, not a new invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)