### PR TITLE
feat(printables): detach and relist a published printable on Etsy

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -607,6 +607,45 @@ no migration; bump `BoardPrintable::VIDEO_SPEC_VERSION` to force a fleet-wide
 re-render. A hand-uploaded clip (`VIDEO_MANUAL`, the admin's "Upload instead"
 field) is never stale — nothing could re-render it.
 
+## Replacing a draft — "Detach & relist"
+
+This app **creates** listings and implements no call that updates one. So a
+re-rendered gallery or a newly rendered video **cannot reach an existing draft**
+— there is no code path, by design. `POST relist_on_etsy` is the way round it:
+it clears `etsy_listing_id` / `etsy_listing_url` so `guard_failure` stops
+refusing, and Publish then creates a fresh draft carrying the current images and
+video. It sends **nothing** to Etsy; deleting the superseded draft is the
+operator's job, because doing it here would mean adding the delete call the
+drafts-only invariant exists to keep out.
+
+**Two published-states, and they must not be collapsed:**
+
+| Predicate | Column | Means | Cleared by relist? |
+|---|---|---|---|
+| `etsy_published?` | `etsy_listing_id` | attached to a listing right now | **yes** |
+| `etsy_ever_published?` | `etsy_published_at` **OR** `etsy_listing_id` | a draft was made at some point | never |
+
+`etsy_ever_published?` is a **union**, and that is not belt-and-braces for its
+own sake: protection must never end up narrower than the `etsy_listing_id` test
+it replaced. A row carrying a listing id but no timestamp — set by hand, or by
+anything predating the two being written together — protected its boards before
+and has to keep doing so. `#relist!` stamps `etsy_published_at` before it drops
+the id, so such a row doesn't lose its only remaining evidence on the way past.
+Widening can only over-protect; narrowing unfreezes printed paper.
+
+**Marketplace protection keys on `etsy_ever_published?`.** It used to key on
+`etsy_listing_id`, which was fine while that column only ever went from nil to
+set. Relisting clears it, so leaving protection there would silently unfreeze
+boards whose printed pages already carry their QR codes — the precise failure
+protection exists to prevent. `Boards::MarketplaceProtection`'s SQL scope and
+`BoardPrintable#protects_board?` read the same column and must not diverge; the
+model spec asserts a relisted printable still protects.
+
+Everything protection-facing follows the same rule — the waiver action, the
+delete confirm, the release confirm, and the protection block in `_etsy` — since
+a detached printable still freezes its boards and would otherwise lose the only
+control that releases them.
+
 ## Publishing is never retried
 
 `PublishBoardPrintableToEtsyJob` is `retry: 0`. A retry after a partial success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A published printable can be relisted.** The app only ever creates Etsy
+  listings — it has no way to update one — so re-rendering a gallery or a video
+  could never reach a draft that already existed. "Detach & relist" on the Etsy
+  card releases the link so Publish makes a fresh draft with the current images
+  and video. Nothing is sent to Etsy; the old draft is yours to delete. The
+  boards the printable protects stay protected.
+
 - **The credits endpoint now reports your actual monthly allowance.**
   `GET /api/me/credits` returns a `plan_allowance` field alongside the existing
   balances, taken from the amount you were really granted this period rather

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -89,6 +89,29 @@ module Admin
       end
     end
 
+    # Detaches this printable from its Etsy draft so Publish can create a fresh
+    # one. The only way a re-rendered gallery reaches Etsy at all: this app
+    # CREATES listings and has no call that updates one, by design, so an
+    # existing draft can never be brought up to date in place.
+    #
+    # Deliberately does not touch Etsy. The old draft stays there until an
+    # operator deletes it, because deleting it from here would mean adding the
+    # delete call the drafts-only invariant exists to keep out.
+    def relist_on_etsy
+      printable = BoardPrintable.find(params[:id])
+
+      if !printable.etsy_published?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable isn't attached to an Etsy listing, so there's nothing to relist."
+      else
+        previous = printable.etsy_listing_id
+        printable.relist!
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    notice: "Detached from Etsy listing #{previous}. Delete that draft on Etsy, then publish " \
+                            "again to create a new one. The boards it protects stay protected."
+      end
+    end
+
     # Re-runs the whole PDF pipeline on the SAME record so the printable picks
     # up board edits. The tree is re-walked (Generate rewrites board_ids), so a
     # subboard added since the first run is included.
