### PR TITLE
feat(kit-pages): autofill the landing page and show the printable's mockups

### DIFF
--- a/.claude-notes/kit-landing-pages-handoff.md
+++ b/.claude-notes/kit-landing-pages-handoff.md
@@ -253,11 +253,62 @@ changing the model or the contract.
 - **No `destroy` action.** Unpublish is the way to take a page down; the row is
   the only record of which leads came from where.
 
+## Autofill (`POST /admin/kit_pages/autofill`)
+
+The v1 screen was a raw data-entry form: slug, title, eyebrow, subhead, two CTA
+fields, and a JSON blob typed into a monospace textarea. **Autofill the page**
+writes all of it from the printable the page gives away.
+
+- `KitPages::CopySuggester` is one OpenAI JSON-mode call returning
+  `{eyebrow, title, subhead, items, closing}`, built the same way as
+  `Boards::AdminBuilder::MetadataSuggester` (same `GenerationError`, same
+  `instance_variable_set(:@model, …)` idiom, same hard clamps on every field).
+- **It never feeds `listing_copy["description"]` to the model.** That is Etsy
+  checkout prose — "instant download", "no sign-in required" — and reads as a
+  sales pitch on a page that is giving the thing away. `summary` and `tags` are
+  the clean borrow. A spec asserts the description never reaches the prompt.
+- **Blanks only, and it never saves.** Same rule as
+  `Admin::BoardBuildsController#suggest_context`: anything typed survives,
+  including a hand-written content blob (clear the textarea and autofill again
+  to have it rewritten). The action renders; it does not persist.
+- The slug is derived from the board name **only into a blank field**, and
+  uniquified with a `-2` suffix. Re-deriving a slug that already exists would
+  move a live `/kit/<slug>` URL — the same rule boards got in #727.
+- `mailchimp_tag` is deliberately left blank: `resolved_mailchimp_tag` already
+  derives one, so filling it would freeze a value that currently follows a slug
+  correction.
+- Routed on **both** the collection and a member, because one form partial
+  serves `new` and `edit`; `autofill_path(@kit_page)` picks. The button is a
+  `formaction` submit with `formnovalidate` (slug and title are `required`, and
+  filling them is the point), and the form carries `data: { turbo: false }` —
+  without it Turbo Drive refuses the rendered 200 and the button is a silent
+  no-op. A request spec asserts that attribute for exactly that reason.
+
+## Mockup images on the public page
+
+`KitPage#gallery_images` puts the printable's rendered marketplace mockups into
+`public_view` as `images: [{variant, url}]`, first one first.
+
+- It is a curated **allowlist**, `KitPage::KIT_IMAGE_ORDER` — hero, on_paper,
+  flip_book, whats_included, on_a_device. `about` and `page_index` are Etsy shop
+  framing and read wrong on a free page. Narrowing by allowlist rather than by
+  exclusion is the same discipline `BoardPrintable#pdf_files` keeps: a new image
+  variant has to be opted in before it can reach a visitor.
+- It reuses `BoardPrintable#listing_images_view`, which has already dropped
+  blobs from retired gallery designs, and drops any entry whose `url` came back
+  nil (`url_for_file` returns nil rather than raising).
+- **This does not weaken the no-file-URL rule.** That rule is about the
+  *product* — the PDF, which is still revealed only by the download endpoint
+  after a `DownloadLead` is written. These are marketing renders on the same
+  public CDN, and they are what persuades a visitor to enter an email at all.
+
 ### Files
 
 - `db/migrate/20260819120000_create_kit_pages.rb`, `app/models/kit_page.rb`
 - `app/controllers/api/kit_pages_controller.rb` (public read + download)
 - `app/controllers/admin/kit_pages_controller.rb`, `app/views/admin/kit_pages/`
+- `app/services/kit_pages/copy_suggester.rb` (autofill), plus
+  `spec/services/kit_pages/copy_suggester_spec.rb`
 - `app/sidekiq/mailchimp_upsert_lead_job.rb` (the `kit_` tag fallback)
 - Specs: `spec/models/kit_page_spec.rb`, `spec/requests/api/kit_pages_spec.rb`,
   `spec/requests/api/download_leads_kit_pages_regression_spec.rb`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **Kit landing pages write themselves.** Creating a `/kit/<slug>` lead-magnet
+  page used to mean typing a slug, headline, subhead, call to action and a raw
+  JSON blob by hand. Pick the printable it gives away, press **Autofill the
+  page**, and all of it is written from that printable. It only fills what's
+  blank, so anything already typed survives, and nothing is saved until the
+  usual Save.
+- **Kit landing pages show the printable.** The mockup images already rendered
+  for a printable's marketplace gallery — the printed sheet on a desk, the
+  flip-book, the pages open on a tablet — now appear on its free landing page.
+  The download itself still stays behind the email form.
 - **Turn a whole selection into text tiles at once.** The board editor's bulk
   actions can now render every selected tile's own word as its picture, in one
   step, instead of opening each tile in turn. Free — no AI credits. Tiles with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,6 +575,26 @@ an explicit decision, not a drive-by edit.
   to the default tag rather than strand the lead. And the download always comes
   from `BoardPrintable#files_view`, the PDF ALLOWLIST, so a listing image or the
   listing video can never be handed to a visitor as the product.
