### PR TITLE
feat(kit-pages): back /kit/:slug lead-magnet landing pages from the database

### DIFF
--- a/.claude-notes/kit-landing-pages-handoff.md
+++ b/.claude-notes/kit-landing-pages-handoff.md
@@ -1,0 +1,265 @@
+# Handoff: Dynamic kit landing pages (backend)
+
+**Date:** 2026-08-19 · **Status:** built — see "As built" at the foot of this doc
+**Full plan:** `../drafts/kit-landing-pages-plan.md` (this doc is self-contained; the plan adds context)
+**Counterpart:** `../itty-bitty-frontend/.claude-notes/kit-landing-pages-handoff.md` (blocked on this PR)
+**Issue:** none filed
+**Related spokes:** `.claude-notes/board-printables-etsy.md`, `.claude-notes/marketing-integrations.md`,
+`.claude-notes/classroom-lead-tag-handoff.md`
+
+## Goal
+
+Back a reusable lead-magnet landing page at `app.speakanyway.com/kit/:slug`. Brittany creates and edits
+these pages in `/admin`, picks one of her existing `BoardPrintable` records as the download, and the
+page goes live with no deploy.
+
+## Decisions (already made — don't re-litigate)
+
+- Config lives in the **database**, not a frontend config file. New `KitPage` model.
+- The download is an existing **`BoardPrintable`** plus a chosen PDF variant. Not `MarketingAsset`,
+  not a live `/boards/:id/pdf` render.
+- URLs are `/kit/:slug`. `/classroom` and `/ctg` are **not** migrated and must keep working exactly
+  as they do now — they're printed on QR codes and campaign emails.
+- Leads reuse `DownloadLead` with `source = "kit_<slug>"`. No new lead model, no new table for leads.
+- The email gate is soft by design (see "Known constraint" below). Don't try to harden it in this PR.
+
+## Current state
+
+**`DownloadLead`** — `app/models/download_lead.rb`, table at `db/schema.rb:510-521`
+(`email`, `name`, `board_id`, `source`, `mailchimp_status`, `data` jsonb). Created anonymously via
+`POST /api/download_leads` (`app/controllers/api/download_leads_controller.rb:11` skips auth;
+`config/routes.rb:188`). Sources in use: `free_download`, `classroom_kit`, `ctg`, `playground_nomination`.
+The model header (lines 6-11) documents that new sources should ride the `data` jsonb rather than add columns.
+
+**Mailchimp tagging** — `app/sidekiq/mailchimp_upsert_lead_job.rb:13-21`:
+
+```ruby
+SOURCE_TAGS = {
+  "classroom_kit" => "ClassroomKitLead",
+  "ctg" => "ctg-2026",
+  "playground_nomination" => "PlaygroundNomination",
+}.freeze # fallback DEFAULT_LEAD_TAG = "BoardDownloadLead"
+```
+
+This frozen hash is the only reason a new landing page currently needs a code change. Work item 4 fixes that.
+
+**`BoardPrintable`** — `app/models/board_printable.rb`, table at `db/schema.rb:227-254`.
+- `has_many_attached :files` (line 139); blobs are distinguished by **blob metadata**, not separate
+  attachments. `metadata["kind"]` ∈ `"pdf"` / `"image"` / `"video"`, with **nil meaning legacy PDF**.
+  `KIND_DOWNLOADABLE = [nil, KIND_PDF]` (line 55) is a deliberate allowlist — read the comment there
+  before touching selection logic.
+- PDF variants: `DOWNLOAD_VARIANTS` (line 33) = `color`, `low_ink`, `trim_ready`; single-board docs use `full`.
+- `files_view` (line 268) returns `[{variant, filename, url, byte_size}]` for PDFs only, and its comment
+  states both the admin download buttons and `/api/board_printables/:id/download_url` read it. **Reuse it.**
+- `status` is a plain string, not an enum: `STATUSES = %w[pending generating complete failed]` (line 12);
+  `complete?` at line 145.
+- `protects_board?` (line 407) = `etsy_ever_published? && protection_waived_at.nil?`.
+
+**Existing admin** — `Admin::BoardPrintablesController` (`app/controllers/admin/board_printables_controller.rb`,
+routes at `config/routes.rb:107-120`). `Admin::ApplicationController:3` sets `layout "admin"` and
+requires `authenticate_user!` + `require_admin!`.
+
+**No CMS model exists.** `app/models/page.rb` is `Page < Profile` (MySpeak), not a content page — don't
+confuse the two when naming.
+
+### Known constraint — the gate is soft, don't over-build
+
+`config/storage.yml:9-15` configures the `amazon` service with `public: true`, and
+`config/environments/production.rb:54` uses it. `has_many_attached :files` names no service, so every
+printable file already sits behind a permanent, unsigned `CDN_HOST/board_printables/<id>/<hex>/<file>.pdf`
+URL. The hex path segment is the only protection. Requiring an email before revealing the URL is exactly
+what `/classroom` does today and is the intended behavior here. Do **not** move printables to
+`amazon_private` or add presigned URLs in this PR.
+
+## Work items
+
+### 1. `KitPage` model + migration
+
+```ruby
+create_table :kit_pages do |t|
+  t.string  :slug, null: false                 # kebab-case, unique index
+  t.string  :title, null: false                # h1
+  t.string  :eyebrow                           # pill above the h1, e.g. "Free classroom kit"
+  t.text    :subhead
+  t.jsonb   :content, null: false, default: {} # see shape below
+  t.references :board_printable, foreign_key: true   # nullable until a printable is picked
+  t.string  :printable_variant, null: false, default: "color"
+  t.string  :mailchimp_tag                     # nil => derived default
+  t.string  :cta_label
+  t.string  :cta_path
+  t.boolean :published, null: false, default: false
+  t.datetime :etsy_override_at                 # see item 5
+  t.references :etsy_override_by, foreign_key: { to_table: :users }
+  t.timestamps
+end
+add_index :kit_pages, :slug, unique: true
+```
+
+`content` jsonb shape — keep it small and validated loosely; this is what the frontend renders:
+
+```json
+{
+  "items": [{ "title": "Core word poster", "description": "..." }],
+  "closing": { "heading": "Make it personal", "body": "...", "cta_label": "...", "cta_path": "/sign-up" }
+}
+```
+
+Model requirements:
+- Slug validated against a kebab format — copy `MarketingAsset::SLUG_FORMAT` (`app/models/marketing_asset.rb`).
+- `printable_variant` inclusion in `BoardPrintable::DOWNLOAD_VARIANTS + ["full"]`.
+- `lead_source` → `"kit_#{slug}"`.
+- `resolved_mailchimp_tag` → `mailchimp_tag.presence || "#{slug.camelize}Lead"` (so `at-school` → `AtSchoolLead`).
+- `downloadable?` → `board_printable&.complete? && board_printable.files.attached?`.
+- `download_files` → `board_printable.files_view.select { _1[:variant] == printable_variant }`,
+  falling back to all of `files_view` if that variant isn't present (a printable may only have `full`).
+- Scope `published`.
+
+### 2. Public read endpoint
+
+`GET /api/kit_pages/:slug` → `Api::KitPagesController#show`, `skip_before_action :authenticate_token!`.
+Look up by slug among `published`; 404 `{ error: "kit_page_not_found" }` otherwise.
+
+Response — **never include a file URL here**:
+
+```json
+{
+  "slug": "at-school", "title": "...", "eyebrow": "...", "subhead": "...",
+  "content": { ... }, "cta_label": "...", "cta_path": "...",
+  "downloadable": true
+}
+```
+
+`downloadable: false` tells the frontend to hide the form rather than render a broken gate.
+
+### 3. Public download endpoint
+
+`POST /api/kit_pages/:slug/download` → `Api::KitPagesController#download`, auth skipped.
+
+Params: `{ email:, name?, data?: {} }` (`data` carries UTM, same as `/classroom`).
+
+Behavior:
+1. Find the published page; 404 if missing.
+2. 422 `{ error: "not_available" }` unless `downloadable?`.
+3. Create a `DownloadLead` with `source: page.lead_source`, `email`, `name`, `data` merged with
+   `{ "kit_slug" => page.slug }`. On validation failure return `422 { errors: [...] }` matching the shape
+   `Api::DownloadLeadsController` already returns — the frontend surfaces `errors[0]` inline.
+4. Return `200 { files: page.download_files }`.
+
+Routes, inside `namespace :api` alongside the other public routes near `config/routes.rb:183-188`:
+
+```ruby
+resources :kit_pages, only: [:show], param: :slug do
+  member { post :download }
+end
+```
+
+Watch route ordering — put these with the other `public_*` flat routes, not inside an authenticated block.
+
+### 4. Dynamic Mailchimp tag (the "no deploy per page" piece)
+
+In `app/sidekiq/mailchimp_upsert_lead_job.rb`, keep `SOURCE_TAGS` as the explicit map for the existing
+three sources, then add a fallback: when `source` starts with `kit_`, look up
+`KitPage.find_by(slug: source.delete_prefix("kit_"))` and use `resolved_mailchimp_tag`; if the page is
+gone, fall back to `DEFAULT_LEAD_TAG`. Never raise — a missing page must not fail the job and lose the lead.
+
+Do not add a Customer Journey trigger. Per issue #640 the classroom flow deliberately does not promise
+an emailed kit because no journey fires on the tag; the same is true here.
+
+### 5. Admin CRUD — `/admin/kit_pages`
+
+`Admin::KitPagesController` with `index`, `new`, `create`, `edit`, `update`, plus a `publish` /
+`unpublish` member. Follow `app/views/admin/video_boards/` for structure — it's the closest plain-CRUD
+screen. Conventions in `app/views/layouts/admin.html.erb`: `content_for :page_title`, `admin-card` /
+`admin-input` / `admin-hover-row` / `admin-badge` helper classes, `text-t1/t2/t3`, flash rendered by the
+layout so controllers just `redirect_to ..., notice:`. Forms use plain `form_tag` +
+`text_field_tag`/`text_area_tag` and controllers read flat `params[:foo]` — match that, don't introduce
+`form_with`. **Add the nav link** to the hardcoded list in the layout (lines ~113-138); active state is
+`request.path.start_with?("/admin/kit_pages")`.
+
+Form fields: slug, title, eyebrow, subhead, content items (a repeatable title/description pair is fine;
+a raw JSON textarea is acceptable for v1 if it validates and shows parse errors), printable select,
+variant select, mailchimp tag, CTA label/path, published checkbox.
+
+**Printable select rules:**
+- Only offer `BoardPrintable.where(status: "complete")` with files attached, labeled with the board name
+  and page count.
+- If the selected printable's `protects_board?` is true, **block the save** and re-render with an
+  `admin-flash-err` explaining that this printable is published on Etsy, plus an explicit
+  "Give this away for free anyway" checkbox that, when checked, stamps `etsy_override_at` /
+  `etsy_override_by_id`. Two-step on purpose — selling a printable on Etsy and giving it away from a
+  landing page should never happen by accidentally picking the wrong dropdown row.
+- Show a live "Preview" link to `#{ENV['FRONT_END_URL']}/kit/#{slug}` on the index and edit screens.
+
+## Testing
+
+Run `bundle exec rspec` for the files you touch.
+
+| Case | Expected |
+|---|---|
+| `GET /api/kit_pages/:slug`, published, no token | 200, no file URL in the body |
+| `GET /api/kit_pages/:slug`, unpublished | 404 `kit_page_not_found` |
+| `GET /api/kit_pages/:slug`, unknown slug | 404 |
+| `POST .../download`, valid email | 200 with `files[]`; a `DownloadLead` exists with `source == "kit_<slug>"` |
+| `POST .../download`, blank/invalid email | 422 with `errors[]` |
+| `POST .../download`, page has no printable | 422 `not_available` |
+| `POST .../download` | enqueues `MailchimpUpsertLeadJob` |
+| `MailchimpUpsertLeadJob` with `kit_at-school` | tags `AtSchoolLead` |
+| Same, page deleted | tags `BoardDownloadLead`, does not raise |
+| Variant selection | only the chosen variant is returned when present; falls back to all PDFs when absent |
+| Admin save with an Etsy-published printable, no override | rejected, no record change |
+| Same, with override checked | saved, `etsy_override_at` stamped |
+| Admin routes without an admin session | redirected / rejected |
+
+Also add a regression spec asserting `POST /api/download_leads` still behaves as before — `/classroom`
+and `/ctg` depend on it and must not change.
+
+## Deploy notes
+
+- One migration: `create_kit_pages`. No backfill.
+- No new ENV vars. The preview link uses the existing `FRONT_END_URL`.
+- Ships safely on its own; nothing user-visible until the frontend PR lands.
+- After deploy, create one page in `/admin/kit_pages` so the frontend has something to point at, and
+  put its slug in the frontend PR description.
+
+## Wrap-up
+
+Follow this repo's CLAUDE.md for git workflow and conventions. Open the PR and stop — never merge.
+Commit this doc in the PR so it survives the session. Add a short entry pointing at it from the
+`.claude-notes/` spoke table in CLAUDE.md if the model outlives this feature.
+
+## As built
+
+Shipped as written, with these deliberate deviations — read them before
+changing the model or the contract.
+
+- **`downloadable?` is stricter than the sketch.** It requires a real PDF
+  (`download_files.any?`), not merely `files.attached?`. A printable carrying
+  only listing images or the listing video is "attached" but has nothing a
+  visitor can be handed, and rendering the email gate for it means a form that
+  can only ever 422. Same reason the admin's printable dropdown filters on
+  `pdf_files.any?` rather than on `files.attached?`.
+- **`resolved_mailchimp_tag` underscores before camelizing.** `"at-school".camelize`
+  is `"At-school"`, which is not a usable tag — the slug's hyphens are converted
+  first, so `at-school` → `AtSchoolLead` as specified.
+- **Admin route helpers are `*_dashboard_kit_page(s)`**, matching every other
+  controller in the `admin` namespace. The PATH is still `/admin/kit_pages`, so
+  the nav's `request.path.start_with?` active state is as described.
+- **Content is a raw JSON textarea** (the v1 the doc allows). A parse failure
+  re-renders the form with what was typed, not with the last saved value.
+- **The Etsy override is scoped to the printable it was granted for.** A stamped
+  override lets later edits of the same page through, but swapping in a
+  *different* protected printable asks again, and moving to an unprotected one
+  clears the stamp — a stale grant must not silently authorize the next swap.
+- **No `destroy` action.** Unpublish is the way to take a page down; the row is
+  the only record of which leads came from where.
+
+### Files
+
+- `db/migrate/20260819120000_create_kit_pages.rb`, `app/models/kit_page.rb`
+- `app/controllers/api/kit_pages_controller.rb` (public read + download)
+- `app/controllers/admin/kit_pages_controller.rb`, `app/views/admin/kit_pages/`
+- `app/sidekiq/mailchimp_upsert_lead_job.rb` (the `kit_` tag fallback)
+- Specs: `spec/models/kit_page_spec.rb`, `spec/requests/api/kit_pages_spec.rb`,
+  `spec/requests/api/download_leads_kit_pages_regression_spec.rb`,
+  `spec/requests/admin/kit_pages_spec.rb`, plus additions to
+  `spec/sidekiq/mailchimp_upsert_lead_job_spec.rb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Free-kit landing pages can be built without a deploy.** A new admin screen
+  (`/admin/kit_pages`) creates a lead-magnet page served at `/kit/<slug>`: its
+  headline, blurb, "what's inside" list and call to action are edited in the
+  admin, and the download is one of your existing board printables. A visitor
+  enters an email and gets the PDF; the email lands in Mailchimp under a tag
+  named for the page, so each campaign is its own segment. Pages start as
+  drafts and go live when you publish them. `/classroom` and `/ctg` are
+  untouched — they're printed on QR codes and keep working exactly as before.
+  Picking a printable that's for sale on Etsy is refused until you tick a
+  separate "give this away for free anyway" box, which records who chose it.
+
 - **A printable's topic can be edited after it's created, and the listing copy
   rebuilt from it.** The topic is the only part of a listing that describes the
   product — without one, the generic tag pools fill all 13 of Etsy's slots and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,23 @@ an explicit decision, not a drive-by edit.
   correct, larger, and — the part that matters — never `""`, the marker for
   "this tile has no picture".
 
+- **A kit landing page's public read carries no file URL.** `/kit/:slug` is a
+  lead magnet: `KitPage#public_view` publishes copy plus a `downloadable`
+  boolean, and the printable's URL is revealed only by `POST
+  /api/kit_pages/:slug/download`, after a `DownloadLead` is written with
+  `source = "kit_<slug>"`. That gate is SOFT on purpose and must not be
+  "hardened" in place — production S3 is `public: true`, so every
+  `board_printables` blob already sits behind a permanent unsigned CDN URL whose
+  hex path segment is the only protection; making it real means moving
+  printables to a private service, not adding a check to this controller. Two
+  things ride on the `kit_` source prefix. `MailchimpUpsertLeadJob` resolves the
+  tag from the `KitPage` row rather than from its frozen `SOURCE_TAGS` hash —
+  that lookup is the whole reason a new landing page needs no deploy, and it may
+  never raise, since a page deleted after its leads were captured must fall back
+  to the default tag rather than strand the lead. And the download always comes
+  from `BoardPrintable#files_view`, the PDF ALLOWLIST, so a listing image or the
+  listing video can never be handed to a visitor as the product.
+
 ## Subsystem map (read the spoke before working in the area)
 
 | Spoke | Covers |
