### PR TITLE
feat(boards): link a tile to an existing board as it is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Added
 
+- **A tile can be pointed at an existing board as it is created.**
+  `POST /api/boards/:id/add_image` now accepts an optional `predictive_board_id`
+  and links the tile it creates in the same request, so the frontend's new
+  "Link a board" tab never leaves a half-made unlinked tile behind. The id is
+  resolved against the caller's own boards plus the public library — anything
+  else is ignored and the tile arrives unlinked rather than erroring — and a
+  self-link is dropped, since the API already renders those as ordinary tiles.
+  The tile is marked `mute_name`, which is what makes it count as a folder tile
+  in the board-set map, and falls back to the linked board's cover picture when
+  its own image has no art.
+
 - **Care plan downloads can be narrowed to the sections you want.** The care
   plan endpoint takes a `sections` allowlist, so a sheet for a bus driver
   doesn't have to carry the meals and personal-care pages. Sending no

--- a/app/controllers/api/boards_controller.rb
+++ b/app/controllers/api/boards_controller.rb
@@ -1114,6 +1114,38 @@ class API::BoardsController < API::ApplicationController
         board_image&.update(data: (board_image.data || {}).merge(gestalt))
       end
 
+      # "Link a board" (the Add-tiles modal's third tab): make the tile we just
+      # created open one of the caller's existing boards. Top-level param, not
+      # part of image_params — it describes the tile, not the Image. Absent
+      # means a plain word tile, which is the pre-existing behaviour.
+      if params[:predictive_board_id].present? && @board
+        board_image ||= @board.board_images.find_by(image_id: @image.id)
+        target = linkable_board(params[:predictive_board_id])
+        # A tile pointing at its own board is not a link. BoardImage#is_dynamic?
+        # rejects the self-case and api_view_with_predictive_images forces
+        # dynamic=false for a tile aimed at the root board, so it would render
+        # as an ordinary tile with no folder badge and no navigation. Drop it
+        # rather than storing a link that silently does nothing.
+        target = nil if target && target.id == @board.id
+        if board_image && target
+          board_image.predictive_board_id = target.id
+          # mute_name is not merely "don't speak": it is what makes
+          # BoardImage#door_tile? true, which is what the board-set map reads to
+          # draw the folder edge. Merge — the gestalt block above writes the
+          # same jsonb blob.
+          board_image.data = (board_image.data || {}).merge("mute_name" => true)
+          # Fall back to the linked board's cover only when the resolved Image
+          # brought no art of its own. A blank string is the deliberate
+          # "no picture" marker, so this must never assign "".
+          if board_image.display_image_url.blank? &&
+             @image.display_image_url(current_user).blank? &&
+             target.display_image_url.present?
+            board_image.display_image_url = target.display_image_url
+          end
+          board_image.save
+        end
+      end
+
       screen_size = params[:screen_size] || "lg"
       # @board.calculate_grid_layout_for_screen_size(screen_size)
       @board.reload
@@ -1851,6 +1883,18 @@ class API::BoardsController < API::ApplicationController
           .permit(:gestalt_source, :utterance_function)
           .to_h
           .reject { |_k, v| v.blank? }
+  end
+
+  # A board the caller may point a tile at: one of their own, or one from the
+  # public library. Deliberately mirrors what the frontend's board picker
+  # offers (GET boards/list + GET public_boards) and the IDOR scoping in
+  # #associate_image. An id outside that set resolves to nil and is ignored —
+  # the tile is still created, just unlinked — rather than 404ing a request
+  # whose main job (add a tile) succeeded.
+  def linkable_board(id)
+    return Board.find_by(id: id) if current_user.admin?
+
+    current_user.boards.find_by(id: id) || Board.public_boards.find_by(id: id)
   end
 
   # Optional communicator-profile fields passed by the frontend's

--- a/spec/requests/api/boards_spec.rb
+++ b/spec/requests/api/boards_spec.rb
@@ -888,6 +888,120 @@ RSpec.describe "API::Boards", type: :request do
     end
   end
 
