### PR TITLE
feat(board-images): bulk "set text image" endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Turn a whole selection into text tiles at once.** The board editor's bulk
+  actions can now render every selected tile's own word as its picture, in one
+  step, instead of opening each tile in turn. Free — no AI credits. Tiles with
+  no word are left alone, as is any tile already showing that exact picture.
+
 ### Fixed
 
 - **Pasting a word list makes exactly those tiles.** Building a board from a

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -2,7 +2,7 @@ class API::BoardImagesController < API::ApplicationController
   respond_to :json
   before_action :set_board_image, only: %i[ show ]
   before_action :set_owned_board_image, only: %i[ update destroy create_image_variation create_image_edit create_text_image set_current_audio attach_youtube_video upload_video clear_video ]
-  before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation create_text_image upload_audio reset_audio move destroy attach_youtube_video upload_video clear_video ]
+  before_action :check_board_image_editable!, only: %i[ save_layout set_current_audio update update_multiple remove_multiple create_image_edit create_image_variation create_text_image create_text_images upload_audio reset_audio move destroy attach_youtube_video upload_video clear_video ]
 
   # Extension used for the stored blob, keyed by the uploaded content type.
   # Only covers types in BoardImage.accepted_video_content_types — anything
@@ -302,7 +302,7 @@ class API::BoardImagesController < API::ApplicationController
     # Nothing about the picture changed and we still have it — skip the Chrome
     # fork. Tweaking a colour back and forth is cheap to do and expensive to
     # serve, so the no-op case must not cost a render.
-    if unchanged_render?(stored, options)
+    if unchanged_render?(@board_image, stored, options)
       @board_image.save!
       render json: @board_image.api_view(current_user)
       return
@@ -313,6 +313,81 @@ class API::BoardImagesController < API::ApplicationController
     RenderTextTileJob.perform_async(@board_image.id, options.to_h)
 
     render json: @board_image.api_view(current_user)
+  end
+
+  # POST /api/board_images/create_text_images
+  #
+  # The bulk drawer's "Set text image": every selected tile gets ITS OWN label
+  # rendered as its picture. There is deliberately no form on this path — one
+  # shared string would paint every tile the same picture, and the whole point
+  # of the bulk action is skipping the per-tile editor. So nothing here may
+  # depend on a preview to come out right, which is why the two colours are
+  # derived rather than defaulted:
+  #
+  #   * the background is TRANSPARENT, not the tile's colour. A baked-in colour
+  #     goes stale the moment the tile is recoloured, while a transparent PNG
+  #     keeps following it — the same reason generate_placeholder_image is
+  #     transparent, so screen and print keep agreeing.
+  #   * the text colour is derived from the tile's own background. Options'
+  #     near-black default is unreadable on a dark tile, and with no preview
+  #     nobody would see it happen.
+  #
+  # Free, like its single-tile sibling create_text_image — deliberately NO
+  # check_credits!. Ownership comes from scoping to @board.board_images plus
+  # check_board_image_editable!, as on update_multiple.
+  def create_text_images
+    # Rack encodes an empty array as a single empty element, so a selection of
+    # nothing arrives as [""] rather than [] — reject blanks before the guard
+    # or it reads as a real selection and answers 200 having done nothing.
+    board_image_ids = Array(params[:board_image_ids]).reject(&:blank?)
+    @board = Board.includes(:board_images).find_by(id: params[:board_id])
+    if @board.nil?
+      render json: { error: "Board not found" }, status: :unprocessable_content
+      return
+    end
+    if board_image_ids.empty?
+      render json: { error: "No board image IDs provided" }, status: :unprocessable_content
+      return
+    end
+
+    queued = 0
+    unlabeled = 0
+    unchanged = 0
+
+    @board.board_images.where(id: board_image_ids).each do |board_image|
+      options = default_text_tile_options_for(board_image)
+
+      # A picture-only tile has no text to render. Skip it rather than failing
+      # the batch: one of them in a select-all must not cost the other twenty-nine.
+      unless options.valid?
+        unlabeled += 1
+        next
+      end
+
+      stored = board_image.data&.dig("text_image")
+      board_image.data = (board_image.data || {}).merge("text_image" => options.to_h)
+      board_image.data["hide_label"] = options.hide_label
+
+      # Already showing exactly this render — don't pay for another Chrome fork.
+      if unchanged_render?(board_image, stored, options)
+        board_image.save!
+        unchanged += 1
+        next
+      end
+
+      board_image.status = "generating"
+      board_image.save!
+      RenderTextTileJob.perform_async(board_image.id, options.to_h)
+      queued += 1
+    end
+
+    @board.broadcast_board_update!
+    render json: {
+      board: @board.api_view_with_predictive_images(current_user, true),
+      queued: queued,
+      unlabeled: unlabeled,
+      unchanged: unchanged,
+    }
   end
 
   def create_image_variation