@@ -555,6 +572,7 @@ an explicit decision, not a drive-by edit.
 | `.claude-notes/image-generation.md` | AI tile art: `Images::PromptBuilder` (the single prompt source of truth, always-wrap rule), symbol vs illustrated style resolution, part-of-speech homograph disambiguation, transparency/quality API params + model fallback, refusal retry, variations via the edit endpoint, prompt provenance on docs |
 | `.claude-notes/board-printables-etsy.md` | Publishing a board printable to a marketplace: the drafts-only rule, Etsy's rotating refresh token + why Rails holds a separate grant, the ported Etsy v3 API quirks, listing-copy rules (and their Ruby↔TypeScript drift), Grover-rendered gallery images, the TPT paste sheet |
 | `.claude-notes/writing-suggestions.md` | Contextual writing suggestions (`POST /api/suggestions`): field registry + context allow-list, the no-safety-keys privacy invariant, OpenAI generator + fixtures, free/no-credit contract, user opt-out toggle |
+| `.claude-notes/kit-landing-pages-handoff.md` | Kit landing pages (`/kit/:slug`): the `KitPage` model, the public read/download contract, the `kit_<slug>` lead source and its dynamic Mailchimp tag, the `/admin/kit_pages` CRUD and its Etsy give-away guard |
 
 Related tracked docs: `docs/rds-migration-runbook.md`, `docs/stripe-setup.md`,
 `docs/credits-handoff.md`, `.claude-notes/artifact-generation-services.md`,

