### PR TITLE
feat(printables): edit a printable's topic after creation and rebuild its copy

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -185,6 +185,29 @@ typed one (`ListingCopy#topic_source` mines the sub-board names). The
 `Etsy::TagOverlap` warning on the printable's admin page is the backstop — it is
 advisory on purpose, since three sizes of one product genuinely share tags.
 
+**A topic has to yield at least `TagOverlap::MIN_TOPIC_TAGS` (4) tags to clear
+that warning, and the number is arithmetic, not taste.** Every pool but `topic`
+is shared boilerplate, and whatever slots the topic leaves empty are filled from
+the same ORDERED `top_up` list — so a short topic collides twice over. Two
+listings differing only in topic share `TAG_MAX - t` tags for `t` topic tags
+each, which puts a three-phrase topic at exactly the 10 the warning fires on.
+`MIN_TOPIC_TAGS` is derived from `TAG_MAX` and `HIGH_OVERLAP` rather than
+written down, because the admin hint quotes it — moving either constant must not
+leave the form telling an admin a stale number.
+
+**`topic` is editable after creation.** The listing form writes the column, and
+`BoardPrintable#regenerate_listing_copy!` behind a confirmed POST re-runs
+`ListingCopy` over it. It has to be: `ListingCopy` is deterministic and reads
+`topic` only when it runs, so a listing generated before anyone typed one keeps
+the boilerplate tags forever otherwise. Three rules hold it together — saving
+the topic deliberately does NOT rewrite the copy (the copy is hand-edited before
+publishing, so rebuilding it is a separate action with its own confirm);
+regenerating KEEPS `price_cents`, which isn't topic-derived at all (the
+generator emits a constant, so it would silently reset a chosen price); and it
+merges over the stored hash rather than replacing it, so a key the generator
+doesn't emit survives. It is local — a published printable's live listing is
+unchanged until the copy is pushed with the printables CLI.
+
 One deliberate difference: the Ruby description is **plain text**. Etsy renders
 no markup, and TPT takes a plain-text paste cleanly, so skipping the
 markdown→text conversion means what an admin reads in the textarea is exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A printable's topic can be edited after it's created, and the listing copy
+  rebuilt from it.** The topic is the only part of a listing that describes the
+  product — without one, the generic tag pools fill all 13 of Etsy's slots and
+  every listing ships the same tags. It used to be settable only when the
+  printable was created. It now sits on the listing form, with a
+  "Regenerate from topic" action that rebuilds the title, summary, description
+  and tags (keeping the price). Nothing is sent to any marketplace.
+
 - **A listing video can be sent to a listing that already exists.** Publishing
   carries the video with it, so a listing created before its video was rendered
   could never get one without relisting. The video card now offers "Send video

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -58,8 +58,30 @@ module Admin
     def update_listing
       printable = BoardPrintable.find(params[:id])
 
-      printable.update!(listing_copy: listing_copy_params(printable))
+      # `topic` is a column, not part of the listing_copy jsonb, but it is
+      # edited on the same form because it is the input that DRIVES that copy.
+      # Saving it does not rewrite the copy — that is the separate, confirmed
+      # regenerate below, since rebuilding would discard hand edits.
+      printable.update!(
+        listing_copy: listing_copy_params(printable),
+        topic: params[:topic].presence,
+      )
       redirect_to admin_dashboard_board_printable_path(printable), notice: "Listing copy saved."
+    end
+
+    # Re-runs Etsy::ListingCopy over the record, which is the only way a topic
+    # set after creation can reach the copy — the generator is deterministic, so
+    # nothing else re-reads it. Destructive to hand-edited title/summary/
+    # description/tags, which is what the confirm dialog is for.
+    #
+    # Local only: this touches no marketplace. A published printable's live
+    # listing is unaffected until the copy is pushed with the printables CLI.
+    def regenerate_listing_copy
+      printable = BoardPrintable.find(params[:id])
+
+      printable.regenerate_listing_copy!
+      redirect_to admin_dashboard_board_printable_path(printable),
+                  notice: "Listing copy regenerated from the topic. Nothing has been sent to Etsy."
     end
 
     # Enqueues the DRAFT-only Etsy publish. Nothing here can activate a

--- a/app/helpers/admin/board_printables_helper.rb
+++ b/app/helpers/admin/board_printables_helper.rb
@@ -66,6 +66,19 @@ module Admin
       "bg-amber-900/60 text-amber-300"
     end
 