+- **The PRODUCT is gated; a PICTURE of it is not.** `public_view` also carries
+  `images`, the printable's rendered marketplace mockups, and that is not a hole
+  in the bullet above — a lead magnet no one can see converts nothing, and these
+  renders are marketing art on the same public CDN, not the document. The line
+  is drawn by `KitPage::KIT_IMAGE_ORDER`, a curated ALLOWLIST over
+  `BoardPrintable#listing_images_view` (which has already dropped retired
+  gallery designs). Narrow by allowlist, exactly as `pdf_files` does: a new
+  image variant must be opted in before a visitor can see it, and `about` /
+  `page_index` stay out because they are Etsy shop framing. Never widen this by
+  excluding what you don't want.
+- **Kit-page autofill populates the form and nothing else.**
+  `KitPages::CopySuggester` writes a whole page from the printable it gives
+  away; `Admin::KitPagesController#autofill` merges it BLANKS-ONLY and never
+  saves, so nothing typed is lost and a bad suggestion is discarded by
+  navigating away. Two rails: the slug is derived only into a blank field (it is
+  the `/kit/<slug>` URL a campaign links to — same rule boards got for renames),
+  and `listing_copy["description"]` is never fed to the model, because Etsy
+  checkout prose reads as a sales pitch on a page giving the thing away. The
+  form needs `data: { turbo: false }` — the action renders a 200 instead of
+  redirecting, and Turbo Drive silently no-ops such a response.
 
 ## Subsystem map (read the spoke before working in the area)
 

--- a/app/controllers/admin/kit_pages_controller.rb
+++ b/app/controllers/admin/kit_pages_controller.rb
@@ -45,7 +45,102 @@ module Admin
       redirect_to admin_dashboard_kit_pages_path, notice: "“#{@kit_page.title}” is no longer public."
     end
 
+    # Writes the page from the printable it gives away, so launching a campaign
+    # is a dropdown and a button rather than an afternoon of copywriting.
+    #
+    # Populates the form and NOTHING ELSE — it never saves, so a suggestion that
+    # reads badly is discarded by navigating away. Because it answers with a
+    # rendered 200 rather than a redirect, the form carries `data-turbo="false"`;
+    # without it Turbo Drive refuses the response and the button does nothing.
+    def autofill
+      @kit_page = params[:id].present? ? KitPage.find_by(id: params[:id]) : KitPage.new
+      return redirect_to(admin_dashboard_kit_pages_path, alert: "Kit page not found.") unless @kit_page
+
+      assign_form_attributes(@kit_page)
+      @content_raw = params[:content].to_s.strip
+
+      @error = apply_autofill(@kit_page)
+      return render_form(status: :unprocessable_entity) if @error
+
+      flash.now[:notice] = autofill_notice
+      render_form
+    end
+
     private
+
+    # `new` posts to the collection route, `edit` to the member one.
+    def autofill_path(page)
+      if page.persisted?
+        autofill_admin_dashboard_kit_page_path(page)
+      else
+        autofill_admin_dashboard_kit_pages_path
+      end
+    end
+
+    def render_form(status: :ok)
+      render(@kit_page.persisted? ? :edit : :new, status: status)
+    end
+
+    # Only the blanks are filled — anything already typed survives, including a
+    # hand-written content blob. Returns an error string, or nil on success.
+    def apply_autofill(page)
+      copy = KitPages::CopySuggester.new(
+        slug: page.slug, title: page.title, printable: page.board_printable,
+      ).call
+
+      page.slug = page.slug.presence || derived_slug(page)
+      page.title = page.title.presence || copy[:title]
+      page.eyebrow = page.eyebrow.presence || copy[:eyebrow]
+      page.subhead = page.subhead.presence || copy[:subhead]
+      page.cta_label = page.cta_label.presence || copy.dig(:closing, "cta_label")
+      page.cta_path = page.cta_path.presence || copy.dig(:closing, "cta_path")
+
+      # mailchimp_tag is left alone on purpose: `resolved_mailchimp_tag` already
+      # derives one from the slug, so filling it in would only freeze a value
+      # that currently follows a slug correction.
+      fill_content(page, copy)
+      nil
+    rescue KitPages::CopySuggester::GenerationError => e
+      "Couldn't write the copy: #{e.message}"
+    end
+
+    def fill_content(page, copy)
+      @content_filled = false
+      return if @content_raw.present?
+
+      content = {}
+      content["items"] = copy[:items] if copy[:items].any?
+      content["closing"] = copy[:closing] if copy[:closing].present?
+      return if content.empty?
+
+      page.content = content
+      @content_raw = JSON.pretty_generate(content)
+      @content_filled = true
+    end
+
+    def autofill_notice
+      if @content_filled
+        "Filled in what was blank — read it over, then save."
+      else
+        "Filled in what was blank. Left the content JSON alone — clear it and autofill again to rewrite it."
+      end
+    end
+
+    # Derived from the board's name, and only ever into a BLANK field: the slug
+    # is the /kit/<slug> URL a campaign link points at, so re-deriving one that
+    # already exists would move a live page.
+    def derived_slug(page)
+      base = page.board_printable&.board&.name.to_s.parameterize.first(60)
+      return nil if base.blank?
+
+      candidate = base
+      suffix = 1
+      while KitPage.where(slug: candidate).where.not(id: page.id).exists?
+        suffix += 1
+        candidate = "#{base}-#{suffix}"
+      end
+      candidate
+    end
 
     def set_kit_page
       @kit_page = KitPage.find_by(id: params[:id])
@@ -53,7 +148,9 @@ module Admin
     end
 
     # Flat params, matching the rest of the admin (form_tag + *_tag helpers).
-    def assign_and_save(page)
+    # Split out of the save so `autofill` can rebuild the whole form from what
+    # was submitted without persisting any of it.
+    def assign_form_attributes(page)
       page.assign_attributes(
         slug: params[:slug].to_s.strip,
         title: params[:title].to_s.strip,
@@ -66,6 +163,10 @@ module Admin
         cta_path: params[:cta_path].to_s.strip.presence,
         published: ActiveModel::Type::Boolean.new.cast(params[:published]) || false,
       )
+    end
+
+    def assign_and_save(page)
+      assign_form_attributes(page)
 
       return false unless assign_content(page)
       return false unless resolve_etsy_override(page)
@@ -127,7 +228,7 @@ module Admin
       ActiveModel::Type::Boolean.new.cast(params[:etsy_override]) || false
     end
 