--- a/app/controllers/admin/kit_pages_controller.rb
+++ b/app/controllers/admin/kit_pages_controller.rb
@@ -1,0 +1,149 @@
+module Admin
+  # CRUD for the /kit/:slug landing pages. The point of the screen is that a new
+  # lead-magnet page — copy, download, and Mailchimp tag — ships without a
+  # deploy on either side.
+  #
+  # One rail is load-bearing: picking a printable that is SOLD on Etsy is
+  # refused until it is confirmed a second time. Giving away a product that is
+  # listed for sale should never be one mis-clicked dropdown row away, so the
+  # confirmation is an explicit checkbox and it is stamped on the record with
+  # who did it and when.
+  class KitPagesController < Admin::ApplicationController
+    before_action :set_kit_page, only: %i[edit update publish unpublish]
+
+    def index
+      @kit_pages = KitPage.includes(board_printable: :board).order(created_at: :desc)
+    end
+
+    def new
+      @kit_page = KitPage.new(printable_variant: BoardPrintable::VARIANT_COLOR)
+    end
+
+    def create
+      @kit_page = KitPage.new
+      return render(:new, status: :unprocessable_entity) unless assign_and_save(@kit_page)
+
+      redirect_to edit_admin_dashboard_kit_page_path(@kit_page),
+                  notice: "Created “#{@kit_page.title}”#{@kit_page.published? ? " — it is live now." : " as a draft."}"
+    end
+
+    def edit; end
+
+    def update
+      return render(:edit, status: :unprocessable_entity) unless assign_and_save(@kit_page)
+
+      redirect_to edit_admin_dashboard_kit_page_path(@kit_page), notice: "Saved “#{@kit_page.title}”."
+    end
+
+    def publish
+      @kit_page.update!(published: true)
+      redirect_to admin_dashboard_kit_pages_path, notice: "“#{@kit_page.title}” is live at /kit/#{@kit_page.slug}."
+    end
+
+    def unpublish
+      @kit_page.update!(published: false)
+      redirect_to admin_dashboard_kit_pages_path, notice: "“#{@kit_page.title}” is no longer public."
+    end
+
+    private
+
+    def set_kit_page
+      @kit_page = KitPage.find_by(id: params[:id])
+      redirect_to admin_dashboard_kit_pages_path, alert: "Kit page not found." unless @kit_page
+    end
+
+    # Flat params, matching the rest of the admin (form_tag + *_tag helpers).
+    def assign_and_save(page)
+      page.assign_attributes(
+        slug: params[:slug].to_s.strip,
+        title: params[:title].to_s.strip,
+        eyebrow: params[:eyebrow].to_s.strip.presence,
+        subhead: params[:subhead].to_s.strip.presence,
+        board_printable_id: params[:board_printable_id].presence,
+        printable_variant: params[:printable_variant].presence || BoardPrintable::VARIANT_COLOR,
+        mailchimp_tag: params[:mailchimp_tag].to_s.strip.presence,
+        cta_label: params[:cta_label].to_s.strip.presence,
+        cta_path: params[:cta_path].to_s.strip.presence,
+        published: ActiveModel::Type::Boolean.new.cast(params[:published]) || false,
+      )
+
+      return false unless assign_content(page)
+      return false unless resolve_etsy_override(page)
+
+      page.save
+    end
+
+    # The content blob is edited as raw JSON in v1. A parse failure re-renders
+    # the form with what was typed, not with the last saved value.
+    def assign_content(page)
+      raw = params[:content].to_s.strip
+      @content_raw = raw
+
+      if raw.blank?
+        page.content = {}
+        return true
+      end
+
+      parsed = JSON.parse(raw)
+      unless parsed.is_a?(Hash)
+        @error = "Content must be a JSON object — it starts with { and ends with }."
+        return false
+      end
+
+      page.content = parsed
+      true
+    rescue JSON::ParserError => e
+      @error = "Content isn't valid JSON: #{e.message.truncate(160)}"
+      false
+    end
+
+    # Refuses the save when the chosen printable is sold on Etsy and the admin
+    # hasn't confirmed. An override already stamped on the record stands only
+    # for the printable it was stamped for — swapping in a different protected
+    # printable asks again.
+    def resolve_etsy_override(page)
+      unless page.gives_away_protected_printable?
+        # The selection is no longer protected, so a stale stamp must not sit
+        # there authorizing the next swap.
+        page.etsy_override_at = nil
+        page.etsy_override_by = nil
+        return true
+      end
+
+      if override_confirmed?
+        page.etsy_override_at = Time.current
+        page.etsy_override_by = current_user
+        return true
+      end
+
+      return true if page.etsy_override? && !page.board_printable_id_changed?
+
+      @error = "“#{page.board_printable.board&.name}” is published on Etsy — printed copies of it are " \
+               "sold. Tick “Give this away for free anyway” below if you really mean to hand it out free."
+      false
+    end
+
+    def override_confirmed?
+      ActiveModel::Type::Boolean.new.cast(params[:etsy_override]) || false
+    end
+
+    helper_method :selectable_printables, :kit_preview_url
+
+    # Only printables an admin could actually hand to a visitor: finished, and
+    # carrying at least one PDF (a printable holding only listing images would
+    # render a download form that can never deliver).
+    def selectable_printables
+      @selectable_printables ||= BoardPrintable
+        .where(status: "complete")
+        .includes(:board)
+        .with_attached_files
+        .order(created_at: :desc)
+        .select { |printable| printable.pdf_files.any? }
+    end
+
+    def kit_preview_url(page)
+      host = ENV["FRONT_END_URL"].presence || "https://app.speakanyway.com"
+      "#{host.chomp("/")}/kit/#{page.slug}"
+    end
+  end
+end

--- a/app/controllers/api/kit_pages_controller.rb
+++ b/app/controllers/api/kit_pages_controller.rb
@@ -1,0 +1,72 @@
+module API
+  # Public (no-auth) surface behind app.speakanyway.com/kit/:slug — a reusable
+  # lead-magnet landing page whose copy and download live in the database.
+  #
+  # #show never carries a file URL. The URL is revealed only by #download, and
+  # only after an email has been captured as a DownloadLead. That gate is soft
+  # by design (the underlying S3 objects are public), and matches what
+  # /classroom already does — see KitPage's header.
+  class KitPagesController < API::ApplicationController
+    skip_before_action :authenticate_token!, only: %i[show download]
+
+    before_action :set_kit_page
+
+    def show
+      render json: @kit_page.public_view
+    end
+
+    def download
+      # `downloadable: false` in #show already tells the frontend to hide the
+      # form; this answers the race where a printable is swapped out between
+      # page load and submit.
+      unless @kit_page.downloadable?
+        return render json: { error: "not_available" }, status: :unprocessable_content
+      end
+
+      lead = DownloadLead.new(
+        email: params[:email],
+        name: params[:name],
+        source: @kit_page.lead_source,
+        data: lead_data,
+      )
+
+      unless lead.save
+        return render json: { success: false, errors: lead.errors.full_messages },
+                      status: :unprocessable_content
+      end
+
+      enqueue_or_skip_mailchimp(lead)
+      render json: { files: @kit_page.download_files }
+    end
+
+    private
+
+    # Unpublished and unknown are the same answer on purpose: a draft page's
+    # existence isn't public information.
+    def set_kit_page
+      @kit_page = KitPage.published.find_by(slug: params[:slug])
+      return if @kit_page
+
+      render json: { error: "kit_page_not_found" }, status: :not_found
+    end
+
+    # UTM/campaign metadata, same free-form jsonb /classroom sends, stamped
+    # with the slug so a lead is traceable to its page even if the source
+    # naming convention ever changes.
+    def lead_data
+      submitted = params.permit(data: {}).to_h["data"] || {}
+      submitted.merge("kit_slug" => @kit_page.slug)
+    end
+
+    # Mirrors API::DownloadLeadsController: consent is asked once, in the
+    # model, so a lead that never opted in is marked "skipped" rather than
+    # sitting in mailchimp_pending forever.
+    def enqueue_or_skip_mailchimp(lead)
+      if lead.sync_to_mailchimp?
+        MailchimpUpsertLeadJob.perform_async(lead.id)
+      else
+        lead.update_column(:mailchimp_status, DownloadLead::MAILCHIMP_SKIPPED)
+      end
+    end
+  end
+end

--- a/app/models/kit_page.rb
+++ b/app/models/kit_page.rb
@@ -1,0 +1,120 @@
+# A lead-magnet landing page served at /kit/:slug. Brittany creates and edits
+# these in /admin; the frontend renders whatever this row says, so a new
+# campaign page needs no deploy on either side.
+#
+# Three things are deliberately NOT here:
+#
+#   * The leads. A kit signup is a DownloadLead with `source = "kit_<slug>"`,
+#     the same table /classroom and /ctg already use. No parallel lead model.
+#   * The file. The download is an existing BoardPrintable plus a chosen
+#     variant, so a visitor gets the same reviewed document the admin looked at
+#     rather than a live board render.
+#   * The gate. Production S3 is `public: true`, so every printable already sits
+#     behind a permanent unsigned CDN URL and the hex path segment is the only
+#     protection. Asking for an email before revealing that URL is a soft gate
+#     on purpose — exactly what /classroom does today.
+class KitPage < ApplicationRecord
+  # Same kebab-case rule as MarketingAsset::SLUG_FORMAT — these slugs end up in
+  # a public URL and in a Mailchimp tag, so neither may carry punctuation.
+  SLUG_FORMAT = /\A[a-z0-9]+(?:-[a-z0-9]+)*\z/
+
+  # Leads are discriminated by this prefix everywhere `DownloadLead#source` is
+  # read, notably MailchimpUpsertLeadJob's dynamic tag lookup.
+  LEAD_SOURCE_PREFIX = "kit_".freeze
+
+  # A subboard bundle carries the three DOWNLOAD_VARIANTS; a single-board
+  # printable carries one "full" document holding all of them.
+  VARIANTS = (BoardPrintable::DOWNLOAD_VARIANTS + [BoardPrintable::VARIANT_FULL]).freeze
+
+  belongs_to :board_printable, optional: true
+  belongs_to :etsy_override_by, class_name: "User", optional: true
+
+  validates :slug, presence: true, uniqueness: true, format: { with: SLUG_FORMAT }
+  validates :title, presence: true
+  validates :printable_variant, inclusion: { in: VARIANTS }
+  validate :content_shape
+
+  scope :published, -> { where(published: true) }
+
+  # Resolve the page a `kit_<slug>` lead source came from. Returns nil for any
+  # other source, and for a page that has since been deleted.
+  def self.for_lead_source(source)
+    slug = source.to_s
+    return nil unless slug.start_with?(LEAD_SOURCE_PREFIX)
+
+    published_or_not = slug.delete_prefix(LEAD_SOURCE_PREFIX)
+    return nil if published_or_not.blank?
+
+    find_by(slug: published_or_not)
+  end
+
+  def lead_source = "#{LEAD_SOURCE_PREFIX}#{slug}"
+
+  # `camelize` alone leaves the hyphen in place ("at-school" -> "At-school"),
+  # which is not a usable Mailchimp tag — so the slug is underscored first.
+  def resolved_mailchimp_tag
+    mailchimp_tag.presence || "#{slug.to_s.tr("-", "_").camelize}Lead"
+  end
+
+  # Whether the page can actually hand a file over. Keyed on there being a
+  # readable PDF, not merely on a printable being selected: a page whose
+  # printable is still generating (or which only carries listing images) must
+  # tell the frontend to hide the email form rather than render a gate that
+  # 422s on submit.
+  def downloadable? = download_files.any?
+
+  # The PDFs a visitor receives. `files_view` is the existing PDF-only
+  # allowlist — reused rather than reimplemented so a marketing image or the
+  # listing video can never be served as a download.
+  #
+  # Falls back to every PDF when the chosen variant isn't present, since a
+  # single-board printable only ever has "full".
+  def download_files
+    return [] unless board_printable&.complete?
+
+    @download_files ||= begin
+      all = board_printable.files_view
+      all.select { |file| file[:variant] == printable_variant }.presence || all
+    end
+  end
+
+  # The public payload. Deliberately carries no file URL — the URL is revealed
+  # only by the download endpoint, after an email.
+  def public_view
+    {
+      slug: slug,
+      title: title,
+      eyebrow: eyebrow,
+      subhead: subhead,
+      content: content.presence || {},
+      cta_label: cta_label,
+      cta_path: cta_path,
+      downloadable: downloadable?,
+    }
+  end
+
+  # True when this page gives away a printable that is sold on Etsy. The admin
+  # form refuses such a save until the override is confirmed.
+  def gives_away_protected_printable? = board_printable&.protects_board? || false
+
+  def etsy_override? = etsy_override_at.present?
+
+  private
+
+  # Loose on purpose: the frontend renders whatever it finds and the admin
+  # edits this as JSON, so the only thing worth refusing is a shape that would
+  # make the renderer throw.
+  def content_shape
+    return errors.add(:content, "must be a JSON object") unless content.is_a?(Hash)
+
+    # Keyed on nil, not on `present?` — an empty array is a fine "no items",
+    # but an empty array under "closing" is still the wrong type.
+    items = content["items"]
+    if !items.nil? && !(items.is_a?(Array) && items.all?(Hash))
+      errors.add(:content, "items must be a list of objects")
+    end
+
+    closing = content["closing"]
+    errors.add(:content, "closing must be an object") if !closing.nil? && !closing.is_a?(Hash)
+  end
+end

