### PR TITLE
feat(printables): send a listing video to an existing Etsy listing, and backfill tools

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -607,11 +607,78 @@ no migration; bump `BoardPrintable::VIDEO_SPEC_VERSION` to force a fleet-wide
 re-render. A hand-uploaded clip (`VIDEO_MANUAL`, the admin's "Upload instead"
 field) is never stale — nothing could re-render it.
 
+### Sending a video to a listing that already exists
+
+Publishing carries the video with it, so a listing created before its video was
+rendered can never get one from the publish path again. `POST push_video_to_etsy`
+(`Etsy::PushListingVideo`) is the way in, and it is **not** a hole in the
+drafts-only rule: adding a video to a listing that has none is an additive POST,
+the same class of call as `upload_image` and `upload_file`, which have always run
+against listings. No state, no title, no tags, and still no call anywhere that
+activates a listing or deletes anything from one.
+
+The gallery deliberately does **not** get the same treatment. Replacing photos
+means deleting the ones already on the listing, and a DELETE against a live
+listing is exactly what the drafts-only invariant keeps out — that path stays in
+`speakanyway-printables` (below).
+
+**The hazard is Etsy's one-video-per-listing rule, and the guard is local
+memory.** This app cannot read a listing back — `Etsy::Client` implements no list
+or delete counterpart for videos on purpose — so it can't discover a video that
+is already there, and a second POST has no outcome it could verify.
+`board_printables.etsy_video_pushed_at` is the only thing that makes the second
+push refusable. Three rails hold it:
+
+- **The publish path stamps it too.** A draft born with a video would otherwise
+  be offered another one by the admin control.
+- **A failed upload does not stamp it.** Writing it on failure would lock a
+  listing out of ever getting its video.
+- **`relist!` clears it.** A detached printable is heading for a new listing that
+  has nothing on it; leaving the stamp set would hide the control.
+
+Once a video has gone, replacing it needs Etsy's `video_id` form field — an
+update call this app does not have — so the control retires itself and names the
+seller UI instead.
+
+## Backfilling listings made before the current gallery and video
+
+Two admin rake tasks, for the population of listings that went up before a slide
+or the video slot existed:
+
+- `rake printables:render_listing_videos` — enqueues a flip-through for every
+  complete printable whose `listing_video_current?` is false, which covers both
+  "has none" and "has one from a different version of this printable". A
+  hand-uploaded clip reports current and is skipped: nothing could re-render it.
+  `PUBLISHED_ONLY=1` narrows to printables already attached to a listing. It
+  aborts rather than enqueueing when ffmpeg is missing, because the job checks
+  too and would return immediately — which looks exactly like the task having
+  worked.
+- `rake 'printables:export_listing[<id>]'` — writes a printable's gallery images
+  (in `LISTING_IMAGE_ORDER`, which is what decides Etsy's ranks) plus a
+  `listing.json` of its copy, for `npm run etsy -- update <listingId>
+  ./listing.json --replace-images` in `speakanyway-printables`. Read-only; with
+  no id it exports every listed printable.
+
+**The export is how a LIVE listing's tags and photos get fixed**, and the split
+is deliberate: that repo already owns and tests delete-then-reupload, and
+importing it here would mean adding the delete call this app pointedly lacks.
+
+Two keys are absent from the generated config, and adding either is a behaviour
+change rather than a convenience: **`state`**, because writing `"active"` there
+would be this app activating a listing; and **`files`**, so `--replace-files`
+can't be pointed at an export that never intended it — replacing downloads
+deletes the buyer's files first, and a backfill of marketing assets has no
+business touching them. A printable whose gallery isn't current is refused
+outright rather than warned about: `--replace-images` deletes before it uploads,
+so a partial gallery would take nine good images off and put five back.
+
 ## Replacing a draft — "Detach & relist"
 
 This app **creates** listings and implements no call that updates one. So a
-re-rendered gallery or a newly rendered video **cannot reach an existing draft**
-— there is no code path, by design. `POST relist_on_etsy` is the way round it:
+re-rendered **gallery** cannot reach an existing draft — replacing photos needs a
+delete this app does not have, by design. (A *video* is the one exception, and
+only because adding one is additive rather than an update — see above.)
+`POST relist_on_etsy` is the way round it:
 it clears `etsy_listing_id` / `etsy_listing_url` so `guard_failure` stops
 refusing, and Publish then creates a fresh draft carrying the current images and
 video. It sends **nothing** to Etsy; deleting the superseded draft is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A listing video can be sent to a listing that already exists.** Publishing
+  carries the video with it, so a listing created before its video was rendered
+  could never get one without relisting. The video card now offers "Send video
+  to the listing" for a printable already attached to one. It only ADDS a video
+  — Etsy allows one per listing and the app can't read a listing back to check,
+  so the control retires itself once a clip has gone and points at the Etsy
+  seller UI for a swap.
+
+- **Two admin backfill tasks for listings made before the current gallery and
+  video.** `rake printables:render_listing_videos` queues a flip-through for
+  every printable with no video or a stale one (`PUBLISHED_ONLY=1` narrows to
+  listed ones), and `rake 'printables:export_listing[<id>]'` writes a
+  printable's copy and gallery images to disk with a `listing.json` for the
+  `speakanyway-printables` Etsy CLI, so a live listing's tags and photos can be
+  replaced without relisting it.
+
 - **A published printable can be relisted.** The app only ever creates Etsy
   listings — it has no way to update one — so re-rendering a gallery or a video
   could never reach a draft that already existed. "Detach & relist" on the Etsy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,7 +420,12 @@ an explicit decision, not a drive-by edit.
   `Etsy::Client#create_listing` hardcodes `state: "draft"` and the client
   implements no activate call — the absence is the guarantee. Publishing a
   board printable to Etsy means creating a draft; going live stays a deliberate
-  click in the Etsy seller UI. Relatedly, Etsy's refresh token is single-use and
+  click in the Etsy seller UI. The line the invariant draws is between ADDING
+  media and UPDATING a listing: `upload_image`/`upload_file`/`upload_video` all
+  run against listings and always have, so sending a video to a listing that has
+  none (`Etsy::PushListingVideo`) is in bounds, while replacing a gallery needs a
+  DELETE and stays out — that path lives in `speakanyway-printables`. Relatedly,
+  Etsy's refresh token is single-use and
   rotates on every exchange, so it lives in `oauth_credentials` (not ENV) and
   Rails holds a **separate authorization** from the one `speakanyway-printables`
   uses — a shared grant makes the two invalidate each other.

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -89,6 +89,34 @@ module Admin
       end
     end
 
+    # Sends an already-rendered video to the listing this printable is attached
+    # to. The one listing mutation this app performs after creation, and it is
+    # additive: Etsy allows one video per listing, none of these listings has
+    # one, and a POST adds it. No state, no delete, no update call — the
+    # drafts-only invariant is untouched. See Etsy::PushListingVideo.
+    def push_video_to_etsy
+      printable = BoardPrintable.find(params[:id])
+
+      if !printable.etsy_published?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "This printable isn't attached to an Etsy listing, so there's nothing to send a video to."
+      elsif !printable.listing_video?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "There's no listing video yet. Render or upload one first."
+      elsif printable.etsy_video_pushed?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "A video has already been sent to listing #{printable.etsy_listing_id}. Etsy allows " \
+                           "one per listing and this app can't replace it — swap it in the Etsy seller UI."
+      elsif !Etsy::Client.configured?
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    alert: "Etsy isn't configured. Set the ETSY_* env vars and run `rake etsy:seed_refresh_token`."
+      else
+        PushBoardPrintableVideoToEtsyJob.perform_async(printable.id)
+        redirect_to admin_dashboard_board_printable_path(printable),
+                    notice: "Sending the video to listing #{printable.etsy_listing_id}… refresh in a moment."
+      end
+    end
+
     # Detaches this printable from its Etsy draft so Publish can create a fresh
     # one. The only way a re-rendered gallery reaches Etsy at all: this app
     # CREATES listings and has no call that updates one, by design, so an

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -78,6 +78,17 @@ module Admin
       "#{count == 1 ? "stays" : "stay"} protected."
     end
 
+    # The confirm on "Send video to the listing". States the precondition the
+    # app cannot check for itself: Etsy allows one video per listing, and
+    # nothing here can read a listing back to find out whether it already has
+    # one. Naming the listing id is what lets an admin go and look.
+    def push_video_confirm(printable)
+      "Send this video to Etsy listing #{printable.etsy_listing_id}? " \
+      "Etsy allows ONE video per listing and this app can't read the listing to check — " \
+      "only continue if that listing has no video yet. It can't be undone from here; " \
+      "replacing a listing's video is a seller-UI job."
+    end
+
     # The confirm on the release button. Names the listing id, because that's
     # the thing an admin should go look at before deciding the paper is dead.
     def waive_protection_confirm(printable)

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -368,6 +368,29 @@ class BoardPrintable < ApplicationRecord
   # them. Widening can only over-protect; narrowing unfreezes printed paper.
   def etsy_ever_published? = etsy_published_at.present? || etsy_listing_id.present?
 
+  # Whether this app has already sent a listing video to the listing this
+  # printable is attached to.
+  #
+  # Etsy allows exactly one video per listing, and Etsy::Client implements no
+  # list or delete counterpart — so the app cannot ask a listing whether it
+  # already has one. A POST against a listing with NO video is the safe,
+  # intended call; a second POST has no outcome this app could verify. This
+  # column is the only memory that makes the second one refusable.
+  def etsy_video_pushed? = etsy_video_pushed_at.present?
+
+  # Whether "Send video to the listing" should be offered at all.
+  #
+  # Note this deliberately does NOT require `listing_video_current?`: a stale
+  # rendered clip is a judgement call the admin makes with the badge in front of
+  # them, exactly as publishing does. What it does require is that a video
+  # exists and that a listing is attached right now — a detached printable has
+  # nothing to push to, and publishing will carry the video anyway.
+  def can_push_listing_video? = etsy_published? && listing_video? && !etsy_video_pushed?
+
+  def mark_etsy_video_pushed!
+    update_columns(etsy_video_pushed_at: Time.current, updated_at: Time.current)
+  end
+
   # Whether this printable freezes the boards it was rendered from.
   #
   # Keyed on `etsy_published_at`, NOT on the record existing: generating a
@@ -401,6 +424,11 @@ class BoardPrintable < ApplicationRecord
       etsy_listing_id: nil,
       etsy_listing_url: nil,
       etsy_error: nil,
+      # Scoped to the listing it was pushed to, so detaching from that listing
+      # retires the fact. The replacement draft has no video until publishing
+      # gives it one, and leaving the stamp set would hide the push control for
+      # a listing that genuinely has nothing on it.
+      etsy_video_pushed_at: nil,
     )
   end
 

