### PR TITLE
feat(care-plan): pick which care sections print, and lead with the name

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -294,7 +294,32 @@ behind the controller-wide owner gate. **Nothing is added to the public MySpeak
 page**: the page keeps its two gated reveals and gains no download button, so
 this introduces no new path to emergency data.
 
+`&sections=` narrows the document to an allowlist of care section keys (the
+download picker in the frontend's `CarePlanOptionsModal`). Accepted as a
+comma-separated string or an array.
+
 Things that will bite a future change:
+
+- **`sections` absent is not `sections` empty.** Absent means every stored
+  section — what every caller sent before the picker shipped, and what keeps
+  those documents' signatures stable. Empty means none of them, which on the
+  `:full` variant is a real request for the emergency page alone. `Array(nil)`
+  collapses the two, so every hop (controller → `GenerateCarePlan` →
+  `CarePlanDocument`) guards on nil explicitly.
+- **A selection that doesn't reach `GenerateCarePlan#signature` does nothing at
+  all.** There is one attachment per variant, so a narrowed request would be
+  answered by the cached full document and the picker would appear to be
+  ignored. The corollary is that a narrowed download REPLACES the stored
+  document, so `care_plan_url` on `Profile#api_view` can point at a narrowed
+  sheet until the next download — acceptable because the client regenerates on
+  every click.
+- **The selection also has to reach `.printable?`.** Otherwise a `:care_only`
+  request narrowed down to nothing prints headings over nothing, which is the
+  exact "a finished plan that says this child needs nothing" failure the 422
+  exists to refuse.
+- Section keys need no validation: they are only ever intersected with the
+  profile's own stored keys, so an unknown one can only remove sections. The
+  list is capped in the controller because it rides in the signature.
 
 - **A flowing document is not a card, and the two render paths are different
   on purpose.** `BaseAssetGenerator#generate_pdf_from_html` pins Grover to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+
+- **Care plan downloads can be narrowed to the sections you want.** The care
+  plan endpoint takes a `sections` allowlist, so a sheet for a bus driver
+  doesn't have to carry the meals and personal-care pages. Sending no
+  `sections` still prints everything, as before.
+
+### Changed
+
+- **The care plan PDF leads with the communicator's name.** The "SpeakAnyWay"
+  eyebrow above it is gone — on a sheet whose job is to introduce one person,
+  the brand was the first thing a reader saw. The mark still signs the footnote
+  on every page.
+
 ### Fixed
 
 - **Deleting a demo account from the admin dashboard works again.** Selecting

--- a/app/controllers/api/profiles/assets_controller.rb
+++ b/app/controllers/api/profiles/assets_controller.rb
@@ -3,6 +3,11 @@ class API::Profiles::AssetsController < API::ApplicationController
   before_action :set_profile
   before_action :require_owner!
 
+  # Six built-in sections plus four custom ones is the whole ceiling today
+  # (Profile::CARE_SECTIONS + Profile::MAX_CUSTOM_CARE_SECTIONS); the cap is
+  # slack over that, not a limit anyone can reach by filling in the form.
+  MAX_CARE_SECTIONS = 50
+
   def safety_id
     Rails.logger.info "Generating safety ID for Profile ID: #{@profile.id}, Regenerate: #{params[:regenerate]}"
     Communicators::GenerateSafetyIdCard.call(@profile, regenerate: truthy?(params[:regenerate]))
@@ -36,6 +41,7 @@ class API::Profiles::AssetsController < API::ApplicationController
   # builds them.
   def care_plan
     variant = params[:variant].presence || "full"
+    sections = care_sections_param
 
     unless Communicators::GenerateCarePlan::VARIANTS.key?(variant.to_sym)
       render json: { error: "unknown_variant" }, status: :unprocessable_content
@@ -46,7 +52,7 @@ class API::Profiles::AssetsController < API::ApplicationController
     # rather than emitting a near-blank document is deliberate: a printed sheet
     # with headings and nothing under them looks like a finished plan that says
     # this child needs nothing.
-    unless Communicators::GenerateCarePlan.printable?(@profile, variant: variant)
+    unless Communicators::GenerateCarePlan.printable?(@profile, variant: variant, sections: sections)
       render json: { error: empty_reason_for(variant) }, status: :unprocessable_content
       return
     end
@@ -55,6 +61,7 @@ class API::Profiles::AssetsController < API::ApplicationController
       @profile,
       variant: variant,
       regenerate: truthy?(params[:regenerate]),
+      sections: sections,
     )
 
     attachment = @profile.public_send(
@@ -69,6 +76,23 @@ class API::Profiles::AssetsController < API::ApplicationController
   end
 
   private
+
+  # The care sections to include, as an ALLOWLIST. Absent means every section —
+  # what every caller sent before the picker shipped — so nil and [] are
+  # different answers and the nil check comes first.
+  #
+  # Accepts either `sections[]=meals&sections[]=sensory` or a comma-separated
+  # string, since the frontend sends the latter. The list is capped because it
+  # rides in the document's freshness signature; the keys themselves need no
+  # validation, as they are only ever intersected with the profile's own stored
+  # section keys.
+  def care_sections_param
+    raw = params[:sections]
+    return nil if raw.nil?
+
+    list = raw.is_a?(Array) ? raw : raw.to_s.split(",")
+    list.map { |key| key.to_s.strip }.reject(&:empty?).first(MAX_CARE_SECTIONS)
+  end
 
   # `full` can print on emergency info alone, so the two variants run out of
   # things to say for different reasons and the frontend should be able to say

--- a/app/services/communicators/care_plan_document.rb
+++ b/app/services/communicators/care_plan_document.rb
@@ -45,12 +45,20 @@ module Communicators
     # signal at the cost of a line instead of ten.
     OMIT_BLANK_EMERGENCY_FIELDS = true
 
-    def initialize(profile, locale: I18n.locale)
+    # `only_sections` is an ALLOWLIST of section keys, and nil is not the same
+    # thing as an empty array: nil means "every stored section" (what every
+    # caller did before the picker existed), while [] means the caller asked for
+    # none of them — a real request on the :full variant, where the emergency
+    # page alone is the document. `Array(nil)` collapses the two, so the
+    # normalization has to guard on nil explicitly.
+    def initialize(profile, locale: I18n.locale, only_sections: nil)
       @profile = profile
       @locale = locale
+      @only_sections =
+        only_sections.nil? ? nil : Array(only_sections).map { |key| key.to_s.strip }.reject(&:empty?)
     end
 
-    attr_reader :profile, :locale
+    attr_reader :profile, :locale, :only_sections
 
     def care_sections
       @care_sections ||= ordered_keys.filter_map { |key| build_section(key) }
@@ -120,12 +128,21 @@ module Communicators
 
     # Stored order first, then whatever it forgot. A section must never vanish
     # from the printed sheet just because `order` went stale.
+    #
+    # The allowlist is applied HERE, after the order walk, so a narrowed
+    # document still prints in the owner's own order and a filtered-out section
+    # is never built. A key in the selection that isn't stored simply doesn't
+    # intersect — which is also why the selection needs no validation: it only
+    # ever gets to remove keys the profile already had.
     def ordered_keys
       ordered = Array(care_settings["order"]).select do |key|
         key.is_a?(String) && stored_sections.key?(key)
       end
 
-      ordered + (stored_sections.keys - ordered)
+      keys = ordered + (stored_sections.keys - ordered)
+      return keys if only_sections.nil?
+
+      keys & only_sections
     end
 
     def build_section(key)

--- a/app/services/communicators/generate_care_plan.rb
+++ b/app/services/communicators/generate_care_plan.rb
@@ -25,7 +25,10 @@ module Communicators
     # forever — a gap the existing card generators still have.
     # 2: condensed layout — merged header band, two-column emergency grid,
     #    omitted blank emergency fields, two-column care sections.
-    LAYOUT_VERSION = 2
+    # 3: the band's "SpeakAnyWay" eyebrow is gone — the communicator's name is
+    #    the first thing read on a sheet that exists to introduce them, and the
+    #    mark still signs the footnote on every page.
+    LAYOUT_VERSION = 3
 
     VARIANTS = {
       full: { attachment: :care_emergency_plan_pdf, filename: "care-and-emergency-plan", emergency: true },
@@ -34,8 +37,9 @@ module Communicators
 
     class UnknownVariant < ArgumentError; end
 
-    def self.call(profile, variant: :full, regenerate: false, locale: I18n.locale, qr_target_url: nil)
-      new(profile, variant: variant, locale: locale, qr_target_url: qr_target_url)
+    def self.call(profile, variant: :full, regenerate: false, locale: I18n.locale, qr_target_url: nil,
+                  sections: nil)
+      new(profile, variant: variant, locale: locale, qr_target_url: qr_target_url, sections: sections)
         .call(regenerate: regenerate)
     end
 
@@ -43,8 +47,12 @@ module Communicators
     # generating so it can answer 422 — a service that raises can't, and a
     # near-blank document that looks like a finished plan is worse than a
     # refusal.
-    def self.printable?(profile, variant: :full)
-      document = CarePlanDocument.new(profile)
+    #
+    # The section selection has to reach this check too, or a :care_only request
+    # narrowed down to nothing prints the sheet of empty headings the 422 exists
+    # to refuse.
+    def self.printable?(profile, variant: :full, sections: nil)
+      document = CarePlanDocument.new(profile, only_sections: sections)
 
       config_for(variant)[:emergency] ? document.care? || document.emergency? : document.care?
     end
@@ -53,15 +61,22 @@ module Communicators
       VARIANTS.fetch(variant.to_sym) { raise UnknownVariant, "unknown care plan variant" }
     end
 
-    def initialize(profile, variant: :full, locale: I18n.locale, qr_target_url: nil)
+    def initialize(profile, variant: :full, locale: I18n.locale, qr_target_url: nil, sections: nil)
       super(profile, qr_target_url: qr_target_url)
       @variant = variant.to_sym
       @config = self.class.config_for(@variant)
       @locale = locale
+      # nil means every section — see the note on CarePlanDocument#initialize.
+      @sections = sections.nil? ? nil : Array(sections).map { |key| key.to_s.strip }.reject(&:empty?)
     end
 
-    attr_reader :variant, :config, :locale
+    attr_reader :variant, :config, :locale, :sections
 
+    # There is one attachment per VARIANT, not per selection, so a narrowed
+    # download replaces the stored document and the `care_plan_url` on
+    # Profile#api_view points at the narrowed sheet until the next download.
+    # That is deliberate — the screen regenerates on every click, so it
+    # self-corrects — and an attachment per selection would be unbounded.
     def call(regenerate: false)
       return profile if !regenerate && attached_and_fresh?(config[:attachment], signature: signature)
 
@@ -85,19 +100,26 @@ module Communicators
     # The two variants live in separate attachments so they can't literally
     # collide, but a mistake that crossed them would otherwise serve a care-only
     # download containing medications — cheap insurance for an expensive failure.
+    #
+    # The section selection rides along too, and it MUST: the two variants share
+    # one attachment each, so without it a narrowed download is answered by the
+    # cached full document and the picker silently does nothing. Omitted
+    # entirely when nothing was selected away, so an unfiltered download keeps
+    # the signature it has always had.
     def signature
       asset_signature(
         [
           profile.safety_info_signature,
           "care_plan=#{variant}",
           "locale=#{locale}",
+          ("sections=#{sections.sort.join(",")}" if sections),
           "v#{LAYOUT_VERSION}",
-        ].join("::"),
+        ].compact.join("::"),
       )
     end
 
     def document
-      @document ||= CarePlanDocument.new(profile, locale: locale)
+      @document ||= CarePlanDocument.new(profile, locale: locale, only_sections: sections)
     end
 
     def rendered_document

--- a/app/views/communicators/assets/care_plan.html.erb
+++ b/app/views/communicators/assets/care_plan.html.erb
@@ -24,8 +24,10 @@
     <div class="avatar-placeholder"></div>
   <% end %>
 
+  <%# No brand eyebrow above the name, deliberately: this sheet exists to
+      introduce one person, and the first thing read should be who they are.
+      The mark signs the footnote on every page instead. %>
   <div class="who">
-    <div class="eyebrow">SpeakAnyWay</div>
     <h1><%= @display_name %></h1>
     <div class="meta">
       <%= @title %><% if @pronouns.present? %> · <%= @pronouns %><% end %> · <%= @public_url %>

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -151,14 +151,7 @@
         border: 2pt solid rgba(255, 255, 255, 0.7);
       }
       .band .who { flex: 1 1 auto; min-width: 0; }
