### PR TITLE
feat(care): add your own chip to a Care & routines row, retire the built-in detail lines

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -166,6 +166,39 @@ the free-text bio.
   **drops rather than rejects** — a stale frontend must not be able to 422 a
   parent out of saving. If nothing survives, the key is deleted so
   `has_care_info?` stays honest.
+- **A parent can add their OWN chip to a preset row, stored in the same array
+  behind `Profile::CARE_CUSTOM_OPTION_PREFIX` (`custom:`).** The preset lists are
+  deliberately short, so an answer that isn't on the list is typed rather than
+  missing. Three things make the sentinel work. The prefix contains a colon and a
+  registry option key is `/\A[a-z_]+\z/`, so a custom value can never collide
+  with a present or future key. It lives IN the array rather than beside it,
+  because a deployed client — the iOS/Android bundles live a long time —
+  round-trips `values[<field>]` verbatim and so preserves a chip it has never
+  heard of, while a sibling key would be dropped by the frontend's
+  `settingsFromCareValue` on that client's next save. And `CareLabels.option`
+  guards the prefix in ONE place, returning the parent's words verbatim, so the
+  printed plan and anything else server-side gets it right without knowing the
+  feature exists — `humanize` would otherwise eat the underscores out of their
+  own text. Custom chips are capped per field (`MAX_CARE_CUSTOM_OPTIONS`) INSIDE
+  `MAX_CARE_MULTI_SELECT`, deduped case-insensitively, and cleaned through
+  `CareText` like every other free-text value.
+- **Detail lines on a BUILT-IN section are accepted but no longer offered.** The
+  label/value rows under each built-in section were once its only free-text
+  surface; custom chips and a per-section `short_text` field replaced them and
+  the editor stopped rendering "+ Add a line". `clean_care_items` is still wired
+  into `clean_builtin_care_section` on purpose, and removing it is the same
+  silent-erasure trap as deleting an option from `CARE_SECTIONS`:
+  `sanitize_care_settings` is a `before_save` over the whole blob, so the rows
+  would vanish from every profile on its next save for any reason. `rake
+  care:audit_items` is the gate — only once it reports zero is the call safe to
+  delete. The editor still renders stored rows so a parent can clear their own,
+  and the card and printed plan still show them. Custom sections keep offering
+  rows; that is now the only place a label/value pair is authored.
+- **Every built-in section carries exactly one `short_text` field.** Retiring the
+  detail lines left Communication, Personal care and Moving around with no
+  free-text surface at all, so each gained a `notes` field. The "exactly one"
+  rule is asserted in `spec/models/care_preset_reshape_spec.rb` — two free-text
+  boxes side by side just split the same answer.
 - **The text cleaner strips markup and stores it UNESCAPED — `CareText.clean` is
   the single rule.** The trap is that `strip_tags` escapes entities on *output*,
   and the cleaner runs in a `before_save`, so a lone `strip_tags` PERSISTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   thumbnail is rendered from the same HTML as the PDF and shares its freshness
   signature, so it can never show a document you no longer have; on the full
   sheet, which flows to as many pages as it needs, the picture is page one.