@@ -507,13 +582,25 @@ class API::BoardImagesController < API::ApplicationController
 
   private
 
+  # The bulk path's option set: defaults, seeded from the tile itself. See
+  # create_text_images for why the two colours are derived rather than left to
+  # Options' defaults.
+  def default_text_tile_options_for(board_image)
+    Images::TextTile::Options.new(
+      text: board_image.display_label.presence || board_image.label,
+      bg_color: Images::TextTile::Options::TRANSPARENT,
+      text_color: ColorHelper.text_hex_for(board_image.bg_hex),
+      hide_label: true,
+    )
+  end
+
   # Would this text-tile request paint exactly what the tile already shows?
   # Compares only the pixel-affecting options (Options#render_digest drops
   # hide_label), and insists the doc it produced is still there and still the
   # picture on screen — a stale config with a deleted doc must re-render.
-  def unchanged_render?(stored, options)
+  def unchanged_render?(board_image, stored, options)
     return false if stored.blank?
-    return false if @board_image.display_image_url.blank?
+    return false if board_image.display_image_url.blank?
 
     doc_id = stored["doc_id"]
     return false if doc_id.blank?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -94,7 +94,9 @@ class Rack::Attack
   AI_GEN_SUFFIXES = %w[generate generate_audio generate_preview_image regenerate_images].freeze
 
   # Free in-house text-tile rendering. Not in AI_GEN_SUFFIXES on purpose.
-  TEXT_IMAGE_PATHS = %r{\A/api/board_images/\d+/create_text_image\z}
+  # The bulk form is here too: one request, but it fans out to a render per
+  # selected tile, so it is exactly the traffic this throttle exists to bound.
+  TEXT_IMAGE_PATHS = %r{\A/api/board_images/(\d+/create_text_image|create_text_images)\z}
 
   # POST export-package surfaces: single board (+ linked set) and Board Set.
   EXPORT_PACKAGE_PATHS = %r{\A/api/(boards/\d+|board_groups/\d+)/export_package(\.\w+)?\z}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -378,6 +378,7 @@ Rails.application.routes.draw do
       collection do
         put "update", to: "board_images#update_multiple"
         delete "remove", to: "board_images#remove_multiple"
+        post "create_text_images", to: "board_images#create_text_images"
       end
     end
     resources :scenarios do

--- a/spec/requests/api/board_images_text_image_spec.rb
+++ b/spec/requests/api/board_images_text_image_spec.rb
@@ -126,4 +126,114 @@ RSpec.describe "API::BoardImages text tiles", type: :request do
       expect { post_text_image }.to change(RenderTextTileJob.jobs, :size).by(1)
     end
   end