-      .band .eyebrow {
-        font-size: 6.5pt;
-        font-weight: 800;
-        letter-spacing: 0.16em;
-        text-transform: uppercase;
-        opacity: 0.9;
-      }
-      .band h1 { font-size: 16pt; font-weight: 900; line-height: 1.1; margin: 1pt 0 2pt; }
+      .band h1 { font-size: 16pt; font-weight: 900; line-height: 1.1; margin: 0 0 2pt; }
       .band .meta { font-size: 7.5pt; font-weight: 600; opacity: 0.92; }
       .band .qr {
         flex: none;

--- a/spec/requests/api/profiles_care_plan_spec.rb
+++ b/spec/requests/api/profiles_care_plan_spec.rb
@@ -94,6 +94,65 @@ RSpec.describe "API::Profiles care plan", type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
+    # The section picker's wire format. The frontend sends a comma-separated
+    # string; the array form is what a form-encoded client would send, and both
+    # have to mean the same thing.
+    it "passes a comma-separated selection through to the generator" do
+      expect(Communicators::GenerateCarePlan).to receive(:call)
+        .with(profile, hash_including(sections: %w[meals sensory]))
+        .and_call_original
+
+      post_care_plan(parent, sections: "meals,sensory")
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "accepts the selection as an array" do
+      expect(Communicators::GenerateCarePlan).to receive(:call)
+        .with(profile, hash_including(sections: %w[meals sensory]))
+        .and_call_original
+
+      post_care_plan(parent, sections: %w[meals sensory])
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # Absent means every section, which is what every caller sent before the
+    # picker existed — so it must stay distinguishable from "none selected".
+    it "passes nil when no selection is sent" do
+      expect(Communicators::GenerateCarePlan).to receive(:call)
+        .with(profile, hash_including(sections: nil))
+        .and_call_original
+
+      post_care_plan(parent)
+    end
+
+    # An emergency-only sheet, and the reason an empty selection is a request
+    # rather than a missing one.
+    it "builds the combined plan from emergency info alone when nothing is selected" do
+      post_care_plan(parent, sections: "")
+
+      expect(response).to have_http_status(:ok)
+      expect(profile.reload.care_emergency_plan_pdf).to be_attached
+    end
+
+    it "answers no_care_info when a care-only selection resolves to nothing" do
+      post_care_plan(parent, variant: "care_only", sections: "sensory")
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)["error"]).to eq("no_care_info")
+      expect(profile.reload.care_plan_pdf).not_to be_attached
+    end
+
+    # A key the profile has no section for can only ever remove sections, so it
+    # needs no validation and gets no error.
+    it "ignores a section key the profile does not have" do
+      post_care_plan(parent, variant: "care_only", sections: "meals,not_a_section")
+
+      expect(response).to have_http_status(:ok)
+      expect(profile.reload.care_plan_pdf).to be_attached
+    end
+
     it "rejects an unknown variant rather than falling back to the combined plan" do
       post_care_plan(parent, variant: "everything")
 

