### PR TITLE
fix(boards): stop board saves from severing a board's Menu parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Menu boards keep their menu photo.** Renaming a board built from a menu —
+  or changing its color, or saving its words — used to disconnect it from the
+  menu it was made from, so the "View Menu" button vanished from the board page
+  and never came back. Saving a board no longer touches where it came from.
+  Boards already disconnected can be reconnected with `rake menu_boards:relink`.
+
 ### Added
 
 - **A published printable can be relisted.** The app only ever creates Etsy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,19 @@ an explicit decision, not a drive-by edit.
 - **`User#paid_plan?` is the single paid-tier gate.** It checks both
   `plan_type` and `plan_status`; `basic_trial` and Stripe `trialing` count as
   paid while active. Never read `plan_type` directly for a paid-feature check.
+- **A board's `parent` is PROVENANCE, not ownership — never reassign it on a
+  save.** `user_id` says who owns a board; `parent` says where it came from
+  (the `Menu` a menu board was extracted from, the `Image` behind a
+  predictive/category board, the `Board` that spawned a subboard, the
+  `OpenaiPrompt` behind a generated one). Both update paths used to set
+  `parent_type = "User"` unconditionally, which severed that link on the first
+  rename — and no other column points back, so it was unrecoverable from the
+  row. A menu board silently lost `original_menu_image_url` (the frontend's
+  "View Menu" button), `menu_description`, and reported its *owner's* user id
+  as `menu_id`. Route every assignment through `Board#sync_user_parent`, which
+  re-points only a `"User"` parent (so a hand-off still follows the owner).
+  Anything derived from `parent` must key on `parent_type`, never on
+  `board_type`. Repair for already-severed rows: `rake menu_boards:relink`.
 - **`User#countable_board_count` / `at_board_limit?` is the single source of
   truth for board counting.** Builder sub-boards (`builder_child`) are
   excluded so a built tree counts as one; every creation gate routes through

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -531,8 +531,10 @@ class API::BoardsController < API::ApplicationController
       settings = !board_params[:settings].blank? ? board_params[:settings] : params[:settings] || {}
       settings["board_type"] = board_type
 
-      @board.parent_type = "User"
-      @board.parent_id = @board_user&.id || User::DEFAULT_ADMIN_ID
+      # Never stomp a Menu/Image/Board/OpenaiPrompt parent here — that link is
+      # the board's provenance and nothing else records it. See
+      # Board#sync_user_parent.
+      @board.sync_user_parent(@board_user&.id)
       new_board_settings = @board.settings.merge(settings)
       @board.settings = new_board_settings
 

--- a/app/controllers/api/internal/boards_controller.rb
+++ b/app/controllers/api/internal/boards_controller.rb
@@ -175,8 +175,9 @@ class API::Internal::BoardsController < API::Internal::ApplicationController
       @board.settings = @board.settings.merge(incoming_settings)
     end
 
-    @board.parent_type = "User"
-    @board.parent_id = @board.user_id || User::DEFAULT_ADMIN_ID
+    # Same guard as the public update path — an admin edit must not sever a
+    # menu board from its Menu. See Board#sync_user_parent.
+    @board.sync_user_parent
 
     # A published board's slug is frozen (printed QR codes encode `/pb/<slug>`
     # — see Board#slug_locked?). This admin surface is the deliberate rename

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -550,6 +550,27 @@ class Board < ApplicationRecord
     generated_token.present?
   end
 
+  # A board's `parent` records PROVENANCE, not ownership — a menu board points
+  # at the Menu it was extracted from, a predictive/category board at its Image,
+  # a subboard at the Board that spawned it, a generated board at its
+  # OpenaiPrompt. Ownership is `user_id`, and only `user_id`.
+  #
+  # The controllers used to reassign parent to the owner on EVERY save, which
+  # severed that link permanently on the first rename or color change: a menu
+  # board silently lost `original_menu_image_url` (the "View Menu" button),
+  # `menu_description`, and `menu_id`, and there is no other column pointing
+  # back at the Menu, so the association could not be recovered from the row.
+  # Call this instead of assigning parent_type/parent_id directly.
+  #
+  # A "User" parent IS re-pointed at the current owner, deliberately: that
+  # parent means "this board belongs to a person" and must follow a hand-off.
+  def sync_user_parent(owner_id = nil)
+    return if parent_id.present? && parent_type.present? && parent_type != "User"
+
+    self.parent_type = "User"
+    self.parent_id = owner_id || user_id || User::DEFAULT_ADMIN_ID
+  end
+
   def set_parent
     if parent_type.nil? && parent_id.nil?
       self.parent_type = "User"
