### PR TITLE
fix(boards): admin printables list widens to any admin-owned published board

### DIFF
--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -402,21 +402,18 @@ module Admin
       ids.filter_map { |id| by_id[id] }
     end
 
-    # The boards worth offering a one-click printable for. `public_boards` is
-    # the catalogue; Board Builder boards are the other half — published and
-    # authored for print, but deliberately not `predefined`, so the catalogue
-    # scope can't see them (see Boards::AdminBuilder::Build#new_board).
+    # The boards worth offering a one-click printable for: every admin-owned
+    # published board, not just the curated catalogue (`predefined: true`).
+    # This is deliberately wider than `Board.public_boards` — it also picks up
+    # Board Builder roots and any other admin-owned board that was published
+    # without ever being flagged predefined (see Boards::AdminBuilder::Build#new_board).
     #
-    # Builder CHILD pages are excluded: a printable walks the tree from its
-    # root, so listing every folder page as its own row would bury the board
-    # they belong to. They're still reachable through the search box below.
+    # Builder CHILD pages are excluded (via `Board.admin_owned_boards`): a
+    # printable walks the tree from its root, so listing every folder page as
+    # its own row would bury the board they belong to. They're still
+    # reachable through the search box below.
     def printable_boards
-      @printable_boards ||= Board.where(id: Board.public_boards.select(:id))
-                                 .or(Board.where(id: builder_root_boards.select(:id)))
-    end
-
-    def builder_root_boards
-      AdminBoardBuild.builder_boards.published.not_builder_child
+      @printable_boards ||= Board.admin_owned_boards
     end
 
     # @board_sort / @board_dir are whitelisted above, so they are safe to

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -170,7 +170,15 @@ class Board < ApplicationRecord
   scope :not_builder_child, -> { where("NOT COALESCE((settings->>'builder_child')::boolean, false)") }
 
   scope :including_images, -> { includes(board_images: :image) }
-  scope :public_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, predefined: true, published: true).where.not(parent_type: "Menu").where(obf_id: nil) }
+  # Every admin-owned board eligible to be treated as public: published, not a
+  # Menu extraction, not an OBF import, and not a Board Builder child page (the
+  # whole tree counts as its root). `public_boards` narrows this to the
+  # curated catalogue (`predefined: true`); the admin printables dashboard
+  # wants this wider set — predefined or not — so a Board Builder root or any
+  # other admin-owned published board is offered without needing the
+  # catalogue flag.
+  scope :admin_owned_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, published: true).where.not(parent_type: "Menu").where(obf_id: nil).not_builder_child }
+  scope :public_boards, -> { admin_owned_boards.where(predefined: true) }
   scope :public_menu_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, predefined: true, published: true, parent_type: "Menu") }
   scope :without_preset_display_image, -> { where.missing(:preset_display_image_attachment) }
   scope :preset, -> { where(predefined: true) }

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1352,6 +1352,37 @@ RSpec.describe Board, type: :model do
     end
   end
 