-    helper_method :selectable_printables, :kit_preview_url
+    helper_method :selectable_printables, :kit_preview_url, :autofill_path
 
     # Only printables an admin could actually hand to a visitor: finished, and
     # carrying at least one PDF (a printable holding only listing images would

--- a/app/models/kit_page.rb
+++ b/app/models/kit_page.rb
@@ -26,6 +26,18 @@ class KitPage < ApplicationRecord
   # printable carries one "full" document holding all of them.
   VARIANTS = (BoardPrintable::DOWNLOAD_VARIANTS + [BoardPrintable::VARIANT_FULL]).freeze
 
+  # The mockups a visitor sees, in landing-page order. A curated ALLOWLIST of
+  # the Etsy gallery rather than the whole of it: `about` is shop framing and
+  # `page_index` answers an objection only a buyer has, so both read wrong on a
+  # page that is giving the thing away.
+  KIT_IMAGE_ORDER = [
+    BoardPrintable::IMAGE_HERO,
+    BoardPrintable::IMAGE_ON_PAPER,
+    BoardPrintable::IMAGE_FLIP_BOOK,
+    BoardPrintable::IMAGE_WHATS_INCLUDED,
+    BoardPrintable::IMAGE_ON_A_DEVICE,
+  ].freeze
+
   belongs_to :board_printable, optional: true
   belongs_to :etsy_override_by, class_name: "User", optional: true
 
@@ -78,8 +90,31 @@ class KitPage < ApplicationRecord
     end
   end
 
+  # The mockup renders shown on the page — the printed sheet on a desk, the
+  # flip-book, the same pages open on a tablet.
+  #
+  # These are MARKETING art, not the product, which is why they may sit in the
+  # public read while `download_files` may not. The rule the public payload
+  # keeps is that the PDF a visitor came for is revealed only after an email;
+  # a photograph of it is the thing that persuades them to enter one.
+  #
+  # Reuses BoardPrintable#listing_images_view, which has already dropped blobs
+  # from retired gallery designs, then narrows by ALLOWLIST — never by
+  # excluding what we don't want, so a new image variant has to be opted in
+  # here before it can reach a visitor. `url_for_file` returns nil rather than
+  # raising when a blob can't be resolved, hence the presence guard.
+  def gallery_images
+    return [] unless board_printable&.complete?
+
+    @gallery_images ||= board_printable.listing_images_view
+      .select { |image| KIT_IMAGE_ORDER.include?(image[:variant]) && image[:url].present? }
+      .sort_by { |image| KIT_IMAGE_ORDER.index(image[:variant]) }
+      .map { |image| { variant: image[:variant], url: image[:url] } }
+  end
+
   # The public payload. Deliberately carries no file URL — the URL is revealed
-  # only by the download endpoint, after an email.
+  # only by the download endpoint, after an email. `images` is the exception
+  # that proves it: see #gallery_images.
   def public_view
     {
       slug: slug,
@@ -90,6 +125,7 @@ class KitPage < ApplicationRecord
       cta_label: cta_label,
       cta_path: cta_path,
       downloadable: downloadable?,
+      images: gallery_images,
     }
   end
 