@@ -2302,7 +2323,7 @@ class Board < ApplicationRecord
       source_type: source_type,
       vendor: vendor,
       week_chart: week_chart,
-      menu_id: board_type === "menu" ? parent_id : nil,
+      menu_id: parent_type === "Menu" ? parent_id : nil,
       name: name,
       root_board: @root_board,
       language: language,
@@ -2329,7 +2350,7 @@ class Board < ApplicationRecord
       parent_description: parent_type === "User" ? "User" : parent&.to_s,
       menu_description: parent_type === "Menu" ? parent&.description : nil,
       original_menu_image_url: parent_type === "Menu" ? parent&.menu_image_url : nil,
-      parent_prompt: parent_type === "OpenaiPrompt" ? parent.prompt_text : nil,
+      parent_prompt: parent_type === "OpenaiPrompt" ? parent&.prompt_text : nil,
       predefined: predefined,
       favorite: favorite,
       published: published,

--- a/lib/tasks/menu_boards.rake
+++ b/lib/tasks/menu_boards.rake
@@ -1,0 +1,77 @@
+namespace :menu_boards do
+  # Re-link menu boards whose Menu parent was severed.
+  #
+  # Until Board#sync_user_parent landed, every board save reassigned
+  # parent_type/parent_id to the owning User. For a board created from a menu
+  # that permanently dropped the only pointer back to its Menu, so the API
+  # started returning original_menu_image_url: nil (the "View Menu" button
+  # disappears), menu_description: nil, and menu_id: <the owner's user id>.
+  #
+  # The Menu row and its attached menu_image survive, so the link can be
+  # rebuilt by matching owner + name — menus_controller#create names the board
+  # after the menu. The fingerprint of a severed board is parent_id == user_id.
+  #
+  # Read-only by default. Apply with DRY_RUN=false.
+  #
+  #   rake menu_boards:relink                        # report
+  #   DRY_RUN=false rake menu_boards:relink          # apply
+  #   DRY_RUN=false USER_ID=160 rake menu_boards:relink
+  #
+  # A board with no name match, or with an ambiguous one, is reported and left
+  # alone — re-parenting a board onto the wrong Menu would show a stranger's
+  # menu photo, which is worse than the missing button.
+  desc "Re-link menu boards to the Menu they came from (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task relink: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    match_window = 24.hours
+
+    scope = Board.where(board_type: "menu", parent_type: "User")
+    scope = scope.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    relinked = 0
+    no_match = []
+    ambiguous = []
+
+    scope.find_each do |board|
+      candidates = Menu.where(user_id: board.user_id, name: board.name).to_a
+
+      menu =
+        if candidates.one?
+          candidates.first
+        elsif candidates.many?
+          # Same request creates the menu and then the board, so the closest
+          # created_at is the right one — but only trust it inside a window.
+          nearest = candidates.min_by { |m| (m.created_at - board.created_at).abs }
+          nearest if (nearest.created_at - board.created_at).abs <= match_window
+        end
+
+      if menu.nil?
+        (candidates.empty? ? no_match : ambiguous) << board
+        next
+      end
+
+      puts "  board #{board.id} #{board.name.inspect} (user #{board.user_id}) -> menu #{menu.id}" \
+           "#{menu.menu_image.attached? ? "" : " [menu has no image attached]"}"
+
+      unless dry_run
+        board.update_columns(parent_type: "Menu", parent_id: menu.id)
+      end
+      relinked += 1
+    end
+
+    puts ""
+    puts "#{dry_run ? "would re-link" : "re-linked"} #{relinked} board(s)"
+
+    if no_match.any?
+      puts "#{no_match.size} board(s) with no Menu of the same name — left alone:"
+      no_match.each { |b| puts "  board #{b.id} #{b.name.inspect} (user #{b.user_id})" }
+    end
+
+    if ambiguous.any?
+      puts "#{ambiguous.size} board(s) with an ambiguous match — left alone, re-parent by hand:"
+      ambiguous.each { |b| puts "  board #{b.id} #{b.name.inspect} (user #{b.user_id})" }
+    end
+
+    puts "(dry run — re-run with DRY_RUN=false to apply)" if dry_run
+  end
+end