@@ -123,7 +146,9 @@ module Admin
     def waive_protection
       printable = BoardPrintable.find(params[:id])
 
-      if !printable.etsy_published?
+      # `ever_published`, not `published`: a relisted printable has no listing id
+      # while its boards are still frozen, and the waiver has to stay reachable.
+      if !printable.etsy_ever_published?
         redirect_to admin_dashboard_board_printable_path(printable),
                     alert: "This printable was never published to Etsy, so it isn't protecting anything."
       elsif printable.protection_waived?

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -43,12 +43,22 @@ module Admin
     # with it.
     def board_printable_delete_confirm(printable)
       base = "Delete this printable and its PDFs? This can't be undone."
-      return base unless printable.etsy_published?
+      return base unless printable.etsy_ever_published?
 
       # The second sentence is the less obvious consequence: this record is what
       # freezes its boards, so deleting it makes them deletable and renameable
       # again while the listing is still up.
-      "#{base} Etsy draft #{printable.etsy_listing_id} stays on Etsy — remove it there yourself. " \
+      #
+      # A relisted printable has no listing id to name — the draft it was
+      # detached from is still on Etsy, so the warning is if anything more
+      # important there, just less specific.
+      draft = if printable.etsy_published?
+        "Etsy draft #{printable.etsy_listing_id} stays on Etsy — remove it there yourself."
+      else
+        "Any Etsy draft made from this printable stays on Etsy — remove it there yourself."
+      end
+
+      "#{base} #{draft} " \
       "The #{pluralize(printable.protected_board_ids.size, "board")} it protects will no longer be protected."
     end
 
@@ -56,11 +66,25 @@ module Admin
       "bg-amber-900/60 text-amber-300"
     end
 
+    # The confirm on "Detach & relist". Says the two things an admin could
+    # otherwise get wrong: nothing here touches the draft on Etsy, and the
+    # boards stay frozen (protection is keyed on having ever been published, not
+    # on the listing id this clears).
+    def relist_confirm(printable)
+      "Detach this printable from Etsy listing #{printable.etsy_listing_id}? " \
+      "That draft is NOT deleted — remove it on Etsy yourself, or you'll have two. " \
+      "Publishing again creates a new draft with the current images and video. " \
+      "The #{pluralize(count = printable.protected_board_ids.size, "board")} it protects " \
+      "#{count == 1 ? "stays" : "stay"} protected."
+    end
+
     # The confirm on the release button. Names the listing id, because that's
     # the thing an admin should go look at before deciding the paper is dead.
     def waive_protection_confirm(printable)
+      listing = printable.etsy_published? ? "Etsy listing #{printable.etsy_listing_id}" : "The Etsy listing"
+
       "Release protection on #{pluralize(printable.protected_board_ids.size, "board")}? " \
-      "Etsy listing #{printable.etsy_listing_id} may still be live, and printed copies keep pointing at these boards. " \
+      "#{listing} may still be live, and printed copies keep pointing at these boards. " \
       "They become deletable, renameable and unpublishable again."
     end
 

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -354,17 +354,55 @@ class BoardPrintable < ApplicationRecord
     ids.filter_map { |id| by_id[id] }
   end
 
+  # Whether this printable is CURRENTLY linked to a marketplace listing. This is
+  # what stops a second draft being created for the same printable, and it is
+  # the one thing #relist! clears.
   def etsy_published? = etsy_listing_id.present?
+
+  # Whether a draft was EVER created from this printable.
+  #
+  # A UNION of the two columns, and deliberately never narrower than the
+  # `etsy_listing_id` test protection used to use: a row carrying a listing id
+  # but no timestamp (set by hand, or by any path that predates the two being
+  # written together) protected its boards before, and must keep protecting
+  # them. Widening can only over-protect; narrowing unfreezes printed paper.
+  def etsy_ever_published? = etsy_published_at.present? || etsy_listing_id.present?
 
   # Whether this printable freezes the boards it was rendered from.
   #
-  # Keyed on `etsy_listing_id`, NOT on the record existing: generating a
+  # Keyed on `etsy_published_at`, NOT on the record existing: generating a
   # printable to look at it is the normal way to use the admin, and locking a
