### PR TITLE
feat(admin): signup source column, demo-delete fix, condensed nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **Deleting a demo account from the admin dashboard works again.** Selecting
+  demo accounts and pressing **Delete selected** reported "Skipped 1 selected
+  user(s) that weren't demo accounts" and deleted nothing. The check treated an
+  account with no role set — which is every ordinary signup — as failing the
+  "not an admin" test, so every real demo account was skipped. The same skip
+  applied to Mission Control's demo cleanup and to the JSON admin API's bulk
+  delete; all three now agree with the checkbox the dashboard shows.
+
 - **Imported boards show up on the boards page like any other board.** A board
   set imported from a `.obf`/`.obz` file was filtered out of board search and
   out of the public board library, so the only way back to it was the group it
@@ -16,6 +24,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   imports are settled by `bin/rails obf_import:classify_sets`.
 
 ### Added
+
+- **The admin Users table shows where each account signed up.** A new **Source**
+  column badges every user as iOS, Android, web, or unknown (accounts created
+  before signup source was recorded), sortable like the other columns and
+  filterable from the same dropdown as plans and demo accounts. The user detail
+  page gains **Signup source** and **Signup method** alongside the existing
+  signup ref.
+
+- **The admin nav is shorter.** Board Builds, Board Printables, and Kit Pages
+  now sit together under a single **Content** menu instead of each taking a slot
+  in a bar that had run out of room.
 
 - **Kit landing pages write themselves.** Creating a `/kit/<slug>` lead-magnet
   page used to mean typing a slug, headline, subhead, call to action and a raw

--- a/app/controllers/admin/mission_control_controller.rb
+++ b/app/controllers/admin/mission_control_controller.rb
@@ -24,7 +24,10 @@ module Admin
 
       demo_users = User.demo_accounts.includes(:boards)
       excluded = demo_users.where(id: exclude_ids)
-      candidates = demo_users.where.not(id: exclude_ids).where.not(role: "admin")
+      # No `.where.not(role: "admin")` — `demo_accounts` already excludes admins
+      # NULL-safely via `non_admin`, and stacking the plain form drops every
+      # ordinary signup, whose role is NULL. See Admin::UsersController#destroy_users.
+      candidates = demo_users.where.not(id: exclude_ids)
 
       ranked = candidates.sort_by { |u| -u.boards.size }
       kept = ranked.first(keep_count)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -33,7 +33,13 @@ module Admin
           # jsonb key, not a column — and accounts created before signup
           # context shipped have no key at all, so they sort last either way
           # rather than clumping at the top of an ascending sort.
-          scope.order(Arel.sql("users.settings ->> 'signup_platform' #{@dir.upcase} NULLS LAST"))
+          #
+          # Built in Arel rather than an interpolated Arel.sql string, same
+          # reasoning as User.demo_accounts: @dir is validated against a
+          # two-element allowlist above, but an interpolated ORDER BY is
+          # indistinguishable from injection to Brakeman (and to the next
+          # person who widens that allowlist).
+          scope.order(signup_platform_ordering)
         else
           scope.order(@sort => @dir.to_sym)
         end
@@ -250,6 +256,13 @@ module Admin
     end
 
     private
+
+    def signup_platform_ordering
+      key = Arel::Nodes::InfixOperation.new(
+        "->>", User.arel_table[:settings], Arel::Nodes.build_quoted("signup_platform")
+      )
+      (@dir == "asc" ? key.asc : key.desc).nulls_last
+    end
 
     def user_params
       params.require(:user).permit(:name, :email, :role, :locked, :play_demo,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,7 +15,7 @@ module Admin
     }.freeze
 
     def index
-      @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count current_sign_in_at boards]) || "created_at"
+      @sort = params[:sort].presence_in(%w[created_at email name plan_type sign_in_count current_sign_in_at boards signup_platform]) || "created_at"
       @dir = params[:dir].presence_in(%w[asc desc]) || "desc"
       @filter = params[:filter]
       @search = params[:search]
