### PR TITLE
fix(admin): dashboard 500 for anonymous visitors + runaway printable auto-refresh

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,4 +1,6 @@
 class MainController < ApplicationController
+  before_action :authenticate_user!, only: :dashboard
+
   def index
     render json: { status: "API is running", version: "1.0", status_code: 200 }
   end

--- a/app/javascript/controllers/auto_refresh_controller.js
+++ b/app/javascript/controllers/auto_refresh_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="auto-refresh"
+//
+// Reloads the page on an interval while something finishes server-side (a
+// board printable generating, say). This replaces a
+// `<meta http-equiv="refresh">`: Turbo Drive merges <head> across visits and
+// leaves a stale refresh meta behind, so the timer followed you off the page
+// and reloaded whatever you navigated to next. A controller's timer is tied to
+// the element, and disconnect() runs on every Turbo navigation and before the
+// page is cached — so leaving the page stops the refresh, which is the whole
+// point.
+export default class extends Controller {
+  static values = { interval: { type: Number, default: 5000 } }
+
+  connect() {
+    this.timer = setTimeout(() => window.location.reload(), this.intervalValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timer)
+    this.timer = null
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import AddImagesController from "./add_images_controller"
 application.register("add-images", AddImagesController)
 
+import AutoRefreshController from "./auto_refresh_controller"
+application.register("auto-refresh", AutoRefreshController)
+
 import DemoController from "./demo_controller"
 application.register("demo", DemoController)
 

--- a/app/policies/board_policy.rb
+++ b/app/policies/board_policy.rb
@@ -1,22 +1,16 @@
 class BoardPolicy < ApplicationPolicy
-    class Scope
-        def initialize(user, scope)
-          @user  = user
-          @scope = scope
-        end
-    
-        def resolve
-          if user.admin?
-            scope.all.user_made
-          else
-            scope.where(user: user).user_made
-          end
-        end
-    
-        private
-    
-        attr_reader :user, :scope
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      return scope.none unless user
+
+      if user.admin?
+        scope.all.user_made
+      else
+        scope.where(user: user).user_made
+      end
     end
+  end
+
   def create?
     user.admin?
   end

--- a/app/views/admin/board_printables/show.html.erb
+++ b/app/views/admin/board_printables/show.html.erb
@@ -1,11 +1,8 @@
 <% content_for :page_title, "Printable ##{@printable.id}" %>
-<% if %w[pending generating].include?(@printable.status) %>
-  <% content_for :head_extra, tag.meta("http-equiv": "refresh", content: "5") %>
-<% end %>
-
 <%# Everything below the status card renders only when the printable is
-    complete, which is also the only time the auto-refresh above is switched
-    off — so a half-typed listing description can never be wiped by a reload. %>
+    complete, which is also the only time the auto-refresh on the status card is
+    switched off — so a half-typed listing description can never be wiped by a
+    reload. %>
 
 <div class="flex items-center justify-between mb-6">
   <div>
@@ -46,7 +43,12 @@
   <div class="flex items-center gap-3 mb-4">
     <span class="<%= board_printable_status_badge(@printable.status) %> inline-block text-xs rounded px-2.5 py-1"><%= @printable.status %></span>
     <% if %w[pending generating].include?(@printable.status) %>
-      <span class="text-xs text-t3">This page refreshes automatically every 5 seconds.</span>
+      <%# A Stimulus controller, not a <meta http-equiv="refresh">: Turbo Drive
+          keeps stale head elements across visits, so the meta version kept
+          reloading pages you'd navigated on to. %>
+      <span class="text-xs text-t3"
+            data-controller="auto-refresh"
+            data-auto-refresh-interval-value="5000">This page refreshes automatically every 5 seconds.</span>
     <% else %>
       <%# Regenerating re-walks the board tree, so this is how a printable picks
           up board edits. It keeps the listing copy and any Etsy draft. %>

--- a/spec/policies/board_policy_spec.rb
+++ b/spec/policies/board_policy_spec.rb
@@ -33,4 +33,21 @@ RSpec.describe BoardPolicy do
       expect(described_class.new(paid, board).update?).to be true
     end
   end
+
+  describe BoardPolicy::Scope do
+    it "returns no boards for a nil user rather than raising" do
+      create(:board, user: create(:user))
+
+      expect { described_class.new(nil, Board.all).resolve }.not_to raise_error
+      expect(described_class.new(nil, Board.all).resolve).to be_empty
+    end
+
+    it "returns only the user's own boards" do
+      user = create(:user)
+      own = create(:board, user: user, board_type: "user")
+      create(:board, user: create(:user), board_type: "user")
+
+      expect(described_class.new(user, Board.all).resolve).to contain_exactly(own)
+    end
+  end
 end

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -267,14 +267,30 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
   end
 
   describe "GET /admin/board_printables/:id" do
-    it "shows a pending printable with an auto-refresh meta tag" do
+    # The refresh is a Stimulus controller rather than a
+    # `<meta http-equiv="refresh">` on purpose: Turbo Drive carries stale head
+    # elements across visits, so the meta version kept reloading whatever page
+    # the admin navigated to next. A controller's timer is cleared by
+    # disconnect() when the element leaves the page.
+    it "shows a pending printable with the scoped auto-refresh controller" do
       sign_in admin
       printable = BoardPrintable.create!(board: board, status: "pending", board_ids: [board.id])
 
       get admin_dashboard_board_printable_path(printable)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include('http-equiv="refresh"')
+      expect(response.body).to include('data-controller="auto-refresh"')
+      expect(response.body).not_to include('http-equiv="refresh"')
+    end
+
+    it "does not auto-refresh a generating printable via a head meta tag" do
+      sign_in admin
+      printable = BoardPrintable.create!(board: board, status: "generating", board_ids: [board.id])
+
+      get admin_dashboard_board_printable_path(printable)
+
+      expect(response.body).to include('data-controller="auto-refresh"')
+      expect(response.body).not_to include('http-equiv="refresh"')
     end
 
     it "shows download links for a complete printable" do
@@ -289,6 +305,7 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
 
       expect(response.body).to include("https://cdn.example.com/core-words.pdf")
       expect(response.body).not_to include('http-equiv="refresh"')
+      expect(response.body).not_to include('data-controller="auto-refresh"')
     end
 
     it "shows the error message for a failed printable" do

--- a/spec/requests/dashboard_access_control_spec.rb
+++ b/spec/requests/dashboard_access_control_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+# GET /dashboard renders an HTML page that assumes a signed-in user: the view
+# reads @user.teams and the action runs policy_scope(Board). Without a gate an
+# anonymous request reached BoardPolicy::Scope#resolve with a nil user and 500'd
+# on `undefined method 'admin?' for nil`.
+RSpec.describe "MainController#dashboard access control", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  before do
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(ActionView::Helpers::AssetTagHelper).to receive(:javascript_include_tag).and_return("")
+  end
+
+  it "redirects an anonymous visitor to sign in instead of raising" do
+    get "/dashboard"
+
+    expect(response).to have_http_status(:redirect)
+    expect(response.location).to include("/users/sign_in")
+  end
+
+  it "renders for a signed-in user" do
+    sign_in create(:user)
+
+    get "/dashboard"
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
Two admin-side fixes, both reported from production.

## 1. `GET /dashboard` 500'd for anonymous visitors

```
NoMethodError: undefined method `admin?' for nil
app/policies/board_policy.rb:9:in `resolve'
```

`MainController#dashboard` had no authentication gate, so an anonymous request
ran `policy_scope(Board)` with `current_user == nil` and died in
`BoardPolicy::Scope#resolve`. Pundit's nil-user guard only lives in
`ApplicationPolicy#initialize` (record policies); `BoardPolicy::Scope` defined
its own `initialize` and inherited nothing — unlike `TeamPolicy::Scope` and
`TeamAccountPolicy::Scope`, which both guard nil.

The page was never renderable signed-out anyway (the view reads `@user.teams`),
so this was bot/crawler traffic on a public URL, not a signed-in admin.

- `before_action :authenticate_user!, only: :dashboard` — anonymous visitors get
  the sign-in redirect.
- `BoardPolicy::Scope` now inherits `ApplicationPolicy::Scope` and returns
  `scope.none` for a nil user, so no future caller can reintroduce the crash.

## 2. A generating printable kept refreshing pages you'd navigated to

`admin/board_printables/show` auto-refreshed with
`<meta http-equiv="refresh" content="5">` while the status was
`pending`/`generating`. Turbo Drive merges `<head>` across visits and leaves
stale head elements in place, so the tag survived navigation and kept reloading
whatever page the admin moved on to, until a full non-Turbo load cleared it.

Replaced with an `auto-refresh` Stimulus controller on the status card. The
timer is tied to the element, so `disconnect()` clears it on the next Turbo
navigation and before the page is cached — leaving the page stops the refresh.
Refresh behaviour on the page itself is unchanged (5s, only while
pending/generating, so a half-typed listing description still can't be wiped).

Note: `app/assets/builds` isn't committed, so the new controller ships with the
deploy-time `yarn build`. Verified the bundle compiles locally.

## Test plan

- New `spec/requests/dashboard_access_control_spec.rb` — anonymous → sign-in
  redirect, signed-in → 200.
- New `BoardPolicy::Scope` cases in `spec/policies/board_policy_spec.rb` — nil
  user returns empty without raising; a user sees only their own boards.
- `spec/requests/admin/board_printables_spec.rb` updated — `pending` and
  `generating` both assert `data-controller="auto-refresh"` **and** no
  `http-equiv="refresh"`; `complete` asserts neither.

Ran locally, all green:

- `spec/policies/board_policy_spec.rb` + `spec/requests/dashboard_access_control_spec.rb` — 8 examples, 0 failures
- `spec/requests/admin/board_printables_spec.rb` — 87 examples, 0 failures
- `spec/requests/users_access_control_spec.rb` + `spec/requests/users_spec.rb` (nearest existing gate coverage) — 16 examples, 0 failures
- `yarn build` — bundle compiles with the new controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)