--- a/app/services/etsy/publish_board_printable.rb
+++ b/app/services/etsy/publish_board_printable.rb
@@ -152,6 +152,11 @@ module Etsy
       return if file.blank?
 
       client.upload_video(listing_id, bytes: file.download, filename: file.filename.to_s)
+      # Etsy allows one video per listing and this app can't read back whether
+      # one is there, so the draft having received one has to be remembered
+      # here — otherwise the admin's "Send video to the listing" control would
+      # offer a second POST against a listing that already has one.
+      printable.mark_etsy_video_pushed!
     rescue StandardError => e
       Rails.logger.error("[Etsy::PublishBoardPrintable] printable #{printable.id} video: #{e.class} - #{e.message}")
       printable.update_columns(

--- a/app/services/etsy/push_listing_video.rb
+++ b/app/services/etsy/push_listing_video.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Sends an already-rendered listing video to the Etsy listing a BoardPrintable
+# is ALREADY attached to.
+#
+# Why this exists as its own path: Etsy::PublishBoardPrintable uploads the video
+# as part of creating a draft, and this app implements no call that updates a
+# listing — so a video rendered after the draft was made could not reach it at
+# all. The usual answer to that is "Detach & relist", which is right for a
+# GALLERY (replacing photos needs a delete Etsy::Client deliberately doesn't
+# have) but disproportionate for a video: adding one to a listing that has none
+# is a plain additive POST, the same class of call as #upload_image and
+# #upload_file, which already run against listings.
+#
+# INVARIANT — this does not weaken the drafts-only rule. It adds media; it
+# sends no state, no title, no tags, and there is still no path in this app that
+# activates a listing or deletes anything from one.
+#
+# The hazard it DOES have to hold is Etsy's one-video-per-listing rule. The app
+# cannot read a listing back, so it can't discover an existing video; a second
+# POST has no outcome it could verify. `BoardPrintable#etsy_video_pushed_at` is
+# the local memory that makes the second one refusable, and it is stamped by
+# the publish path too — a draft that was born with a video must not be offered
+# another.
+#
+# Never retried (see PushBoardPrintableVideoToEtsyJob), for the same reason
+# publishing isn't: a retry after a partial success is a second video against a
+# listing that may already have taken the first.
+module Etsy
+  class PushListingVideo
+    Result = Struct.new(:ok?, :error, keyword_init: true)
+
+    def initialize(printable, client: nil)
+      @printable = printable
+      @client = client
+    end
+
+    def call
+      guard = guard_failure
+      return failure(guard) if guard
+
+      file = printable.video_file
+      client.upload_video(printable.etsy_listing_id, bytes: file.download, filename: file.filename.to_s)
+
+      # Stamped only after Etsy accepted it. A failed upload must leave the
+      # control available, or a transient error would lock the listing out of
+      # ever getting its video.
+      printable.mark_etsy_video_pushed!
+      printable.update_columns(etsy_error: nil, updated_at: Time.current)
+
+      Result.new(ok?: true)
+    rescue StandardError => e
+      Rails.logger.error("[Etsy::PushListingVideo] printable #{printable.id}: #{e.class} - #{e.message}")
+      failure("The listing video failed to upload: #{e.message}")
+    end
+
+    private
+
+    attr_reader :printable
+
+    def client = @client ||= Client.new
+
+    def guard_failure
+      return "This printable isn't attached to an Etsy listing." unless printable.etsy_published?
+      return "This printable has no listing video. Render or upload one first." unless printable.listing_video?
+
+      if printable.etsy_video_pushed?
+        # Naming the way out matters, and the way out is NOT another POST from
+        # here: replacing a listing's video needs Etsy's `video_id` field, which
+        # is the update call this app pointedly does not implement.
+        return "A video has already been sent to listing #{printable.etsy_listing_id}. Etsy allows one per " \
+               "listing, and this app can't replace it — swap it in the Etsy seller UI."
+      end
+
+      nil
+    end
+
+    def failure(message)
+      printable.update_columns(etsy_error: message.to_s.truncate(1000), updated_at: Time.current)
+      Result.new(ok?: false, error: message)
+    end
+  end
+end

--- a/app/sidekiq/push_board_printable_video_to_etsy_job.rb
+++ b/app/sidekiq/push_board_printable_video_to_etsy_job.rb
@@ -1,0 +1,24 @@
+# Sends a rendered listing video to the Etsy listing a printable is already
+# attached to. Off the request thread because the work is downloading up to
+# 100 MB from S3 and posting it back out as multipart.
+#
+# retry: 0, for the same reason PublishBoardPrintableToEtsyJob is: this writes
+# to a real Etsy shop, and Etsy allows exactly one video per listing. A retry
+# after a partial success is a second video against a listing that may already
+# have taken the first, and this app has no way to read a listing back and find
+# out. A failure records itself on the printable and waits for a human.
+class PushBoardPrintableVideoToEtsyJob
+  include Sidekiq::Job
+  sidekiq_options retry: 0, queue: :default
+
+  def perform(board_printable_id)
+    printable = BoardPrintable.find_by(id: board_printable_id)
+    return unless printable
+    # Belt and braces against a double-click enqueueing twice. The service
+    # guards on this too; checking here keeps the second job from downloading
+    # the clip before finding out.
+    return if printable.etsy_video_pushed?
+
+    Etsy::PushListingVideo.new(printable).call
+  end
+end

--- a/app/views/admin/board_printables/_etsy.html.erb
+++ b/app/views/admin/board_printables/_etsy.html.erb
@@ -42,14 +42,20 @@
           target: "_blank", rel: "noopener",
           class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white" %>
 
-    <%# The app CREATES listings and implements no call that updates one, so a
-        re-rendered gallery can never reach this draft in place. Replacing it is
-        a deliberate two-step: detach here, delete the old draft on Etsy
-        yourself, publish again. Nothing here touches Etsy. %>
+    <%# The app CREATES listings and implements no call that UPDATES one, so a
+        re-rendered gallery can never reach this draft in place: replacing photos
+        needs a delete Etsy::Client deliberately doesn't have. Replacing it is a
+        deliberate two-step: detach here, delete the old draft on Etsy yourself,
+        publish again. Nothing here touches Etsy.
+
+        The video is the one exception, and it is not an update: adding a video
+        to a listing that has none is an additive POST, offered on the video card
+        above. Everything else needs a relist. %>
     <div class="mt-4 pt-4 border-t border-white/10 flex items-start justify-between gap-4">
       <p class="text-[11px] text-t3">
-        Re-rendered the images or the video? They <strong>won't</strong> reach this draft — the app
-        only ever creates listings. Detach, delete the old draft on Etsy, then publish again.
+        Re-rendered the <strong>images</strong>? They won't reach this draft — the app only ever creates
+        listings. Detach, delete the old draft on Etsy, then publish again. A <strong>video</strong> is the
+        exception: if this listing hasn't got one, send it from the video card above without relisting.
       </p>
       <%= button_to "Detach & relist", relist_on_etsy_admin_dashboard_board_printable_path(@printable),
             method: :post,

--- a/app/views/admin/board_printables/_listing_video.html.erb
+++ b/app/views/admin/board_printables/_listing_video.html.erb
@@ -60,6 +60,40 @@
     </p>
   <% end %>
 
+  <%# Sending the clip to a listing that already exists. Publishing carries the
+      video with it, so this is only for a listing that was created before its
+      video was rendered — which is every listing made before the video slot
+      existed. Additive: Etsy takes one video per listing and this adds it. The
+      app cannot read a listing back to check, so once one has been sent the
+      control retires itself and says where to swap it instead. %>
+  <% if @printable.etsy_published? %>
+    <div class="mb-4 pt-3 border-t" style="border-color: var(--border);">
+      <% if @printable.etsy_video_pushed? %>
+        <p class="text-[11px] text-t3">
+          Sent to listing <%= @printable.etsy_listing_id %>
+          <%= "on #{@printable.etsy_video_pushed_at.strftime('%b %-d, %Y')}" if @printable.etsy_video_pushed_at %>.
+          Etsy allows one video per listing and this app can't replace it — swap it in the seller UI.
+        </p>
+      <% elsif video %>
+        <div class="flex items-start justify-between gap-4">
+          <p class="text-[11px] text-t3">
+            This listing was created without a video. Send this clip to it — Etsy takes one video per
+            listing, so only do this if listing <%= @printable.etsy_listing_id %> hasn't got one already.
+          </p>
+          <%= button_to "Send video to the listing", push_video_to_etsy_admin_dashboard_board_printable_path(@printable),
+                method: :post,
+                class: "shrink-0 text-xs font-medium px-3 py-2 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
+                form: { data: { turbo_confirm: push_video_confirm(@printable) } } %>
+        </div>
+      <% else %>
+        <p class="text-[11px] text-t3">
+          Listing <%= @printable.etsy_listing_id %> has no video. Render or upload a clip above and you
+          can send it without relisting.
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+
   <%# For the listings worth filming. A real recording of a board being used
       beats a rendered slideshow, and no renderer can produce one. %>
   <%= form_with url: upload_listing_video_admin_dashboard_board_printable_path(@printable),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
         patch :update_listing
         post :publish_to_etsy
         post :relist_on_etsy
+        post :push_video_to_etsy
         post :regenerate_listing_images
         post :regenerate_listing_video
         post :upload_listing_video

--- a/db/migrate/20260818120000_add_etsy_video_pushed_at_to_board_printables.rb
+++ b/db/migrate/20260818120000_add_etsy_video_pushed_at_to_board_printables.rb
@@ -1,0 +1,19 @@
+# Records that this app has sent a listing video to the Etsy listing a
+# printable is attached to.
+#
+# Needed because Etsy allows exactly ONE video per listing and this app
+# implements no list or delete counterpart for them (see Etsy::Client
+# #upload_video) — so it cannot look at a listing and find out whether one is
+# already there. A POST is safe against a listing with no video and is the
+# whole point of the push; a SECOND one has no defined outcome this app could
+# check. The column is the local memory that makes the second push refusable.
+#
+# Deliberately not cleared by re-rendering the video: replacing a listing's
+# existing video needs Etsy's `video_id` form field, which is an update call
+# the drafts-only invariant keeps out. Once a listing has one, swapping it is
+# a seller-UI job.
+class AddEtsyVideoPushedAtToBoardPrintables < ActiveRecord::Migration[8.0]
+  def change
+    add_column :board_printables, :etsy_video_pushed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_17_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -244,6 +244,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_17_120000) do
     t.datetime "protection_waived_at"
     t.bigint "protection_waived_by_id"
     t.string "protection_waived_reason"
