### PR TITLE
fix(boards): show an imported set's root board like any other board

### DIFF
--- a/.claude-notes/boards-and-teams.md
+++ b/.claude-notes/boards-and-teams.md
@@ -376,6 +376,48 @@ Two rails keep a malformed file from producing a monster tile:
 A file with neither repeated ids nor `ext_` fields imports exactly as it did
 before — every tile 1x1 — so this is additive for every OBF already in use.
 
+## OBF/OBZ import — an imported set is ONE board in a listing
+
+An imported set is represented everywhere by its **root**; the interior pages
+are sub-boards. This used to be enforced with a blanket `where(obf_id: nil)` on
+`Board.searchable` and `Board.admin_owned_boards`, which hid the root too — an
+import was unreachable from anywhere but the BoardGroup it arrived in, while a
+user's own index (no such filter) showed all thirty pages at once.
+
+`Boards::ImportedSetClassifier` is what makes `sub_board` trustworthy enough to
+carry that rule instead:
+
+- **root** → `sub_board: false` plus `settings["main_board"]`
+  (`Board::MAIN_BOARD_PIN`). The pin is not optional: every page of a set
+  carries a way home, so `parent_boards` always finds tiles pointing at the
+  root and the next save for any unrelated reason would demote it. Same job
+  `builder_root` does for a Board Builder tree; `check_is_sub_board` honours
+  both.
+- **pages** → `sub_board: true`, tagged `sub-board`.
+
+Import can't get this right on its own — `ObzImporter` links the tiles with
+`update_columns` (callbacks skipped) and only once every board in the package
+exists, so `check_is_sub_board` never sees the finished graph. Run the
+classifier AFTER `Boards::BackTileStamper`: without membership it walks the set
+with `Boards::ReachableBoardIds(skip_back_tiles: true)`, and an unflagged way
+home would walk it straight out of the set. A `.obz` import passes
+`member_ids:` (the BoardGroup's boards — every member but the root is a page,
+including one nothing links to); a seeded robust set has no BoardGroup and is
+walked from its `board_builder_robust` root.
+
+Scopes read `Board.without_imported_pages`
+(`obf_id IS NULL OR NOT sub_board`). Backfill for anything imported before the
+classifier existed: `bin/rails obf_import:classify_sets` (`DRY_RUN=false` to
+apply).
+
+**Board Builder seed material is excluded by name, not by accident.** The
+robust-set roots (Core 60/84) and the fringe page templates are admin-owned,
+`predefined` and `published` so the builder can clone them — they were kept out
+of the public catalogue only as a side effect of the OBF filter. That is now
+`Board.not_builder_seed`, keyed on `Boards::RobustSets::ROOT_MARKER` and
+`Boards::FringeTemplates::TEMPLATE_MARKER`. Dropping it publishes a dozen
+builder building blocks into the public board gallery.
+
 ## OBF/OBZ import — copyright policy
 
 Imports via `POST /api/boards/import_obf` are gated to avoid silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Imported boards show up on the boards page like any other board.** A board
+  set imported from a `.obf`/`.obz` file was filtered out of board search and
+  out of the public board library, so the only way back to it was the group it
+  came in with. Imports now behave like everything else: the set's home board
+  appears under the "Main Boards" filter and in search, and its interior pages
+  sit under it as sub-boards instead of burying the rest of the list. Existing
+  imports are settled by `bin/rails obf_import:classify_sets`.
+
 ### Added
 
 - **Turn a whole selection into text tiles at once.** The board editor's bulk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,22 @@ an explicit decision, not a drive-by edit.
   `board_type: "predictive"`. `#authored_tile_text?` widens that to every tile
   whose text isn't a word — doors plus keyboard keys ("A", "Space"), which
   carry a `data["tile_type"]`.