--- a/app/services/kit_pages/copy_suggester.rb
+++ b/app/services/kit_pages/copy_suggester.rb
@@ -1,0 +1,213 @@
+module KitPages
+  # Writes a whole /kit/:slug landing page from the printable it gives away —
+  # eyebrow, title, subhead, the "what's inside" items, and the closing block —
+  # in one OpenAI call.
+  #
+  # The screen it feeds is a lead-magnet form whose only real decision is WHICH
+  # printable. Everything else was hand-typed, including a raw JSON blob, so the
+  # cost of launching a campaign page was an afternoon of copywriting rather
+  # than a dropdown and a button.
+  #
+  # Two constraints come from outside this class and must not be relaxed here:
+  #
+  #   * **Never feed it `listing_copy["description"]`.** That is long-form Etsy
+  #     marketplace prose — "instant download", "no sign-in required", delivery
+  #     mechanics — written for a buyer at a checkout. On a free landing page it
+  #     reads as a sales pitch for something already being given away. The
+  #     `summary` (capped at 150 chars by Etsy::ListingCopy) is the clean borrow.
+  #   * **Every string is rendered as text by the frontend.** KitLandingPage
+  #     prints these into headings and paragraphs, so an HTML answer shows up as
+  #     literal tags. Markup is stripped here rather than trusted.
+  #
+  # ONLY EVER POPULATES THE FORM. No writes, no credit charge: admin-owned.
+  class CopySuggester
+    class GenerationError < StandardError; end
+
+    MAX_EYEBROW_LENGTH = 40
+    MAX_TITLE_LENGTH = 80
+    MAX_SUBHEAD_LENGTH = 200
+    MAX_ITEMS = 6
+    MIN_ITEMS = 3
+    MAX_ITEM_TITLE_LENGTH = 60
+    MAX_ITEM_DESCRIPTION_LENGTH = 140
+    MAX_CLOSING_HEADING_LENGTH = 60
+    MAX_CLOSING_BODY_LENGTH = 300
+    MAX_CTA_LABEL_LENGTH = 24
+
+    # A CTA path is pasted straight into the frontend's router. Anything that
+    # isn't a site-relative path — an absolute URL most of all — would send a
+    # visitor off the page the campaign paid for.
+    CTA_PATH_FORMAT = %r{\A/[a-z0-9\-/]*\z}
+    DEFAULT_CTA_PATH = "/sign-up".freeze
+    DEFAULT_CTA_LABEL = "Start free".freeze
+
+    # Enough tags to steer the register without pasting the whole listing.
+    TAG_SAMPLE_SIZE = 8
+
+    def initialize(slug:, title: nil, printable: nil)
+      @slug = slug.to_s.strip
+      @title = title.to_s.strip
+      @printable = printable
+    end
+
+    def call
+      if subject.blank?
+        raise GenerationError, "pick a printable, or give the page a slug to work from"
+      end
+
+      parse_response(generate_via_openai)
+    end
+
+    private
+
+    attr_reader :slug, :title, :printable
+
+    # What the page is about, in plain words. The printable's board name is the
+    # most specific thing available; the slug is the fallback so the button
+    # still works on a page whose download hasn't been chosen yet.
+    def subject
+      @subject ||= board_name.presence || topic.presence || title.presence || slug.tr("-", " ").strip
+    end
+
+    def board_name = printable&.board&.name.to_s.strip
+
+    def topic = printable&.topic.to_s.strip
+
+    def page_count = printable&.page_count.to_i
+
+    def listing_copy = @listing_copy ||= printable ? printable.listing_copy_or_default.to_h : {}
+
+    def summary = listing_copy["summary"].to_s.strip
+
+    def tags
+      Array(listing_copy["tags"]).map { |tag| tag.to_s.strip }.reject(&:blank?).first(TAG_SAMPLE_SIZE)
+    end
+
+    def generate_via_openai
+      client = OpenAiClient.new(
+        prompt: subject,
+        messages: [{ role: "user", content: build_prompt }],
+      )
+      client.instance_variable_set(:@model, OpenAiClient::GTP_MODEL)
+      result = client.create_chat(true)
+
+      raise GenerationError, "OpenAI returned no content" if result[:content].blank?
+
+      result[:content]
+    end
+
+    def build_prompt
+      <<~PROMPT
+        You are writing a landing page that gives away a free printable AAC
+        (Augmentative and Alternative Communication) resource to teachers, therapists
+        and parents. A visitor lands here, sees what the printable is, and enters an
+        email address to download it.
+
+        The printable is about: #{subject}
+        #{topic.present? ? "Its topic: #{topic}" : ""}
+        #{page_count.positive? ? "It is #{page_count} pages." : ""}
+        #{summary.present? ? "A one-line summary of it: #{summary}" : ""}
+        #{tags.any? ? "Keywords: #{tags.join(", ")}" : ""}
+
+        Write the page. Warm, plain, specific. Speak to the adult who will print it,
+        never to the child. Say "nonspeaking", never "nonverbal". No exclamation marks,
+        no "unlock", no "empower", no marketing throat-clearing. Do not mention Etsy,
+        prices, purchases, or instant downloads — this is free.
+
+        Plain text in every field: no HTML, no markdown, no emoji.
+
+        "eyebrow" — a short label for the pill above the headline, at most
+        #{MAX_EYEBROW_LENGTH} characters. For example "Free classroom kit".
+
+        "title" — the headline, at most #{MAX_TITLE_LENGTH} characters. Say what the
+        thing is, not how great it is.
+
+        "subhead" — one or two sentences under the headline saying who it is for and
+        what they can do with it. At most #{MAX_SUBHEAD_LENGTH} characters.
+
+        "items" — between #{MIN_ITEMS} and #{MAX_ITEMS} things that are inside the
+        printable. Each has a "title" (at most #{MAX_ITEM_TITLE_LENGTH} characters) and
+        a "description" (one concrete sentence, at most
+        #{MAX_ITEM_DESCRIPTION_LENGTH} characters). Be concrete about what is on the
+        pages rather than restating the benefit.
+
+        "closing" — the block under the list, with "heading" (at most
+        #{MAX_CLOSING_HEADING_LENGTH} characters), "body" (one or two sentences, at most
+        #{MAX_CLOSING_BODY_LENGTH} characters) inviting them to build their own boards
+        in the app, "cta_label" (at most #{MAX_CTA_LABEL_LENGTH} characters) and
+        "cta_path" (a site-relative path beginning with "/", normally "#{DEFAULT_CTA_PATH}").
+
+        Respond in JSON format:
+        {
+          "eyebrow": "Free classroom kit",
+          "title": "The at-school communication kit",
+          "subhead": "Print it once and put it where the talking happens.",
+          "items": [{ "title": "Core word poster", "description": "One page, 36 words, big enough to read across a room." }],
+          "closing": { "heading": "Make it yours", "body": "Build the same board in the app and change the words to fit your student.", "cta_label": "#{DEFAULT_CTA_LABEL}", "cta_path": "#{DEFAULT_CTA_PATH}" }
+        }
+
+        Return ONLY the JSON, no other text.
+      PROMPT
+    end
+
+    def parse_response(raw)
+      data = JSON.parse(raw)
+      raise GenerationError, "AI returned #{data.class.name.downcase}, not an object" unless data.is_a?(Hash)
+
+      copy = {
+        eyebrow: clean(data["eyebrow"], MAX_EYEBROW_LENGTH),
+        title: clean(data["title"], MAX_TITLE_LENGTH),
+        subhead: clean(data["subhead"], MAX_SUBHEAD_LENGTH),
+        items: clean_items(data["items"]),
+        closing: clean_closing(data["closing"]),
+      }
+
+      if copy[:title].blank? && copy[:subhead].blank? && copy[:items].empty?
+        raise GenerationError, "AI returned nothing usable"
+      end
+
+      copy
+    rescue JSON::ParserError => e
+      raise GenerationError, "Failed to parse AI response: #{e.message}"
+    end
+
+    # Models answer a "short phrase" request with a sentence often enough, and a
+    # "plain text" request with markup often enough, to be worth handling rather
+    # than trusting.
+    def clean(value, limit)
+      value.to_s.gsub(/<[^>]*>/, " ").squish.truncate(limit)
+    end
+
+    # Order is the model's, so its best material survives the cap. An entry
+    # missing both halves is dropped rather than rendered as an empty card.
+    def clean_items(raw_items)
+      Array(raw_items).filter_map do |item|
+        next unless item.is_a?(Hash)
+
+        item_title = clean(item["title"], MAX_ITEM_TITLE_LENGTH)
+        description = clean(item["description"], MAX_ITEM_DESCRIPTION_LENGTH)
+        next if item_title.blank? && description.blank?
+
+        { "title" => item_title, "description" => description }
+      end.first(MAX_ITEMS)
+    end
+
+    def clean_closing(raw_closing)
+      return {} unless raw_closing.is_a?(Hash)
+
+      closing = {
+        "heading" => clean(raw_closing["heading"], MAX_CLOSING_HEADING_LENGTH),
+        "body" => clean(raw_closing["body"], MAX_CLOSING_BODY_LENGTH),
+        "cta_label" => clean(raw_closing["cta_label"], MAX_CTA_LABEL_LENGTH).presence || DEFAULT_CTA_LABEL,
+        "cta_path" => clean_cta_path(raw_closing["cta_path"]),
+      }
+
+      closing.values.all?(&:blank?) ? {} : closing
+    end
+
+    def clean_cta_path(value)
+      path = value.to_s.strip.downcase
+      CTA_PATH_FORMAT.match?(path) ? path : DEFAULT_CTA_PATH
+    end
+  end
+end

--- a/app/views/admin/kit_pages/_form.html.erb
+++ b/app/views/admin/kit_pages/_form.html.erb
@@ -10,7 +10,12 @@
   </div>
 <% end %>
 
-<%= form_tag url, method: method do %>
+<%# turbo: false is load-bearing. Autofill answers with a rendered 200 rather
+    than a redirect, because it hands the admin's own submission back to them
+    with the blanks filled. Turbo Drive refuses a 2xx form response that isn't a
+    redirect, throws, and leaves the page untouched — so with Turbo on, the
+    autofill button is a no-op. %>
+<%= form_tag url, method: method, data: { turbo: false } do %>
   <div class="admin-card border rounded-xl p-5 mb-6">
     <h2 class="text-sm font-medium text-t1 mb-4">Page</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -46,8 +51,23 @@
     <h2 class="text-sm font-medium text-t1 mb-1">Download</h2>
     <p class="text-[11px] text-t3 mb-4">
       Only finished printables that actually carry a PDF are listed. The visitor gets this exact document
-      after entering an email.
+      after entering an email. Its mockup images are shown on the page automatically.
     </p>
+
+    <%# formaction, not a second form: the copy is written from the printable
+        chosen here plus anything already typed above, so the whole form has to
+        travel. formnovalidate because slug and title are required fields and
+        filling them in is the point of the button. %>
+    <div class="flex items-center gap-3 mb-4">
+      <button type="submit" formaction="<%= autofill_path(@kit_page) %>" formnovalidate
+              class="text-xs font-medium px-3 py-2 rounded border admin-input cursor-pointer text-t1 whitespace-nowrap">
+        Autofill the page
+      </button>
+      <span class="text-[11px] text-t3">
+        Writes the slug, headline, subhead, what's-inside list and call to action from the printable.
+        Only fills what's blank — nothing you've typed is replaced.
+      </span>
+    </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
@@ -92,6 +112,7 @@
     <h2 class="text-sm font-medium text-t1 mb-1">Content</h2>
     <p class="text-[11px] text-t3 mb-4">
       JSON. <code>items</code> is the "what's inside" list; <code>closing</code> is the block under it.
+      Autofill writes this only when it's empty — clear it and autofill again to have it rewritten.
     </p>
     <%= text_area_tag :content, @content_raw || (@kit_page.content.presence && JSON.pretty_generate(@kit_page.content)),
           id: "content", rows: 14, spellcheck: false,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,12 @@ Rails.application.routes.draw do
       member do
         post :publish
         post :unpublish
+        # Autofill is on both the collection and a member because the same form
+        # partial serves `new` and `edit`.
+        post :autofill
+      end
+      collection do
+        post :autofill
       end
     end
     get "feedback", to: "feedback#index", as: :dashboard_feedback

--- a/spec/models/kit_page_spec.rb
+++ b/spec/models/kit_page_spec.rb
@@ -124,9 +124,77 @@ RSpec.describe KitPage, type: :model do
       page = create(:kit_page, board_printable: printable)
 
       expect(page.public_view.keys).to match_array(
-        %i[slug title eyebrow subhead content cta_label cta_path downloadable]
+        %i[slug title eyebrow subhead content cta_label cta_path downloadable images]
       )
       expect(page.public_view[:downloadable]).to eq(true)
+      expect(page.public_view.values_at(:slug, :title)).to all(be_present)
+    end
+
+    it "still carries no PDF URL once the mockups are in the payload" do
+      printable.attach_pdf!(filename: "a.color.pdf", bytes: "%PDF", variant: "color")
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      page = create(:kit_page, board_printable: printable)
+
+      urls = page.public_view[:images].map { |image| image[:url] }
+      expect(urls).to be_present
+      expect(urls.join).not_to include(".pdf")
+    end
+  end
+
+  describe "#gallery_images" do
+    it "returns the curated variants, in landing-page order" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_ON_A_DEVICE)
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_ON_PAPER)
+      page = create(:kit_page, board_printable: printable)
+
+      expect(page.gallery_images.map { |image| image[:variant] })
+        .to eq([BoardPrintable::IMAGE_HERO, BoardPrintable::IMAGE_ON_PAPER, BoardPrintable::IMAGE_ON_A_DEVICE])
+    end
+
+    it "leaves out gallery images that are Etsy shop framing" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_ABOUT)
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_PAGE_INDEX)
+      page = create(:kit_page, board_printable: printable)
+
+      expect(page.gallery_images.map { |image| image[:variant] }).to eq([BoardPrintable::IMAGE_HERO])
+    end
+
+    it "carries only the variant and the URL" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      page = create(:kit_page, board_printable: printable)
+
+      expect(page.gallery_images.first.keys).to match_array(%i[variant url])
+    end
+
+    it "is empty with no printable" do
+      expect(create(:kit_page, board_printable: nil).gallery_images).to eq([])
+    end
+
+    it "is empty while the printable is still generating" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      printable.update!(status: "pending")
+
+      expect(create(:kit_page, board_printable: printable.reload).gallery_images).to eq([])
+    end
+
+    it "is empty when the printable carries only PDFs" do
+      printable.attach_pdf!(filename: "a.color.pdf", bytes: "%PDF", variant: "color")
+
+      expect(create(:kit_page, board_printable: printable).gallery_images).to eq([])
+    end
+
+    it "drops an image whose URL can't be resolved" do
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+      printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_ON_PAPER)
+      page = create(:kit_page, board_printable: printable)
+      allow(page.board_printable).to receive(:listing_images_view).and_return([
+        { variant: BoardPrintable::IMAGE_HERO, url: nil },
+        { variant: BoardPrintable::IMAGE_ON_PAPER, url: "https://cdn.example/on-paper.png" },
+      ])
+
+      expect(page.gallery_images).to eq([{ variant: BoardPrintable::IMAGE_ON_PAPER, url: "https://cdn.example/on-paper.png" }])
     end
   end
 