+    # The confirm on "Regenerate from topic". Says the destructive part first —
+    # the copy is meant to be hand-edited before publishing, so rebuilding it is
+    # the one action here that can lose work. The second half is the reassurance
+    # an admin needs on a printable that is already listed: this is local.
+    def regenerate_copy_confirm(printable)
+      base = "Rebuild the title, summary, description and tags from the topic? " \
+             "Any hand edits to them are replaced. The price is kept."
+      return base unless printable.etsy_published?
+
+      "#{base} Nothing is sent to Etsy — listing #{printable.etsy_listing_id} keeps its current copy " \
+      "until you push it with the printables CLI."
+    end
+
     # The confirm on "Detach & relist". Says the two things an admin could
     # otherwise get wrong: nothing here touches the draft on Etsy, and the
     # boards stay frozen (protection is keyed on having ever been published, not

--- a/app/models/board_printable.rb
+++ b/app/models/board_printable.rb
@@ -454,6 +454,30 @@ class BoardPrintable < ApplicationRecord
     listing_copy.presence || Etsy::ListingCopy.new(self).build
   end
 
+  # Rebuild the saved listing copy from the record as it stands — which in
+  # practice means "from `topic`", the only input that describes THIS product.
+  #
+  # Destructive on purpose: title, summary, description and tags are all
+  # regenerated, so hand edits to them are lost. That is the point — the reason
+  # to press it is that the generated copy is wrong because the topic was blank
+  # when the printable was created, and Etsy::ListingCopy is deterministic, so
+  # the only way to benefit from a new topic is to re-run it.
+  #
+  # Two things it deliberately keeps:
+  #
+  #   price_cents — not topic-derived at all (the generator emits a constant),
+  #                 so regenerating would silently reset a price someone chose.
+  #   any other key — merged over rather than replaced, so a key the generator
+  #                 doesn't emit (the TPT overrides listing_copy_params folds
+  #                 back in) survives. Same discipline as that method.
+  def regenerate_listing_copy!
+    existing = listing_copy.to_h
+    generated = Etsy::ListingCopy.new(self).build
+    generated["price_cents"] = existing["price_cents"] if existing["price_cents"].present?
+
+    update!(listing_copy: existing.merge(generated))
+  end
+
   def api_view
     {
       id: id,

--- a/app/services/etsy/tag_overlap.rb
+++ b/app/services/etsy/tag_overlap.rb
@@ -18,6 +18,19 @@ module Etsy
     # audience boilerplate is expected and not worth a warning.
     HIGH_OVERLAP = 10
 
+    # How many tags a printable's TOPIC has to yield to stay under the warning.
+    #
+    # Every other pool is shared boilerplate by design, so two listings differing
+    # only in topic share `TAG_MAX - t` tags, where t is the number of topic tags
+    # each one has (the shortfall is made up from the same ordered `top_up` list,
+    # which is why a short topic collides twice over). Setting `13 - t <
+    # HIGH_OVERLAP` gives the minimum below.
+    #
+    # It is derived rather than written as a number so that moving either
+    # constant can't leave the admin hint quoting a stale one — the number an
+    # admin is told is the number the check actually uses.
+    MIN_TOPIC_TAGS = CopyRules::TAG_MAX - HIGH_OVERLAP + 1
+
     # Only printables that already have saved listing copy are compared, and
     # only the most recent slice of them: generating defaults for every row to
     # compare against would make this page's cost grow with the table.

--- a/app/views/admin/board_printables/_listing_form.html.erb
+++ b/app/views/admin/board_printables/_listing_form.html.erb
@@ -11,6 +11,31 @@
   <p class="text-[11px] text-t3 mb-4">Used for Etsy and for the copy-and-paste blocks below. Edit freely, then Save.</p>
 
   <%= form_tag update_listing_admin_dashboard_board_printable_path(@printable), method: :patch, data: { turbo: false } do %>
+    <%# Topic is a COLUMN, not part of the listing_copy jsonb, but it is edited
+        here because it is what drives every field below it. It is the only
+        input that describes THIS product: the generic tag pools can fill all 13
+        of Etsy's slots on their own, so a blank topic is how a listing ends up
+        with the same tags as every other one. Saving it does not rewrite the
+        copy — Regenerate does, and it is separate because it discards hand
+        edits. %>
+    <div class="mb-4">
+      <label class="block text-xs font-medium text-t2 mb-1" for="listing_topic">
+        Topic
+        <span class="text-t3 font-normal">— comma separated, short phrases; drives the tags, title and opening line</span>
+      </label>
+      <%= text_field_tag :topic, @printable.topic, id: "listing_topic", class: "admin-input w-full",
+            placeholder: "hospital stay, doctor visit, medical vocabulary, nurse words" %>
+      <p class="text-[11px] text-t3 mt-1">
+        The only part of the copy that describes <em>this</em> product — up to
+        <%= Etsy::CopyRules::TOPIC_TAG_MAX %> of the <%= Etsy::CopyRules::TAG_MAX %> tags come from it, and
+        without it the rest are the same boilerplate every listing gets.
+        <strong>Give it at least <%= Etsy::TagOverlap::MIN_TOPIC_TAGS %> phrases</strong> — below that,
+        the generic pools fill the gap from the same ordered list and two listings still collide.
+        Keep each phrase under <%= Etsy::CopyRules::TAG_LEN_MAX %> characters or only its last few words
+        survive. Save, then <strong>Regenerate</strong> to apply it.
+      </p>
+    </div>
+
     <div class="mb-4">
       <label class="block text-xs font-medium text-t2 mb-1" for="listing_title">
         Title
@@ -60,6 +85,22 @@
     <%= submit_tag "Save listing copy",
           class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer" %>
   <% end %>
+
+  <%# Outside the form above: this is a POST of its own, and it REPLACES the
+      fields in it. Deliberately not wired to the topic input changing — the
+      copy is hand-edited before publishing, so rebuilding it has to be
+      something an admin asks for and confirms. Touches no marketplace. %>
+  <div class="mt-4 pt-4 border-t flex items-start justify-between gap-4" style="border-color: var(--border);">
+    <p class="text-[11px] text-t3">
+      Changed the topic? Rebuild the title, summary, description and tags from it.
+      <strong>Replaces</strong> everything above except the price — hand edits are lost.
+      Nothing is sent to Etsy<%= " (listing #{@printable.etsy_listing_id} is untouched)" if @printable.etsy_published? %>.
+    </p>
+    <%= button_to "Regenerate from topic", regenerate_listing_copy_admin_dashboard_board_printable_path(@printable),
+          method: :post,
+          class: "shrink-0 text-xs font-medium px-3 py-2 rounded admin-card-alt text-t2 hover:text-t1 cursor-pointer",
+          form: { data: { turbo_confirm: regenerate_copy_confirm(@printable) } } %>
+  </div>
 </div>
 
 <% content_for :head_extra do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
     resources :board_printables, only: [:index, :show, :create, :destroy], as: :dashboard_board_printables do
       member do
         patch :update_listing
+        post :regenerate_listing_copy
         post :publish_to_etsy
         post :relist_on_etsy
         post :push_video_to_etsy

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -651,6 +651,108 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       end
     end
 
+    describe "editing the topic and regenerating copy" do
+      # The topic is create-only no longer: it is the ONLY pool that describes
+      # the product, so a listing made without one carries the same 13 tags as
+      # every other listing in the shop.
+      it "saves the topic alongside the copy" do
+        sign_in admin
+
+        patch update_listing_admin_dashboard_board_printable_path(printable), params: {
+          title: "T", summary: "S", description: "D", tags: "aac", price: "5.00",
+          topic: "hospital stay, doctor visit",
+        }
+
+        expect(printable.reload.topic).to eq("hospital stay, doctor visit")
+      end
+
+      it "clears the topic when the field is emptied" do
+        sign_in admin
+        printable.update!(topic: "hospital stay")
+
+        patch update_listing_admin_dashboard_board_printable_path(printable), params: {
+          title: "T", summary: "S", description: "D", tags: "aac", price: "5.00", topic: "",
+        }
+
+        expect(printable.reload.topic).to be_nil
+      end
+
+      # Saving the topic must NOT rewrite the copy: the copy is hand-edited
+      # before publishing, and rebuilding it silently would discard that.
+      it "leaves the saved copy alone when only the topic changes" do
+        sign_in admin
+
+        patch update_listing_admin_dashboard_board_printable_path(printable), params: {
+          title: "Hand written title", summary: "S", description: "D", tags: "aac", price: "5.00",
+          topic: "hospital stay",
+        }
+
+        expect(printable.reload.listing_copy["title"]).to eq("Hand written title")
+      end
+
+      it "rebuilds the copy from the topic on regenerate" do
+        sign_in admin
+        printable.update!(topic: "hospital stay, doctor visit")
+        printable.update!(listing_copy: {
+          "title" => "stale", "description" => "stale", "tags" => ["aac"], "price_cents" => 500,
+        })
+
+        post regenerate_listing_copy_admin_dashboard_board_printable_path(printable)
+
+        tags = printable.reload.listing_copy["tags"]
+        expect(printable.listing_copy["title"]).not_to eq("stale")
+        expect(tags).to include("hospital stay")
+        # The whole point: the topic tags rank straight after the always-on
+        # three, so they can't be crowded out by the generic pools.
+        expect(tags.index("hospital stay")).to be < tags.index("speech therapy") if tags.include?("speech therapy")
+      end
+
+      # The generator emits a constant price, so regenerating would silently
+      # reset a price someone chose.
+      it "keeps a hand-set price" do
+        sign_in admin
+        printable.update!(topic: "hospital stay", listing_copy: {
+          "title" => "t", "description" => "d", "tags" => [], "price_cents" => 1250,
+        })
+
+        post regenerate_listing_copy_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.listing_copy["price_cents"]).to eq(1250)
+      end
+
+      it "preserves keys the generator doesn't emit" do
+        sign_in admin
+        printable.update!(topic: "hospital stay", listing_copy: {
+          "title" => "t", "description" => "d", "tags" => [], "tpt_title_override" => "kept",
+        })
+
+        post regenerate_listing_copy_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.listing_copy["tpt_title_override"]).to eq("kept")
+      end
+
+      # Regenerating is local. A published printable's live listing only changes
+      # when the copy is pushed with the printables CLI.
+      it "sends nothing to Etsy and leaves the listing attached" do
+        sign_in admin
+        printable.update!(topic: "hospital stay", etsy_listing_id: 987, etsy_published_at: 1.day.ago)
+        allow(Etsy::Client).to receive(:new).and_raise("no Etsy call should be made")
+
+        post regenerate_listing_copy_admin_dashboard_board_printable_path(printable)
+
+        expect(printable.reload.etsy_listing_id).to eq(987)
+        expect(flash[:notice]).to match(/[Nn]othing has been sent to Etsy/)
+      end
+
+      it "redirects a non-admin away" do
+        sign_in create(:user)
+
+        post regenerate_listing_copy_admin_dashboard_board_printable_path(printable)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
     describe "POST push_video_to_etsy" do
       before do
         printable.update!(etsy_listing_id: 987, etsy_listing_url: "https://etsy.test/987", etsy_published_at: 2.days.ago)

