### PR TITLE
fix(boards): stop appending AI words to pasted word lists

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -1032,6 +1032,46 @@ collections of boards. CRUD is open to any signed-in user;
     bounded; enumerating simple paths over one is factorial (~1.08e8 here) and
     froze the map page.
 
+## Board creation — `board_creation_type` and the AI topic
+
+`POST /api/boards` (`API::BoardsController#create`) enqueues `GenerateBoardJob`
+for every create. What the job does depends entirely on whether it receives a
+**topic**:
+
+- `topic` present → `Board#get_words_for_scenario` calls OpenAI and the
+  generated words are appended to any seed `word_list`.
+- `topic` blank → the board gets exactly the seed `word_list`, or nothing at
+  all (the job short-circuits to status `complete`).
+
+**Invariant: the board name is never an implicit AI topic.** `name` is a
+required column, so any `topic ||= @board.name` fallback makes *every* create an
+AI generation. Commit `68a5fe35` introduced exactly that when it merged the
+`"default"` and `"scenario"` branches, and the result shipped for ~2.5 months:
+pasting a word list silently appended AI words to the end of the board, and
+"Start with an empty board" came back full. Fixed by scoping the name fallback
+to `creation_type == "scenario"`.
+
+The three fill modes on `/boards/new` map like this:
+
+| UI mode | `board_creation_type` | sends `prompt`? | AI words? |
+|---|---|---|---|
+| Describe a situation | `scenario` | yes (name is a valid fallback) | yes |
+| List specific words | `default` | no | **no** |
+| Start blank | `default` | no | **no** |
+
+AI top-up in word-list mode is available, but only explicitly — the
+"Generate words" button (`GET /api/boards/words`) merges suggestions into the
+list *before* create, so the user reviews them first.
+
+Seed and generated words are merged with a **case-insensitive** uniq
+(`GenerateBoardJob`). `Image.by_label` matches on `LOWER(images.label)`, so
+"Dog" and "dog" resolve to one `Image`; a case-sensitive uniq left two tiles
+showing the same picture.
+
+`GenerateBoardJob` logs its start and its `seed=/generated=/final=` counts at
+`info` so the pipeline is traceable in the production journal
+(`bin/prod-logs worker`). Don't demote these to `debug` — prod runs at `info`.
+
 ## Responsive board layouts (sm/md derived from lg)
 
 A board stores a per-tile `layout` for each screen size (`lg`/`md`/`sm`, plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Pasting a word list makes exactly those tiles.** Building a board from a
+  pasted word list quietly appended extra AI-generated words to the end, and
+  "Start with an empty board" came back full of them. Both happened because the
+  board's own name was being used as an AI topic whenever no topic was typed.
+  Words are now generated only when you ask for them — a situation in the story
+  field, or the "Generate words" button.
+- **No more duplicate tiles from mixed capitalization.** A word list containing
+  both "Dog" and "dog" produced two tiles showing the same picture.
+
 - **Menu boards keep their menu photo.** Renaming a board built from a menu —
   or changing its color, or saving its words — used to disconnect it from the
   menu it was made from, so the "View Menu" button vanished from the board page

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -386,7 +386,13 @@ class API::BoardsController < API::ApplicationController
           # both paths share the same job args. age_range is optional —
           # GenerateBoardJob falls back to its own default when it's blank.
           word_list = params[:word_list]&.compact
-          topic     = params[:topic] || params[:prompt] || @board.name
+          # Only "scenario" implies "generate words about this". A "default"
+          # board (pasted word list, or start-blank) gets AI words ONLY when
+          # the caller sent an explicit topic/prompt. Falling back to the
+          # always-present board name here turned every create into an AI
+          # generation, silently appending words nobody asked for (68a5fe35).
+          topic     = params[:topic].presence || params[:prompt].presence
+          topic     = @board.name if topic.blank? && creation_type == "scenario"
           age_range = params[:ageRange].presence || params[:age_range].presence
 
           job_args = {

--- a/app/sidekiq/generate_board_job.rb
+++ b/app/sidekiq/generate_board_job.rb
@@ -5,7 +5,9 @@ class GenerateBoardJob
   def perform(board_id, board_creation_type, options = {})
     word_count = options["word_count"].presence || options["wordCount"].presence.to_i || 12
     board = Board.find_by(id: board_id)
-    Rails.logger.debug "Starting GenerateBoardJob for Board ID #{board_id} with creation type #{board_creation_type} and options: #{options.inspect}"
+    # info, not debug: production runs at :info, so this pipeline was
+    # invisible in the journal when we had to trace a bad board.
+    Rails.logger.info "GenerateBoardJob start board=#{board_id} creation_type=#{board_creation_type} topic_present=#{options["topic"].to_s.strip.present?} word_count=#{word_count} seed_count=#{(options["word_list"] || options["wordList"] || []).compact.size}"
     if board
       words = []
       begin
@@ -37,7 +39,11 @@ class GenerateBoardJob
             end
             generated = board.get_words_for_scenario(topic, age_range, word_count, profile: profile) || []
           end
-          words = (seed_words + generated).uniq
+          # Case-insensitive: Image.by_label matches on LOWER(label), so
+          # "Dog" and "dog" resolve to one Image but a plain .uniq would
+          # still create two tiles showing the same picture.
+          words = (seed_words + generated).uniq { |w| w.to_s.strip.downcase }
+          Rails.logger.info "GenerateBoardJob words board=#{board.id} seed=#{seed_words.size} generated=#{generated.size} final=#{words.size}"
         when "menu"
           # Placeholder for future menu-based word generation logic
           words = []

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -263,6 +263,76 @@ RSpec.describe "API::Boards", type: :request do
             expect(opts["age_range"]).to be_nil
           end
         end
+
+        # The board name must never become an implicit AI topic. It is a
+        # required column, so falling back to it made every "default" create
+        # an AI generation — pasting a word list silently appended extra
+        # words, and "start blank" came back full. Regression from 68a5fe35.
+        it "sends no topic for a default board with a word list and no prompt" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Riding The School Bus" },
+                 board_creation_type: "default",
+                 word_list: %w[bus driver seat],
+                 wordCount: 48,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, type, opts|
+            expect(type).to eq("default")
+            expect(opts["topic"]).to be_blank
+            expect(opts["word_list"]).to eq(%w[bus driver seat])
+          end
+        end
+
+        it "sends no topic for a default board with neither word list nor prompt" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Empty Board" },
+                 board_creation_type: "default",
+                 wordCount: 48,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts["topic"]).to be_blank
+            expect(opts["word_list"]).to be_nil
+          end
+        end
+
+        it "uses an explicit prompt as the topic for a default board" do
+          post "/api/boards",
+               params: {
+                 board: { name: "Board Name Not Used" },
+                 board_creation_type: "default",
+                 prompt: "getting ready for bed",
+                 word_list: %w[pajamas],
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, _type, opts|
+            expect(opts["topic"]).to eq("getting ready for bed")
+          end
+        end
+
+        it "still falls back to the board name as the topic for scenario creation" do
+          post "/api/boards",
+               params: {
+                 board: { name: "A Trip To The Zoo" },
+                 board_creation_type: "scenario",
+                 wordCount: 12,
+               },
+               headers: auth_headers(creator)
+
+          expect(response).to have_http_status(:created)
+          expect(GenerateBoardJob).to have_received(:perform_async) do |_id, type, opts|
+            expect(type).to eq("scenario")
+            expect(opts["topic"]).to eq("A Trip To The Zoo")
+          end
+        end
       end
     end
   end

--- a/spec/sidekiq/generate_board_job_spec.rb
+++ b/spec/sidekiq/generate_board_job_spec.rb
@@ -175,5 +175,23 @@ RSpec.describe GenerateBoardJob, type: :job do
 
       expect(captured).to eq(%w[apple banana])
     end
+
+    # Image.by_label matches on LOWER(label), so "Dog" and "dog" resolve to
+    # one Image — a case-sensitive uniq left two tiles showing one picture.
+    it "dedupes seeds against generated words case-insensitively" do
+      allow(Board).to receive(:find_by).with(id: board.id).and_return(board)
+      allow(board).to receive(:get_words_for_scenario).and_return(%w[dog Bus])
+
+      captured = nil
+      allow(board).to receive(:find_or_create_images_from_word_list) { |w| captured = w }
+
+      described_class.new.perform(
+        board.id,
+        "default",
+        { "topic" => "pets", "word_list" => %w[Dog cat], "word_count" => 5 },
+      )
+
+      expect(captured).to eq(%w[Dog cat Bus])
+    end
   end
 end


### PR DESCRIPTION
## Summary

A board built through the normal `/boards/new` UI by pasting a word list came back with 4 tiles nobody asked for, appended to the end (board 6206, `pb/riding-the-school-bus`, 2026-08-19).

`boards#create` fell back to the board *name* as the AI topic whenever no topic or prompt was sent:

```ruby
topic = params[:topic] || params[:prompt] || @board.name
```

`name` is a required column, so a topic was **always** present, and `GenerateBoardJob` reads a present topic as "the user asked for AI words" — appending `get_words_for_scenario` output after the seed list. The frontend only sends `prompt` in story mode, so word-list mode tripped this on every create.

Regression from `68a5fe35` (2026-06-03), which merged the `"default"` and `"scenario"` branches. Before it, `"default"` passed only `word_list` — no topic, no AI call. The job's own spec already asserted the intended behavior (`generate_board_job_spec.rb:163`); the controller just never let that case happen.

**Same cause, second bug:** "Start with an empty board" also sends no prompt and no `word_list`, so a board the user asked to leave blank came back filled with up to 48 AI words.

### Production log evidence

| Time (UTC) | Event |
|---|---|
| 13:33:50 | `POST /api/boards` → 201, board 6206 |
| — | **no `GET /api/boards/words`** — the "Generate words" button was never clicked |
| 13:34:00–13:35:14 | 11 `ActiveStorage::AnalyzeJob` runs (art for the new words) |
| 13:37:41 | `DELETE /api/board_images/remove` — the extra tiles removed by hand |

## Changes

- **`boards_controller.rb`** — scope the board-name topic fallback to `creation_type == "scenario"`. A `"default"` board generates AI words only when the caller sends an explicit topic/prompt. Safe for older clients: pre-`68a5fe35`, `"default"` with no word list enqueued nothing at all.
- **`generate_board_job.rb`** — dedupe the seed+generated merge **case-insensitively**. `Image.by_label` matches on `LOWER(images.label)`, so "Dog" and "dog" resolved to one `Image` but a plain `.uniq` still created two tiles showing the same picture.
- **`generate_board_job.rb`** — promote the start line from `debug` to `info` and log `seed=/generated=/final=` counts. Production runs at `:info`, so this whole pipeline was invisible in the journal while tracing this bug. No word content is logged.
- **`.claude-notes/boards-and-teams.md`** — write down the invariant: the board name is never an implicit AI topic. This is what `68a5fe35` broke.

Frontend half: brittanyjohns/itty-bitty-frontend#711

## Test plan

`bundle exec rspec spec/requests/api/boards_spec.rb spec/sidekiq/generate_board_job_spec.rb` → **77 examples, 0 failures.**

New coverage:
- `"default"` + word list, no prompt → blank topic (the reported bug)
- `"default"`, nothing else → blank topic (blank board stays blank)
- `"default"` + explicit prompt → topic is the prompt
- `"scenario"`, no prompt → still falls back to the board name (no story-mode regression)
- seeds `%w[Dog cat]` + generated `%w[dog Bus]` → `%w[Dog cat Bus]`

Existing enqueue-arg examples all pass an explicit topic and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)