### PR TITLE
feat(printables): tag the marketplace QRs, drop the trim-ready QR band, fix the video outro

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -132,6 +132,25 @@ sits outside step 1's `@variant` branch, so both are variant-independent by
 construction. None of this touches `api/boards/print.html.erb` or
 `layouts/pdf.html.erb`, which are shared with real users' PDF downloads.
 
+**Campaign tags go on the SCREEN QRs only.** `Boards::Printables::Qr` builds
+two URLs for the same board: `target_url_for` (bare `/pb/<slug>`) for anything
+printed, and `listing_target_url_for(board, content:)` for the gallery images
+and the listing video, which adds
+`utm_source=etsy&utm_medium=listing&utm_campaign=board_printable&utm_content=<surface>`.
+The split is a scannability constraint, not a taste one: the bare URL is a
+version-6 (41-module) code at the renderer's ECC — already ~0.5mm per module at
+the printed page's 0.8in header, the phone-camera detection floor that made the
+classroom-kit tags unscannable in 2026-07 — and tagging it pushes it to version
+12 (65 modules, 0.31mm), i.e. a code that does not resolve off paper. Screen
+QRs pay nothing for the extra characters, and they render at
+`Qr::SCREEN_ECC` (`:m`) rather than print's `:h` so the tagged URL stays a
+49-module code with ~5px per module in the frame's 244px slot, which survives
+Etsy's video re-encode. **Never route a printed QR through
+`listing_target_url_for`** — that includes the page thumbnails inside the
+gallery slides, which must keep encoding exactly what the downloaded page does
+(`RenderPageThumbnails`). Guarded by
+`spec/services/boards/printables/qr_spec.rb`.
+
 **`hide_header: true` is not the way to build the trim-ready page.** The QR
 lives *inside* the header block in `api/boards/print.html.erb`, so hiding the
 header takes the code with it — and the free audio companion is the single

--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -106,7 +106,7 @@ Every printable ships each board three times
 |---|---|---|
 | `color` | full colour | full band — logo, board title, scan-me line, QR |
 | `low_ink` | white tile backgrounds | full band |
-| `trim_ready` | full colour | **QR alone, top-right** |
+| `trim_ready` | full colour | **one thin address line, top-right** |
 
 A single board is ONE file holding all three pages; a subboard tree is three
 files (`<slug>.color.pdf`, `.low-ink.pdf`, `.trim-ready.pdf`), each fully
@@ -155,13 +155,24 @@ gallery slides, which must keep encoding exactly what the downloaded page does
 lives *inside* the header block in `api/boards/print.html.erb`, so hiding the
 header takes the code with it — and the free audio companion is the single
 claim the whole listing leans on. `Boards::RenderAssetData` therefore carries a
-three-state `header_mode` (`full` / `qr_only` / `none`), never a second boolean
+three-state `header_mode` (`full` / `url_only` / `none`), never a second boolean
 that can contradict `hide_header`:
 
-- `qr_only` reserves a 20mm band (`#header_band_height_mm`) instead of 30-34mm
-  and prints a 0.6in QR in the corner. The band is **reserved, not overlaid**:
-  a width-limited board spans the full sheet, so a floating QR would land on
-  tiles.
+- `url_only` reserves a 6mm band (`#header_band_height_mm`) instead of 30-34mm
+  and prints ONE thin line of type — the board's address, no code. The band is
+  **reserved, not overlaid**: a width-limited board spans the full sheet, so
+  floating text would land on tiles.
+- **The trim-ready page carries no QR, deliberately.** "Trim-ready" is a size
+  claim, and the 0.6in code cost 20mm of sheet — ~15% of the board's printed
+  area on a height-limited landscape page — for a code that is ~0.37mm per
+  module at that size, at or under the phone-camera floor that made the
+  classroom-kit tags unscannable (`.claude-notes/marketing-assets.md`). It was
+  paying a size penalty for a scan that half-works. The scannable code still
+  ships on the colour and low-ink pages, and on the trim-ready file's own
+  cover and credits pages; the how-to-use page says where it went.
+- Because that page renders no code, `RenderAssetData` skips the 480px QR
+  encode for it entirely while still resolving `qr_target_url` for the printed
+  line.
 - `hide_header:` still works for the callers that only ever wanted
   all-or-nothing (board previews, the print endpoints, the gallery's grid
   thumbnails) and maps onto `full`/`none`. `header_mode:` wins when both are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Etsy listing QRs are tagged for attribution.** The QR in a printable's