+    t.datetime "etsy_video_pushed_at"
     t.index ["board_id", "status"], name: "index_board_printables_on_board_id_and_status"
     t.index ["board_id"], name: "index_board_printables_on_board_id"
     t.index ["board_ids"], name: "index_board_printables_on_board_ids", using: :gin

--- a/lib/tasks/printables.rake
+++ b/lib/tasks/printables.rake
@@ -24,4 +24,143 @@ namespace :printables do
     end
     puts "Done. Watch Sidekiq; each printable is up to #{Boards::Printables::ContentTilePlan::MAX_TILES + 4} renders."
   end
+
+  # The video counterpart of refresh_listing_images. Rendering one is up to ten
+  # Grover frames plus an ffmpeg encode, so this enqueues rather than renders —
+  # same reason, one more zero on the clock.
+  #
+  # Selects on #listing_video_current?, which covers both "has no video" and
+  # "has one rendered from a different version of this printable". A
+  # hand-uploaded clip reports current and is correctly skipped: nothing here
+  # could re-render it, and replacing it is exactly what an operator did NOT
+  # ask for.
+  #
+  # PUBLISHED_ONLY=1 narrows to printables already attached to a listing — the
+  # backlog you work through when the video slot arrives after the listings did.
+  desc "Render the listing video for printables that have none, or a stale one"
+  task render_listing_videos: :environment do
+    unless VideoTranscoder.available?
+      # Said out loud rather than enqueued: the job checks too and would return
+      # immediately, which looks exactly like the task having worked.
+      abort("ffmpeg isn't available on this host, so no listing video can be rendered here.")
+    end
+
+    scope = BoardPrintable.where(status: "complete")
+    scope = scope.where.not(etsy_listing_id: nil) if ENV["PUBLISHED_ONLY"] == "1"
+    pending = scope.reject(&:listing_video_current?)
+
+    if pending.empty?
+      puts "Nothing to do: every printable in scope already has a current listing video."
+      next
+    end
+
+    puts "Enqueuing #{pending.size} printable(s):"
+    pending.each do |printable|
+      state = printable.listing_video? ? "stale" : "none"
+      puts "  ##{printable.id} #{printable.board&.name.inspect} (video: #{state})"
+      RenderBoardPrintableListingVideoJob.perform_async(printable.id)
+    end
+    puts "Done. Watch Sidekiq; each one is minutes, not seconds."
+  end
+
+  # Exports a printable's listing so `speakanyway-printables` can push it to an
+  # EXISTING Etsy listing.
+  #
+  #   rake 'printables:export_listing[123]'   # one printable
+  #   rake printables:export_listing          # every printable attached to a listing
+  #
+  # Why an export rather than doing it from Rails: replacing a live listing's
+  # photos means DELETING the ones already on it, and Etsy::Client implements no
+  # delete — deliberately, because a delete against a live listing is what the
+  # drafts-only invariant exists to keep out. That repo's `etsy update
+  # --replace-images` already owns and tests that path; it just needs the files
+  # on disk and a config, which is all this writes.
+  #
+  # Two things are deliberately ABSENT from the config, and adding either would
+  # be a behaviour change, not a convenience:
+  #
+  #   state       — omitted so the CLI leaves the listing's state alone. Writing
+  #                 "active" here would be this app activating a listing.
+  #   files       — omitted so --replace-files can't be used against an export
+  #                 that never intended it. The download PDFs are not what this
+  #                 backfill is fixing, and replacing them deletes the buyer's
+  #                 files first.
+  #
+  # Read-only: nothing here writes to the database or to Etsy.
+  desc "Export a printable's listing copy + gallery images for the printables Etsy CLI"
+  task :export_listing, [:printable_id] => :environment do |_t, args|
+    out_root = Pathname.new(ENV["OUT_DIR"].presence || Rails.root.join("tmp", "etsy_exports").to_s)
+
+    printables =
+      if args[:printable_id].present?
+        [BoardPrintable.find(args[:printable_id])]
+      else
+        BoardPrintable.where(status: "complete").where.not(etsy_listing_id: nil).order(:id).to_a
+      end
+
+    if printables.empty?
+      puts "Nothing to export."
+      next
+    end
+
+    exported = []
+    printables.each do |printable|
+      label = "##{printable.id} #{printable.board&.name.inspect}"
+
+      # Refused rather than warned: the whole point of the export is to replace
+      # a live listing's photos, and a partial gallery would delete nine good
+      # images and put five back.
+      unless printable.listing_images_current?
+        puts "  SKIP #{label} — gallery isn't current. Run printables:refresh_listing_images and wait for Sidekiq."
+        next
+      end
+
+      copy = printable.listing_copy_or_default
+      if copy["title"].blank? || copy["description"].blank?
+        puts "  SKIP #{label} — listing copy has no title or description."
+        next
+      end
+
+      dir = out_root.join(printable.id.to_s)
+      FileUtils.mkdir_p(dir)
+
+      # Written in LISTING_IMAGE_ORDER: the CLI uploads the array in order and
+      # ranks them 1..N, and rank 1 is Etsy's search thumbnail. The numeric
+      # filename prefix is for the human reviewing the folder — the ORDER of the
+      # array is what actually decides the ranks.
+      image_names = printable.current_image_files
+                             .sort_by { |f| BoardPrintable::LISTING_IMAGE_ORDER.index(f.metadata["variant"]) }
+                             .each_with_index.map do |file, index|
+        name = format("%02d-%s.png", index + 1, file.metadata["variant"].to_s.dasherize)
+        File.binwrite(dir.join(name), file.download)
+        name
+      end
+
+      config = {
+        "title" => copy["title"],
+        "description" => copy["description"],
+        "price" => (copy["price_cents"].to_i / 100.0).round(2),
+        "tags" => Array(copy["tags"]),
+        "images" => image_names,
+      }
+      File.write(dir.join("listing.json"), JSON.pretty_generate(config) + "\n")
+
+      puts "  #{label} → #{dir} (#{image_names.size} images, #{config['tags'].size} tags)"
+      exported << [printable, dir]
+    end
+
+    if exported.empty?
+      puts "Nothing exported."
+      next
+    end
+
+    puts
+    puts "Review the tags in each listing.json, then from the speakanyway-printables repo:"
+    exported.each do |printable, dir|
+      puts "  npm run etsy -- update #{printable.etsy_listing_id} #{dir}/listing.json --replace-images"
+    end
+    puts
+    puts "Do ONE first and check it in the seller UI: --replace-images deletes the listing's existing"
+    puts "photos before uploading these. The listing VIDEO is a separate slot and is untouched by this."
+  end
 end