--- a/spec/requests/admin/kit_pages_spec.rb
+++ b/spec/requests/admin/kit_pages_spec.rb
@@ -263,6 +263,137 @@ RSpec.describe "Admin kit pages", type: :request do
       end
     end
 
+    describe "POST /admin/kit_pages/autofill" do
+      let(:ai_copy) do
+        {
+          "eyebrow" => "Free classroom kit",
+          "title" => "The at-school communication kit",
+          "subhead" => "Print it once and put it where the talking happens.",
+          "items" => [{ "title" => "Snack time page", "description" => "One page, 36 words." }],
+          "closing" => { "heading" => "Make it yours", "body" => "Build it in the app.",
+                         "cta_label" => "Start free", "cta_path" => "/sign-up" },
+        }.to_json
+      end
+
+      before do
+        allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+          .and_return({ role: "assistant", content: ai_copy })
+      end
+
+      def blank_params(overrides = {})
+        {
+          slug: "", title: "", eyebrow: "", subhead: "", cta_label: "", cta_path: "", content: "",
+          board_printable_id: printable.id, printable_variant: "color",
+        }.merge(overrides)
+      end
+
+      it "fills every blank field from the printable" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("The at-school communication kit")
+        expect(response.body).to include("Free classroom kit")
+        expect(response.body).to include("Snack time page")
+      end
+
+      it "derives the slug from the board name" do
+        # A board name that isn't the form's own "at-school" placeholder, or the
+        # assertion would pass without any derivation happening.
+        other = create(:board, user: owner, name: "Playground talk")
+        other_printable = BoardPrintable.create!(board: other, status: "complete", board_ids: [other.id], page_count: 2)
+          .tap { |p| p.attach_pdf!(filename: "p.color.pdf", bytes: "%PDF", variant: "color") }
+
+        post autofill_admin_dashboard_kit_pages_path,
+             params: blank_params(board_printable_id: other_printable.id)
+
+        expect(response.body).to include('value="playground-talk"')
+      end
+
+      it "uniquifies a derived slug that is already taken" do
+        create(:kit_page, slug: "at-school")
+
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params
+
+        expect(response.body).to include('value="at-school-2"')
+      end
+
+      it "never saves" do
+        expect { post autofill_admin_dashboard_kit_pages_path, params: blank_params }
+          .not_to change(KitPage, :count)
+      end
+
+      it "leaves a slug that was already typed alone" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params(slug: "my-own-slug")
+
+        expect(response.body).to include("my-own-slug")
+        expect(response.body).not_to include('value="at-school"')
+      end
+
+      it "leaves a title that was already typed alone" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params(title: "My own headline")
+
+        expect(response.body).to include("My own headline")
+        expect(response.body).not_to include("The at-school communication kit")
+      end
+
+      it "leaves a hand-written content blob alone" do
+        typed = { "items" => [{ "title" => "Mine", "description" => "Hand written." }] }.to_json
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params(content: typed)
+
+        expect(response.body).to include("Hand written.")
+        expect(response.body).not_to include("Snack time page")
+      end
+
+      it "works with no printable chosen, from the slug alone" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params(slug: "at-the-dentist", board_printable_id: "")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("The at-school communication kit")
+      end
+
+      it "renders an error when there is nothing to work from" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params(board_printable_id: "")
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("write the copy")
+      end
+
+      it "renders an error when the model answers with nonsense" do
+        allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+          .and_return({ role: "assistant", content: "not json" })
+
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("write the copy")
+      end
+
+      it "autofills an existing page without saving it" do
+        page = create(:kit_page, slug: "at-school", title: "Old title", eyebrow: nil)
+
+        post autofill_admin_dashboard_kit_page_path(page), params: blank_params(slug: "at-school", title: "Old title")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Old title")
+        expect(response.body).to include("Free classroom kit")
+        expect(page.reload.eyebrow).to be_nil
+      end
+
+      it "redirects when the page is gone" do
+        post autofill_admin_dashboard_kit_page_path(id: 0), params: blank_params
+
+        expect(response).to redirect_to(admin_dashboard_kit_pages_path)
+      end
+
+      # Request specs never run Turbo, so this assertion is the only thing that
+      # catches the button silently becoming a no-op in a browser.
+      it "renders the form with Turbo disabled" do
+        post autofill_admin_dashboard_kit_pages_path, params: blank_params
+
+        expect(response.body).to include('data-turbo="false"')
+      end
+    end
+
     describe "GET /admin/kit_pages/:id/edit" do
       it "renders the stored content as pretty JSON" do
         page = create(:kit_page, slug: "at-school", content: { "items" => [{ "title" => "Poster" }] })