+- **An imported board set is ONE board in a listing: its root.** The interior
+  pages are sub-boards. That rule used to be a blanket `where(obf_id: nil)` on
+  `Board.searchable` / `Board.admin_owned_boards`, which hid the root too — an
+  import was unreachable from anywhere but the BoardGroup it arrived in, while
+  the user's own index (no such filter) listed all thirty pages. The scopes now
+  read `Board.without_imported_pages` (`obf_id IS NULL OR NOT sub_board`), and
+  `Boards::ImportedSetClassifier` is what makes `sub_board` true enough to carry
+  it: import links tiles with `update_columns` and only after every board
+  exists, so `check_is_sub_board` never sees the finished graph. The root is
+  PINNED (`settings["main_board"]`, alongside `builder_root`) because every page
+  carries a way home — without the pin the next unrelated save demotes it.
+  Run the classifier after `Boards::BackTileStamper`; the walk it falls back to
+  skips back tiles, and an unflagged way home walks straight out of the set.
+  Board Builder seed material (robust-set roots, fringe templates) stays out of
+  the public catalogue by name — `Board.not_builder_seed` — not as a side effect
+  of the OBF filter. Details: `.claude-notes/boards-and-teams.md`.
 - **`data["back_tile"]` is the navigation-DIRECTION signal; `mute_name` is not.**
   Folder links run both ways in practice — every page in a set carries a way
   home stored as an ordinary folder tile — so a walk over `predictive_board_id`

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -52,7 +52,6 @@ class API::BoardsController < API::ApplicationController
     unless current_user
       static_scope = Board.public_boards
       static_scope = static_scope.with_all_tags(selected_tags) if selected_tags.present?
-      static_scope = static_scope.where(obf_id: nil)
       static_scope = static_scope.search_by_name(query) if query.present?
 
       last_modified = static_scope.maximum(:updated_at) || Time.zone.at(0)
@@ -133,13 +132,13 @@ class API::BoardsController < API::ApplicationController
     # ---------------------------
     # 3. NORMAL MODE (no search)
     # ---------------------------
-    # NOTE: deliberately no `where(obf_id: nil)` here. That filter belongs
-    # on cross-user discovery scopes (Board.searchable, Board.public_boards)
-    # — it keeps a user's imports out of OTHER users' search results. On a
-    # user's OWN index, we have to show their imports too; otherwise
-    # `boards.count` (which exposes board_count in api_view) reports 6 while
-    # this listing renders 4, and imported boards become unreachable from
-    # the boards page.
+    # NOTE: deliberately no obf filter here. A user's OWN index shows their
+    # imports, pages included; otherwise `boards.count` (which exposes
+    # board_count in api_view) reports 6 while this listing renders 4. The
+    # interior pages of an import are `sub_board: true`
+    # (Boards::ImportedSetClassifier), so the default "Main Boards" filter
+    # already collapses each imported set to its root — no obf-specific rule
+    # needed on any of these listings.
     base_scope = current_user.boards
     filtered_scope = apply_filter(base_scope, filter)
     filtered_scope = filtered_scope.with_any_tags(selected_tags) if selected_tags.present?

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -145,7 +145,16 @@ class Board < ApplicationRecord
   scope :alphabetical, -> { order(Arel.sql("LOWER(name) ASC")) }
   scope :reverse_alphabetical, -> { order(Arel.sql("LOWER(name) DESC")) }
   scope :with_image_parent, -> { where.associated(:image_parent) }
-  scope :searchable, -> { where.not(board_type: "menu").where(obf_id: nil) }
+  # An imported (.obz) set is ONE entry in a listing: its ROOT board. The set's
+  # interior pages are sub-boards, and a 30-page core set would otherwise bury
+  # every other board in search and in the public gallery. That is what the
+  # blanket `where(obf_id: nil)` used to buy — at the cost of hiding the root
+  # too, which made an import unreachable from anywhere but its own group.
+  # `Boards::ImportedSetClassifier` is what makes `sub_board` trustworthy here:
+  # import links the tiles with `update_columns`, so `check_is_sub_board` never
+  # sees the finished graph on its own.
+  scope :without_imported_pages, -> { where("boards.obf_id IS NULL OR NOT COALESCE(boards.sub_board, false)") }
+  scope :searchable, -> { where.not(board_type: "menu").without_imported_pages }
   scope :menus, -> { where(board_type: "menu").or(where(parent_type: "Menu")) }
   scope :non_menus, -> { where.not(board_type: "menu").where.not(parent_type: "Menu") }
   scope :user_made, -> { where(parent_type: "User") }
@@ -171,13 +180,23 @@ class Board < ApplicationRecord
 
   scope :including_images, -> { includes(board_images: :image) }
   # Every admin-owned board eligible to be treated as public: published, not a