-  # board every time would make the feature something to avoid. It is also not
-  # keyed on any "is the listing still live" state — the thing protection
-  # defends is a printed sheet with a QR on it, and ending an Etsy listing
-  # doesn't un-print that sheet. Release is the explicit waiver below.
-  def protects_board? = etsy_published? && protection_waived_at.nil?
+  # board every time would make the feature something to avoid.
+  #
+  # It is also not keyed on any "is the listing still live" state, and
+  # deliberately not on `etsy_listing_id` either. The thing protection defends
+  # is a printed sheet with a QR on it: ending an Etsy listing doesn't un-print
+  # that sheet, and neither does relisting. #relist! clears the listing id so a
+  # fresh draft can be created, so keying protection there would silently
+  # unfreeze boards whose printed pages are already in someone's hands — the
+  # exact failure this exists to prevent. Release is the explicit waiver below.
+  def protects_board? = etsy_ever_published? && protection_waived_at.nil?
+
+  # Forget which listing this printable is attached to, so Publish can create a
+  # fresh draft. For replacing a draft whose gallery is out of date: this app
+  # only ever CREATES listings — it has no path that updates one — so a
+  # re-rendered gallery can't reach an existing draft any other way.
+  #
+  # Deliberately does NOT touch `etsy_published_at` (protection reads it) or
+  # `protection_waived_at`. The old draft is left alone on Etsy; deleting it
+  # there is the operator's job, and doing it from here would mean implementing
+  # a delete call this app pointedly does not have.
+  def relist!
+    # Backfilled BEFORE the id is dropped, so a row that somehow carries a
+    # listing id without a timestamp doesn't lose its only remaining evidence of
+    # having been published — which is what protection reads.
+    update!(
+      etsy_published_at: etsy_published_at || Time.current,
+      etsy_listing_id: nil,
+      etsy_listing_url: nil,
+      etsy_error: nil,
+    )
+  end
 
   def protection_waived? = protection_waived_at.present?
 

--- a/app/services/boards/marketplace_protection.rb
+++ b/app/services/boards/marketplace_protection.rb
@@ -2,7 +2,8 @@ module Boards
   # Read-only "does a marketplace listing depend on this board?" check.
   #
   # A board is protected when a BoardPrintable that reached Etsy
-  # (`etsy_listing_id` present, protection not waived) was rendered from it.
+  # (ever published, protection not waived) was rendered from it — see
+  # BoardPrintable#etsy_ever_published? for why that is a union of two columns.
   # That covers the WHOLE printed tree, not just the printable's root board:
   # every interior page carries its own QR pointing at its own `/pb/<slug>`, so
   # deleting page 4 of a twelve-page set breaks the product exactly as badly as

--- a/app/services/boards/marketplace_protection.rb
+++ b/app/services/boards/marketplace_protection.rb
@@ -78,8 +78,14 @@ module Boards
         scope.or(BoardPrintable.where("board_printables.board_ids @> ?", [id].to_json))
       end
 
+      # The UNION of both columns, matching BoardPrintable#etsy_ever_published?.
+      # Not `etsy_listing_id` alone — #relist! clears that so a fresh draft can
+      # be created, and keying here on it would unfreeze every relisted
+      # printable's boards. Not `etsy_published_at` alone either: a row with an
+      # id and no timestamp used to be protected and still must be. The two
+      # definitions must not be able to disagree.
       BoardPrintable
-        .where.not(etsy_listing_id: nil)
+        .where("board_printables.etsy_published_at IS NOT NULL OR board_printables.etsy_listing_id IS NOT NULL")
         .where(protection_waived_at: nil)
         .merge(matching)
     end

--- a/app/services/etsy/publish_board_printable.rb
+++ b/app/services/etsy/publish_board_printable.rb
@@ -81,7 +81,11 @@ module Etsy
       return "This printable has no PDF files attached." if printable.pdf_files.empty?
 
       if printable.etsy_published?
-        return "Already on Etsy as listing #{printable.etsy_listing_id}. Delete that draft first if you want a new one."
+        # Naming the way out matters: deleting the draft on Etsy does NOT free
+        # this printable, because nothing there writes back here. "Detach &
+        # relist" is the only thing that clears the listing id.
+        return "Already on Etsy as listing #{printable.etsy_listing_id}. Use \"Detach & relist\" to " \
+               "make a replacement draft — deleting it on Etsy alone won't free this printable."
       end
 
       return "Listing title and description are required." if copy["title"].blank? || copy["description"].blank?

--- a/app/views/admin/board_printables/_etsy.html.erb
+++ b/app/views/admin/board_printables/_etsy.html.erb
@@ -1,7 +1,16 @@
 <%# Etsy. This creates a DRAFT and only a draft — there is no code path in the
     app that activates a listing. Going live stays a deliberate click in the
     Etsy seller UI, after a human has checked the category, the photos, and the