--- a/app/sidekiq/mailchimp_upsert_lead_job.rb
+++ b/app/sidekiq/mailchimp_upsert_lead_job.rb
@@ -9,7 +9,8 @@ class MailchimpUpsertLeadJob
 
   DEFAULT_LEAD_TAG = "BoardDownloadLead".freeze
   # Source-specific Mailchimp tags so distinct lead funnels can be segmented.
-  # Anything not listed here falls back to DEFAULT_LEAD_TAG (existing behavior).
+  # A "kit_<slug>" source reads its tag off the KitPage row (see #tag_for);
+  # anything else falls back to DEFAULT_LEAD_TAG.
   SOURCE_TAGS = {
     "classroom_kit" => "ClassroomKitLead",
     # Closing the Gap 2026 booth capture. Matches the tag the ctg-2026 campaign
@@ -54,8 +55,21 @@ class MailchimpUpsertLeadJob
 
   # Derive the Mailchimp tag from the lead's source so different capture funnels
   # (e.g. the /classroom kit) land under their own segmentable tag.
+  #
+  # SOURCE_TAGS stays the explicit map for the three hardcoded funnels; a
+  # `kit_<slug>` source resolves its tag from the KitPage row instead, which is
+  # the whole reason a new landing page needs no deploy.
   def tag_for(lead)
-    SOURCE_TAGS.fetch(lead.source, DEFAULT_LEAD_TAG)
+    SOURCE_TAGS.fetch(lead.source) { kit_page_tag(lead.source) || DEFAULT_LEAD_TAG }
+  end
+
+  # Never raises. A page deleted after its leads were captured must fall back
+  # to the default tag, not fail the job and strand the lead outside Mailchimp.
+  def kit_page_tag(source)
+    KitPage.for_lead_source(source)&.resolved_mailchimp_tag
+  rescue StandardError => e
+    Rails.logger.error("[Mailchimp] kit page tag lookup failed for #{source.inspect}: #{e.class}: #{e.message}")
+    nil
   end
 
   # A nil status means we never got an HTTP response (network/timeout), which is

--- a/app/views/admin/kit_pages/_form.html.erb
+++ b/app/views/admin/kit_pages/_form.html.erb
@@ -1,0 +1,131 @@
+<% input_class = "admin-input border rounded px-3 py-2 text-sm w-full focus:border-indigo-500 focus:outline-none" %>
+
+<% if @error.present? %>
+  <div class="admin-flash-err border rounded-lg px-4 py-3 mb-6 text-sm"><%= @error %></div>
+<% end %>
+
+<% if @kit_page.errors.any? %>
+  <div class="admin-flash-err border rounded-lg px-4 py-3 mb-6 text-sm">
+    <%= @kit_page.errors.full_messages.to_sentence %>
+  </div>
+<% end %>
+
+<%= form_tag url, method: method do %>
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <h2 class="text-sm font-medium text-t1 mb-4">Page</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="slug">Slug</label>
+        <%= text_field_tag :slug, @kit_page.slug, id: "slug", required: true,
+              placeholder: "at-school", class: input_class %>
+        <p class="text-[11px] text-t3 mt-1">Lowercase and hyphens only. The page lives at /kit/&lt;slug&gt;.</p>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="title">Title <span class="text-t3">(the h1)</span></label>
+        <%= text_field_tag :title, @kit_page.title, id: "title", required: true, class: input_class %>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="eyebrow">Eyebrow <span class="text-t3">(pill above the h1)</span></label>
+        <%= text_field_tag :eyebrow, @kit_page.eyebrow, id: "eyebrow", placeholder: "Free classroom kit", class: input_class %>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="mailchimp_tag">Mailchimp tag</label>
+        <%= text_field_tag :mailchimp_tag, @kit_page.mailchimp_tag, id: "mailchimp_tag",
+              placeholder: @kit_page.slug.present? ? @kit_page.resolved_mailchimp_tag : "derived from the slug",
+              class: input_class %>
+        <p class="text-[11px] text-t3 mt-1">Leave blank to derive it from the slug.</p>
+      </div>
+      <div class="md:col-span-2">
+        <label class="block text-xs font-medium text-t2 mb-1" for="subhead">Subhead</label>
+        <%= text_area_tag :subhead, @kit_page.subhead, id: "subhead", rows: 2, class: input_class %>
+      </div>
+    </div>
+  </div>
+
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <h2 class="text-sm font-medium text-t1 mb-1">Download</h2>
+    <p class="text-[11px] text-t3 mb-4">
+      Only finished printables that actually carry a PDF are listed. The visitor gets this exact document
+      after entering an email.
+    </p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="board_printable_id">Printable</label>
+        <%= select_tag :board_printable_id,
+              options_for_select(
+                selectable_printables.map { |p|
+                  [
+                    "#{p.board&.name || "Board ##{p.board_id}"} — #{p.page_count.to_i} pages#{p.protects_board? ? " · SOLD ON ETSY" : ""}",
+                    p.id,
+                  ]
+                },
+                @kit_page.board_printable_id
+              ),
+              include_blank: "— none yet —", id: "board_printable_id", class: input_class %>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="printable_variant">Variant</label>
+        <%= select_tag :printable_variant,
+              options_for_select(KitPage::VARIANTS, @kit_page.printable_variant), id: "printable_variant", class: input_class %>
+        <p class="text-[11px] text-t3 mt-1">Falls back to every PDF on the printable when the chosen variant isn't there.</p>
+      </div>
+    </div>
+
+    <% if @kit_page.gives_away_protected_printable? || @kit_page.etsy_override? %>
+      <label class="flex items-start gap-2 mt-4 text-xs text-t1 cursor-pointer">
+        <%= check_box_tag :etsy_override, "1", @kit_page.etsy_override?, class: "mt-0.5" %>
+        <span>
+          Give this away for free anyway
+          <span class="block text-[11px] text-t3">
+            This printable is published on Etsy. Ticking this records who chose to hand it out free, and when.
+            <% if @kit_page.etsy_override? %>
+              Currently overridden <%= @kit_page.etsy_override_at&.strftime("%b %-d, %Y") %><%= " by #{@kit_page.etsy_override_by.email}" if @kit_page.etsy_override_by %>.
+            <% end %>
+          </span>
+        </span>
+      </label>
+    <% end %>
+  </div>
+
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <h2 class="text-sm font-medium text-t1 mb-1">Content</h2>
+    <p class="text-[11px] text-t3 mb-4">
+      JSON. <code>items</code> is the "what's inside" list; <code>closing</code> is the block under it.
+    </p>
+    <%= text_area_tag :content, @content_raw || (@kit_page.content.presence && JSON.pretty_generate(@kit_page.content)),
+          id: "content", rows: 14, spellcheck: false,
+          placeholder: JSON.pretty_generate(
+            "items" => [{ "title" => "Core word poster", "description" => "One page, 36 words." }],
+            "closing" => { "heading" => "Make it personal", "body" => "…", "cta_label" => "Start free", "cta_path" => "/sign-up" }
+          ),
+          class: "#{input_class} font-mono text-xs" %>
+  </div>
+
+  <div class="admin-card border rounded-xl p-5 mb-6">
+    <h2 class="text-sm font-medium text-t1 mb-4">Call to action</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="cta_label">CTA label</label>
+        <%= text_field_tag :cta_label, @kit_page.cta_label, id: "cta_label", placeholder: "Start free", class: input_class %>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-t2 mb-1" for="cta_path">CTA path</label>
+        <%= text_field_tag :cta_path, @kit_page.cta_path, id: "cta_path", placeholder: "/sign-up", class: input_class %>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= submit_tag submit_label,
+          class: "text-xs font-medium px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer border-0" %>
+    <label class="flex items-center gap-2 text-xs text-t1 cursor-pointer">
+      <%= check_box_tag :published, "1", @kit_page.published? %>
+      Published
+    </label>
+    <% if @kit_page.persisted? %>
+      <%= link_to "Preview", kit_preview_url(@kit_page), target: "_blank", rel: "noopener",
+            class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/kit_pages/edit.html.erb
+++ b/app/views/admin/kit_pages/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Edit Kit Page" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight"><%= @kit_page.title %></h1>
+    <p class="text-sm text-t3 mt-0.5 font-mono">/kit/<%= @kit_page.slug %></p>
+  </div>
+  <%= link_to "← All kit pages", admin_dashboard_kit_pages_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", url: admin_dashboard_kit_page_path(@kit_page), method: :patch, submit_label: "Save changes" %>

--- a/app/views/admin/kit_pages/index.html.erb
+++ b/app/views/admin/kit_pages/index.html.erb
@@ -1,0 +1,79 @@
+<% content_for :page_title, "Kit Pages" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">Kit Pages</h1>
+    <p class="text-sm text-t3 mt-0.5">Lead-magnet landing pages at /kit/:slug. New pages start as drafts.</p>
+  </div>
+  <%= link_to "New kit page", new_admin_dashboard_kit_page_path,
+        class: "text-xs font-medium px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors" %>
+</div>
+
+<div class="admin-card border rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead>
+      <tr style="border-bottom: 1px solid var(--border);">
+        <% ["Page", "Download", "Mailchimp tag", "Status", "Created", "Actions"].each do |label| %>
+          <th class="text-left text-xs font-medium text-t2 px-5 py-3 whitespace-nowrap"><%= label %></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @kit_pages.each do |page| %>
+        <tr class="admin-hover-row transition-colors align-top" style="border-bottom: 1px solid var(--border-light);">
+          <td class="px-5 py-3">
+            <%= link_to page.title, edit_admin_dashboard_kit_page_path(page),
+                  class: "text-xs text-t1 hover:text-accent transition-colors font-medium" %>
+            <div class="text-[10px] text-t3 font-mono">/kit/<%= page.slug %></div>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2">
+            <% if page.board_printable %>
+              <div><%= page.board_printable.board&.name || "Board ##{page.board_printable.board_id}" %></div>
+              <div class="text-[10px] text-t3"><%= page.printable_variant %></div>
+              <% unless page.downloadable? %>
+                <div class="text-[10px] text-amber-500">no PDF yet</div>
+              <% end %>
+              <% if page.etsy_override? %>
+                <div class="text-[10px] text-amber-500">Etsy override</div>
+              <% end %>
+            <% else %>
+              <span class="text-t3">none picked</span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t2 font-mono"><%= page.resolved_mailchimp_tag %></td>
+          <td class="px-5 py-3 whitespace-nowrap">
+            <% if page.published? %>
+              <span class="bg-green-900/60 text-green-300 inline-block text-xs rounded px-2 py-0.5">published</span>
+            <% else %>
+              <span class="admin-card-alt text-t2 inline-block text-xs rounded px-2 py-0.5">draft</span>
+            <% end %>
+          </td>
+          <td class="px-5 py-3 text-xs text-t3 whitespace-nowrap"><%= page.created_at.strftime("%b %-d, %Y") %></td>
+          <td class="px-5 py-3 whitespace-nowrap">
+            <div class="flex items-center gap-2">
+              <%= link_to "Edit", edit_admin_dashboard_kit_page_path(page),
+                    class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+              <%= link_to "Preview", kit_preview_url(page), target: "_blank", rel: "noopener",
+                    class: "text-xs font-medium px-3 py-1.5 rounded border admin-input text-t1" %>
+              <% if page.published? %>
+                <%= button_to "Unpublish", unpublish_admin_dashboard_kit_page_path(page), method: :post,
+                      class: "text-xs font-medium px-3 py-1.5 rounded border admin-input cursor-pointer text-t1",
+                      form: { data: { turbo_confirm: "Unpublish “#{page.title}”? /kit/#{page.slug} will stop working." } } %>
+              <% else %>
+                <%= button_to "Publish", publish_admin_dashboard_kit_page_path(page), method: :post,
+                      class: "text-xs font-medium px-3 py-1.5 rounded bg-green-600 hover:bg-green-500 text-white cursor-pointer",
+                      form: { data: { turbo_confirm: "Publish “#{page.title}”? It goes live at /kit/#{page.slug}." } } %>
+              <% end %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <% if @kit_pages.empty? %>
+    <div class="px-5 py-10 text-center text-sm text-t3">
+      No kit pages yet. <%= link_to "Create one", new_admin_dashboard_kit_page_path, class: "text-accent hover:underline" %>.
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/kit_pages/new.html.erb
+++ b/app/views/admin/kit_pages/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "New Kit Page" %>
+
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-semibold text-t1 tracking-tight">New Kit Page</h1>
+    <p class="text-sm text-t3 mt-0.5">Nothing is public until "Published" is ticked.</p>
+  </div>
+  <%= link_to "← All kit pages", admin_dashboard_kit_pages_path, class: "text-xs text-t2 hover:text-t1 transition-colors" %>
+</div>
+
+<%= render "form", url: admin_dashboard_kit_pages_path, method: :post, submit_label: "Create kit page" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -126,6 +126,8 @@
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Board Builds", admin_dashboard_board_builds_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_builds") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%= link_to "Kit Pages", admin_dashboard_kit_pages_path,
+                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/kit_pages") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Feedback", admin_dashboard_feedback_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/feedback") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Word Events", admin_dashboard_word_events_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,13 @@ Rails.application.routes.draw do
         post :finish
       end
     end
