### PR TITLE
fix: point safety-cards email at a real communicator route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- **The "Download updated cards" button in the safety-cards email goes to a
+  real page.** It pointed at `/communicators/:id/safety`, a path the app has no
+  route or redirect for, so parents told to reprint their child's safety ID
+  card and device tag landed on a 404. It now opens the Print & share section
+  of the communicator's MySpeak tab, where those cards actually live.
+
 - **Detaching a printable from an Etsy draft no longer loses the draft.**
   "Detach & relist" used to forget the listing id, so the superseded draft was
   left in the shop with nothing naming it. Detaching now keeps the listing on

--- a/app/mailers/communication_account_mailer.rb
+++ b/app/mailers/communication_account_mailer.rb
@@ -18,7 +18,11 @@ class CommunicationAccountMailer < BaseMailer
     @child_account = child_account
     @profile = child_account.profile
     @child_name = child_account.display_name
-    @download_url = "#{frontend_url}/communicators/#{child_account.id}/safety"
+    # /communicators/:id/... is not a route the frontend declares (and no
+    # Netlify redirect covers it) — that URL 404s. The communicator screen
+    # lives at /communicator-accounts/:id/:tab, and the device tag + safety
+    # cards are in the "Print & share" section of the MySpeak tab.
+    @download_url = "#{frontend_url}/communicator-accounts/#{child_account.id}/myspeak#print-share"
 
     with_user_locale(user) do
       mail(

--- a/spec/mailers/communication_account_mailer_spec.rb
+++ b/spec/mailers/communication_account_mailer_spec.rb
@@ -107,14 +107,38 @@ RSpec.describe CommunicationAccountMailer, type: :mailer do
   end
 
   describe "#safety_cards_updated" do
-    it "addresses the owner and links to the communicator's safety page" do
-      mail = described_class.safety_cards_updated(owner, account).deliver_now
+    # Mirrors the communicator route declared in the frontend
+    # (itty-bitty-frontend/src/App.tsx):
+    #   /communicator-accounts/:id/:tab(stats|boards|team|myspeak|settings|safety)?
+    # Nothing else under /communicator-accounts/:id/ resolves, and no Netlify
+    # rule in public/_redirects rewrites another prefix onto it — so a link
+    # that doesn't match this 404s. Keep the slug list in sync with the route.
+    FRONTEND_TAB_SLUGS = %w[stats boards team myspeak settings safety].freeze
+    COMMUNICATOR_ROUTE = %r{\A/communicator-accounts/\d+(?:/(?:#{FRONTEND_TAB_SLUGS.join("|")}))?(?:\#[\w-]+)?\z}
 
+    let(:mail) { described_class.safety_cards_updated(owner, account).deliver_now }
+    let(:body) { mail.html_part&.body&.decoded || mail.body.decoded }
+
+    it "addresses the owner" do
       expect(mail.to).to eq([owner.email])
       expect(mail.subject).to eq("Sam Carter's safety cards have been updated")
-      body = mail.html_part&.body&.decoded || mail.body.decoded
       expect(body).to include("Sam Carter")
-      expect(body).to include("/communicators/#{account.id}/safety")
+    end
+
+    it "links to the Print & share section of the communicator's MySpeak tab" do
+      expect(body).to include("/communicator-accounts/#{account.id}/myspeak#print-share")
+    end
+
+    it "builds a download URL that matches a real frontend route" do
+      href = body[/<a[^>]+class="button"[^>]+href="([^"]+)"/, 1]
+      expect(href).to be_present
+
+      path = URI.parse(href).then { |uri| "#{uri.path}#{"##{uri.fragment}" if uri.fragment}" }
+      expect(path).to match(COMMUNICATOR_ROUTE)
+    end
+
+    it "does not use the /communicators/ prefix, which the frontend never declares" do
+      expect(body).not_to include("/communicators/")
     end
   end
 end


### PR DESCRIPTION
## Summary

`CommunicationAccountMailer#safety_cards_updated` built its "Download updated cards" button as `#{frontend_url}/communicators/:id/safety`. The frontend has no such route:

- `src/App.tsx:851` declares the only communicator route as `/communicator-accounts/:id/:tab(stats|boards|team|myspeak|settings|safety)?`
- nothing in `public/_redirects` rewrites a `/communicators/` prefix onto it — the only thing that matches is the SPA catch-all

So every parent told to reprint their child's safety ID card and device tag after the random-slug migration landed on a 404.

The URL now points at `/communicator-accounts/:id/myspeak#print-share` — the **Print & share** section of the MySpeak tab, which is where the device tag and safety cards actually live (`ViewChildAccountScreen.tsx:556`, rendered at `:2554`).

The spec now pins the URL against a regex mirroring the frontend route's closed tab-slug list, so a future path change that doesn't resolve fails here rather than in a parent's inbox.

## Known limitation (frontend follow-up, not this PR)

The `#print-share` fragment is currently **inert**. `ViewChildAccountScreen` derives its section anchor from `TAB_BY_SLUG[tabSlug]` or the `initialSegment` prop — it never reads `location.hash`. The link now lands correctly on the MySpeak tab (no more 404) but at the top of the page rather than scrolled to Print & share. Making the hash work is a change in `itty-bitty-frontend`, so it's tracked separately.

## Test plan

- `bundle exec rspec spec/mailers/communication_account_mailer_spec.rb spec/jobs/regenerate_safety_cards_job_spec.rb` → **14 examples, 0 failures**
- Confirmed the new route-shape guard isn't vacuous: reverting the mailer to the old URL fails it with
  `expected "/communicators/1066/safety" to match /\A\/communicator-accounts\/\d+(?:\/(?:stats|boards|team|myspeak|settings|safety))?(?:\#[\w-]+)?\z/`
- `bundle exec rails zeitwerk:check` → clean
- `CHANGELOG.md` entry added under Unreleased → Fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)