### PR TITLE
perf(text-tiles): render each picture once and batch the bulk action

### DIFF
--- a/.claude-notes/image-generation.md
+++ b/.claude-notes/image-generation.md
@@ -263,3 +263,42 @@ sit behind minute-long OpenAI calls). Sets `status: "generating"` and
   default 60/min), not the AI one — free renders shouldn't consume a budget the
   user paid for, but each is still a Chrome fork.
 - Nothing is staging-gated: there are no paid calls on this path.
+
+## Dedupe and batching
+
+A render is deterministic, and `Options#render_digest` is defined as everything
+that changes the pixels and nothing that doesn't — so two tiles with the same
+digest are byte-identical no matter whose board they sit on. That digest is the
+dedupe key, stored on the Doc as `data["render_digest"]` (partial index
+`index_docs_on_text_tile_render_digest`).
+
+- **`Creator` looks the digest up before forking Chrome**, in two tiers. Same
+  Image + same user + same digest reuses the **Doc row** outright (a second row
+  is just a duplicate thumbnail in that tile's gallery). Any other match creates
+  this Image's own Doc row — the row is per-Image/per-user, since docs carry
+  `user_id` and seed `UserDoc` — but attaches the **same blob**: no render, no
+  upload.
+- **Sharing a blob across Doc rows is safe because of the FK.**
+  `active_storage_attachments.blob_id` has a foreign key and
+  `ActiveStorage::Blob#purge` rescues `InvalidForeignKey`, so hard-deleting one
+  Doc (`docs#destroy?hard_delete=1`, or `ConvertDocToWebpJob` purging the
+  original) can't take the bytes out from under the others. Don't drop that FK,
+  and don't "fix" a dedupe miss by copying bytes into a fresh blob.
+- A doc whose blob was purged is not a reuse source — the lookup joins
+  `image_attachment`.
+- The controller's unchanged-render short circuit is still worth keeping: it
+  answers without touching the queue at all. The `Creator` dedupe is the second
+  net, for tiles that have never carried this render.
+
+**Bulk is one job, not one per tile.** `create_text_images` enqueues a single
+`RenderTextTilesJob` carrying `[[board_image_id, options], ...]`.
+
+- The queue runs three workers, so a select-all used to park everyone else's
+  single-tile render behind thirty Chrome forks.
+- Sequential inside the job **on purpose**: rendering the selection in parallel
+  would race the digest lookup and fork Chrome N times for the same picture.
+- One tile's failure marks only that tile `failed`; the batch still raises at
+  the end so Sidekiq retries, which is cheap because every tile that succeeded
+  now dedupes to its own Doc instead of re-rendering.
+- The board is broadcast once per board at the end, not once per tile —
+  `Creator.call(broadcast: false)` is what the batch passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Changed
 
+- **Text tiles render once and are reused.** A text-tile picture is fully
+  determined by its settings, so identical renders now share one rendered image
+  instead of each forking headless Chrome and uploading its own copy — the same
+  word on the same coloured tile is rendered the first time and reused after
+  that. The bulk "Set text image" action also queues one job for the whole
+  selection rather than one per tile, so selecting thirty tiles no longer parks
+  everyone else's single-tile render behind thirty renders.
+
 - **Etsy listing copy leads with the terms buyers search.** Generated tags are
   now always phrases — `aac`, `printable`, `slp`, `classroom` and `nonspeaking`
   were burning five of every listing's thirteen slots and don't rank, so

--- a/app/controllers/api/board_images_controller.rb
+++ b/app/controllers/api/board_images_controller.rb
@@ -353,6 +353,9 @@ class API::BoardImagesController < API::ApplicationController
     queued = 0
     unlabeled = 0
     unchanged = 0
+    # One job for the whole selection, not one per tile — see RenderTextTilesJob
+    # for why (queue fairness, plus in-batch dedupe of identical renders).
+    entries = []
 
     @board.board_images.where(id: board_image_ids).each do |board_image|
       options = default_text_tile_options_for(board_image)
@@ -377,9 +380,11 @@ class API::BoardImagesController < API::ApplicationController
 
       board_image.status = "generating"
       board_image.save!
-      RenderTextTileJob.perform_async(board_image.id, options.to_h)
+      entries << [board_image.id, options.to_h]
       queued += 1
     end
+
+    RenderTextTilesJob.perform_async(entries) if entries.any?
 
     @board.broadcast_board_update!
     render json: {

--- a/app/services/images/text_tile/creator.rb
+++ b/app/services/images/text_tile/creator.rb
@@ -14,44 +14,111 @@
 # The Doc still hangs off the Image (not the BoardImage) so it picks up
 # tile_variant/tile_url, shows in that tile's picture gallery, and can be
 # re-selected later like any other doc.
+#
+# DEDUPE. A text render is deterministic: Options#render_digest is defined as
+# everything that changes the pixels and nothing that doesn't, so two tiles
+# with the same digest are byte-identical no matter whose board they are on.
+# Rendering is the expensive part (a Grover fork spawns node + Chromium, ~1s),
+# and the bulk "Set text image" path fires one per selected tile — a 30-tile
+# core board used to mean 30 Chrome launches for maybe a dozen distinct
+# pictures. So before rendering we look the digest up, in two tiers:
+#
+#   1. Same Image, same user, same digest — reuse the Doc ROW outright. This is
+#      the same picture in the same tile's gallery; a second row would just be
+#      a duplicate thumbnail for the user to scroll past.
+#   2. Any other Doc with that digest — this Image needs its own Doc row (the
+#      row is per-user/per-Image; see docs.current and UserDoc in CLAUDE.md),
+#      but it can share the BLOB. No render, no upload.
+#
+# Sharing one blob across Doc rows is safe: active_storage_attachments has a
+# foreign key on blob_id and ActiveStorage::Blob#purge rescues
+# InvalidForeignKey, so destroying one Doc can't delete the bytes out from
+# under the others. Don't drop that FK.
 module Images
   module TextTile
     module Creator
       module_function
 
-      def call(board_image:, user:, options:)
-        png = Renderer.new(options).to_png
+      # broadcast: false is for the batch job, which rebroadcasts each board
+      # once at the end rather than once per tile.
+      def call(board_image:, user:, options:, broadcast: true)
         image = board_image.image
         raise ArgumentError, "board_image #{board_image.id} has no image" if image.nil?
+
+        digest = options.render_digest
+        doc = reusable_doc(image, user, digest) || build_doc(board_image, image, user, options, digest)
+
+        apply_to_tile(board_image, doc, options)
+        board_image.board&.broadcast_board_update! if broadcast
+
+        doc
+      end
+
+      # Tier 1: this Image already carries this exact render for this user.
+      def reusable_doc(image, user, digest)
+        text_tile_docs(digest)
+          .where(documentable_type: "Image", documentable_id: image.id, user_id: user&.id)
+          .order(id: :desc)
+          .first
+      end
+
+      # Tier 2: somebody has rendered these exact pixels before — take the blob.
+      def reusable_blob(digest)
+        text_tile_docs(digest).order(id: :desc).first&.image&.blob
+      end
+
+      # Only docs whose bytes are actually still attached: a row whose blob was
+      # purged (the webp conversion rake task does that) is not a source.
+      def text_tile_docs(digest)
+        Doc
+          .joins(:image_attachment)
+          .where(source_type: Doc::SOURCE_TYPE_TEXT_TILE)
+          .where("docs.data->>'render_digest' = ?", digest)
+      end
+
+      def build_doc(board_image, image, user, options, digest)
+        blob = reusable_blob(digest)
 
         doc = image.docs.create!(
           raw: options.text,
           user_id: user&.id,
           board_id: board_image.board_id,
           source_type: Doc::SOURCE_TYPE_TEXT_TILE,
-          data: { "text_image" => options.to_h, "content_type" => "image/png" },
+          data: {
+            "text_image" => options.to_h,
+            "content_type" => blob&.content_type || "image/png",
+            "render_digest" => digest,
+          },
         )
 
-        doc.image.attach(
-          io: StringIO.new(png),
-          filename: "text_#{image.id}_doc_#{doc.id}.png",
-          content_type: "image/png",
-        )
+        if blob
+          doc.image.attach(blob)
+        else
+          doc.image.attach(
+            io: StringIO.new(Renderer.new(options).to_png),
+            filename: "text_#{image.id}_doc_#{doc.id}.png",
+            content_type: "image/png",
+          )
+        end
 
         # Force the 288px variant now so the first board load isn't the thing
         # that pays for it — same reason save_image_from_base64 does. Falls
-        # back to a queued render if a transaction happens to be open.
+        # back to a queued render if a transaction happens to be open. A shared
+        # blob's variant is already processed, so this is a lookup, not work.
         doc.ensure_tile_variant!
 
+        doc
+      end
+
+      def apply_to_tile(board_image, doc, options)
         board_image.data = (board_image.data || {}).merge(
           "text_image" => options.to_h.merge("doc_id" => doc.id),
         )
         board_image.data["hide_label"] = options.hide_label
         board_image.update!(status: "complete", display_image_url: doc.tile_url)
-        board_image.board&.broadcast_board_update!
-
-        doc
       end
+
+      private_class_method :reusable_doc, :reusable_blob, :text_tile_docs, :build_doc, :apply_to_tile
     end
   end
 end

--- a/app/sidekiq/render_text_tiles_job.rb
+++ b/app/sidekiq/render_text_tiles_job.rb
@@ -1,0 +1,56 @@
+# The bulk "Set text image" render: ONE job for a whole selection, instead of
+# one job per tile.
+#
+# Two reasons it isn't just N RenderTextTileJobs. The queue only runs three
+# workers, so a select-all on a 30-tile board used to park everyone else's
+# single-tile render behind thirty Chrome forks. And running the selection in
+# one process is what lets Images::TextTile::Creator's digest dedupe pay off
+# within the batch: the first tile of a given render creates the Doc, and every
+# later tile with the same digest finds it and shares the blob — no second fork.
+#
+# Sequential on purpose. Rendering the selection in parallel would race the
+# dedupe lookup and fork Chrome N times for the same picture, which is the
+# thing this exists to stop.
+#
+# One bad tile must not cost the other twenty-nine, so each is rescued
+# individually and only marked failed itself. The batch still raises at the end
+# so Sidekiq retries it — cheap, because every tile that succeeded now dedupes
+# to its own Doc on the second pass rather than re-rendering.
+class RenderTextTilesJob
+  include Sidekiq::Job
+  sidekiq_options queue: :text_images, retry: 2, backtrace: true
+
+  # entries: [[board_image_id, options_hash], ...]
+  def perform(entries)
+    boards = {}
+    failures = []
+
+    Array(entries).each do |entry|
+      board_image_id, options_hash = entry
+      board_image = BoardImage.find_by(id: board_image_id)
+      next unless board_image
+
+      board = board_image.board
+      boards[board.id] = board if board
+
+      begin
+        options = Images::TextTile::Options.from_params((options_hash || {}).symbolize_keys)
+
+        Images::TextTile::Creator.call(
+          board_image: board_image,
+          user: board&.user,
+          options: options,
+          broadcast: false,
+        )
+      rescue => e
+        Rails.logger.error("[text-tile] batch render failed for BoardImage #{board_image_id}: #{e.message}")
+        board_image.update_column(:status, "failed")
+        failures << board_image_id
+      end
+    end
+
+    boards.each_value(&:broadcast_board_update!)
+
+    raise "text tile batch failed for board_images #{failures.join(", ")}" if failures.any?
+  end
+end

--- a/db/migrate/20260820160000_add_text_tile_render_digest_index_to_docs.rb
+++ b/db/migrate/20260820160000_add_text_tile_render_digest_index_to_docs.rb
@@ -1,0 +1,14 @@
+class AddTextTileRenderDigestIndexToDocs < ActiveRecord::Migration[8.0]
+  # Images::TextTile::Creator looks a render up by digest before forking
+  # Chrome. Partial: text tiles are a sliver of docs, and only they carry the
+  # key.
+  disable_ddl_transaction!
+
+  def change
+    add_index :docs,
+              "(data->>'render_digest')",
+              name: "index_docs_on_text_tile_render_digest",
+              where: "source_type = 'SpeakAnyWayText'",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_20_140000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_20_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -526,6 +526,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_20_140000) do
     t.string "prompt_for_prompt"
     t.jsonb "data"
     t.jsonb "license"
+    t.index "((data ->> 'render_digest'::text))", name: "index_docs_on_text_tile_render_digest", where: "((source_type)::text = 'SpeakAnyWayText'::text)"
     t.index ["deleted_at"], name: "index_docs_on_deleted_at"
     t.index ["documentable_id", "documentable_type", "deleted_at"], name: "idx_on_documentable_id_documentable_type_deleted_at_a6715ad541"
     t.index ["documentable_type", "documentable_id"], name: "index_docs_on_documentable"

--- a/spec/requests/api/board_images_text_image_spec.rb
+++ b/spec/requests/api/board_images_text_image_spec.rb
@@ -145,7 +145,9 @@ RSpec.describe "API::BoardImages text tiles", type: :request do
     end
 
     it "renders one tile per selection and reports them queued" do
-      expect { post_bulk }.to change(RenderTextTileJob.jobs, :size).by(2)
+      expect { post_bulk }.to change(RenderTextTilesJob.jobs, :size).by(1)
+      expect(RenderTextTilesJob.jobs.last["args"].first.map(&:first))
+        .to contain_exactly(board_image.id, second_tile.id)
 
       expect(response).to have_http_status(:success)
       body = JSON.parse(response.body)
@@ -179,15 +181,16 @@ RSpec.describe "API::BoardImages text tiles", type: :request do
     it "skips a tile with no text instead of failing the batch" do
       second_tile.update_columns(label: nil, display_label: nil)
 
-      expect { post_bulk }.to change(RenderTextTileJob.jobs, :size).by(1)
+      expect { post_bulk }.to change(RenderTextTilesJob.jobs, :size).by(1)
 
+      expect(RenderTextTilesJob.jobs.last["args"].first.map(&:first)).to eq([board_image.id])
       expect(JSON.parse(response.body)).to include("queued" => 1, "unlabeled" => 1)
       expect(second_tile.reload.data&.dig("text_image")).to be_nil
     end
 
     it "does not re-render a tile that already shows this exact picture" do
       post_bulk
-      RenderTextTileJob.jobs.clear
+      RenderTextTilesJob.jobs.clear
       [board_image, second_tile].each do |tile|
         tile.reload
         doc = tile.image.docs.create!(source_type: Doc::SOURCE_TYPE_TEXT_TILE, user_id: user.id)
@@ -198,7 +201,7 @@ RSpec.describe "API::BoardImages text tiles", type: :request do
         )
       end
 