-    return policy. %>
+    return policy.
+
+    Two states are tracked separately and must not be collapsed:
+
+      etsy_published?       — attached to a listing RIGHT NOW. Gates publishing,
+                              and is what "Detach & relist" clears.
+      etsy_ever_published?  — a draft was made from this printable at some
+                              point. Gates marketplace PROTECTION, and is never
+                              cleared, because relisting doesn't un-print the
+                              paper already carrying these boards' QR codes. %>
 <div class="admin-card border rounded-xl p-5 mb-6">
   <h2 class="text-sm font-medium text-t1 mb-1">Etsy</h2>
   <p class="text-[11px] text-t3 mb-4">
@@ -32,14 +41,51 @@
     <%= link_to "Edit draft on Etsy ↗", etsy_listing_url_for(@printable),
           target: "_blank", rel: "noopener",
           class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
-    <p class="text-[11px] text-t3 mt-3">
-      To replace this draft, delete it in Etsy first — the app won't create a second listing for the
-      same printable, because a duplicate in a live shop is easy to miss and hard to undo.
-    </p>
 
-    <%# Protection is turned on by the listing id, so it belongs on this card.
-        Every board in the printed tree is covered, not just the root — each
-        interior page carries its own QR. %>
+    <%# The app CREATES listings and implements no call that updates one, so a
+        re-rendered gallery can never reach this draft in place. Replacing it is
+        a deliberate two-step: detach here, delete the old draft on Etsy
+        yourself, publish again. Nothing here touches Etsy. %>
+    <div class="mt-4 pt-4 border-t border-white/10 flex items-start justify-between gap-4">
+      <p class="text-[11px] text-t3">
+        Re-rendered the images or the video? They <strong>won't</strong> reach this draft — the app
+        only ever creates listings. Detach, delete the old draft on Etsy, then publish again.
+      </p>
+      <%= button_to "Detach & relist", relist_on_etsy_admin_dashboard_board_printable_path(@printable),
+            method: :post,
+            class: "shrink-0 text-xs font-medium px-3 py-2 rounded admin-card-alt text-t2 hover:text-t1 cursor-pointer",
+            form: { data: { turbo_confirm: relist_confirm(@printable) } } %>
+    </div>
+  <% elsif !@etsy_configured %>
+    <p class="text-xs text-t3">
+      Etsy isn't configured. Set <code>ETSY_KEYSTRING</code>, <code>ETSY_SHARED_SECRET</code>,
+      <code>ETSY_OAUTH_CLIENT_ID</code> and <code>ETSY_SHOP_ID</code>, then seed this app's own
+      refresh token with <code>rake etsy:seed_refresh_token</code>.
+    </p>
+  <% else %>
+    <% if @printable.etsy_ever_published? %>
+      <p class="text-[11px] text-t3 mb-3">
+        <%# The date is when the FIRST draft was made, not when it was detached —
+            nothing records the detach, and dating it wrongly is worse than not
+            dating it. %>
+        Detached from a previous draft<%= " (first published #{@printable.etsy_published_at.strftime('%b %-d, %Y')})" if @printable.etsy_published_at %>.
+        Delete that draft on Etsy if you haven't — publishing here makes a new one, it can't update the old.
+      </p>
+    <% end %>
+    <%= button_to @printable.etsy_ever_published? ? "Create replacement draft" : "Create Etsy draft",
+          publish_to_etsy_admin_dashboard_board_printable_path(@printable),
+          method: :post,
+          class: "text-xs font-medium px-3 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
+          form: { data: { turbo_confirm: "Create a draft Etsy listing for \"#{@listing['title']}\"? " \
+                                         "It will NOT go live — you publish it in Etsy yourself." } } %>
+  <% end %>
+
+  <%# Protection is keyed on having EVER been published, so this block sits
+      outside the branch above — a detached printable still freezes its boards,
+      and hiding the release control there would strand it. Every board in the
+      printed tree is covered, not just the root: each interior page carries its
+      own QR. %>
+  <% if @printable.etsy_ever_published? %>
     <div class="mt-4 pt-4 border-t border-white/10">
       <% if @printable.protection_waived? %>
         <p class="text-[11px] text-t3">
@@ -62,17 +108,5 @@
         </div>
       <% end %>
     </div>