+  describe ".admin_owned_boards" do
+    let(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+    it "includes an admin-owned published board regardless of the predefined flag" do
+      catalogue_board = FactoryBot.create(:board, user: admin_user, predefined: true, published: true)
+      wizard_board = FactoryBot.create(:board, user: admin_user, predefined: false, published: true)
+
+      ids = described_class.admin_owned_boards.pluck(:id)
+
+      expect(ids).to include(catalogue_board.id, wizard_board.id)
+    end
+
+    it "excludes an unpublished board, a Menu extraction, an OBF import, and a Board Builder child page" do
+      unpublished = FactoryBot.create(:board, user: admin_user, predefined: false, published: false)
+      menu_board = FactoryBot.create(:board, user: admin_user, predefined: false, published: true, parent_type: "Menu")
+      obf_board = FactoryBot.create(:board, user: admin_user, predefined: false, published: true, obf_id: "abc123")
+      builder_child = FactoryBot.create(:board, user: admin_user, predefined: false, published: true,
+                                                 settings: { "builder_child" => true })
+
+      ids = described_class.admin_owned_boards.pluck(:id)
+
+      expect(ids).not_to include(unpublished.id, menu_board.id, obf_board.id, builder_child.id)
+    end
+
+    it "excludes a published board owned by a regular user" do
+      user_board = FactoryBot.create(:board, user: FactoryBot.create(:user), predefined: false, published: true)
+
+      expect(described_class.admin_owned_boards.pluck(:id)).not_to include(user_board.id)
+    end
+  end
+
   describe "#public_card_view / .public_board_cards" do
     let(:admin_user) { User.find_by(id: User::DEFAULT_ADMIN_ID) || FactoryBot.create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
     let!(:public_board) do

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -76,6 +76,31 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
       expect(response.body).to include("value=\"#{builder_board.id}\"")
     end
 
+    # The list isn't limited to the curated catalogue or the Board Builder
+    # wizard — any admin-owned published board qualifies, predefined or not.
+    it "lists a published admin-owned board that was never marked predefined or built via the wizard" do
+      sign_in admin
+      backup_voice = create(:board, user: default_admin, predefined: false, published: true,
+                                    name: "My Backup Voice")
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).to include("My Backup Voice")
+      expect(response.body).to include("value=\"#{backup_voice.id}\"")
+    end
+
+    # Widening past `predefined` must not widen past ownership — a regular
+    # user's own published board (e.g. a personal safety board) still isn't
+    # the admin's catalogue to offer printables from.
+    it "leaves a published board owned by a regular user out of the list" do
+      sign_in admin
+      create(:board, user: owner, predefined: false, published: true, name: "Owner's Safety Board")
+
+      get admin_dashboard_board_printables_path
+
+      expect(response.body).not_to include("Owner's Safety Board")
+    end
+
     # A printable walks the tree from its root, so a folder page listed as its
     # own row would bury the board it belongs to.
     it "leaves builder child pages and unpublished builder boards out of the list" do


### PR DESCRIPTION
## Summary

- Board #6131 ("My Backup Voice") is genuinely published and viewable at `/pb/my-backup-voice`, but never appeared on the admin printables dashboard's "published boards" list — that list required `predefined: true`, which is meant for the curated catalogue, not every admin-owned published board.
- Added `Board.admin_owned_boards`: admin-owned, published, not a Menu extraction, not OBF-imported, not a Board Builder child page — with no `predefined` requirement. `Board.public_boards` now narrows this to `predefined: true`, so its existing behavior (catalogue, MySpeak feed, frontend public listing) is unchanged.
- `Admin::BoardPrintablesController#printable_boards` now uses `Board.admin_owned_boards` directly, which also makes the old separate Board Builder OR-clause redundant (a Board Builder root board is admin-owned, published, and not a builder-child page, so it's already covered).

## Why

The printables dashboard exists to let an admin generate a one-click printable from any board they own and have published — not just the ones flagged as catalogue content. Requiring `predefined: true` silently hid legitimate admin-owned boards like #6131 from that workflow.

## Test plan

- `bundle exec rspec spec/requests/admin/board_printables_spec.rb spec/models/board_spec.rb` — 214 examples, 0 failures.
- New coverage:
  - Request spec: an admin-owned, published, non-predefined, non-builder board now shows up; a regular user's published board still does not.
  - Model spec (`Board.admin_owned_boards`): includes predefined-or-not admin boards; excludes unpublished, Menu-parented, OBF-imported, and Board Builder child-page boards; excludes boards owned by a non-admin user.
- Also ran the full suite of every other spec file referencing `Board.public_boards` (`board_builds_spec`, `mass_assignment_spec`, `public_boards_myspeak_spec`, `profiles_spec`, `free_download_boards_spec`, `onboarding/myspeak_spec`, `video_demo_rake_spec`, seed specs, `admin_builder` specs) — 320 examples, 0 failures, confirming the shared scope change doesn't regress the catalogue/MySpeak/API paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)