--- a/spec/services/etsy/tag_overlap_spec.rb
+++ b/spec/services/etsy/tag_overlap_spec.rb
@@ -59,6 +59,71 @@ RSpec.describe Etsy::TagOverlap do
     expect(described_class.new(subject_printable, tags: BOILERPLATE)).to be_any
   end
 
+  # The acceptance criterion for making `topic` editable after creation: the
+  # warning exists to catch listings that don't describe themselves, and a topic
+  # is the only thing that can fix one. Two printables that each say what they
+  # are must stop colliding — otherwise the control is theatre.
+  describe "a topic set after creation" do
+    def with_topic(name, topic)
+      board = create(:board, user: owner, name: name)
+      p = BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], topic: topic)
+      p.regenerate_listing_copy!
+      p
+    end
+
+    it "silences the warning between two printables that describe themselves" do
+      with_topic("Hospital Words", "hospital stay, doctor visit, medical vocabulary, nurse words")
+      subject_printable = with_topic("Playground Words", "playground, outdoor play, park vocabulary, swing words")
+
+      expect(described_class.new(subject_printable)).not_to be_any
+    end
+
+    # The boundary, and the reason MIN_TOPIC_TAGS is derived rather than a
+    # number in the hint text. Every pool but `topic` is shared, and the
+    # shortfall is topped up from the same ORDERED list — so a short topic
+    # collides twice over, and three phrases lands exactly on the threshold.
+    it "still warns when each topic yields one tag fewer than the minimum" do
+      short = Etsy::TagOverlap::MIN_TOPIC_TAGS - 1
+      with_topic("Hospital Words", Array.new(short) { |i| "hospital word #{i}" }.join(", "))
+      subject_printable = with_topic("Playground Words", Array.new(short) { |i| "park word #{i}" }.join(", "))
+
+      overlap = described_class.new(subject_printable)
+      expect(overlap).to be_any
+      expect(overlap.matches.first.count).to eq(Etsy::CopyRules::TAG_MAX - short)
+    end
+
+    it "stops warning at exactly MIN_TOPIC_TAGS" do
+      enough = Etsy::TagOverlap::MIN_TOPIC_TAGS
+      with_topic("Hospital Words", Array.new(enough) { |i| "hospital word #{i}" }.join(", "))
+      subject_printable = with_topic("Playground Words", Array.new(enough) { |i| "park word #{i}" }.join(", "))
+
+      expect(described_class.new(subject_printable)).not_to be_any
+    end
+
+    # The failure the reordering fixed: with nothing topical to say, the generic
+    # pools fill all 13 slots identically.
+    it "still warns when neither has a topic" do
+      first = create(:board, user: owner, name: "No Topic One")
+      second = create(:board, user: owner, name: "No Topic Two")
+      [first, second].each do |board|
+        BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id])
+                      .regenerate_listing_copy!
+      end
+
+      subject_printable = BoardPrintable.order(:id).last
+      expect(described_class.new(subject_printable)).to be_any
+    end
+
+    it "puts the topic's own tags ahead of the generic pools" do
+      p = with_topic("Hospital Words", "hospital stay, doctor visit")
+
+      tags = p.listing_copy["tags"]
+      expect(tags).to include("hospital stay", "doctor visit")
+      # always_on is three, then topic — so a topic tag can never be crowded out.
+      expect(tags.index("hospital stay")).to be < tags.index("communication board")
+    end
+  end
+
   it "shows the worst collision first and caps how many it lists" do
     4.times { |i| printable("Clone #{i}", tags: BOILERPLATE) }
     near = printable("Near Miss", tags: BOILERPLATE.first(11) + ["hair salon", "washing hair"])