-  <% elsif !@etsy_configured %>
-    <p class="text-xs text-t3">
-      Etsy isn't configured. Set <code>ETSY_KEYSTRING</code>, <code>ETSY_SHARED_SECRET</code>,
-      <code>ETSY_OAUTH_CLIENT_ID</code> and <code>ETSY_SHOP_ID</code>, then seed this app's own
-      refresh token with <code>rake etsy:seed_refresh_token</code>.
-    </p>
-  <% else %>
-    <%= button_to "Create Etsy draft", publish_to_etsy_admin_dashboard_board_printable_path(@printable),
-          method: :post,
-          class: "text-xs font-medium px-3 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
-          form: { data: { turbo_confirm: "Create a draft Etsy listing for \"#{@listing['title']}\"? " \
-                                         "It will NOT go live — you publish it in Etsy yourself." } } %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
       member do
         patch :update_listing
         post :publish_to_etsy
+        post :relist_on_etsy
         post :regenerate_listing_images
         post :regenerate_listing_video
         post :upload_listing_video

--- a/spec/models/board_printable_spec.rb
+++ b/spec/models/board_printable_spec.rb
@@ -173,4 +173,78 @@ RSpec.describe BoardPrintable do
       expect(printable.etsy_published?).to be true
     end
   end
+
+  describe "relisting" do
+    let(:board) { FactoryBot.create(:board, name: "Core Words") }
+    let(:printable) do
+      described_class.create!(board: board, status: "complete", board_ids: [board.id])
+    end
+
+    before do
+      printable.update!(
+        etsy_listing_id: 987,
+        etsy_listing_url: "https://etsy.test/987",
+        etsy_published_at: 3.days.ago,
+        etsy_error: "something went wrong last time",
+      )
+    end
+
+    it "detaches from the listing so a fresh draft can be created" do
+      printable.relist!
+
+      expect(printable.reload.etsy_listing_id).to be_nil
+      expect(printable.etsy_listing_url).to be_nil
+      expect(printable.etsy_published?).to be false
+      expect(printable.etsy_error).to be_nil
+    end
+
+    # The whole reason protection moved off `etsy_listing_id`. Relisting must
+    # not unfreeze boards whose printed pages are already in someone's hands.
+    it "keeps the boards it protects frozen" do
+      expect { printable.relist! }.not_to change { printable.reload.protects_board? }.from(true)
+      expect(printable.etsy_ever_published?).to be true
+    end
+
+    it "stays protected in the query the board guard actually uses" do
+      printable.relist!
+
+      expect(Boards::MarketplaceProtection.new(board).protected?).to be true
+      expect(Boards::MarketplaceProtection.protected_board_ids([board.id])).to include(board.id)
+    end
+
+    it "leaves an explicit waiver alone" do
+      printable.waive_protection!(user: FactoryBot.create(:admin_user), reason: "sold out")
+
+      printable.relist!
+
+      expect(printable.reload.protection_waived?).to be true
+      expect(printable.protects_board?).to be false
+    end
+
+    # Protection must never NARROW. A row carrying a listing id but no timestamp
+    # protected its boards before the rekey; relisting it has to keep them
+    # frozen, which means stamping the timestamp on the way past.
+    it "protects, and keeps protecting, a row that has an id but no timestamp" do
+      legacy = described_class.create!(board: board, status: "complete", board_ids: [board.id])
+      legacy.update_columns(etsy_listing_id: 555, etsy_published_at: nil)
+
+      expect(legacy.reload.protects_board?).to be true
+
+      legacy.relist!
+
+      expect(legacy.reload.etsy_listing_id).to be_nil
+      expect(legacy.etsy_published_at).to be_present
+      expect(legacy.protects_board?).to be true
+      expect(Boards::MarketplaceProtection.protected_board_ids([board.id])).to include(board.id)
+    end
+
+    # A printable that was never published isn't protecting anything, and has no
+    # listing to detach from.
+    it "does not protect a printable that was never published" do
+      fresh = described_class.create!(board: FactoryBot.create(:board), status: "complete")
+
+      expect(fresh.etsy_ever_published?).to be false
+      expect(fresh.protects_board?).to be false
+    end
+  end
 end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -651,6 +651,59 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       end
     end
 