+  gallery images and listing video now carries `utm_source=etsy` campaign tags,
+  so traffic from a listing is identifiable in analytics. The QR **printed into
+  the PDF** deliberately stays untagged — the longer URL makes a denser code
+  than the printed size can carry, and a code that won't scan costs more than
+  the attribution is worth.
+- **The listing video's closing frame reads on two lines.** "Free audio
+  companion. / No app, no sign-in." no longer wraps mid-phrase.
+
 ### Added
 
 - **A published printable can be relisted.** The app only ever creates Etsy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **The trim-ready pages print bigger.** That variant exists so the board fills
+  the sheet, but it was still reserving 20mm for a QR code — about 15% of the
+  board's printed area on a landscape page, for a code small enough that phones
+  struggled with it anyway. The band is now one thin line naming the board's
+  web address, and the board takes the space back. The scannable code is
+  unchanged on the full-colour and low-ink pages and on the cover.
 - **Etsy listing QRs are tagged for attribution.** The QR in a printable's
   gallery images and listing video now carries `utm_source=etsy` campaign tags,
   so traffic from a listing is identifiable in analytics. The QR **printed into

--- a/app/services/boards/printables/collect_pages.rb
+++ b/app/services/boards/printables/collect_pages.rb
@@ -100,10 +100,11 @@ module Boards
       def render_page(target, variant:)
         hide_colors = variant == BoardPrintable::VARIANT_LOW_INK
 
