### PR TITLE
perf(communicators): stop GET /child_accounts/:id fanning out per board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **The communicator page loads quickly again.** Opening a communicator could
+  hang for over 12 seconds for anyone with a large board library — the page
+  rebuilt a picture-and-word preview for every board the owner had, one
+  database round trip at a time, so the wait grew with the size of the library
+  rather than with anything on screen. The page now gathers those previews in a
+  fixed number of queries, so it opens at the same speed whether the owner has
+  ten boards or a thousand. The "recently used" strip is also fixed: on a board
+  shared with other people it could show activity that wasn't this
+  communicator's.
+
 - **Boards on a communicator's MySpeak page now actually open.** A board put on
   a communicator's public page showed up in the grid, but tapping it gave a
   "board not found" page unless the board had separately been published — and

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1526,14 +1526,24 @@ class Board < ApplicationRecord
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"]
   end
 
+  # Read path — hit by `word_sample` for every board in a card list, so it must
+  # never write. `set_current_word_list` only stages onto the in-memory record;
+  # persistence happens on the write paths and via `boards:backfill_word_lists`.
   def current_word_list
     return data["current_word_list"] if data && data["current_word_list"].present?
     set_current_word_list
   end
 
+  # Computes the word list AND stages it on `data` so the caller's `save` sticks.
+  #
+  # This used to open with `data = self.data || {}`, which bound a LOCAL `data`
+  # shadowing the attribute, then mutated that hash in place. In-place jsonb
+  # mutation is not tracked as dirty, so the list was never persisted — not even
+  # by the `set_current_word_list` + `save!` pair in `add_images`. Every board
+  # that had never been written through another path therefore recomputed its
+  # word list on every single request, forever. Assign through `self.data =` so
+  # ActiveRecord sees the change.
   def set_current_word_list
-    data = self.data || {}
-
     # display_label, not label: this list is surfaced as `word_list` in the
     # board payload, and before `label` became a pure matching key it carried
     # the tile's text. Both sides of the clone-dedup comparison in
@@ -1541,7 +1551,7 @@ class Board < ApplicationRecord
     words = board_images.order(:position).pluck(:display_label)
     return [] if words.blank?
 
-    data["current_word_list"] = words
+    self.data = (data || {}).merge("current_word_list" => words)
     words
   end
 
@@ -2825,6 +2835,42 @@ class Board < ApplicationRecord
 
   def word_sample
     current_word_list ? current_word_list.join(", ").truncate(150) : nil
+  end
+
+  # Batched `word_sample` for a list of boards: {board_id => sample_or_nil}.
+  #
+  # `word_sample` alone is one query per board whenever the board has no cached
+  # `data["current_word_list"]` — and `api_view` on a communicator renders it
+  # for every board the owner has (four figures on a heavy account), so the
+  # per-board fallback was thousands of queries. Resolve the cached ones in
+  # memory and the rest in a single grouped board_images read.
+  def self.word_samples_for(boards)
+    boards = Array(boards)
+    return {} if boards.empty?
+
+    words_by_board = {}
+    missing_ids = []
+
+    boards.each do |board|
+      cached = board.data && board.data["current_word_list"]
+      if cached.present?
+        words_by_board[board.id] = cached
+      else
+        missing_ids << board.id
+      end
+    end
+
+    if missing_ids.any?
+      BoardImage.where(board_id: missing_ids)
+                .order(:position)
+                .pluck(:board_id, :display_label)
+                .each { |board_id, label| (words_by_board[board_id] ||= []) << label }
+    end
+
+    boards.each_with_object({}) do |board, out|
+      words = words_by_board[board.id]
+      out[board.id] = words.present? ? words.join(", ").truncate(150) : nil
+    end
   end
 
   def user_api_view(viewing_user = nil)

--- a/app/models/child_account.rb
+++ b/app/models/child_account.rb
@@ -678,6 +678,12 @@ class ChildAccount < ApplicationRecord
     cached_supervisors = supervisors
     cached_go_to_boards = go_to_boards
     cached_most_used_words = most_clicked_words
