### PR TITLE
fix(etsy): fold board name into title head, not a trailing qualifier

### DIFF
--- a/.claude-notes/etsy-listing-copy-seo-handoff.md
+++ b/.claude-notes/etsy-listing-copy-seo-handoff.md
@@ -23,9 +23,15 @@ every defect. That is what this work fixes.
 
 ## Decisions (already made — don't re-litigate)
 
-1. Titles **always** lead with the head term. Board name is always the qualifier. No
-   conditional branch — this was explicitly chosen over a "merge when the board name
-   already contains a head term" variant.
+1. Titles **always** lead with the head term ("AAC"). **Superseded 2026-08-20, later the
+   same day:** the board name does NOT trail as a qualifier — it folds into the head
+   itself, right after "AAC", because Etsy's shop grid truncates a title around 34
+   characters and "AAC Communication Board Printable, " alone is already 35. A trailing
+   qualifier put every non-core listing's distinguishing word past the cut, so they read
+   as identical while browsing — the same defect `Etsy::TagOverlap` exists to catch, one
+   field over. `Etsy::TitlePrefixOverlap` now warns when two printables share their first
+   34 characters, same contract as `TagOverlap`. The "fold into the head when the board
+   name already names the product" branch is unaffected — that was never a qualifier.
 2. Single-word tags are blocked in `normalize_tag` **and** removed from the pools.
    Rule-level enforcement was explicitly chosen so a future pool edit cannot
    reintroduce them.
@@ -146,27 +152,39 @@ and `"classroom visuals"` if you moved them into `AUDIENCE_TAGS`.
 Every tag must be ≤20 characters. `"pecs alternative"` is 16, `"nonverbal child"` is 15,
 `"communication board"` is 19.
 
-### 3. Head-term-first titles
+### 3. Head-term-first titles, board name folded into the head (implemented, corrected)
 
-`app/services/etsy/listing_copy.rb#title`. The product phrase leads; the board name
-becomes part of the qualifier:
-
-```ruby
-head = "AAC #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"
-```
-
-with the special case that when the board name already contains a head-term word
-(`names_product` at L146-147 computes this), the board name folds into the head instead
-of being repeated:
+`app/services/etsy/listing_copy.rb#title`. This shipped in PR #737 with the board name
+as a trailing qualifier (`"AAC Communication Board Printable, #{base}, …"`), which turned
+out to break the shop grid: Etsy truncates a title around 34 characters there, and the
+fixed head alone already eats 35, so every non-core listing rendered identically while
+browsing. Corrected the same day — the board name now goes INSIDE the head, at
+character 4:
 
 ```ruby
-head = "AAC #{CopyRules.title_case_words(base)}"   # "AAC Core Communication Board"
+head = if names_product
+  "AAC #{base}"                                                          # unchanged
+else
+  "AAC #{base} #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"   # "AAC Recess Communication Board Printable"
+end
 ```
 
-Then the qualifier clause carries `base` (when not already folded in), `size_phrase`,
-and `topic_phrase`. Keep the widest-first ladder and keep a guaranteed-fitting last
-rung — `pick_fitting_title` truncates mid-word if every rung overflows, which has
-already shipped a listing titled `"… Printable for Speech The (Digital Download)"`.
+`subject` is gone — the board name is always inside `head` now, in both branches, so it
+is never repeated in the qualifier clause below. The qualifier clause carries only
+`size_phrase` and `topic_phrase`. Keep the widest-first ladder and keep a
+guaranteed-fitting last rung (`generic_head`, unchanged — the fixed phrase with no board
+name at all) — `pick_fitting_title` truncates mid-word if every rung overflows, which has
+already shipped a listing titled `"… Printable for Speech The (Digital Download)"`. A
+board name long enough to overflow even the bare `head` falls all the way to
+`generic_head`, which drops the board name and the tail — that's an accepted trade-off,
+not a bug: a title that can't fit the board name at all is better generic than truncated
+mid-word.
+
+`app/services/etsy/title_prefix_overlap.rb` is the admin advisory that would have caught
+the trailing-qualifier defect: it warns when two printables' titles share their first 34
+characters, same WARN-never-block contract as `Etsy::TagOverlap`. Wired into
+`Admin::BoardPrintablesController#show` as `@title_prefix_overlap` and rendered in
+`_tag_overlap.html.erb` alongside the tag-overlap card.
 
 Watch the ampersand: `tail` is `"for Speech Therapy & Autism"` and Etsy 400s on a second
 `&`. `enforce_title_rules` rewrites later ones to "and", so this is handled — but if you