--- a/spec/services/communicators/care_plan_document_spec.rb
+++ b/spec/services/communicators/care_plan_document_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Communicators::CarePlanDocument do
     described_class.new(profile.reload)
   end
 
+  def with_care_only(care, only_sections)
+    profile.update!(settings: { "care" => care })
+    described_class.new(profile.reload, only_sections: only_sections)
+  end
+
   describe "#care_sections" do
     it "labels the section, its fields, and its option values" do
       doc = with_care(
@@ -272,6 +277,61 @@ RSpec.describe Communicators::CarePlanDocument do
     it "reports whether there is any emergency info at all" do
       expect(with_care({ "sections" => {} }, emergency).emergency?).to be(true)
       expect(with_care("sections" => {}).emergency?).to be(false)
+    end
+  end
+
+  # The section picker's server half. The selection is an ALLOWLIST, applied
+  # after the order walk, and nil is not [] — see the note on #initialize.
+  describe "only_sections" do
+    let(:three_sections) do
+      {
+        "order" => %w[meals sensory communication],
+        "sections" => {
+          "communication" => { "values" => { "methods" => ["aac_device"] } },
+          "meals" => { "values" => { "preferences" => "hates anything cold" } },
+          "sensory" => { "values" => { "calming" => "quiet spaces" } },
+        },
+      }
+    end
+
+    it "prints every stored section when nil" do
+      doc = with_care_only(three_sections, nil)
+
+      expect(doc.care_sections.map(&:key)).to eq(%w[meals sensory communication])
+    end
+
+    it "prints only the selected sections, still in the owner's order" do
+      # Passed in a different order than stored, to pin that the SELECTION does
+      # not reorder the sheet.
+      doc = with_care_only(three_sections, %w[communication meals])
+
+      expect(doc.care_sections.map(&:key)).to eq(%w[meals communication])
+    end
+
+    it "ignores a key the profile has no section for" do
+      doc = with_care_only(three_sections, %w[meals not_a_section])
+
+      expect(doc.care_sections.map(&:key)).to eq(%w[meals])
+    end
+
+    # [] is a real request on the :full variant — the emergency page alone.
+    # This is why the argument can't be normalized with Array().
+    it "prints no sections when given an empty selection" do
+      doc = with_care_only(three_sections, [])
+
+      expect(doc.care_sections).to be_empty
+      expect(doc.care?).to be(false)
+    end
+
+    it "answers #care? about the selected sections only" do
+      expect(with_care_only(three_sections, %w[meals]).care?).to be(true)
+      expect(with_care_only(three_sections, %w[transportation]).care?).to be(false)
+    end
+
+    it "tolerates blanks and symbols in the selection" do
+      doc = with_care_only(three_sections, [:meals, "", "  sensory  ", nil])
+
+      expect(doc.care_sections.map(&:key)).to eq(%w[meals sensory])
     end
   end
 end

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe Communicators::GenerateCarePlan do
     captured
   end
 
+  # The visible text of the header band, in order — everything from the band to
+  # whatever section follows it, tags stripped. Asserting on the ORDER is the
+  # point: "the name is not preceded by anything" is the claim, and a check for
+  # the absence of one particular string would pass again the moment someone
+  # put a different eyebrow back.
+  def band_text(html)
+    band = html[/<div class="band">.*?(?=<section|<div class="care-heading"|<div class="footnote")/m]
+    raise "no header band in the rendered document" unless band
+
+    band.gsub(/<[^>]+>/, "\n").split("\n").map(&:strip).reject(&:empty?)
+  end
+
   # settings holds care under "care", plus the emergency keys at the top level.
   before do
     profile.update!(settings: { "care" => care }.merge(emergency))
@@ -225,6 +237,18 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html).to match(/\.page-frame\s*\{[^}]*inset:\s*0/m)
     end
 
