### PR TITLE
fix(boards): renaming a board no longer changes its slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Renaming a board no longer changes its share link.** A board's URL
+  (`/pb/<slug>`) used to be re-derived from the name on every rename, so
+  renaming an unpublished board quietly broke any link already shared for it.
+  The URL is now set when the board is created and stays put. Admins can still
+  change it by hand, or ask for a fresh one from the current name.
+- **Copied boards get a clean URL.** Duplicating a board names it "<name> Copy",
+  and that "Copy" was ending up in the board's URL. Copy markers are now
+  stripped from both ends of the name — "Copy of Snack Time" and "Snack Time
+  Copy" both produce `snack-time`. Honest names survive: "Photocopy Board" is
+  left alone.
+
 - **Pasting a word list makes exactly those tiles.** Building a board from a
   pasted word list quietly appended extra AI-generated words to the end, and
   "Start with an empty board" came back full of them. Both happened because the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,11 +320,31 @@ an explicit decision, not a drive-by edit.
   paths used to do, one line after `set_labels` had folded it) makes every seed
   board's casing permanent in every board built from it: that is what kept the
   Board Builder emitting Title Case after the creation paths were fixed.
-- **A published board's slug is frozen.** `/pb/<slug>` is printed into QR codes
-  and pasted into IEPs, with no redirect behind it. `Board#freeze_published_slug`
-  silently reverts a slug change on a published board (reverts, never raises —
-  the frontend re-derives the slug on every rename). Deliberate renames go
-  through `Board#rename_slug!`.
+- **A slug is derived from the name once, at creation, and a rename never
+  changes it.** `slug` is the `/pb/<slug>` key that a shared link, a MySpeak
+  tile and a printed QR code all resolve through; the name is just a label.
+  BoardForm used to re-derive the slug on every keystroke of the name field, so
+  renaming an unpublished board silently moved its public URL. `Api::BoardsController#update`
+  now leaves the slug alone unless the caller asks for a change:
+  `regenerate_slug: true` (the "Generate slug from name" toggle), a blank
+  `slug` (clearing the field), or an explicit new `slug`. A blank *stored* slug
+  is always backfilled — `validates :slug, uniqueness: true` does not skip
+  blanks and the column is `default: ""`, so two slug-less rows collide.
+- **`slug` and `regenerate_slug` are admin-only params**, stripped from
+  `board_params` for non-admins exactly like `predefined`. Owners rename their
+  boards freely; re-keying a live URL is an admin act.
+- **`Board.create_slug` strips copy markers from both ends.** `COPY_MARKERS`
+  handles "Copy of X" (the API clone path) and "X Copy" / "X (copy)" / "X copy 2"
+  (what CloneBoardModal pre-fills). The trailing pattern requires a separator
+  before "copy" so "Photocopy Board" survives, and a name that strips to nothing
+  ("Copy") falls back to the un-stripped name rather than a blank slug.
+- **A published board's slug is frozen** — the stricter rule on top of all of
+  that. `/pb/<slug>` is printed into QR codes and pasted into IEPs, with no
+  redirect behind it. `Board#freeze_published_slug` silently reverts any slug
+  change on a published board (reverts, never raises, so a slug in the payload
+  can't 422 an otherwise-valid update). Deliberate renames go through
+  `Board#rename_slug!` — the internal API's `force_slug` or the
+  `boards:rename_slug` rake task.
 - **A board that backs a marketplace listing can't be deleted, unpublished or
   renamed.** Same reason as the frozen slug, one step further: the board's
   content was sold as a PDF and every printed page carries a QR pointing at its

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -521,14 +521,34 @@ class API::BoardsController < API::ApplicationController
         incoming_published = ActiveModel::Type::Boolean.new.cast(board_params["published"])
         @board.published = incoming_published unless incoming_published.nil?
       end
-      # Renaming a board re-derives this param from the name on the frontend,
-      # so it arrives on ordinary renames. On a PUBLISHED board the change is
-      # dropped by Board#freeze_published_slug — `/pb/<slug>` is printed into
-      # QR codes and paper can't be re-issued (#611). Deliberate renames go
-      # through the internal API's `force_slug` or `boards:rename_slug`.
-      if board_params["slug"].present? && board_params["slug"] != @board.slug
-        new_slug = @board.generate_unique_slug(board_params["slug"])
-        @board.slug = new_slug
+      # A slug is derived from the name ONCE, at creation. Renaming a board must
+      # NOT re-key its URL: `/pb/<slug>` is what a shared link and a printed QR
+      # code point at, and the frontend used to re-derive the slug on every
+      # keystroke of the name field, so an ordinary rename silently moved an
+      # unpublished board's public URL out from under anyone holding the link.
+      #
+      # Changing the slug is now deliberate and admin-only (`:slug` and
+      # `:regenerate_slug` are stripped from board_params for non-admins). The
+      # three ways an admin asks for a change, in order:
+      #
+      #   1. `regenerate_slug: true`  — the "Generate slug from name" toggle
+      #   2. `slug: ""`               — clearing the Slug field in BoardForm
+      #   3. `slug: "something-else"` — typing a slug by hand
+      #
+      # A blank stored slug is backfilled from the name regardless: `validates
+      # :slug, uniqueness: true` does not skip blanks (see #build_obf_placeholder_board).
+      #
+      # On a PUBLISHED board every one of these is still reverted by
+      # Board#freeze_published_slug — printed paper can't be re-issued (#611).
+      # Deliberate published renames go through the internal API's `force_slug`
+      # or the `boards:rename_slug` rake task.
+      regenerate_slug = ActiveModel::Type::Boolean.new.cast(board_params["regenerate_slug"])
+      slug_cleared = board_params.key?("slug") && board_params["slug"].blank?
+
+      if @board.slug.blank? || regenerate_slug || slug_cleared
+        @board.generate_unique_slug(@board.name)
+      elsif board_params["slug"].present? && board_params["slug"] != @board.slug
+        @board.generate_unique_slug(board_params["slug"])
       end
 
       @board.vendor_id = current_user.vendor_id if current_user.vendor_id.present?
@@ -1856,6 +1876,7 @@ class API::BoardsController < API::ApplicationController
   def board_params
     permitted = params.require(:board).permit(:name,
                                   :slug,
+                                  :regenerate_slug,
                                   :text_color,
                                   :bg_color,
                                   :parent_id,
@@ -1894,7 +1915,19 @@ class API::BoardsController < API::ApplicationController
     # (check_board_view_edit_permissions + User#can_edit?, which also refuses
     # any predefined board), so the only non-admin who can set it is the person
     # who owns the board.
+    #
+    # `slug` IS curation in the same sense: it is the `/pb/<slug>` key that
+    # shared links, MySpeak tiles and printed QR codes resolve through. It is
+    # issued from the name once at creation and then belongs to the URL, not to
+    # the name — owners rename their boards freely, but re-keying a live URL is
+    # an admin act. `regenerate_slug` is the opt-in that asks for a re-derive,
+    # so it is gated the same way. Stripping both is what makes an ordinary
+    # rename a no-op on the slug (see #update).
     permitted.delete(:predefined) unless current_user&.admin?
+    unless current_user&.admin?
+      permitted.delete(:slug)
+      permitted.delete(:regenerate_slug)
+    end
     permitted
   end
 

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -1622,15 +1622,42 @@ class Board < ApplicationRecord
     self.save!
   end
 
+  # Copy markers a duplicated board carries in its NAME but must not carry in
+  # its slug. Both ends matter: the admin/API path names clones "Copy of X",
+  # while CloneBoardModal (frontend) pre-fills "X Copy" — the trailing form was
+  # missed for a long time, so copied boards got `snack-time-copy` URLs.
+  #
+  # The trailing pattern requires at least one separator before "copy"
+  # (`[\s_(\[-]+`) so an honest name ending in the letters -copy survives:
+  # "Photocopy Board" must not slugify to "photo-board".
+  COPY_MARKERS = [
+    /\Acopy[\s_-]+of[\s_-]+/i,                    # "Copy of X", "copy-of-X"
+    /[\s_(\[-]+[(\[]?copy[)\]]?[\s_-]*\d*\z/i,     # "X Copy", "X - copy", "X (Copy)", "X copy 2"
+  ].freeze
+
   def self.create_slug(name_to_use)
-    cleaned_name = name_to_use.gsub(/(copy[- ]of[\s_-]*)/i, "").squeeze(" ").strip
-    cleaned_name = cleaned_name.parameterize
-    cleaned_name
+    cleaned_name = name_to_use.to_s.squeeze(" ").strip
+
+    # Applied until stable so a twice-duplicated "X Copy Copy" collapses to "x".
+    loop do
+      before = cleaned_name
+      COPY_MARKERS.each { |marker| cleaned_name = cleaned_name.gsub(marker, "") }
+      cleaned_name = cleaned_name.squeeze(" ").strip
+      break if cleaned_name == before
+    end
+
+    slug = cleaned_name.parameterize
+    # A board genuinely named "Copy" strips to nothing. An empty slug is not a
+    # safe fallback: `slug` is `default: ""` with a non-allow_blank uniqueness
+    # validation, so a blank slug collides with the first slug-less row and the
+    # save fails. Keep the un-stripped name instead.
+    slug = name_to_use.to_s.parameterize if slug.blank?
+    slug
   end
 
   def generate_unique_slug(initial_slug = nil)
     name_to_use = initial_slug || name
-    # Remove both "Copy of " and "copy-of-" (case-insensitive)
+    # Strips "Copy of X" / "X Copy" markers — see COPY_MARKERS.
     cleaned_name = Board.create_slug(name_to_use)
     slug = cleaned_name
     # counter = 1

--- a/spec/models/board_slug_spec.rb
+++ b/spec/models/board_slug_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+# `Board.create_slug` is the one place a board name becomes a URL key. It has to
+# strip the "copy" markers a duplicated board carries in its name, because the
+# slug outlives the name: it is what `/pb/<slug>` resolves through.
+RSpec.describe Board, ".create_slug" do
+  describe "copy markers" do
+    # The API/admin clone path names duplicates "Copy of X"; CloneBoardModal on
+    # the frontend pre-fills "X Copy". Both have to collapse to the same slug.
+    {
+      "Snack Time" => "snack-time",
+      "Copy of Snack Time" => "snack-time",
+      "copy-of-Snack Time" => "snack-time",
+      "COPY OF Snack Time" => "snack-time",
+      "Snack Time Copy" => "snack-time",
+      "Snack Time copy" => "snack-time",
+      "Snack Time - Copy" => "snack-time",
+      "Snack Time (Copy)" => "snack-time",
+      "Snack Time [copy]" => "snack-time",
+      "Snack Time copy 2" => "snack-time",
+      "Snack Time Copy Copy" => "snack-time",
+      "Copy of Copy of Snack Time" => "snack-time",
+      "Feelings & Emotions Copy" => "feelings-emotions",
+    }.each do |name, expected|
+      it "slugifies #{name.inspect} to #{expected.inspect}" do
+        expect(described_class.create_slug(name)).to eq(expected)
+      end
+    end
+  end
+
+  describe "names that only look like copies" do
+    # The trailing marker requires a separator before "copy", so a word that
+    # merely ENDS in those letters keeps them.
+    it "leaves a word ending in -copy alone" do
+      expect(described_class.create_slug("Photocopy Board")).to eq("photocopy-board")
+      expect(described_class.create_slug("Photocopy")).to eq("photocopy")
+    end
+
+    it "leaves 'copy' in the middle of a name alone" do
+      expect(described_class.create_slug("My Copy Board")).to eq("my-copy-board")
+    end
+  end
+
+  describe "when stripping would empty the name" do
+    # `slug` is `default: ""` with a non-allow_blank uniqueness validation, so a
+    # blank slug collides with the first slug-less row and the save fails.
+    # Falling back to the un-stripped name is the safe answer.
+    it "falls back to the un-stripped name rather than returning blank" do
+      expect(described_class.create_slug("Copy")).to eq("copy")
+      expect(described_class.create_slug("copy")).to eq("copy")
+    end
+  end
+
+  describe "#generate_unique_slug" do
+    let(:user) { create(:user) }
+
+    it "derives from the name with copy markers stripped" do
+      board = build(:board, user: user, name: "Snack Time Copy", slug: nil)
+      expect(board.generate_unique_slug).to eq("snack-time")
+    end
+
+    it "suffixes on collision instead of reusing a taken slug" do
+      create(:board, user: user, slug: "snack-time")
+      board = build(:board, user: user, name: "Snack Time Copy", slug: nil)
+
+      expect(board.generate_unique_slug).to match(/\Asnack-time-[0-9a-f]{8}\z/)
+    end
+  end
+end

--- a/spec/requests/api/boards_published_slug_freeze_spec.rb
+++ b/spec/requests/api/boards_published_slug_freeze_spec.rb
@@ -2,10 +2,16 @@ require "rails_helper"
 
 # A published board's slug is permanent: `/pb/<slug>` is what the QR codes on
 # printed board printables encode, and printed paper can't be re-issued (#611).
-# The change is IGNORED rather than rejected — the frontend re-derives the slug
-# from the name on every rename, so a 422 would break ordinary board renaming.
+# The change is IGNORED rather than rejected, so a 422 can never break an
+# ordinary board update that happens to carry a slug.
+#
+# This is the STRICTER of the two slug rules. The general one — a rename never
+# re-keys the slug on any board, published or not, and only an admin may change
+# it — lives in boards_slug_rename_spec.rb. An admin is used here so the slug
+# param actually reaches the model; the freeze, not the param strip, is what
+# must hold it.
 RSpec.describe "API::Boards published slug freeze", type: :request do
-  let(:user) { create(:user) }
+  let(:user) { create(:admin_user) }
 
   def update_board(board, params)
     put "/api/boards/#{board.id}", params: params, headers: auth_headers(user)
@@ -56,7 +62,10 @@ RSpec.describe "API::Boards published slug freeze", type: :request do
 
     before { board.generate_unique_slug && board.save! }
 
-    it "still renames the slug — nothing shareable has been handed out" do
+    # The freeze does not apply, so an admin's deliberate slug change lands.
+    # A rename on its own still would not — that is the general rule, covered
+    # in boards_slug_rename_spec.rb.
+    it "lets an admin set the slug — nothing shareable has been handed out" do
       update_board(board, board: { name: "Second Draft", slug: "second-draft" })
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/boards_slug_rename_spec.rb
+++ b/spec/requests/api/boards_slug_rename_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+
+# A board's slug is derived from its name ONCE, at creation, and then belongs to
+# the URL rather than to the name. Renaming a board must not re-key `/pb/<slug>`
+# — that is the link a user shares and the QR code a printable carries.
+#
+# Changing it is deliberate and admin-only. The published freeze (#611) is a
+# separate, stricter rule that still wins on top of all of this — see
+# boards_published_slug_freeze_spec.rb.
+RSpec.describe "API::Boards slug on rename", type: :request do
+  let(:owner) { create(:user) }
+  let(:admin) { create(:admin_user) }
+
+  def update_board(board, params, as:)
+    put "/api/boards/#{board.id}", params: { board: params }, headers: auth_headers(as)
+  end
+
+  describe "an ordinary rename" do
+    let(:board) { create(:board, user: owner, name: "Snack Time", slug: "snack-time", published: false) }
+
+    it "leaves the slug untouched for the owner" do
+      update_board(board, { name: "Lunch Time" }, as: owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.name).to eq("Lunch Time")
+      expect(board.slug).to eq("snack-time")
+    end
+
+    it "leaves the slug untouched for an admin too" do
+      update_board(board, { name: "Lunch Time" }, as: admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.name).to eq("Lunch Time")
+      expect(board.slug).to eq("snack-time")
+    end
+
+    it "keeps the public URL stable so a shared link still resolves" do
+      shared_url = board.public_url
+
+      update_board(board, { name: "Lunch Time" }, as: owner)
+
+      expect(board.reload.public_url).to eq(shared_url)
+    end
+  end
+
+  describe "a non-admin trying to set the slug" do
+    let(:board) { create(:board, user: owner, name: "Snack Time", slug: "snack-time", published: false) }
+
+    it "ignores an explicit slug — the param is stripped, not rejected" do
+      update_board(board, { name: "Lunch Time", slug: "lunch-time" }, as: owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("snack-time")
+      expect(board.name).to eq("Lunch Time")
+    end
+
+    it "ignores regenerate_slug" do
+      update_board(board, { name: "Lunch Time", regenerate_slug: true }, as: owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("snack-time")
+    end
+  end
+
+  describe "an admin changing the slug" do
+    let(:board) { create(:board, user: admin, name: "Snack Time", slug: "snack-time", published: false) }
+
+    it "applies a hand-typed slug" do
+      update_board(board, { slug: "second-snack" }, as: admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("second-snack")
+    end
+
+    it "re-derives from the new name when the slug field is cleared" do
+      update_board(board, { name: "Lunch Time", slug: "" }, as: admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("lunch-time")
+    end
+
+    it "re-derives from the new name when regenerate_slug is set" do
+      update_board(board, { name: "Lunch Time", slug: "snack-time", regenerate_slug: true }, as: admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("lunch-time")
+    end
+
+    it "strips copy markers when re-deriving" do
+      update_board(board, { name: "Lunch Time Copy", regenerate_slug: true }, as: admin)
+
+      expect(board.reload.slug).to eq("lunch-time")
+    end
+  end
+
+  describe "a board with no slug yet" do
+    # `validates :slug, uniqueness: true` does not skip blanks and the column
+    # defaults to "", so a slug-less board must be backfilled or the second one
+    # fails to save.
+    let(:board) { create(:board, user: owner, name: "Snack Time", slug: "", published: false) }
+
+    it "backfills from the name on the next update, even for a non-admin" do
+      update_board(board, { name: "Lunch Time" }, as: owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("lunch-time")
+    end
+  end
+
+  describe "the published freeze still wins" do
+    let(:board) { create(:board, user: admin, name: "Snack Time", slug: "snack-time", published: true) }
+
+    it "ignores an admin regenerate on a published board" do
+      update_board(board, { name: "Lunch Time", regenerate_slug: true }, as: admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(board.reload.slug).to eq("snack-time")
+      expect(board.name).to eq("Lunch Time")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A board's `slug` is the `/pb/<slug>` key that shared links, MySpeak tiles and printed QR codes all resolve through. It was being treated as a derivative of the name: `BoardForm` re-derived it on every keystroke and shipped it with the save, and `#update` applied it. So **renaming an unpublished board silently moved its public URL** out from under anyone holding the link. Only `Board#freeze_published_slug` stopped this, and only for published boards (#611).

The slug is now derived from the name **once, at creation**, and a rename leaves it alone.

### `Api::BoardsController#update`

The slug changes only when the caller asks:

| Ask | Trigger |
|---|---|
| `regenerate_slug: true` | the new "Generate slug from name" toggle |
| `slug: ""` | clearing the Slug field in BoardForm |
| `slug: "something-else"` | typing one by hand |

A blank **stored** slug is still backfilled from the name regardless — `validates :slug, uniqueness: true` does not skip blanks and the column is `default: ""`, so two slug-less rows collide (this is what `build_obf_placeholder_board` depends on).

### `slug` / `regenerate_slug` are admin-only

Both are stripped from `board_params` for non-admins, exactly like `:predefined`. Owners rename their boards freely; re-keying a live URL is an admin act.

### Copy markers (separate bug, same function)

`Board.create_slug` stripped only a **leading** `"Copy of"` — but `CloneBoardModal` pre-fills `"<name> Copy"`, so every copied board got a `snack-time-copy` slug. `COPY_MARKERS` now handles both ends and repeated markers:

- `"Copy of Snack Time"`, `"Snack Time Copy"`, `"Snack Time (Copy)"`, `"Snack Time copy 2"`, `"Snack Time Copy Copy"` → `snack-time`
- `"Photocopy Board"` → `photocopy-board` (the trailing pattern requires a separator before `copy`)
- `"Copy"` → `copy`, not `""` (a blank slug would fail the uniqueness validation)

### Unchanged on purpose

`Board#freeze_published_slug` is the stricter rule and still wins on top of everything above — a published board's slug is permanent. Deliberate published renames still go through the internal API's `force_slug` or `boards:rename_slug`.

## Test plan

New:
- `spec/models/board_slug_spec.rb` — 18 examples covering `create_slug` copy markers, the look-alike names that must survive, the blank fallback, and `generate_unique_slug` collision suffixing.
- `spec/requests/api/boards_slug_rename_spec.rb` — 11 examples: rename leaves the slug alone (owner and admin), non-admin `slug`/`regenerate_slug` ignored, admin hand-typed slug applies, cleared slug re-derives, `regenerate_slug` re-derives, copy markers stripped on re-derive, blank stored slug backfills, published freeze still wins.

Changed: `spec/requests/api/boards_published_slug_freeze_spec.rb` — the *"still renames the slug"* unpublished case asserted the exact behavior this PR removes. Rewritten as an admin-sets-the-slug case, and the file's user switched to `:admin_user` so the **freeze**, not the new param strip, is what the test proves.

Ran:
- `bundle exec rspec spec/models/board_slug_spec.rb spec/models/board_slug_freeze_spec.rb spec/requests/api/boards_slug_rename_spec.rb spec/requests/api/boards_published_slug_freeze_spec.rb spec/requests/api/boards_spec.rb` → **115 examples, 0 failures**
- Wider pass over every `generate_unique_slug` caller (`board_spec`, `internal/boards_spec`, `seeded_set_cloner_spec`, `build_board_set_job_spec`, `import_from_obf_job_spec`, `admin_builder/existing_boards_spec`) → **320 examples, 0 failures**

Docs: `CLAUDE.md` slug section rewritten; `CHANGELOG.md` entry added.

Pairs with brittanyjohns/itty-bitty-frontend — same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)