-  # Menu extraction, not an OBF import, and not a Board Builder child page (the
-  # whole tree counts as its root). `public_boards` narrows this to the
-  # curated catalogue (`predefined: true`); the admin printables dashboard
-  # wants this wider set — predefined or not — so a Board Builder root or any
-  # other admin-owned published board is offered without needing the
-  # catalogue flag.
-  scope :admin_owned_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, published: true).where.not(parent_type: "Menu").where(obf_id: nil).not_builder_child }
+  # Menu extraction, not an interior page of an imported set, and not a Board
+  # Builder child page (the whole tree counts as its root). `public_boards`
+  # narrows this to the curated catalogue (`predefined: true`); the admin
+  # printables dashboard wants this wider set — predefined or not — so a Board
+  # Builder root or any other admin-owned published board is offered without
+  # needing the catalogue flag.
+  # Board Builder's seed material — the robust vocab-set roots (Core 60/84) and
+  # the fringe page templates — is admin-owned, predefined and published so the
+  # builder can clone it, not because it belongs in the public catalogue. It
+  # used to be kept out of `admin_owned_boards` as a side effect of the blanket
+  # OBF filter (all of it is seeded from .obf). Name the exclusion instead, or
+  # lifting that filter silently publishes a dozen builder building blocks.
+  scope :not_builder_seed, -> {
+    where("boards.settings->>'#{Boards::FringeTemplates::TEMPLATE_MARKER}' IS NULL")
+      .where("NOT COALESCE((boards.settings->>'#{Boards::RobustSets::ROOT_MARKER}')::boolean, false)")
+  }
+  scope :admin_owned_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, published: true).where.not(parent_type: "Menu").without_imported_pages.not_builder_seed.not_builder_child }
   scope :public_boards, -> { admin_owned_boards.where(predefined: true) }
   scope :public_menu_boards, -> { where(user_id: User::DEFAULT_ADMIN_ID, predefined: true, published: true, parent_type: "Menu") }
   scope :without_preset_display_image, -> { where.missing(:preset_display_image_attachment) }
@@ -280,6 +299,42 @@ class Board < ApplicationRecord
   # and marks settings["builder_root"] (see BoardTreeBuilder/SeededSetCloner).
   def builder_root?
     settings.is_a?(Hash) && !!settings["builder_root"]
+  end
+
+  # settings["main_board"] — "this board is the top of its own set; never demote
+  # it." An imported set's root needs it for the same reason a Board Builder
+  # root does: every page of a set carries a way home, so `parent_boards` always
+  # finds tiles pointing AT the root, and the next save for any unrelated reason
+  # would flip it to a sub-board and drop it out of `main_boards`.
+  MAIN_BOARD_PIN = "main_board".freeze
+
+  def pinned_main_board?
+    settings.is_a?(Hash) && !!settings[MAIN_BOARD_PIN]
+  end
+
+  # Pin + demote are derived state, written with update_columns on purpose: a
+  # full save re-runs the whole before_save chain (layout, parent, voice, cover
+  # render) on a board nobody asked us to edit, and would re-derive the very
+  # flag we are setting.
+  def pin_as_main_board!
+    return false if pinned_main_board? && sub_board == false
+
+    remove_tag(IS_SUB_BOARD_TAG)
+    update_columns(
+      settings: (settings || {}).merge(MAIN_BOARD_PIN => true),
+      sub_board: false,
+      tags: tags,
+      updated_at: Time.current,
+    )
+    true
+  end
+
+  def mark_as_sub_board!
+    return false if sub_board? && Array(tags).include?(self.class.normalize_tag_value(IS_SUB_BOARD_TAG))
+
+    add_tag(IS_SUB_BOARD_TAG)
+    update_columns(sub_board: true, tags: tags, updated_at: Time.current)
+    true
   end
 
   # The builder BoardGroup that owns this root's built tree (issue #407).
@@ -933,8 +988,10 @@ class Board < ApplicationRecord
     # the root. Those back-links would otherwise make the root look like a
     # sub-board (it has "parent" boards) and drop it out of the main_boards scope
     # / the communicator's dashboard. Pin it as a main board regardless of who
-    # links to it.
-    if builder_root?
+    # links to it. `MAIN_BOARD_PIN` is the same pin for an imported set's root
+    # (Boards::ImportedSetClassifier) — every page of an .obz carries a way
+    # home, so its root has inbound links from the moment it finishes importing.
+    if builder_root? || pinned_main_board?
       self.sub_board = false
       remove_tag(IS_SUB_BOARD_TAG)
       return

--- a/app/models/obz_importer.rb
+++ b/app/models/obz_importer.rb
@@ -97,6 +97,8 @@ class ObzImporter
 
     stamp_back_tiles!
 