+    # Same batching as `api_view` — this serializer shares every board helper
+    # with it, so a vendor with a large library hits the same per-board fanout.
+    cached_available_boards = available_boards_for_user(viewing_user).to_a
+    cached_teams_boards = available_teams_boards.to_a
+    available_word_samples = Board.word_samples_for(cached_available_boards)
+    teams_word_samples = Board.word_samples_for(cached_teams_boards.map(&:board).compact)
 
     {
       id: id,
@@ -776,19 +782,19 @@ class ChildAccount < ApplicationRecord
       can_sign_in: can_sign_in?,
       fallback_mode: fallback_mode?,
       fallback_since: settings&.dig("fallback_since"),
-      available_boards: available_boards_for_user(viewing_user).map do |b|
+      available_boards: cached_available_boards.map do |b|
         {
           id: b.id,
           name: b.name,
           display_image_url: b.display_image_url,
           board_type: b.board_type,
-          word_sample: b.word_sample,
+          word_sample: available_word_samples[b.id],
           predefined: b.predefined,
           user_id: b.user_id,
           is_owner: b.user_id == viewing_user&.id,
         }
       end,
-      teams_boards: available_teams_boards.map do |tb|
+      teams_boards: cached_teams_boards.map do |tb|
         b = tb.board
         {
           id: tb.board_id,
@@ -797,7 +803,7 @@ class ChildAccount < ApplicationRecord
           display_image_url: b.display_image_url,
           added_by: tb.created_by&.display_name,
           added_by_id: tb.created_by&.id,
-          word_sample: b.word_sample,
+          word_sample: teams_word_samples[tb.board_id],
         }
       end,
     }
@@ -922,9 +928,15 @@ class ChildAccount < ApplicationRecord
   #   user.boards.where.not(id: current_boards.pluck(:id)).order(:name)
   # end
 
+  # Every board this returns is serialized through the `available_boards` block
+  # in `api_view`, which reads `display_image_url` and `word_sample` per row.
+  # `display_image_url` is an ActiveStorage lookup (2-3 queries a board), and an
+  # owner can easily have four figures of boards, so without the preload this
+  # single method issued thousands of queries per request. Same fix, same
+  # constant, as `perf(profiles): serialize public page boards as cards` (#667).
   def available_boards
     board_ids = child_boards.select(:board_id)
-    user_boards = user.boards.where.not(id: board_ids).alphabetical
+    user_boards = user.boards.where.not(id: board_ids).alphabetical.includes(*Profile::BOARD_CARD_PRELOADS)
     #  predefined boards too
     # public_boards = Board.public_boards.where.not(id: board_ids)
     # user_boards.or(public_boards).order(:name)
@@ -938,7 +950,7 @@ class ChildAccount < ApplicationRecord
       available_boards
     else
       board_ids = child_boards.select(:board_id)
-      viewing_user.boards.where.not(id: board_ids).order(:name)
+      viewing_user.boards.where.not(id: board_ids).order(:name).includes(*Profile::BOARD_CARD_PRELOADS)
     end
   end
 
@@ -950,7 +962,7 @@ class ChildAccount < ApplicationRecord
 
   def available_teams_boards
     used_ids = child_boards.select(:board_id)
-    TeamBoard.includes(:board, :created_by)
+    TeamBoard.includes(:created_by, board: Profile::BOARD_CARD_PRELOADS)
              .where(team_id: teams.select(:id))
              .where.not(board_id: used_ids)
   end
@@ -1001,18 +1013,30 @@ class ChildAccount < ApplicationRecord
     profile&.bg_color
   end
 
+  # Memoized: `api_view` reaches this twice per request — once through
+  # `most_used_board` and again through `go_to_boards` when the communicator has
+  # no favourites — and each call is an unbounded aggregate over the account's
+  # whole word_event history.
   def boards_by_most_used
-    board_ids = word_events.group(:board_id).count.sort_by { |_k, v| v }.reverse.to_h.keys
-    Board.where(id: board_ids)
+    @boards_by_most_used ||= begin
+      board_ids = word_events.group(:board_id).count.sort_by { |_k, v| v }.reverse.to_h.keys
+      Board.where(id: board_ids)
+    end
   end
 
+  # Polymorphic in RETURN TYPE, not just receiver: `favorite_boards` gives
+  # ChildBoard join rows (which delegate name/slug/display_image_url to :board),
+  # every other branch gives Boards. The cover preload has to follow that —
+  # `includes(board: ...)` on a Board relation raises AssociationNotFoundError.
+  # Same trap `Profile#communication_boards` documents.
   def go_to_boards
-    gt_boards = favorite_boards.any? ? favorite_boards : boards_by_most_used
-    if gt_boards.none?
-      # Handle case where there are no boards to go to
-      gt_boards = Board.public_boards.limit(5)
+    if favorite_boards.any?
+      return favorite_boards.includes(board: Profile::BOARD_CARD_PRELOADS)
     end
-    gt_boards
+
+    gt_boards = boards_by_most_used
+    gt_boards = Board.public_boards.limit(5) if gt_boards.none?
+    gt_boards.includes(*Profile::BOARD_CARD_PRELOADS)
   end
 
   def most_used_board