+    # The sheet exists to introduce one person. The band used to open with a
+    # "SpeakAnyWay" eyebrow, so the brand was the first thing read on a page
+    # whose whole job is to say who this is.
+    it "reads the communicator's name first, with no brand eyebrow above it" do
+      html = render_html
+
+      expect(band_text(html).first).to eq("Rosa")
+      expect(html).not_to include(%(class="eyebrow"))
+      # The mark still signs the sheet — in the footnote, at the bottom.
+      expect(band_text(html)).not_to include("SpeakAnyWay")
+    end
+
     it "signs the document with the logo in the footnote" do
       html = render_html
 
@@ -367,6 +391,80 @@ RSpec.describe Communicators::GenerateCarePlan do
       care_only = profile.care_plan_pdf.metadata["signature"]
 
       expect(full).not_to eq(care_only)
+    end
+  end
+
+  # The section picker. `sections` is an allowlist; nil means all of them, and
+  # the selection has to reach the freshness signature or a narrowed download is
+  # answered by the cached full document.
+  describe "a narrowed selection" do
+    it "prints only the selected sections" do
+      html = render_html(sections: %w[meals])
+
+      expect(html).to include("hates cold food")
+      expect(html).not_to include("Bedtime")
+      expect(html).not_to include("Eye gaze")
+    end
+
+    it "keeps the emergency block on the full variant" do
+      html = render_html(sections: %w[meals])
+
+      expect(html).to include("zzpeanutszz")
+    end
+
+    # An emergency-only sheet is a real request, and the reason [] can't be
+    # normalized into nil anywhere along the way.
+    it "prints the emergency page alone when no section is selected" do
+      html = render_html(sections: [])
+
+      expect(html).to include("zzpeanutszz")
+      expect(html).not_to include("hates cold food")
+      expect(html).not_to include("Bedtime")
+    end
+
+    it "re-renders when the selection changes" do
+      render_html(sections: %w[meals])
+
+      expect(Grover).to receive(:new).and_return(instance_double(Grover, to_pdf: "%PDF-stub"))
+      described_class.call(profile.reload, variant: :full, sections: %w[communication])
+    end
+
+    it "does not re-render for the same selection" do
+      render_html(sections: %w[meals])
+
+      expect(Grover).not_to receive(:new)
+      described_class.call(profile.reload, variant: :full, sections: %w[meals])
+    end
+
+    # Order is not part of the request — it is the owner's stored order that
+    # decides the sheet — so two spellings of one selection are one document.
+    it "treats a reordered selection as the same document" do
+      render_html(sections: %w[meals communication])
+
+      expect(Grover).not_to receive(:new)
+      described_class.call(profile.reload, variant: :full, sections: %w[communication meals])
+    end
+
+    # Every document generated before the picker shipped carries a signature
+    # with no sections term. Adding one unconditionally would invalidate all of
+    # them at once for no change in output.
+    it "leaves the signature untouched when nothing is selected away" do
+      render_html
+      unfiltered = profile.reload.care_emergency_plan_pdf.metadata["signature"]
+
+      expect(Grover).not_to receive(:new)
+      described_class.call(profile.reload, variant: :full, sections: nil)
+      expect(profile.reload.care_emergency_plan_pdf.metadata["signature"]).to eq(unfiltered)
+    end
+
+    it "is not printable for care-only when the selection resolves to nothing" do
+      expect(described_class.printable?(profile.reload, variant: :care_only, sections: [])).to be(false)
+      expect(described_class.printable?(profile.reload, variant: :care_only, sections: %w[meals])).to be(true)
+    end
+
+    # The emergency page carries the full variant on its own.
+    it "is still printable for full when the selection resolves to nothing" do
+      expect(described_class.printable?(profile.reload, variant: :full, sections: [])).to be(true)
     end
   end
 