-      expect { post_bulk }.not_to change(RenderTextTileJob.jobs, :size)
+      expect { post_bulk }.not_to change(RenderTextTilesJob.jobs, :size)
       expect(JSON.parse(response.body)).to include("queued" => 0, "unchanged" => 2)
     end
 
@@ -212,7 +215,8 @@ RSpec.describe "API::BoardImages text tiles", type: :request do
       )
 
       expect { post_bulk(ids: [board_image.id, stranger.id]) }
-        .to change(RenderTextTileJob.jobs, :size).by(1)
+        .to change(RenderTextTilesJob.jobs, :size).by(1)
+      expect(RenderTextTilesJob.jobs.last["args"].first.map(&:first)).to eq([board_image.id])
 
       expect(JSON.parse(response.body)).to include("queued" => 1)
       expect(stranger.reload.data&.dig("text_image")).to be_nil

--- a/spec/services/images/text_tile/creator_spec.rb
+++ b/spec/services/images/text_tile/creator_spec.rb
@@ -78,4 +78,106 @@ RSpec.describe Images::TextTile::Creator do
 
     described_class.call(board_image: board_image, user: user, options: options)
   end
+
+  describe "dedupe" do
+    # Rendering is the expensive part — a Grover fork spawns node + Chromium.
+    # Two tiles with the same render_digest are byte-identical, so the second
+    # one must never pay for it.
+    def render_count
+      count = 0
+      allow_any_instance_of(Images::TextTile::Renderer).to receive(:to_png) do
+        count += 1
+        png
+      end
+      -> { count }
+    end
+
+    it "reuses the same Image's doc rather than rendering (or stacking) a second one" do
+      counter = render_count
+      first = described_class.call(board_image: board_image, user: user, options: options)
+
+      sibling = create(:board_image, board: create(:board, user: user), image: image)
+      again = described_class.call(board_image: sibling, user: user, options: options)
+
+      expect(again).to eq(first)
+      expect(counter.call).to eq(1)
+      expect(image.docs.where(source_type: Doc::SOURCE_TYPE_TEXT_TILE).count).to eq(1)
+      expect(sibling.reload.display_image_url).to eq(first.tile_url)
+    end
+
+    # A different Image needs its own Doc row — the row is per-Image/per-user,
+    # and it shows in that tile's picture gallery — but not its own render.
+    it "shares the blob with another Image's identical render" do
+      counter = render_count
+      first = described_class.call(board_image: board_image, user: user, options: options)
+
+      other_image = create(:image, user: user, label: "more please")
+      other_tile = create(:board_image, board: board, image: other_image)
+      second = described_class.call(board_image: other_tile, user: user, options: options)
+
+      expect(second).not_to eq(first)
+      expect(second.documentable).to eq(other_image)
+      expect(second.image.blob).to eq(first.image.blob)
+      expect(counter.call).to eq(1)
+    end
+
+    it "renders again when anything that changes the pixels changes" do
+      counter = render_count
+      described_class.call(board_image: board_image, user: user, options: options)
+      described_class.call(
+        board_image: board_image, user: user,
+        options: Images::TextTile::Options.from_params(text: "more", font: "lexend"),
+      )
+
+      expect(counter.call).to eq(2)
+    end
+
+    # hide_label is a tile setting, not paint — render_digest excludes it.
+    it "does not render again for a hide_label flip" do
+      counter = render_count
+      described_class.call(board_image: board_image, user: user,
+                           options: Images::TextTile::Options.from_params(text: "more", hide_label: "true"))
+      described_class.call(board_image: board_image, user: user,
+                           options: Images::TextTile::Options.from_params(text: "more", hide_label: "false"))
+
+      expect(counter.call).to eq(1)
+      expect(board_image.reload.data["hide_label"]).to be(false)
+    end
+
+    it "stamps the digest so a later render can find it" do
+      doc = described_class.call(board_image: board_image, user: user, options: options)
+      expect(doc.data["render_digest"]).to eq(options.render_digest)
+    end
+
+    # Another user's identical picture is fine to share bytes with, but the row
+    # stays theirs — docs carry user_id and seed UserDoc.
+    it "gives a second user their own doc row over the shared blob" do
+      counter = render_count
+      first = described_class.call(board_image: board_image, user: user, options: options)
+
+      stranger = create(:user)
+      stranger_tile = create(:board_image, board: create(:board, user: stranger), image: image)
+      second = described_class.call(board_image: stranger_tile, user: stranger, options: options)
+
+      expect(second).not_to eq(first)
+      expect(second.user_id).to eq(stranger.id)
+      expect(second.image.blob).to eq(first.image.blob)
+      expect(counter.call).to eq(1)
+    end
+
+    it "does not reuse a doc whose bytes were purged" do
+      counter = render_count
+      first = described_class.call(board_image: board_image, user: user, options: options)
+      first.image.purge
+
+      described_class.call(board_image: board_image, user: user, options: options)
+      expect(counter.call).to eq(2)
+    end
+  end
+
+  it "can skip the broadcast, for the batch job that sends one per board" do
+    expect_any_instance_of(Board).not_to receive(:broadcast_board_update!)
+
+    described_class.call(board_image: board_image, user: user, options: options, broadcast: false)
+  end
 end