@@ -1054,9 +1078,30 @@ class ChildAccount < ApplicationRecord
 
   include LocaleResolution
 
+  # Boards THIS communicator used in the last week.
+  #
+  # The previous implementation joined `child_boards -> board -> word_events`,
+  # which is the wrong direction: it matched events recorded by *any* user on a
+  # board this communicator happens to have, so a shared or predefined board
+  # leaked other people's activity into this account's "recently used" strip.
+  # It also instantiated every matched WordEvent just to `.uniq` in Ruby, and
+  # put a raw string condition on an `includes` without `.references`, which
+  # Rails 8 does not treat as a reason to force the join.
+  #
+  # Go through this account's own word_events instead, pull the distinct board
+  # ids in the window, and load just those child boards.
   def recently_used_boards
-    # word_events.includes(:board).where("created_at >= ?", 1.week.ago).order("created_at DESC").map(&:board).uniq
-    child_boards.includes(board: :word_events).where("word_events.created_at >= ?", 1.week.ago).order("word_events.created_at DESC").uniq
+    recent = word_events.where(created_at: 1.week.ago..)
+                        .where.not(board_id: nil)
+                        .group(:board_id)
+                        .maximum(:created_at)
+    return child_boards.none if recent.empty?
+
+    ordered_board_ids = recent.sort_by { |_board_id, last_used| last_used }.reverse.map(&:first)
+    boards_by_id = child_boards.where(board_id: ordered_board_ids)
+                               .includes(board: Profile::BOARD_CARD_PRELOADS)
+                               .index_by(&:board_id)
+    ordered_board_ids.filter_map { |board_id| boards_by_id[board_id] }
   end
 
   def update_board_layout(screen_size)
@@ -1079,6 +1124,12 @@ class ChildAccount < ApplicationRecord
     cached_supporters = supporters
     cached_supervisors = supervisors
     cached_go_to_boards = go_to_boards
+    cached_available_boards = available_boards_for_user(viewing_user).to_a
+    cached_teams_boards = available_teams_boards.to_a
+    # One grouped board_images read for every board still missing a cached
+    # word list, rather than one query per board.
+    available_word_samples = Board.word_samples_for(cached_available_boards)
+    teams_word_samples = Board.word_samples_for(cached_teams_boards.map(&:board).compact)
 
     {
       id: id,
@@ -1129,12 +1180,16 @@ class ChildAccount < ApplicationRecord
           text_color: b.text_color,
         }
       end,
-      heat_map: heat_map,
+      # `heat_map`, `week_chart` and `most_clicked_words` used to be emitted here
+      # and nothing read them: the communicator page renders `stats.heat_map` /
+      # `stats.most_clicked_words` from the range-bounded /api/word_events/stats
+      # instead. `heat_map` in particular was called with no range, so every
+      # load ran an all-time group_by_day over the account's whole event
+      # history. `vendor_api_view` still emits all three — the vendor screen
+      # genuinely reads them — so only this serializer drops them.
       profile: cached_profile&.api_view(viewing_user),
       startup_url: startup_url,
       public_url: public_url,
-      week_chart: week_chart,
-      most_clicked_words: most_clicked_words,
       teams: teams.map { |t| t.index_api_view(viewing_user) },
       settings: settings,
       details: details,
@@ -1158,7 +1213,14 @@ class ChildAccount < ApplicationRecord
       bio_audio_url: cached_profile&.bio_audio_url,
       supporters: cached_supporters.map { |s| { id: s.id, name: s.name, email: s.email } },
       supervisors: cached_supervisors.map { |s| { id: s.id, name: s.name, email: s.email } },