### PR DESCRIPTION
## Summary

Two changes to the communicator care plan PDFs, both driven by what the sheet is
actually for.

**1. The download can be narrowed to the sections you want.**
`POST /api/profiles/:id/care_plan` now takes a `sections` allowlist (a
comma-separated string or an array). A parent handing a sheet to a bus driver no
longer has to include the meals and personal-care pages. The frontend half — a
picker modal on both Download buttons — is brittanyjohns/itty-bitty-frontend#722.

Three things are load-bearing and are pinned by specs:

- **Absent is not empty, at every hop.** Absent means every stored section —
  what every caller sent before this shipped, which is what keeps their
  documents' signatures stable — and empty means none of them, which on the
  `:full` variant is a real request for the emergency page alone. `Array(nil)`
  collapses the two, so controller, `GenerateCarePlan` and `CarePlanDocument`
  each guard on nil explicitly.
- **The selection rides in the freshness signature.** There is one attachment
  per variant, so without it a narrowed request is answered by the cached full
  document and the picker silently does nothing. It is omitted from the
  signature entirely when nothing was selected away, so no existing cached
  document is invalidated.
- **It also reaches `.printable?`.** Otherwise a `:care_only` request narrowed
  down to nothing prints headings over nothing — the exact "a finished plan that
  says this child needs nothing" failure the 422 exists to refuse.