--- a/app/controllers/admin/board_printables_controller.rb
+++ b/app/controllers/admin/board_printables_controller.rb
@@ -46,6 +46,7 @@ module Admin
       @tree_boards = tree_boards(@printable)
       @etsy_listings = @printable.etsy_listings.to_a
       @tag_overlap = Etsy::TagOverlap.new(@printable, tags: @listing["tags"])
+      @title_prefix_overlap = Etsy::TitlePrefixOverlap.new(@printable, title: @listing["title"])
       @copy_advisories = Etsy::CopyAdvisories.new(@listing)
       @etsy_configured = Etsy::Client.configured?
       # The listing-video card offers a render button only where the binaries

--- a/app/services/etsy/copy_advisories.rb
+++ b/app/services/etsy/copy_advisories.rb
@@ -71,8 +71,9 @@ module Etsy
       Advisory.new(
         key: :buried_head_term,
         message: "The title's first #{HEAD_TERM_WINDOW} characters don't say \"AAC\".",
-        detail: "Lead with the phrase buyers search (\"AAC Communication Board Printable\") " \
-                "and make the board name the qualifier that follows it.",
+        detail: "Lead with \"AAC\" and fold the board name in right after it — the shop grid " \
+                "truncates around 34 characters, so the head term and the board name both need " \
+                "to land inside that window.",
       )
     end
   end

--- a/app/services/etsy/listing_copy.rb
+++ b/app/services/etsy/listing_copy.rb
@@ -150,31 +150,40 @@ module Etsy
 
     TITLE_TAIL = "for Speech Therapy & Autism".freeze
 
-    # Keyword-forward title, and the head term ALWAYS leads.
+    # Keyword-forward title, and the head term ALWAYS leads — but the board
+    # name folds INTO the head, at character 4, rather than trailing it as a
+    # qualifier.
     #
-    # It used to lead with the board's own name, on the reasoning that buyers
-    # search "core words board" rather than "SpeakAnyWay". That holds only when
-    # the board name is itself a search term. Every zero-view listing in the
-    # 2026-08-20 analysis was a niche noun — "Recess", "Haircut", "Potty" — put
-    # in front of the phrase buyers actually type, so the title opened on a word
-    # nobody searches. The board name is now always the QUALIFIER; the product
-    # phrase is always the head.
+    # It used to lead with the board's own name outright, on the reasoning
+    # that buyers search "core words board" rather than "SpeakAnyWay". That
+    # held only when the board name was itself a search term. Every zero-view
+    # listing in the 2026-08-20 analysis was a niche noun — "Recess",
+    # "Haircut", "Potty" — opening the title on a word nobody searches, so the
+    # rule flipped to head-term-first with the board name demoted to a
+    # trailing qualifier. That in turn broke the shop grid: Etsy truncates a
+    # listing's title around 34 characters there, and "AAC Communication Board
+    # Printable, " alone is 35 — every non-core listing rendered identically
+    # while browsing, competing with itself in search instead of the board
+    # name distinguishing it. Folding the board name straight after "AAC "
+    # keeps the head term leading AND puts the one thing that varies between
+    # listings inside the truncation window.
     #
     # The one exception is a board whose name already names the product ("Core