-      boards: child_boards.includes(:original_board, :board).order(:created_at).map do |cb|
+      # `display_image_url` (both the board's and the original's), `created_by`
+      # and `board.user` are all read per row below — preload or each row costs
+      # a handful of queries.
+      boards: child_boards.includes(
+        :created_by,
+        original_board: Profile::BOARD_CARD_PRELOADS,
+        board: [:user, *Profile::BOARD_CARD_PRELOADS],
+      ).order(:created_at).map do |cb|
         b = cb.board
         og_board = cb.original_board
         {
@@ -1189,19 +1251,19 @@ class ChildAccount < ApplicationRecord
       can_sign_in: can_sign_in?,
       fallback_mode: fallback_mode?,
       fallback_since: settings&.dig("fallback_since"),
-      available_boards: available_boards_for_user(viewing_user).map do |b|
+      available_boards: cached_available_boards.map do |b|
         {
           id: b.id,
           name: b.name,
           display_image_url: b.display_image_url,
           board_type: b.board_type,
-          word_sample: b.word_sample,
+          word_sample: available_word_samples[b.id],
           predefined: b.predefined,
           user_id: b.user_id,
           is_owner: b.user_id == viewing_user&.id,
         }
       end,
-      teams_boards: available_teams_boards.map do |tb|
+      teams_boards: cached_teams_boards.map do |tb|
         b = tb.board
         {
           id: tb.board_id,
@@ -1210,7 +1272,7 @@ class ChildAccount < ApplicationRecord
           display_image_url: b.display_image_url,
           added_by: tb.created_by&.display_name,
           added_by_id: tb.created_by&.id,
-          word_sample: b.word_sample,
+          word_sample: teams_word_samples[tb.board_id],
         }
       end,
     }

--- a/db/migrate/20260818140000_add_word_event_lookup_indexes.rb
+++ b/db/migrate/20260818140000_add_word_event_lookup_indexes.rb
@@ -1,0 +1,21 @@
+class AddWordEventLookupIndexes < ActiveRecord::Migration[8.0]
+  # CONCURRENTLY can't run inside a transaction. word_events is the hottest
+  # append-only table in the app (~140k rows in production and growing), and
+  # these indexes back a request-path read, so take the slower build over an
+  # exclusive lock on writes.
+  disable_ddl_transaction!
+
+  def change
+    # `ChildAccount#boards_by_most_used` does `GROUP BY board_id` over an
+    # account's whole history, and `recently_used_boards` filters on it.
+    # There was no index on this column at all.
+    add_index :word_events, :board_id, algorithm: :concurrently, if_not_exists: true
+
+    # Every range query (week_chart_data, most_clicked_words,
+    # word_events_summary, part_of_speech_breakdown, and the stats endpoint)
+    # filters child_account_id AND timestamp. The existing single-column
+    # child_account_id index makes Postgres walk the account's entire history
+    # and discard by date; the composite lets it seek straight to the window.
+    add_index :word_events, [:child_account_id, :timestamp], algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_18_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_18_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -1146,7 +1146,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_18_120000) do
     t.bigint "board_group_id"
     t.bigint "board_image_id"
     t.index ["board_group_id"], name: "index_word_events_on_board_group_id"
+    t.index ["board_id"], name: "index_word_events_on_board_id"
     t.index ["board_image_id"], name: "index_word_events_on_board_image_id"
+    t.index ["child_account_id", "timestamp"], name: "index_word_events_on_child_account_id_and_timestamp"
     t.index ["child_account_id"], name: "index_word_events_on_child_account_id"
     t.index ["data"], name: "index_word_events_on_data", using: :gin
     t.index ["image_id"], name: "index_word_events_on_image_id"

--- a/lib/tasks/board_word_lists.rake
+++ b/lib/tasks/board_word_lists.rake
@@ -1,0 +1,59 @@
+namespace :board_word_lists do
+  # Backfill data["current_word_list"] for boards that never got one.
+  #
+  # `Board#word_sample` (rendered for every board in every card list, including
+  # the ~1k-board `available_boards` array on GET /api/child_accounts/:id) falls
+  # back to `set_current_word_list`, which queries board_images. Until
+  # `set_current_word_list` was fixed to assign through `self.data =`, the
+  # computed list was never persisted, so those boards re-queried on every
+  # request forever. This task fills the backlog left behind by that bug.
+  #
+  # Read-only by default (reports what would change). Apply with DRY_RUN=false.
+  # Scope to one owner with USER_ID=N.
+  #
+  #   rake board_word_lists:backfill                    # dry run, all
+  #   DRY_RUN=false rake board_word_lists:backfill      # apply all
+  #   DRY_RUN=false USER_ID=1 rake board_word_lists:backfill
+  desc "Backfill data.current_word_list on boards missing it (DRY_RUN=false to apply; USER_ID=N to scope)"
+  task backfill: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    scope = Board.where("data->'current_word_list' IS NULL")
+    scope = scope.where(user_id: ENV["USER_ID"]) if ENV["USER_ID"].present?
+
+    total = scope.count
+    puts "#{dry_run ? "[dry run] " : ""}#{total} board(s) missing current_word_list"
+
+    filled = 0
+    empty = 0
+    failed = 0
+
+    scope.find_each(batch_size: 200) do |board|
+      words = board.set_current_word_list
+
+      # A board with no tiles has nothing to cache — leave it null rather than
+      # writing an empty array, so a later add_images run still populates it.
+      if words.blank?
+        empty += 1
+        next
+      end
+
+      if dry_run
+        filled += 1
+        next
+      end
+
+      # Only the jsonb column changes; skip validations and callbacks so a board
+      # that is invalid for unrelated reasons still gets its word list.
+      board.update_column(:data, board.data)
+      filled += 1
+    rescue StandardError => e
+      failed += 1
+      warn "  board #{board.id}: #{e.class}: #{e.message}"
+    end
+
+    puts "#{dry_run ? "would fill" : "filled"}: #{filled}"
+    puts "skipped (no tiles): #{empty}"
+    puts "failed: #{failed}" if failed.positive?
+    puts "Re-run with DRY_RUN=false to apply." if dry_run && filled.positive?
+  end
+end

