### PR TITLE
fix(care-plan): rebalance the fold sizes and make the subheader a choice

### DIFF
--- a/.claude-notes/safety-profiles.md
+++ b/.claude-notes/safety-profiles.md
@@ -297,7 +297,7 @@ Each cell also has a `*_preview_png` twin holding the thumbnail — see "Each
 document carries a PNG thumbnail" below.
 
 `:care_only` + `wallet` is deliberately absent — strip the emergency block out
-of a wallet card and what's left is a name, a photo, and five care lines,
+of a wallet card and what's left is a name, a photo, and a few care lines,
 which isn't worth the paper. `GenerateCarePlan.supported?(variant, size)`
 answers this without raising; the endpoint uses it to return 422
 `unsupported_size` rather than emitting the card. An unrecognized size string
@@ -324,6 +324,19 @@ data.
   (`WALLET_LINE_MAX_CHARS`) — a maxed-out section's joined values run to
   hundreds of characters on their own, and capping only the line count let
   one long line silently overflow the 2in strip on its own.
+
+  **The line count and the character cap are ONE budget, and the half size's
+  last-resort tier needs both too** (`HALF_TRUNCATED_LINE_LIMIT` /
+  `HALF_TRUNCATED_LINE_MAX_CHARS`). That tier had only a line cap, on the
+  theory that a 4.5in back panel is roomy — but eight lines that each wrap to
+  four visual lines is thirty-two lines, and the panel clipped the last of
+  them plus its own footnote. Pick the pair together: characters that fit N
+  visual lines, times a count that fits the panel at N.
+
+  `#condensed_care_lines` cuts on a WORD boundary. The lines are a
+  comma-joined list of short care options, so a mid-word cut lands inside one
+  and prints a fragment ("Keep my device close, Wai…") that reads as a
+  different answer from the one the parent picked.
 - **A long unbroken token (a 300-character short_text field with no spaces,
   a URL) needs `overflow-wrap: break-word` on `body`** in
   `layouts/pdf_care_plan.html.erb` — without it such a token doesn't wrap, it
@@ -333,6 +346,30 @@ data.
   additionally needs `flex: 1; min-width: 0` — a flex item's default
   `min-width: auto` refuses to shrink below its own content's natural width,
   which overflows the row even with `break-word` set.
+- **A fixed-height fold face is a flex column, and a flex column SHRINKS
+  before it overflows.** `.fpanel` (half) and `.wstrip .half` (wallet) are
+  fixed-height `overflow: hidden` flex columns, so an over-full face doesn't
+  spill — the flex algorithm takes the height out of whichever child can give,
+  and that child then clips its own content in silence. It picked the glance
+  strip, which printed as a row of half-height cells with "Allergies" and
+  "How I talk" sliced through the middle: a layout bug that looks like a
+  content bug. `.fpanel > *` and `.wstrip .half > *` are pinned to
+  `flex: none` so nothing on either face may shrink. The honest failure for an
+  over-full face is content running past the fold, which is visible; the
+  overflow ladder is what stops it getting there.
+
+  For the same reason, anything that CENTRES content inside such a face uses
+  `justify-content: safe center`, never plain `center` — plain `center` splits
+  an overflow across both edges, and on a back face that means spilling over
+  the fold onto the front.
+- **One subject per face on both fold sizes.** Front: who this is and who to
+  call (identity, allergies, contacts). Back: day-to-day support. The wallet
+  card used to keep the contacts on the back above the care lines with a
+  one-line "Call first" repeat of the top contact squeezed onto the front,
+  which printed the same phone number on both faces of a card small enough to
+  read at a glance, and left the front half-empty while the back overflowed. A
+  reader turning the card over should be answering a different question, not
+  re-reading the last one.
 - **`half` and `wallet` print single-sided; the back face is authored upright
   and rotated 180deg by a `.flip` class** (folding print-side-out applies
   exactly that rotation — see the CSS comment above `.flip` in the layout for
@@ -352,13 +389,41 @@ data.
   no-network rule applies to icons same as fonts). A custom section maps to
   `"trav"` (navy) rather than getting a colour of its own, so four
   parent-authored sections don't turn the sheet into a paint chart.
-- **The identity block's first-person line (`CarePlanDocument#says`) and the
-  glance strip's "How I talk" (`#glance_how_i_talk`) are derived from the
-  communication section independently of `only_sections`.** They introduce the
+- **The glance strip's "How I talk" (`#glance_how_i_talk`) is derived from the
+  communication section independently of `only_sections`.** It introduces the
   person; narrowing the printed sections to "meals only" shouldn't erase how
   the subject talks. A communication section the parent explicitly disabled
   (`enabled: false`) is still respected, though — that's a real "nothing to
   say" state, not a filter.
+- **The line under the name is the CALLER's `subheader`, not derived data, and
+  its default is never stored.** `subheader` supplies the words,
+  `include_subheader: false` drops the line, and blank or absent means the
+  default copy (`care.document.subheader.default`), resolved at RENDER time.
+  Storing that default would break the same rule `profiles.bio` /
+  `profiles.intro` are under — the line prints in the communicator's own
+  first-person voice, so seeding it publishes words nobody wrote and makes "is
+  there a subheader" stop meaning "did someone write one". Blank and absent are
+  the SAME answer here, unlike `sections`, where `[]` is a real request.
+  `SUBHEADER_MAX_CHARS` caps it because it rides the freshness signature.
+
+  It used to be `CarePlanDocument#says`, a sentence built from the
+  communication answers ("I communicate using AAC device and gestures. Keep my
+  device close.") — which restated the "How I talk" glance cell a centimetre
+  below it. The struct, the `care.document.says.*` keys and the derivation are
+  all retired; `#glance_how_i_talk` still carries that fact.
+
+  The controller's `include_subheader` is **absent-means-included**: reading a
+  missing param through `truthy?` would have silently dropped the line from
+  every download made by the client in production, which predates the option
+  and sends neither param. Rendered by `sheet` and `half`; the wallet's 2in
+  front face has no room and doesn't ask for it.
+- **The "At a glance" strip is two cells, not three.** It carried a third
+  "Call first" cell repeating the first contact's phone number — a few
+  millimetres above the contact cards in the emergency block directly below
+  it, on both sizes that render the strip. The contact list is ordered and its
+  first entry IS the one to call, so the cell said nothing the page didn't
+  already say, and on the half size it was part of what pushed the front face
+  over its height budget. `CarePlanDocument#call_first_contact` went with it.
 - **Allergies render in the "At a glance" strip and nowhere else.** The
   emergency grid's field loop explicitly skips `field.key == "allergies"`;
   `CarePlanDocument::EMERGENCY_FIELDS` still includes it (nothing else changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   `half`, or `wallet`); `half` is one Letter page folded once, `wallet` is
   four cut-and-fold strips per Letter page, and both print single-sided. The
   care-only variant is offered at `sheet` and `half` but not `wallet` — a
-  wallet card with no emergency block isn't worth the paper.
+  wallet card with no emergency block isn't worth the paper. Both fold sizes
+  put one subject on each face: who this is and who to call on the front,
+  day-to-day support on the back, so nothing is printed twice and neither
+  face folds down half-empty.
 
 ### Changed
 
@@ -41,9 +44,20 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.
   section gets its own colour and icon; the header is a cream identity card
   with a gradient hairline instead of a full gradient band; the emergency
   block is a white card with a red left rail instead of a red-filled box; and
-  a new "At a glance" strip (allergies, how the communicator talks, who to
-  call first) sits above it. Existing downloads keep serving the old look
-  until regenerated.
+  a new "At a glance" strip (allergies and how the communicator talks) sits
+  above it. Existing downloads keep serving the old look until regenerated.
+
+- **The line under the communicator's name is now yours to write, or to turn
+  off.** It used to be assembled from the communication section ("I communicate
+  using AAC device and gestures. Keep my device close."), which repeated the
+  "How I talk" cell in the At a glance strip just below it. It defaults to
+  "I communicate differently. Please be kind & give me time.", and `POST
+  /api/profiles/:id/care_plan` takes `subheader` (your own words, up to 160
+  characters) and `include_subheader=false` (no line at all). Both are
+  per-download choices — nothing is saved to the profile — and both ride the
+  document's freshness signature, so changing either regenerates the PDF. A
+  client that sends neither keeps the default line. It prints on the sheet and
+  half sizes; the wallet card has no room for it.
 
 - **Text tiles render once and are reused.** A text-tile picture is fully
   determined by its settings, so identical renders now share one rendered image

--- a/app/controllers/api/profiles/assets_controller.rb
+++ b/app/controllers/api/profiles/assets_controller.rb
@@ -77,6 +77,8 @@ class API::Profiles::AssetsController < API::ApplicationController
       size: size,
       regenerate: truthy?(params[:regenerate]),
       sections: sections,
+      subheader: subheader_param,
+      include_subheader: include_subheader_param,
     )
 
     attachment = @profile.public_send(
@@ -107,6 +109,26 @@ class API::Profiles::AssetsController < API::ApplicationController
 
     list = raw.is_a?(Array) ? raw : raw.to_s.split(",")
     list.map { |key| key.to_s.strip }.reject(&:empty?).first(MAX_CARE_SECTIONS)
+  end
+
+  # The line under the communicator's name. Blank and absent are the same
+  # answer — both mean "print the default copy" — unlike `sections`, where an
+  # empty list is a real request. Capped because it rides the document's
+  # freshness signature; never validated further, since it is the parent's own
+  # words and the template escapes on output like any ERB tag.
+  def subheader_param
+    params[:subheader].to_s.strip.presence&.slice(
+      0, Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS
+    )
+  end
+
+  # Absent means INCLUDED. `truthy?` alone would read a missing param as
+  # false and silently drop the line from every download made by a client that
+  # predates this option — including the one in production today.
+  def include_subheader_param
+    return true unless params.key?(:include_subheader)
+
+    truthy?(params[:include_subheader])
   end
 
   # `full` can print on emergency info alone, so the two variants run out of

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -825,8 +825,15 @@ class Profile < ApplicationRecord
         item_label_max: CARE_ITEM_LABEL_MAX,
         item_value_max: CARE_ITEM_VALUE_MAX,
         short_text_max: CARE_SHORT_TEXT_MAX,
+        subheader_max: Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS,
       },
       custom_key_format: js_custom_key_format,
+      # The care plan's default line under the name, served rather than
+      # duplicated: the download form shows it as the placeholder for "leave
+      # blank for the default", and a hand-copied string there would drift from
+      # what actually prints the first time the copy is edited. Same reason
+      # custom_key_format is derived above rather than written out.
+      subheader_default: I18n.t("care.document.subheader.default", locale: locale),
     }
   end
 