@@ -24,12 +24,19 @@ module Admin
       scope = apply_filter(scope)
       scope = scope.where("email ILIKE ? OR name ILIKE ?", "%#{@search}%", "%#{@search}%") if @search.present?
 
-      if @sort == "boards"
-        @users = scope.includes(:boards).sort_by { |u| u.boards.size }
-        @users.reverse! if @dir == "desc"
-      else
-        @users = scope.order(@sort => @dir.to_sym)
-      end
+      @users =
+        case @sort
+        when "boards"
+          sorted = scope.includes(:boards).sort_by { |u| u.boards.size }
+          @dir == "desc" ? sorted.reverse : sorted
+        when "signup_platform"
+          # jsonb key, not a column — and accounts created before signup
+          # context shipped have no key at all, so they sort last either way
+          # rather than clumping at the top of an ascending sort.
+          scope.order(Arel.sql("users.settings ->> 'signup_platform' #{@dir.upcase} NULLS LAST"))
+        else
+          scope.order(@sort => @dir.to_sym)
+        end
 
       @total_count = scope.count
     end
@@ -199,7 +206,12 @@ module Admin
         return
       end
 
-      users = User.where(id: user_ids).demo_accounts.where.not(role: "admin")
+      # `demo_accounts` already excludes admins via `non_admin`, which spells the
+      # check as "role IS NULL OR role != 'admin'". A plain `where.not(role:)`
+      # compiles to `role != 'admin'`, which is NULL — and therefore false — for
+      # the NULL role every ordinary signup has, so stacking it here skipped
+      # every real demo account and reported it as "not a demo account".
+      users = User.where(id: user_ids).demo_accounts
       skipped = user_ids.size - users.size
       users.each { |u| u.soft_delete_account!(reason: "admin_deleted", actor_id: current_user.id) unless u.soft_deleted? }
 
@@ -255,6 +267,7 @@ module Admin
       when "free"   then scope.where(plan_type: "free")
       when "trial"  then scope.where(plan_type: "basic_trial")
       when "demo"   then scope.demo_accounts
+      when "ios", "android", "web" then scope.where("users.settings ->> 'signup_platform' = ?", @filter)
       when "locked" then scope.where(locked: true)
       else scope
       end

--- a/app/controllers/api/admin/users_controller.rb
+++ b/app/controllers/api/admin/users_controller.rb
@@ -268,7 +268,10 @@ class API::Admin::UsersController < API::Admin::ApplicationController
       render json: { error: "No user_ids provided" }, status: :unprocessable_content
       return
     end
-    users = User.where(id: params[:user_ids]).where.not(role: "admin")
+    # `non_admin`, not `where.not(role: "admin")`: role is nullable and the
+    # plain form compiles to `role != 'admin'`, which is NULL — and so false —
+    # for every ordinary signup, silently skipping them all.
+    users = User.where(id: params[:user_ids]).non_admin
     users.each do |u|
       u.soft_delete_account!(reason: "admin_deleted", actor_id: current_admin.id) unless u.soft_deleted?
     end
@@ -286,9 +289,9 @@ class API::Admin::UsersController < API::Admin::ApplicationController
 
     demo_users = User.demo_accounts.includes(:boards)
     excluded = demo_users.where(id: exclude_ids)
+    # `demo_accounts` already excludes admins NULL-safely; a stacked
+    # `where.not(role: "admin")` would drop every NULL-role signup.
     candidates = demo_users.where.not(id: exclude_ids)
-
-    candidates = candidates.where.not(role: "admin")
     ranked = candidates.sort_by { |u| -u.boards.size }
     kept = ranked.first(keep_count)
     to_delete = ranked.drop(keep_count)

--- a/app/helpers/admin/mission_control_helper.rb
+++ b/app/helpers/admin/mission_control_helper.rb
@@ -27,6 +27,25 @@ module Admin
       PLAN_BADGE_CLASSES.fetch(user.plan_type.to_s, "bg-gray-800 text-gray-400")
     end
 