+    classify_set!(root_board)
+
     persist_import_audit!
 
     { boards: boards_by_obf_id, root_board: root_board, dynamic_data: dynamic_data_rows }
@@ -181,6 +183,23 @@ class ObzImporter
     Boards::BackTileStamper.new(@board_group.reload).call
   rescue StandardError => e
     Rails.logger.warn "[ObzImporter] Failed to flag back tiles: #{e.message}"
+  end
+
+  # An imported set is ONE board in every listing: its root. Until this runs the
+  # links were written with update_columns, so Board#check_is_sub_board never
+  # saw them and all 30 pages of a core set sat in `main_boards`. Runs AFTER
+  # stamp_back_tiles! — the classifier reads direction off those flags when it
+  # has to walk the set. Never fatal: an unclassified set still imported fine,
+  # and `obf_import:classify_sets` can settle it later.
+  def classify_set!(root_board)
+    return unless root_board
+
+    Boards::ImportedSetClassifier.new(
+      root_board,
+      member_ids: @board_group&.reload&.board_ids,
+    ).call
+  rescue StandardError => e
+    Rails.logger.warn "[ObzImporter] Failed to classify imported set: #{e.message}"
   end
 
   def resolve_link_target(dynamic_board, boards_by_obf_id, obf_id_by_path)

--- a/app/services/boards/imported_set_classifier.rb
+++ b/app/services/boards/imported_set_classifier.rb
@@ -1,0 +1,61 @@
+module Boards
+  # Settles `sub_board` across an imported board set so the set reads as ONE
+  # board everywhere a board is listed.
+  #
+  # An import can't get this right on its own: `ObzImporter` writes the tile
+  # links with `update_columns` (callbacks skipped) and only once every board in
+  # the package exists, so `Board#check_is_sub_board` never sees the finished
+  # graph. Every page of a 30-page set stays `sub_board: false` and the whole
+  # set lands in `main_boards`, in board search, and — for an admin-owned set —
+  # in the public gallery. Run this once the links and the back-tile flags are
+  # in place and the set collapses to the one board a human would name:
+  #
+  #   root  → `sub_board: false`, pinned with `settings["main_board"]` so a
+  #           later save can't demote it (every page carries a way home, so the
+  #           root always has inbound links)
+  #   pages → `sub_board: true`, tagged "sub-board"
+  #
+  # Membership: pass `member_ids` when the caller knows it (a BoardGroup import
+  # — every member other than the root is a page, including a page nothing links
+  # to). Without it the set is walked from the root with
+  # `Boards::ReachableBoardIds(skip_back_tiles: true)`, which is how a seeded
+  # robust set (Core 60/84 — no BoardGroup, root identified by its own settings
+  # marker) is classified. Skipping back tiles matters: a way home points at the
+  # root, and following it would walk out of the set entirely.
+  #
+  # Idempotent — a board already on the right side is left untouched, so a
+  # re-run doesn't churn `updated_at` and bust the boards-index ETag.
+  class ImportedSetClassifier
+    def initialize(root_board, member_ids: nil, dry_run: false)
+      @root_board = root_board
+      @member_ids = member_ids
+      @dry_run = dry_run
+    end
+
+    # => Array<Integer> — the page board ids that were (or would be) demoted.
+    def call
+      return [] if root_board.blank?
+
+      page_ids = page_board_ids
+      return page_ids if dry_run
+
+      root_board.pin_as_main_board!
+      Board.where(id: page_ids).find_each(&:mark_as_sub_board!)
+      page_ids
+    end
+
+    private
+
+    attr_reader :root_board, :member_ids, :dry_run
+
+    def page_board_ids
+      ids = if member_ids.present?
+          Array(member_ids)
+        else
+          Boards::ReachableBoardIds.new(root_board.id, skip_back_tiles: true).ids
+        end
+
+      ids.map(&:to_i).uniq - [root_board.id]
+    end
+  end
+end

--- a/app/services/vocab_sets.rb
+++ b/app/services/vocab_sets.rb
@@ -106,6 +106,14 @@ module VocabSets
     dedupe_tiles!(boards_by_obf_id)
     repair_layout!(slug, boards_by_obf_id)
 
+    # LAST, so it classifies the set that actually survived the prune passes.
+    # A seeded set has no BoardGroup, so the classifier walks it from the root:
+    # the root stays a main board, every page under it becomes a sub-board.
+    # Without this the set's ~30 interior pages are all main boards, and since
+    # the seeder marks them predefined + published they land in the public
+    # gallery and in every user's board search.
+    Boards::ImportedSetClassifier.new(root.reload).call
+
     root
   end
 