+
+  describe "POST /api/board_images/create_text_images (bulk)" do
+    let!(:second_tile) do
+      create(:board_image, board: board, image: create(:image, user: user, label: "want"))
+    end
+
+    def post_bulk(ids: nil, as: user, board_id: board.id)
+      post "/api/board_images/create_text_images",
+           params: { board_id: board_id, board_image_ids: ids || [board_image.id, second_tile.id] },
+           headers: auth_headers(as)
+    end
+
+    it "rejects an unauthenticated caller" do
+      post "/api/board_images/create_text_images",
+           params: { board_id: board.id, board_image_ids: [board_image.id] }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "renders one tile per selection and reports them queued" do
+      expect { post_bulk }.to change(RenderTextTileJob.jobs, :size).by(2)
+
+      expect(response).to have_http_status(:success)
+      body = JSON.parse(response.body)
+      expect(body).to include("queued" => 2, "unlabeled" => 0, "unchanged" => 0)
+      expect(body["board"]).to be_present
+    end
+
+    it "renders each tile's OWN label, not one shared string" do
+      post_bulk
+
+      expect(board_image.reload.data.dig("text_image", "text")).to eq("more")
+      expect(second_tile.reload.data.dig("text_image", "text")).to eq("want")
+    end
+
+    it "hides the label — the picture is the word" do
+      post_bulk
+      expect(board_image.reload.data["hide_label"]).to be(true)
+    end
+
+    it "renders on a transparent background so the tile's colour still shows" do
+      board_image.update!(bg_color: "blue")
+      post_bulk
+
+      stored = board_image.reload.data["text_image"]
+      expect(stored["bg_color"]).to eq("transparent")
+      # Derived from the tile's own background: there is no preview on this
+      # path, so a near-black default on a dark tile would go unnoticed.
+      expect(stored["text_color"]).to eq(ColorHelper.text_hex_for(board_image.bg_hex))
+    end
+
+    it "skips a tile with no text instead of failing the batch" do
+      second_tile.update_columns(label: nil, display_label: nil)
+
+      expect { post_bulk }.to change(RenderTextTileJob.jobs, :size).by(1)
+
+      expect(JSON.parse(response.body)).to include("queued" => 1, "unlabeled" => 1)
+      expect(second_tile.reload.data&.dig("text_image")).to be_nil
+    end
+
+    it "does not re-render a tile that already shows this exact picture" do
+      post_bulk
+      RenderTextTileJob.jobs.clear
+      [board_image, second_tile].each do |tile|
+        tile.reload
+        doc = tile.image.docs.create!(source_type: Doc::SOURCE_TYPE_TEXT_TILE, user_id: user.id)
+        tile.update!(
+          status: "complete",
+          display_image_url: "https://cdn.example/text.png",
+          data: tile.data.merge("text_image" => tile.data["text_image"].merge("doc_id" => doc.id)),
+        )
+      end
+
+      expect { post_bulk }.not_to change(RenderTextTileJob.jobs, :size)
+      expect(JSON.parse(response.body)).to include("queued" => 0, "unchanged" => 2)
+    end
+
+    it "ignores an id that is not on this board" do
+      # Deliberately someone else's tile: the ids come from the client, and
+      # scoping to @board.board_images is the only thing keeping them honest.
+      stranger = create(
+        :board_image,
+        board: create(:board, user: other_user),
+        image: create(:image, user: other_user, label: "stop"),
+      )
+
+      expect { post_bulk(ids: [board_image.id, stranger.id]) }
+        .to change(RenderTextTileJob.jobs, :size).by(1)
+
+      expect(JSON.parse(response.body)).to include("queued" => 1)
+      expect(stranger.reload.data&.dig("text_image")).to be_nil
+    end
+
+    it "422s when no tiles were given" do
+      # Rack turns an empty array into [""], so this also pins the blank-reject.
+      post_bulk(ids: [])
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it "422s an unknown board" do
+      post_bulk(board_id: 0)
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    # Same headline as the single-tile path: this renders in-house, so bulk
+    # must not become the place a credit gate sneaks in.
+    it "spends nothing" do
+      expect { post_bulk }.not_to change(CreditTransaction, :count)
+      expect(user.reload.tokens).to eq(user.tokens)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Backend half of the board editor's new **Set text image** bulk action. Text tiles — a tile picture rendered from typed text instead of AI art — exist today only per-tile (`POST /api/board_images/:id/create_text_image`, driven from the tile editor's Text style). Doing that 30 times is the problem this solves.

Adds `POST /api/board_images/create_text_images`, a collection sibling of `update_multiple`: takes `board_id` + `board_image_ids`, renders **each tile's own label** as its picture, and returns the same board payload the bulk drawer already consumes plus `queued` / `unlabeled` / `unchanged` counts.

Deliberately **no form** on this path — a single shared string would paint every selected tile an identical picture, and the point of the bulk action is skipping the per-tile editor. So the option set is defaults-only, with two colours derived rather than defaulted, because nothing here has a preview in which a bad choice would be noticed:

- **Transparent background**, not the tile's colour. A baked-in colour goes stale the moment the tile is recoloured; a transparent PNG keeps following it — the same reason `generate_placeholder_image` is transparent, so screen and print keep agreeing.
- **Text colour derived from the tile's own background.** `Options`' near-black default is unreadable on a dark tile.

`hide_label: true`, so the word isn't drawn twice.

### Notes

- **Free, like its single-tile sibling** — no `check_credits!`. Same reason documented on `create_text_image`: the feature's headline is that it costs nothing.
- **A tile with no text is skipped, not fatal.** One picture-only tile in a select-all must not cost the other twenty-nine.
- **Unchanged renders short-circuit** via the existing `unchanged_render?`, which now takes the tile as an argument since the bulk path has no `@board_image`.
- **Not transactional**, matching `update_multiple` — and per the hub invariant, a Sidekiq job naming a row must not be pushed from inside the transaction that writes it.
- **Rack::Attack**: the `text_image/user` matcher was anchored to the member path, so the new endpoint would have been unthrottled. Widened to cover both — it's one request, but it fans out to a render per tile, which is exactly the traffic that throttle exists to bound.
- Found in passing: Rack encodes an empty array as `[""]`, so an empty selection wasn't blank and answered 200 having done nothing. Blank ids are rejected before the guard.

Frontend PR follows and depends on this.

## Test plan

`spec/requests/api/board_images_text_image_spec.rb` gains a bulk block: one render per selection, each tile's own label (not a shared string), `hide_label` set, transparent bg + derived text colour, unlabeled tiles skipped and counted, unchanged renders not re-queued, ids outside the board ignored, 422 on empty selection and unknown board, unauthenticated rejected, and nothing spent.

```
bundle exec rspec spec/requests/api/board_images_text_image_spec.rb   # 26 examples, 0 failures
bundle exec rspec spec/requests/rack_attack_spec.rb                   # 21 examples, 0 failures
bundle exec rspec spec/requests/api/board_images_*_spec.rb            # 77 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)