+    # Lead-magnet landing pages served at /kit/:slug on the frontend.
+    resources :kit_pages, only: [:index, :new, :create, :edit, :update], as: :dashboard_kit_pages do
+      member do
+        post :publish
+        post :unpublish
+      end
+    end
     get "feedback", to: "feedback#index", as: :dashboard_feedback
     get "word_events", to: "word_events#index", as: :dashboard_word_events
     resources :board_printables, only: [:index, :show, :create, :destroy], as: :dashboard_board_printables do
@@ -186,6 +193,16 @@ Rails.application.routes.draw do
     # Anonymous free-board-download lead capture (both public / no-auth).
     get "free_download_boards", to: "boards#free_download_boards"
     post "download_leads", to: "download_leads#create"
+
+    # Reusable lead-magnet landing pages (/kit/:slug on the frontend). Public
+    # by design — #show carries no file URL, and #download reveals one only
+    # after capturing a DownloadLead. Sits with the other public routes, NOT in
+    # an authenticated block.
+    resources :kit_pages, only: [:show], param: :slug do
+      member do
+        post :download
+      end
+    end
     post "google_images", to: "google_search_results#image_search"
     post "youtube_search", to: "youtube_search#search"
 

--- a/db/migrate/20260819120000_create_kit_pages.rb
+++ b/db/migrate/20260819120000_create_kit_pages.rb
@@ -1,0 +1,37 @@
+# A reusable lead-magnet landing page served at /kit/:slug. The page's copy,
+# its download, and its Mailchimp tag all live here rather than in a frontend
+# config file, so adding a campaign page is an admin action instead of a deploy.
+#
+# The download is an existing BoardPrintable plus a chosen PDF variant — not a
+# live board render — so what a visitor gets is the same reviewed document the
+# admin looked at.
+class CreateKitPages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :kit_pages do |t|
+      t.string :slug, null: false
+      t.string :title, null: false
+      t.string :eyebrow
+      t.text :subhead
+      # { "items": [{ "title": ..., "description": ... }],
+      #   "closing": { "heading": ..., "body": ..., "cta_label": ..., "cta_path": ... } }
+      t.jsonb :content, null: false, default: {}
+      # Nullable: a page is drafted before a printable is picked, and it simply
+      # renders without the download form until one is.
+      t.references :board_printable, foreign_key: true
+      t.string :printable_variant, null: false, default: "color"
+      # nil means "derive from the slug" — see KitPage#resolved_mailchimp_tag.
+      t.string :mailchimp_tag
+      t.string :cta_label
+      t.string :cta_path
+      t.boolean :published, null: false, default: false
+      # Stamped only when an admin deliberately confirms giving away a
+      # printable that is published on Etsy.
+      t.datetime :etsy_override_at
+      t.references :etsy_override_by, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :kit_pages, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_18_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -590,6 +590,27 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_18_140000) do
     t.index ["obf_id"], name: "index_images_on_obf_id"
     t.index ["use_custom_audio"], name: "index_images_on_use_custom_audio"
     t.index ["voice"], name: "index_images_on_voice"
+  end
+
+  create_table "kit_pages", force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "title", null: false
+    t.string "eyebrow"
+    t.text "subhead"
+    t.jsonb "content", default: {}, null: false
+    t.bigint "board_printable_id"
+    t.string "printable_variant", default: "color", null: false
+    t.string "mailchimp_tag"
+    t.string "cta_label"
+    t.string "cta_path"
+    t.boolean "published", default: false, null: false
+    t.datetime "etsy_override_at"
+    t.bigint "etsy_override_by_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["board_printable_id"], name: "index_kit_pages_on_board_printable_id"
+    t.index ["etsy_override_by_id"], name: "index_kit_pages_on_etsy_override_by_id"
+    t.index ["slug"], name: "index_kit_pages_on_slug", unique: true
   end
 
   create_table "marketing_assets", force: :cascade do |t|
@@ -1188,6 +1209,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_18_140000) do
   add_foreign_key "contest_entries", "events"
   add_foreign_key "credit_transactions", "users"
   add_foreign_key "feedback_items", "users"
+  add_foreign_key "kit_pages", "board_printables"
+  add_foreign_key "kit_pages", "users", column: "etsy_override_by_id"
   add_foreign_key "menus", "users"
   add_foreign_key "openai_prompts", "users"
   add_foreign_key "order_items", "orders"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
     source { "free_download" }
   end
 
+  factory :kit_page do
+    sequence(:slug) { |n| "kit-page-#{n}" }
+    title { "Free AAC kit" }
+    published { true }
+  end
+
   factory :event do
     name { FFaker::Name.name }
     slug { FFaker::Internet.slug }

