### PR TITLE
fix(printables): stop tag-overlap check flagging a printable against itself

### DIFF
--- a/app/services/etsy/tag_overlap.rb
+++ b/app/services/etsy/tag_overlap.rb
@@ -94,10 +94,19 @@ module Etsy
 
     # Other listings on this same printable. Their RESOLVED copy, since a
     # listing that overrides nothing still ships the printable's tags.
+    #
+    # When the subject is the printable itself (no @listing — the printable's
+    # show page, comparing its own base copy), a listing with no tags override
+    # of its own isn't a sibling to compare against: it ships the exact tags
+    # being compared, so it would always "match" itself at 100%. Only a
+    # listing that has actually diverged represents an independent product
+    # worth flagging.
     def sibling_candidates
       return [] if @printable.id.nil?
 
-      @printable.etsy_listings.reject { |other| other.id == @listing&.id }.map do |other|
+      @printable.etsy_listings.reject { |other| other.id == @listing&.id }
+                .reject { |other| @listing.nil? && other.listing_copy.to_h["tags"].blank? }
+                .map do |other|
         { printable: @printable, listing: other, tags: normalize(other.resolved_copy["tags"]) }
       end
     end

--- a/spec/services/etsy/tag_overlap_spec.rb
+++ b/spec/services/etsy/tag_overlap_spec.rb
@@ -170,5 +170,37 @@ RSpec.describe Etsy::TagOverlap do
 
       expect(described_class.new(only).any?).to be false
     end
+
+    # The printable's show page instantiates from the printable itself, not a
+    # specific listing — the case the admin screenshot caught: a single
+    # standalone listing with no tags override of its own always ships the
+    # printable's exact tags, so comparing the printable's base copy against
+    # it is a comparison against itself wearing a listing's label.
+    it "does not warn when comparing the printable itself against a single non-overriding listing" do
+      board = create(:board, name: "Core Words")
+      printable = BoardPrintable.create!(
+        board: board, status: "complete",
+        listing_copy: { "title" => "T", "tags" => Etsy::CopyRules::TAG_MAX.times.map { |i| "tag#{i}" } },
+      )
+      printable.etsy_listings.create!(purpose: "standalone")
+
+      overlap = described_class.new(printable, tags: printable.listing_copy_or_default["tags"])
+
+      expect(overlap.any?).to be false
+    end
+
+    it "still warns from the printable when a sibling listing has genuinely diverged tags that overlap" do
+      board = create(:board, name: "Core Words")
+      base_tags = Etsy::CopyRules::TAG_MAX.times.map { |i| "tag#{i}" }
+      printable = BoardPrintable.create!(
+        board: board, status: "complete",
+        listing_copy: { "title" => "T", "tags" => base_tags },
+      )
+      printable.etsy_listings.create!(purpose: "bundle", label: "holiday", listing_copy: { "tags" => base_tags })
+
+      overlap = described_class.new(printable, tags: base_tags)
+
+      expect(overlap.any?).to be true
+    end
   end
 end


### PR DESCRIPTION
## Summary
- The printable show page's Etsy tag-overlap warning compared the printable's own base copy against its Etsy listings, but a listing with no `tags` override just inherits those exact tags — so it always "matched" itself at 100% overlap.
- This showed up as, e.g., printable #28 being reported as overlapping heavily with itself (labeled as a "standalone listing") since it had one non-overriding listing.
- `Etsy::TagOverlap#sibling_candidates` now skips a sibling listing that hasn't diverged from the base copy when the subject is the printable itself (no specific listing selected), while still flagging genuinely overlapping listings that have their own tag overrides.

## Test plan
- `bundle exec rspec spec/services/etsy/tag_overlap_spec.rb` — 15 examples, 0 failures (added two regression tests: no warning for a printable vs. its own non-overriding listing, and still warns when a sibling listing has genuinely diverged but overlapping tags).
- `bin/rails zeitwerk:check` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)