+    # settings["signup_platform"] is written by User#record_signup_context! and
+    # only ever holds what the signup request declared. Accounts created before
+    # that shipped have no key at all — "unknown", not "web", since guessing
+    # would quietly inflate the web share of every cohort read off this table.
+    SIGNUP_PLATFORM_BADGE_CLASSES = {
+      "ios"     => "bg-blue-900/60 text-blue-300",
+      "android" => "bg-green-900/60 text-green-300",
+      "web"     => "bg-indigo-900/60 text-indigo-300",
+    }.freeze
+
+    def signup_platform(user)
+      settings = user.settings.is_a?(Hash) ? user.settings : {}
+      settings["signup_platform"].presence || "unknown"
+    end
+
+    def signup_platform_badge_class(platform)
+      SIGNUP_PLATFORM_BADGE_CLASSES.fetch(platform.to_s, "bg-gray-800 text-gray-400")
+    end
+
     PARTNER_PILOT_STATE_META = {
       ended:        { label: "Pilot ended",  badge: "bg-red-900/60 text-red-300" },
       ending_soon:  { label: "Ending soon",  badge: "bg-yellow-900/60 text-yellow-300" },

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -26,6 +26,9 @@
       <option value="trial" <%= "selected" if @filter == "trial" %>>Trial</option>
       <option value="demo" <%= "selected" if @filter == "demo" %>>Demo accounts</option>
       <option value="locked" <%= "selected" if @filter == "locked" %>>Locked</option>
+      <option value="ios" <%= "selected" if @filter == "ios" %>>Signed up on iOS</option>
+      <option value="android" <%= "selected" if @filter == "android" %>>Signed up on Android</option>
+      <option value="web" <%= "selected" if @filter == "web" %>>Signed up on web</option>
     </select>
 
     <input type="hidden" name="sort" value="<%= @sort %>">
@@ -63,6 +66,7 @@
             ["Email",      "email"],
             ["Name",       "name"],
             ["Plan",       "plan_type"],
+            ["Source",     "signup_platform"],
             ["Boards",     "boards"],
             ["Sign-ins",   "sign_in_count"],
             ["Last login", "current_sign_in_at"],
@@ -111,6 +115,12 @@
                 <%= pilot[:label] %>
               </span>
             <% end %>
+          </td>
+          <td class="px-5 py-3">
+            <% platform = signup_platform(user) %>
+            <span class="<%= signup_platform_badge_class(platform) %> inline-block text-xs rounded px-2 py-0.5">
+              <%= platform == "ios" ? "iOS" : platform %>
+            </span>
           </td>
           <td class="px-5 py-3 text-xs text-t2 text-center">
             <%= user.boards.size %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -363,6 +363,8 @@
         ["Stripe sub",       @user.stripe_subscription_id.present? ?
           link_to(@user.stripe_subscription_id, "https://dashboard.stripe.com/subscriptions/#{@user.stripe_subscription_id}",
                   target: "_blank", rel: "noopener", class: "text-accent hover:underline") : "—"],
+        ["Signup source",    signup_platform(@user) == "ios" ? "iOS" : signup_platform(@user)],
+        ["Signup method",    @user.settings&.dig("signup_method").presence || "—"],
         ["Signup ref",       @user.settings&.dig("signup_ref").presence || "—"],
         ["Created",          @user.created_at.strftime("%b %-d, %Y %H:%M %Z")],
         ["Last sign-in",     @user.last_sign_in_at&.strftime("%b %-d, %Y %H:%M %Z") || "Never"],

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -80,6 +80,12 @@
     html.dark .admin-flash-ok { background: rgba(34,197,94,0.15); color: #86efac; }
     html.dark .admin-flash-err { background: rgba(239,68,68,0.15); color: #fca5a5; }
 
+    /* Safari still draws the disclosure triangle without this. */
+    .admin-menu > summary::-webkit-details-marker { display: none; }
+    .admin-menu > summary::marker { content: ""; }
+    .admin-menu[open] > summary { background: var(--bg-surface-alt); color: var(--text-primary); }
+    .admin-menu a:hover { background: var(--hover-row); }
+
     .theme-toggle {
       display: inline-flex; align-items: center; gap: 6px;
       padding: 4px 10px; border-radius: 6px; cursor: pointer;
@@ -124,16 +130,32 @@
           <% end %>
           <%= link_to "Video Boards", admin_dashboard_video_boards_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/video_boards") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
-          <%= link_to "Board Builds", admin_dashboard_board_builds_path,
-                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_builds") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
-          <%= link_to "Kit Pages", admin_dashboard_kit_pages_path,
-                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/kit_pages") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+          <%# Board Builds / Kit Pages / Board Printables share one "Content"
+              menu — the flat nav had outgrown the bar. <details> so the menu
+              works with no JS; the inline script below only closes it on an
+              outside click. %>
+          <% content_items = [
+               ["Board Builds",     admin_dashboard_board_builds_path,     "/admin/board_builds"],
+               ["Board Printables", admin_dashboard_board_printables_path, "/admin/board_printables"],
+               ["Kit Pages",        admin_dashboard_kit_pages_path,        "/admin/kit_pages"],
+             ] %>
+          <% content_active = content_items.any? { |_, _, prefix| request.path.start_with?(prefix) } %>
+          <details class="admin-menu relative">
+            <summary class="text-xs px-3 py-1.5 rounded cursor-pointer list-none inline-flex items-center gap-1 <%= content_active ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1" %> transition-colors">
+              Content
+              <span class="text-[9px] leading-none">&#9660;</span>
+            </summary>
+            <div class="admin-card border rounded-lg absolute left-0 mt-1 py-1 w-48 z-50 shadow-lg">
+              <% content_items.each do |label, path, prefix| %>
+                <%= link_to label, path,
+                      class: "block text-xs px-3 py-2 #{request.path.start_with?(prefix) ? "text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
+              <% end %>
+            </div>
+          </details>
           <%= link_to "Feedback", admin_dashboard_feedback_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/feedback") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Word Events", admin_dashboard_word_events_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/word_events") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
-          <%= link_to "Board Printables", admin_dashboard_board_printables_path,
-                class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/board_printables") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Users", admin_dashboard_users_path,
                 class: "text-xs px-3 py-1.5 rounded #{request.path.start_with?("/admin/users") ? "admin-card-alt text-t1 font-medium" : "text-t2 hover:text-t1"} transition-colors" %>
           <%= link_to "Sidekiq", "/sidekiq", target: "_blank", rel: "noopener",
@@ -172,6 +194,13 @@
       localStorage.setItem('admin_theme', isDark ? 'dark' : 'light');
       updateThemeButton();
     }
+    // Close the nav menu when the click lands outside it — <details> has no
+    // dismiss-on-outside-click behavior of its own.
+    document.addEventListener('click', function (e) {
+      document.querySelectorAll('details.admin-menu[open]').forEach(function (d) {
+        if (!d.contains(e.target)) d.removeAttribute('open');
+      });
+    });
     function updateThemeButton() {
       var isDark = document.documentElement.classList.contains('dark');
       document.getElementById('theme-icon').innerHTML = isDark ? '&#9790;' : '&#9788;';

--- a/spec/requests/admin/mission_control_spec.rb
+++ b/spec/requests/admin/mission_control_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe "Admin::MissionControl", type: :request do
       expect(User.exists?(admin_demo.id)).to be true
     end
 
+    # The factory sets an explicit role; every real signup's is NULL, and a
+    # plain `where.not(role: "admin")` treats NULL as "not a match".
+    it "deletes a demo user whose role is NULL" do
+      nil_role = create(:user, email: "bhannajohns+nilrole@gmail.com", role: nil)
+
+      post cleanup_demo_admin_mission_control_path, params: { keep_count: 0 }
+
+      expect(User.exists?(nil_role.id)).to be false
+    end
+
     it "never deletes non-demo users" do
       post cleanup_demo_admin_mission_control_path, params: { keep_count: 0 }
 

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -37,6 +37,34 @@ RSpec.describe "Admin::Users", type: :request do
       expect(response.body).not_to include("bob@example.com")
     end
 
+    it "shows each user's signup source" do
+      create(:user, email: "ios-signup@example.com", settings: { "signup_platform" => "ios" })
+
+      get admin_dashboard_users_path
+
+      expect(response.body).to include("Source")
+      expect(response.body).to include("iOS")
+    end
+
+    it "filters by signup platform" do
+      create(:user, email: "ios-only@example.com", settings: { "signup_platform" => "ios" })
+      create(:user, email: "web-only@example.com", settings: { "signup_platform" => "web" })
+
+      get admin_dashboard_users_path(filter: "ios")
+
+      expect(response.body).to include("ios-only@example.com")
+      expect(response.body).not_to include("web-only@example.com")
+    end
+
+    it "sorts by signup platform" do
+      create(:user, email: "ios-sorted@example.com", settings: { "signup_platform" => "ios" })
+
+      get admin_dashboard_users_path(sort: "signup_platform", dir: "asc")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("ios-sorted@example.com")
+    end
+
     it "sorts by column" do
       get admin_dashboard_users_path(sort: "email", dir: "asc")
       expect(response).to have_http_status(:ok)
@@ -557,6 +585,28 @@ RSpec.describe "Admin::Users", type: :request do
       expect(user1.reload.soft_deleted?).to be(false)
       expect(flash[:notice]).to include("Deleted 2 demo account")
       expect(flash[:notice]).to include("Skipped 1")
+    end
+
+    # Every real signup has a NULL role — nothing defaults the column — so the
+    # factory's explicit `role: "user"` hides the exact case the bulk delete
+    # used to drop on the floor.
+    it "deletes a demo account whose role is NULL" do
+      demo = create(:user, email: "bhannajohns+nilrole@gmail.com", role: nil)
+
+      post destroy_users_admin_dashboard_users_path, params: { user_ids: [demo.id] }
+
+      expect(demo.reload.soft_deleted?).to be(true)
+      expect(flash[:notice]).to include("Deleted 1 demo account")
+      expect(flash[:notice]).not_to include("Skipped")
+    end
+
+    it "still refuses an admin with a demo-pattern email" do
+      demo_admin = create(:admin_user, email: "bhannajohns+bulkadmin@gmail.com")
+
+      post destroy_users_admin_dashboard_users_path, params: { user_ids: [demo_admin.id] }
+
+      expect(demo_admin.reload.soft_deleted?).to be(false)
+      expect(flash[:notice]).to include("Deleted 0 demo account")
     end
 
     it "alerts when nothing is selected" do

--- a/spec/requests/api/admin/users_spec.rb
+++ b/spec/requests/api/admin/users_spec.rb
@@ -145,6 +145,30 @@ RSpec.describe "API::Admin::Users", type: :request do
     end
   end
 
+  describe "DELETE /api/admin/users/destroy_users" do
+    it "deletes the selected users, including NULL-role accounts" do
+      nil_role = create(:user, email: "nilrole@example.com", role: nil)
+
+      delete "/api/admin/users/destroy_users",
+             params: { user_ids: [nil_role.id] },
+             headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(nil_role.reload.soft_deleted?).to be(true)
+    end
+
+    it "never deletes an admin" do
+      other_admin = create(:admin_user, email: "other-admin@example.com")
+
+      delete "/api/admin/users/destroy_users",
+             params: { user_ids: [other_admin.id] },
+             headers: auth_headers(admin)
+
+      expect(response).to have_http_status(:ok)
+      expect(other_admin.reload.soft_deleted?).to be(false)
+    end
+  end
+
   describe "DELETE /api/admin/users/cleanup_demo" do
     let!(:demo1) { create(:user, email: "bhannajohns+one@gmail.com") }
     let!(:demo2) { create(:user, email: "bhannajohns+two@gmail.com") }
@@ -211,6 +235,18 @@ RSpec.describe "API::Admin::Users", type: :request do
 
         expect(User.exists?(user.id)).to be true
         expect(User.exists?(admin.id)).to be true
+      end
+
+      # The factory sets an explicit role; every real signup's is NULL, and a
+      # plain `where.not(role: "admin")` treats NULL as "not a match".
+      it "includes a demo user whose role is NULL" do
+        nil_role = create(:user, email: "bhannajohns+nilrole@gmail.com", role: nil)
+
+        delete "/api/admin/users/cleanup_demo",
+               params: { keep_count: 0 },
+               headers: auth_headers(admin)
+
+        expect(User.exists?(nil_role.id)).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary

Three admin-dashboard changes.

### 1. Signup source in the Users table

`settings["signup_platform"]` has been written by `User#record_signup_context!` on every signup since the admin signup alert shipped, but nothing rendered it. Adds:

- a **Source** column badging `iOS` / `Android` / `web` / `unknown`, sortable on the jsonb key (`settings ->> 'signup_platform'`, `NULLS LAST` in both directions so pre-feature accounts never clump at the top)
- iOS / Android / web options in the existing filter dropdown
- **Signup source** and **Signup method** on the user detail page, next to the signup ref it already showed

Accounts created before signup context shipped render as `unknown`, not `web` — guessing would quietly inflate the web share of every cohort read off this table.

### 2. Demo-account delete reported "not a demo account" and deleted nothing

`Admin::UsersController#destroy_users` stacked `.where.not(role: "admin")` on top of `demo_accounts`, which already excludes admins via the `non_admin` scope. The plain form compiles to `role != 'admin'`, which is NULL — and therefore false — for the NULL role that every ordinary signup carries (nothing defaults the column). So the scope skipped exactly the accounts the view had drawn a checkbox for, and reported them as "not demo accounts."

The same stacking was in two more places, with the same silent skip:

- `Admin::MissionControlController#cleanup_demo`
- `API::Admin::UsersController#cleanup_demo`

and `API::Admin::UsersController#destroy_users` used the plain form as its *only* admin guard, so the React admin's bulk delete skipped every non-admin it was asked to delete. All four now go through `non_admin`, which spells the check `role IS NULL OR role != 'admin'`.

The spec factory sets `role { "user" }` explicitly, which is why the existing tests passed against the broken code. The new regression tests pass `role: nil`.

### 3. Condensed nav

Board Builds, Board Printables, and Kit Pages move into one **Content** menu. It's a `<details>`/`<summary>` disclosure, so it opens with no JS at all; the only script is a listener that closes it on an outside click. The summary highlights when any of the three pages is active, and the active page is bolded inside the menu. Nav goes from 11 top-level items to 9.

## Test plan

- `bundle exec rspec spec/requests/admin/ spec/requests/api/admin/` — **468 examples, 0 failures**
- New tests:
  - `admin/users_spec.rb` — Source column renders; filter by signup platform; sort by signup platform; bulk-delete a demo account with `role: nil`; still refuses a demo-pattern admin
  - `admin/mission_control_spec.rb` — cleanup_demo deletes a demo user with `role: nil`
  - `api/admin/users_spec.rb` — JSON `destroy_users` deletes a NULL-role account and still refuses an admin; cleanup_demo includes a NULL-role demo user
- Confirmed the NULL-role test **fails** against the pre-fix controller and passes after, so it's a real regression guard rather than a tautology.
- `bin/rails zeitwerk:check` clean.
- Rendered the admin nav through a request spec and checked the markup: Content menu active on `/admin/kit_pages`, Kit Pages bolded inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