--- a/app/services/communicators/care_plan_document.rb
+++ b/app/services/communicators/care_plan_document.rb
@@ -23,10 +23,6 @@ module Communicators
     Section = Struct.new(:key, :label, :custom, :fields, :items, keyword_init: true)
     Field = Struct.new(:key, :label, :type, :values, keyword_init: true)
     Item = Struct.new(:label, :value, keyword_init: true)
-    # The first-person "says" line's resolved parts. `rest` is an array of
-    # labels, not a joined string — grammar (the "and", the comma list) is the
-    # view's job so it can go through I18n; this struct is data only.
-    Says = Struct.new(:primary, :rest, :helps, keyword_init: true)
 
     # The emergency fields, in the order a responder reads them. Contacts are
     # handled separately — they're structured, not free text.
@@ -125,32 +121,19 @@ module Communicators
       all_emergency_fields.find { |field| field.key == "allergies" }&.values&.first
     end
 
-    # The glance strip's "Call first" cell: the same first contact
-    # #emergency_contacts would return, exposed under its own name so a caller
-    # reading the glance data doesn't have to know that's where it comes from.
-    def call_first_contact
-      emergency_contacts.first
-    end
-
-    # The identity block's first-person line and the glance strip's "How I
-    # talk" are both built from the communication section's stored answers —
-    # deliberately independent of `only_sections`. They introduce the person,
-    # they aren't part of the printed detail sections, and narrowing the sheet
-    # to "meals only" shouldn't erase how the sheet's subject talks. A section
-    # the parent explicitly disabled is still respected, though.
-    def says
-      return nil if communication_methods.empty? && communication_what_helps.empty?
-
-      Says.new(
-        primary: communication_methods.first,
-        rest: communication_methods[1..].to_a.map { |v| decapitalize(v) },
-        helps: communication_what_helps.first,
-      )
-    end
-
-    # { primary:, sub: } for the glance strip, or nil when nothing is stored —
-    # the template falls back to a neutral cell in that case, same as an
-    # unanswered allergy field falls back to "None listed".
+    # The glance strip's "How I talk" cell — { primary:, sub: }, or nil when
+    # nothing is stored (the template falls back to a neutral cell, same as an
+    # unanswered allergy field falls back to "None listed").
+    #
+    # Built from the communication section's stored answers but deliberately
+    # independent of `only_sections`: it introduces the person, it isn't part
+    # of the printed detail sections, and narrowing the sheet to "meals only"
+    # shouldn't erase how the sheet's subject talks. A section the parent
+    # explicitly disabled is still respected, though.
+    #
+    # The identity block's line under the name used to be derived from these
+    # same answers ("I communicate using AAC device and gestures…") and is not
+    # any more — it is the caller's `subheader` now. See GenerateCarePlan.
     def glance_how_i_talk
       return nil if communication_methods.empty?
 
@@ -169,15 +152,20 @@ module Communicators
     # custom section's Profile::MAX_CARE_CUSTOM_ITEMS items) joins into one
     # very long string, and even a five-line cap silently overflowed the
     # wallet's 2in half once that string wrapped to several visual lines on
-    # its own. The wallet passes this; the half size's more spacious back
-    # panel does not need to.
+    # its own. Both fixed-height sizes pass it — the half page's back panel is
+    # more spacious, not unbounded.
+    #
+    # It cuts on a WORD boundary. These lines are a comma-joined list of short
+    # care options, so a mid-word cut lands inside one of them and prints a
+    # fragment ("Keep my device close, Wai…") that reads as a different answer
+    # from the one the parent chose — worse than dropping it.
     def condensed_care_lines(limit: nil, truncate_at: nil)
       lines = care_sections.filter_map do |section|
         parts = section.fields.map { |f| f.values.join(", ") } + section.items.map(&:value)
         next if parts.empty?
 
         text = parts.join(", ")
-        text = "#{text[0, truncate_at - 1]}…" if truncate_at && text.length > truncate_at
+        text = text.truncate(truncate_at, separator: " ", omission: "…") if truncate_at
 
         { label: section.label, text: text }
       end
@@ -252,10 +240,6 @@ module Communicators
 
     def communication_methods
       communication_fields.find { |f| f.key == "methods" }&.values || []
-    end
-
-    def communication_what_helps
-      communication_fields.find { |f| f.key == "what_helps" }&.values || []
     end
 
     def glance_how_i_talk_sub

--- a/app/services/communicators/generate_care_plan.rb
+++ b/app/services/communicators/generate_care_plan.rb
@@ -11,7 +11,7 @@ module Communicators
   #   :care_only "Care Plan"             — care sections, no medical data
   #
   # Three sizes, same class again — they share every derived string
-  # (CarePlanDocument#says, #glance_how_i_talk, ...) and the whole design
+  # (CarePlanDocument#glance_how_i_talk, #allergies, ...) and the whole design
   # system (layouts/pdf_care_plan.html.erb); only the template and the Grover
   # page options change.
   #
@@ -20,7 +20,7 @@ module Communicators
   #   :wallet one Letter page, 4-up strips, cut and folded — lanyard, bus driver
   #
   # `:care_only` + `:wallet` is not offered: strip the emergency block out of a
-  # wallet card and what's left is a name, a photo, and five care lines, which
+  # wallet card and what's left is a name, a photo, and a few care lines, which
   # isn't worth the paper. See .supported?.
   #
   # Each document ships a PDF and a PNG thumbnail, rendered from the SAME HTML
@@ -51,7 +51,12 @@ module Communicators
     # 4: visual redesign (identity card, per-section colour + icons, chips,
     #    "At a glance" strip, red-rail emergency block) plus the half and
     #    wallet sizes.
-    LAYOUT_VERSION = 4
+    # 5: fold-size rebalance — the glance strip's duplicate "Call first" cell
+    #    is gone, the wallet's contacts moved to its front face, and neither
+    #    fold size shrinks-and-clips a face any more.
+    # 6: the line under the name is the caller's `subheader`, not a sentence
+    #    derived from the communication section.
+    LAYOUT_VERSION = 6
 
     SIZES = %w[sheet half wallet].freeze
 
@@ -109,23 +114,56 @@ module Communicators
     # CarePlanDocument#half_condensed?) — chosen so a maxed field
     # (Profile::MAX_CARE_MULTI_SELECT values) still fits a wrapped line.
     HALF_CONDENSED_MAX_VALUES = 6
-    # The wallet card's hard caps: five lines is what a 2in half-strip has
-    # room for without shrinking the type past legibility, and each line is
-    # further capped in length — a maxed-out section's joined values can run
-    # to hundreds of characters on their own, which wraps to several visual
-    # lines and overflows the strip even at five lines.
-    WALLET_LINE_LIMIT = 5
-    WALLET_LINE_MAX_CHARS = 60
+    # The wallet card's hard caps. The back face is day-to-day lines and
+    # nothing else now that the contacts print on the front, which bought
+    # roughly two more lines of room — so the limit went up, not down.
+    #
+    # Each line is ALSO capped in length, and that cap is the load-bearing
+    # half: a maxed-out section's joined values run to hundreds of characters
+    # on their own, and a line that wraps costs the same room as two. The two
+    # numbers are one budget — 62 characters is at most two visual lines in
+    # the value column, and six of those fill the face.
+    WALLET_LINE_LIMIT = 6
+    WALLET_LINE_MAX_CHARS = 62
+    # The line under the communicator's name, on the sheet and half sizes.
+    #
+    # It is a per-download CHOICE, not stored data: `subheader` supplies the
+    # words and `include_subheader: false` drops the line entirely. Blank or
+    # absent means the default copy, which lives in the locale files and is
+    # resolved at RENDER time — never written anywhere. That is the same rule
+    # `profiles.bio` / `profiles.intro` are under: this line prints in the
+    # communicator's own first-person voice, so seeding it would publish words
+    # nobody wrote and make "is there a subheader" stop meaning "did someone
+    # write one".
+    #
+    # It used to be derived from the communication section
+    # ("I communicate using AAC device and gestures. Keep my device close."),
+    # which repeated the "How I talk" cell in the glance strip a centimetre
+    # below it. The glance strip still carries that fact; this line is now
+    # what the person handing the card over wants a stranger to read first.
+    #
+    # The cap exists because the text rides the freshness signature, same
+    # reason `sections` is capped in the controller — and because two printed
+    # lines under the name is the most the identity block can hold before it
+    # starts competing with the name again.
+    SUBHEADER_MAX_CHARS = 160
+
     # The half page's own last-resort tier: more generous than the wallet's,