+  # "Link a board" — the third tab of the frontend's Add-tiles modal. One
+  # request both creates the tile and points it at an existing board, so there
+  # is never a half-made unlinked tile, and the whole thing stays behind
+  # add_image's existing editable / marketplace guards.
+  describe "POST /api/boards/:id/add_image with predictive_board_id" do
+    # A paid owner on purpose: the Free plan's board_limit of 1 makes every
+    # board but the designated one read-only, and these examples need two
+    # boards at once — a hub and something to link it to.
+    let(:owner) { create(:user, plan_type: "pro", plan_status: "active") }
+    let(:hub_board) { create(:board, user: owner, name: "Hub") }
+    let(:target_board) { create(:board, user: owner, name: "Big Feelings") }
+
+    def tile_for(label)
+      image = Image.by_label(label).first
+      hub_board.reload.board_images.find_by(image_id: image&.id)
+    end
+
+    it "links the new tile to the chosen board and mutes it" do
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "feelings link" }, predictive_board_id: target_board.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+
+      tile = tile_for("feelings link")
+      expect(tile.predictive_board_id).to eq(target_board.id)
+      # mute_name is not decoration: it is what makes door_tile? true, which is
+      # what the board-set map reads to draw the folder edge.
+      expect(tile.data["mute_name"]).to be(true)
+      expect(tile.is_dynamic?).to be(true)
+
+      # The frontend's folder badge keys off the serialized `dynamic` flag, not
+      # off predictive_board_id, so the response has to carry it or the tile
+      # navigates while looking like an ordinary word tile.
+      rendered = JSON.parse(response.body)["images"].find { |i| i["label"] == "feelings link" }
+      expect(rendered["dynamic"]).to be(true)
+      expect(rendered["predictive_board_id"]).to eq(target_board.id)
+      expect(rendered["predictive_board_name"]).to eq("Big Feelings")
+    end
+
+    it "lets a user link to a board from the public library" do
+      admin = User.find_by(id: User::DEFAULT_ADMIN_ID) || create(:admin_user, id: User::DEFAULT_ADMIN_ID)
+      public_board = create(:board, user: admin, name: "Core 24", published: true, predefined: true)
+      expect(Board.public_boards).to include(public_board)
+
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "core link" }, predictive_board_id: public_board.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(tile_for("core link").predictive_board_id).to eq(public_board.id)
+    end
+
+    it "ignores another user's board and still creates the tile" do
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "foreign link" }, predictive_board_id: other_board.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      tile = tile_for("foreign link")
+      expect(tile).to be_present
+      expect(tile.predictive_board_id).to be_nil
+      expect(tile.data).not_to have_key("mute_name")
+    end
+
+    it "ignores a self-link, which would render as a plain tile anyway" do
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "self link" }, predictive_board_id: hub_board.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(tile_for("self link").predictive_board_id).to be_nil
+    end
+
+    it "falls back to the linked board's cover when the image brings no art" do
+      target_board.update!(display_image_url: "https://cdn.example.com/cover.png")
+
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "artless link" }, predictive_board_id: target_board.id },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      expect(tile_for("artless link").display_image_url).to eq("https://cdn.example.com/cover.png")
+    end
+
+    it "does not overwrite an uploaded picture with the linked board's cover" do
+      target_board.update!(display_image_url: "https://cdn.example.com/cover.png")
+      upload = Rack::Test::UploadedFile.new(Rails.root.join("public", "logo_bubble.png"), "image/png")
+
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: {
+             image: { label: "uploaded link", docs: { image: upload } },
+             predictive_board_id: target_board.id,
+           },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      tile = tile_for("uploaded link")
+      expect(tile.predictive_board_id).to eq(target_board.id)
+      expect(tile.display_image_url).not_to eq("https://cdn.example.com/cover.png")
+    end
+
+    it "leaves the tile unlinked when the param is absent" do
+      post "/api/boards/#{hub_board.id}/add_image",
+           params: { image: { label: "unlinked word" } },
+           headers: auth_headers(owner)
+
+      expect(response).to have_http_status(:ok)
+      tile = tile_for("unlinked word")
+      expect(tile.predictive_board_id).to be_nil
+      expect(tile.data).not_to have_key("mute_name")
+    end
+  end
+
   # Mailchimp "hit_limit" Customer Journey trigger (issue #291, journey #3).
   # Enqueued from check_board_create_permissions when a Free user trips the
   # board cap on create / clone / create_from_template. Deduped 14d via


### PR DESCRIPTION
## Summary

`POST /api/boards/:id/add_image` now accepts an optional top-level `predictive_board_id` and links the tile it creates **in the same request**.

This is the backend half of the frontend's new **Link a board** tab (itty-bitty-frontend PR to follow). Without it, that tab would need two calls — create the tile, then `PUT board_images/:id` — with a window in between where an unlinked tile exists on the board.

Routing it through `add_image` rather than `images#find_or_create` is deliberate: `add_image` is already behind `check_board_editable!` and `check_marketplace_edit_confirmed!`, so the whole flow stays guarded. (`find_or_create` resolves `Board.find_by(id:)` with no ownership check and no guards at all — worth its own issue, not touched here.)

**Merge this before the frontend PR.** The frontend sends a param an un-deployed backend would silently ignore, producing unlinked tiles.

## Three details worth reviewing

- **Scoping.** A new `linkable_board` helper resolves the id against the caller's own boards plus `Board.public_boards` — mirroring what the frontend's picker offers (`GET boards/list` + `GET public_boards`) and the IDOR scoping in `#associate_image`. An id outside that set is **ignored**, and the tile is still created unlinked, rather than 404ing a request whose main job succeeded.
- **Self-links are dropped.** `BoardImage#is_dynamic?` rejects the self-case and `api_view_with_predictive_images` forces `dynamic = false` for a tile aimed at the root board — so storing one renders an ordinary tile with no folder badge and no navigation. A link that silently does nothing is worse than no link.
- **`mute_name` is not just "don't speak".** It is what makes `BoardImage#door_tile?` true, and that is what the board-set map reads to draw the folder edge. Set via a `merge` — the gestalt block immediately above writes the same jsonb blob.

The linked board's cover picture is used **only** when the resolved `Image` brought no art of its own, and never as a blank string — that value is the deliberate "no picture" marker honoured by the PDF/print renderer.

## Test plan

`bundle exec rspec` — **6042 examples, 0 failures, 7 pending** (the 7 were already pending on `main`). Re-ran `boards_spec`, marketplace protection, and the `BoardImage`/`Image` model specs after rebasing onto the current `main` — 183 examples, 0 failures.

New coverage in `spec/requests/api/boards_spec.rb`:

- links the tile, sets `mute_name`, and the **serialized `dynamic` flag** the frontend's folder badge keys off (plus `predictive_board_id` / `predictive_board_name` on the response body)
- links to a board from the public library
- ignores another user's board — tile still created, unlinked
- ignores a self-link
- cover fallback fires only for an art-less image, and never overwrites an uploaded picture
- omitting the param leaves behaviour byte-identical

One note from writing those specs, product-side rather than test scaffolding: the examples need a **paid** owner, because on Free `board_limit` is 1 and `effective_editable_board_id` picks the most-recently-updated board — so merely creating a second board makes the first read-only. A Free user can't really use this feature; every add 403s `board_locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