--- a/spec/lib/tasks/board_word_lists_backfill_spec.rb
+++ b/spec/lib/tasks/board_word_lists_backfill_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# Fills data["current_word_list"] on boards that never got one, because
+# `set_current_word_list` used to mutate the jsonb hash in place and so never
+# persisted. Until they are backfilled, `word_sample` re-queries board_images
+# for each of them on every card-list render.
+RSpec.describe "board_word_lists:backfill rake task", type: :task do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  let(:task) { Rake::Task["board_word_lists:backfill"] }
+
+  def run_task
+    task.reenable
+    task.invoke
+  end
+
+  around do |example|
+    original = ENV.to_hash.slice("DRY_RUN", "USER_ID")
+    example.run
+    ENV["DRY_RUN"] = original["DRY_RUN"]
+    ENV["USER_ID"] = original["USER_ID"]
+  end
+
+  before do
+    ENV.delete("DRY_RUN")
+    ENV.delete("USER_ID")
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+
+  def board_missing_word_list
+    board = FactoryBot.create(:board, user: user)
+    FactoryBot.create(:board_image, board: board)
+    board.update_column(:data, (board.data || {}).except("current_word_list"))
+    board
+  end
+
+  it "fills the word list when applied" do
+    board = board_missing_word_list
+    ENV["DRY_RUN"] = "false"
+
+    expect { run_task }.to output(/filled: \d+/).to_stdout
+
+    expect(board.reload.data["current_word_list"]).to be_present
+  end
+
+  it "changes nothing on a dry run" do
+    board = board_missing_word_list
+
+    expect { run_task }.to output(/would fill/).to_stdout
+
+    expect(board.reload.data["current_word_list"]).to be_nil
+  end
+
+  it "leaves a board with no tiles alone" do
+    empty = FactoryBot.create(:board, user: user)
+    empty.update_column(:data, (empty.data || {}).except("current_word_list"))
+    ENV["DRY_RUN"] = "false"
+
+    expect { run_task }.to output(/skipped \(no tiles\)/).to_stdout
+
+    expect(empty.reload.data["current_word_list"]).to be_nil
+  end
+
+  it "honors USER_ID scoping" do
+    mine = board_missing_word_list
+    other = FactoryBot.create(:board, user: FactoryBot.create(:user))
+    FactoryBot.create(:board_image, board: other)
+    other.update_column(:data, (other.data || {}).except("current_word_list"))
+
+    ENV["DRY_RUN"] = "false"
+    ENV["USER_ID"] = user.id.to_s
+    run_task
+
+    expect(mine.reload.data["current_word_list"]).to be_present
+    expect(other.reload.data["current_word_list"]).to be_nil
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -50,6 +50,57 @@
 require "rails_helper"
 
 RSpec.describe Board, type: :model do
+
+  describe "#set_current_word_list" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+
+    it "persists the computed list so it is not recomputed on every read" do
+      FactoryBot.create(:board_image, board: board)
+      board.reload
+
+      expect(board.data["current_word_list"]).to be_nil
+
+      board.set_current_word_list
+      board.save!
+
+      # This used to fail: the method bound a LOCAL `data` shadowing the
+      # attribute and mutated the jsonb hash in place, so ActiveRecord never
+      # saw the record as dirty and the list was never written. Every board
+      # missing it therefore re-queried board_images forever.
+      expect(board.reload.data["current_word_list"]).to be_present
+    end
+
+    it "marks the record dirty so a caller's save writes the column" do
+      FactoryBot.create(:board_image, board: board)
+      board.reload
+
+      board.set_current_word_list
+
+      expect(board.changed).to include("data")
+    end
+
+    it "leaves the list unset for a board with no tiles" do
+      board.set_current_word_list
+
+      expect(board.data["current_word_list"]).to be_nil
+    end
+  end
+
+  describe "#current_word_list" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:board) { FactoryBot.create(:board, user: user) }
+
+    it "does not write on the read path" do
+      FactoryBot.create(:board_image, board: board)
+      board.reload
+
+      expect(board.current_word_list).to be_present
+      # `word_sample` calls this for every board in a card list; a GET must not
+      # issue an UPDATE per board.
+      expect(board.reload.data["current_word_list"]).to be_nil
+    end
+  end
   describe "#clone_with_images" do
     let(:user)  { FactoryBot.create(:user) }
     let(:board) { FactoryBot.create(:board, user: user, name: "Original Board") }