--- a/lib/tasks/obf_import_sets.rake
+++ b/lib/tasks/obf_import_sets.rake
@@ -1,0 +1,53 @@
+namespace :obf_import do
+  # Backfill for every set imported (or seeded) before
+  # Boards::ImportedSetClassifier existed.
+  #
+  # An import writes its tile links with update_columns and only after every
+  # board in the package exists, so Board#check_is_sub_board never ran against
+  # the finished graph: all 30 pages of a core set are main boards, while the
+  # ROOT drifts the other way — the first unrelated save sees the pages' ways
+  # home pointing at it and demotes it. This settles both halves: root pinned as
+  # a main board, its pages marked sub-boards.
+  #
+  # Roots come from the two places a set records one: BoardGroup#root_board_id
+  # (a user .obz import) and the robust-set marker on a seeded Core 60/84 root
+  # (settings["board_builder_robust"] — those have no BoardGroup).
+  #
+  #   bin/rails obf_import:classify_sets                   # preview (default)
+  #   DRY_RUN=false bin/rails obf_import:classify_sets     # apply
+  desc "Collapse imported board sets to their root board (DRY_RUN=false to apply)"
+  task classify_sets: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    prefix = dry_run ? "[DRY RUN] " : ""
+
+    group_roots = BoardGroup.where.not(root_board_id: nil).pluck(:root_board_id, :id).to_h
+    roots = Board.where(id: group_roots.keys).order(:id).to_a
+    roots += Boards::RobustSets.all_roots.reject { |b| roots.any? { |r| r.id == b.id } }
+
+    puts "Imported set roots found: #{roots.size}"
+
+    demoted = 0
+    roots.each do |root|
+      group_id = group_roots[root.id]
+      member_ids = group_id ? BoardGroup.find_by(id: group_id)&.board_ids : nil
+
+      page_ids = Boards::ImportedSetClassifier.new(
+        root,
+        member_ids: member_ids,
+        dry_run: dry_run,
+      ).call
+
+      already_sub = Board.where(id: page_ids, sub_board: true).count
+      changing = page_ids.size - already_sub
+      demoted += changing
+
+      puts "#{prefix}root ##{root.id} #{root.name.inspect} " \
+           "(user #{root.user_id}, #{group_id ? "group #{group_id}" : "walked"}) " \
+           "-> main board; #{page_ids.size} pages, #{changing} newly demoted"
+    end
+
+    puts
+    puts "#{prefix}#{roots.size} roots pinned, #{demoted} pages demoted to sub-boards"
+    puts "Re-run with DRY_RUN=false to apply." if dry_run
+  end
+end