Section keys need no validation: they are only ever intersected with the
profile's own stored keys, so an unknown one can only remove sections. The list
is capped in the controller because it rides in the signature.

**2. The header band leads with the communicator's name.** The `SpeakAnyWay`
eyebrow above it is gone. On a sheet whose whole job is to say who this person
is and how to support them, the brand was the first thing a reader's eye landed
on. The mark still signs the footnote on every page. `LAYOUT_VERSION` bumped
2 → 3 so already-generated documents re-render.

## Test plan

`bundle exec rspec spec/services/communicators/care_plan_document_spec.rb spec/services/communicators/generate_care_plan_spec.rb spec/requests/api/profiles_care_plan_spec.rb spec/requests/api/profiles_care_view_spec.rb spec/services/care_labels_spec.rb` — **all green** (117 examples across the runs, 0 failures).

New coverage:
- `CarePlanDocument`: nil vs `[]` vs a subset; the selection does not reorder the
  sheet; an unknown key is ignored; `#care?` answers about the filtered set.
- `GenerateCarePlan`: a narrowed render omits the other sections and keeps the
  emergency block; re-renders when the selection changes; does **not** re-render
  for the same selection or for a reordered one; the signature is byte-identical
  when `sections` is nil; `.printable?` in both variants.
- Request spec: comma string and array forms, absent → nil, empty → emergency
  page alone, `no_care_info` when a `care_only` selection resolves to nothing.
- Header: the band's first text is the communicator's name, and it carries no
  eyebrow — asserted on the ORDER of the band's text, so putting a different
  eyebrow back fails the spec.

Rendered the template directly to confirm the band reads `["Rosa Martinez",
"Care & Emergency Plan · she/her · https://…"]`. The band is
`align-items: center`, so removing a line leaves it balanced.

## Docs

- `.claude-notes/safety-profiles.md` — the `sections` param and the four traps
  above.
- `CHANGELOG.md` — both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)