-    # since a 4.5in back panel has room for it.
+    # since a 4.5in back panel has room for it. It needs the per-line cap for
+    # the same reason the wallet does, though — the line COUNT alone bounds
+    # nothing when one maxed-out section joins to 400-plus characters and wraps
+    # to four visual lines on its own. Eight lines at two wrapped lines each is
+    # what the panel holds under the footnote.
     HALF_TRUNCATED_LINE_LIMIT = 8
+    HALF_TRUNCATED_LINE_MAX_CHARS = 240
 
     class UnknownVariant < ArgumentError; end
     class UnsupportedSize < ArgumentError; end
 
     def self.call(profile, variant: :full, size: :sheet, regenerate: false, locale: I18n.locale,
-                  qr_target_url: nil, sections: nil)
-      new(profile, variant: variant, size: size, locale: locale, qr_target_url: qr_target_url, sections: sections)
+                  qr_target_url: nil, sections: nil, subheader: nil, include_subheader: true)
+      new(profile, variant: variant, size: size, locale: locale, qr_target_url: qr_target_url,
+        sections: sections, subheader: subheader, include_subheader: include_subheader)
         .call(regenerate: regenerate)
     end
 
@@ -161,7 +199,8 @@ module Communicators
       variant_config(variant)[:sizes].fetch(size.to_sym) { raise UnsupportedSize, "unsupported size for this variant" }
     end
 
-    def initialize(profile, variant: :full, size: :sheet, locale: I18n.locale, qr_target_url: nil, sections: nil)
+    def initialize(profile, variant: :full, size: :sheet, locale: I18n.locale, qr_target_url: nil,
+                   sections: nil, subheader: nil, include_subheader: true)
       super(profile, qr_target_url: qr_target_url)
       @variant = variant.to_sym
       @size = size.to_sym
@@ -170,9 +209,13 @@ module Communicators
       @locale = locale
       # nil means every section — see the note on CarePlanDocument#initialize.
       @sections = sections.nil? ? nil : Array(sections).map { |key| key.to_s.strip }.reject(&:empty?)
+      # Blank and absent are the same answer here — both mean "the default
+      # copy" — unlike `sections`, where [] is a real request for none.
+      @subheader = subheader.to_s.strip.presence&.slice(0, SUBHEADER_MAX_CHARS)
+      @include_subheader = include_subheader != false
     end
 
-    attr_reader :variant, :size, :config, :emergency, :locale, :sections
+    attr_reader :variant, :size, :config, :emergency, :locale, :sections, :subheader, :include_subheader
 
     # There is one attachment per [variant, size], not per selection, so a
     # narrowed download replaces the stored document and the URL on
@@ -234,9 +277,32 @@ module Communicators
           "size=#{size}",
           "locale=#{locale}",
           ("sections=#{sections.sort.join(",")}" if sections),
+          subheader_signature,
           "v#{LAYOUT_VERSION}",
         ].compact.join("::"),
       )
+    end
+
+    # Omitted entirely when the caller took the default, so an ordinary
+    # download keeps the signature it has always had — the same rule
+    # `sections` follows. It has to be here at all for the same reason
+    # `sections` does: there is one attachment per [variant, size], so without
+    # it a custom or hidden subheader is answered by the cached document and
+    # the control silently does nothing.
+    def subheader_signature
+      return "subheader=off" unless include_subheader
+      return if subheader.nil?
+
+      "subheader=#{subheader}"
+    end
+
+    # The words that print under the name, or nil for no line at all. The
+    # default is resolved HERE, at render time, and never stored — see the
+    # note on SUBHEADER_MAX_CHARS.
+    def resolved_subheader
+      return nil unless include_subheader
+
+      subheader || I18n.t("care.document.subheader.default", locale: locale)
     end
 
     def document
@@ -263,10 +329,10 @@ module Communicators
 
     def template_assigns
       {
-        # No subtitle: the identity card carries the doctype line and the says
-        # line, and "How to support Rosa day to day" is the one line on the old
-        # sheet a reader already knows. care.document.subtitle is left in the
-        # locale files for whoever brings it back.
+        # No subtitle: the identity card carries the doctype line and the
+        # subheader, and "How to support Rosa day to day" is the one line on
+        # the old sheet a reader already knows. care.document.subtitle is left
+        # in the locale files for whoever brings it back.
         #
         # No prepared-on date either: the sheet lives in a backpack or a school
         # folder for a whole year, and a printed date only makes a still-current
@@ -285,23 +351,26 @@ module Communicators
         blank_emergency_field_names: emergency ? document.blank_emergency_field_names : [],
         emergency_contacts: emergency ? document.emergency_contacts : [],
         care_sections: document.care_sections,
-        # Communication-derived, not emergency data — shown on both variants,
-        # same as the rest of the identity block.
-        says: document.says,
+        # The line under the name. Shown on both variants — it is not emergency
+        # data, it is the introduction the identity block exists to make.
+        # Rendered by the sheet and half sizes; the wallet's 2in front face has
+        # no room for it and doesn't ask for it.
+        subheader: resolved_subheader,
         # The "At a glance" strip only ever renders on the :full variant (see
-        # the templates): allergies and the first contact ARE emergency data,
-        # so they're computed only when this document carries emergency info
-        # at all, mirroring the pattern above rather than trusting the
-        # template's `if @emergency` guard alone.
+        # the templates): allergies IS emergency data, so it's computed only
+        # when this document carries emergency info at all, mirroring the
+        # pattern above rather than trusting the template's `if @emergency`
+        # guard alone.
         glance_how_i_talk: document.glance_how_i_talk,
         allergies: emergency ? document.allergies : nil,
-        call_first_contact: emergency ? document.call_first_contact : nil,
         # Only the half and wallet templates use these; harmless to compute
         # for :sheet too since both are cheap (no rendering happens here).
         half_condensed: document.half_condensed?,
         half_truncated: document.half_truncated?,
         care_sections_condensed: document.care_sections(max_values: HALF_CONDENSED_MAX_VALUES),
-        half_condensed_lines: document.condensed_care_lines(limit: HALF_TRUNCATED_LINE_LIMIT),
+        half_condensed_lines: document.condensed_care_lines(
+          limit: HALF_TRUNCATED_LINE_LIMIT, truncate_at: HALF_TRUNCATED_LINE_MAX_CHARS,
+        ),
         wallet_lines: document.condensed_care_lines(limit: WALLET_LINE_LIMIT, truncate_at: WALLET_LINE_MAX_CHARS),
       }
     end