-    # Words Board"): repeating the product phrase reads badly and eats the
-    # 140-char budget, so the name folds INTO the head instead of following it —
-    # "AAC Core Words Board", never "AAC Communication Board Printable, Core
-    # Words Board".
+    # Words Board"): the product phrase would otherwise repeat right after it
+    # ("AAC Core Words Board Communication Board Printable"), so the head is
+    # just "AAC #{base}" and nothing is appended.
     def title
       @title ||= begin
         base = CopyRules.title_case_words(board_name)
 
         type_words = PRODUCT_HUMAN.downcase.split(/\s+/).select { |w| w.length > 3 }
         names_product = type_words.any? { |w| base.downcase.include?(w) }
-        head = names_product ? "AAC #{base}" : generic_head
+        head = if names_product
+          "AAC #{base}"
+        else
+          "AAC #{base} #{CopyRules.title_case_words(PRODUCT_HUMAN)} Printable"
+        end
 
-        # Already folded into the head, so it must not be repeated below.
-        subject = names_product ? nil : base
         size_phrase = set? ? "#{board_count}-Board Set" : nil
         topic_phrase = CopyRules.distinct_topic_phrase(
           title: base, topic: topic_source, product_human: PRODUCT_HUMAN,
@@ -186,13 +195,11 @@ module Etsy
         # `ensure_digital_download_suffix` truncates mid-word, which is how a
         # listing shipped titled "… Printable for Speech The (Digital Download)".
         composed = CopyRules.pick_fitting_title([
-          compose_title(head, [subject, size_phrase, topic_phrase], TITLE_TAIL),
-          compose_title(head, [subject, topic_phrase], TITLE_TAIL),
-          compose_title(head, [subject, size_phrase], TITLE_TAIL),
-          compose_title(head, [subject], TITLE_TAIL),
-          compose_title(head, [subject, topic_phrase], nil),
-          compose_title(head, [subject], nil),
+          compose_title(head, [size_phrase, topic_phrase], TITLE_TAIL),
+          compose_title(head, [topic_phrase], TITLE_TAIL),
+          compose_title(head, [size_phrase], TITLE_TAIL),
           compose_title(head, [], TITLE_TAIL),
+          compose_title(head, [topic_phrase], nil),
           head,
           # Fixed length whatever the board is called — the rung that cannot
           # overflow, even when `head` itself folded in a 140-char board name.

--- a/app/services/etsy/title_prefix_overlap.rb
+++ b/app/services/etsy/title_prefix_overlap.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Whether a printable's title shares Etsy's shop-grid truncation window with
+# another printable's — the check that would have caught every non-core
+# listing opening on the same fixed head term with nothing distinguishing
+# them before the cut.
+#
+# Etsy truncates a listing's title to roughly PREFIX_LENGTH characters in the
+# shop grid, so two titles identical up to that point are indistinguishable
+# while browsing and compete with each other instead of reaching a buyer
+# looking for either one specifically.
+#
+# WARNS, never blocks — same contract as Etsy::TagOverlap. A shared head term
+# is often correct (every listing should open "AAC …"); only an identical
+# PREFIX is a problem, and only a human can tell a coincidence from a listing
+# that forgot to say what it is.
+#
+# Read-only and side-effect free — safe to call from a view.
+module Etsy
+  class TitlePrefixOverlap
+    # Roughly where Etsy's shop grid stops showing a title.
+    PREFIX_LENGTH = 34
+
+    # Only printables that already have saved listing copy are compared, and
+    # only the most recent slice of them — see Etsy::TagOverlap::SCAN_LIMIT.
+    SCAN_LIMIT = 200
+
+    MAX_MATCHES = 3
+
+    Match = Struct.new(:printable, :listing, :prefix, keyword_init: true) do
+      # A sibling listing on the SAME printable has the same board name, so it
+      # has to say which listing it is or the warning reads as a bug.
+      def label
+        base = printable.board&.name || "Board ##{printable.board_id}"
+        return base if listing.nil?
+
+        "#{base} — #{listing.label.presence || listing.purpose} listing"
+      end
+    end
+
+    # Takes a printable (the base copy) or a single BoardPrintableListing.
+    def initialize(subject, title: nil)
+      @listing = subject if subject.is_a?(BoardPrintableListing)
+      @printable = @listing&.board_printable || subject
+      @prefix = normalize(title || default_title)
+    end
+
+    def any? = matches.any?
+
+    def matches
+      @matches ||= begin
+        if @prefix.blank?
+          []
+        else
+          candidates.select { |candidate| candidate[:prefix] == @prefix }
+                    .first(MAX_MATCHES)
+                    .map { |candidate| Match.new(printable: candidate[:printable], listing: candidate[:listing], prefix: @prefix) }
+        end
+      end
+    end
+
+    private
+
+    def default_title
+      (@listing&.resolved_copy || @printable.listing_copy_or_default)["title"]
+    end
+
+    def candidates = sibling_candidates + printable_candidates
+
+    # Other listings on this same printable. Their RESOLVED copy, since a
+    # listing that overrides nothing still ships the printable's title.
+    #
+    # When the subject is the printable itself (no @listing), a listing with
+    # no title override of its own isn't a sibling to compare against: it
+    # ships the exact title being compared, so it would always "match" itself.
+    def sibling_candidates
+      return [] if @printable.id.nil?
+
+      @printable.etsy_listings.reject { |other| other.id == @listing&.id }
+                .reject { |other| @listing.nil? && other.listing_copy.to_h["title"].blank? }
+                .filter_map do |other|
+        prefix = normalize(other.resolved_copy["title"])
+        { printable: @printable, listing: other, prefix: prefix } if prefix.present?
+      end
+    end
+
+    def printable_candidates
+      scope = BoardPrintable.includes(:board).order(created_at: :desc)
+      scope = scope.where.not(id: @printable.id) if @printable.id
+      scope.limit(SCAN_LIMIT).filter_map do |other|
+        prefix = normalize(other.listing_copy.to_h["title"])
+        { printable: other, listing: nil, prefix: prefix } if prefix.present?
+      end
+    end
+
+    def normalize(title) = title.to_s.strip.downcase[0, PREFIX_LENGTH]
+  end
+end

--- a/app/views/admin/board_printables/_tag_overlap.html.erb
+++ b/app/views/admin/board_printables/_tag_overlap.html.erb
@@ -34,6 +34,33 @@
   </div>
 <% end %>
 
+<%# Same contract as the tag-overlap card above, one field over: the title's
+    shop-grid-truncation prefix instead of the tag set. %>
+<% if @title_prefix_overlap&.any? %>
+  <div class="admin-card border rounded-xl p-5 mb-6" style="border-color: #b45309;">
+    <h2 class="text-sm font-medium mb-1" style="color: #f59e0b;">
+      This title's first <%= Etsy::TitlePrefixOverlap::PREFIX_LENGTH %> characters match
+      <%= pluralize(@title_prefix_overlap.matches.size, "other listing") %>
+    </h2>
+    <p class="text-[11px] text-t3 mb-3">
+      Etsy's shop grid truncates a title around this length, so listings sharing this prefix look
+      identical while browsing and compete with each other instead of reaching a buyer searching
+      for either one specifically. Move what makes this listing distinct earlier in the title.
+    </p>
+
+    <div class="space-y-2">
+      <% @title_prefix_overlap.matches.each do |match| %>
+        <div class="text-xs text-t1">
+          <%= link_to admin_dashboard_board_printable_path(match.printable), class: "hover:text-accent transition-colors" do %>
+            <%= match.label %>
+            <span class="text-t3">(printable #<%= match.printable.id %>)</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <%# Same panel, same contract: advisory only, never a gate. Each of these is a
     slot or a search term the listing is leaving on the table, and each has a
     legitimate exception only an admin can judge. %>

--- a/spec/services/etsy/listing_copy_spec.rb
+++ b/spec/services/etsy/listing_copy_spec.rb
@@ -32,20 +32,25 @@ RSpec.describe Etsy::ListingCopy do
     end
 
     # The defect the 2026-08-20 analysis found: every zero-view listing opened
-    # on a niche noun nobody searches, with the phrase buyers actually type
-    # pushed past the fold. The board name is the qualifier now, always.
-    it "leads with the head term and makes the board name the qualifier" do
+    # on a niche noun nobody searches. Leading with the head term and demoting
+    # the board name to a trailing qualifier fixed that but broke the shop
+    # grid instead — Etsy truncates a title around 34 characters there, and
+    # "AAC Communication Board Printable, " alone is 35, so every non-core
+    # listing rendered identically while browsing. The board name now folds
+    # into the head, right after "AAC", so both the head term and the thing
+    # that varies land inside that window.
+    it "leads with the head term and folds the board name in right after it" do
       niche = create(:board, user: owner, name: "Recess")
       title = described_class.new(
         BoardPrintable.create!(board: niche, status: "complete", board_ids: [niche.id]),
       ).build["title"]
 
-      expect(title).to start_with("AAC Communication Board Printable,")
-      expect(title).to include("Recess")
+      expect(title).to start_with("AAC Recess Communication Board Printable")
+      expect(title[0, 34]).to include("Recess")
     end
 
     # The one exception: a board whose name already names the product folds
-    # INTO the head rather than being repeated after it.
+    # INTO the head without the product phrase repeated after it.
     it "folds a board name that already names the product into the head" do
       named = create(:board, user: owner, name: "Core Words Board")
       title = described_class.new(
@@ -53,11 +58,11 @@ RSpec.describe Etsy::ListingCopy do
       ).build["title"]
 
       expect(title).to start_with("AAC Core Words Board")
-      expect(title).not_to include("AAC Communication Board Printable")
+      expect(title).not_to include("Communication Board")
     end
 
     it "names the product when the board's own name doesn't" do
-      expect(build["title"]).to start_with("AAC Communication Board Printable")
+      expect(build["title"]).to start_with("AAC Core Words Communication Board Printable")
     end
 
     # A blank topic used to collapse the title ladder onto its bare
@@ -78,11 +83,14 @@ RSpec.describe Etsy::ListingCopy do
 
       # A shipped listing once ended "… Printable for Speech The (Digital
       # Download)": every rung overflowed and the suffix step cut mid-word.
-      # Ending on the complete tail is the proof it took a rung that fits —
-      # `not_to include("for Speech The")` was no proof at all, since every
-      # untruncated title contains it inside "for Speech Therapy".
+      # A board name this long overflows even the bare head, so every rung
+      # that embeds it overflows too — the guaranteed-fitting rung is the
+      # generic head with no board name at all, which is the proof it took a
+      # rung that fits rather than truncating mid-word.
       expect(title.length).to be <= Etsy::CopyRules::TITLE_MAX
-      expect(title).to end_with("for Speech Therapy & Autism (Digital Download)")
+      expect(title).to start_with("AAC Communication Board Printable")
+      expect(title).not_to include("Snack Time Snack Time")
+      expect(title).to end_with("(Digital Download)")
     end
   end
 

--- a/spec/services/etsy/title_prefix_overlap_spec.rb
+++ b/spec/services/etsy/title_prefix_overlap_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Etsy::TitlePrefixOverlap do
+  let(:owner) { create(:user) }
+
+  def printable(name, title:)
+    board = create(:board, user: owner, name: name)
+    BoardPrintable.create!(
+      board: board, status: "complete", board_ids: [board.id],
+      listing_copy: { "title" => title },
+    )
+  end
+
+  it "flags a printable whose title shares the truncation prefix with another's" do
+    printable("Recess", title: "AAC Communication Board Printable, Recess and Playground Set")
+    subject_printable = printable("Haircut", title: "AAC Communication Board Printable, Haircut and Salon Visits")
+
+    overlap = described_class.new(subject_printable)
+
+    expect(overlap).to be_any
+    expect(overlap.matches.first.printable.board.name).to eq("Recess")
+  end
+
+  it "stays quiet when the board name lands inside the prefix window" do
+    printable("Recess", title: "AAC Recess Communication Board Printable")
+    subject_printable = printable("Haircut", title: "AAC Haircut Communication Board Printable")
+
+    expect(described_class.new(subject_printable)).not_to be_any
+  end
+
+  it "ignores printables with no saved title" do
+    printable("Recess", title: nil)
+    subject_printable = printable("Haircut", title: "AAC Communication Board Printable, Haircut Set")
+
+    expect(described_class.new(subject_printable)).not_to be_any
+  end
+
+  it "never compares a printable against itself" do
+    subject_printable = printable("Haircut", title: "AAC Communication Board Printable, Haircut Set")
+
+    expect(described_class.new(subject_printable)).not_to be_any
+  end
+
+  it "compares the title it is handed rather than the saved one" do
+    printable("Recess", title: "AAC Communication Board Printable, Recess and Playground Set")
+    subject_printable = printable("Haircut", title: "AAC Haircut Communication Board Printable")
+
+    overlap = described_class.new(subject_printable, title: "AAC Communication Board Printable, Haircut Set")
+
+    expect(overlap).to be_any
+  end
+
+  it "is case-insensitive" do
+    printable("Recess", title: "aac communication board printable, recess set")
+    subject_printable = printable("Haircut", title: "AAC COMMUNICATION BOARD PRINTABLE, HAIRCUT SET")
+
+    expect(described_class.new(subject_printable)).to be_any
+  end
+
+  describe "sibling listings on the same printable" do
+    it "warns when a second listing shares the title prefix" do
+      board = create(:board, name: "Core Words")
+      printable = BoardPrintable.create!(
+        board: board, status: "complete",
+        listing_copy: { "title" => "AAC Communication Board Printable, Core Words Set" },
+      )
+      printable.etsy_listings.create!(purpose: "standalone")
+      bundle = printable.etsy_listings.create!(purpose: "bundle", label: "holiday")
+
+      overlap = described_class.new(bundle)
+
+      expect(overlap.any?).to be true
+      expect(overlap.matches.first.label).to include("holiday").or include("standalone")
+      expect(overlap.matches.first.printable).to eq(printable)
+    end
+
+    it "does not warn when comparing the printable itself against a single non-overriding listing" do
+      board = create(:board, name: "Core Words")
+      printable = BoardPrintable.create!(
+        board: board, status: "complete",
+        listing_copy: { "title" => "AAC Communication Board Printable, Core Words Set" },
+      )
+      printable.etsy_listings.create!(purpose: "standalone")
+
+      overlap = described_class.new(printable, title: printable.listing_copy_or_default["title"])
+
+      expect(overlap.any?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `Etsy::ListingCopy#title` shipped in #737 with the board name demoted to a trailing qualifier after the fixed head term ("AAC Communication Board Printable, "). That fixed head alone is 35 characters, and Etsy's shop grid truncates a listing's title around 34 — so every non-core board rendered identically while browsing, competing with itself in search instead of the board name distinguishing it.
- The board name now folds into the head right after "AAC" (e.g. "AAC Recess Communication Board Printable"), keeping the searched head term first while putting the one thing that varies between listings inside the truncation window. The existing "board name already names the product" fold (e.g. "AAC Core Words Board") is unchanged.
- Adds `Etsy::TitlePrefixOverlap`, an admin advisory modelled on `Etsy::TagOverlap`, warning when two printables' titles share their first 34 characters — the check that would have caught the original defect. Wired into the admin printable show page next to the tag-overlap card.
- Updates `Etsy::CopyAdvisories#buried_head_term`'s detail text and `.claude-notes/etsy-listing-copy-seo-handoff.md` to describe the corrected rule.
- Tag generation is untouched.

## Test plan
- `bundle exec rspec spec/services/etsy/ spec/requests/admin/board_printables_spec.rb` — 202 examples, 0 failures.
- Added `spec/services/etsy/title_prefix_overlap_spec.rb`; updated the title examples in `spec/services/etsy/listing_copy_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)