+- **Care & routines: add your own chip to any preset row.** The preset lists
+  ("AAC device", "Toilet training") are deliberately short, so a parent whose
+  answer isn't on the list can now type their own and it becomes a chip on the
+  same row — shown on the care card and printed on the care plan like any other.
+- **Communication, Personal care and Moving around gained an "Anything else
+  worth knowing" field**, so every care section now has one place for a
+  sentence. Meals, Sensory and Getting around already had theirs.
 
 - **The Care & Emergency Plan can be downloaded as a half-page fold card or a
   wallet fold strip, not just the full Letter sheet.** `POST
@@ -36,6 +43,12 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   endpoint can still build one; nothing is built unprompted any more. A side
   effect: saving a communicator's page (an avatar, a theme change) now runs two
   headless-Chrome renders instead of four, so it finishes noticeably sooner.
+- **The per-section "Anything else worth knowing" detail lines are no longer
+  offered on the built-in care sections** — custom chips cover the short
+  answers, the new sentence field covers the rest, and "Your own sections" is
+  still there for anything that genuinely wants a label and a value. Lines
+  already saved are kept: they still show on the card and the printed plan, and
+  the editor still lets you edit or clear them.
 
 - **The care plan PDF has a new look.** Field labels sit on their own line in
   small caps above their value instead of inline with it; a picked

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -609,12 +609,25 @@ class Profile < ApplicationRecord
   #      "independent / some help / full help" scales, which said little on
   #      their own, into concrete supports someone can actually act on.
   #   2. Presets stay SHORT (3-4 options) and answer "which of these applies".
-  #      Anything specific or provisional belongs in the section's detail lines
-  #      ("Bus: back left seat, by the window"), which every section carries.
-  #      That is what makes a short option list lossless rather than lossy.
+  #      A parent whose answer isn't on the list adds their OWN chip — stored in
+  #      the same array behind CARE_CUSTOM_OPTION_PREFIX — and anything longer
+  #      than a chip goes in the section's `short_text` field. That is what makes
+  #      a short option list lossless rather than lossy.
   #
-  # There is deliberately no per-section `notes` field: the detail lines are the
-  # free-text surface, and two of them side by side just split the same answer.
+  # EVERY section carries exactly one `short_text` field, and that is the whole
+  # free-text surface. It used to be the per-section detail lines (label/value
+  # rows) instead, on the reasoning that two free-text surfaces side by side just
+  # split the same answer. That reasoning still holds — what changed is which one
+  # survived. Custom chips absorbed the short answers, "Your own sections" already
+  # did label/value rows better, and a sentence field is simpler than a row
+  # builder repeated under all six sections. So the editor stopped offering detail
+  # lines on a built-in section.
+  #
+  # It stopped OFFERING them. It did not stop accepting them, and clean_care_items
+  # below is deliberately still wired up for built-in sections — see the note
+  # there. sanitize_care_settings is a before_save over the whole blob, so
+  # deleting that handling erases every stored line on the next save of each
+  # profile, for any reason. Same two-step rule as DEPRECATED_CARE_OPTIONS.
   CARE_SECTIONS = {
     "communication" => {
       fields: [
@@ -627,6 +640,7 @@ class Profile < ApplicationRecord
         { key: "what_helps", type: :multi_select,
           options: %w[keep_my_device_close model_on_my_device wait_and_pause
                       offer_choices] },
+        { key: "notes", type: :short_text },
       ],
     },
     "personal_care" => {
@@ -640,6 +654,7 @@ class Profile < ApplicationRecord
           options: %w[handwashing toothbrushing face_and_hands hair_brushing] },
         { key: "dressing", type: :multi_select,
           options: %w[independent some_help full_help] },
+        { key: "notes", type: :short_text },
       ],
     },
     "meals" => {
@@ -685,6 +700,7 @@ class Profile < ApplicationRecord
         { key: "support", type: :multi_select,
           options: %w[independent standby_supervision hands_on_help
                       help_with_transfers] },
+        { key: "notes", type: :short_text },
       ],
     },
     "transportation" => {
@@ -705,6 +721,26 @@ class Profile < ApplicationRecord
   # A parent-added section. The key is generated client-side; the format is what
   # keeps an arbitrary attacker-chosen key out of the settings hash.
   CARE_CUSTOM_KEY_FORMAT = /\Ac_[0-9a-f]{6}\z/.freeze
+
+  # A chip a parent typed themselves, stored in the SAME multi_select array as
+  # the registry keys and told apart by this prefix. The colon is what makes it
+  # safe: a registry option key is /\A[a-z_]+\z/, so a custom value can never
+  # collide with a present or future one, and the sanitizer can partition the
+  # array without a second column or a sibling key.
+  #
+  # In-array rather than beside it, deliberately. A deployed client that predates
+  # this feature round-trips `values[<field>]` verbatim, so a custom chip survives
+  # an older build editing the same profile — it even renders as a removable
+  # selected chip, since the editor already shows a stored-but-unoffered option
+  # that way for retired options. A sibling key would instead be dropped by the
+  # frontend's settingsFromCareValue on the next save from any older build, which
+  # is silent data loss on the long-lived iOS/Android bundles.
+  CARE_CUSTOM_OPTION_PREFIX = "custom:"
+  # A chip has to stay chip-sized — one line, next to presets like "AAC device".
+  # Anything longer is what the section's `short_text` field is for.
+  CARE_CUSTOM_OPTION_MAX = 40
+  # Per field, and inside MAX_CARE_MULTI_SELECT rather than on top of it.
+  MAX_CARE_CUSTOM_OPTIONS = 4
 
   MAX_CUSTOM_CARE_SECTIONS = 4
   MAX_CARE_CUSTOM_ITEMS = 8
@@ -821,6 +857,8 @@ class Profile < ApplicationRecord
         max_custom_sections: MAX_CUSTOM_CARE_SECTIONS,
         max_custom_items: MAX_CARE_CUSTOM_ITEMS,
         max_multi_select: MAX_CARE_MULTI_SELECT,
+        max_custom_options: MAX_CARE_CUSTOM_OPTIONS,
+        custom_option_max: CARE_CUSTOM_OPTION_MAX,
         title_max: CARE_TITLE_MAX,
         item_label_max: CARE_ITEM_LABEL_MAX,
         item_value_max: CARE_ITEM_VALUE_MAX,
@@ -834,6 +872,10 @@ class Profile < ApplicationRecord
       # what actually prints the first time the copy is edited. Same reason
       # custom_key_format is derived above rather than written out.
       subheader_default: I18n.t("care.document.subheader.default", locale: locale),
+      # A SIBLING key, like `label`/`option_labels` above and for the same
+      # reason: an older client ignores it and keeps working. It never appears
+      # inside `options`, which must stay an array of plain strings.
+      custom_option_prefix: CARE_CUSTOM_OPTION_PREFIX,
     }
   end
 
@@ -1370,9 +1412,7 @@ class Profile < ApplicationRecord
         case field[:type]
         when :multi_select
           next unless raw_value.is_a?(Array)
-          raw_value.map(&:to_s).uniq
-                   .select { |v| accepted.include?(v) }
-                   .first(MAX_CARE_MULTI_SELECT)
+          clean_care_multi_select(raw_value, accepted)
         when :single_select
           value = raw_value.to_s
           value if accepted.include?(value)
@@ -1383,12 +1423,19 @@ class Profile < ApplicationRecord
       clean_values[field[:key]] = cleaned if cleaned.present?
     end
 
-    # Detail lines. The preset chips answer "which of these applies"; the real
-    # thing a parent needs to hand a substitute is usually specific and
-    # provisional — "Bus: back left seat, by the window". That doesn't compress
-    # into a chip, so a built-in section carries the same label/value rows a
-    # custom one does. These are the ONLY free-text surface on a built-in
-    # section, which is why the option lists above can stay short.
+    # Detail lines on a BUILT-IN section: accepted, no longer offered.
+    #
+    # These label/value rows were once the only free-text surface here. Custom
+    # chips and the per-section `short_text` field replaced them, and the editor
+    # stopped rendering "+ Add a line" — but real profiles still hold rows, and
+    # this method runs on EVERY save of a profile for any reason. Deleting the
+    # call erases them all, silently, with nothing to restore from.
+    #
+    # So it stays until `rake care:audit_items` reports zero, exactly like the
+    # two-step rule for DEPRECATED_CARE_OPTIONS. The editor still renders stored
+    # rows so a parent can clear their own; the card and the printed plan still
+    # show them. Custom sections keep offering rows — that is now the only place
+    # a label/value pair is authored.
     items = clean_care_items(section["items"])
 
     return nil if clean_values.empty? && items.empty?
@@ -1396,6 +1443,49 @@ class Profile < ApplicationRecord
     cleaned = { "enabled" => care_enabled?(section["enabled"]), "values" => clean_values }
     cleaned["items"] = items if items.any?
     cleaned
+  end
+
+  # One multi_select answer: registry keys and the parent's own chips, in one
+  # array, told apart by CARE_CUSTOM_OPTION_PREFIX.
+  #
+  # Walks the array ONCE and appends in the order given, so the parent's chip
+  # order survives the round trip — partitioning into presets-then-customs would
+  # silently reorder the row on every save. Everything that is neither an
+  # accepted option nor a well-formed custom value is dropped, same as before:
+  # this is a whitelist, and an unknown value has never been a 422.
+  def clean_care_multi_select(raw_value, accepted)
+    out = []
+    seen_presets = Set.new
+    seen_customs = Set.new
+
+    raw_value.each do |value|
+      break if out.length >= MAX_CARE_MULTI_SELECT
+
+      value = value.to_s
+
+      if value.start_with?(CARE_CUSTOM_OPTION_PREFIX)
+        next if seen_customs.size >= MAX_CARE_CUSTOM_OPTIONS
+
+        # care_text is the shared stripper — strip_tags + squish + truncate. A
+        # custom chip renders as text on an unauthenticated page like every other
+        # care value, so it gets exactly the same treatment.
+        text = care_text(value.delete_prefix(CARE_CUSTOM_OPTION_PREFIX),
+                         CARE_CUSTOM_OPTION_MAX)
+        next if text.blank?
+        # Case-insensitively: "no straw" and "No straw" are one chip, and the
+        # first spelling wins because it is the one already on the page.
+        next unless seen_customs.add?(text.downcase)
+
+        out << CARE_CUSTOM_OPTION_PREFIX + text
+      else
+        next unless accepted.include?(value)
+        next unless seen_presets.add?(value)
+
+        out << value
+      end
+    end
+
+    out
   end
 
   # Shared by built-in and custom sections — same caps, same stripping, same

--- a/app/services/care_labels.rb
+++ b/app/services/care_labels.rb
@@ -25,6 +25,14 @@ module CareLabels
     # and `mobility.equipment` are different fields with entirely different
     # option sets. Never key an option label on the option alone.
     def option(section_key, field_key, option_key, locale: I18n.locale)
+      # A chip the parent typed themselves is already words, in whatever
+      # language they wrote it. It is never translated and never humanized —
+      # humanize would eat the underscores out of their own text. Guarding here
+      # rather than at each caller is what gets CarePlanDocument (and any future
+      # server-rendered sheet) the right string for free.
+      custom = custom_option_text(option_key)
+      return custom if custom
+
       translate(
         "care.options.#{section_key}.#{field_key}.#{option_key}",
         option_key,
@@ -40,6 +48,16 @@ module CareLabels
       Profile.accepted_care_options(section_key, field).index_with do |option_key|
         option(section_key, field[:key], option_key, locale: locale)
       end
+    end
+
+    # The parent's own words out of a `custom:`-prefixed option value, or nil
+    # when this isn't one. Mirrors customOptionText in the frontend's
+    # src/data/careSections.ts.
+    def custom_option_text(option_key)
+      key = option_key.to_s
+      return nil unless key.start_with?(Profile::CARE_CUSTOM_OPTION_PREFIX)
+
+      key.delete_prefix(Profile::CARE_CUSTOM_OPTION_PREFIX).strip.presence
     end
 
     # Deliberately NOT String#humanize: that strips a trailing `_id` and

--- a/app/services/care_text_repair.rb
+++ b/app/services/care_text_repair.rb
@@ -35,9 +35,16 @@ module CareTextRepair
       spec = Profile::CARE_SECTIONS[section_key]
 
       if spec
-        # Only short_text fields. Select values are registry KEYS, not prose —
-        # re-cleaning them is a no-op today, but running the caps over them is
-        # not something this task has any business doing.
+        # Only short_text fields.
+        #
+        # A multi_select array is mostly registry KEYS, and running this task's
+        # caps over a key is not something it has any business doing. It can
+        # also hold a custom chip, which IS prose — but custom chips were added
+        # after CareText fixed the escaping, and every one of them was written
+        # through it, so no stored chip can be escaped and there is nothing here
+        # to repair. If that ever stops being true, walk the array and re-clean
+        # only the CARE_CUSTOM_OPTION_PREFIX entries, at CARE_CUSTOM_OPTION_MAX
+        # — never the whole array at the short_text cap.
         values = section["values"]
         if values.is_a?(Hash)
           spec[:fields].each do |field|

--- a/config/locales/care.en.yml
+++ b/config/locales/care.en.yml
@@ -32,11 +32,13 @@ en:
       communication:
         methods: How I communicate
         what_helps: What helps me
+        notes: Anything else worth knowing
       personal_care:
         toileting: Toileting
         schedule: Schedule
         hygiene: Help with hygiene
         dressing: Dressing
+        notes: Anything else worth knowing
       meals:
         eating: What helps at meals
         textures: Textures
@@ -50,6 +52,7 @@ en:
       mobility:
         equipment: Equipment I use
         support: Help I need moving around
+        notes: Anything else worth knowing
       transportation:
         school_travel: To & from school
         seating: Seating

--- a/config/locales/care.es.yml
+++ b/config/locales/care.es.yml
@@ -32,11 +32,13 @@ es:
       communication:
         methods: How I communicate
         what_helps: What helps me
+        notes: Algo más que valga la pena saber
       personal_care:
         toileting: Toileting
         schedule: Schedule
         hygiene: Help with hygiene
         dressing: Dressing
+        notes: Algo más que valga la pena saber
       meals:
         eating: What helps at meals
         textures: Textures
@@ -50,6 +52,7 @@ es:
       mobility:
         equipment: Equipment I use
         support: Help I need moving around
+        notes: Algo más que valga la pena saber
       transportation:
         school_travel: To & from school
         seating: Seating

--- a/lib/tasks/care.rake
+++ b/lib/tasks/care.rake
@@ -122,4 +122,41 @@ namespace :care do
       "\nDRY RUN — #{changed} profile(s) would change. Re-run with DRY_RUN=false to apply." :
       "\nDone — #{changed} profile(s) updated."
   end
+  desc "Report profiles still holding detail lines on a BUILT-IN care section"
+  task audit_items: :environment do
+    # The editor stopped offering "+ Add a line" on built-in sections when
+    # custom chips landed, but clean_builtin_care_section still ACCEPTS the rows
+    # so nobody loses what they already wrote. Same two-step rule as
+    # care:audit_options: only once this reports zero is it safe to delete the
+    # clean_care_items call from clean_builtin_care_section — before that, the
+    # before_save would erase every stored line on the next save of each row.
+    #
+    # Custom sections are excluded. Rows are still authored there, and that is
+    # now the only place they are.
+    counts = Hash.new(0)
+    profiles = 0
+
+    Profile.where.not(settings: nil).find_each do |profile|
+      sections = profile.settings.dig("care", "sections")
+      next unless sections.is_a?(Hash)
+
+      held = sections.select do |key, section|
+        Profile::CARE_SECTIONS.key?(key) && section.is_a?(Hash) && section["items"].present?
+      end
+      next if held.empty?
+
+      profiles += 1
+      held.each_key { |key| counts[key] += 1 }
+    end
+
+    if counts.empty?
+      puts "No profile holds detail lines on a built-in section. Safe to drop " \
+           "clean_care_items from Profile#clean_builtin_care_section."
+      next
+    end
+
+    puts "#{profiles} profile(s) still hold built-in detail lines:"
+    counts.sort_by { |_, n| -n }.each { |section, n| puts "  #{section}: #{n}" }
+    puts "\nLeave clean_care_items wired up until this reports zero."
+  end
 end

--- a/spec/models/care_preset_reshape_spec.rb
+++ b/spec/models/care_preset_reshape_spec.rb
@@ -8,8 +8,10 @@ require "rails_helper"
 # next person adding one finds out here rather than on a public page:
 #
 #   * every preset is multi-select
-#   * option lists stay short — specifics go in the detail lines
-#   * no built-in section carries a `notes` catch-all
+#   * option lists stay short — an answer that isn't on the list is a chip the
+#     parent types themselves, and anything longer than a chip is the section's
+#     one free-text field
+#   * every built-in section carries exactly one short_text field
 #
 # The content assertions below are deliberate too. They landed before the
 # feature was announced, when deleting an option destroyed nothing because
@@ -73,10 +75,19 @@ RSpec.describe "the care presets" do
       end
     end
 
-    it "gives no built-in section a `notes` catch-all" do
-      # The detail lines ARE the free-text surface. Two of them side by side
-      # just split the same answer across two boxes.
-      expect(every_field.map { |_, f| f[:key] }).not_to include("notes")
+    it "gives every built-in section exactly one free-text field" do
+      # This used to assert the opposite — no `notes` field anywhere — because
+      # the per-section detail lines were the free-text surface and two of them
+      # side by side just split the same answer across two boxes. The editor
+      # stopped offering detail lines when custom chips landed, so a single
+      # short_text is now that surface. The "exactly one" half of the rule is
+      # the part that carried over unchanged.
+      Profile::CARE_SECTIONS.each_key do |section_key|
+        short_texts = fields_for(section_key).select { |f| f[:type] == :short_text }
+
+        expect(short_texts.length).to eq(1),
+                                      "#{section_key} has #{short_texts.length} free-text fields, expected exactly 1"
+      end
     end
 
     it "has no duplicate field keys inside a section" do
@@ -112,7 +123,7 @@ RSpec.describe "the care presets" do
     it "separates mobility from getting around" do
       # A wheelchair or a pair of AFOs is true all day, in every room. It is
       # not a fact about the trip to school.
-      expect(fields_for("mobility").map { |f| f[:key] }).to eq(%w[equipment support])
+      expect(fields_for("mobility").map { |f| f[:key] }).to eq(%w[equipment support notes])
       expect(field("mobility", "equipment")[:options]).to include("wheelchair", "braces_or_afos")
     end
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -428,6 +428,110 @@ RSpec.describe Profile, type: :model do
         end
       end
 
+      describe "custom chips on a preset row" do
+        # A chip the parent typed themselves, stored in the same array as the
+        # registry keys behind Profile::CARE_CUSTOM_OPTION_PREFIX.
+        def custom(text)
+          Profile::CARE_CUSTOM_OPTION_PREFIX + text
+        end
+
+        def methods_for(*values)
+          care(
+            "communication" => { "enabled" => true, "values" => { "methods" => values } },
+          ).dig("sections", "communication", "values", "methods")
+        end
+
+        it "keeps a custom chip alongside the presets, in the order given" do
+          expect(methods_for("aac_device", custom("Loud crowds"), "sign"))
+            .to eq(["aac_device", custom("Loud crowds"), "sign"])
+        end
+
+        it "strips markup and squishes whitespace, like every other care value" do
+          expect(methods_for(custom("  <b>No</b>   straw  ")))
+            .to eq([custom("No straw")])
+        end
+
+        it "truncates a chip to the chip cap" do
+          long = "z" * (Profile::CARE_CUSTOM_OPTION_MAX + 20)
+          stored = methods_for(custom(long)).first
+
+          expect(stored.delete_prefix(Profile::CARE_CUSTOM_OPTION_PREFIX).length)
+            .to eq(Profile::CARE_CUSTOM_OPTION_MAX)
+        end
+
+        it "drops a chip that is blank once stripped" do
+          expect(methods_for("aac_device", custom("   "), custom("<i></i>")))
+            .to eq(%w[aac_device])
+        end
+
+        it "collapses case-insensitive duplicates, keeping the first spelling" do
+          # The first spelling is the one already on the page.
+          expect(methods_for(custom("No straw"), custom("no straw"), custom("NO STRAW")))
+            .to eq([custom("No straw")])
+        end
+
+        it "caps how many custom chips one field can hold" do
+          typed = Array.new(Profile::MAX_CARE_CUSTOM_OPTIONS + 3) { |i| custom("chip #{i}") }
+
+          expect(methods_for(*typed).length).to eq(Profile::MAX_CARE_CUSTOM_OPTIONS)
+        end
+
+        it "counts customs inside the multi-select cap, not on top of it" do
+          presets = Profile::CARE_SECTIONS["communication"][:fields]
+                    .find { |f| f[:key] == "methods" }[:options]
+          typed = Array.new(Profile::MAX_CARE_CUSTOM_OPTIONS) { |i| custom("chip #{i}") }
+
+          expect(methods_for(*presets, *typed).length).to eq(Profile::MAX_CARE_MULTI_SELECT)
+        end
+
+        it "still drops an unprefixed value that isn't a registry option" do
+          # The prefix is the whole licence. Without it this is exactly the
+          # unknown-option case, and a whitelist drops it.
+          expect(methods_for("aac_device", "Loud crowds")).to eq(%w[aac_device])
+        end
+
+        it "renders as the parent's own words, never humanized" do
+          field = Profile::CARE_SECTIONS["communication"][:fields].find { |f| f[:key] == "methods" }
+
+          expect(CareLabels.option("communication", "methods", custom("no_straw cups")))
+            .to eq("no_straw cups")
+          expect(CareLabels.options_map("communication", field).keys)
+            .not_to include(a_string_starting_with(Profile::CARE_CUSTOM_OPTION_PREFIX))
+        end
+      end
+
+      describe "detail lines on a built-in section, after the editor stopped offering them" do
+        it "still round-trips a stored line through an unrelated save" do
+          # THE regression guard for this feature. sanitize_care_settings is a
+          # before_save over the whole blob, so dropping clean_care_items from
+          # clean_builtin_care_section would erase every stored line the next
+          # time anything saved the profile — an avatar upload is enough.
+          care(
+            "personal_care" => {
+              "enabled" => true,
+              "values" => { "toileting" => %w[needs_reminders] },
+              "items" => [{ "label" => "Bathroom", "value" => "needs a five-minute warning" }],
+            },
+          )
+
+          profile.update!(username: profile.username + "-x")
+
+          expect(profile.reload.settings.dig("care", "sections", "personal_care", "items"))
+            .to eq([{ "label" => "Bathroom", "value" => "needs a five-minute warning" }])
+        end
+
+        it "keeps a section alive on its stored lines alone" do
+          result = care(
+            "mobility" => {
+              "enabled" => true,
+              "items" => [{ "label" => "Ramp", "value" => "back door only" }],
+            },
+          )
+
+          expect(result["sections"]).to have_key("mobility")
+        end
+      end
+
       it "drops unknown sections, unknown fields, and out-of-registry options" do
         result = care(
           "communication" => {

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe "API::CareSections", type: :request do
         "max_custom_sections" => Profile::MAX_CUSTOM_CARE_SECTIONS,
         "max_custom_items" => Profile::MAX_CARE_CUSTOM_ITEMS,
         "max_multi_select" => Profile::MAX_CARE_MULTI_SELECT,
+        "max_custom_options" => Profile::MAX_CARE_CUSTOM_OPTIONS,
+        "custom_option_max" => Profile::CARE_CUSTOM_OPTION_MAX,
         "title_max" => Profile::CARE_TITLE_MAX,
         "item_label_max" => Profile::CARE_ITEM_LABEL_MAX,
         "item_value_max" => Profile::CARE_ITEM_VALUE_MAX,

--- a/spec/services/communicators/care_plan_document_spec.rb
+++ b/spec/services/communicators/care_plan_document_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe Communicators::CarePlanDocument do
       expect(section.fields.first.values).to eq(["AAC device", "Eye gaze"])
     end
 
+    it "prints a custom chip as the parent typed it" do
+      # A chip the parent typed themselves is already words. It must reach paper
+      # verbatim — humanizing it would eat the underscores out of their own text.
+      doc = with_care(
+        "sections" => {
+          "communication" => {
+            "enabled" => true,
+            "values" => {
+              "methods" => ["aac_device", "#{Profile::CARE_CUSTOM_OPTION_PREFIX}taps_my arm"],
+            },
+          },
+        },
+      )
+
+      expect(doc.care_sections.first.fields.first.values)
+        .to eq(["AAC device", "taps_my arm"])
+    end
+
     it "renders short_text verbatim rather than labeling it" do
       doc = with_care(
         "sections" => {


### PR DESCRIPTION
## Summary

The care preset lists are short on purpose, so a parent whose answer isn't on one had nowhere to put it inside the field it belongs to. This lets them type their own chip.

A custom chip is stored **in the same `multi_select` array** as the registry keys, behind a `custom:` sentinel:

```json
"communication": { "values": { "methods": ["aac_device", "custom:Loud crowds at pickup"] } }
```

Three things make that safe:

- The prefix contains a colon and a registry option key is `/\A[a-z_]+\z/`, so a custom value can never collide with a present or future key.
- **In the array rather than beside it, deliberately.** The long-lived iOS/Android bundles round-trip `values[<field>]` verbatim, so a chip they've never heard of survives them editing the same profile — the editor even renders it as a removable chip already, via the retired-option path. A sibling key would be dropped by the frontend's `settingsFromCareValue` on that client's next save.
- `CareLabels.option` guards the prefix in **one** place, so `CarePlanDocument` and any future server-rendered sheet print the parent's words verbatim without knowing the feature exists. `humanize` would otherwise eat the underscores out of their own text.

Custom chips are capped per field (`MAX_CARE_CUSTOM_OPTIONS = 4`) *inside* `MAX_CARE_MULTI_SELECT`, deduped case-insensitively, and cleaned through `CareText` like every other free-text value.

## Retiring the detail lines

The editor stops offering the per-section label/value rows — custom chips took the short answers, and Communication / Personal care / Moving around each gained a `notes` `short_text` field so every section keeps exactly one free-text surface.

**`clean_care_items` is deliberately still wired into `clean_builtin_care_section`.** `sanitize_care_settings` is a `before_save` over the whole blob, so deleting that call would silently erase every stored line on each profile's next save for any reason — an avatar upload is enough. Same two-step rule as `DEPRECATED_CARE_OPTIONS`. `rake care:audit_items` (new) is the gate: only once it reports zero is the call safe to remove.

`spec/models/care_preset_reshape_spec.rb` had an assertion encoding the *old* rule ("no built-in section carries a `notes` catch-all"). Its premise was that detail lines are the free-text surface; it is now inverted to the stronger invariant — every section has **exactly one** `short_text` field.

## Test plan

`bundle exec rspec` over the care surface — **357 examples, 0 failures**:
`profile_spec` · `care_preset_reshape_spec` · `care_option_retirement_spec` · `care_labels_spec` · `care_text_repair_spec` · `spec/services/communicators/` · `care_sections_spec` · `profiles_care_view_spec` · `profiles_care_plan_spec`

New coverage: a prefixed value survives; markup stripped and text truncated; blank-after-strip dropped; case-insensitive duplicates collapse; the per-field cap; presets + customs together stay inside `MAX_CARE_MULTI_SELECT`; an unprefixed unknown value is **still** dropped; a custom chip renders verbatim through `CareLabels` and on the care plan; **and the regression guard — a stored detail line survives an unrelated save.**

Also verified end to end against a real dev database and a booted server:

- `GET /api/care_sections` serves `custom_option_prefix`, both new caps, and all six sections with exactly one free-text field. `options` is still an array of plain strings (the invariant that keeps deployed clients working).
- Saving `"custom:  <b>Loud</b>   crowds "` stores `custom:Loud crowds`; a `LOUD CROWDS` duplicate collapses; `not_real` is dropped.
- `profile.update!(username: …)` — an unrelated save — left the stored detail line intact.
- `CarePlanDocument` prints `["AAC device", "Loud crowds"]`, verbatim.

## Ships first

The frontend PR depends on this contract — until the sanitizer accepts the prefix it drops custom values silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)