### PR DESCRIPTION
Follow-on to #716.

## Why

`topic` is the **only** pool in `Etsy::ListingCopy` that describes the product — the always-on, product-type, audience and top-up pools can fill all 13 of Etsy's slots between them. It was settable only when a printable was created, and `ListingCopy` is deterministic and reads it only when it runs. So a listing generated without a topic carried the boilerplate tag set permanently, with no way back short of deleting the printable and starting over.

That's the state the shop's live listings are in, and it's what the `TagOverlap` warning has been flagging.

## What

- **Topic moves onto the listing form.** It's a column rather than part of the `listing_copy` jsonb, but it's edited there because it drives every field below it. Saving it deliberately does **not** rewrite the copy — the copy is hand-edited before publishing, so rebuilding it silently would discard that work.
- **`BoardPrintable#regenerate_listing_copy!`** behind a confirmed POST re-runs the generator. Two things it keeps: `price_cents`, which isn't topic-derived at all (the generator emits a constant, so regenerating would silently reset a chosen price), and any key the generator doesn't emit — it merges over the stored hash rather than replacing it, the same discipline `listing_copy_params` already follows for the TPT overrides. Local only; no marketplace is contacted.

## The finding worth reading

I wrote the acceptance spec first — *"two printables that each describe themselves stop colliding"* — and **it failed**. The arithmetic is tighter than it looks:

```
13 tags = 3 always-on + t topic + 1 product-type + 3 audience + (6−t) top-up
```

Two listings differing only in topic share `TAG_MAX − t` tags, because the slots a short topic leaves empty get filled from the *same ordered* `top_up` list — so a thin topic collides twice over. At `t = 3` that's exactly the 10 the warning fires on. **A three-phrase topic doesn't clear it**, and my first draft of the admin hint (and its placeholder) said it would.

So the minimum is now derived rather than written down:

```ruby
MIN_TOPIC_TAGS = CopyRules::TAG_MAX - HIGH_OVERLAP + 1   # => 4
```

The form quotes that constant, so moving either input can't leave the admin reading a stale number. Specs pin both sides of the boundary.

## Test plan

`228 examples, 0 failures`:

```
bundle exec rspec spec/services/etsy/ spec/models/board_printable_spec.rb \
  spec/requests/admin/board_printables_spec.rb \
  spec/requests/admin/board_printables_protection_spec.rb \
  spec/lib/tasks/printables_listing_export_spec.rb
```

New coverage:
- `tag_overlap_spec.rb` (3) — the acceptance criterion (the warning actually goes quiet), plus `MIN_TOPIC_TAGS − 1` still warning and `MIN_TOPIC_TAGS` not.
- Request specs (8) — saving and clearing the topic, that saving it leaves hand-edited copy alone, the rebuild, the kept price, preserved non-generated keys, that nothing reaches Etsy, and the admin gate.

No migration.

## Docs

`CHANGELOG.md` and the `board-printables-etsy.md` spoke, which now records the tag arithmetic and why `MIN_TOPIC_TAGS` is derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)