--- a/app/views/communicators/assets/_care_plan_glance.html.erb
+++ b/app/views/communicators/assets/_care_plan_glance.html.erb
@@ -1,11 +1,19 @@
 <%# The "At a glance" strip — the five-second read. Shared by the sheet and
     half sizes (the wallet's front face has its own, more compact markup).
-    Reads @allergies / @glance_how_i_talk / @call_first_contact directly, the
-    same ivars GenerateCarePlan sets for every size.
+    Reads @allergies / @glance_how_i_talk directly, the same ivars
+    GenerateCarePlan sets for every size.
 
     Allergies print HERE and nowhere else — the emergency block's grid skips
     the allergies field on purpose. Printing it twice was the first mockup's
-    bug. %>
+    bug.
+
+    TWO cells, not three: a "Call first" cell used to sit alongside these, and
+    it repeated the first contact's phone number a few millimetres above the
+    contact cards in the emergency block directly below it. Both sizes that
+    render this strip render those contacts on the SAME face, so the cell was
+    never the only place a reader could find that number — it just made the
+    glance strip say something the page already said. The contact list is
+    ordered, and its first entry is the one to call. %>
 <section class="glance">
   <div class="cell danger">
     <div class="k"><%= t("care.document.glance.allergies") %></div>
@@ -16,15 +24,6 @@
     <% if @glance_how_i_talk %>
       <div class="v"><%= @glance_how_i_talk[:primary] %></div>
       <% if @glance_how_i_talk[:sub] %><div class="sub"><%= @glance_how_i_talk[:sub] %></div><% end %>
-    <% else %>
-      <div class="v muted"><%= t("care.document.glance.none_listed") %></div>
-    <% end %>
-  </div>
-  <div class="cell">
-    <div class="k"><%= t("care.document.glance.call_first") %></div>
-    <% if @call_first_contact %>
-      <div class="v"><%= @call_first_contact["phone"] %></div>
-      <div class="sub"><%= [@call_first_contact["name"], @call_first_contact["relationship"]].select(&:present?).join(" · ") %></div>
     <% else %>
       <div class="v muted"><%= t("care.document.glance.none_listed") %></div>
     <% end %>

--- a/app/views/communicators/assets/_care_plan_identity.html.erb
+++ b/app/views/communicators/assets/_care_plan_identity.html.erb
@@ -1,9 +1,14 @@
 <%# The identity block: avatar, name, pronoun chip (own line, deliberately not
     inline with the h1 — see the layout's .pronoun comment), the first-person
-    "says" line, and the QR. Shared by the sheet (wrapped in <header
+    subheader, and the QR. Shared by the sheet (wrapped in <header
     class="identity">) and the half size's front face (wrapped in <div
     class="fid">) — the CSS scales by that ancestor class, so the markup
     inside is identical between the two sizes.
+
+    @subheader is the caller's choice and arrives already resolved — the
+    default copy when they didn't supply words, nil when they asked for no
+    line. There is nothing to fall back to here; a missing line is a decision,
+    not a gap. The `.says` class name predates the option and is left alone.
 
     The wallet card's front face does not use this partial — it's compact
     enough (photo, name, QR on one row, no doctype line) not to be worth
@@ -22,12 +27,8 @@
   <% if @pronouns.present? %>
     <div><span class="pronoun"><%= @pronouns %></span></div>
   <% end %>
-  <% if @says %>
-    <div class="says">
-      <%= t("care.document.says.intro_html", primary: content_tag(:em, @says.primary)) %><% if @says.rest.any? %><%= t("care.document.says.rest_and_html", values: @says.rest.join(", ")) %><% end %>.<% if @says.helps.present? %> <%= @says.helps %>.<% end %>
-    </div>
-  <% else %>
-    <div class="says muted"><%= t("care.document.says.neutral") %></div>
+  <% if @subheader.present? %>
+    <div class="says"><%= @subheader %></div>
   <% end %>
 </div>
 

--- a/app/views/communicators/assets/_care_plan_wallet_strip.html.erb
+++ b/app/views/communicators/assets/_care_plan_wallet_strip.html.erb
@@ -3,21 +3,23 @@
     per page by care_plan_wallet.html.erb — identical copies, so a parent has
     spares to cut out.
 
+    ONE SUBJECT PER FACE. The front is who this is and who to call — photo,
+    name, QR, allergies, every emergency contact; the back is the day-to-day
+    care lines and nothing else. The contacts used to live on the BACK, above
+    the care lines, with a one-line "Call first" repeat of the top contact
+    squeezed onto the front — which left the front half-empty, the back
+    over-full, and the same phone number printed on both faces of a card
+    small enough to read at a glance. Keep the split: a reader turning the
+    card over should be answering a different question, not re-reading the
+    last one.
+
     Always condensed (Communicators::GenerateCarePlan::WALLET_LINE_LIMIT
     lines, no chips) regardless of how much the profile has answered — a
     wallet card has no room for the overflow ladder the half size has. %>
 <div class="wstrip">
   <div class="half flip wback">
     <div class="wtop"></div>
-    <div class="bhead"><%= t("care.document.wallet.call_first") %></div>
-    <div class="wcontacts">
-      <% @emergency_contacts.first(2).each do |contact| %>
-        <div class="c">
-          <div class="n"><%= [contact["name"].presence || t("care.document.emergency.relationship_unknown"), contact["relationship"]].select(&:present?).join(" · ") %></div>
-          <div class="p"><%= contact["phone"] %></div>
-        </div>
-      <% end %>
-    </div>
+    <div class="bhead"><%= t("care.document.care_heading") %></div>
     <div class="wlist">
       <% @wallet_lines.each do |line| %>
         <div class="li"><span class="k"><%= line[:label] %></span><span class="v"><%= line[:text] %></span></div>
@@ -35,6 +37,7 @@
       </div>
       <div class="nm">
         <h4><%= @display_name %></h4>
+        <div class="u"><%= @public_url %></div>
       </div>
       <% if @qr_data_url.present? %>
         <div class="qr">
@@ -51,16 +54,14 @@
       </div>
     <% end %>
 
-    <% if @call_first_contact %>
-      <div class="wcall">
-        <span class="k"><%= t("care.document.wallet.call_first") %></span>
-        <span class="p"><%= @call_first_contact["phone"] %></span>
-        <span class="n"><%= [@call_first_contact["name"], @call_first_contact["relationship"]].select(&:present?).join(" · ") %></span>
-      </div>
-    <% end %>
-
-    <div class="wfoot">
-      <span class="u"><%= @public_url %></span>
+    <div class="wcontacts">
+      <div class="chead"><%= t("care.document.emergency.contacts") %></div>
+      <% @emergency_contacts.first(3).each do |contact| %>
+        <div class="c">
+          <div class="n"><%= [contact["name"].presence || t("care.document.emergency.relationship_unknown"), contact["relationship"]].select(&:present?).join(" · ") %></div>
+          <div class="p"><%= contact["phone"] %></div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/communicators/assets/care_plan_half.html.erb
+++ b/app/views/communicators/assets/care_plan_half.html.erb
@@ -3,10 +3,14 @@
     with Grover's margin set to 0 (no Chrome header/footer — a folded card
     doesn't get page numbers).
 
-    Two 5.5in panels. The BACK panel is authored upright here and rotated
-    180deg by the `.flip` class — see the fold-mechanics comment in the
-    layout's <style> block before touching that rotation. Bottom panel = front
-    (what's showing on a table), top panel = back (day-to-day support).
+    Two 5.5in panels — the fold is the sheet's exact middle. The BACK panel is
+    authored upright here and rotated 180deg by the `.flip` class — see the
+    fold-mechanics comment in the layout's <style> block before touching that
+    rotation. Bottom panel = front (what's showing on a table), top panel =
+    back (day-to-day support).
+
+    One subject per face, the same split the wallet size makes: the front is
+    who this is and who to call, the back is day-to-day support.
 
     Fixed height, `overflow: hidden` (in .fpanel) — a maxed-out profile WILL
     silently clip past the fold. The overflow ladder below is what keeps that
@@ -21,36 +25,41 @@
   <div class="fpanel flip">
     <div class="fbar"></div>
 
-    <% if @care_sections.any? %>
-      <div class="care-heading"><%= t("care.document.care_heading") %></div>
+    <%# .fbody absorbs whatever height the care block leaves and centres it,
+        so a lightly-answered profile prints a balanced face rather than a
+        band of cards against one edge. See the .fbody note in the layout. %>
+    <div class="fbody">
+      <% if @care_sections.any? %>
+        <div class="care-heading"><%= t("care.document.care_heading") %></div>
 
-      <% if @half_truncated %>
-        <%# Last-resort tier: even comma-joined text would overflow. Drop to
-            one line per section and say where the rest lives. %>
-        <div class="condensed-lines">
-          <% @half_condensed_lines.each do |line| %>
-            <div class="cline">
-              <span class="k"><%= line[:label] %></span>
-              <span class="v"><%= line[:text] %></span>
-            </div>
-          <% end %>
-        </div>
-      <% elsif @half_condensed %>
-        <%# Middle tier: every section and field, comma-joined text instead of
-            chips — roughly half the height per row. %>
-        <div class="cols">
-          <% @care_sections_condensed.each do |section| %>
-            <%= render "communicators/assets/care_plan_card", section: section, chips: false %>
-          <% end %>
-        </div>
-      <% else %>
-        <div class="cols">
-          <% @care_sections.each do |section| %>
-            <%= render "communicators/assets/care_plan_card", section: section %>
-          <% end %>
-        </div>
+        <% if @half_truncated %>
+          <%# Last-resort tier: even comma-joined text would overflow. Drop to
+              one line per section and say where the rest lives. %>
+          <div class="condensed-lines">
+            <% @half_condensed_lines.each do |line| %>
+              <div class="cline">
+                <span class="k"><%= line[:label] %></span>
+                <span class="v"><%= line[:text] %></span>
+              </div>
+            <% end %>
+          </div>
+        <% elsif @half_condensed %>
+          <%# Middle tier: every section and field, comma-joined text instead of
+              chips — roughly half the height per row. %>
+          <div class="cols">
+            <% @care_sections_condensed.each do |section| %>
+              <%= render "communicators/assets/care_plan_card", section: section, chips: false %>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="cols">
+            <% @care_sections.each do |section| %>
+              <%= render "communicators/assets/care_plan_card", section: section %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
 
     <div class="ffoot">
       <p>

--- a/app/views/layouts/pdf_care_plan.html.erb
+++ b/app/views/layouts/pdf_care_plan.html.erb
@@ -206,10 +206,15 @@
         text-transform: uppercase; color: var(--blue-mid); background: #fff;
         border: 0.75pt solid #CBDCEA; border-radius: 999pt; padding: 1pt 6pt; margin-top: 3pt;
       }
+      /* The "says" line is a caption under the name, not a second headline.
+         It ran at nearly the body size and in two weights of navy, so on the
+         half size it read as a subtitle competing with the h1 it sits under —
+         the name is what a reader is looking for first. Sized down and set in
+         one weight here; .fid scales it a little for the bigger panel. */
       .identity .says, .fid .says {
-        font-size: 8.3pt; font-weight: 600; color: #3B3A38; margin-top: 3pt; line-height: 1.25;
+        font-size: 7.4pt; font-weight: 600; color: #4A4845; margin-top: 2.5pt; line-height: 1.25;
       }
-      .says em { font-style: normal; font-weight: 800; color: var(--navy); }
+      .says em { font-style: normal; font-weight: 700; color: var(--navy); }
       .says.muted { color: var(--muted); font-style: italic; font-weight: 500; }
 
       .qrblock { flex: none; text-align: center; width: 62pt; }
@@ -222,8 +227,10 @@
       .qrblock .url { font-size: 5pt; font-weight: 600; color: var(--muted); word-break: break-all; line-height: 1.15; margin-top: 1pt; }
 
       /* ================= at a glance (sheet + half) ================= */
+      /* Two cells — allergies and how I talk. The third, "Call first", is gone:
+         see the note in _care_plan_glance.html.erb. */
       .glance {
-        display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0;
+        display: grid; grid-template-columns: 1fr 1fr; gap: 0;
         margin-top: 8pt; border: 1pt solid var(--rule); border-radius: 8pt; overflow: hidden;
       }
       .glance .cell { padding: 6pt 9pt; border-left: 1pt solid var(--rule); }
@@ -349,32 +356,51 @@
       }
 
       /* ================= half-page fold card ================= */
+      /* The fold is at the geometric middle of the sheet — 5.5in of 11in — and
+         each panel is the same 5.5in tall, so a printed copy creases exactly
+         in half. Never trade that for a taller face: the crease is what a
+         reader lines up when they fold it back along an existing fold. */
       .foldsheet { width: 8.5in; height: 11in; position: relative; overflow: hidden; }
       .fpanel { height: 5.5in; padding: 0 0.5in 0.3in; position: relative; overflow: hidden; display: flex; flex-direction: column; }
+      /* A panel is a fixed-height flex column with `overflow: hidden`, which
+         means an over-full face does not simply spill — the flex algorithm
+         SHRINKS whichever child can give, and that child then clips its own
+         content silently. It picked the glance strip, so "Allergies / How I
+         talk" printed as a row of half-height cells with the values sliced
+         through the middle. Nothing on either face may shrink: if a face is
+         over-full the honest failure is content running past the fold, which
+         is visible, and the overflow ladder is what prevents it. */
+      .fpanel > * { flex: none; }
       /* Gradient sits on each face's OUTER edge, not at the fold — two bars
          meeting at the crease made a 12pt band that got creased in half and
          collided with the fold marks. */
       .fbar { position: absolute; left: 0; right: 0; bottom: 0; height: 6pt; background: var(--brand-gradient-hairline); }
 
-      .fid { display: flex; align-items: center; gap: 13pt; padding: 12pt 0 10pt; }
-      .fid .portrait { width: 80pt; height: 80pt; padding: 2.5pt; }
+      .fid { display: flex; align-items: center; gap: 12pt; padding: 9pt 0 7pt; }
+      .fid .portrait { width: 68pt; height: 68pt; padding: 2.5pt; }
       .fid .portrait img { border: 2pt solid #fff; }
-      .fid h1 { font-size: 25pt; font-weight: 900; line-height: 1; letter-spacing: -0.02em; color: var(--navy); }
-      .fid .says { font-size: 10.5pt; margin-top: 4pt; }
+      .fid h1 { font-size: 23pt; font-weight: 900; line-height: 1; letter-spacing: -0.02em; color: var(--navy); }
+      .fid .says { font-size: 8.6pt; margin-top: 3pt; }
       .fid .qrblock { width: 78pt; }
       .fid .qrblock img { width: 58pt; height: 58pt; }
       .fid .qrblock .cap { font-size: 6pt; }
       .fid .qrblock .url { font-size: 5.4pt; }
 
-      .fpanel .glance { margin-top: 9pt; }
-      .fpanel .glance .v { font-size: 13.5pt; }
+      /* The front face is the tight one — identity, glance, emergency and the
+         footnote all have to land inside 5.5in for a profile with three
+         contacts and a long notes field. Everything below is sized against
+         that budget; trimming the glance or the contact cards is what buys
+         room, never letting a child shrink (see `.fpanel > *`). */
+      .fpanel .glance { margin-top: 7pt; }
+      .fpanel .glance .v { font-size: 12.5pt; }
       .fpanel .glance .k { font-size: 6.5pt; }
       .fpanel .glance .sub { font-size: 7.5pt; }
-      .fpanel .glance .cell { padding: 7pt 11pt; }
+      .fpanel .glance .cell { padding: 6pt 11pt; }
 
-      .fpanel .emergency { margin-top: 9pt; }
-      .fpanel .contact .phone { font-size: 17pt; }
-      .fpanel .contact .name { font-size: 9pt; }
+      .fpanel .emergency { margin-top: 7pt; padding: 6pt 10pt; }
+      .fpanel .contact { padding: 4pt 8pt; }
+      .fpanel .contact .phone { font-size: 15.5pt; }
+      .fpanel .contact .name { font-size: 8.5pt; }
 
       .ffoot { margin-top: auto; padding-top: 7pt; display: flex; align-items: center; gap: 7pt; border-top: 0.75pt solid var(--rule); }
       .ffoot p { flex: 1; font-size: 6.8pt; color: var(--muted); line-height: 1.3; }
@@ -382,8 +408,18 @@
       .ffoot img { width: 14pt; height: 14pt; flex: none; }
       .ffoot .full-plan-note { display: block; font-size: 6.5pt; font-weight: 700; color: var(--navy); margin-top: 2pt; }
 
-      /* Back face is tighter than the sheet — 4.5in of usable height. */
-      .fpanel .care-heading { margin: 8pt 0 5pt; }
+      /* Back face is tighter than the sheet — 4.5in of usable height.
+         .fbody takes whatever the care block doesn't use and splits it above
+         and below, so a profile that answered three sections prints as a
+         balanced face rather than a band of cards jammed against one edge
+         with an inch of white under it. The footnote stays pinned to the
+         bottom (its own margin-top: auto) either way. */
+      /* `safe center` centres only while the content FITS. Plain `center`
+         splits an overflow across both edges, which on the back face means
+         spilling over the fold and onto the front — the one direction an
+         over-full face must never grow. */
+      .fpanel .fbody { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; justify-content: safe center; }
+      .fpanel .care-heading { margin: 0 0 5pt; }
       .fpanel .cols { column-gap: 16pt; }
       .fpanel .card { padding: 5.5pt 8pt; margin-bottom: 5pt; }
       .fpanel .card .hd { margin-bottom: 3pt; }
@@ -416,44 +452,65 @@
         display: grid; grid-template-columns: repeat(2, 3.5in); grid-template-rows: repeat(2, 4in);
         justify-content: center; align-content: center; gap: 0;
       }
+      /* Each strip folds at 2in of 4in — the exact middle, same rule the half
+         size's 5.5in crease follows. Both faces are sized to be FILLED: the
+         front carries identity + allergies + every contact, the back carries
+         the day-to-day lines. See the one-subject-per-face note in
+         _care_plan_wallet_strip.html.erb. */
       .wstrip { width: 3.5in; height: 4in; position: relative; background: #fff; border: 1pt solid #B9B6C4; overflow: hidden; }
-      .wstrip .half { height: 2in; position: relative; overflow: hidden; padding: 7pt 9pt; }
+      .wstrip .half { height: 2in; position: relative; overflow: hidden; padding: 7pt 9pt; display: flex; flex-direction: column; }
+      /* Same rule as .fpanel > *: a fixed-height flex column with hidden
+         overflow shrinks-then-clips instead of spilling, and the clip is
+         silent. Nothing on a wallet face may shrink. */
+      .wstrip .half > * { flex: none; }
       .wstrip .half .wtop { position: absolute; left: 0; right: 0; bottom: 0; top: auto; height: 4pt; background: var(--brand-gradient-hairline); }
 
       .wfront .who { display: flex; gap: 7pt; align-items: center; }
-      .wfront .pic { flex: none; width: 38pt; height: 38pt; border-radius: 999pt; padding: 1.5pt; background: var(--brand-gradient-hairline); }
+      .wfront .pic { flex: none; width: 36pt; height: 36pt; border-radius: 999pt; padding: 1.5pt; background: var(--brand-gradient-hairline); }
       .wfront .pic img { width: 100%; height: 100%; border-radius: 999pt; object-fit: cover; object-position: 50% 22%; display: block; }
       .wfront .nm { flex: 1; min-width: 0; }
       .wfront .nm h4 { font-size: 12pt; font-weight: 900; line-height: 1.05; color: var(--navy); letter-spacing: -0.015em; }
+      /* The live-page URL, moved off the old absolutely-positioned .wfoot at
+         the bottom edge — that strip of the front is contacts now. */
+      .wfront .nm .u { font-size: 4.6pt; font-weight: 700; color: var(--muted); line-height: 1.2; margin-top: 1.5pt; word-break: break-all; }
       .wfront .qr { flex: none; text-align: center; width: 38pt; }
       .wfront .qr img { width: 34pt; height: 34pt; display: block; margin: 0 auto; }
       .wfront .qr .c { font-size: 4.2pt; font-weight: 800; color: var(--muted); letter-spacing: 0.04em; margin-top: 1pt; line-height: 1.1; }
 
-      .wallergy { margin-top: 6pt; background: var(--alert-tint); border-left: 2.5pt solid var(--alert); border-radius: 4pt; padding: 3.5pt 6pt; }
+      .wallergy { margin-top: 5pt; background: var(--alert-tint); border-left: 2.5pt solid var(--alert); border-radius: 4pt; padding: 3pt 6pt; }
       .wallergy .k { font-size: 5.4pt; font-weight: 900; letter-spacing: 0.14em; text-transform: uppercase; color: var(--alert); }
-      .wallergy .v { font-size: 10pt; font-weight: 900; color: var(--alert); line-height: 1.1; letter-spacing: -0.01em; }
+      .wallergy .v { font-size: 9.5pt; font-weight: 900; color: var(--alert); line-height: 1.1; letter-spacing: -0.01em; }
 
-      .wcall { display: flex; align-items: baseline; gap: 4pt; margin-top: 4pt; }
-      .wcall .k { font-size: 5.4pt; font-weight: 900; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
-      .wcall .p { font-size: 9pt; font-weight: 900; letter-spacing: -0.02em; color: var(--ink); }
-      .wcall .n { font-size: 6pt; font-weight: 700; color: var(--muted); }
+      /* Contacts on the FRONT. One row per contact — the relationship and name
+         on the left, the number right-aligned and set large, because that
+         number is the whole reason the card is in someone's pocket. */
+      /* margin-top: auto settles the contacts against the cut edge, so the
+         face's leftover height falls between the blocks instead of pooling at
+         the bottom — the whitespace this card used to print under a lone
+         "Call first" line. */
+      .wcontacts { margin-top: auto; padding-top: 4pt; border-top: 0.75pt solid var(--rule); }
+      .wcontacts .chead {
+        font-size: 5.2pt; font-weight: 900; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--alert); margin-bottom: 2.5pt;
+      }
+      .wcontacts .c { display: flex; align-items: baseline; justify-content: space-between; gap: 5pt; margin-bottom: 1.5pt; }
+      .wcontacts .c .n { flex: 1; min-width: 0; font-size: 5.8pt; font-weight: 800; color: var(--navy); line-height: 1.15; }
+      .wcontacts .c .p { flex: none; font-size: 9.5pt; font-weight: 900; letter-spacing: -0.02em; line-height: 1.15; white-space: nowrap; }
 
-      .wfoot { position: absolute; left: 9pt; right: 9pt; bottom: 5pt; display: flex; align-items: center; justify-content: space-between; gap: 5pt; }
-      .wfoot .u { font-size: 5pt; font-weight: 700; color: var(--muted); }
-      .wfoot img { width: 8pt; height: 8pt; }
-
-      .wback .bhead { font-size: 5.6pt; font-weight: 900; letter-spacing: 0.16em; text-transform: uppercase; color: var(--alert); margin-bottom: 3pt; }
-      .wcontacts { display: flex; gap: 6pt; margin-bottom: 5pt; }
-      .wcontacts .c { flex: 1; background: var(--cream); border-radius: 5pt; padding: 3pt 5pt; }
-      .wcontacts .c .n { font-size: 5.6pt; font-weight: 800; color: var(--navy); line-height: 1.1; }
-      .wcontacts .c .p { font-size: 9.5pt; font-weight: 900; letter-spacing: -0.02em; line-height: 1.15; }
-      .wlist { border-top: 0.75pt solid var(--rule); padding-top: 4pt; }
-      .wlist .li { display: flex; gap: 4pt; margin-bottom: 2.5pt; align-items: baseline; }
+      .wback .bhead {
+        font-size: 5.6pt; font-weight: 900; letter-spacing: 0.16em; text-transform: uppercase;
+        color: var(--navy); margin-bottom: 3pt; display: flex; align-items: center; gap: 4pt;
+      }
+      .wback .bhead::after { content: ""; flex: 1; height: 1pt; background: var(--cyan); }
+      /* The back is one block in a 2in face, so it centres in whatever it
+         doesn't fill — same reason .fbody exists on the half size. */
+      .wback .wlist { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; justify-content: safe center; }
+      .wlist .li { display: flex; gap: 4pt; margin-bottom: 2pt; align-items: baseline; }
       .wlist .li .k {
-        flex: none; width: 58pt; font-size: 4.4pt; font-weight: 900; letter-spacing: 0.04em;
+        flex: none; width: 52pt; font-size: 4.4pt; font-weight: 900; letter-spacing: 0.04em;
         text-transform: uppercase; color: var(--muted); line-height: 1.25;
       }
-      .wlist .li .v { flex: 1; min-width: 0; font-size: 6.8pt; font-weight: 700; line-height: 1.2; color: #2A2724; }
+      .wlist .li .v { flex: 1; min-width: 0; font-size: 6.6pt; font-weight: 700; line-height: 1.18; color: #2A2724; }
 
       /* Cut/fold legend, printed once in the page margin below the 2x2 grid. */
       .wallet-legend {

--- a/config/locales/care.en.yml
+++ b/config/locales/care.en.yml
@@ -162,21 +162,17 @@ en:
       glance:
         allergies: Allergies
         how_i_talk: How I talk
-        call_first: Call first
         none_listed: None listed
         plus_one: plus %{value}
         plus_many: plus %{count} more
-      says:
-        intro_html: I communicate using %{primary}
-        rest_and_html: " and %{values}"
-        neutral: How I communicate and what helps me varies day to day.
+      subheader:
+        default: I communicate differently. Please be kind & give me time.
       half:
         fold_here: Fold here
         turn_over: Turn me over for how %{name} eats, moves, communicates, and what helps them through the day.
         full_plan_note: "Full plan on my live page →"
       wallet:
         my_live_page: MY LIVE PAGE
-        call_first: Call first
         legend_cut: cut
         legend_fold: fold
       emergency:

--- a/config/locales/care.es.yml
+++ b/config/locales/care.es.yml
@@ -162,21 +162,17 @@ es:
       glance:
         allergies: Alergias
         how_i_talk: Cómo me comunico
-        call_first: A quién llamar
         none_listed: No indicado
         plus_one: más %{value}
         plus_many: más %{count}
-      says:
-        intro_html: Me comunico usando %{primary}
-        rest_and_html: " y %{values}"
-        neutral: Cómo me comunico y qué ayuda varía día a día.
+      subheader:
+        default: Me comunico de otra manera. Por favor, ten paciencia y dame tiempo.
       half:
         fold_here: Doblar aquí
         turn_over: Dale la vuelta para ver cómo %{name} come, se mueve, se comunica y qué le ayuda durante el día.
         full_plan_note: "El plan completo está en mi página en línea →"
       wallet:
         my_live_page: MI PÁGINA EN LÍNEA
-        call_first: A quién llamar
         legend_cut: cortar
         legend_fold: doblar
       emergency:

--- a/spec/requests/api/care_sections_spec.rb
+++ b/spec/requests/api/care_sections_spec.rb
@@ -51,7 +51,13 @@ RSpec.describe "API::CareSections", type: :request do
       expect(preferences).not_to have_key("options")
     end
 
-    it "serves every cap the sanitizer enforces" do
+    # Exhaustive on purpose: a cap the editor doesn't know about is a field it
+    # will let a parent overrun and then watch the server truncate.
+    # `subheader_max` is the one here the sanitizer doesn't enforce — it bounds
+    # a per-download param the care plan controller caps, not stored data — but
+    # it is served alongside the rest because it bounds a field in the same
+    # editor.
+    it "serves every cap a care form has to respect" do
       get "/api/care_sections"
       limits = JSON.parse(response.body)["limits"]
 
@@ -63,6 +69,7 @@ RSpec.describe "API::CareSections", type: :request do
         "item_label_max" => Profile::CARE_ITEM_LABEL_MAX,
         "item_value_max" => Profile::CARE_ITEM_VALUE_MAX,
         "short_text_max" => Profile::CARE_SHORT_TEXT_MAX,
+        "subheader_max" => Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS,
       )
     end
 

--- a/spec/requests/api/profiles_care_plan_spec.rb
+++ b/spec/requests/api/profiles_care_plan_spec.rb
@@ -216,6 +216,88 @@ RSpec.describe "API::Profiles care plan", type: :request do
     end
   end
 
+  # The line under the communicator's name. Nothing is persisted — the words
+  # and the on/off ride the request, and the default copy is resolved at render
+  # time from the locale files.
+  describe "the subheader params" do
+    before { profile.update!(settings: care.merge(emergency)) }
+
+    # Both Grover calls of a generate are handed the identical HTML — that is
+    # the point of rendering the ERB once — so the first one is the document.
+    def rendered_html
+      captured = nil
+      allow(Grover).to receive(:new) do |html, **_opts|
+        captured ||= html
+        instance_double(Grover, to_pdf: "%PDF-stub", to_png: "\x89PNG-stub")
+      end
+      yield
+      captured
+    end
+
+    # The default copy has an ampersand in it, so the rendered HTML holds the
+    # escaped form — the same one level of escaping every other output tag
+    # produces.
+    def default_copy
+      CGI.escapeHTML(I18n.t("care.document.subheader.default"))
+    end
+
+    it "prints the default copy when neither param is sent" do
+      html = rendered_html { post_care_plan(parent) }
+
+      expect(html).to include(default_copy)
+    end
+
+    it "prints the caller's own words" do
+      html = rendered_html { post_care_plan(parent, subheader: "Give me time to answer.") }
+
+      expect(html).to include("Give me time to answer.")
+      expect(html).not_to include(default_copy)
+    end
+
+    it "drops the line when include_subheader is false" do
+      html = rendered_html { post_care_plan(parent, include_subheader: "false") }
+
+      expect(html.split("</style>").last).not_to include(%(class="says"))
+      expect(html).not_to include(default_copy)
+    end
+
+    # `truthy?` alone reads an absent param as false, which would have silently
+    # dropped the line from every download made by the client in production
+    # today — it predates this option and sends neither param.
+    it "includes the line for a client that sends neither param" do
+      html = rendered_html { post_care_plan(parent, size: "half") }
+
+      expect(html.split("</style>").last).to include(%(class="says"))
+    end
+
+    it "caps the words it accepts" do
+      long = "z" * (Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS + 50)
+      html = rendered_html { post_care_plan(parent, subheader: long) }
+
+      expect(html).to include("z" * Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS)
+      expect(html).not_to include("z" * (Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS + 1))
+    end
+
+    # The default copy is SERVED, not duplicated into the download form — the
+    # placeholder there would otherwise drift from what actually prints the
+    # first time the copy is edited.
+    it "is served by the care registry alongside its cap" do
+      get "/api/care_sections"
+
+      body = JSON.parse(response.body)
+      expect(body["subheader_default"]).to eq(I18n.t("care.document.subheader.default"))
+      expect(body["limits"]["subheader_max"])
+        .to eq(Communicators::GenerateCarePlan::SUBHEADER_MAX_CHARS)
+    end
+
+    it "escapes the parent's own words like any other output" do
+      html = rendered_html { post_care_plan(parent, subheader: "Ask me <first> & wait") }
+
+      expect(html).to include("Ask me &lt;first&gt; &amp; wait")
+      expect(html).not_to include("Ask me <first>")
+    end
+  end
+
   # Refusing beats emitting a sheet of empty headings, which reads as a finished
   # plan asserting this child needs nothing.
   describe "empty states" do

--- a/spec/services/communicators/care_plan_document_spec.rb
+++ b/spec/services/communicators/care_plan_document_spec.rb
@@ -354,31 +354,15 @@ RSpec.describe Communicators::CarePlanDocument do
     end
   end
 
-  # The identity block's first-person line and the glance strip's "How I
-  # talk" cell — both derived from the communication section, independent of
-  # `only_sections`.
-  describe "#says and #glance_how_i_talk" do
+  # The glance strip's "How I talk" cell — derived from the communication
+  # section, independent of `only_sections`. (The identity block's line under
+  # the name used to be derived from the same answers; it is the caller's
+  # `subheader` now — see generate_care_plan_spec.rb.)
+  describe "#glance_how_i_talk" do
     it "is nil when nothing is stored for communication" do
       doc = with_care("sections" => { "meals" => { "values" => { "preferences" => "hates cold food" } } })
 
-      expect(doc.says).to be_nil
       expect(doc.glance_how_i_talk).to be_nil
-    end
-
-    it "carries the primary method, the rest, and what helps" do
-      doc = with_care(
-        "sections" => {
-          "communication" => {
-            "values" => { "methods" => %w[aac_device eye_gaze some_speech], "what_helps" => ["wait_and_pause"] },
-          },
-        },
-      )
-
-      says = doc.says
-      expect(says.primary).to eq("AAC device")
-      # Sentence-cased for the middle of a sentence, not the label's own casing.
-      expect(says.rest).to eq(["eye gaze", "some speech"])
-      expect(says.helps).to eq("Wait and pause")
     end
 
     it "builds the glance cell's primary value and a 'plus N more' sub line" do
@@ -402,7 +386,7 @@ RSpec.describe Communicators::CarePlanDocument do
         "sections" => { "communication" => { "enabled" => false, "values" => { "methods" => ["aac_device"] } } },
       )
 
-      expect(doc.says).to be_nil
+      expect(doc.glance_how_i_talk).to be_nil
     end
 
     it "is independent of only_sections — narrowing to another section keeps it" do
@@ -417,11 +401,11 @@ RSpec.describe Communicators::CarePlanDocument do
       )
 
       expect(doc.care_sections.map(&:key)).to eq(%w[meals])
-      expect(doc.says.primary).to eq("AAC device")
+      expect(doc.glance_how_i_talk[:primary]).to eq("AAC device")
     end
   end
 
-  describe "#allergies and #call_first_contact" do
+  describe "#allergies" do
     it "resolves allergies from the emergency data" do
       doc = with_care({ "sections" => {} }, { "allergies" => "peanuts" })
       expect(doc.allergies).to eq("peanuts")
@@ -430,23 +414,6 @@ RSpec.describe Communicators::CarePlanDocument do
     it "is nil when allergies were never answered" do
       doc = with_care({ "sections" => {} }, {})
       expect(doc.allergies).to be_nil
-    end
-
-    it "is the first stored emergency contact" do
-      doc = with_care(
-        { "sections" => {} },
-        {
-          "ice_contact_1" => { "name" => "Sam", "phone" => "555-0100", "relationship" => "Dad" },
-          "ice_contact_2" => { "name" => "Alex", "phone" => "555-0200", "relationship" => "Mom" },
-        },
-      )
-
-      expect(doc.call_first_contact["name"]).to eq("Sam")
-    end
-
-    it "is nil when there are no contacts" do
-      doc = with_care({ "sections" => {} }, {})
-      expect(doc.call_first_contact).to be_nil
     end
   end
 
@@ -466,6 +433,41 @@ RSpec.describe Communicators::CarePlanDocument do
       expect(lines.length).to eq(1)
       expect(lines.first[:label]).to eq("Meals & snacks")
       expect(lines.first[:text]).to eq("Soft, Chopped, watered-down apple juice")
+    end
+
+    # These lines are a comma-joined list of short care options, so a mid-word
+    # cut lands inside one of them and prints a fragment that reads as a
+    # different answer from the one the parent picked.
+    it "truncates on a word boundary, never mid-option" do
+      doc = with_care(
+        "order" => %w[communication],
+        "sections" => {
+          "communication" => {
+            "values" => { "methods" => %w[aac_device sign gestures eye_gaze partner_assisted] },
+          },
+        },
+      )
+
+      text = doc.condensed_care_lines(truncate_at: 30).first[:text]
+
+      kept = text.delete_suffix("…")
+      full = doc.condensed_care_lines.first[:text]
+
+      expect(text.length).to be <= 30
+      expect(text).to end_with("…")
+      # What survives is a prefix of the full line that stops at a space —
+      # i.e. the cut landed between options, not inside one.
+      expect(full).to start_with(kept)
+      expect(full[kept.length]).to eq(" ")
+    end
+
+    it "leaves a line that fits the cap alone" do
+      doc = with_care(
+        "order" => %w[communication],
+        "sections" => { "communication" => { "values" => { "methods" => %w[aac_device] } } },
+      )
+
+      expect(doc.condensed_care_lines(truncate_at: 60).first[:text]).to eq("AAC device")
     end
 
     it "caps the number of lines when a limit is given" do

--- a/spec/services/communicators/generate_care_plan_spec.rb
+++ b/spec/services/communicators/generate_care_plan_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe Communicators::GenerateCarePlan do
     captured
   end
 
+  # The rendered document minus the layout's <style> block — the CSS carries
+  # explanatory comments naming the very strings some of these assertions
+  # check the absence of.
+  def document_body(html)
+    html.split("</style>").last
+  end
+
+  # Each wallet strip as a [back_face, front_face] pair. The strip's markup is
+  # back, fold rule, front — see _care_plan_wallet_strip.html.erb.
+  def wallet_strips(html)
+    document_body(html).split(%(<div class="wstrip">)).drop(1).map do |strip|
+      back, front = strip.split(%(<div class="foldrule"))
+      [back, front]
+    end
+  end
+
   # The PDF call's options specifically. The thumbnail's call carries
   # `format: "png"` and a pixel viewport instead of page options, so capturing
   # the LAST call would quietly assert against the preview rather than the
@@ -255,9 +271,8 @@ RSpec.describe Communicators::GenerateCarePlan do
     end
   end
 
-  # The "At a glance" strip: allergies, how the communicator talks, and the
-  # first contact — only on the :full variant, and allergies renders here and
-  # ONLY here.
+  # The "At a glance" strip: allergies and how the communicator talks — only on
+  # the :full variant, and allergies renders here and ONLY here.
   describe "the at-a-glance strip" do
     it "prints allergies exactly once, in the glance strip, never in the emergency grid" do
       html = render_html(variant: :full)
@@ -265,6 +280,19 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html.scan("zzpeanutszz").length).to eq(1)
       expect(html).not_to include(%(<span class="k">Allergies</span>))
       expect(html).to include(%(<div class="k">Allergies</div>))
+    end
+
+    # The strip used to carry a third "Call first" cell repeating the top
+    # contact's phone number a few millimetres above the contact cards in the
+    # emergency block directly below it, on both sizes that render the strip.
+    it "does not repeat a contact's number above the emergency block" do
+      %i[sheet half].each do |size|
+        body = document_body(render_html(variant: :full, size: size))
+
+        expect(body.scan("555-0100").length).to eq(1)
+        expect(body).not_to include("Call first")
+        expect(body.scan(%(class="cell)).length).to eq(2)
+      end
     end
 
     it "falls back to a neutral cell when a value is unanswered" do
@@ -547,6 +575,95 @@ RSpec.describe Communicators::GenerateCarePlan do
     end
   end
 
+  # The line under the communicator's name. A per-download choice, not stored
+  # data: the words come from `subheader`, `include_subheader: false` drops the
+  # line, and blank or absent means the default copy — which is resolved from
+  # the locale files at render time and never written anywhere.
+  describe "the subheader" do
+    def subheader_line(html)
+      document_body(html)[%r{<div class="says">\s*(.*?)\s*</div>}m, 1]
+    end
+
+    it "prints the default copy when the caller asks for nothing" do
+      expect(subheader_line(render_html)).to eq(CGI.escapeHTML(I18n.t("care.document.subheader.default")))
+    end
+
+    it "prints the caller's own words instead" do
+      html = render_html(subheader: "Please talk to me, not about me.")
+
+      expect(subheader_line(html)).to eq("Please talk to me, not about me.")
+      expect(html).not_to include(I18n.t("care.document.subheader.default"))
+    end
+
+    it "treats a blank subheader as no answer, not as an empty line" do
+      expect(subheader_line(render_html(subheader: "   ")))
+        .to eq(CGI.escapeHTML(I18n.t("care.document.subheader.default")))
+    end
+
+    it "caps the caller's words" do
+      html = render_html(subheader: "z" * (described_class::SUBHEADER_MAX_CHARS + 40))
+
+      expect(subheader_line(html).length).to eq(described_class::SUBHEADER_MAX_CHARS)
+    end
+
+    it "prints no line at all when the caller turns it off" do
+      html = render_html(include_subheader: false)
+
+      expect(document_body(html)).not_to include(%(class="says"))
+      expect(html).not_to include(I18n.t("care.document.subheader.default"))
+    end
+
+    it "renders on the half size too, and not on the wallet" do
+      expect(document_body(render_html(size: :half))).to include(%(class="says"))
+      expect(document_body(render_html(size: :wallet))).not_to include(%(class="says"))
+    end
+
+    # The identity block used to open with "I communicate using AAC device and
+    # gestures…", restating the "How I talk" glance cell a centimetre below it.
+    # (The cell and the Communication card still both name the method — a
+    # summary strip over its own section is the design; an identity line over
+    # that summary was the duplication.)
+    it "does not restate the communication section" do
+      html = render_html
+
+      expect(html).not_to include("I communicate using")
+      expect(identity_text(html).join(" ")).not_to include("AAC device")
+    end
+
+    # Same trap `sections` has: there is one attachment per [variant, size], so
+    # a choice that misses the signature is answered by the cached document and
+    # the control appears to do nothing.
+    it "re-renders when the words change" do
+      render_html(subheader: "One")
+
+      expect_rerender
+      described_class.call(profile.reload, variant: :full, subheader: "Two")
+    end
+
+    it "re-renders when the line is turned off" do
+      render_html
+
+      expect_rerender
+      described_class.call(profile.reload, variant: :full, include_subheader: false)
+    end
+
+    it "does not re-render for the same words" do
+      render_html(subheader: "One")
+
+      expect(Grover).not_to receive(:new)
+      described_class.call(profile.reload, variant: :full, subheader: "One")
+    end
+
+    # Taking the default must leave the signature exactly as it was, or the
+    # option invalidates every document already generated for no change in
+    # output — the same rule the sections term follows.
+    it "adds no signature term when the caller takes the default" do
+      render_html
+
+      expect(profile.reload.care_emergency_plan_pdf.metadata["signature"]).not_to include("subheader")
+    end
+  end
+
   # The section picker. `sections` is an allowlist; nil means all of them, and
   # the selection has to reach the freshness signature or a narrowed download is
   # answered by the cached full document.
@@ -698,6 +815,45 @@ RSpec.describe Communicators::GenerateCarePlan do
       expect(html.scan(%(class="wstrip")).length).to eq(4)
       lines_per_strip = html.scan(%(class="li")).length / 4
       expect(lines_per_strip).to be <= described_class::WALLET_LINE_LIMIT
+    end
+
+    # One subject per face: the front is who this is and who to call, the back
+    # is day-to-day support. The contacts used to print on the BACK with a
+    # one-line "Call first" repeat of the top one squeezed onto the front.
+    it "prints the wallet's contacts on the front face and the care lines on the back" do
+      strips = wallet_strips(render_html(variant: :full, size: :wallet))
+
+      expect(strips.length).to eq(4)
+
+      strips.each do |back, front|
+        expect(front).to include("zzSamzz").and include("555-0100")
+        expect(front).not_to include(%(class="li"))
+        expect(back).to include(%(class="li"))
+        expect(back).not_to include("555-0100")
+      end
+    end
+
+    it "caps each wallet line's length as well as the number of lines" do
+      profile.update_columns(settings: maxed_out_care_settings)
+
+      html = render_html(variant: :full, size: :wallet)
+
+      values = html.scan(%r{<span class="v">([^<]*)</span>}).flatten
+      expect(values).to be_present
+      expect(values.map(&:length).max).to be <= described_class::WALLET_LINE_MAX_CHARS
+    end
+
+    # Same trap on the half size's last-resort tier: the LINE COUNT bounds
+    # nothing when one maxed-out section joins to hundreds of characters and
+    # wraps to four visual lines on its own, and the panel clips in silence.
+    it "caps each line's length in the half size's truncated tier too" do
+      profile.update_columns(settings: maxed_out_care_settings)
+
+      html = render_html(variant: :full, size: :half)
+
+      values = html.scan(%r{<span class="v">\s*([^<]*?)\s*</span>}).flatten
+      expect(values).to be_present
+      expect(values.map(&:length).max).to be <= described_class::HALF_TRUNCATED_LINE_MAX_CHARS
     end
 
     it "condenses the wallet size the same way for a maxed-out profile" do


### PR DESCRIPTION
Care plan print fixes from a round of review on the half and wallet sizes, plus the subheader option that came out of it.

## What changed

**The glance strip was being clipped.** `.fpanel` is a fixed-height `overflow: hidden` flex column, so an over-full front face didn't spill — the flex algorithm took the height out of whichever child could give, and that child clipped its own contents silently. It picked the glance strip, so "Allergies" and "How I talk" printed as a row of half-height cells with the values sliced through the middle. Every face child is now pinned to `flex: none`, and the front's height budget was trimmed (portrait 80→68pt, tighter glance/emergency/contact padding) so it genuinely fits.

**"Call first" is gone from the glance strip.** It repeated the first contact's phone number a few millimetres above the contact cards in the emergency block directly below it, on both sizes that render the strip. The contact list is ordered and its first entry *is* the one to call. `CarePlanDocument#call_first_contact` went with it.

**One subject per face on the wallet card.** Front: identity, allergies, every contact. Back: day-to-day lines. The contacts used to sit on the back above the care lines with a one-line "Call first" repeat squeezed onto the front — the same phone number on both faces of a card small enough to read at a glance, with the front half-empty and the back over-full. The back gained the freed room (`WALLET_LINE_LIMIT` 5→6, `WALLET_LINE_MAX_CHARS` 60→62), and `#condensed_care_lines` now cuts on a **word boundary** — a mid-word cut landed inside an option and printed a fragment ("Keep my device close, Wai…") that reads as a different answer from the one the parent picked.

**The half size's last-resort tier gains a per-line cap** (`HALF_TRUNCATED_LINE_MAX_CHARS`). It bounded the line COUNT only, on the theory that a 4.5in back panel is roomy — but eight lines each wrapping to four visual lines is thirty-two, and a maxed-out profile clipped the last of them plus its own footnote. The line count and the character cap are one budget; pick them together.

**The line under the name is now the caller's to write, or to turn off.** It was assembled from the communication section ("I communicate using AAC device and gestures. Keep my device close."), restating the "How I talk" glance cell a centimetre below it. `POST /api/profiles/:id/care_plan` takes:

- `subheader` — the parent's own words, stripped and capped at `SUBHEADER_MAX_CHARS` (160)
- `include_subheader=false` — no line at all

Blank or absent means the default copy, resolved from the locale files at render time and **never stored**. That's the `profiles.bio` / `profiles.intro` rule: the line prints in the communicator's own first-person voice, so seeding it would publish words nobody wrote and make "is there a subheader" stop meaning "did someone write one". `CarePlanDocument#says`, the `Says` struct, and the `care.document.says.*` keys are retired; `#glance_how_i_talk` still carries the AAC fact.

`LAYOUT_VERSION` 4 → 6, so already-generated documents refresh rather than serving the old look forever.

## Two things worth a second look in review

- **`include_subheader` is absent-means-included.** Reading a missing param through `truthy?` would have silently dropped the line from every download made by the client in production, which predates the option and sends neither param. Pinned by a spec.
- **The choice rides the freshness signature.** There is one attachment per `[variant, size]`, so a custom or hidden subheader that missed the signature would be answered by the cached document and the control would appear to do nothing — the trap `sections` already documents. Taking the default adds **no** signature term, so ordinary downloads aren't all invalidated at once.

The default copy and its cap are served through `GET /api/care_sections` (`subheader_default`, `limits.subheader_max`) rather than duplicated into the frontend — that registry exists to kill exactly this kind of Ruby↔TypeScript drift, and the download form only needs the string as a placeholder.

## Test plan

Verified the rendered PDFs through **real headless Chrome** (not just the stubbed-Grover specs) against three profiles — an ordinary one, a nearly-empty one, and one with every documented care limit maxed out — at all three sizes. The maxed-out half page now fits inside both panels including its footnote, which it did not before this branch.

```
bundle exec rspec spec/services/communicators spec/requests/api/profiles_care_plan_spec.rb spec/requests/api/care_sections_spec.rb spec/models/profile_spec.rb
299 examples, 0 failures
```

Also green: `spec/models/care_preset_reshape_spec.rb`, `spec/models/care_option_retirement_spec.rb`, `spec/jobs/regenerate_safety_cards_job_spec.rb`, and `bin/rails zeitwerk:check`.

New coverage: the two-cell glance with no repeated number, the wallet's per-face split, word-boundary truncation, both per-line caps, all three subheader modes, the signature rules, absent-means-included, and HTML escaping of the parent's own words.

Docs: `.claude-notes/safety-profiles.md` and `CHANGELOG.md`.

## Frontend

Companion PR adds the tick box and text field to the download options — opening next, and it depends on this one for the `subheader_default` / `subheader_max` registry fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)