--- a/spec/requests/api/kit_pages_spec.rb
+++ b/spec/requests/api/kit_pages_spec.rb
@@ -94,6 +94,39 @@ RSpec.describe "API kit_pages", type: :request do
       expect(response).to have_http_status(:not_found)
       expect(JSON.parse(response.body)).to eq("error" => "kit_page_not_found")
     end
+    context "the mockup images" do
+      it "returns the curated gallery, in landing-page order" do
+        attach_all_variants
+        printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_ON_PAPER)
+        printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+
+        get "/api/kit_pages/#{page.slug}"
+
+        body = JSON.parse(response.body)
+        expect(body["images"].map { |image| image["variant"] })
+          .to eq([BoardPrintable::IMAGE_HERO, BoardPrintable::IMAGE_ON_PAPER])
+        expect(body["images"].map { |image| image["url"] }).to all(be_present)
+      end
+
+      it "returns an empty list for a page with no printable" do
+        page.update!(board_printable: nil)
+
+        get "/api/kit_pages/#{page.slug}"
+
+        expect(JSON.parse(response.body)["images"]).to eq([])
+      end
+
+      it "reveals a mockup but still no PDF, which stays behind the email" do
+        attach_all_variants
+        printable.attach_image!(bytes: "PNG", variant: BoardPrintable::IMAGE_HERO)
+
+        get "/api/kit_pages/#{page.slug}"
+
+        expect(JSON.parse(response.body)["images"]).to be_present
+        expect(response.body).not_to include(".pdf")
+      end
+    end
+
   end
 
   describe "POST /api/kit_pages/:slug/download" do