--- a/spec/models/board_imported_set_visibility_spec.rb
+++ b/spec/models/board_imported_set_visibility_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+# An imported (.obz) set is one board as far as every listing is concerned: its
+# ROOT. The interior pages are sub-boards. This used to be enforced with a
+# blanket `where(obf_id: nil)`, which hid the root too — an import was
+# unreachable from anywhere but its own group.
+RSpec.describe "imported board set visibility", type: :model do
+  let(:user) { create(:user) }
+  let(:admin) { User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID) }
+
+  describe "Board.searchable" do
+    it "includes an imported set's root board" do
+      root = create(:board, user: user, name: "Imported Core", obf_id: "core", board_type: "dynamic", sub_board: false)
+
+      expect(Board.searchable).to include(root)
+    end
+
+    it "excludes an imported set's interior pages" do
+      # update_column: Board#check_is_sub_board re-derives the flag on save from
+      # who links in, so the attribute can't just be assigned on create.
+      page = create(:board, user: user, name: "Imported Food", obf_id: "food", board_type: "category")
+      page.update_column(:sub_board, true)
+
+      expect(Board.searchable).not_to include(page)
+    end
+
+    it "still includes a hand-made sub-board" do
+      sub = create(:board, user: user, name: "My Sub Board", board_type: "category")
+      sub.update_column(:sub_board, true)
+
+      expect(Board.searchable).to include(sub)
+    end
+  end
+
+  describe "Board.admin_owned_boards" do
+    it "includes an admin-owned imported root" do
+      root = create(:board, user: admin, name: "Imported Catalogue Board",
+                            obf_id: "cat", sub_board: false, published: true, predefined: true)
+
+      expect(Board.admin_owned_boards).to include(root)
+      expect(Board.public_boards).to include(root)
+    end
+
+    it "excludes that set's interior pages" do
+      page = create(:board, user: admin, name: "Imported Catalogue Page",
+                            obf_id: "cat-food", board_type: "category", published: true, predefined: true)
+      page.update_column(:sub_board, true)
+
+      expect(Board.admin_owned_boards).not_to include(page)
+    end
+
+    # Board Builder seed material is admin-owned + predefined + published so the
+    # builder can clone it, not because it belongs in the public catalogue. It
+    # was kept out as a side effect of the old OBF filter.
+    it "excludes a seeded robust-set root" do
+      root = create(:board, user: admin, name: "Core 84", obf_id: "core-84",
+                            sub_board: false, published: true, predefined: true,
+                            settings: { Boards::RobustSets::ROOT_MARKER => true })
+
+      expect(Board.admin_owned_boards).not_to include(root)
+    end
+
+    it "excludes a fringe page template" do
+      template = create(:board, user: admin, name: "Animals", obf_id: "fringe:animals",
+                                sub_board: false, published: true, predefined: true,
+                                settings: { Boards::FringeTemplates::TEMPLATE_MARKER => "animals" })
+
+      expect(Board.admin_owned_boards).not_to include(template)
+    end
+  end
+
+  describe "Board.main_boards" do
+    it "collapses a classified set to its root" do
+      root = create(:board, user: user, name: "Imported Core", obf_id: "core", board_type: "dynamic")
+      page = create(:board, user: user, name: "Imported Food", obf_id: "food", board_type: "category")
+      create(:board_image, board: root, predictive_board_id: page.id)
+
+      Boards::ImportedSetClassifier.new(root).call
+
+      expect(Board.main_boards).to include(root)
+      expect(Board.main_boards).not_to include(page)
+    end
+  end
+end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1364,16 +1364,27 @@ RSpec.describe Board, type: :model do
       expect(ids).to include(catalogue_board.id, wizard_board.id)
     end
 
-    it "excludes an unpublished board, a Menu extraction, an OBF import, and a Board Builder child page" do
+    it "excludes an unpublished board, a Menu extraction, an imported set's page, and a Board Builder child page" do
       unpublished = FactoryBot.create(:board, user: admin_user, predefined: false, published: false)
       menu_board = FactoryBot.create(:board, user: admin_user, predefined: false, published: true, parent_type: "Menu")
-      obf_board = FactoryBot.create(:board, user: admin_user, predefined: false, published: true, obf_id: "abc123")
+      # An import is no longer excluded wholesale — only its interior pages are
+      # (see spec/models/board_imported_set_visibility_spec.rb). update_column:
+      # check_is_sub_board re-derives the flag from who links in on every save.
+      obf_page = FactoryBot.create(:board, user: admin_user, predefined: false, published: true, obf_id: "abc123")
+      obf_page.update_column(:sub_board, true)
       builder_child = FactoryBot.create(:board, user: admin_user, predefined: false, published: true,
                                                  settings: { "builder_child" => true })
 
       ids = described_class.admin_owned_boards.pluck(:id)
 
-      expect(ids).not_to include(unpublished.id, menu_board.id, obf_board.id, builder_child.id)
+      expect(ids).not_to include(unpublished.id, menu_board.id, obf_page.id, builder_child.id)
+    end
+
+    it "includes an imported set's root board" do
+      root = FactoryBot.create(:board, user: admin_user, predefined: false, published: true,
+                                       obf_id: "abc123-root", board_type: "dynamic")
+
+      expect(described_class.admin_owned_boards.pluck(:id)).to include(root.id)
     end
 
     it "excludes a published board owned by a regular user" do