--- a/spec/sidekiq/render_text_tiles_job_spec.rb
+++ b/spec/sidekiq/render_text_tiles_job_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe RenderTextTilesJob do
+  let(:user) { create(:user) }
+  let(:board) { create(:board, user: user) }
+  let(:first_tile) { create(:board_image, board: board, image: create(:image, user: user, label: "more")) }
+  let(:second_tile) { create(:board_image, board: board, image: create(:image, user: user, label: "want")) }
+
+  def entry(tile, **params)
+    [tile.id, Images::TextTile::Options.from_params({ text: tile.label }.merge(params)).to_h]
+  end
+
+  it "runs on the text queue, not behind the OpenAI work" do
+    expect(described_class.sidekiq_options["queue"].to_s).to eq("text_images")
+  end
+
+  it "renders every tile in the selection" do
+    rendered = []
+    allow(Images::TextTile::Creator).to receive(:call) do |board_image:, options:, **|
+      rendered << [board_image.id, options.text]
+    end
+
+    described_class.new.perform([entry(first_tile), entry(second_tile)])
+
+    expect(rendered).to contain_exactly([first_tile.id, "more"], [second_tile.id, "want"])
+  end
+
+  it "hands the creator the board's owner and suppresses the per-tile broadcast" do
+    expect(Images::TextTile::Creator).to receive(:call).once do |user:, broadcast:, **|
+      expect(user).to eq(self.user)
+      expect(broadcast).to be(false)
+    end
+
+    described_class.new.perform([entry(first_tile)])
+  end
+
+  # One broadcast per board, not one per tile — the whole point of batching.
+  it "broadcasts each board once at the end" do
+    allow(Images::TextTile::Creator).to receive(:call)
+    expect_any_instance_of(Board).to receive(:broadcast_board_update!).once
+
+    described_class.new.perform([entry(first_tile), entry(second_tile)])
+  end
+
+  it "fails only the tile that blew up, and still renders the rest" do
+    allow(Images::TextTile::Creator).to receive(:call) do |board_image:, **|
+      raise "chrome died" if board_image.id == first_tile.id
+    end
+
+    expect { described_class.new.perform([entry(first_tile), entry(second_tile)]) }
+      .to raise_error(/#{first_tile.id}/)
+
+    expect(first_tile.reload.status).to eq("failed")
+    expect(second_tile.reload.status).not_to eq("failed")
+  end
+
+  it "is a no-op for a tile deleted between enqueue and run" do
+    allow(Images::TextTile::Creator).to receive(:call)
+
+    expect { described_class.new.perform([[-1, { "text" => "gone" }]]) }.not_to raise_error
+  end
+
+  it "tolerates an empty selection" do
+    expect { described_class.new.perform([]) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## What changed

Text tiles used to fork headless Chrome once per tile and create a fresh Doc + S3 blob every single time, even when the pixels were identical. Bulk "Set text image" on a 30-tile board meant 30 Sidekiq jobs, 30 Chrome launches, and 30 blobs for maybe a dozen distinct pictures — on a queue that runs three workers, which parked everyone else's single-tile render behind it.

### Dedupe (`Images::TextTile::Creator`)

A render is deterministic, and `Options#render_digest` is already defined as "everything that changes the pixels and nothing that doesn't". It's now the dedupe key, stamped on the Doc as `data["render_digest"]`. Before any Grover fork, two tiers:

1. **Same Image + same user + same digest** → reuse the Doc row outright. A second row is just a duplicate thumbnail in that tile's picture gallery.
2. **Any other match** → this Image gets its own Doc row (the row is per-Image/per-user — docs carry `user_id` and seed `UserDoc`), attaching the **same blob**. No render, no upload.

Sharing a blob across Doc rows is safe here: `active_storage_attachments.blob_id` has a foreign key and `ActiveStorage::Blob#purge` rescues `InvalidForeignKey` (verified against the installed activestorage 8.0.5), so hard-deleting one Doc — `docs#destroy?hard_delete=1`, or `ConvertDocToWebpJob` purging the original — can't take the bytes out from under the others. A doc whose blob *was* purged isn't a reuse source; the lookup joins `image_attachment`.

Migration `20260820160000` adds a partial index on `(data->>'render_digest') WHERE source_type = 'SpeakAnyWayText'`, created concurrently.

### Batching (`RenderTextTilesJob`)

`create_text_images` now enqueues **one** job carrying `[[board_image_id, options], ...]` instead of one per tile.

- Sequential inside the job **on purpose** — rendering the selection in parallel would race the digest lookup and fork Chrome N times for the same picture.
- One tile's failure marks only that tile `failed`; the batch still raises at the end so Sidekiq retries, which is cheap because every tile that succeeded now dedupes to its own Doc rather than re-rendering.
- The board is broadcast once per board at the end, not once per tile — that's the new `Creator.call(broadcast: false)`.

Net effect on a 30-tile select-all with 12 distinct label/colour combinations: **1 job, 12 renders, 30 Docs**, down from 30 jobs, 30 renders, 30 blobs.

## What did NOT change

- The single-tile path (`create_text_image` → `RenderTextTileJob`) still enqueues per tile — it's one tile. It just picks up the dedupe for free.
- The controller's unchanged-render short circuit stays: it answers without touching the queue at all. The `Creator` dedupe is the second net, for tiles that have never carried this render.
- Still free — no `check_credits!` was added anywhere.
- Still no fan-out: a text tile never repaints a sibling board (existing spec still green).

A third possible step — one Chrome fork for N tiles, via a sheet of stacked squares cropped with vips — was deliberately left out. It needs chunking under Chrome's ~16384px height limit and crop-alignment tests, and the dedupe here may drop the render count enough that it isn't worth the complexity. Worth measuring the queue after this lands.

## Test plan

`bundle exec rspec` over the touched areas — **256 examples, 0 failures**:

- `spec/services/images/text_tile/` — new `dedupe` block: Doc-row reuse, cross-Image blob sharing, a re-render when the pixels genuinely change, no re-render on a `hide_label` flip, the digest stamp, a second user getting their own row over the shared blob, and the purged-blob fallback. Plus the `broadcast: false` case.
- `spec/sidekiq/render_text_tiles_job_spec.rb` (new) — renders the whole selection, hands the creator the board owner with `broadcast: false`, broadcasts each board once, isolates a failing tile while still rendering the rest and raising for retry, and no-ops on a deleted tile / empty selection.
- `spec/requests/api/board_images_text_image_spec.rb` — bulk expectations moved to the batch job, asserting the enqueued payload carries exactly the right tile ids (and excludes unlabeled tiles and tiles from another board).
- `spec/sidekiq/render_text_tile_job_spec.rb`, `spec/models/doc_spec.rb`, `spec/requests/api/docs_*`, `spec/requests/api/board_images_rate_limit_spec.rb` — unchanged, still green.

Migration ran clean locally; `db/schema.rb` regenerated.

## Docs

- `.claude-notes/image-generation.md` — new "Dedupe and batching" section under the text-tile spoke, including the FK rule ("don't drop that FK, and don't 'fix' a dedupe miss by copying bytes into a fresh blob").
- `CHANGELOG.md` — user-facing entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)