+    describe "POST relist_on_etsy" do
+      before { printable.update!(etsy_listing_id: 987, etsy_listing_url: "https://etsy.test/987", etsy_published_at: 2.days.ago) }
+
+      it "detaches the listing so publishing can create a fresh draft" do
+        sign_in admin
+
+        post relist_on_etsy_admin_dashboard_board_printable_path(printable)
+
+        printable.reload
+        expect(printable.etsy_published?).to be false
+        expect(flash[:notice]).to include("987")
+      end
+
+      # The reason protection was rekeyed. A relisted printable's boards still
+      # have printed QR codes pointing at them.
+      it "leaves the boards it protects frozen" do
+        sign_in admin
+
+        post relist_on_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.protects_board?).to be true
+        expect(Boards::MarketplaceProtection.protected_board_ids([board.id])).to include(board.id)
+      end
+
+      it "unblocks the publish guard it was previously failing" do
+        sign_in admin
+        post publish_to_etsy_admin_dashboard_board_printable_path(printable)
+        expect(flash[:alert]).to match(/Already on Etsy/)
+
+        post relist_on_etsy_admin_dashboard_board_printable_path(printable)
+        expect(Etsy::PublishBoardPrintable.new(printable.reload).send(:guard_failure))
+          .not_to match(/Already on Etsy/)
+      end
+
+      it "refuses a printable that isn't attached to a listing" do
+        sign_in admin
+        printable.update!(etsy_listing_id: nil)
+
+        post relist_on_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(flash[:alert]).to match(/nothing to relist/)
+      end
+
+      # Detaching must never reach Etsy — deleting the old draft is the
+      # operator's job, and this app implements no delete call at all.
+      it "sends nothing to Etsy" do
+        sign_in admin
+        expect(Etsy::Client).not_to receive(:new)
+
+        post relist_on_etsy_admin_dashboard_board_printable_path(printable)
+      end
+    end
+
     describe "POST regenerate" do
       it "re-runs the PDF pipeline on the same record" do
         sign_in admin


### PR DESCRIPTION
Follow-up to #713. Answers "will Regenerate republish to Etsy?" — it didn't, and it couldn't.

## The problem

This app **creates** Etsy listings and implements no call that updates one, and `guard_failure` refuses to publish a printable that already has a listing id. So the new nine-slide gallery and the listing video could never reach anything already on Etsy — there was no code path at all.

Worse, the Etsy card told you a workaround that doesn't work: *"To replace this draft, delete it in Etsy first."* Deleting the draft on Etsy writes nothing back here, so the printable stays attached and the button keeps refusing. Nothing in the app has ever cleared `etsy_listing_id`.

## The change

**"Detach & relist"** on the Etsy card clears `etsy_listing_id` / `etsy_listing_url` so Publish creates a fresh draft carrying the current images and video. It sends **nothing** to Etsy — deleting the superseded draft stays yours to do, because doing it from here would mean adding the delete call the drafts-only invariant exists to keep out.

## The load-bearing part: protection had to move

Marketplace protection was keyed on `etsy_listing_id`, which relisting now clears. Left alone, relisting would have **silently unfrozen boards whose printed pages already carry their QR codes** — precisely the failure protection exists to prevent.

It now reads `etsy_ever_published?`, a **union** of `etsy_published_at` and `etsy_listing_id`:

| Predicate | Means | Cleared by relist? |
|---|---|---|
| `etsy_published?` | attached to a listing right now | yes |
| `etsy_ever_published?` | a draft was made at some point | never |

The union is the point, and the specs caught why: protection must never end up **narrower** than the test it replaced. A row with a listing id but no timestamp protected its boards before, so it must keep doing so — and `relist!` stamps the timestamp before dropping the id so such a row keeps its evidence. Widening can only over-protect; narrowing unfreezes printed paper.

`MarketplaceProtection`'s SQL scope moves in lockstep (the two must not be able to disagree), and the waiver action, both confirm strings and the protection block in `_etsy` follow — a detached printable still freezes its boards and would otherwise lose the only control that releases them.

## Test plan

- `3638 examples, 0 failures` across `spec/models`, `spec/services`, `spec/requests/admin`, `spec/sidekiq`; `2575` more after the final comment-only commit.
- New specs cover: detaching unblocks the publish guard; boards stay protected through a relist (both the model predicate and the SQL scope); an explicit waiver survives; a legacy row with an id and no timestamp stays protected and gets backfilled; and detaching sends nothing to Etsy.
- The Etsy card rendered in all three states (attached / detached / never published) and its copy read back, including both confirm dialogs.

## Not done here

- Deleting the old draft on Etsy. Still manual, still deliberate.
- Updating a live listing in place. Still impossible, still by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)