--- a/spec/requests/api/boards_menu_parent_spec.rb
+++ b/spec/requests/api/boards_menu_parent_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+# A board's `parent` records PROVENANCE — the Menu it was extracted from, the
+# Image behind a predictive board, the Board that spawned a subboard. Every
+# board save used to reassign it to the owning User, which permanently severed
+# that link: the first rename or color change on a menu board dropped
+# `original_menu_image_url` (the "View Menu" button on the board page),
+# `menu_description`, and turned `menu_id` into the OWNER'S user id.
+#
+# Nothing else on the row points back at the Menu, so this was unrecoverable
+# without a name-match backfill (`rake menu_boards:relink`).
+RSpec.describe "API::Boards parent preservation", type: :request do
+  let(:user) { create(:user) }
+
+  def update_board(board, params)
+    put "/api/boards/#{board.id}", params: params, headers: auth_headers(user)
+  end
+
+  describe "a board created from a menu" do
+    let(:menu) { create(:menu, user: user, name: "Applebees", description: "Dinner menu") }
+    let(:board) do
+      create(:board, user: user, name: "Applebees", board_type: "menu",
+                     parent_type: "Menu", parent_id: menu.id)
+    end
+
+    before do
+      menu.menu_image.attach(
+        io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+        filename: "menu.png",
+        content_type: "image/png",
+      )
+    end
+
+    it "keeps the Menu parent through an ordinary rename" do
+      update_board(board, board: { name: "Applebees Dinner" })
+
+      expect(response).to have_http_status(:ok)
+      board.reload
+      expect(board.name).to eq("Applebees Dinner")
+      expect(board.parent_type).to eq("Menu")
+      expect(board.parent_id).to eq(menu.id)
+    end
+
+    it "still serves the menu photo and description after a save" do
+      update_board(board, board: { name: "Applebees Dinner" })
+
+      get "/api/boards/#{board.reload.id}", headers: auth_headers(user)
+      body = JSON.parse(response.body)
+
+      expect(body["original_menu_image_url"]).to be_present
+      expect(body["menu_description"]).to eq("Dinner menu")
+      expect(body["menu_id"]).to eq(menu.id)
+    end
+
+    it "reports menu_id from the Menu association, never the owner's user id" do
+      # The old derivation was `board_type == "menu" ? parent_id : nil`, so a
+      # severed board handed the frontend a User id labelled as a menu id.
+      board.update_columns(parent_type: "User", parent_id: user.id)
+
+      get "/api/boards/#{board.id}", headers: auth_headers(user)
+      body = JSON.parse(response.body)
+
+      expect(body["menu_id"]).to be_nil
+      expect(body["menu_id"]).not_to eq(user.id)
+    end
+  end
+
+  describe "other provenance parents" do
+    it "keeps an Image parent (predictive/category boards)" do
+      image = create(:image, user_id: user.id)
+      board = create(:board, user: user, board_type: "predictive",
+                             parent_type: "Image", parent_id: image.id)
+
+      update_board(board, board: { name: "Renamed" })
+
+      expect(board.reload.parent_type).to eq("Image")
+      expect(board.parent_id).to eq(image.id)
+    end
+
+    it "keeps a Board parent (subboards spawned from a tile)" do
+      parent_board = create(:board, user: user)
+      board = create(:board, user: user, parent_type: "Board", parent_id: parent_board.id)
+
+      update_board(board, board: { name: "Renamed" })
+
+      expect(board.reload.parent_type).to eq("Board")
+      expect(board.parent_id).to eq(parent_board.id)
+    end
+  end
+
+  describe "a User-parented board" do
+    it "still points the parent at the owner" do
+      board = create(:board, user: user, parent_type: "User", parent_id: user.id)
+
+      update_board(board, board: { name: "Renamed" })
+
+      expect(board.reload.parent_type).to eq("User")
+      expect(board.parent_id).to eq(user.id)
+    end
+
+  end
+
+  # Both parent columns are NOT NULL, so a blank parent only exists on a record
+  # that hasn't been saved yet — the case Board#set_parent covers on create.
+  describe "Board#sync_user_parent" do
+    it "fills in a blank parent on an unsaved board" do
+      board = Board.new(user: user, name: "Fresh")
+
+      board.sync_user_parent
+
+      expect(board.parent_type).to eq("User")
+      expect(board.parent_id).to eq(user.id)
+    end
+
+    it "prefers the explicit owner id over the board's user_id" do
+      new_owner = create(:user)
+      board = create(:board, user: user, parent_type: "User", parent_id: user.id)
+
+      board.sync_user_parent(new_owner.id)
+
+      expect(board.parent_id).to eq(new_owner.id)
+    end
+
+    it "ignores the explicit owner id when the parent is provenance" do
+      menu = create(:menu, user: user)
+      board = create(:board, user: user, parent_type: "Menu", parent_id: menu.id)
+
+      board.sync_user_parent(create(:user).id)
+
+      expect(board.parent_type).to eq("Menu")
+      expect(board.parent_id).to eq(menu.id)
+    end
+  end
+end