--- a/spec/models/child_account_api_view_performance_spec.rb
+++ b/spec/models/child_account_api_view_performance_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+
+# Regression cover for the ViewCommunicatorAccount hang: GET
+# /api/child_accounts/45 took 12.9s in production (1,788,964 allocations,
+# db_runtime 9376ms) because `api_view` serialized all 1,126 boards the owner
+# had, reading `display_image_url` (an ActiveStorage lookup) and `word_sample`
+# on each without preloads — roughly 3,700 queries in one request.
+RSpec.describe ChildAccount, "#api_view performance", type: :model do
+  # Counts real SQL, ignoring transaction bookkeeping — same shape as
+  # spec/services/boards/image_resolver_spec.rb.
+  def count_queries
+    queries = 0
+    callback = lambda do |_name, _start, _finish, _id, payload|
+      next if payload[:sql].to_s.match?(/\A\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)/i)
+
+      queries += 1
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    queries
+  end
+
+  def build_account_with_owner_boards(board_count)
+    owner = FactoryBot.create(:user)
+    account = FactoryBot.create(:child_account, user: owner, owner_id: owner.id)
+
+    board_count.times do
+      board = FactoryBot.create(:board, user: owner)
+      # A tile makes `word_sample` fall through to board_images unless the word
+      # list is cached — which is exactly the path that used to re-query.
+      FactoryBot.create(:board_image, board: board)
+    end
+
+    [account, owner]
+  end
+
+  describe "query count" do
+    it "does not grow with the number of boards the owner has" do
+      small_account, small_owner = build_account_with_owner_boards(3)
+      large_account, large_owner = build_account_with_owner_boards(18)
+
+      # Warm anything memoized at the class level so the first call isn't
+      # charged for schema loads the second one gets for free.
+      small_account.api_view(small_owner)
+      ChildAccount.find(large_account.id).api_view(large_owner)
+
+      small = count_queries { ChildAccount.find(small_account.id).api_view(small_owner) }
+      large = count_queries { ChildAccount.find(large_account.id).api_view(large_owner) }
+
+      # 6x the boards must not mean materially more queries. Before the
+      # preloads this gap was ~15 queries per extra board.
+      expect(large - small).to be <= 2
+    end
+
+    it "stays under a flat ceiling for an owner with many boards" do
+      account, owner = build_account_with_owner_boards(25)
+      ChildAccount.find(account.id).api_view(owner)
+
+      # Measured at 18 on this branch and flat from 1 to 100 boards. The
+      # headroom is for incidental additions, not for per-board growth — the
+      # test above is what guards the flatness.
+      expect(count_queries { ChildAccount.find(account.id).api_view(owner) }).to be <= 25
+    end
+  end
+
+  describe "payload" do
+    let(:owner) { FactoryBot.create(:user) }
+    let(:account) { FactoryBot.create(:child_account, user: owner, owner_id: owner.id) }
+
+    it "omits the aggregations nothing reads" do
+      # The communicator page renders stats.heat_map / stats.most_clicked_words
+      # from the range-bounded /api/word_events/stats. `heat_map` here ran with
+      # no range at all — an all-time group_by_day on every page load.
+      view = account.api_view(owner)
+
+      expect(view).not_to have_key(:heat_map)
+      expect(view).not_to have_key(:week_chart)
+      expect(view).not_to have_key(:most_clicked_words)
+    end
+
+    it "serializes a populated recently_used_boards through api_view" do
+      # `recently_used_boards` returns ChildBoard rows whose name/bg_color/
+      # text_color/board_type are delegates. If its return type ever shifts back
+      # to Boards (or to WordEvents) this block raises rather than silently
+      # emptying, so exercise it with real data.
+      board = FactoryBot.create(:board, user: owner)
+      FactoryBot.create(:child_board, board: board, child_account: account)
+      FactoryBot.create(:word_event, user: owner, child_account: account,
+                                     board_id: board.id, created_at: 1.day.ago)
+
+      recent = ChildAccount.find(account.id).api_view(owner)[:recently_used_boards]
+
+      expect(recent.map { |b| b[:board_id] }).to eq([board.id])
+      expect(recent.first[:name]).to eq(board.name)
+      expect(recent.first).to have_key(:bg_color)
+      expect(recent.first).to have_key(:text_color)
+      expect(recent.first).to have_key(:board_type)
+    end
+
+    it "still serializes the board collections the page renders" do
+      board = FactoryBot.create(:board, user: owner)
+      FactoryBot.create(:child_board, board: board, child_account: account)
+
+      view = ChildAccount.find(account.id).api_view(owner)
+
+      expect(view[:boards].map { |b| b[:board_id] }).to include(board.id)
+      expect(view).to have_key(:available_boards)
+      expect(view).to have_key(:teams_boards)
+      expect(view).to have_key(:recently_used_boards)
+    end
+  end
+
+  describe "#boards_by_most_used" do
+    it "is computed once even though api_view reaches it twice" do
+      owner = FactoryBot.create(:user)
+      account = FactoryBot.create(:child_account, user: owner, owner_id: owner.id)
+
+      # No favourites, so `go_to_boards` falls through to boards_by_most_used —
+      # the second caller after `most_used_board`.
+      expect(account.child_boards.where(favorite: true)).to be_empty
+
+      grouped = 0
+      callback = lambda do |_name, _start, _finish, _id, payload|
+        grouped += 1 if payload[:sql].to_s.match?(/FROM "word_events".*GROUP BY.*board_id/im)
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        account.most_used_board
+        account.go_to_boards
+      end
+
+      expect(grouped).to eq(1)
+    end
+  end
+
+  describe "#recently_used_boards" do
+    let(:owner) { FactoryBot.create(:user) }
+    let(:account) { FactoryBot.create(:child_account, user: owner, owner_id: owner.id) }
+    let(:shared_board) { FactoryBot.create(:board, user: owner) }
+
+    before { FactoryBot.create(:child_board, board: shared_board, child_account: account) }
+
+    it "includes a board this account used in the last week" do
+      FactoryBot.create(:word_event, user: owner, child_account: account,
+                                     board_id: shared_board.id, created_at: 2.days.ago)
+
+      expect(account.recently_used_boards.map(&:board_id)).to include(shared_board.id)
+    end
+
+    it "excludes a board only OTHER accounts used" do
+      # The old implementation joined child_boards -> board -> word_events, so
+      # any user's activity on a shared board leaked into this account's strip.
+      other_owner = FactoryBot.create(:user)
+      other_account = FactoryBot.create(:child_account, user: other_owner, owner_id: other_owner.id)
+      FactoryBot.create(:word_event, user: other_owner, child_account: other_account,
+                                     board_id: shared_board.id, created_at: 2.days.ago)
+
+      expect(account.recently_used_boards.map(&:board_id)).not_to include(shared_board.id)
+    end
+
+    it "excludes events older than a week" do
+      FactoryBot.create(:word_event, user: owner, child_account: account,
+                                     board_id: shared_board.id, created_at: 3.weeks.ago)
+
+      expect(account.recently_used_boards.map(&:board_id)).not_to include(shared_board.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`https://app.speakanyway.com/communicator-accounts/45` hangs. Confirmed in the production Puma journal — 2026-08-18 15:16:44 UTC:

```
path=/api/child_accounts/45 action=show status=200 allocations=1788964 duration=12945.91 view=6.56 db=9376.24
```

| Account | Allocations | Duration | DB time |
|---|---|---|---|
| **45** | **1,788,964** | **12,946 ms** | 9,376 ms |
| 54 | ~95,000 | ~250 ms | ~110 ms |
| 226 | 58,341 | ~140 ms | 71 ms |

A read-only production probe found the cause — and it isn't word events:

```
ChildAccount 45   word_events: 20,403   child_boards: 13
                  owner total boards: 1,126   available_boards: 1,126
                  owner boards missing cached word_list: 359
acct 54: owner_boards=47   |   acct 226: owner_boards=12
```

`ChildAccount#api_view` serializes **every board the owner has** into `available_boards` on every load. Per board it called `display_image_url` (2–3 ActiveStorage queries, nothing preloaded) and `word_sample` (a `board_images` query whenever the cached word list was missing) — roughly **3,700 queries in one request**. The 24× board ratio between accounts 45 and 54 matches their 19× allocation ratio.

**`api_view` is now flat at 18 queries — measured identical at 1, 5, 25 and 100 boards.**

## Changes

- **Preload board cover attachments** on every collection the serializer touches, reusing `Profile::BOARD_CARD_PRELOADS` from #667. `go_to_boards` is polymorphic in *return type* (ChildBoard rows when favourites exist, Boards otherwise), so it preloads per branch — the same trap `Profile#communication_boards` documents. The `boards:` block also picks up `:created_by` and `board.user`, which it reads per row.
- **`Board.word_samples_for`** resolves a whole list's word samples from cached data plus **one** grouped `board_images` read, instead of one query per board. Used by both `api_view` and `vendor_api_view`.
- **Fixed `Board#set_current_word_list`.** It opened with `data = self.data || {}` — binding a *local* that shadowed the attribute — then mutated that hash in place. In-place jsonb mutation isn't tracked as dirty, so the computed list was **never persisted**, not even by the `set_current_word_list` + `save!` pair in `add_images`. Every board never written through another path recomputed its word list on every request, forever. `rake board_word_lists:backfill` cleans up what that bug left behind.
- **Dropped `heat_map`, `week_chart`, `most_clicked_words` from `api_view`.** Nothing read them — the page renders `stats.heat_map` / `stats.most_clicked_words` from the range-bounded `/api/word_events/stats`. `heat_map` ran with **no range at all**: an all-time `group_by_day` on every page load. `vendor_api_view` keeps all three, since the vendor screen genuinely reads them.
- **Memoized `boards_by_most_used`**, which `api_view` reached twice per request.
- **Rewrote `recently_used_boards`** — a correctness fix as well as a perf one. It joined `child_boards → board → word_events`, matching events recorded by **any** user on a board this communicator has, so shared and predefined boards leaked other people's activity into the strip. It also instantiated every matched row to `.uniq` in Ruby, and put a raw string condition on an `includes` without `.references`, which Rails 8 doesn't treat as a reason to force the join.
- **Indexes** on `word_events(board_id)` (there was none at all) and `word_events(child_account_id, timestamp)`, both `CONCURRENTLY`.

No API contract change beyond the three dropped dead keys; no frontend changes.

## Test plan

New `spec/models/child_account_api_view_performance_spec.rb`:
- query count **does not grow with board count** (this is the real guard — 6× the boards must not cost materially more queries), plus a flat ceiling
- `api_view` omits the three dead aggregations; board collections still serialize
- a **populated** `recently_used_boards` round-trips through `api_view`, so a return-type regression raises instead of silently emptying
- `recently_used_boards` excludes another account's activity on a shared board, and events older than a week
- `boards_by_most_used` runs one query across both callers

New `spec/models/board_spec.rb` cases: `set_current_word_list` persists and marks the record dirty (**fails on `main` today**), and `current_word_list` does not write on the read path.

New `spec/lib/tasks/board_word_lists_backfill_spec.rb`: apply, dry-run, no-tiles, and `USER_ID` scoping.

Ran and passing:

- `spec/models/child_account_api_view_performance_spec.rb`, `board_spec.rb`, `child_account*_spec.rb`, `child_board_spec.rb`, `profile_spec.rb`, `spec/lib/tasks/board_word_lists_backfill_spec.rb`, all `spec/requests/api/*child*`, `profiles_spec.rb` — **430 examples, 0 failures**
- `spec/requests/api/boards`, `spec/sidekiq` — **392 examples, 0 failures, 1 pending**

## Post-deploy step

Run the backfill once (dry-run first):

```
DRY_RUN=false rake board_word_lists:backfill
```

Then reload `/communicator-accounts/45` and confirm in `bin/prod-logs` that allocations drop from 1.79M to ~100k and duration to well under 1s, in line with account 54.

## Follow-ups (not in this PR)

- The page requests `/api/child_accounts/:id` **twice** per load — `fetchCommunicatorAccount` is called from both a `useEffect` and `useIonViewWillEnter`, and the in-flight dedupe in `cacheFetch` is commented out. Visible in the logs as back-to-back identical requests.
- `available_boards` ships all 1,126 boards purely to feed `AddBoardsModal`, which usually never opens; it should move behind its own paginated endpoint. It also uses `user.boards` (including menus and Board Builder sub-pages) where `Profile#user_boards` filters `.main_boards` — worth deciding whether the picker should offer sub-pages at all.
- `GET /api/public_boards` is fetched on every tab with no server-side limit; measured at 16.5s / 878k allocations in the same log window.
- `AuditsController#communicator_stats` is missing `:user` and `:profile` in its `includes` (~1,000 extra queries for its 500-row limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)