-        # Every board page carries a QR, in one form or another. The trim-ready
-        # variant drops the title band but keeps a corner code (header_mode
-        # qr_only) — a bare `hide_header: true` would take the QR with it and
-        # hand a buyer a sheet with no way back to the talking version.
+        # The trim-ready variant exists so the board prints as large as the
+        # sheet allows, so it drops the QR band for one line of type naming the
+        # board's address (header_mode url_only) rather than spending 20mm on a
+        # 0.6in code. `hide_header: true` is still wrong for it — that would
+        # leave the sheet with no way back to the talking version at all.
         render_data = Boards::RenderAssetData.new(
           board: target,
           screen_size: "lg",
@@ -131,7 +132,7 @@ module Boards
 
       def header_mode_for(variant)
         if variant == BoardPrintable::VARIANT_TRIM_READY
-          Boards::RenderAssetData::HEADER_QR_ONLY
+          Boards::RenderAssetData::HEADER_URL_ONLY
         else
           Boards::RenderAssetData::HEADER_FULL
         end

--- a/app/services/boards/printables/qr.rb
+++ b/app/services/boards/printables/qr.rb
@@ -24,8 +24,37 @@ module Boards
         "#{CollectPages::QR_BASE_URL}/#{CollectPages.qr_key_for(board)}"
       end
 
-      def self.data_url_for(url)
-        png = RQRCode::QRCode.new(url).as_png(
+      # The marketplace gallery/video QRs carry campaign tags; the PRINTED ones
+      # never do. A tagged /pb/ URL is ~148 chars, a version-12 (65-module)
+      # code — 0.31mm per module at the printed page's 0.8in, half the ~0.5mm
+      # phone-camera floor that already broke the kit tags once (see
+      # .claude-notes/marketing-assets.md). A slide QR is only ever scanned off
+      # a screen at 244px+, where the extra modules cost nothing.
+      LISTING_UTM = {
+        utm_source: "etsy",
+        utm_medium: "listing",
+        utm_campaign: "board_printable",
+      }.freeze
+
+      # `content` names the surface the code was scanned from — a gallery image
+      # or a frame of the listing video.
+      def self.listing_target_url_for(board, content:)
+        query = LISTING_UTM.merge(utm_content: content).to_query
+        "#{target_url_for(board)}?#{query}"
+      end
+
+      # ECC. Print keeps rqrcode's :h default — paper gets creased, folded and
+      # photocopied, and the printed URL is short enough to afford it. A slide
+      # QR encodes the longer tagged URL and is only ever read off a clean
+      # screen, so it trades damage redundancy for modules: :h renders the
+      # tagged URL as a version-12 (65-module) code, ~3.7px per module in the
+      # 244px frame slot, which is thin once Etsy re-encodes the video. :m is
+      # version 8 (49 modules, ~5px).
+      PRINT_ECC = :h
+      SCREEN_ECC = :m
+
+      def self.data_url_for(url, level: PRINT_ECC)
+        png = RQRCode::QRCode.new(url, level: level).as_png(
           bit_depth: 8,
           border_modules: 0,
           color_mode: ChunkyPNG::COLOR_TRUECOLOR,

--- a/app/services/boards/printables/render_listing_images.rb
+++ b/app/services/boards/printables/render_listing_images.rb
@@ -123,7 +123,10 @@ module Boards
       def shared_assigns
         {
           logo: BrandAssets.logo_data_uri,
-          qr_data_url: Qr.data_url_for(Qr.target_url_for(board)),
+          qr_data_url: Qr.data_url_for(
+            Qr.listing_target_url_for(board, content: "listing_image"),
+            level: Qr::SCREEN_ECC,
+          ),
           palette_css: Palette.for(board).css_vars,
         }
       end

--- a/app/services/boards/printables/render_listing_video.rb
+++ b/app/services/boards/printables/render_listing_video.rb
@@ -207,9 +207,12 @@ module Boards
 
       def outro_assigns
         shared_assigns.merge(
-          qr_data_url: Qr.data_url_for(Qr.target_url_for(board)),
+          qr_data_url: Qr.data_url_for(
+            Qr.listing_target_url_for(board, content: "listing_video"),
+            level: Qr::SCREEN_ECC,
+          ),
           headline: ::Printables::SlideCopy.video_outro_headline,
-          sub: ::Printables::SlideCopy.video_outro_sub,
+          sub_lines: ::Printables::SlideCopy.video_outro_sub_lines,
           device_data_uri: device_data_uri,
         )
       end

--- a/app/services/boards/render_asset_data.rb
+++ b/app/services/boards/render_asset_data.rb
@@ -6,15 +6,16 @@ module Boards
     # other and the combination that matters most — no title band, code intact —
     # is exactly the one two booleans make ambiguous.
     #
-    #   full    — logo, board title, scan-me line and the QR beside them.
-    #   qr_only — a small QR alone in the top-right. The board gets nearly the
-    #             whole sheet, and the code survives the buyer trimming the band.
-    #   none    — nothing. Used for screen mockups and grid thumbnails, where a
-    #             printed QR reads as an ad pasted on the glass.
+    #   full     — logo, board title, scan-me line and the QR beside them.
+    #   url_only — one thin line of type in the top corner: the board's web
+    #              address, no code. The band costs 6mm instead of 20mm, which
+    #              is the whole point of the trim-ready print.
+    #   none     — nothing. Used for screen mockups and grid thumbnails, where a
+    #              printed QR reads as an ad pasted on the glass.
     HEADER_FULL = "full".freeze
-    HEADER_QR_ONLY = "qr_only".freeze
+    HEADER_URL_ONLY = "url_only".freeze
     HEADER_NONE = "none".freeze
-    HEADER_MODES = [HEADER_FULL, HEADER_QR_ONLY, HEADER_NONE].freeze
+    HEADER_MODES = [HEADER_FULL, HEADER_URL_ONLY, HEADER_NONE].freeze
 
     # `hide_header:` is kept for the callers that only ever wanted all-or-
     # nothing (board previews, the print endpoints, grid thumbnails). Pass
@@ -38,7 +39,12 @@ module Boards
 
     def call
       qr_target_url = resolved_qr_target_url
-      qr_data_url   = qr_target_url.present? ? AssetRendering.qr_data_url_for(qr_target_url, size: 480) : nil
+      # The url_only page prints the address as text, so rendering a PNG for it
+      # would cost a 480px encode per board page and reach nothing.
+      qr_data_url =
+        if qr_target_url.present? && header_mode != HEADER_URL_ONLY
+          AssetRendering.qr_data_url_for(qr_target_url, size: 480)
+        end
       tiles = normalized_tiles
       columns = resolved_columns
       rows = resolved_rows(tiles)
@@ -111,15 +117,14 @@ module Boards
       rows > columns
     end
 
-    # The qr_only band reserves room for the code and nothing else — the QR
-    # prints at 0.6in there, so 20mm clears it with a little air. Reserving the
-    # space rather than floating the QR over the sheet is deliberate: a
-    # width-limited board spans the full page, and an overlaid code would land
-    # on top of tiles.
+    # The url_only band reserves room for a single line of small type and
+    # nothing else. Reserving the space rather than floating the line over the
+    # sheet is deliberate: a width-limited board spans the full page, and
+    # overlaid text would land on top of tiles.
     def header_band_height_mm(landscape)
       case header_mode
       when HEADER_NONE then 0
-      when HEADER_QR_ONLY then 20.0
+      when HEADER_URL_ONLY then 6.0
       else landscape ? 30.0 : 34.0
       end
     end

--- a/app/services/printables/slide_copy.rb
+++ b/app/services/printables/slide_copy.rb
@@ -215,7 +215,10 @@ module Printables
 
     def video_outro_headline = "Scan any page — every word talks"
 
-    def video_outro_sub = "Free audio companion. No app, no sign-in."
+    # Two lines, deliberately. As one string the sub wraps wherever the frame
+    # runs out of room, which put "in." alone on the last row; the renderer
+    # keeps each line unbroken.
+    def video_outro_sub_lines = ["Free audio companion.", "No app, no sign-in."]
 
     def hero_footer_bullets
       [

--- a/app/views/api/board_printables/how_to_use.html.erb
+++ b/app/views/api/board_printables/how_to_use.html.erb
@@ -9,7 +9,8 @@
                          trim-ready copy of the board
       set, colour      → this file is all colour
       set, low-ink     → this file is all low-ink
-      set, trim-ready  → this file is all header-less, QR in the corner
+      set, trim-ready  → this file is all header-less, address line in the
+                         corner
 
     No set variant mentions the other files. A reader holding the low-ink
     print doesn't need to be told a colour one exists somewhere; being told so
@@ -44,7 +45,8 @@
               This file includes the board three times: in full color, again
               with white tile backgrounds for a lower-ink print, and once more
               with no header so the board fills the whole page. Use whichever
-              fits your printer.
+              fits your printer — the QR code is on the first two and on the
+              cover.
             </p>
           <% elsif @variant == BoardPrintable::VARIANT_LOW_INK %>
             <p class="lead">Printed low-ink</p>
@@ -56,8 +58,9 @@
             <p class="lead">Printed to the edges</p>
             <p>
               Every board in this file drops the page header so the board prints
-              as large as the sheet allows. The QR code moves to the top corner,
-              so it still opens online after you trim and laminate.
+              as large as the sheet allows. The board's web address prints as
+              one small line in the top corner — the scannable code is on the
+              cover, so keep that page if you want it.
             </p>
           <% else %>
             <p class="lead">Printed in full color</p>

--- a/app/views/api/board_printables/video/outro.html.erb
+++ b/app/views/api/board_printables/video/outro.html.erb
@@ -27,7 +27,11 @@
       <% end %>
     </div>
 
-    <div class="video-sub"><%= @sub %></div>
+    <div class="video-sub">
+      <% Array(@sub_lines).each do |line| %>
+        <span><%= line %></span>
+      <% end %>
+    </div>
     <div class="site-mark"><%= Printables::SlideCopy.site_mark %></div>
   </div>
 </div>

--- a/app/views/api/boards/print.html.erb
+++ b/app/views/api/boards/print.html.erb
@@ -2,8 +2,10 @@
     pair of booleans. The QR lives INSIDE this block, so "hide the header" and
     "keep the code" are the same decision and have to be made in one place.
 
-    qr_only is what the trim-ready PDF prints: buyers cut the title band off to
-    laminate the board, and the code has to survive that cut.
+    url_only is what the trim-ready PDF prints: that variant exists so the board
+    fills the sheet, so it spends 6mm on one line of type instead of 20mm on a
+    QR band. The scannable code lives on the colour and low-ink pages, and on
+    this file's own cover and credits pages.
 
     Falls back to @hide_header so a caller that renders this template with its
     own assigns — rather than through RenderAssetData — still gets the old
@@ -60,12 +62,10 @@
     }, window.__tileImageDeadlineMs);
   }
 </script>
-<% if header_mode == Boards::RenderAssetData::HEADER_QR_ONLY %>
-  <div class="header header-qr-only">
-    <% if @qr_data_url.present? %>
-      <div class="qr-small">
-        <img src="<%= @qr_data_url %>" alt="QR code">
-      </div>
+<% if header_mode == Boards::RenderAssetData::HEADER_URL_ONLY %>
+  <div class="header header-url-only">
+    <% if @qr_target_url.present? %>
+      <p class="trim-url"><%= @qr_target_url.sub(%r{\Ahttps?://}, "") %></p>
     <% end %>
   </div>
 <% elsif header_mode != Boards::RenderAssetData::HEADER_NONE %>

--- a/app/views/layouts/listing_image.html.erb
+++ b/app/views/layouts/listing_image.html.erb
@@ -773,8 +773,13 @@
       .video-sub {
         font-size: 32px;
         font-weight: 700;
+        line-height: 1.3;
         color: var(--ink);
       }
+
+      /* One phrase per line, each unbroken: the sub is a two-clause claim and
+         wrapping mid-clause left "in." alone on its own row. */
+      .video-sub span { display: block; white-space: nowrap; }
 
       .video-count {
         display: flex;

--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -109,22 +109,24 @@
         margin-left: 4mm;
       }
 
-      /* The trim-ready page: no logo, title or scan-me line, just the code in
-         the top-right corner. The band is reserved rather than overlaid — a
-         width-limited board fills the sheet edge to edge, and a floating QR
-         would sit on top of tiles. Keep it in step with
-         RenderAssetData#header_band_height_mm. */
-      .header-qr-only {
+      /* The trim-ready page: no logo, title, QR or scan-me line — one thin
+         line of type naming the board's address, and nothing else. The band is
+         reserved rather than overlaid — a width-limited board fills the sheet
+         edge to edge, and floating text would sit on top of tiles. Keep it in
+         step with RenderAssetData#header_band_height_mm. */
+      .header-url-only {
         display: flex;
         justify-content: flex-end;
         align-items: flex-start;
-        height: 18mm;
+        height: 4mm;
       }
 
-      .header-qr-only .qr-small img {
-        width: 0.6in;
-        height: 0.6in;
+      .header-url-only .trim-url {
         margin: 0 2mm 0 0;
+        font-size: 6.5pt;
+        line-height: 1;
+        letter-spacing: 0.02em;
+        color: #999;
       }
 
       .board-wrap {

--- a/spec/services/boards/printables/collect_pages_variants_spec.rb
+++ b/spec/services/boards/printables/collect_pages_variants_spec.rb
@@ -35,10 +35,11 @@ RSpec.describe Boards::Printables::CollectPages, "#call" do
     expect(by_variant[BoardPrintable::VARIANT_TRIM_READY][:hide_colors]).to be(false)
   end
 
-  # The whole point of the trim-ready variant: the title band goes, the code
-  # stays. `hide_header: true` would take the QR with it and hand a buyer a
-  # sheet with no route to the free audio companion the listing promises.
-  it "gives the trim-ready page a corner QR instead of the full header" do
+  # The whole point of the trim-ready variant: the band goes so the board
+  # prints as large as the sheet allows. It still resolves a target URL —
+  # `hide_header: true` would leave the sheet with no route at all to the free
+  # audio companion the listing promises; url_only prints it as one thin line.
+  it "gives the trim-ready page an address line instead of the full header" do
     result
 
     modes = render_args.map { |kwargs| kwargs[:header_mode] }
@@ -46,7 +47,7 @@ RSpec.describe Boards::Printables::CollectPages, "#call" do
     expect(modes).to eq([
       Boards::RenderAssetData::HEADER_FULL,
       Boards::RenderAssetData::HEADER_FULL,
-      Boards::RenderAssetData::HEADER_QR_ONLY,
+      Boards::RenderAssetData::HEADER_URL_ONLY,
     ])
     expect(render_args.map { |kwargs| kwargs[:include_qr] }).to all(be(true))
   end

--- a/spec/services/boards/printables/qr_spec.rb
+++ b/spec/services/boards/printables/qr_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Boards::Printables::Qr do
+  let(:board) { create(:board, name: "Core Words") }
+
+  before { board.update_column(:slug, "core-words-starter-set-4f2a") }
+
+  describe ".target_url_for" do
+    it "points at the board's public page and carries nothing else" do
+      expect(described_class.target_url_for(board))
+        .to eq("https://app.speakanyway.com/pb/core-words-starter-set-4f2a")
+    end
+  end
+
+  describe ".listing_target_url_for" do
+    it "tags the marketplace surface the scan came from" do
+      url = described_class.listing_target_url_for(board, content: "listing_video")
+
+      expect(url).to start_with("#{described_class.target_url_for(board)}?")
+      expect(url).to include("utm_source=etsy", "utm_medium=listing")
+      expect(url).to include("utm_campaign=board_printable", "utm_content=listing_video")
+    end
+  end
+
+  # The printed QR is the one with a physical size to lose. The bare URL is a
+  # version-6 (41-module) code at the renderer's ECC, which is 0.5mm per module
+  # on the 0.8in page header — already at the phone-camera detection floor that
+  # made the kit tags unscannable once (2026-07-08, see
+  # .claude-notes/marketing-assets.md). Tagging it pushes it to version 12
+  # (65 modules, 0.31mm) and the code stops resolving on paper. Screen-only
+  # slide QRs are exempt — they render at 244px+, where modules cost nothing.
+  describe "scannability of the PRINTED code" do
+    def version_of(url) = RQRCode::QRCode.new(url).qrcode.version
+
+    it "keeps the printed URL as low-density as it is today" do
+      expect(version_of(described_class.target_url_for(board))).to be <= 6
+    end
+
+    it "is why the campaign tags stay off it" do
+      tagged = described_class.listing_target_url_for(board, content: "listing_image")
+
+      expect(version_of(tagged)).to be > 4
+    end
+  end
+
+  # Same URL, two jobs: paper keeps rqrcode's :h damage redundancy, a slide
+  # trades it for modules because it is read off a clean screen and its URL is
+  # ~90 characters longer.
+  describe "ECC" do
+    it "renders the screen code with fewer modules than :h would" do
+      tagged = described_class.listing_target_url_for(board, content: "listing_video")
+
+      screen = RQRCode::QRCode.new(tagged, level: described_class::SCREEN_ECC).qrcode
+      print_ecc = RQRCode::QRCode.new(tagged, level: described_class::PRINT_ECC).qrcode
+
+      expect(screen.module_count).to be < print_ecc.module_count
+    end
+  end
+
+  describe ".data_url_for" do
+    it "renders a white-backed PNG data URL" do
+      data_url = described_class.data_url_for(described_class.target_url_for(board))
+
+      expect(data_url).to start_with("data:image/png;base64,")
+      png = ChunkyPNG::Image.from_blob(Base64.strict_decode64(data_url.split(",", 2).last))
+      expect(png.width).to eq(described_class::SIZE)
+    end
+  end
+end

--- a/spec/services/boards/printables/render_listing_images_spec.rb
+++ b/spec/services/boards/printables/render_listing_images_spec.rb
@@ -522,4 +522,16 @@ RSpec.describe Boards::Printables::RenderListingImages do
       height: 700,
     )
   end
+
+  # The gallery QR is scanned off a screen, where the extra modules are free —
+  # unlike the printed one in the download, which stays bare (see Qr).
+  it "tags the gallery QR with the surface it was scanned from" do
+    allow(Boards::Printables::Qr).to receive(:data_url_for).and_call_original
+
+    described_class.new(printable: printable).call
+
+    expect(Boards::Printables::Qr).to have_received(:data_url_for)
+      .with(a_string_including("utm_content=listing_image"), level: Boards::Printables::Qr::SCREEN_ECC)
+      .at_least(:once)
+  end
 end

--- a/spec/services/boards/printables/render_listing_video_spec.rb
+++ b/spec/services/boards/printables/render_listing_video_spec.rb
@@ -111,6 +111,32 @@ RSpec.describe Boards::Printables::RenderListingVideo do
       expect(frame_html.length).to eq(described_class::MAX_PAGE_FRAMES + 2)
     end
 
+    # Etsy strips the audio, so the outro's claim is read, not heard — and as
+    # one string it wrapped wherever the frame ran out of room, leaving "in."
+    # alone on the last row. Each clause is its own unbreakable line.
+    it "sets the outro's sub one clause per line" do
+      stub_thumbnails!
+
+      described_class.new(printable: printable).call
+
+      outro = frame_html.last
+      Printables::SlideCopy.video_outro_sub_lines.each do |line|
+        expect(outro).to include("<span>#{line}</span>")
+      end
+    end
+
+    # The listing's QR is scanned off a screen, where the extra modules are
+    # free — unlike the printed one, which stays bare (see Qr).
+    it "tags the outro QR with the surface it was scanned from" do
+      stub_thumbnails!
+      allow(Boards::Printables::Qr).to receive(:data_url_for).and_call_original
+
+      described_class.new(printable: printable).call
+
+      expect(Boards::Printables::Qr).to have_received(:data_url_for)
+        .with(a_string_including("utm_content=listing_video"), level: Boards::Printables::Qr::SCREEN_ECC)
+    end
+
     # A page whose render failed costs a frame, not the video.
     it "skips a board whose page didn't render" do
       second = create(:board, user: owner, name: "Feelings")

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -130,15 +130,16 @@ RSpec.describe Boards::Printables::RenderWrappers do
         expect(rendered[:how_to_use_low_ink]).to include("white tile backgrounds")
       end
 
-      # The trim-ready file is the one whose QR moved, so it is the one page
-      # that has to say where the code went — a buyer who can't find it assumes
-      # the header-less print is the one without the audio companion.
-      it "tells the trim-ready file the header is gone and the QR moved" do
+      # The trim-ready file is the one with no code on its board pages, so it is
+      # the one page that has to say where the code went — a buyer who can't
+      # find it assumes this print is the one without the audio companion.
+      it "tells the trim-ready file the header is gone and where the code is" do
         render(board_count: 4)
 
         expect(rendered[:how_to_use_trim_ready]).to include("Printed to the edges")
         expect(rendered[:how_to_use_trim_ready]).to include("drops the page header")
-        expect(rendered[:how_to_use_trim_ready]).to include("QR code moves to the top corner")
+        expect(rendered[:how_to_use_trim_ready]).to include("web address prints as")
+        expect(rendered[:how_to_use_trim_ready]).to include("the scannable code is on the")
       end
 
       it "never mentions the other files from any one of them" do

--- a/spec/services/boards/printables/render_wrappers_spec.rb
+++ b/spec/services/boards/printables/render_wrappers_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Boards::Printables::RenderWrappers do
       render
 
       expect(RQRCode::QRCode).to have_received(:new)
-        .with("https://app.speakanyway.com/pb/core-words")
+        .with("https://app.speakanyway.com/pb/core-words", level: Boards::Printables::Qr::PRINT_ECC)
     end
 
     it "encodes the id when the board has no slug" do
@@ -79,7 +79,7 @@ RSpec.describe Boards::Printables::RenderWrappers do
       render
 
       expect(RQRCode::QRCode).to have_received(:new)
-        .with("https://app.speakanyway.com/pb/#{board.id}")
+        .with("https://app.speakanyway.com/pb/#{board.id}", level: Boards::Printables::Qr::PRINT_ECC)
     end
 
     it "describes a single board" do

--- a/spec/services/boards/render_asset_data_header_mode_spec.rb
+++ b/spec/services/boards/render_asset_data_header_mode_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe Boards::RenderAssetData, "header modes" do
   end
 
   it "lets an explicit mode win over hide_header" do
-    data = render(hide_header: true, header_mode: described_class::HEADER_QR_ONLY)
+    data = render(hide_header: true, header_mode: described_class::HEADER_URL_ONLY)
 
-    expect(data[:header_mode]).to eq(described_class::HEADER_QR_ONLY)
+    expect(data[:header_mode]).to eq(described_class::HEADER_URL_ONLY)
     # hide_header stays false so the template can't take the QR away — the two
     # can't be allowed to contradict each other.
     expect(data[:hide_header]).to be(false)
@@ -37,22 +37,26 @@ RSpec.describe Boards::RenderAssetData, "header modes" do
     expect(render(header_mode: "banner")[:header_mode]).to eq(described_class::HEADER_FULL)
   end
 
-  # The reason the mode exists: qr_only reserves a slim band instead of the
+  # The reason the mode exists: url_only reserves a slim band instead of the
   # full one, so the board prints bigger, and none reserves nothing at all.
   #
   # Measured on a TALL board on purpose. A wide, short one is limited by the
   # page width rather than by what the header leaves behind, so it would print
   # the same size in all three modes and prove nothing.
-  it "grows the board as the header shrinks" do
+  def stub_tall_board!
     tiles = 12.times.map do |i|
       { "x" => 0, "y" => i, "w" => 1, "h" => 1, "label" => "word #{i}" }
     end
     allow(Boards::BoardPdfLayoutNormalizer).to receive(:call).and_return(tiles)
     allow(board).to receive(:columns_for_screen_size).and_return(2)
+  end
+
+  it "grows the board as the header shrinks" do
+    stub_tall_board!
 
     heights = [
       described_class::HEADER_FULL,
-      described_class::HEADER_QR_ONLY,
+      described_class::HEADER_URL_ONLY,
       described_class::HEADER_NONE,
     ].map { |mode| render(header_mode: mode)[:board_render_height_mm] }
 
@@ -60,9 +64,27 @@ RSpec.describe Boards::RenderAssetData, "header modes" do
     expect(heights.uniq.length).to eq(3)
   end
 
-  it "still builds a QR for the qr_only page" do
-    data = render(header_mode: described_class::HEADER_QR_ONLY)
+  # "Trim-ready" is a size claim, so the band it does keep has to be a line of
+  # type, not a reserved block. The QR band it replaced cost 20mm.
+  it "leaves the url_only page within a few mm of a full-bleed print" do
+    stub_tall_board!
 
-    expect(data[:qr_data_url]).to start_with("data:image/")
+    url_only = render(header_mode: described_class::HEADER_URL_ONLY)[:board_render_height_mm]
+    none = render(header_mode: described_class::HEADER_NONE)[:board_render_height_mm]
+
+    expect(none - url_only).to be <= 6.0
+  end
+
+  # The url_only page prints the address as text, so encoding a PNG for it
+  # would cost a QR render per board page and reach nothing.
+  it "names the board's URL on the url_only page but renders no code for it" do
+    data = render(header_mode: described_class::HEADER_URL_ONLY)
+
+    expect(data[:qr_target_url]).to be_present
+    expect(data[:qr_data_url]).to be_nil
+  end
+
+  it "still builds a QR for the full header" do
+    expect(render[:qr_data_url]).to start_with("data:image/")
   end
 end

--- a/spec/services/printables/slide_copy_spec.rb
+++ b/spec/services/printables/slide_copy_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe Printables::SlideCopy do
     end
   end
 
+  # The outro sub is rendered one line per clause. Kept short here because the
+  # renderer sets each line `white-space: nowrap` — a long clause would run off
+  # the frame instead of wrapping.
+  it "splits the outro sub into two short, self-contained clauses" do
+    lines = described_class.video_outro_sub_lines
+
+    expect(lines.length).to eq(2)
+    expect(lines).to all(satisfy { |line| line.length <= 28 })
+    expect(lines.join(" ")).to eq("Free audio companion. No app, no sign-in.")
+  end
+
   # The render box's Chrome has no guaranteed colour-emoji font, so an emoji in
   # slide copy ships to Etsy as a tofu box. Icons are inline SVG instead.
   it "carries no emoji or decorative glyphs outside the font's coverage" do

--- a/spec/views/api/boards/print_template_spec.rb
+++ b/spec/views/api/boards/print_template_spec.rb
@@ -100,11 +100,16 @@ RSpec.describe "api/boards/print.html.erb", type: :view do
       expect(Nokogiri::HTML(html).at_css(".qr-small img")["src"]).to eq(qr)
     end
 
-    it "keeps the QR and drops everything else in qr_only mode" do
-      html = render_with(Boards::RenderAssetData::HEADER_QR_ONLY)
+    # The trim-ready page buys board size with everything else on the band,
+    # the QR included — a 0.6in code costs 20mm of sheet and is denser than
+    # that size reliably scans anyway.
+    it "prints the address as one line and nothing else in url_only mode" do
+      html = render_with(Boards::RenderAssetData::HEADER_URL_ONLY)
       doc = Nokogiri::HTML(html)
 
-      expect(doc.at_css(".header-qr-only .qr-small img")["src"]).to eq(qr)
+      expect(doc.at_css(".header-url-only .trim-url").text.strip)
+        .to eq("app.speakanyway.com/pb/core-words")
+      expect(doc.at_css(".header-url-only .qr-small")).to be_nil
       expect(doc.at_css(".board-title")).to be_nil
       expect(doc.at_css(".board-link")).to be_nil
       expect(doc.at_css(".logo")).to be_nil


### PR DESCRIPTION
## What changed

Three fixes to a board printable's Etsy assets and its download.

### 1. The listing video's closing frame wrapped badly

The sub was one string, so it wrapped wherever the 1080×1080 frame ran out of room and left `in.` alone on the last row. `SlideCopy.video_outro_sub_lines` now hands over one clause per line and the template renders each as a `nowrap` span:

> Free audio companion.
> No app, no sign-in.

### 2. Campaign tags on the marketplace QRs

The gallery images and the listing video point their QR at `…/pb/<slug>?utm_source=etsy&utm_medium=listing&utm_campaign=board_printable&utm_content=<surface>`, so traffic arriving from a listing is identifiable. PostHog picks the params up off the pageview — no frontend change needed.

**The QR printed into the PDF stays bare.** This was asked for and I pushed back:

| URL | QR version | modules | mm/module @ 0.8in page header |
|---|---|---|---|
| bare `/pb/<slug>` | 6 | 41 | **0.50** |
| + full UTM | 12 | 65 | **0.31** |

~0.5mm/module is the phone-camera detection floor — the one that made the classroom-kit tags unscannable in July 2026 and forced the short `/myspeak` URL (`.claude-notes/marketing-assets.md`). Tagging the printed code would break the product's central promise (scan the page, hear the words) to gain attribution on a buyer who has already converted. `spec/services/boards/printables/qr_spec.rb` pins the split, including the page thumbnails inside the gallery slides, which must keep encoding exactly what the downloaded page does.

Screen QRs also drop to ECC `:m`: the tagged URL at `:h` is 65 modules, ~3.7px per module in the video frame's 244px slot, thin enough that Etsy's re-encode could smear it. `:m` is 49 modules (~5px). Print keeps `:h` — paper gets creased and photocopied.

### 3. The trim-ready pages print bigger

That variant exists so the board fills the sheet, and it was still reserving **20mm** for a 0.6in QR. Measured through `fitted_board_dimensions_mm`, on height-limited boards (which is most landscape ones):

| Board | old 20mm QR band | new 6mm address line | gain |
|---|---|---|---|
| 4×3 landscape | 47 075 mm² | 54 351 mm² | **+15.5%** |
| 5×4 landscape | 44 133 mm² | 50 955 mm² | **+15.5%** |
| 3×6 portrait | 31 601 mm² | 35 219 mm² | **+11.4%** |

And the code it was buying is ~0.37mm/module at 0.6in — at or under the same detection floor. It was paying a size penalty for a scan that half-works.

`header_mode` `qr_only` → `url_only`: a 6mm band with one 6.5pt line naming the board's address, no code. `RenderAssetData` skips the 480px QR encode for that page since nothing renders it. The scannable code is untouched on the colour and low-ink pages and on the trim-ready file's own cover and credits pages, and the how-to-use page now says where it went. (Width-limited boards see no change — they were already spanning the full sheet.)

## Test plan

- `bundle exec rspec spec/services/boards spec/views/api/boards spec/services/printables` → **1089 examples, 0 failures**
- `bundle exec rspec spec/requests/api/admin/board_printables_spec.rb spec/requests/admin/board_printables_spec.rb spec/services/boards/generate_preview_assets_spec.rb` → **92 examples, 0 failures**
- Rendered the video outro and a real trim-ready board page through Grover and eyeballed both.

Docs: `.claude-notes/board-printables-etsy.md` gains the screen-vs-print QR rule and the trim-ready rationale; CHANGELOG entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)