--- a/spec/services/kit_pages/copy_suggester_spec.rb
+++ b/spec/services/kit_pages/copy_suggester_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.describe KitPages::CopySuggester do
+  def ai_copy(overrides = {})
+    {
+      "eyebrow" => "Free classroom kit",
+      "title" => "The at-school communication kit",
+      "subhead" => "Print it once and put it where the talking happens.",
+      "items" => [
+        { "title" => "Core word poster", "description" => "One page, 36 words." },
+        { "title" => "Snack board", "description" => "For the table." },
+        { "title" => "Playground page", "description" => "For outside." },
+      ],
+      "closing" => {
+        "heading" => "Make it yours",
+        "body" => "Build the same board in the app.",
+        "cta_label" => "Start free",
+        "cta_path" => "/sign-up",
+      },
+    }.merge(overrides).to_json
+  end
+
+  def stub_ai(content)
+    allow_any_instance_of(OpenAiClient).to receive(:create_chat)
+      .and_return({ role: "assistant", content: content })
+  end
+
+  before { stub_ai(ai_copy) }
+
+  def suggest(**overrides)
+    described_class.new(**{ slug: "at-school" }.merge(overrides)).call
+  end
+
+  describe "#call" do
+    it "returns the whole page" do
+      copy = suggest
+
+      expect(copy[:eyebrow]).to eq("Free classroom kit")
+      expect(copy[:title]).to eq("The at-school communication kit")
+      expect(copy[:subhead]).to eq("Print it once and put it where the talking happens.")
+      expect(copy[:items].first).to eq({ "title" => "Core word poster", "description" => "One page, 36 words." })
+      expect(copy[:closing]["heading"]).to eq("Make it yours")
+    end
+
+    it "works from the slug alone, so the button still helps before a printable is chosen" do
+      expect { suggest(printable: nil) }.not_to raise_error
+    end
+
+    it "refuses to run with nothing to work from" do
+      expect { described_class.new(slug: "", title: "", printable: nil).call }
+        .to raise_error(described_class::GenerationError, /pick a printable/)
+    end
+
+    it "raises when the response isn't parseable" do
+      stub_ai("not json at all")
+      expect { suggest }.to raise_error(described_class::GenerationError, /Failed to parse/)
+    end
+
+    it "raises when the response is a JSON array rather than an object" do
+      stub_ai("[]")
+      expect { suggest }.to raise_error(described_class::GenerationError, /not an object/)
+    end
+
+    it "raises when nothing usable comes back" do
+      stub_ai({ "eyebrow" => "Free kit" }.to_json)
+      expect { suggest }.to raise_error(described_class::GenerationError, /nothing usable/)
+    end
+  end
+
+  describe "cleanup" do
+    it "strips HTML, because the frontend renders these as text" do
+      stub_ai(ai_copy("title" => "<h1>The at-school kit</h1>"))
+
+      expect(suggest[:title]).to eq("The at-school kit")
+    end
+
+    it "truncates every runaway field" do
+      stub_ai(ai_copy(
+        "eyebrow" => "word " * 40,
+        "title" => "word " * 60,
+        "subhead" => "word " * 120,
+      ))
+      copy = suggest
+
+      expect(copy[:eyebrow].length).to be <= described_class::MAX_EYEBROW_LENGTH
+      expect(copy[:title].length).to be <= described_class::MAX_TITLE_LENGTH
+      expect(copy[:subhead].length).to be <= described_class::MAX_SUBHEAD_LENGTH
+    end
+
+    it "caps the number of items" do
+      many = Array.new(12) { |i| { "title" => "Item #{i}", "description" => "A page." } }
+      stub_ai(ai_copy("items" => many))
+
+      expect(suggest[:items].length).to eq(described_class::MAX_ITEMS)
+    end
+
+    it "drops an item with neither a title nor a description" do
+      stub_ai(ai_copy("items" => [{ "title" => "", "description" => "" }, { "title" => "Real", "description" => "Yes." }]))
+
+      expect(suggest[:items]).to eq([{ "title" => "Real", "description" => "Yes." }])
+    end
+
+    it "ignores an items entry that isn't an object" do
+      stub_ai(ai_copy("items" => ["just a string", { "title" => "Real", "description" => "Yes." }]))
+
+      expect(suggest[:items]).to eq([{ "title" => "Real", "description" => "Yes." }])
+    end
+  end
+
+  describe "the CTA path" do
+    it "keeps a site-relative path" do
+      expect(suggest[:closing]["cta_path"]).to eq("/sign-up")
+    end
+
+    it "replaces an absolute URL, which would send the visitor off the page" do
+      stub_ai(ai_copy("closing" => { "heading" => "Go", "cta_path" => "https://example.com/steal" }))
+
+      expect(suggest[:closing]["cta_path"]).to eq(described_class::DEFAULT_CTA_PATH)
+    end
+
+    it "replaces a path that doesn't start with a slash" do
+      stub_ai(ai_copy("closing" => { "heading" => "Go", "cta_path" => "sign-up" }))
+
+      expect(suggest[:closing]["cta_path"]).to eq(described_class::DEFAULT_CTA_PATH)
+    end
+
+    it "falls back to a default label when the model omits one" do
+      stub_ai(ai_copy("closing" => { "heading" => "Go", "cta_label" => "" }))
+
+      expect(suggest[:closing]["cta_label"]).to eq(described_class::DEFAULT_CTA_LABEL)
+    end
+
+    it "returns an empty closing when the model omits the block" do
+      stub_ai(ai_copy("closing" => nil))
+
+      expect(suggest[:closing]).to eq({})
+    end
+  end
+
+  describe "what the printable contributes to the prompt" do
+    let(:board) { create(:board, name: "At school") }
+    let(:printable) do
+      BoardPrintable.create!(board: board, status: "complete", page_count: 6,
+                             topic: "the school day",
+                             listing_copy: { "summary" => "Six pages for the classroom.",
+                                             "description" => "INSTANT DOWNLOAD. No sign-in required.",
+                                             "tags" => %w[aac classroom] })
+    end
+
+    it "feeds the board name, topic, page count, summary and tags" do
+      prompt = nil
+      allow_any_instance_of(OpenAiClient).to receive(:create_chat) do |client|
+        prompt = client.instance_variable_get(:@messages).first[:content]
+        { role: "assistant", content: ai_copy }
+      end
+
+      described_class.new(slug: "at-school", printable: printable).call
+
+      expect(prompt).to include("At school")
+      expect(prompt).to include("the school day")
+      expect(prompt).to include("6 pages")
+      expect(prompt).to include("Six pages for the classroom.")
+      expect(prompt).to include("aac, classroom")
+    end
+
+    it "never feeds the Etsy description, which is checkout prose for a paid buyer" do
+      prompt = nil
+      allow_any_instance_of(OpenAiClient).to receive(:create_chat) do |client|
+        prompt = client.instance_variable_get(:@messages).first[:content]
+        { role: "assistant", content: ai_copy }
+      end
+
+      described_class.new(slug: "at-school", printable: printable).call
+
+      expect(prompt).not_to include("INSTANT DOWNLOAD")
+      expect(prompt).not_to include("No sign-in required")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`/admin/kit_pages` was a raw data-entry form: to launch a `/kit/<slug>` lead magnet you typed a slug, headline, eyebrow, subhead, two CTA fields, and then hand-wrote a JSON blob in a monospace textarea. And the page it produced had no picture of the printable it was giving away.