--- a/spec/requests/api/boards_imported_set_listing_spec.rb
+++ b/spec/requests/api/boards_imported_set_listing_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+# The boards page defaults to the "Main Boards" filter. An imported .obz set has
+# to read there like any other board: one entry, its root — not thirty pages,
+# and not nothing at all (which is what the blanket `where(obf_id: nil)` on the
+# discovery scopes used to produce).
+RSpec.describe "API::Boards imported set listing", type: :request do
+  let(:user) { create(:user) }
+
+  def board_names(response)
+    JSON.parse(response.body).fetch("boards").map { |b| b["name"] }
+  end
+
+  let!(:root) do
+    create(:board, user: user, name: "Imported Core Set", obf_id: "core", board_type: "dynamic")
+  end
+  let!(:page_board) do
+    create(:board, user: user, name: "Imported Food Page", obf_id: "food", board_type: "category")
+  end
+
+  before do
+    create(:board_image, board: root, predictive_board_id: page_board.id)
+    # Every page of a real set carries a way home; without the back-tile flag
+    # this link is what would demote the root on its next save.
+    create(:board_image, board: page_board, predictive_board_id: root.id, data: { "back_tile" => true })
+    Boards::ImportedSetClassifier.new(root).call
+  end
+
+  it "shows the set's root under the Main Boards filter and hides its pages" do
+    get "/api/boards", params: { filter: "main_boards", per_page: 50 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(board_names(response)).to include("Imported Core Set")
+    expect(board_names(response)).not_to include("Imported Food Page")
+  end
+
+  it "finds the set's root by name in search" do
+    get "/api/boards", params: { query: "Imported Core", per_page: 50 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(board_names(response)).to include("Imported Core Set")
+  end
+
+  it "still lists every page under the All filter, so board_count matches" do
+    get "/api/boards", params: { filter: "all", per_page: 50 }, headers: auth_headers(user)
+
+    expect(response).to have_http_status(:ok)
+    expect(board_names(response)).to include("Imported Core Set", "Imported Food Page")
+  end
+end

--- a/spec/services/boards/imported_set_classifier_spec.rb
+++ b/spec/services/boards/imported_set_classifier_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe Boards::ImportedSetClassifier do
+  let(:user) { create(:user) }
+
+  def board(name, obf_id: "obf-#{name.parameterize}")
+    create(:board, user: user, name: name, obf_id: obf_id)
+  end
+
+  def link(from, to, data: {})
+    create(:board_image, board: from, predictive_board_id: to.id, data: data)
+  end
+
+  describe "walking the set from its root" do
+    it "pins the root as a main board and demotes every page under it" do
+      root = board("Core")
+      food = board("Food")
+      snacks = board("Snacks")
+      link(root, food)
+      link(food, snacks)
+
+      described_class.new(root).call
+
+      expect(root.reload.sub_board).to be false
+      expect(root.pinned_main_board?).to be true
+      expect(food.reload.sub_board).to be true
+      expect(snacks.reload.sub_board).to be true
+    end
+
+    it "tags demoted pages so the sub-board tag filter agrees with the flag" do
+      root = board("Core")
+      page = board("Food")
+      link(root, page)
+
+      described_class.new(root).call
+
+      expect(page.reload.tags).to include(Board::IS_SUB_BOARD_TAG)
+      expect(root.reload.tags || []).not_to include(Board::IS_SUB_BOARD_TAG)
+    end
+
+    it "does not follow a back tile out of the set" do
+      root = board("Core")
+      page = board("Food")
+      outsider = board("Someone else's board")
+      link(root, page)
+      link(page, outsider, data: { "back_tile" => true })
+
+      described_class.new(root).call
+
+      expect(outsider.reload.sub_board).to be false
+    end
+  end
+
+  describe "with explicit membership" do
+    it "demotes every member but the root, including a page nothing links to" do
+      root = board("Core")
+      linked = board("Food")
+      orphan = board("Unreachable")
+      link(root, linked)
+
+      described_class.new(root, member_ids: [root.id, linked.id, orphan.id]).call
+
+      expect(root.reload.sub_board).to be false
+      expect(linked.reload.sub_board).to be true
+      expect(orphan.reload.sub_board).to be true
+    end
+  end
+
+  it "keeps the root a main board across a later unrelated save" do
+    root = board("Core")
+    page = board("Food")
+    link(root, page)
+    # Every page of a set carries a way home, so the root has inbound links.
+    link(page, root, data: { "back_tile" => true })
+
+    described_class.new(root).call
+    root.reload.update!(description: "renamed the description")
+
+    expect(root.reload.sub_board).to be false
+  end
+
+  it "is idempotent and leaves settled boards untouched" do
+    root = board("Core")
+    page = board("Food")
+    link(root, page)
+    described_class.new(root).call
+
+    root_touched_at = root.reload.updated_at
+    page_touched_at = page.reload.updated_at
+    described_class.new(root).call
+
+    expect(root.reload.updated_at).to eq(root_touched_at)
+    expect(page.reload.updated_at).to eq(page_touched_at)
+  end
+
+  it "reports the pages without writing anything when dry_run" do
+    root = board("Core")
+    page = board("Food")
+    link(root, page)
+
+    expect(described_class.new(root, dry_run: true).call).to eq([page.id])
+    expect(page.reload.sub_board).to be_falsey
+    expect(root.reload.pinned_main_board?).to be false
+  end
+
+  it "no-ops without a root board" do
+    expect(described_class.new(nil).call).to eq([])
+  end
+end


### PR DESCRIPTION
## Summary

An OBF/OBZ import was filtered out of board search (`Board.searchable`) and the public board library (`Board.admin_owned_boards`) by a blanket `where(obf_id: nil)`, so the only way back to an imported set was the `BoardGroup` it arrived in. The user's own index had no such filter, so it listed every page of the set at once — 30 pages burying everything else.

Imported boards now behave like any other board, with the set collapsed to the **one board a human would name**: its root.

- `Board.without_imported_pages` (`obf_id IS NULL OR NOT sub_board`) replaces the blanket filter on `searchable` and `admin_owned_boards`. The guest index no longer re-applies the obf filter either.
- `Boards::ImportedSetClassifier` (new) is what makes `sub_board` trustworthy enough to carry that rule: root → `sub_board: false` + pinned `settings["main_board"]`; pages → `sub_board: true`, tagged `sub-board`. Import can't do this inline — `ObzImporter` links tiles with `update_columns` and only after every board in the package exists, so `check_is_sub_board` never sees the finished graph.
- The **pin** is load-bearing, not belt-and-braces. Every page of a set carries a way home, so `parent_boards` always finds tiles pointing at the root and the first unrelated save demoted it straight back out of `main_boards`. `check_is_sub_board` now honours `MAIN_BOARD_PIN` alongside the existing `builder_root`, which exists for exactly the same reason.
- Called from `ObzImporter#import!` (after `Boards::BackTileStamper`, passing the BoardGroup's members) and from `VocabSets#seed_slug!` (no BoardGroup — walked from the robust-set root with `ReachableBoardIds(skip_back_tiles: true)`; an unflagged way home would walk clean out of the set).
- `bin/rails obf_import:classify_sets` backfills everything imported before the classifier existed. `DRY_RUN=false` to apply.

### One deliberate call worth reviewing

Lifting the filter on `admin_owned_boards` would have dumped Board Builder's seed material into the public gallery — Core 60/84 plus 11 fringe page templates, all admin-owned + `predefined` + `published`, and previously excluded only *because* they're obf-seeded. That exclusion is now explicit (`Board.not_builder_seed`, keyed on the robust-set and fringe-template markers) rather than a side effect. Public gallery count is unchanged. If Core 60/84 should actually be listed publicly, that's a one-line follow-up, not this PR.

## Test plan

`bundle exec rspec` over the classifier, scopes, listing, importer, board model, boards request, back-tile stamper and vocab-set specs — **282 examples, 0 failures**:

- `spec/services/boards/imported_set_classifier_spec.rb` (new, 8) — root pinned / pages demoted, tag written, back tile not followed out of the set, explicit membership demotes an unreachable page, root survives a later unrelated save, idempotent (no `updated_at` churn), dry run writes nothing.
- `spec/models/board_imported_set_visibility_spec.rb` (new, 8) — `searchable` / `admin_owned_boards` / `public_boards` / `main_boards` include the root and exclude the pages; hand-made sub-boards unaffected; robust-set roots and fringe templates stay out of the catalogue.
- `spec/requests/api/boards_imported_set_listing_spec.rb` (new, 3) — `filter=main_boards` shows the root and hides the pages, search finds the root by name, `filter=all` still lists every page so `board_count` matches the listing.
- Existing: `board_spec.rb`, `obz_importer_spec.rb`, `boards_spec.rb`, `back_tile_stamper_spec.rb`, `vocab_sets_spec.rb`, plus builder/admin/public-board suites (`board_builder`, `onboarding/myspeak`, `admin/board_builds`, `admin/board_printables`, `existing_boards`, `free_download_boards`, `public_boards_myspeak`, `obz_round_trip`, `seeded_set_cloner`, `import_obz_job`) — all green.
- One existing example in `board_spec.rb` asserted the old "an OBF import is excluded" behaviour; rewritten to assert page-excluded / root-included.
- `bin/rails zeitwerk:check` clean.

Backfill dry run against the dev DB: 6 roots, 22 pages demoted, public gallery count unchanged at 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
