### PR TITLE
feat(etsy): phrase-only tags and head-term-first listing titles

### DIFF
--- a/.claude-notes/board-printables-etsy.md
+++ b/.claude-notes/board-printables-etsy.md
@@ -200,8 +200,56 @@ rules and needs the matching change — see that repo's
 `.claude-notes/etsy-listing-copy-fix-handoff.md`. What differs until it lands:
 the product phrase is `"communication board"` here and `"vocabulary board"`
 there; `assemble_tags` runs `topic` second here (capped at
-`CopyRules::TOPIC_TAG_MAX`) and fourth there; and the description's opening
-sentence is per-product here and a frozen constant there.
+`CopyRules::TOPIC_TAG_MAX`) and fourth there; the description's opening
+sentence is per-product here and a frozen constant there; and the two SEO rules
+below (no single-word tags, head-term-first titles) exist only here.
+
+**A tag is a PHRASE — `normalize_tag` refuses a single word.** Analysis of all
+21 live listings on 2026-08-20 (views normalized by `original_creation_timestamp`,
+since the API's `created` resets on renewal) found five of every listing's
+thirteen slots going to `aac`, `printable`, `slp`, `classroom` and
+`nonspeaking`. A one-word tag competes with the entire marketplace and does not
+rank; the listings earning views were found by phrases. The rule lives in
+`CopyRules.normalize_tag`, NOT in the pools, deliberately: a future pool edit
+cannot put the slots back, and the same rule reaches `Etsy::Client#normalize_tags`
+— so a one-word tag typed into the admin listing form is dropped on save too.
+That silent drop is intended; the advisory panel names it.
+
+Two consequences worth knowing. A one-word segment of a `topic` now yields
+nothing at all (`topic_tags("core words / feelings")` → `["core words"]`), since
+there is no legal tag to make from it. And the pools trade brand voice for
+search: tags say `nonverbal child`, description prose keeps `nonspeaking`. Etsy
+tags are a search index, not a brand surface — that split is approved, not an
+inconsistency to fix.
+
+**The head term always leads the title; the board name is always the
+qualifier.** `ListingCopy#title` used to open on the board's own name, on the
+reasoning that buyers search "core words board" rather than "SpeakAnyWay". That
+holds only when the board name is itself a search term. Every zero-view listing
+in the same analysis was a niche noun — "Recess", "Haircut", "Potty" — placed in
+front of the phrase buyers actually type, so the title opened on a word nobody
+searches. There is no conditional: the product phrase leads, always.
+
+The single exception is folding, not reordering — a board whose name already
+contains a product word ("Core Words Board") folds INTO the head as
+`"AAC Core Words Board"` rather than being repeated after
+`"AAC Communication Board Printable"`. The widest-first candidate ladder and its
+guaranteed-fitting last rung are unchanged and still load-bearing:
+`pick_fitting_title` truncates mid-word when every rung overflows, which is how
+a listing shipped titled `"… Printable for Speech The (Digital Download)"`. The
+last rung is now a fixed phrase rather than the board name, because the folded
+head can itself be arbitrarily long.
+
+**`Etsy::CopyAdvisories` renders beside the overlap warning and is equally
+advisory.** Three checks — fewer than 13 tags, any single-word tag still stored
+from before the rule, and no "AAC" in the title's first 40 characters. Never a
+gate: each has legitimate exceptions only an admin can judge, and a listing that
+can't be published is worse than one published with twelve tags.
+
+Seven listings were hand-rewritten to this shape on 2026-08-20 and are live. Do
+NOT run `regenerate_listing_copy!` against them — it merges generated copy over
+the stored hash, overwriting hand-tuned title, summary, description and tags:
+`4554491916 4557544635 4556388009 4554121725 4554595592 4559346650 4556507027`.
 
 **The tag pools describe the product LAST unless something stops them.** The
 generic pools — always-on, product-type, audience, top-up — can fill all 13 of

--- a/.claude-notes/etsy-listing-copy-seo-handoff.md
+++ b/.claude-notes/etsy-listing-copy-seo-handoff.md
@@ -1,0 +1,236 @@
+# Handoff: Etsy listing copy SEO rules (Rails)
+
+**Date:** 2026-08-20 · **Status:** implemented (all four work items)
+**Full plan:** `../../drafts/etsy-listing-copy-seo-plan.md` (this doc is self-contained; the plan adds context)
+**Related:** `.claude-notes/board-printables-etsy.md` — read it first, it owns the pipeline's invariants
+**Issue:** none filed
+
+## Why this exists
+
+All 21 live SpeakAnyWay Etsy listings were analyzed on 2026-08-20 with views
+normalized by true listing age (`original_creation_timestamp` — the API's `created`
+field resets on renewal and is misleading).
+
+Core-vocabulary boards run 6–8 views/day. Niche-occasion boards — haircut, potty,
+travel, feelings, classroom, recess — run ~0. The top listing has the shop's weakest
+description and only six images, and a 20-day-old core board with no video was
+outpacing it. Age, video, and description quality do not explain the gap. The title's
+leading phrase and the tag set do.
+
+Seven listings were hand-rewritten that day and are now live. **This generator still
+produces the old shape**, so the next printable published from the admin reintroduces
+every defect. That is what this work fixes.
+
+## Decisions (already made — don't re-litigate)
+
+1. Titles **always** lead with the head term. Board name is always the qualifier. No
+   conditional branch — this was explicitly chosen over a "merge when the board name
+   already contains a head term" variant.
+2. Single-word tags are blocked in `normalize_tag` **and** removed from the pools.
+   Rule-level enforcement was explicitly chosen so a future pool edit cannot
+   reintroduce them.
+3. Rails only. Do **not** touch `speakanyway-printables` — its generator has already
+   diverged deliberately and has its own sync doc.
+4. Tags say `nonverbal`; description prose keeps `nonspeaking`. Etsy tags are a search
+   index, not a brand surface. This is an approved, deliberate split — do not
+   "fix" the inconsistency.
+5. `pecs alternative` gets a permanent top-up slot.
+
+## Current state
+
+### `app/services/etsy/copy_rules.rb`
+
+`normalize_tag` (L66-72) enforces Etsy's character set and the 20-char cap, and rejects
+all-small-word phrases. It does **not** enforce a minimum word count, so a one-word tag
+passes cleanly.
+
+`assemble_tags` (L129-151) is correct and was fixed in a prior pass — `topic` runs
+second, capped at `TOPIC_TAG_MAX = 6` (L113). Preserve that order; the comment at
+L118-124 explains what breaks if it moves back.
+
+`pick_fitting_title` (L165+) takes a widest-first candidate ladder and requires the last
+rung to always fit. Keep that contract.
+
+### `app/services/etsy/listing_copy.rb` — where the defects are
+
+```ruby
+ALWAYS_ON_TAGS = ["aac", "printable", "digital download"].freeze   # L25
+AUDIENCE_TAGS  = ["autism support", "slp", "classroom"].freeze     # L30
+```
+
+Five of thirteen slots, on every listing, spent on terms that compete with the entire
+marketplace. `TOP_UP_TAGS` (L47-59) is otherwise good but carries `nonspeaking` (L52)
+and has no `pecs alternative`.
+
+`#title` (L139-175) builds:
+
+```ruby
+head = if names_product
+  "#{base} AAC Printable"                                          # L149
+else
+  "#{base} AAC #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"  # L151
+end
+```
+
+`base` is the board name, so a board called "Recess" produces *"Recess AAC
+Communication Board Printable, …"* — the exact shape that shipped at zero views. The
+comment at L136-138 justifies leading with the board name over the brand name; that
+reasoning is sound but incomplete, since it only holds when the board name is itself a
+search term ("Core Words Board"), not when it's a niche noun ("Recess", "Haircut").
+
+`PRODUCT_HUMAN = "communication board"` (L23) is correct — leave it.
+
+### Reference: the seven approved live titles
+
+These are the target shape. Match them.
+
+```
+AAC Communication Board Printable, Haircut and Salon Visits, 3-Board Autism Speech Therapy Set (Digital Download)
+AAC Communication Board Printable, Potty Training 3-Board Visual Set for Autism and Speech Therapy (Digital Download)
+AAC Communication Board Printable, Travel and Vacation 3-Board Set for Autism and Speech Therapy (Digital Download)
+AAC Communication Board Printable, Feelings and Emotions 5-Board Set for Autism and Self Regulation (Digital Download)
+AAC Communication Board Printable, Classroom and School 4-Board Set for Special Education (Digital Download)
+AAC Communication Board Printable, Recess and Playground Set for School and Speech Therapy (Digital Download)
+AAC Core Communication Board, 84-Word Core Vocabulary Printable for Speech Therapy and Aphasia (Digital Download)
+```
+
+## Work items
+
+### 1. Block single-word tags in `normalize_tag`
+
+`app/services/etsy/copy_rules.rb`, after the existing small-word check (L69):
+
+```ruby
+return nil if cleaned.split(" ").length < 2
+```
+
+Add a comment saying why: single-word tags compete with the whole marketplace and
+measurably do not rank; five slots per listing were being burned this way.
+
+This is a behavior change with real reach. `normalize_tag` is called by `topic_tags`
+(L91, L102) and by `Etsy::Client#normalize_tags` (`app/services/etsy/client.rb` L247-249,
+public), which is itself called from `Admin::BoardPrintablesController` L383 — so the
+**admin hand-edit save path runs through it too**, not just generation. A one-word tag
+typed by hand in the admin form will now be silently dropped. That is intended, but
+know it before you're surprised by it.
+
+It breaks existing specs. These are pinned assertions, not accidents — update each one
+deliberately:
+
+| File | Lines | What breaks |
+|---|---|---|
+| `spec/services/etsy/listing_copy_spec.rb` | **L131-139** | Exact-equality pin on the full 13-tag boilerplate array containing `"aac"`, `"printable"`, `"slp"`, `"classroom"`, `"nonspeaking"`. Fails against all three changes at once. **This is the intended-behavior pin — rewrite it in lockstep with the pool changes, don't patch around it.** |
+| `spec/services/etsy/listing_copy_spec.rb` | L82-89 | Asserts 13 slots and `include("aac", "printable", …)` |
+| `spec/services/etsy/copy_rules_spec.rb` | L131-133 | `topic_tags("core words / feelings")` expects `"feelings"` to survive — the only direct single-word-survives assertion |
+| `spec/services/etsy/copy_rules_spec.rb` | L49-63, L65-77, L84-96, L100-111 | Four `assemble_tags` examples whose fixtures include single-word tags and assert exact arrays or a length of 13 |
+
+### 2. Fix the pools
+
+`app/services/etsy/listing_copy.rb`:
+
+```ruby
+ALWAYS_ON_TAGS = ["printable aac", "communication board", "low tech aac"].freeze
+AUDIENCE_TAGS  = ["autism support", "slp resources", "classroom visuals"].freeze
+```
+
+`PRODUCT_TYPE_TAGS` is `[PRODUCT_HUMAN]` = `"communication board"`, which now duplicates
+an always-on entry. `assemble_tags` dedups, so this is harmless at runtime — but resolve
+it rather than leaving two sources of the same tag. Either drop it from `ALWAYS_ON_TAGS`
+or make `PRODUCT_TYPE_TAGS` carry the secondary term. Note the existing comment at
+L43-46 already reasons about this exact overlap; keep it truthful to whatever you choose.
+
+In `TOP_UP_TAGS`: add `"pecs alternative"` near the top (highest buyer intent in the
+pool), replace `"nonspeaking"` with `"nonverbal child"`, and remove `"slp resources"`
+and `"classroom visuals"` if you moved them into `AUDIENCE_TAGS`.
+
+Every tag must be ≤20 characters. `"pecs alternative"` is 16, `"nonverbal child"` is 15,
+`"communication board"` is 19.
+
+### 3. Head-term-first titles
+
+`app/services/etsy/listing_copy.rb#title`. The product phrase leads; the board name
+becomes part of the qualifier:
+
+```ruby
+head = "AAC #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"
+```
+
+with the special case that when the board name already contains a head-term word
+(`names_product` at L146-147 computes this), the board name folds into the head instead
+of being repeated:
+
+```ruby
+head = "AAC #{CopyRules.title_case_words(base)}"   # "AAC Core Communication Board"
+```
+
+Then the qualifier clause carries `base` (when not already folded in), `size_phrase`,
+and `topic_phrase`. Keep the widest-first ladder and keep a guaranteed-fitting last
+rung — `pick_fitting_title` truncates mid-word if every rung overflows, which has
+already shipped a listing titled `"… Printable for Speech The (Digital Download)"`.
+
+Watch the ampersand: `tail` is `"for Speech Therapy & Autism"` and Etsy 400s on a second
+`&`. `enforce_title_rules` rewrites later ones to "and", so this is handled — but if you
+add another `&` anywhere, know that's why the first survives and the rest don't.
+
+### 4. Extend the admin advisory panel
+
+`app/services/etsy/tag_overlap.rb` already warns on ≥10-of-13 overlap and renders via
+`app/views/admin/board_printables/_tag_overlap.html.erb`. Add three checks in the same
+panel: tag count below 13, any single-word tag present, and head term absent from the
+title's first 40 characters. Advisory only — never block a publish.
+
+## Testing
+
+Specs live in `spec/services/etsy/`. Run at minimum:
+
+```
+bundle exec rspec spec/services/etsy/copy_rules_spec.rb \
+                  spec/services/etsy/listing_copy_spec.rb \
+                  spec/services/etsy/tag_overlap_spec.rb
+```
+
+Prove these cases:
+
+| Case | Expected |
+|---|---|
+| `normalize_tag("aac")` | `nil` |
+| `normalize_tag("printable aac")` | `"printable aac"` |
+| `normalize_tag("a communication board that talks")` | `nil` (over 20 chars, unchanged behavior) |
+| Board named "Recess", no topic | title starts `"AAC Communication Board Printable,"` |
+| Board named "Core Words Board" | title starts `"AAC Core Words Board"` — not repeated |
+| Any generated printable | exactly 13 tags, none single-word, none over 20 chars |
+| Two different boards, different topics | tag sets differ by ≥4 tags (the `MIN_TOPIC_TAGS` premise) |
+| Long board name, no topic | title fits 140 including suffix, not truncated mid-word |
+
+Also run `bundle exec rspec spec/requests/admin/board_printables_spec.rb` — the admin
+show page renders generated copy and the advisory panel, and its save path calls
+`Etsy::Client#normalize_tags`.
+
+## Deploy notes
+
+No migrations. No new ENV vars. No API contract change. Copy generation only, confined
+to `app/services/etsy/`.
+
+**Do not run `regenerate_listing_copy!` against these seven listings** — they were
+hand-tuned and approved on 2026-08-20, and regenerating overwrites `listing_copy`:
+
+```
+4554491916  4557544635  4556388009  4554121725  4554595592  4559346650  4556507027
+```
+
+`BoardPrintable#regenerate_listing_copy!` (`app/models/board_printable.rb` L473-479) does
+`existing.merge(generated)` — so it overwrites title, summary, description and tags, while
+`price_cents` and any other non-generated key (the TPT overrides named in the comment at
+L470-472) survive. New printables only.
+
+## Wrap-up
+
+Git workflow lives in the **workspace-root** `CLAUDE.md` and the global instructions, not
+in this repo's `CLAUDE.md` — feature branch in a worktree cut from `origin/main`, never
+commit to `main`. There is no `bin/install-hooks` in this repo.
+
+**`.claude-notes/` is gitignored here** (repo CLAUDE.md L8-10). To commit this doc in the
+PR you must `git add -f .claude-notes/etsy-listing-copy-seo-handoff.md` — a plain
+`git add` silently skips it and the doc dies with the session.
+
+Open the PR and stop — never merge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Changed
+
+- **Etsy listing copy leads with the terms buyers search.** Generated tags are
+  now always phrases — `aac`, `printable`, `slp`, `classroom` and `nonspeaking`
+  were burning five of every listing's thirteen slots and don't rank, so
+  single-word tags are refused outright and the pools were rebuilt around
+  `printable aac`, `communication board`, `low tech aac`, `slp resources`,
+  `classroom visuals`, `pecs alternative` and `nonverbal child`. Titles now lead
+  with the product phrase and make the board name the qualifier
+  ("AAC Communication Board Printable, Recess …" rather than "Recess AAC …"),
+  except where the board name already names the product, which folds into the
+  head ("AAC Core Words Board"). The admin printable page gained an advisory
+  panel for unused tag slots, leftover single-word tags, and a title that buries
+  the head term. Applies to newly generated copy only — existing listings are
+  untouched until regenerated.
+
 ### Added
 
 - **A tile can be pointed at an existing board as it is created.**

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -46,6 +46,7 @@ module Admin
       @tree_boards = tree_boards(@printable)
       @etsy_listings = @printable.etsy_listings.to_a
       @tag_overlap = Etsy::TagOverlap.new(@printable, tags: @listing["tags"])
+      @copy_advisories = Etsy::CopyAdvisories.new(@listing)
       @etsy_configured = Etsy::Client.configured?
       # The listing-video card offers a render button only where the binaries
       # exist; a button that enqueues a job which immediately returns looks

--- a/app/services/etsy/copy_advisories.rb
+++ b/app/services/etsy/copy_advisories.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# The cheap, per-listing SEO checks an admin should see before publishing,
+# rendered in the same panel as Etsy::TagOverlap.
+#
+# ADVISORY ONLY — nothing here blocks a save or a publish, for the same reason
+# TagOverlap doesn't: each check has legitimate exceptions only a human can
+# judge, and a listing that can't be published is worse than one published with
+# twelve tags.
+#
+# Read-only and side-effect free — safe to call from a view.
+module Etsy
+  class CopyAdvisories
+    # The phrase every title must lead with. All seven titles hand-rewritten on
+    # 2026-08-20 open on "AAC"; the zero-view ones opened on a niche noun
+    # ("Recess", "Haircut") and buried the searched term. 40 characters is about
+    # where Etsy's search results and the browser tab stop showing a title, so
+    # a head term past it is a head term nobody reads.
+    HEAD_TERM = /\baac\b/i
+    HEAD_TERM_WINDOW = 40
+
+    Advisory = Struct.new(:key, :message, :detail, keyword_init: true)
+
+    def initialize(listing)
+      @listing = listing || {}
+    end
+
+    def any? = advisories.any?
+
+    def advisories
+      @advisories ||= [short_tag_set, single_word_tags, buried_head_term].compact
+    end
+
+    private
+
+    def tags = @tags ||= Array(@listing["tags"]).map { |tag| tag.to_s.strip }.reject(&:empty?)
+
+    def title = @listing["title"].to_s
+
+    # Etsy gives thirteen slots and charges nothing for using them; an unused
+    # slot is a search query this listing can never be found by.
+    def short_tag_set
+      return if tags.length >= CopyRules::TAG_MAX
+
+      Advisory.new(
+        key: :short_tag_set,
+        message: "Only #{tags.length} of #{CopyRules::TAG_MAX} tag slots are used.",
+        detail: "Every empty slot is a search this listing can't appear in. Add a phrase.",
+      )
+    end
+
+    # Generation can no longer produce one — CopyRules.normalize_tag refuses it
+    # — but a tag saved before that rule existed is still sitting in the jsonb.
+    def single_word_tags
+      offenders = tags.select { |tag| tag.split(/\s+/).length < 2 }
+      return if offenders.empty?
+
+      Advisory.new(
+        key: :single_word_tags,
+        message: "#{offenders.length} single-word #{'tag'.pluralize(offenders.length)}: " \
+                 "#{offenders.join(', ')}.",
+        detail: "One-word tags compete with the whole marketplace and don't rank. " \
+                "Replace each with a phrase a buyer would actually type.",
+      )
+    end
+
+    def buried_head_term
+      return if title.blank?
+      return if title[0, HEAD_TERM_WINDOW] =~ HEAD_TERM
+
+      Advisory.new(
+        key: :buried_head_term,
+        message: "The title's first #{HEAD_TERM_WINDOW} characters don't say \"AAC\".",
+        detail: "Lead with the phrase buyers search (\"AAC Communication Board Printable\") " \
+                "and make the board name the qualifier that follows it.",
+      )
+    end
+  end
+end

--- a/app/services/etsy/copy_rules.rb
+++ b/app/services/etsy/copy_rules.rb
@@ -67,6 +67,14 @@ module Etsy
       cleaned = phrase.to_s.downcase.gsub(/[^a-z0-9 \-']/, " ").gsub(/\s+/, " ").strip
       return nil if cleaned.empty? || cleaned.length > TAG_LEN_MAX
       return nil if cleaned.split(" ").all? { |w| SMALL_WORDS.include?(w) }
+      # A one-word tag competes with the entire marketplace and measurably does
+      # not rank: on 2026-08-20 every live listing was spending five of its
+      # thirteen slots on "aac", "printable", "slp", "classroom" and
+      # "nonspeaking", and the listings earning views were found by phrases.
+      # Enforced HERE rather than by curating the pools, so a future pool edit
+      # (or a one-word tag typed into the admin form, which reaches this via
+      # Etsy::Client#normalize_tags) cannot put the slots back.
+      return nil if cleaned.split(" ").length < 2
 
       cleaned
     end

--- a/app/services/etsy/listing_copy.rb
+++ b/app/services/etsy/listing_copy.rb
@@ -22,12 +22,22 @@ module Etsy
     # smaller term survives in TOP_UP_TAGS.
     PRODUCT_HUMAN = "communication board".freeze
 
-    ALWAYS_ON_TAGS = ["aac", "printable", "digital download"].freeze
-    PRODUCT_TYPE_TAGS = [PRODUCT_HUMAN].freeze
+    # Phrases, never bare words. "aac", "printable" and "digital download" held
+    # these three slots on every listing until 2026-08-20 and none of them
+    # ranked — a one-word tag competes with the whole marketplace, and
+    # `CopyRules.normalize_tag` now refuses one outright.
+    #
+    # PRODUCT_TYPE_TAGS carries the SECONDARY product term. `PRODUCT_HUMAN`
+    # itself moved into ALWAYS_ON_TAGS (it is the term the top-viewed listings
+    # are found by, so it earns a guaranteed slot ahead of the topic); leaving
+    # it in both pools would have been harmless at runtime — `assemble_tags`
+    # dedups — but two sources for one tag is how the next edit drops it twice.
+    ALWAYS_ON_TAGS = ["printable aac", PRODUCT_HUMAN, "low tech aac"].freeze
+    PRODUCT_TYPE_TAGS = ["aac board"].freeze
 
     # Every printable here genuinely serves all three audiences, so all three
     # contribute tags and all three are named in the description.
-    AUDIENCE_TAGS = ["autism support", "slp", "classroom"].freeze
+    AUDIENCE_TAGS = ["autism support", "slp resources", "classroom visuals"].freeze
     AUDIENCE_LINES = [
       "Parents and caregivers using AAC at home.",
       "Speech-language pathologists running structured sessions.",
@@ -40,21 +50,26 @@ module Etsy
     # the more natural "talking communication board" is 26 and would be silently
     # dropped by normalize_tag.
     #
-    # "communication board" is deliberately absent: it is PRODUCT_TYPE_TAGS now,
-    # and listing it twice would only mislead the next reader (assemble_tags
-    # dedups it either way). "vocabulary board" sits at the bottom — the smaller
-    # search term is worth a slot when one is free, never ahead of a proven one.
+    # "communication board" and "aac board" are deliberately absent: they are
+    # ALWAYS_ON_TAGS and PRODUCT_TYPE_TAGS respectively, and listing one twice
+    # would only mislead the next reader (assemble_tags dedups it either way).
+    # "vocabulary board" sits at the bottom — the smaller search term is worth a
+    # slot when one is free, never ahead of a proven one.
+    #
+    # "pecs alternative" leads: it is the highest buyer-intent phrase in the
+    # pool, typed by someone who already knows they want this product. "nonverbal
+    # child" replaces the bare "nonspeaking" — TAGS are a search index, not a
+    # brand surface, so they use the word buyers type while the description
+    # prose keeps "nonspeaking". That split is deliberate; don't "fix" it.
     TOP_UP_TAGS = [
+      "pecs alternative",
       "aac printable",
       "voice output aac",
       "speech therapy",
       "special education",
-      "nonspeaking",
-      "slp resources",
+      "nonverbal child",
       "visual supports",
       "autism printable",
-      "classroom visuals",
-      "aac board",
       "vocabulary board",
     ].freeze
 
@@ -133,45 +148,69 @@ module Etsy
 
     def set? = board_count > 1
 
-    # Keyword-forward title. Leads with the board's own name (buyers search
-    # "core words board", not "SpeakAnyWay"), then the product type, then the
-    # bundle size, then the two highest-volume qualifiers in this niche.
+    TITLE_TAIL = "for Speech Therapy & Autism".freeze
+
+    # Keyword-forward title, and the head term ALWAYS leads.
+    #
+    # It used to lead with the board's own name, on the reasoning that buyers
+    # search "core words board" rather than "SpeakAnyWay". That holds only when
+    # the board name is itself a search term. Every zero-view listing in the
+    # 2026-08-20 analysis was a niche noun — "Recess", "Haircut", "Potty" — put
+    # in front of the phrase buyers actually type, so the title opened on a word
+    # nobody searches. The board name is now always the QUALIFIER; the product
+    # phrase is always the head.
+    #
+    # The one exception is a board whose name already names the product ("Core
+    # Words Board"): repeating the product phrase reads badly and eats the
+    # 140-char budget, so the name folds INTO the head instead of following it —
+    # "AAC Core Words Board", never "AAC Communication Board Printable, Core
+    # Words Board".
     def title
       @title ||= begin
         base = CopyRules.title_case_words(board_name)
 
-        # When the board's own name already names the product ("Core Words
-        # Board"), repeating "Vocabulary Board" reads badly AND eats the
-        # 140-char budget, so the type decoration shrinks to "AAC Printable".
         type_words = PRODUCT_HUMAN.downcase.split(/\s+/).select { |w| w.length > 3 }
         names_product = type_words.any? { |w| base.downcase.include?(w) }
-        head = if names_product
-          "#{base} AAC Printable"
-        else
-          "#{base} AAC #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"
-        end
+        head = names_product ? "AAC #{base}" : generic_head
 
-        tail = "for Speech Therapy & Autism"
+        # Already folded into the head, so it must not be repeated below.
+        subject = names_product ? nil : base
         size_phrase = set? ? "#{board_count}-Board Set" : nil
         topic_phrase = CopyRules.distinct_topic_phrase(
           title: base, topic: topic_source, product_human: PRODUCT_HUMAN,
         )
 
-        # Widest first, shedding a piece at a time. `base` must stay last: it
-        # is the rung guaranteed to fit, and without it a long board name
-        # overflows every rung and gets truncated mid-word.
+        # Widest first, shedding a piece at a time. The tail rungs carry no
+        # qualifier at all, and the last one is a fixed phrase — without a rung
+        # that always fits, a long board name overflows every candidate and
+        # `ensure_digital_download_suffix` truncates mid-word, which is how a
+        # listing shipped titled "… Printable for Speech The (Digital Download)".
         composed = CopyRules.pick_fitting_title([
-          "#{head}, #{[size_phrase, topic_phrase].compact.join(' — ')} #{tail}",
-          "#{head}, #{topic_phrase} #{tail}",
-          "#{head}, #{size_phrase} #{tail}",
-          "#{head} #{tail}",
-          "#{head}, #{topic_phrase}",
+          compose_title(head, [subject, size_phrase, topic_phrase], TITLE_TAIL),
+          compose_title(head, [subject, topic_phrase], TITLE_TAIL),
+          compose_title(head, [subject, size_phrase], TITLE_TAIL),
+          compose_title(head, [subject], TITLE_TAIL),
+          compose_title(head, [subject, topic_phrase], nil),
+          compose_title(head, [subject], nil),
+          compose_title(head, [], TITLE_TAIL),
           head,
-          base,
+          # Fixed length whatever the board is called — the rung that cannot
+          # overflow, even when `head` itself folded in a 140-char board name.
+          generic_head,
         ])
 
         CopyRules.ensure_digital_download_suffix(CopyRules.enforce_title_rules(composed))
       end
+    end
+
+    def generic_head = "AAC #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"
+
+    # "<head>, <qualifier> <tail>" — with the comma dropped when there is no
+    # qualifier, so a rung whose optional pieces are all absent reads as a
+    # sentence rather than "… Printable, for Speech Therapy".
+    def compose_title(head, parts, tail)
+      qualifier = parts.compact.reject(&:blank?).join(" — ")
+      [qualifier.empty? ? head : "#{head}, #{qualifier}", tail].compact_blank.join(" ")
     end
 
     def summary

--- a/app/views/admin/board_printables/_tag_overlap.html.erb
+++ b/app/views/admin/board_printables/_tag_overlap.html.erb
@@ -33,3 +33,22 @@
     </div>
   </div>
 <% end %>
+
+<%# Same panel, same contract: advisory only, never a gate. Each of these is a
+    slot or a search term the listing is leaving on the table, and each has a
+    legitimate exception only an admin can judge. %>
+<% if @copy_advisories&.any? %>
+  <div class="admin-card border rounded-xl p-5 mb-6" style="border-color: #b45309;">
+    <h2 class="text-sm font-medium mb-3" style="color: #f59e0b;">
+      <%= pluralize(@copy_advisories.advisories.size, "listing SEO note") %>
+    </h2>
+    <div class="space-y-2">
+      <% @copy_advisories.advisories.each do |advisory| %>
+        <div class="text-xs">
+          <div class="text-t1"><%= advisory.message %></div>
+          <div class="text-[11px] text-t3"><%= advisory.detail %></div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/spec/requests/admin/board_printables_spec.rb
+++ b/spec/requests/admin/board_printables_spec.rb
@@ -520,14 +520,16 @@ RSpec.describe "Admin::BoardPrintables (dashboard)", type: :request do
 
         patch update_listing_admin_dashboard_board_printable_path(printable), params: {
           title: "Core Words", summary: "S", description: "D",
-          tags: "AAC, talking communication board, printable", price: "4.50",
+          tags: "AAC Board, talking communication board, AAC, printable aac", price: "4.50",
         }
 
         expect(response).to redirect_to(admin_dashboard_board_printable_path(printable))
         expect(printable.reload.listing_copy).to include(
           "title" => "Core Words",
-          # The 27-char tag is dropped here rather than silently by Etsy later.
-          "tags" => ["aac", "printable"],
+          # The 27-char tag is dropped here rather than silently by Etsy later,
+          # and so is the hand-typed one-word "AAC" — the rule reaches the admin
+          # save path, not just generation.
+          "tags" => ["aac board", "printable aac"],
           "price_cents" => 450,
         )
       end

--- a/spec/services/etsy/client_spec.rb
+++ b/spec/services/etsy/client_spec.rb
@@ -75,19 +75,22 @@ RSpec.describe Etsy::Client do
     it "sends tags as ONE comma-separated value" do
       # Repeated `tags` params are not merged by Etsy — it keeps only the last
       # and silently drops the rest.
-      create!(tags: ["aac", "printable", "slp"])
+      create!(tags: ["printable aac", "aac board", "slp resources"])
 
       expect(a_request(:post, "#{api}/shops/42/listings").with { |req|
         req.body.scan(/(?:^|&)tags=/).length == 1 &&
-          Rack::Utils.parse_nested_query(req.body)["tags"] == "aac,printable,slp"
+          Rack::Utils.parse_nested_query(req.body)["tags"] == "printable aac,aac board,slp resources"
       }).to have_been_made
     end
 
     it "drops tags Etsy would silently reject" do
-      create!(tags: ["aac", "talking communication board", "for the"])
+      # Over 20 chars, all small words, and a single word — the last of these
+      # reaches here too, so a one-word tag typed into the admin form is
+      # dropped on save rather than shipped.
+      create!(tags: ["aac board", "talking communication board", "for the", "aac"])
 
       expect(a_request(:post, "#{api}/shops/42/listings").with { |req|
-        Rack::Utils.parse_nested_query(req.body)["tags"] == "aac"
+        Rack::Utils.parse_nested_query(req.body)["tags"] == "aac board"
       }).to have_been_made
     end
 

--- a/spec/services/etsy/copy_advisories_spec.rb
+++ b/spec/services/etsy/copy_advisories_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Etsy::CopyAdvisories do
+  def advise(**listing)
+    described_class.new({ "title" => "AAC Communication Board Printable, Recess (Digital Download)",
+                          "tags" => Array.new(13) { |i| "tag phrase #{i}" } }.merge(listing.stringify_keys))
+  end
+
+  it "stays quiet on a full, well-formed listing" do
+    expect(advise).not_to be_any
+  end
+
+  it "flags unused tag slots" do
+    advisories = advise(tags: Array.new(9) { |i| "tag phrase #{i}" }).advisories
+
+    expect(advisories.map(&:key)).to include(:short_tag_set)
+    expect(advisories.find { |a| a.key == :short_tag_set }.message).to include("9 of 13")
+  end
+
+  # Generation can no longer emit one, but a tag saved before the rule existed
+  # is still in the jsonb and still burning a slot.
+  it "flags a single-word tag still stored on the listing" do
+    advisories = advise(tags: ["aac", "printable"] + Array.new(11) { |i| "tag phrase #{i}" }).advisories
+
+    message = advisories.find { |a| a.key == :single_word_tags }.message
+    expect(message).to include("aac", "printable")
+  end
+
+  it "flags a title that buries the head term past the first 40 characters" do
+    buried = "Recess and Playground Communication Boards for School, AAC Printable"
+    expect(advise(title: buried).advisories.map(&:key)).to include(:buried_head_term)
+  end
+
+  it "accepts a head term inside the window" do
+    expect(advise(title: "AAC Core Words Board, 84-Word Set").advisories.map(&:key))
+      .not_to include(:buried_head_term)
+  end
+
+  it "says nothing about a title that hasn't been generated yet" do
+    expect(advise(title: "").advisories.map(&:key)).not_to include(:buried_head_term)
+  end
+
+  it "tolerates a listing hash with nothing in it" do
+    expect(described_class.new(nil).advisories.map(&:key)).to eq([:short_tag_set])
+  end
+end

--- a/spec/services/etsy/copy_rules_spec.rb
+++ b/spec/services/etsy/copy_rules_spec.rb
@@ -43,14 +43,27 @@ RSpec.describe Etsy::CopyRules do
     it "rejects a phrase made only of small words" do
       expect(described_class.normalize_tag("for the")).to be_nil
     end
+
+    # Five of every listing's thirteen slots were going to one-word tags that
+    # compete with the whole marketplace. Blocked at the rule, not in the pools,
+    # so a pool edit — or a one-word tag typed into the admin form — can't put
+    # them back.
+    it "rejects a single-word tag" do
+      expect(described_class.normalize_tag("aac")).to be_nil
+      expect(described_class.normalize_tag("Printable!")).to be_nil
+    end
+
+    it "keeps the two-word phrase version of a blocked word" do
+      expect(described_class.normalize_tag("printable aac")).to eq("printable aac")
+    end
   end
 
   describe ".assemble_tags" do
     it "caps at 13, dedupes, and fills the tail from top_up" do
       tags = described_class.assemble_tags(
-        always_on: ["aac", "printable"],
-        product_type: ["aac"],
-        audience: ["slp"],
+        always_on: ["printable aac", "low tech aac"],
+        product_type: ["printable aac"],
+        audience: ["slp resources"],
         topic: ["farm animals"],
         top_up: (1..20).map { |i| "keyword #{i}" },
       )
@@ -59,20 +72,21 @@ RSpec.describe Etsy::CopyRules do
       expect(tags.uniq).to eq(tags)
       # Topic ranks straight after always_on: it is the only pool describing
       # this particular product.
-      expect(tags.first(4)).to eq(["aac", "printable", "farm animals", "slp"])
+      expect(tags.first(4)).to eq(["printable aac", "low tech aac", "farm animals", "slp resources"])
     end
 
     it "ranks the topic above the product-type, audience and top-up pools" do
       tags = described_class.assemble_tags(
-        always_on: ["aac"],
+        always_on: ["printable aac"],
         product_type: ["communication board"],
-        audience: ["classroom"],
+        audience: ["classroom visuals"],
         topic: ["hospital stay", "doctor visit"],
         top_up: ["speech therapy"],
       )
 
       expect(tags).to eq(
-        ["aac", "hospital stay", "doctor visit", "communication board", "classroom", "speech therapy"],
+        ["printable aac", "hospital stay", "doctor visit", "communication board",
+         "classroom visuals", "speech therapy"],
       )
     end
 
@@ -83,9 +97,9 @@ RSpec.describe Etsy::CopyRules do
     # working, and it only happens for a topic of 6+ distinct phrases.
     it "caps the topic so the product-type and audience pools keep their slots" do
       tags = described_class.assemble_tags(
-        always_on: ["aac", "printable", "digital download"],
-        product_type: ["communication board"],
-        audience: ["autism support", "slp", "classroom"],
+        always_on: ["printable aac", "communication board", "low tech aac"],
+        product_type: ["aac board"],
+        audience: ["autism support", "slp resources", "classroom visuals"],
         topic: (1..12).map { |i| "topic phrase #{i}" },
         top_up: ["speech therapy"],
       )
@@ -99,9 +113,9 @@ RSpec.describe Etsy::CopyRules do
     # top-up terms exactly where they were.
     it "leaves the top-up pool intact for a normal-length topic" do
       tags = described_class.assemble_tags(
-        always_on: ["aac", "printable", "digital download"],
-        product_type: ["communication board"],
-        audience: ["autism support", "slp", "classroom"],
+        always_on: ["printable aac", "communication board", "low tech aac"],
+        product_type: ["aac board"],
+        audience: ["autism support", "slp resources", "classroom visuals"],
         topic: ["hospital stay", "doctor visit"],
         top_up: ["aac printable", "voice output aac", "speech therapy", "special education"],
       )
@@ -129,7 +143,13 @@ RSpec.describe Etsy::CopyRules do
     end
 
     it "splits on commas and slashes" do
-      expect(described_class.topic_tags("core words / feelings")).to eq(["core words", "feelings"])
+      expect(described_class.topic_tags("core words / snack time")).to eq(["core words", "snack time"])
+    end
+
+    # A one-word segment yields nothing rather than a one-word tag — the
+    # normalize_tag rule reaching the richest tag source there is.
+    it "drops a segment that is a single word" do
+      expect(described_class.topic_tags("core words / feelings")).to eq(["core words"])
     end
   end
 

--- a/spec/services/etsy/listing_copy_spec.rb
+++ b/spec/services/etsy/listing_copy_spec.rb
@@ -31,18 +31,33 @@ RSpec.describe Etsy::ListingCopy do
       expect(title.count("&")).to be <= 1
     end
 
-    it "shrinks the product decoration when the board already names it" do
-      named = create(:board, user: owner, name: "Feelings Communication Board")
+    # The defect the 2026-08-20 analysis found: every zero-view listing opened
+    # on a niche noun nobody searches, with the phrase buyers actually type
+    # pushed past the fold. The board name is the qualifier now, always.
+    it "leads with the head term and makes the board name the qualifier" do
+      niche = create(:board, user: owner, name: "Recess")
+      title = described_class.new(
+        BoardPrintable.create!(board: niche, status: "complete", board_ids: [niche.id]),
+      ).build["title"]
+
+      expect(title).to start_with("AAC Communication Board Printable,")
+      expect(title).to include("Recess")
+    end
+
+    # The one exception: a board whose name already names the product folds
+    # INTO the head rather than being repeated after it.
+    it "folds a board name that already names the product into the head" do
+      named = create(:board, user: owner, name: "Core Words Board")
       title = described_class.new(
         BoardPrintable.create!(board: named, status: "complete", board_ids: [named.id]),
       ).build["title"]
 
-      expect(title).to include("AAC Printable")
+      expect(title).to start_with("AAC Core Words Board")
       expect(title).not_to include("AAC Communication Board Printable")
     end
 
     it "names the product when the board's own name doesn't" do
-      expect(build["title"]).to include("AAC Communication Board Printable")
+      expect(build["title"]).to start_with("AAC Communication Board Printable")
     end
 
     # A blank topic used to collapse the title ladder onto its bare
@@ -61,8 +76,13 @@ RSpec.describe Etsy::ListingCopy do
         BoardPrintable.create!(board: wordy, status: "complete", board_ids: [wordy.id]),
       ).build["title"]
 
+      # A shipped listing once ended "… Printable for Speech The (Digital
+      # Download)": every rung overflowed and the suffix step cut mid-word.
+      # Ending on the complete tail is the proof it took a rung that fits —
+      # `not_to include("for Speech The")` was no proof at all, since every
+      # untruncated title contains it inside "for Speech Therapy".
       expect(title.length).to be <= Etsy::CopyRules::TITLE_MAX
-      expect(title).not_to include("for Speech The")
+      expect(title).to end_with("for Speech Therapy & Autism (Digital Download)")
     end
   end
 
@@ -85,7 +105,9 @@ RSpec.describe Etsy::ListingCopy do
       expect(tags.length).to eq(Etsy::CopyRules::TAG_MAX)
       expect(tags.map(&:length).max).to be <= Etsy::CopyRules::TAG_LEN_MAX
       expect(tags.uniq).to eq(tags)
-      expect(tags).to include("aac", "printable", "farm animals")
+      expect(tags).to include("printable aac", "communication board", "farm animals")
+      # The rule that recovered five slots on every listing.
+      expect(tags.select { |t| t.split(" ").length < 2 }).to be_empty
     end
 
     # The one that would have caught it: nine printables published to Etsy in
@@ -110,7 +132,7 @@ RSpec.describe Etsy::ListingCopy do
 
       expect(tags).to include("bath time", "at the sink", "getting dry")
       # Below always_on, above the shared boilerplate.
-      expect(tags.index("at the sink")).to be < tags.index("communication board")
+      expect(tags.index("at the sink")).to be < tags.index("autism support")
     end
 
     it "keeps an authored topic ahead of the mined board names" do
@@ -127,14 +149,16 @@ RSpec.describe Etsy::ListingCopy do
 
     # The shared boilerplate is still correct for a printable with nothing
     # topical to say — this pins it so a future reshuffle of the pools is a
-    # deliberate act, not a surprise.
+    # deliberate act, not a surprise. Every entry is a PHRASE: the five slots
+    # that used to hold "aac", "printable", "slp", "classroom" and
+    # "nonspeaking" now hold terms a buyer would type.
     it "yields the stable boilerplate set for a single board with no topic" do
       expect(build["tags"]).to eq([
-        "aac", "printable", "digital download",
-        "communication board",
-        "autism support", "slp", "classroom",
-        "aac printable", "voice output aac", "speech therapy", "special education",
-        "nonspeaking", "slp resources",
+        "printable aac", "communication board", "low tech aac",
+        "aac board",
+        "autism support", "slp resources", "classroom visuals",
+        "pecs alternative", "aac printable", "voice output aac", "speech therapy",
+        "special education", "nonverbal child",
       ])
     end
 

--- a/spec/services/etsy/tag_overlap_spec.rb
+++ b/spec/services/etsy/tag_overlap_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe Etsy::TagOverlap do
     )
   end
 
+  # What Etsy::ListingCopy yields for a printable with nothing topical to say.
   BOILERPLATE = [
-    "aac", "printable", "digital download", "communication board",
-    "autism support", "slp", "classroom", "aac printable", "voice output aac",
-    "speech therapy", "special education", "nonspeaking", "slp resources",
+    "printable aac", "communication board", "low tech aac", "aac board",
+    "autism support", "slp resources", "classroom visuals", "pecs alternative",
+    "aac printable", "voice output aac", "speech therapy", "special education",
+    "nonverbal child",
   ].freeze
 
   it "flags a printable whose tags are a near-duplicate of another's" do
@@ -119,8 +121,9 @@ RSpec.describe Etsy::TagOverlap do
 
       tags = p.listing_copy["tags"]
       expect(tags).to include("hospital stay", "doctor visit")
-      # always_on is three, then topic — so a topic tag can never be crowded out.
-      expect(tags.index("hospital stay")).to be < tags.index("communication board")
+      # always_on is three, then topic — so a topic tag can never be crowded
+      # out by the product-type, audience or top-up pools below it.
+      expect(tags.index("hospital stay")).to be < tags.index("autism support")
     end
   end
 


### PR DESCRIPTION
Implements `.claude-notes/etsy-listing-copy-seo-handoff.md`. All 21 live listings were analyzed on 2026-08-20 with views normalized by true listing age (`original_creation_timestamp` — the API's `created` resets on renewal). Core-vocabulary boards run 6–8 views/day; niche-occasion boards run ~0. The title's leading phrase and the tag set explained the gap. Seven listings were hand-rewritten that day and are live — this makes the generator produce that shape instead of reintroducing the defects on the next publish.

## What changed

**1. Single-word tags are refused (`Etsy::CopyRules.normalize_tag`)**

Five of every listing's thirteen slots were going to `aac`, `printable`, `slp`, `classroom`, `nonspeaking`. A one-word tag competes with the entire marketplace and doesn't rank. Enforced at the rule, not by curating the pools, so a future pool edit can't put the slots back.

Reach worth knowing: `normalize_tag` is also called by `Etsy::Client#normalize_tags`, which the admin listing-form save path runs through — **a one-word tag typed by hand in the admin is now silently dropped on save.** That is intended; the new advisory panel names any that are already stored.

**2. Tag pools rebuilt around phrases (`Etsy::ListingCopy`)**

- `ALWAYS_ON_TAGS` → `["printable aac", "communication board", "low tech aac"]`
- `AUDIENCE_TAGS` → `["autism support", "slp resources", "classroom visuals"]`
- `PRODUCT_TYPE_TAGS` → `["aac board"]` — it carries the *secondary* term now rather than duplicating `PRODUCT_HUMAN`, which moved into the always-on pool.
- `TOP_UP_TAGS` — `pecs alternative` leads (highest buyer intent), `nonspeaking` → `nonverbal child`, and the entries promoted to other pools removed.

Tags say `nonverbal`; description prose keeps `nonspeaking`. Etsy tags are a search index, not a brand surface — an approved split, per the handoff's decision list.

**3. Head-term-first titles (`ListingCopy#title`)**

The product phrase always leads; the board name is always the qualifier. The one exception is *folding*, not reordering — a board name that already names the product becomes the head:

```
AAC Communication Board Printable, Recess for Speech Therapy & Autism (Digital Download)
AAC Communication Board Printable, Haircut and Salon Visits — 3-Board Set for Speech Therapy & Autism (Digital Download)
AAC Core Words Board for Speech Therapy & Autism (Digital Download)
```

The widest-first ladder and its guaranteed-fitting last rung are preserved. That rung is now a fixed phrase rather than the board name, because a folded head can itself be arbitrarily long — without it `pick_fitting_title` falls through to a mid-word truncation, which is how a listing shipped titled `"… Printable for Speech The (Digital Download)"`.

**4. Admin advisory panel (`Etsy::CopyAdvisories`)**

Three checks rendered beside the tag-overlap warning: fewer than 13 tags, any single-word tag still stored, and no "AAC" in the title's first 40 characters. Advisory only, never a gate — same contract as `TagOverlap`.

## Notes

- **Rails only.** `speakanyway-printables` is untouched; it has diverged deliberately and has its own sync doc. The drift note in `.claude-notes/board-printables-etsy.md` now lists these two rules as Rails-only.
- **Do not run `regenerate_listing_copy!` against the seven hand-tuned listings** (`4554491916 4557544635 4556388009 4554121725 4554595592 4559346650 4556507027`) — it merges generated copy over the stored hash. New printables only.
- No migrations, no new ENV, no API contract change.

## Spec changes

Several exact-equality pins had to move in lockstep with the rules, deliberately rather than patched around — most notably the 13-tag boilerplate pin in `listing_copy_spec.rb`, and the two title-shape examples. One incidental fix: `expect(title).not_to include("for Speech The")` was never proof of anything, since every untruncated title contains that substring inside "for Speech Therapy"; it now asserts the title ends on the complete tail.

## Test plan

```
bundle exec rspec spec/services/etsy/ spec/requests/admin/board_printables_spec.rb
# 192 examples, 0 failures
```

Plus the wider set that touches listing copy (`board_printable_spec`, `board_printable_listing_spec`, `board_printable_listings_spec`, `printables_listing_export_spec`, `marketplace_copy_spec`, `kit_pages/copy_suggester_spec`): **300 examples, 0 failures.**

New: `spec/services/etsy/copy_advisories_spec.rb` (7 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)