**Pick the printable, press "Autofill the page".** Everything else is written for you.

### Autofill

- `KitPages::CopySuggester` — one OpenAI JSON-mode call returning `{eyebrow, title, subhead, items, closing}`, built the same way as `Boards::AdminBuilder::MetadataSuggester`: same `GenerationError`, same model-forcing idiom, hard clamps on every field, HTML stripped.
- **Never fed `listing_copy["description"]`.** That's Etsy checkout prose — "instant download", "no sign-in required" — and reads as a sales pitch on a page giving the thing away. Only `summary` and `tags` cross over; a spec asserts the description never reaches the prompt.
- **Blanks-only, and it never saves.** Same rule as `Admin::BoardBuildsController#suggest_context` — anything typed survives, including a hand-written content blob. The action renders; a bad suggestion is discarded by navigating away.
- The slug is derived from the board name **only into a blank field**, and uniquified with a `-2` suffix. Re-deriving an existing slug would move a live `/kit/<slug>` URL — the same rule boards got in #727.
- Routed on both the collection and a member (one form partial serves `new` and `edit`). Button is a `formaction` submit with `formnovalidate`; the form now carries `data: { turbo: false }`, without which Turbo Drive refuses the rendered 200 and the button is a silent no-op.

### Mockup images

`public_view` now carries `images: [{variant, url}]` — the printable's rendered marketplace mockups, so the landing page can show the thing it's giving away.

- Curated **allowlist** (`KitPage::KIT_IMAGE_ORDER`): hero, on_paper, flip_book, whats_included, on_a_device. `about` and `page_index` are Etsy shop framing and read wrong on a free page.
- Reuses `BoardPrintable#listing_images_view` (already filters retired gallery designs). Narrowed by allowlist, never by exclusion — same discipline `pdf_files` keeps.
- **Not a hole in the no-file-URL rule.** The PDF is still revealed only by the download endpoint after a `DownloadLead` is written. These are marketing renders on the same public CDN, and they're what persuades a visitor to enter an email at all.

Frontend rendering ships separately on the kit-landing-pages branch.

## Test plan

```
bundle exec rspec spec/services/kit_pages spec/models/kit_page_spec.rb \
  spec/requests/admin/kit_pages_spec.rb spec/requests/api/kit_pages_spec.rb \
  spec/requests/api/download_leads_kit_pages_regression_spec.rb \
  spec/sidekiq/mailchimp_upsert_lead_job_spec.rb
```

**120 examples, 0 failures.** Plus `spec/requests/admin/access_control_spec.rb` — 15/15, since this adds routes under `/admin`.

New coverage: every suggester clamp, the CTA-path rejection (an absolute URL would send visitors off the page), the "description never reaches the prompt" assertion, blanks-only merging, `not_to change(KitPage, :count)`, the `data-turbo="false"` guard, and gallery curation/order/nil-URL handling.

Docs updated: `CLAUDE.md` invariants, `.claude-notes/kit-landing-pages-handoff.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)