--- a/spec/tasks/menu_boards_relink_spec.rb
+++ b/spec/tasks/menu_boards_relink_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+require "rake"
+
+# Repairs boards whose Menu parent was severed by the old unconditional
+# reassignment in BoardsController#update. The board row keeps no other pointer
+# to its Menu, so the only handle left is owner + name — which is safe because
+# menus_controller#create names the board after the menu.
+RSpec.describe "menu_boards:relink" do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("menu_boards:relink")
+  end
+
+  let(:task) { Rake::Task["menu_boards:relink"] }
+  let(:user) { create(:user) }
+
+  before { task.reenable }
+  after do
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+  end
+
+  def severed_board(name, **attrs)
+    create(:board, user: user, name: name, board_type: "menu",
+                   parent_type: "User", parent_id: user.id, **attrs)
+  end
+
+  it "reports without writing by default" do
+    menu = create(:menu, user: user, name: "Applebees")
+    board = severed_board("Applebees")
+
+    expect { task.invoke }.to output(/would re-link 1 board/).to_stdout
+
+    expect(board.reload.parent_type).to eq("User")
+    expect(menu.reload.boards).to be_empty
+  end
+
+  it "re-links a board to the one Menu of the same name with DRY_RUN=false" do
+    menu = create(:menu, user: user, name: "Applebees")
+    board = severed_board("Applebees")
+
+    ENV["DRY_RUN"] = "false"
+    expect { task.invoke }.to output(/re-linked 1 board/).to_stdout
+
+    board.reload
+    expect(board.parent_type).to eq("Menu")
+    expect(board.parent_id).to eq(menu.id)
+  end
+
+  it "leaves a board with no matching Menu alone" do
+    board = severed_board("Orphan Diner")
+
+    ENV["DRY_RUN"] = "false"
+    expect { task.invoke }.to output(/1 board\(s\) with no Menu of the same name/).to_stdout
+
+    expect(board.reload.parent_type).to eq("User")
+  end
+
+  # Re-parenting onto the wrong Menu would show a stranger's menu photo, which
+  # is worse than the missing button — so an unresolvable tie is left for a human.
+  it "leaves an ambiguous match alone when the menus are far apart in time" do
+    create(:menu, user: user, name: "Applebees", created_at: 2.years.ago)
+    create(:menu, user: user, name: "Applebees", created_at: 1.year.ago)
+    board = severed_board("Applebees", created_at: Time.current)
+
+    ENV["DRY_RUN"] = "false"
+    expect { task.invoke }.to output(/1 board\(s\) with an ambiguous match/).to_stdout
+
+    expect(board.reload.parent_type).to eq("User")
+  end
+
+  # The board is created in the same request as its menu, so when several menus
+  # share a name the one created alongside it is the right one.
+  it "picks the Menu created alongside the board when names collide" do
+    create(:menu, user: user, name: "Applebees", created_at: 2.years.ago)
+    same_request = create(:menu, user: user, name: "Applebees", created_at: Time.current)
+    board = severed_board("Applebees", created_at: Time.current)
+
+    ENV["DRY_RUN"] = "false"
+    task.invoke
+
+    expect(board.reload.parent_id).to eq(same_request.id)
+  end
+
+  it "never touches a board that still has its Menu parent" do
+    menu = create(:menu, user: user, name: "Applebees")
+    intact = create(:board, user: user, name: "Applebees", board_type: "menu",
+                            parent_type: "Menu", parent_id: menu.id)
+
+    ENV["DRY_RUN"] = "false"
+    expect { task.invoke }.to output(/re-linked 0 board/).to_stdout
+
+    expect(intact.reload.parent_id).to eq(menu.id)
+  end
+
+  it "scopes to one owner with USER_ID" do
+    other = create(:user)
+    create(:menu, user: user, name: "Applebees")
+    create(:menu, user: other, name: "Dennys")
+    mine = severed_board("Applebees")
+    theirs = create(:board, user: other, name: "Dennys", board_type: "menu",
+                            parent_type: "User", parent_id: other.id)
+
+    ENV["DRY_RUN"] = "false"
+    ENV["USER_ID"] = user.id.to_s
+    task.invoke
+
+    expect(mine.reload.parent_type).to eq("Menu")
+    expect(theirs.reload.parent_type).to eq("User")
+  end
+end