--- a/spec/lib/tasks/printables_listing_export_spec.rb
+++ b/spec/lib/tasks/printables_listing_export_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+RSpec.describe "printables listing backfill rake tasks", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "Core Words") }
+
+  def complete_printable(**attrs)
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], **attrs)
+  end
+
+  def with_current_gallery(printable)
+    BoardPrintable::LISTING_IMAGE_ORDER.each { |v| printable.attach_image!(bytes: "png-#{v}", variant: v) }
+    printable
+  end
+
+  describe "printables:render_listing_videos" do
+    let(:task) { Rake::Task["printables:render_listing_videos"] }
+
+    def run_task
+      task.reenable
+      task.invoke
+    end
+
+    around do |example|
+      original = ENV["PUBLISHED_ONLY"]
+      example.run
+      ENV["PUBLISHED_ONLY"] = original
+    end
+
+    before { allow(VideoTranscoder).to receive(:available?).and_return(true) }
+
+    it "enqueues a render for a printable with no video" do
+      printable = complete_printable
+
+      expect { run_task }.to change(RenderBoardPrintableListingVideoJob.jobs, :size).by(1)
+      expect(RenderBoardPrintableListingVideoJob.jobs.last["args"]).to eq([printable.id])
+    end
+
+    # Nothing can re-render a hand-uploaded clip, so replacing it is exactly
+    # what the operator who uploaded it did not ask for.
+    it "skips a hand-uploaded clip" do
+      printable = complete_printable
+      printable.attach_video!(bytes: "mp4", duration: 9.0, source: BoardPrintable::VIDEO_MANUAL)
+
+      expect { run_task }.not_to change(RenderBoardPrintableListingVideoJob.jobs, :size)
+    end
+
+    it "skips a printable whose rendered video is already current" do
+      printable = complete_printable
+      printable.attach_video!(bytes: "mp4", duration: 9.0)
+
+      expect { run_task }.not_to change(RenderBoardPrintableListingVideoJob.jobs, :size)
+    end
+
+    it "narrows to listed printables under PUBLISHED_ONLY" do
+      complete_printable
+      listed = complete_printable(etsy_listing_id: 987, etsy_published_at: 1.day.ago)
+      ENV["PUBLISHED_ONLY"] = "1"
+
+      expect { run_task }.to change(RenderBoardPrintableListingVideoJob.jobs, :size).by(1)
+      expect(RenderBoardPrintableListingVideoJob.jobs.last["args"]).to eq([listed.id])
+    end
+
+    # The job checks too and would return immediately, which looks exactly like
+    # the task having worked.
+    it "aborts rather than enqueueing when ffmpeg is unavailable" do
+      complete_printable
+      allow(VideoTranscoder).to receive(:available?).and_return(false)
+
+      expect { run_task }.to raise_error(SystemExit)
+        .and(not_change(RenderBoardPrintableListingVideoJob.jobs, :size))
+    end
+  end
+
+  describe "printables:export_listing" do
+    let(:task) { Rake::Task["printables:export_listing"] }
+    let(:out_dir) { Rails.root.join("tmp", "etsy_exports_spec_#{SecureRandom.hex(4)}") }
+
+    def run_task(printable_id = nil)
+      task.reenable
+      task.invoke(printable_id)
+    end
+
+    around do |example|
+      original = ENV["OUT_DIR"]
+      ENV["OUT_DIR"] = out_dir.to_s
+      example.run
+      ENV["OUT_DIR"] = original
+      FileUtils.rm_rf(out_dir)
+    end
+
+    let(:printable) do
+      p = complete_printable(etsy_listing_id: 987, etsy_published_at: 1.day.ago)
+      p.update!(listing_copy: {
+        "title" => "Core Words Communication Board",
+        "description" => "A printable communication board.",
+        "tags" => ["aac", "hospital stay"],
+        "price_cents" => 450,
+      })
+      with_current_gallery(p)
+    end
+
+    def config_for(p) = JSON.parse(File.read(out_dir.join(p.id.to_s, "listing.json")))
+
+    it "writes a config the printables CLI can read, with every gallery image in rank order" do
+      run_task(printable.id.to_s)
+
+      config = config_for(printable)
+      expect(config["title"]).to eq("Core Words Communication Board")
+      expect(config["tags"]).to eq(["aac", "hospital stay"])
+      expect(config["price"]).to eq(4.5)
+      expect(config["images"].size).to eq(BoardPrintable::LISTING_IMAGE_ORDER.size)
+
+      # The ARRAY order is what decides Etsy's ranks, and rank 1 is the search
+      # thumbnail — so it has to be LISTING_IMAGE_ORDER, not whatever order the
+      # blobs happen to come back in.
+      expected = BoardPrintable::LISTING_IMAGE_ORDER.map { |v| v.dasherize }
+      expect(config["images"].map { |n| n.sub(/\A\d+-/, "").sub(/\.png\z/, "") }).to eq(expected)
+
+      config["images"].each do |name|
+        expect(File).to exist(out_dir.join(printable.id.to_s, name))
+      end
+    end
+
+    # Writing "active" here would be this app activating a listing, which is the
+    # thing the drafts-only invariant exists to prevent. Omitting the key leaves
+    # the CLI no state to send.
+    it "sends no listing state and no download files" do
+      run_task(printable.id.to_s)
+
+      config = config_for(printable)
+      expect(config).not_to have_key("state")
+      expect(config).not_to have_key("files")
+      expect(config).not_to have_key("taxonomyId")
+    end
+
+    # --replace-images DELETES the listing's photos before uploading, so a
+    # partial gallery would take nine good images off and put five back.
+    it "refuses a printable whose gallery isn't current" do
+      stale = complete_printable(etsy_listing_id: 55, etsy_published_at: 1.day.ago)
+      stale.update!(listing_copy: { "title" => "T", "description" => "D", "tags" => [], "price_cents" => 500 })
+      stale.attach_image!(bytes: "png", variant: BoardPrintable::LISTING_IMAGE_ORDER.first)
+
+      run_task(stale.id.to_s)
+
+      expect(File).not_to exist(out_dir.join(stale.id.to_s, "listing.json"))
+    end
+
+    it "exports every listed printable when given no id" do
+      printable
+      unlisted = with_current_gallery(complete_printable)
+      unlisted.update!(listing_copy: { "title" => "T", "description" => "D", "tags" => [], "price_cents" => 500 })
+
+      run_task
+
+      expect(File).to exist(out_dir.join(printable.id.to_s, "listing.json"))
+      # Nothing to push to, so nothing to export.
+      expect(File).not_to exist(out_dir.join(unlisted.id.to_s, "listing.json"))
+    end
+
+    it "writes nothing to the database" do
+      printable
+
+      expect { run_task(printable.id.to_s) }.not_to change { printable.reload.attributes }
+    end
+  end
+end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -651,6 +651,104 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       end
     end
 