--- a/spec/models/kit_page_spec.rb
+++ b/spec/models/kit_page_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+RSpec.describe KitPage, type: :model do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner) }
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id])
+  end
+
+  describe "validations" do
+    it "requires a kebab-case slug" do
+      expect(build(:kit_page, slug: "At School")).not_to be_valid
+      expect(build(:kit_page, slug: "at_school")).not_to be_valid
+      expect(build(:kit_page, slug: "at-school")).to be_valid
+    end
+
+    it "requires the slug to be unique" do
+      create(:kit_page, slug: "at-school")
+      expect(build(:kit_page, slug: "at-school")).not_to be_valid
+    end
+
+    it "requires a title" do
+      expect(build(:kit_page, title: nil)).not_to be_valid
+    end
+
+    it "only accepts a real printable variant" do
+      expect(build(:kit_page, printable_variant: "sideways")).not_to be_valid
+      (BoardPrintable::DOWNLOAD_VARIANTS + [BoardPrintable::VARIANT_FULL]).each do |variant|
+        expect(build(:kit_page, printable_variant: variant)).to be_valid
+      end
+    end
+
+    it "rejects content whose items or closing are the wrong shape" do
+      expect(build(:kit_page, content: { "items" => "nope" })).not_to be_valid
+      expect(build(:kit_page, content: { "items" => ["nope"] })).not_to be_valid
+      expect(build(:kit_page, content: { "closing" => [] })).not_to be_valid
+      expect(build(:kit_page, content: { "items" => [{ "title" => "x" }], "closing" => { "body" => "y" } }))
+        .to be_valid
+    end
+  end
+
+  describe "#lead_source" do
+    it "prefixes the slug so leads are discriminable in download_leads" do
+      expect(build(:kit_page, slug: "at-school").lead_source).to eq("kit_at-school")
+    end
+  end
+
+  describe ".for_lead_source" do
+    it "finds the page behind a kit_ source, published or not" do
+      page = create(:kit_page, slug: "at-school", published: false)
+      expect(described_class.for_lead_source("kit_at-school")).to eq(page)
+    end
+
+    it "ignores the sources that predate kit pages" do
+      expect(described_class.for_lead_source("classroom_kit")).to be_nil
+      expect(described_class.for_lead_source("ctg")).to be_nil
+      expect(described_class.for_lead_source("free_download")).to be_nil
+      expect(described_class.for_lead_source(nil)).to be_nil
+    end
+
+    it "returns nil for a page that no longer exists" do
+      expect(described_class.for_lead_source("kit_gone")).to be_nil
+    end
+  end
+
+  describe "#resolved_mailchimp_tag" do
+    it "derives a CamelCase tag from the slug, hyphens and all" do
+      expect(build(:kit_page, slug: "at-school").resolved_mailchimp_tag).to eq("AtSchoolLead")
+      expect(build(:kit_page, slug: "kit").resolved_mailchimp_tag).to eq("KitLead")
+    end
+
+    it "prefers an explicit tag" do
+      expect(build(:kit_page, slug: "at-school", mailchimp_tag: "BackToSchool2026").resolved_mailchimp_tag)
+        .to eq("BackToSchool2026")
+    end
+  end
+
+  describe "#download_files / #downloadable?" do
+    subject(:page) { create(:kit_page, board_printable: printable, printable_variant: "color") }
+
+    it "is not downloadable without a printable" do
+      expect(create(:kit_page, board_printable: nil)).not_to be_downloadable
+    end
+
+    it "is not downloadable while the printable is still generating" do
+      printable.attach_pdf!(filename: "a.color.pdf", bytes: "%PDF", variant: "color")
+      printable.update!(status: "generating")
+
+      expect(page.reload).not_to be_downloadable
+    end
+
+    it "is not downloadable when the printable carries no PDF" do
+      expect(page).not_to be_downloadable
+      expect(page.download_files).to eq([])
+    end
+
+    it "returns only the chosen variant when present" do
+      printable.attach_pdf!(filename: "a.color.pdf", bytes: "%PDF c", variant: "color")
+      printable.attach_pdf!(filename: "a.low-ink.pdf", bytes: "%PDF l", variant: "low_ink")
+
+      expect(page.download_files.map { |f| f[:variant] }).to eq(["color"])
+      expect(page).to be_downloadable
+    end
+
+    it "falls back to every PDF when the chosen variant is absent" do
+      printable.attach_pdf!(filename: "a.pdf", bytes: "%PDF f", variant: BoardPrintable::VARIANT_FULL)
+
+      expect(page.download_files.map { |f| f[:variant] }).to eq(["full"])
+    end
+
+    # files_view is the PDF allowlist. A listing image must never be handed to
+    # a visitor as the download.
+    it "never returns a marketing image" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+
+      expect(page.download_files).to eq([])
+      expect(page).not_to be_downloadable
+    end
+  end
+
+  describe "#public_view" do
+    it "carries no file URL" do
+      printable.attach_pdf!(filename: "a.color.pdf", bytes: "%PDF", variant: "color")
+      page = create(:kit_page, board_printable: printable)
+
+      expect(page.public_view.keys).to match_array(
+        %i[slug title eyebrow subhead content cta_label cta_path downloadable]
+      )
+      expect(page.public_view[:downloadable]).to eq(true)
+    end
+  end
+
+  describe "#gives_away_protected_printable?" do
+    it "is true only for a printable that was published to Etsy and not waived" do
+      page = create(:kit_page, board_printable: printable)
+      expect(page).not_to be_gives_away_protected_printable
+
+      printable.update!(etsy_published_at: Time.current, etsy_listing_id: 123)
+      expect(page.reload).to be_gives_away_protected_printable
+    end
+
+    it "is false with no printable at all" do
+      expect(create(:kit_page, board_printable: nil)).not_to be_gives_away_protected_printable
+    end
+  end
+end