### PR DESCRIPTION
## Summary

A board's `parent` records **provenance** — the `Menu` a menu board was extracted from, the `Image` behind a predictive board, the `Board` that spawned a subboard, the `OpenaiPrompt` behind a generated one. Ownership is `user_id`, and only `user_id`.

Both update paths set `parent_type = "User"` unconditionally, so the **first rename or color change** on a menu board severed that link. Nothing else on the row points back at the Menu, so it was unrecoverable: `original_menu_image_url` (which gates the frontend's "View Menu" button), `menu_description`, and `menu_id` were gone for good.

Found by tracing a real board — https://app.speakanyway.com/pb/applebees-5e935a8e returns `board_type: "menu"` but `parent_type: "User"`, `parent_id == user_id == 160`, and `original_menu_image_url: null`.

### Changes

- **`Board#sync_user_parent`** — new single entry point for parent assignment. Bails when the board already has a non-`User` parent; still re-points a `"User"` parent at the current owner so a hand-off follows. Called from `API::BoardsController#update` and `API::Internal::BoardsController#update` in place of the direct assignments.
- **`menu_id` keyed on `board_type` instead of `parent_type`** — a severed board handed the frontend its **owner's user id** labelled as a menu id (`menu_id: 160`), which is wrong data rather than missing data. Now derived from the Menu association.
- **`parent_prompt` called `parent.prompt_text` with no safe navigation** — a 500 on any generated board whose `OpenaiPrompt` had been deleted. Fixed alongside, same code path.
- **`rake menu_boards:relink`** — repairs already-severed rows by matching owner + name (`menus_controller#create` names the board after its menu). Dry-run by default; `DRY_RUN=false` applies, `USER_ID=N` scopes. A board with no name match, or an ambiguous one more than 24h from any candidate menu, is reported and left alone — re-parenting onto the wrong Menu would show a stranger's menu photo, which is worse than the missing button.
- Invariant documented in `CLAUDE.md`; user-facing entry in `CHANGELOG.md`.

No frontend change needed — the button's render conditions were correct all along, it was reading a field the backend had nulled.

## Test plan

New: `spec/requests/api/boards_menu_parent_spec.rb`, `spec/tasks/menu_boards_relink_spec.rb` (16 examples) — covering Menu/Image/Board parents surviving a save, the `User` parent still tracking the owner, `menu_id` never reporting a user id, and the backfill's dry-run / apply / no-match / ambiguous / scoped paths.

- **Regression verified:** reverting only the `boards_controller` change fails 4 of the new examples; restored, they pass.
- Targeted suites (boards, menus, internal, board model): **425 examples, 0 failures**
- Full suite: **5673 examples, 0 failures, 7 pending**

Note for reviewers: `spec/models/board_printable_spec.rb`, `spec/requests/admin/mission_control_spec.rb`, and `spec/requests/admin/board_printables_protection_spec.rb` failed on one full-suite run and passed on a re-run at the same seed and when run directly (80 examples, 0 failures). They look order-sensitive; unrelated to this change, but worth a separate look.

## Follow-up

Run the backfill against production once this deploys, starting with a dry run to see the scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)