+    describe "POST push_video_to_etsy" do
+      before do
+        printable.update!(etsy_listing_id: 987, etsy_listing_url: "https://etsy.test/987", etsy_published_at: 2.days.ago)
+        printable.attach_video!(bytes: "mp4-bytes", duration: 9.0)
+        allow(Etsy::Client).to receive(:configured?).and_return(true)
+      end
+
+      it "enqueues the push for the attached listing" do
+        sign_in admin
+
+        expect {
+          post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+        }.to change(PushBoardPrintableVideoToEtsyJob.jobs, :size).by(1)
+
+        expect(flash[:notice]).to include("987")
+      end
+
+      it "refuses a printable that isn't attached to a listing" do
+        sign_in admin
+        printable.update!(etsy_listing_id: nil)
+
+        expect {
+          post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+        }.not_to change(PushBoardPrintableVideoToEtsyJob.jobs, :size)
+
+        expect(flash[:alert]).to match(/nothing to send a video to/)
+      end
+
+      it "refuses when there is no video to send" do
+        sign_in admin
+        printable.video_files.each(&:purge)
+
+        post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(flash[:alert]).to match(/no listing video yet/i)
+      end
+
+      # Etsy allows one video per listing and this app can't read a listing back
+      # to find out whether one is there, so the stamp is the only guard.
+      it "refuses a second push and points at the seller UI" do
+        sign_in admin
+        printable.update_columns(etsy_video_pushed_at: 1.hour.ago)
+
+        expect {
+          post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+        }.not_to change(PushBoardPrintableVideoToEtsyJob.jobs, :size)
+
+        expect(flash[:alert]).to match(/already been sent/)
+        expect(flash[:alert]).to match(/seller UI/)
+      end
+
+      it "refuses when Etsy isn't configured" do
+        sign_in admin
+        allow(Etsy::Client).to receive(:configured?).and_return(false)
+
+        post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(flash[:alert]).to match(/isn't configured/)
+      end
+
+      it "redirects a non-admin away" do
+        sign_in create(:user)
+
+        post push_video_to_etsy_admin_dashboard_board_printable_path(printable)
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      describe "the show page" do
+        it "offers the control for a listed printable whose video hasn't gone" do
+          sign_in admin
+
+          get admin_dashboard_board_printable_path(printable)
+
+          expect(response.body).to include("Send video to the listing")
+        end
+
+        it "retires the control once a video has gone, and says where to swap it" do
+          sign_in admin
+          printable.update_columns(etsy_video_pushed_at: 1.hour.ago)
+
+          get admin_dashboard_board_printable_path(printable)
+
+          expect(response.body).not_to include("Send video to the listing")
+          expect(response.body).to include("seller UI")
+        end
+
+        it "doesn't offer it for a printable with no listing" do
+          sign_in admin
+          printable.update!(etsy_listing_id: nil)
+
+          get admin_dashboard_board_printable_path(printable)
+
+          expect(response.body).not_to include("Send video to the listing")
+        end
+      end
+    end
+
     describe "POST relist_on_etsy" do
       before { printable.update!(etsy_listing_id: 987, etsy_listing_url: "https://etsy.test/987", etsy_published_at: 2.days.ago) }
 

--- a/spec/services/etsy/push_listing_video_spec.rb
+++ b/spec/services/etsy/push_listing_video_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe Etsy::PushListingVideo do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "Core Words") }
+
+  let(:printable) do
+    BoardPrintable.create!(
+      board: board, status: "complete", board_ids: [board.id], page_count: 6,
+      etsy_listing_id: 987, etsy_listing_url: "https://etsy.test/987", etsy_published_at: 1.day.ago,
+    )
+  end
+
+  let(:client) { instance_double(Etsy::Client) }
+
+  before do
+    printable.attach_video!(bytes: "mp4-bytes", duration: 9.0)
+    allow(client).to receive(:upload_video).and_return(true)
+  end
+
+  def push = described_class.new(printable.reload, client: client).call
+
+  describe "a successful push" do
+    it "uploads the clip to the attached listing and stamps that it went" do
+      expect(client).to receive(:upload_video).with(987, hash_including(bytes: "mp4-bytes"))
+
+      expect(push.ok?).to be true
+      expect(printable.reload.etsy_video_pushed_at).to be_present
+    end
+
+    it "clears a previous error" do
+      printable.update_columns(etsy_error: "an earlier failure")
+
+      push
+
+      expect(printable.reload.etsy_error).to be_nil
+    end
+  end
+
+  describe "the one-video-per-listing guard" do
+    it "refuses a second push and names the seller UI as the way to replace it" do
+      printable.update_columns(etsy_video_pushed_at: 1.hour.ago)
+
+      result = push
+
+      expect(result.ok?).to be false
+      expect(result.error).to match(/already been sent to listing 987/)
+      expect(result.error).to match(/seller UI/)
+      expect(client).not_to have_received(:upload_video)
+    end
+
+    # The publish path uploads a video as part of creating the draft. If that
+    # didn't stamp the column, this service would happily post a SECOND one.
+    it "is closed by the publish path too" do
+      fresh = BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id])
+      fresh.attach_video!(bytes: "mp4", duration: 9.0)
+      fresh.attach_pdf!(filename: "b.pdf", bytes: "pdf", variant: BoardPrintable::VARIANT_FULL)
+      fresh.update!(listing_copy: { "title" => "T", "description" => "D", "tags" => [], "price_cents" => 500 })
+
+      publish_client = instance_double(Etsy::Client)
+      allow(publish_client).to receive(:assert_known_taxonomy!).and_return(true)
+      allow(publish_client).to receive(:create_listing).and_return({ listing_id: 55, url: "https://etsy.test/55" })
+      allow(publish_client).to receive(:set_listing_price).and_return(true)
+      allow(publish_client).to receive(:upload_image).and_return(true)
+      allow(publish_client).to receive(:upload_file).and_return(true)
+      allow(publish_client).to receive(:upload_video).and_return(true)
+      allow_any_instance_of(Boards::Printables::RenderListingImages).to receive(:call) do
+        BoardPrintable::LISTING_IMAGE_ORDER.each { |v| fresh.attach_image!(bytes: "png", variant: v) }
+      end
+
+      Etsy::PublishBoardPrintable.new(fresh, client: publish_client).call
+
+      expect(fresh.reload.etsy_video_pushed?).to be true
+      expect(fresh.can_push_listing_video?).to be false
+    end
+  end
+
+  describe "guards" do
+    it "refuses a printable with no attached listing" do
+      printable.update_columns(etsy_listing_id: nil)
+
+      expect(push.ok?).to be false
+      expect(client).not_to have_received(:upload_video)
+    end
+
+    it "refuses a printable with no video" do
+      printable.video_files.each(&:purge)
+      printable.reload
+
+      result = push
+
+      expect(result.ok?).to be false
+      expect(result.error).to match(/no listing video/i)
+    end
+  end
+
+  describe "a failed upload" do
+    # The stamp is what makes a second push refusable, so writing it on failure
+    # would lock the listing out of ever getting its video.
+    it "records the error and leaves the push available to retry by hand" do
+      allow(client).to receive(:upload_video).and_raise(Etsy::Client::Error, "413 too large")
+
+      result = push
+
+      expect(result.ok?).to be false
+      expect(printable.reload.etsy_video_pushed_at).to be_nil
+      expect(printable.etsy_error).to match(/413 too large/)
+      expect(printable.can_push_listing_video?).to be true
+    end
+  end
+
+  describe "the drafts-only invariant" do
+    it "adds media and sends no listing state" do
+      push
+
+      # Adding a video is an additive POST. The absence of an update or delete
+      # call is what keeps this from being a listing mutation.
+      expect(Etsy::Client.instance_methods).not_to include(:activate_listing, :update_listing, :delete_video)
+    end
+  end
+
+  describe "relisting" do
+    # A detached printable is heading for a NEW draft, which has no video until
+    # publishing gives it one. Leaving the stamp set would hide the control for
+    # a listing that genuinely has nothing on it.
+    it "clears the stamp so the replacement listing can receive one" do
+      printable.update_columns(etsy_video_pushed_at: 1.hour.ago)
+
+      printable.relist!
+
+      expect(printable.reload.etsy_video_pushed_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Why

Publishing carries the listing video with it, so a listing created **before** its video was rendered could never get one — the only route was "Detach & relist", which for an *active* listing costs its id, its view/favourite history, and another listing fee. Every listing in the shop is in that state.

Same trip, two backfill tasks the existing listings need: none have a video, and the ones published before the nine-slide gallery (#713) are on the retired five-slide design.

## What

**Sending a video to an existing listing** — `Etsy::PushListingVideo`, a `retry: 0` job, and a control on the video card.

This is **not** a hole in the drafts-only invariant. The line it draws is between *adding media* and *updating a listing*: `upload_image` / `upload_file` / `upload_video` have always run against listings. Adding a video to a listing that has none is an additive POST. Replacing a gallery needs a DELETE and stays out of Rails.

**The one-video-per-listing guard.** Etsy allows one video per listing and this app cannot read a listing back to discover whether one is there, so a second POST has no outcome it could verify. `board_printables.etsy_video_pushed_at` is the local memory that makes it refusable, with three rails:

- the **publish path stamps it too** — a draft born with a video mustn't be offered another
- a **failed upload does not stamp it** — otherwise a transient error locks that listing out of ever getting its video
- **`relist!` clears it** — the replacement listing genuinely has nothing on it

Once a video has gone, replacing it needs Etsy's `video_id` field (an update call this app doesn't have), so the control retires itself and names the seller UI.

**Two backfill rake tasks:**

- `rake printables:render_listing_videos` — queues a flip-through for every printable whose `listing_video_current?` is false (covers "none" and "stale"). Hand-uploaded clips report current and are skipped — nothing could re-render one. `PUBLISHED_ONLY=1` narrows to listed printables. Aborts rather than enqueuing when ffmpeg is missing, since the job would return instantly and look like success.
- `rake 'printables:export_listing[<id>]'` — writes the gallery images in `LISTING_IMAGE_ORDER` (which is what decides Etsy's ranks) plus a `listing.json` for `npm run etsy -- update <id> ./listing.json --replace-images`. Read-only. Delete-then-reupload stays in `speakanyway-printables`, which already owns and tests it.

Two keys are **absent** from the generated config by design: `state` (writing `"active"` would be this app activating a listing) and `files` (so `--replace-files` can't be aimed at an export that never intended it — replacing downloads deletes the buyer's files first). A printable whose gallery isn't current is refused outright, because `--replace-images` deletes before it uploads.

Also corrects the Etsy card copy, which said a re-rendered video won't reach a draft — now true of images only.

## Test plan

`215 examples, 0 failures` across every affected spec file:

```
bundle exec rspec spec/services/etsy/ spec/models/board_printable_spec.rb \
  spec/requests/admin/board_printables_spec.rb \
  spec/requests/admin/board_printables_protection_spec.rb \
  spec/lib/tasks/printables_listing_export_spec.rb
```

New coverage:
- `spec/services/etsy/push_listing_video_spec.rb` (9) — happy path, every guard, the failure path leaving the push retryable, the publish path closing the double-push hole, `relist!` clearing the stamp, and the absence of any update/delete/activate method on the client.
- `spec/lib/tasks/printables_listing_export_spec.rb` (10) — both tasks, including rank order, the absent `state`/`files`/`taxonomyId` keys, the stale-gallery refusal, the hand-uploaded-clip skip, and that the export writes nothing to the DB.
- Request specs (9) — the action's guards plus all three view branches.

`bin/rails zeitwerk:check` clean. Migration is one nullable datetime column.

## Docs

`CHANGELOG.md`, the `board-printables-etsy.md` spoke (two new sections: the video push and the backfill tasks), and the hub invariant now states the add-vs-update line explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)