--- a/spec/requests/admin/kit_pages_spec.rb
+++ b/spec/requests/admin/kit_pages_spec.rb
@@ -1,0 +1,283 @@
+require "rails_helper"
+
+RSpec.describe "Admin kit pages", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin) { create(:admin_user) }
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "At school") }
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id], page_count: 6)
+      .tap { |p| p.attach_pdf!(filename: "at-school.color.pdf", bytes: "%PDF c", variant: "color") }
+  end
+
+  def base_params(overrides = {})
+    {
+      slug: "at-school",
+      title: "The at-school kit",
+      eyebrow: "Free classroom kit",
+      subhead: "Everything for the first week.",
+      board_printable_id: printable.id,
+      printable_variant: "color",
+      cta_label: "Start free",
+      cta_path: "/sign-up",
+      content: { items: [{ title: "Poster", description: "One page." }] }.to_json,
+    }.merge(overrides)
+  end
+
+  describe "authorization" do
+    it "redirects a signed-out visitor away from the index" do
+      get admin_dashboard_kit_pages_path
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it "redirects a non-admin away from the index" do
+      sign_in owner
+      get admin_dashboard_kit_pages_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "refuses a non-admin's create" do
+      sign_in owner
+      expect { post admin_dashboard_kit_pages_path, params: base_params }
+        .not_to change(KitPage, :count)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "as an admin" do
+    before { sign_in admin }
+
+    describe "GET /admin/kit_pages" do
+      it "lists the pages with their slug, tag and status" do
+        create(:kit_page, slug: "at-school", title: "The at-school kit", published: false)
+
+        get admin_dashboard_kit_pages_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("The at-school kit", "/kit/at-school", "AtSchoolLead", "draft")
+      end
+
+      it "renders an empty state" do
+        get admin_dashboard_kit_pages_path
+        expect(response.body).to include("No kit pages yet")
+      end
+    end
+
+    describe "GET /admin/kit_pages/new" do
+      it "offers only complete printables that carry a PDF" do
+        printable
+        no_pdf = BoardPrintable.create!(
+          board: create(:board, user: owner, name: "Nothing attached"),
+          status: "complete", board_ids: [board.id],
+        )
+        pending = BoardPrintable.create!(
+          board: create(:board, user: owner, name: "Still cooking"),
+          status: "generating", board_ids: [board.id],
+        )
+
+        get new_admin_dashboard_kit_page_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("At school")
+        expect(response.body).not_to include("Nothing attached")
+        expect(response.body).not_to include("Still cooking")
+        expect(no_pdf.pdf_files).to be_empty
+        expect(pending).not_to be_complete
+      end
+    end
+
+    describe "POST /admin/kit_pages" do
+      it "creates the page from flat params" do
+        expect { post admin_dashboard_kit_pages_path, params: base_params(published: "1") }
+          .to change(KitPage, :count).by(1)
+
+        page = KitPage.last
+        expect(page.slug).to eq("at-school")
+        expect(page.title).to eq("The at-school kit")
+        expect(page.eyebrow).to eq("Free classroom kit")
+        expect(page.board_printable).to eq(printable)
+        expect(page.printable_variant).to eq("color")
+        expect(page.content["items"].first["title"]).to eq("Poster")
+        expect(page).to be_published
+        expect(response).to redirect_to(edit_admin_dashboard_kit_page_path(page))
+      end
+
+      it "creates an unpublished draft when the box isn't ticked" do
+        post admin_dashboard_kit_pages_path, params: base_params
+
+        expect(KitPage.last).not_to be_published
+      end
+
+      it "re-renders with an error and saves nothing on a bad slug" do
+        expect { post admin_dashboard_kit_pages_path, params: base_params(slug: "At School") }
+          .not_to change(KitPage, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("Slug")
+      end
+
+      it "re-renders with a parse error and keeps what was typed when the content isn't JSON" do
+        expect { post admin_dashboard_kit_pages_path, params: base_params(content: "{ nope") }
+          .not_to change(KitPage, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("isn&#39;t valid JSON").or include("isn't valid JSON")
+        expect(response.body).to include("{ nope")
+      end
+
+      it "rejects a content blob that isn't a JSON object" do
+        expect { post admin_dashboard_kit_pages_path, params: base_params(content: "[1, 2]") }
+          .not_to change(KitPage, :count)
+
+        expect(response.body).to include("must be a JSON object")
+      end
+
+      it "treats a blank content box as an empty object" do
+        post admin_dashboard_kit_pages_path, params: base_params(content: "")
+
+        expect(KitPage.last.content).to eq({})
+      end
+    end
+
+    # Giving away a printable that is sold on Etsy is a two-step on purpose.
+    describe "the Etsy give-away guard" do
+      let(:sold) do
+        BoardPrintable.create!(
+          board: board, status: "complete", board_ids: [board.id],
+          etsy_published_at: 1.week.ago, etsy_listing_id: 4_242_424_242,
+        ).tap { |p| p.attach_pdf!(filename: "sold.color.pdf", bytes: "%PDF s", variant: "color") }
+      end
+
+      it "blocks the save and explains why, with no record written" do
+        expect { post admin_dashboard_kit_pages_path, params: base_params(board_printable_id: sold.id) }
+          .not_to change(KitPage, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("published on Etsy")
+        expect(response.body).to include("Give this away for free anyway")
+      end
+
+      it "saves and stamps the override when it is explicitly confirmed" do
+        post admin_dashboard_kit_pages_path,
+             params: base_params(board_printable_id: sold.id, etsy_override: "1")
+
+        page = KitPage.last
+        expect(page.board_printable).to eq(sold)
+        expect(page.etsy_override_at).to be_present
+        expect(page.etsy_override_by).to eq(admin)
+      end
+
+      it "does not ask again on an unrelated edit of the same page" do
+        post admin_dashboard_kit_pages_path,
+             params: base_params(board_printable_id: sold.id, etsy_override: "1")
+        page = KitPage.last
+        stamped_at = page.etsy_override_at
+
+        patch admin_dashboard_kit_page_path(page),
+              params: base_params(board_printable_id: sold.id, title: "Renamed")
+
+        expect(response).to redirect_to(edit_admin_dashboard_kit_page_path(page))
+        expect(page.reload.title).to eq("Renamed")
+        expect(page.etsy_override_at).to be_within(1.second).of(stamped_at)
+      end
+
+      it "asks again when a DIFFERENT sold printable is swapped in" do
+        post admin_dashboard_kit_pages_path,
+             params: base_params(board_printable_id: sold.id, etsy_override: "1")
+        page = KitPage.last
+
+        other_sold = BoardPrintable.create!(
+          board: create(:board, user: owner, name: "Also sold"), status: "complete",
+          board_ids: [board.id], etsy_published_at: 1.day.ago, etsy_listing_id: 99,
+        ).tap { |p| p.attach_pdf!(filename: "other.color.pdf", bytes: "%PDF o", variant: "color") }
+
+        patch admin_dashboard_kit_page_path(page),
+              params: base_params(board_printable_id: other_sold.id)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(page.reload.board_printable).to eq(sold)
+      end
+
+      it "clears a stale override when the page moves to an unprotected printable" do
+        post admin_dashboard_kit_pages_path,
+             params: base_params(board_printable_id: sold.id, etsy_override: "1")
+        page = KitPage.last
+
+        patch admin_dashboard_kit_page_path(page), params: base_params(board_printable_id: printable.id)
+
+        expect(page.reload.board_printable).to eq(printable)
+        expect(page.etsy_override_at).to be_nil
+        expect(page.etsy_override_by).to be_nil
+      end
+
+      it "lets a waived printable through without the checkbox" do
+        sold.update!(protection_waived_at: Time.current, protection_waived_by: admin)
+
+        expect { post admin_dashboard_kit_pages_path, params: base_params(board_printable_id: sold.id) }
+          .to change(KitPage, :count).by(1)
+      end
+    end
+
+    describe "PATCH /admin/kit_pages/:id" do
+      let!(:page) { create(:kit_page, slug: "at-school", title: "Old", published: false) }
+
+      it "updates the page" do
+        patch admin_dashboard_kit_page_path(page), params: base_params(title: "New title")
+
+        expect(page.reload.title).to eq("New title")
+        expect(response).to redirect_to(edit_admin_dashboard_kit_page_path(page))
+      end
+
+      it "blanks an emptied optional field rather than keeping the old value" do
+        page.update!(eyebrow: "Old eyebrow")
+
+        patch admin_dashboard_kit_page_path(page), params: base_params(eyebrow: "")
+
+        expect(page.reload.eyebrow).to be_nil
+      end
+    end
+
+    describe "publish / unpublish" do
+      let!(:page) { create(:kit_page, slug: "at-school", published: false) }
+
+      it "publishes" do
+        post publish_admin_dashboard_kit_page_path(page)
+
+        expect(page.reload).to be_published
+        expect(response).to redirect_to(admin_dashboard_kit_pages_path)
+      end
+
+      it "unpublishes" do
+        page.update!(published: true)
+
+        post unpublish_admin_dashboard_kit_page_path(page)
+
+        expect(page.reload).not_to be_published
+      end
+    end
+
+    describe "GET /admin/kit_pages/:id/edit" do
+      it "renders the stored content as pretty JSON" do
+        page = create(:kit_page, slug: "at-school", content: { "items" => [{ "title" => "Poster" }] })
+
+        get edit_admin_dashboard_kit_page_path(page)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Poster")
+      end
+
+      it "redirects when the page is gone" do
+        get edit_admin_dashboard_kit_page_path(id: 0)
+
+        expect(response).to redirect_to(admin_dashboard_kit_pages_path)
+      end
+    end
+  end
+end

--- a/spec/requests/api/download_leads_kit_pages_regression_spec.rb
+++ b/spec/requests/api/download_leads_kit_pages_regression_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+# /classroom and /ctg are printed on QR codes and live in campaign emails, and
+# both post to POST /api/download_leads. Kit landing pages reuse the same table
+# and the same Mailchimp job, so this pins the pre-existing contract: nothing
+# about that endpoint, its response shape, its sources, or its tags may change
+# because kit pages exist.
+RSpec.describe "API download_leads — unchanged by kit pages", type: :request do
+  before { MailchimpUpsertLeadJob.jobs.clear }
+
+  # A kit page whose slug could collide with the legacy funnels if anything
+  # ever started resolving tags by slug rather than by the kit_ prefix.
+  let!(:decoy_page) do
+    create(:kit_page, slug: "classroom-kit", mailchimp_tag: "ShouldNeverBeUsedHere")
+  end
+
+  describe "the endpoint itself" do
+    it "still creates a lead and returns 201 { success: true } with no auth" do
+      expect {
+        post "/api/download_leads",
+             params: { download_lead: { email: "teacher@example.com", name: "Sam", source: "classroom_kit" } }
+      }.to change(DownloadLead, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)).to eq("success" => true)
+      expect(DownloadLead.last.source).to eq("classroom_kit")
+    end
+
+    it "still returns 422 { success: false, errors: [...] } for a bad email" do
+      post "/api/download_leads", params: { download_lead: { email: "nope" } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+      expect(body["success"]).to eq(false)
+      expect(body["errors"]).to be_present
+    end
+
+    it "still defaults a source-less lead to free_download" do
+      post "/api/download_leads", params: { download_lead: { email: "anon@example.com" } }
+
+      expect(DownloadLead.last.source).to eq(DownloadLead::DEFAULT_SOURCE)
+    end
+
+    it "still hands the lead straight to MailchimpUpsertLeadJob" do
+      post "/api/download_leads", params: { download_lead: { email: "ctg@example.com", source: "ctg" } }
+
+      expect(MailchimpUpsertLeadJob.jobs.size).to eq(1)
+      expect(MailchimpUpsertLeadJob.jobs.first["args"]).to eq([DownloadLead.last.id])
+    end
+  end
+
+  describe "the tags the legacy funnels resolve to" do
+    let(:mailchimp) { instance_double(MailchimpService) }
+
+    before { allow(MailchimpService).to receive(:new).and_return(mailchimp) }
+
+    {
+      "classroom_kit" => "ClassroomKitLead",
+      "ctg" => "ctg-2026",
+      "playground_nomination" => "PlaygroundNomination",
+      "free_download" => "BoardDownloadLead",
+    }.each do |source, tag|
+      it "still tags a #{source} lead #{tag}" do
+        lead = create(:download_lead, source: source, data: { "marketing_opt_in" => "true" })
+
+        expect(mailchimp).to receive(:record_lead).with(hash_including(tags: [tag]))
+
+        MailchimpUpsertLeadJob.new.perform(lead.id)
+      end
+    end
+
+    it "does not consult a KitPage for a legacy source, even one whose slug looks alike" do
+      lead = create(:download_lead, source: "classroom_kit")
+      allow(mailchimp).to receive(:record_lead)
+
+      expect(KitPage).not_to receive(:for_lead_source)
+
+      MailchimpUpsertLeadJob.new.perform(lead.id)
+    end
+  end
+end

--- a/spec/requests/api/kit_pages_spec.rb
+++ b/spec/requests/api/kit_pages_spec.rb
@@ -1,0 +1,213 @@
+require "rails_helper"
+
+# GET /api/kit_pages/:slug and POST /api/kit_pages/:slug/download are both
+# PUBLIC. The read must never carry a file URL; the URL is revealed only after
+# an email is captured as a DownloadLead.
+RSpec.describe "API kit_pages", type: :request do
+  let(:owner) { create(:user) }
+  let(:board) { create(:board, user: owner, name: "At school") }
+
+  let(:printable) do
+    BoardPrintable.create!(board: board, status: "complete", board_ids: [board.id])
+  end
+
+  def attach_all_variants
+    printable.attach_pdf!(
+      filename: "at-school.color.pdf", bytes: "%PDF-1.5 colour",
+      variant: BoardPrintable::VARIANT_COLOR,
+    )
+    printable.attach_pdf!(
+      filename: "at-school.low-ink.pdf", bytes: "%PDF-1.5 low ink",
+      variant: BoardPrintable::VARIANT_LOW_INK,
+    )
+  end
+
+  let(:content) do
+    {
+      "items" => [{ "title" => "Core word poster", "description" => "One page, 36 words." }],
+      "closing" => { "heading" => "Make it personal", "body" => "Build your own.", "cta_path" => "/sign-up" },
+    }
+  end
+
+  let(:page) do
+    create(
+      :kit_page,
+      slug: "at-school", title: "The at-school kit", eyebrow: "Free classroom kit",
+      subhead: "Everything for the first week.", content: content,
+      cta_label: "Start free", cta_path: "/sign-up",
+      board_printable: printable, printable_variant: BoardPrintable::VARIANT_COLOR,
+    )
+  end
+
+  before { MailchimpUpsertLeadJob.jobs.clear }
+
+  describe "GET /api/kit_pages/:slug" do
+    it "returns the page for an anonymous visitor, with no file URL in the body" do
+      attach_all_variants
+
+      get "/api/kit_pages/#{page.slug}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["slug"]).to eq("at-school")
+      expect(body["title"]).to eq("The at-school kit")
+      expect(body["eyebrow"]).to eq("Free classroom kit")
+      expect(body["subhead"]).to eq("Everything for the first week.")
+      expect(body["content"]).to eq(content)
+      expect(body["cta_label"]).to eq("Start free")
+      expect(body["cta_path"]).to eq("/sign-up")
+      expect(body["downloadable"]).to eq(true)
+
+      # The whole point of the gate: nothing in the read response is a link to
+      # the PDF.
+      expect(response.body).not_to include(".pdf")
+      expect(body.keys).not_to include("files")
+    end
+
+    it "reports downloadable: false when the printable has no files yet" do
+      get "/api/kit_pages/#{page.slug}"
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["downloadable"]).to eq(false)
+    end
+
+    it "reports downloadable: false when no printable is picked" do
+      draft = create(:kit_page, slug: "no-printable", board_printable: nil)
+
+      get "/api/kit_pages/#{draft.slug}"
+
+      expect(JSON.parse(response.body)["downloadable"]).to eq(false)
+    end
+
+    it "404s an unpublished page" do
+      page.update!(published: false)
+
+      get "/api/kit_pages/#{page.slug}"
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)).to eq("error" => "kit_page_not_found")
+    end
+
+    it "404s an unknown slug" do
+      get "/api/kit_pages/nope"
+
+      expect(response).to have_http_status(:not_found)
+      expect(JSON.parse(response.body)).to eq("error" => "kit_page_not_found")
+    end
+  end
+
+  describe "POST /api/kit_pages/:slug/download" do
+    it "captures the lead, enqueues the Mailchimp sync, and returns the files" do
+      attach_all_variants
+
+      expect {
+        post "/api/kit_pages/#{page.slug}/download",
+             params: { email: "teacher@example.com", name: "Sam", data: { utm_source: "qr" } }
+      }.to change(DownloadLead, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      files = JSON.parse(response.body)["files"]
+      expect(files.map { |f| f["variant"] }).to eq(["color"])
+      expect(files.first["filename"]).to eq("at-school.color.pdf")
+      expect(files.first["url"]).to be_present
+
+      lead = DownloadLead.last
+      expect(lead.email).to eq("teacher@example.com")
+      expect(lead.name).to eq("Sam")
+      expect(lead.source).to eq("kit_at-school")
+      expect(lead.data).to eq("utm_source" => "qr", "kit_slug" => "at-school")
+
+      expect(MailchimpUpsertLeadJob.jobs.size).to eq(1)
+      expect(MailchimpUpsertLeadJob.jobs.first["args"]).to eq([lead.id])
+    end
+
+    it "works without auth headers and without a data payload" do
+      attach_all_variants
+
+      post "/api/kit_pages/#{page.slug}/download", params: { email: "bare@example.com" }
+
+      expect(response).to have_http_status(:ok)
+      expect(DownloadLead.last.data).to eq("kit_slug" => "at-school")
+    end
+
+    it "returns only the chosen variant when it is present" do
+      attach_all_variants
+      page.update!(printable_variant: BoardPrintable::VARIANT_LOW_INK)
+
+      post "/api/kit_pages/#{page.slug}/download", params: { email: "teacher@example.com" }
+
+      files = JSON.parse(response.body)["files"]
+      expect(files.map { |f| f["variant"] }).to eq(["low_ink"])
+    end
+
+    # A single-board printable carries one "full" document, so a page asking
+    # for "color" must still hand something over rather than nothing.
+    it "falls back to every PDF when the chosen variant is absent" do
+      printable.attach_pdf!(
+        filename: "at-school.pdf", bytes: "%PDF-1.5 everything",
+        variant: BoardPrintable::VARIANT_FULL,
+      )
+
+      post "/api/kit_pages/#{page.slug}/download", params: { email: "teacher@example.com" }
+
+      files = JSON.parse(response.body)["files"]
+      expect(files.map { |f| f["variant"] }).to eq(["full"])
+    end
+
+    it "422s with errors for a blank email and captures nothing" do
+      attach_all_variants
+
+      expect {
+        post "/api/kit_pages/#{page.slug}/download", params: { name: "No email" }
+      }.not_to change(DownloadLead, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      body = JSON.parse(response.body)
+      expect(body["success"]).to eq(false)
+      expect(body["errors"]).to be_present
+      expect(MailchimpUpsertLeadJob.jobs.size).to eq(0)
+    end
+
+    it "422s for a malformed email" do
+      attach_all_variants
+
+      expect {
+        post "/api/kit_pages/#{page.slug}/download", params: { email: "nope" }
+      }.not_to change(DownloadLead, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "422s not_available when the page has no printable" do
+      draft = create(:kit_page, slug: "no-printable", board_printable: nil)
+
+      expect {
+        post "/api/kit_pages/#{draft.slug}/download", params: { email: "teacher@example.com" }
+      }.not_to change(DownloadLead, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to eq("error" => "not_available")
+    end
+
+    it "422s not_available when the printable is still generating" do
+      attach_all_variants
+      printable.update!(status: "generating")
+
+      post "/api/kit_pages/#{page.slug}/download", params: { email: "teacher@example.com" }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to eq("error" => "not_available")
+    end
+
+    it "404s an unpublished page rather than capturing the lead" do
+      attach_all_variants
+      page.update!(published: false)
+
+      expect {
+        post "/api/kit_pages/#{page.slug}/download", params: { email: "teacher@example.com" }
+      }.not_to change(DownloadLead, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
+++ b/spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
@@ -93,6 +93,45 @@ RSpec.describe MailchimpUpsertLeadJob, type: :job do
       expect(lead.reload.mailchimp_status).to eq("failed")
     end
 
+    # A kit_<slug> source reads its tag off the KitPage row rather than
+    # SOURCE_TAGS, which is what lets a new landing page ship without a deploy.
+    context "with a kit landing-page source" do
+      it "uses the tag derived from the page's slug" do
+        create(:kit_page, slug: "at-school")
+        kit_lead = create(:download_lead, email: "teacher@example.com", name: "Rae", source: "kit_at-school")
+
+        expect(mailchimp).to receive(:record_lead).with(
+          email: "teacher@example.com",
+          name: "Rae",
+          tags: ["AtSchoolLead"],
+        )
+
+        job.perform(kit_lead.id)
+
+        expect(kit_lead.reload.mailchimp_status).to eq("synced")
+      end
+
+      it "uses an explicitly configured tag when the page carries one" do
+        create(:kit_page, slug: "at-school", mailchimp_tag: "BackToSchool2026")
+        kit_lead = create(:download_lead, email: "teacher@example.com", name: "Rae", source: "kit_at-school")
+
+        expect(mailchimp).to receive(:record_lead)
+          .with(hash_including(tags: ["BackToSchool2026"]))
+
+        job.perform(kit_lead.id)
+      end
+
+      it "falls back to the default tag when the page has been deleted, without raising" do
+        kit_lead = create(:download_lead, email: "teacher@example.com", name: "Rae", source: "kit_gone")
+
+        expect(mailchimp).to receive(:record_lead)
+          .with(hash_including(tags: ["BoardDownloadLead"]))
+
+        expect { job.perform(kit_lead.id) }.not_to raise_error
+        expect(kit_lead.reload.mailchimp_status).to eq("synced")
+      end
+    end
+
     it "no-ops for an unknown lead id" do
       expect(mailchimp).not_to receive(:record_lead)
       expect { job.perform(-1) }.not_to raise_error


### PR DESCRIPTION
Implements `.claude-notes/kit-landing-pages-handoff.md` (committed here so it survives the session, with an "As built" section recording the deviations). The frontend counterpart is blocked on this.

## What this adds

A `KitPage` model, a public read/download API, and `/admin/kit_pages` CRUD, so a new lead-magnet landing page at `app.speakanyway.com/kit/:slug` is an admin action rather than a deploy on either side.

- **The download is an existing `BoardPrintable`** plus a chosen variant, read through `BoardPrintable#files_view` — the PDF allowlist — so a listing image or the listing video can never be handed to a visitor as the product. Falls back to every PDF when the chosen variant isn't present, since a single-board printable only has `full`.
- **Leads reuse `DownloadLead`** with `source = "kit_<slug>"`. No new lead model, no new table.
- **`MailchimpUpsertLeadJob` resolves a `kit_` source's tag off the `KitPage` row**, keeping `SOURCE_TAGS` as the explicit map for the three hardcoded funnels. That lookup is the whole "no deploy per page" piece, and it never raises — a page deleted after its leads were captured falls back to `BoardDownloadLead` rather than stranding the lead. No Customer Journey trigger, per #640.

## API contract

| | |
|---|---|
| `GET /api/kit_pages/:slug` | 200 with copy + `downloadable` boolean. **Never a file URL.** 404 `kit_page_not_found` for unpublished or unknown — a draft's existence isn't public. |
| `POST /api/kit_pages/:slug/download` | 200 `{ files: [...] }` after writing the lead. 422 `not_available` when there's no deliverable PDF; 422 `{ success: false, errors: [...] }` on a bad email, matching what `Api::DownloadLeadsController` already returns. |

`downloadable?` is stricter than the handoff sketched: it requires a real PDF, not just `files.attached?`. A printable carrying only listing images is "attached" but has nothing to hand over, and rendering the email gate for it means a form that can only ever 422.

The gate is **soft on purpose**. Production S3 is `public: true`, so every printable blob already sits behind a permanent unsigned CDN URL whose hex path segment is the only protection. Hardening it means moving printables to a private service — out of scope here, and noted as an invariant in `CLAUDE.md`.

## `/classroom` and `/ctg` are untouched

Both post to `POST /api/download_leads`, which is printed on QR codes and lives in campaign emails. `spec/requests/api/download_leads_kit_pages_regression_spec.rb` pins that contract: the 201 `{ success: true }` shape, the 422 shape, the `free_download` default source, the enqueue, and every legacy funnel's tag (`ClassroomKitLead`, `ctg-2026`, `PlaygroundNomination`, `BoardDownloadLead`) — including that a `KitPage` whose slug looks like a legacy funnel is never consulted for one.

## The Etsy give-away guard

Selecting a printable that is **sold on Etsy** blocks the save and re-renders with an explanation plus an explicit "Give this away for free anyway" checkbox, which stamps `etsy_override_at` / `etsy_override_by_id`. The grant is scoped to the printable it was granted for: later edits of the same page pass, swapping in a *different* protected printable asks again, and moving to an unprotected one clears the stamp so a stale grant can't authorize the next swap.

## Test plan

`bundle exec rspec` on everything touched, plus the full admin request suite (the nav link changes the shared layout):

```
spec/models/kit_page_spec.rb
spec/models/download_lead_spec.rb
spec/requests/api/kit_pages_spec.rb
spec/requests/api/download_leads_spec.rb
spec/requests/api/download_leads_kit_pages_regression_spec.rb
spec/requests/admin/kit_pages_spec.rb
spec/requests/admin/access_control_spec.rb
spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
```
**125 examples, 0 failures.**

```
spec/requests/admin  (whole directory) + mailchimp specs
```
**432 examples, 0 failures.**

Covered: no file URL in the read; 404 on unpublished/unknown; lead written with the right source and `kit_slug` stamped into `data`; 422 on blank/invalid email and on no printable; variant selection and its fallback; a marketing image never being served as a download; `AtSchoolLead` derivation and the deleted-page fallback; the Etsy guard in all four states; and the admin namespace sweep confirming `Admin::KitPagesController` inherits the gate.

## Deploy notes

- One migration, `create_kit_pages`. No backfill, no new ENV vars (the preview link uses the existing `FRONT_END_URL`).
- Ships safely alone — nothing is user-visible until the frontend PR lands.
- After deploy, create one page in `/admin/kit_pages` so the frontend has a slug to point at.

## Docs

- `CHANGELOG.md` — user-facing entry under Unreleased → Added.
- `CLAUDE.md` — one invariant bullet (the read carries no file URL; the soft gate; the two things riding on the `kit_` prefix) and a spoke-table row.
- `.claude-notes/kit-landing-pages-handoff.md` — force-added, status updated, "As built" section appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)